### PR TITLE
Ltac2: enforce typing of external declarations

### DIFF
--- a/plugins/ltac2/tac2core.mli
+++ b/plugins/ltac2/tac2core.mli
@@ -44,6 +44,7 @@ module type MapType = sig
   type valmap
   val valmap_eq : (valmap, Tac2val.valexpr M.t) Util.eq
   val repr : S.elt Tac2ffi.repr
+  val typ : Tac2ffi.Types.t option
 end
 
 type ('a,'set,'map) map_tag

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -129,13 +129,14 @@ module MLMap = Map.Make(ML)
 
 let primitive_map = ref MLMap.empty
 
-let define_primitive name f =
+let define_primitive name ty f =
   let f = match f with
     | ValCls f -> ValCls (annotate_closure (FrPrim name) f)
     | _ -> f
   in
-  primitive_map := MLMap.add name f !primitive_map
-let interp_primitive name = MLMap.find name !primitive_map
+  primitive_map := MLMap.add name (ty, f) !primitive_map
+let interp_primitive name = snd (MLMap.find name !primitive_map)
+let primitive_type name = fst (MLMap.find name !primitive_map)
 
 (** Name management *)
 

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -157,6 +157,8 @@ val interp_ml_object : ('a, 'b) Tac2dyn.Arg.tag -> ('a, 'b) ml_object
 
 (** {5 Absolute paths} *)
 
+(* TODO move this to tac2globals *)
+
 val coq_prefix : ModPath.t
 (** Path where primitive datatypes are defined in Ltac2 plugin. *)
 

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -128,8 +128,9 @@ val shortest_qualid_of_projection : ltac_projection -> qualid
 (** This state is not part of the summary, contrarily to the ones above. It is
     intended to be used from ML plugins to register ML-side functions. *)
 
-val define_primitive : ml_tactic_name -> valexpr -> unit
+val define_primitive : ml_tactic_name -> type_scheme option -> valexpr -> unit
 val interp_primitive : ml_tactic_name -> valexpr
+val primitive_type : ml_tactic_name -> type_scheme option
 
 (** {5 ML primitive types} *)
 

--- a/plugins/ltac2/tac2externals.ml
+++ b/plugins/ltac2/tac2externals.ml
@@ -86,4 +86,4 @@ let define : type v f. _ -> (v,f) spec -> f -> unit = fun n ar v ->
         Tac2ffi.of_closure cl
     | _ -> invalid_arg "Tac2def.define: not a pure value"
   in
-  Tac2env.define_primitive n v
+  Tac2env.define_primitive n None v

--- a/plugins/ltac2/tac2externals.ml
+++ b/plugins/ltac2/tac2externals.ml
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Util
 open Proofview
 open Tac2ffi
 
@@ -21,52 +22,52 @@ type 'a with_env = Environ.env -> Evd.evar_map -> 'a
    to be give for this type definition to be accepted. If we remove it, we get
    an error: "a type variable cannot be deduced from the type parameters". *)
 type (_, _, _) spec_aux =
-  | T : 'r to_v -> (v tactic, 'r tactic, 'r) spec_aux
-  | V : 'r to_v -> (v tactic, 'r, 'r) spec_aux
-  | E : 'r to_v -> (v tactic, 'r with_env, 'r) spec_aux
-  | G : 'r to_v -> (v tactic, Goal.t -> 'r, 'r) spec_aux
-  | F : 'a of_v * ('t, 'f, 'r) spec_aux -> (v -> 't , 'a -> 'f, 'r) spec_aux
+  | T : 'r to_v annotated -> (v tactic, 'r tactic, 'r) spec_aux
+  | V : 'r to_v annotated -> (v tactic, 'r, 'r) spec_aux
+  | E : 'r to_v annotated -> (v tactic, 'r with_env, 'r) spec_aux
+  | G : 'r to_v annotated -> (v tactic, Goal.t -> 'r, 'r) spec_aux
+  | F : 'a of_v annotated * ('t, 'f, 'r) spec_aux -> (v -> 't , 'a -> 'f, 'r) spec_aux
 
 type (_,_) spec = S : ('v,'f,'r) spec_aux -> ('v,'f) spec [@@unboxed]
 
-let tac : type r. r repr -> (v tactic, r tactic) spec = fun r ->
-  S (T (repr_of r))
+let tac : type r. r repr annotated -> (v tactic, r tactic) spec = fun r ->
+  S (T (on_fst repr_of r))
 
-let tac': type r. r to_v -> (v tactic, r tactic) spec = fun tr ->
+let tac': type r. r to_v annotated -> (v tactic, r tactic) spec = fun tr ->
   S (T tr)
 
-let ret : type r. r repr -> (v tactic, r) spec = fun r ->
-  S (V (repr_of r))
+let ret : type r. r repr annotated -> (v tactic, r) spec = fun r ->
+  S (V (on_fst repr_of r))
 
-let ret': type r. r to_v -> (v tactic, r) spec = fun tr ->
+let ret': type r. r to_v annotated -> (v tactic, r) spec = fun tr ->
   S (V tr)
 
-let eret : type r. r repr -> (v tactic, r with_env) spec = fun r ->
-  S (E (repr_of r))
+let eret : type r. r repr annotated -> (v tactic, r with_env) spec = fun r ->
+  S (E (on_fst repr_of r))
 
-let eret': type r. r to_v -> (v tactic, r with_env) spec = fun tr ->
+let eret': type r. r to_v annotated -> (v tactic, r with_env) spec = fun tr ->
   S (E tr)
 
-let gret : type r. r repr -> (v tactic, Goal.t -> r) spec = fun r ->
-  S (G (repr_of r))
+let gret : type r. r repr annotated -> (v tactic, Goal.t -> r) spec = fun r ->
+  S (G (on_fst repr_of r))
 
-let gret': type r. r to_v -> (v tactic, Goal.t -> r) spec = fun tr ->
+let gret': type r. r to_v annotated -> (v tactic, Goal.t -> r) spec = fun tr ->
   S (G tr)
 
-let (@->) : type a t f. a repr -> (t,f) spec -> (v -> t, a -> f) spec =
-  fun r (S ar) -> S (F (repr_to r, ar))
+let (@->) : type a t f. a repr annotated -> (t,f) spec -> (v -> t, a -> f) spec =
+  fun r (S ar) -> S (F (on_fst repr_to r, ar))
 
-let (@-->): type a t f. a of_v -> (t,f) spec -> (v -> t, a -> f) spec =
+let (@-->): type a t f. a of_v annotated -> (t,f) spec -> (v -> t, a -> f) spec =
   fun of_v (S ar) -> S (F (of_v, ar))
 
 let rec interp_spec : type v f. (v,f) spec -> f -> v = fun (S ar) f ->
   let open Proofview.Notations in
   match ar with
-  | T tr -> f >>= fun v -> tclUNIT (tr v)
-  | V tr -> tclUNIT (tr f)
-  | E tr -> tclENV >>= fun e -> tclEVARMAP >>= fun s -> tclUNIT (tr (f e s))
-  | G tr -> Goal.enter_one @@ fun g -> tclUNIT (tr (f g))
-  | F (tr,ar) -> fun v -> interp_spec (S ar) (f (tr v))
+  | T tr -> f >>= fun v -> tclUNIT (fst tr v)
+  | V tr -> tclUNIT (fst tr f)
+  | E tr -> tclENV >>= fun e -> tclEVARMAP >>= fun s -> tclUNIT (fst tr (f e s))
+  | G tr -> Goal.enter_one @@ fun g -> tclUNIT (fst tr (f g))
+  | F (tr,ar) -> fun v -> interp_spec (S ar) (f (fst tr v))
 
 let rec arity_of : type v f. (v,f) spec -> v Tac2val.arity = fun (S ar) ->
   match ar with
@@ -77,13 +78,23 @@ let rec arity_of : type v f. (v,f) spec -> v Tac2val.arity = fun (S ar) ->
   | F (_, ar) -> Tac2val.arity_suc (arity_of (S ar))
   | _ -> invalid_arg "Tac2def.arity_of: not a function spec"
 
+let rec type_of_spec : type v f. (v,f) spec -> Types.t = fun (S ar) ->
+  let of_annot (_,t) = Option.default Types.any t in
+  match ar with
+  | T tr -> of_annot tr
+  | V tr -> of_annot tr
+  | E tr -> of_annot tr
+  | G tr -> of_annot tr
+  | F (tr,ar) -> Types.(of_annot tr @-> type_of_spec (S ar))
+
 let define : type v f. _ -> (v,f) spec -> f -> unit = fun n ar v ->
   let v =
     match ar with
-    | S (V tr) -> tr v
+    | S (V tr) -> fst tr v
     | S (F _) ->
         let cl = Tac2val.mk_closure (arity_of ar) (interp_spec ar v) in
         Tac2ffi.of_closure cl
     | _ -> invalid_arg "Tac2def.define: not a pure value"
   in
-  Tac2env.define_primitive n None v
+  let ty = Some (Types.as_scheme @@ type_of_spec ar) in
+  Tac2env.define_primitive n ty v

--- a/plugins/ltac2/tac2externals.mli
+++ b/plugins/ltac2/tac2externals.mli
@@ -24,36 +24,36 @@ type (_, _) spec
 (** [tac r] is the specification of a tactic (in the tactic monad sense) whose
     return type is specified (and converted into an Ltac2 value) via [r]. *)
 val tac :
-  'r repr ->
+  'r repr annotated ->
   (valexpr tactic, 'r tactic) spec
 
 (** [tac'] is similar to [tac], but only needs a conversion function. *)
 val tac' :
-  ('r -> valexpr) ->
+  ('r -> valexpr) annotated ->
   (valexpr tactic, 'r tactic) spec
 
 (** [ret r] is the specification of a pure tactic (i.e., a tactic defined as a
     pure OCaml value, not needing the tactic monad) whose return type is given
     by [r] (see [tac]). *)
 val ret :
-  'r repr ->
+  'r repr annotated ->
   (valexpr tactic, 'r) spec
 
 (** [ret'] is similar to [ret], but only needs a conversion function. *)
 val ret' :
-  ('r -> valexpr) ->
+  ('r -> valexpr) annotated ->
   (valexpr tactic, 'r) spec
 
 (** [eret] is similar to [ret], but for tactics that can be implemented with a
     pure OCaml value, provided extra arguments [env] and [sigma], computed via
     [tclENV] and [tclEVARMAP]. *)
 val eret :
-  'r repr ->
+  'r repr annotated ->
   (valexpr tactic, Environ.env -> Evd.evar_map -> 'r) spec
 
 (** [eret'] is similar to [eret], but only needs a conversion function. *)
 val eret' :
-  ('r -> valexpr) ->
+  ('r -> valexpr) annotated ->
   (valexpr tactic, Environ.env -> Evd.evar_map -> 'r) spec
 
 (** [gret] is similar to [ret], but for tactics that can be implemented with a
@@ -62,24 +62,24 @@ val eret' :
     of using an Ltac2 value defined with this specification. Indeed, the value
     of [g] is computed using [Goal.enter_one]. *)
 val gret :
-  'r repr ->
+  'r repr annotated ->
   (valexpr tactic, Goal.t -> 'r) spec
 
 (** [gret'] is similar to [gret], but only needs a conversion function. *)
 val gret' :
-  ('r -> valexpr) ->
+  ('r -> valexpr) annotated ->
   (valexpr tactic, Goal.t -> 'r) spec
 
 (** [r @-> s] extends the specification [s] with a closure argument whose type
     is specified by (and converted from an Ltac2 value via) [r]. *)
 val (@->) :
-  'a repr ->
+  'a repr annotated ->
   ('t,'f) spec ->
   (valexpr -> 't, 'a -> 'f) spec
 
 (** [(@-->)] is similar to [(@->)], but only needs a conversion function. *)
 val (@-->) :
-  (valexpr -> 'a) ->
+  (valexpr -> 'a) annotated ->
   ('t,'f) spec ->
   (valexpr -> 't, 'a -> 'f) spec
 

--- a/plugins/ltac2/tac2extffi.ml
+++ b/plugins/ltac2/tac2extffi.ml
@@ -24,7 +24,8 @@ let to_qhyp v = match Value.to_block v with
 | (1, [| id |]) -> NamedHyp (CAst.make (Value.to_ident id))
 | _ -> assert false
 
-let qhyp = make_to_repr to_qhyp
+let qhyp_ = make_to_repr to_qhyp
+let qhyp = typed qhyp_ Types.(!! Tac2globals.Types.hypothesis)
 
 let to_bindings = function
 | ValInt 0 -> NoBindings
@@ -34,10 +35,7 @@ let to_bindings = function
   ExplicitBindings ((Value.to_list (fun p -> to_pair to_qhyp Value.to_constr p) vl))
 | _ -> assert false
 
-let bindings = make_to_repr to_bindings
+let bindings_ = make_to_repr to_bindings
+let bindings = typed bindings_ Types.(!! Tac2globals.Types.bindings)
 
-let to_constr_with_bindings v = match Value.to_tuple v with
-| [| c; bnd |] -> (Value.to_constr c, to_bindings bnd)
-| _ -> assert false
-
-let constr_with_bindings = make_to_repr to_constr_with_bindings
+let constr_with_bindings = pair constr bindings

--- a/plugins/ltac2/tac2extffi.mli
+++ b/plugins/ltac2/tac2extffi.mli
@@ -11,8 +11,8 @@
 open Tac2ffi
 open Tac2types
 
-val qhyp : quantified_hypothesis repr
+val qhyp : quantified_hypothesis repr annotated
 
-val bindings : bindings repr
+val bindings : bindings repr annotated
 
-val constr_with_bindings : constr_with_bindings repr
+val constr_with_bindings : constr_with_bindings repr annotated

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -50,7 +50,6 @@ let val_binder = Val.create "binder"
 let val_univ = Val.create "universe"
 let val_quality = Val.create "quality"
 let val_free : Names.Id.Set.t Val.tag = Val.create "free"
-let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
 let val_uint63 = Val.create "uint63"
 let val_float = Val.create "float"
 let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = Val.create "ind_data"
@@ -67,6 +66,57 @@ match Val.eq tag tag' with
 
 exception LtacError of Names.KerName.t * valexpr array
 
+(** Type annotation *)
+
+module Types = struct
+  open Tac2expr
+
+  type t = Any | Var of int | Ref of type_constant * t list | Tuple of t list | Arrow of t * t
+
+  let any = Any
+
+  let default t = Option.default Any t
+
+  let var x = Var x
+
+  let (!) x l = Ref (x, l)
+
+  let (!!) x = ! x []
+
+  let tuple l = Tuple l
+
+  let (@->) x y = Arrow (x, y)
+
+  let as_scheme t =
+    let (!) x = x.contents in
+    let var_cnt = ref 0 in
+    (* find max explicit variable *)
+    let rec iter = function
+      | Any -> ()
+      | Var x -> var_cnt := max !var_cnt (x+1)
+      | Ref (_,l) | Tuple l -> List.iter iter l
+      | Arrow (x,y) -> iter x; iter y
+    in
+    let () = iter t in
+    (* assign each Any to different variables *)
+    let rec as_ty = function
+      | Any -> let x = !var_cnt in var_cnt := x+1; GTypVar x
+      | Var x -> GTypVar x
+      | Ref (kn, l) -> GTypRef (Other kn, List.map as_ty l)
+      | Tuple l -> GTypRef (Tuple (List.length l), List.map as_ty l)
+      | Arrow (x, y) -> GTypArrow (as_ty x, as_ty y)
+    in
+    let t = as_ty t in
+    !var_cnt, t
+end
+open Types
+module T = Tac2globals.Types
+
+type 'a annotated = 'a * Types.t option
+
+let typed x (ty:Types.t) = (x,Some ty)
+let untyped x = (x,None)
+
 (** Conversion functions *)
 
 let valexpr = {
@@ -74,26 +124,32 @@ let valexpr = {
   r_to = (fun obj -> obj);
 }
 
+let valexpr_0 = typed valexpr (Types.var 0)
+
 let of_unit () = ValInt 0
 
 let to_unit = function
 | ValInt 0 -> ()
 | _ -> assert false
 
-let unit = {
+let unit_ = {
   r_of = of_unit;
   r_to = to_unit;
 }
+
+let unit = typed unit_ (!! T.unit)
 
 let of_int n = ValInt n
 let to_int = function
 | ValInt n -> n
 | _ -> assert false
 
-let int = {
+let int_ = {
   r_of = of_int;
   r_to = to_int;
 }
+
+let int = typed int_ (!! T.int)
 
 let of_bool b = if b then ValInt 0 else ValInt 1
 
@@ -102,37 +158,45 @@ let to_bool = function
 | ValInt 1 -> false
 | _ -> assert false
 
-let bool = {
+let bool_ = {
   r_of = of_bool;
   r_to = to_bool;
 }
+
+let bool = typed bool_ (!! T.bool)
 
 let of_char n = ValInt (Char.code n)
 let to_char = function
 | ValInt n -> Char.chr n
 | _ -> assert false
 
-let char = {
+let char_ = {
   r_of = of_char;
   r_to = to_char;
 }
+
+let char = typed char_ (!! T.char)
 
 let of_bytes s = ValStr s
 let to_bytes = function
 | ValStr s -> s
 | _ -> assert false
 
-let bytes = {
+let bytes_ = {
   r_of = of_bytes;
   r_to = to_bytes;
 }
 
+let bytes = typed bytes_ (!! T.string)
+
 let of_string s = of_bytes (Bytes.of_string s)
 let to_string s = Bytes.to_string (to_bytes s)
-let string = {
+let string_ = {
   r_of = of_string;
   r_to = to_string;
 }
+
+let string = typed string_ (!! T.string)
 
 let rec of_list f = function
 | [] -> ValInt 0
@@ -143,10 +207,12 @@ let rec to_list f = function
 | ValBlk (0, [|v; vl|]) -> f v :: to_list f vl
 | _ -> assert false
 
-let list r = {
+let list_ r = {
   r_of = (fun l -> of_list r.r_of l);
   r_to = (fun l -> to_list r.r_to l);
 }
+
+let list (r,t) = typed (list_ r) (! T.list [default t])
 
 let of_closure cls = ValCls cls
 
@@ -171,27 +237,33 @@ let repr_ext tag = {
 
 let of_constr c = of_ext val_constr c
 let to_constr c = to_ext val_constr c
-let constr = repr_ext val_constr
+let constr_ = repr_ext val_constr
+let constr = typed constr_ (!! T.constr)
 
 let of_preterm c = of_ext val_preterm c
 let to_preterm c = to_ext val_preterm c
-let preterm = repr_ext val_preterm
+let preterm_ = repr_ext val_preterm
+let preterm = typed preterm_ (!! T.preterm)
 
 let of_cast c = of_ext val_cast c
 let to_cast c = to_ext val_cast c
-let cast = repr_ext val_cast
+let cast_ = repr_ext val_cast
+let cast = typed cast_ (!! T.cast)
 
 let of_ident c = of_ext val_ident c
 let to_ident c = to_ext val_ident c
-let ident = repr_ext val_ident
+let ident_ = repr_ext val_ident
+let ident = typed ident_ (!! T.ident)
 
 let of_pattern c = of_ext val_pattern c
 let to_pattern c = to_ext val_pattern c
-let pattern = repr_ext val_pattern
+let pattern_ = repr_ext val_pattern
+let pattern = typed pattern_ (!! T.pattern)
 
 let of_evar ev = of_ext val_evar ev
 let to_evar ev = to_ext val_evar ev
-let evar = repr_ext val_evar
+let evar_ = repr_ext val_evar
+let evar = typed evar_ (!! T.evar)
 
 let internal_err =
   let open Names in
@@ -203,14 +275,16 @@ let internal_err =
 let of_exninfo = of_ext val_exninfo
 let to_exninfo = to_ext val_exninfo
 
-let exninfo = {
+let exninfo_ = {
   r_of = of_exninfo;
   r_to = to_exninfo;
 }
+let exninfo = typed exninfo_ (!! T.exninfo)
 
 let of_err e = of_ext val_exn e
 let to_err e = to_ext val_exn e
-let err = repr_ext val_exn
+let err_ = repr_ext val_exn
+let err = typed err_ (!! T.err)
 
 (** FIXME: handle backtrace in Ltac2 exceptions *)
 let of_exn c = match fst c with
@@ -225,10 +299,12 @@ let to_exn c = match c with
     (LtacError (kn, c), Exninfo.null)
 | _ -> assert false
 
-let exn = {
+let exn_ = {
   r_of = of_exn;
   r_to = to_exn;
 }
+
+let exn = typed exn_ (!! T.exn)
 
 let of_option f = function
 | None -> ValInt 0
@@ -239,14 +315,17 @@ let to_option f = function
 | ValBlk (0, [|c|]) -> Some (f c)
 | _ -> assert false
 
-let option r = {
+let option_ r = {
   r_of = (fun l -> of_option r.r_of l);
   r_to = (fun l -> to_option r.r_to l);
 }
 
+let option (r,t) = typed (option_ r) (! T.option [default t])
+
 let of_pp c = of_ext val_pp c
 let to_pp c = to_ext val_pp c
-let pp = repr_ext val_pp
+let pp_ = repr_ext val_pp
+let pp = typed pp_ (!! T.message)
 
 let of_tuple cl = ValBlk (0, cl)
 let to_tuple = function
@@ -257,28 +336,32 @@ let of_pair f g (x, y) = ValBlk (0, [|f x; g y|])
 let to_pair f g = function
 | ValBlk (0, [|x; y|]) -> (f x, g y)
 | _ -> assert false
-let pair r0 r1 = {
+let pair_ r0 r1 = {
   r_of = (fun p -> of_pair r0.r_of r1.r_of p);
   r_to = (fun p -> to_pair r0.r_to r1.r_to p);
 }
+let pair (r0,t0) (r1,t1) = typed (pair_ r0 r1) (tuple [default t0; default t1])
+
 
 let of_triple f g h (x, y, z) = ValBlk (0, [|f x; g y; h z|])
 let to_triple f g h = function
 | ValBlk (0, [|x; y; z|]) -> (f x, g y, h z)
 | _ -> assert false
-let triple r0 r1 r2 = {
+let triple_ r0 r1 r2 = {
   r_of = (fun p -> of_triple r0.r_of r1.r_of r2.r_of p);
   r_to = (fun p -> to_triple r0.r_to r1.r_to r2.r_to p);
 }
+let triple (r0,t0) (r1,t1) (r2,t2) = typed (triple_ r0 r1 r2) (tuple [default t0; default t1; default t2])
 
 let of_array f vl = ValBlk (0, Array.map f vl)
 let to_array f = function
 | ValBlk (0, vl) -> Array.map f vl
 | _ -> assert false
-let array r = {
+let array_ r = {
   r_of = (fun l -> of_array r.r_of l);
   r_to = (fun l -> to_array r.r_to l);
 }
+let array (r,t) = typed (array_ r) (! T.array [default t])
 
 let of_block (n, args) = ValBlk (n, args)
 let to_block = function
@@ -289,6 +372,21 @@ let block = {
   r_of = of_block;
   r_to = to_block;
 }
+
+let of_result r = function
+  | Ok x -> of_block (0, [|r x|])
+  | Error x -> of_block (1, [|of_exn x|])
+
+let to_result r = function
+  | ValBlk (0, [|x|]) -> Ok (r x)
+  | ValBlk (1, [|x|]) -> Error (to_exn x)
+  | _ -> assert false
+
+let result_ r = {
+  r_of = of_result r.r_of;
+  r_to = to_result r.r_to;
+}
+let result (r,t) = typed (result_ r) (! T.result [default t])
 
 let of_open (kn, args) = ValOpn (kn, args)
 
@@ -304,22 +402,25 @@ let open_ = {
 let of_uint63 n = of_ext val_uint63 n
 let to_uint63 x = to_ext val_uint63 x
 
-let uint63 = {
+let uint63_ = {
   r_of = of_uint63;
   r_to = to_uint63;
 }
+let uint63 = typed uint63_ (!! T.uint63)
 
 let of_float f = of_ext val_float f
 let to_float x = to_ext val_float x
 
-let float = {
+let float_ = {
   r_of = of_float;
   r_to = to_float;
 }
+let float = typed float_ (!! T.float)
 
 let of_constant c = of_ext val_constant c
 let to_constant c = to_ext val_constant c
-let constant = repr_ext val_constant
+let constant_ = repr_ext val_constant
+let constant = typed constant_ (!! T.constant)
 
 let of_reference = let open Names.GlobRef in function
 | VarRef id -> ValBlk (0, [| of_ident id |])
@@ -334,16 +435,61 @@ let to_reference = let open Names.GlobRef in function
 | ValBlk (3, [| cstr |]) -> ConstructRef (to_ext val_constructor cstr)
 | _ -> assert false
 
-let reference = {
+let reference_ = {
   r_of = of_reference;
   r_to = to_reference;
 }
+let reference = typed reference_ (!! T.reference)
 
-type ('a, 'b) fun1 = closure
+(* f is supposed to be pure (unit -> 'a tactic with any effects inside the tactic) *)
+let thaw f = f ()
 
-let fun1 (r0 : 'a repr) (r1 : 'b repr) : ('a, 'b) fun1 repr = closure
-let to_fun1 r0 r1 f = to_closure f
+let to_fun1 r0 r' f =
+  let f x =
+    Proofview.Monad.map r' @@ Tac2val.apply (to_closure f) [r0 x]
+  in
+  f
 
-let app_fun1 cls r0 r1 x =
-  let open Proofview.Notations in
-  apply cls [r0.r_of x] >>= fun v -> Proofview.tclUNIT (r1.r_to v)
+let of_fun1 r0 r' f =
+  of_closure @@
+  Tac2val.abstract 1 (function
+      | [x] -> Proofview.Monad.map r' @@ f (r0 x)
+      | _ -> assert false)
+
+let fun1_ r r' = make_repr (of_fun1 r.r_to r'.r_of) (to_fun1 r.r_of r'.r_to)
+let fun1 (r,t) (r',t') = fun1_ r r', Some Types.(default t @-> default t')
+
+let thunk r = fun1 unit r
+
+let to_fun2 r0 r1 r' f =
+  let f x y =
+    Proofview.Monad.map r' @@
+    Tac2val.apply (to_closure f) [r0 x; r1 y]
+  in
+  f
+
+let of_fun2 r0 r1 r' f =
+  of_closure @@
+  Tac2val.abstract 2 (function
+      | [x;y] -> Proofview.Monad.map r' @@ f (r0 x) (r1 y)
+      | _ -> assert false)
+
+let fun2_ r0 r1 r' = make_repr (of_fun2 r0.r_to r1.r_to r'.r_of) (to_fun2 r0.r_of r1.r_of r'.r_to)
+let fun2 (r0,t0) (r1,t1) (r',t') = fun2_ r0 r1 r', Some Types.(default t0 @-> default t1 @-> default t')
+
+let to_fun3 r0 r1 r2 r' f =
+  let f x y z =
+    Proofview.Monad.map r' @@
+    Tac2val.apply (to_closure f) [r0 x; r1 y; r2 z]
+  in
+  f
+
+let of_fun3 r0 r1 r2 r' f =
+  of_closure @@
+  Tac2val.abstract 3 (function
+      | [x;y;z] -> Proofview.Monad.map r' @@ f (r0 x) (r1 y) (r2 z)
+      | _ -> assert false)
+
+let fun3_ r0 r1 r2 r' = make_repr (of_fun3 r0.r_to r1.r_to r2.r_to r'.r_of) (to_fun3 r0.r_of r1.r_of r2.r_of r'.r_to)
+let fun3 (r0,t0) (r1,t1) (r2,t2) (r',t') =
+  fun3_ r0 r1 r2 r', Some Types.(default t0 @-> default t1 @-> default t2 @-> default t')

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -24,66 +24,122 @@ val make_repr : ('a -> valexpr) -> (valexpr -> 'a) -> 'a repr
 
 val map_repr : ('a -> 'b) -> ('b -> 'a) -> 'a repr -> 'b repr
 
+(** Type annotations. *)
+
+module Types : sig
+
+  type t
+  (** Type of an argument of an external. This is basically
+      [int Tac2expr.glb_typexpr] but we may add some smart constructors
+      so that the user doesn't need to pick a number for variables used only once. *)
+
+  val any : t
+
+  val default : t option -> t
+
+  val var : int -> t
+
+  val tuple : t list -> t
+
+  val (!) : Tac2expr.type_constant -> t list -> t
+
+  val (!!) : Tac2expr.type_constant -> t
+  (** Alias of [(!)] for 0-ary type formers. *)
+
+  val (@->) : t -> t -> t
+
+  val as_scheme : t -> Tac2expr.type_scheme
+
+end
+
+type 'a annotated = 'a * Types.t option
+
+val typed : 'r -> Types.t -> 'r annotated
+val untyped : 'r -> 'r annotated
+
 (** These functions allow to convert back and forth between OCaml and Ltac2
     data representation. The [to_*] functions raise an anomaly whenever the data
-    has not expected shape. *)
+    has not expected shape.
+
+    Unless no default annotation is useful, [foo_] is the raw converter
+    and [foo] annotates it with types taking any necessary type arguments.
+*)
 
 val of_unit : unit -> valexpr
 val to_unit : valexpr -> unit
-val unit : unit repr
+val unit : unit repr annotated
+val unit_ : unit repr
 
 val of_int : int -> valexpr
 val to_int : valexpr -> int
-val int : int repr
+val int : int repr annotated
+val int_ : int repr
 
 val of_bool : bool -> valexpr
 val to_bool : valexpr -> bool
-val bool : bool repr
+val bool : bool repr annotated
+val bool_ : bool repr
 
 val of_char : char -> valexpr
 val to_char : valexpr -> char
-val char : char repr
+val char : char repr annotated
+val char_ : char repr
 
 val of_bytes : Bytes.t -> valexpr
 val to_bytes : valexpr -> Bytes.t
-val bytes : Bytes.t repr
+val bytes : Bytes.t repr annotated
+val bytes_ : Bytes.t repr
 
 (** WARNING these functions copy *)
 val of_string : string -> valexpr
 val to_string : valexpr -> string
-val string : string repr
+val string : string repr annotated
+val string_ : string repr
 
 val of_list : ('a -> valexpr) -> 'a list -> valexpr
 val to_list : (valexpr -> 'a) -> valexpr -> 'a list
-val list : 'a repr -> 'a list repr
+val list : 'a repr annotated -> 'a list repr annotated
+val list_ : 'a repr -> 'a list repr
 
 val of_constr : EConstr.t -> valexpr
 val to_constr : valexpr -> EConstr.t
-val constr : EConstr.t repr
+val constr : EConstr.t repr annotated
+val constr_ : EConstr.t repr
 
 val of_preterm : Ltac_pretype.closed_glob_constr -> valexpr
 val to_preterm : valexpr -> Ltac_pretype.closed_glob_constr
-val preterm : Ltac_pretype.closed_glob_constr repr
+val preterm : Ltac_pretype.closed_glob_constr repr annotated
+val preterm_ : Ltac_pretype.closed_glob_constr repr
 
 val of_cast : Constr.cast_kind -> valexpr
 val to_cast : valexpr -> Constr.cast_kind
-val cast : Constr.cast_kind repr
+val cast : Constr.cast_kind repr annotated
+val cast_ : Constr.cast_kind repr
 
 val of_err : Exninfo.iexn -> valexpr
 val to_err : valexpr -> Exninfo.iexn
-val err : Exninfo.iexn repr
+val err : Exninfo.iexn repr annotated
+val err_ : Exninfo.iexn repr
 
 val of_exn : Exninfo.iexn -> valexpr
 val to_exn : valexpr -> Exninfo.iexn
-val exn : Exninfo.iexn repr
+val exn : Exninfo.iexn repr annotated
+val exn_ : Exninfo.iexn repr
+
+val of_result : ('a -> valexpr) -> ('a, Exninfo.iexn) result -> valexpr
+val to_result : (valexpr -> 'a) -> valexpr -> ('a, Exninfo.iexn) result
+val result_ : 'a repr -> ('a, Exninfo.iexn) result repr
+val result  : 'a repr annotated -> ('a, Exninfo.iexn) result repr annotated
 
 val of_exninfo : Exninfo.info -> valexpr
 val to_exninfo : valexpr -> Exninfo.info
-val exninfo : Exninfo.info repr
+val exninfo : Exninfo.info repr annotated
+val exninfo_ : Exninfo.info repr
 
 val of_ident : Id.t -> valexpr
 val to_ident : valexpr -> Id.t
-val ident : Id.t repr
+val ident : Id.t repr annotated
+val ident_ : Id.t repr
 
 val of_closure : closure -> valexpr
 val to_closure : valexpr -> closure
@@ -95,42 +151,51 @@ val block : (int * valexpr array) repr
 
 val of_array : ('a -> valexpr) -> 'a array -> valexpr
 val to_array : (valexpr -> 'a) -> valexpr -> 'a array
-val array : 'a repr -> 'a array repr
+val array : 'a repr annotated -> 'a array repr annotated
+val array_ : 'a repr -> 'a array repr
 
 val of_tuple : valexpr array -> valexpr
 val to_tuple : valexpr -> valexpr array
 
 val of_pair : ('a -> valexpr) -> ('b -> valexpr) -> 'a * 'b -> valexpr
 val to_pair : (valexpr -> 'a) -> (valexpr -> 'b) -> valexpr -> 'a * 'b
-val pair : 'a repr -> 'b repr -> ('a * 'b) repr
+val pair : 'a repr annotated -> 'b repr annotated -> ('a * 'b) repr annotated
+val pair_ : 'a repr -> 'b repr -> ('a * 'b) repr
 
 val of_triple : ('a -> valexpr) -> ('b -> valexpr) -> ('c -> valexpr) -> 'a * 'b * 'c -> valexpr
 val to_triple : (valexpr -> 'a) -> (valexpr -> 'b) -> (valexpr -> 'c) -> valexpr -> 'a * 'b * 'c
-val triple : 'a repr -> 'b repr -> 'c repr -> ('a * 'b * 'c) repr
+val triple : 'a repr annotated -> 'b repr annotated -> 'c repr annotated -> ('a * 'b * 'c) repr annotated
+val triple_ : 'a repr -> 'b repr -> 'c repr -> ('a * 'b * 'c) repr
 
 val of_option : ('a -> valexpr) -> 'a option -> valexpr
 val to_option : (valexpr -> 'a) -> valexpr -> 'a option
-val option : 'a repr -> 'a option repr
+val option : 'a repr annotated -> 'a option repr annotated
+val option_ : 'a repr -> 'a option repr
 
 val of_pattern : Pattern.constr_pattern -> valexpr
 val to_pattern : valexpr -> Pattern.constr_pattern
-val pattern : Pattern.constr_pattern repr
+val pattern : Pattern.constr_pattern repr annotated
+val pattern_ : Pattern.constr_pattern repr
 
 val of_evar : Evar.t -> valexpr
 val to_evar : valexpr -> Evar.t
-val evar : Evar.t repr
+val evar : Evar.t repr annotated
+val evar_ : Evar.t repr
 
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
-val pp : Pp.t repr
+val pp : Pp.t repr annotated
+val pp_ : Pp.t repr
 
 val of_constant : Constant.t -> valexpr
 val to_constant : valexpr -> Constant.t
-val constant : Constant.t repr
+val constant : Constant.t repr annotated
+val constant_ : Constant.t repr
 
 val of_reference : GlobRef.t -> valexpr
 val to_reference : valexpr -> GlobRef.t
-val reference : GlobRef.t repr
+val reference : GlobRef.t repr annotated
+val reference_ : GlobRef.t repr
 
 val of_ext : 'a Val.tag -> 'a -> valexpr
 val to_ext : 'a Val.tag -> valexpr -> 'a
@@ -142,20 +207,38 @@ val open_ : (KerName.t * valexpr array) repr
 
 val of_uint63 : Uint63.t -> valexpr
 val to_uint63 : valexpr -> Uint63.t
-val uint63 : Uint63.t repr
+val uint63 : Uint63.t repr annotated
+val uint63_ : Uint63.t repr
 
 val of_float : Float64.t -> valexpr
 val to_float : valexpr -> Float64.t
-val float : Float64.t repr
+val float : Float64.t repr annotated
+val float_ : Float64.t repr
 
-type ('a, 'b) fun1
+val thaw : (unit -> 'a Proofview.tactic) -> 'a Proofview.tactic
+(** The OCaml closure is suppoed to be pure, with any effects being inside the [tactic] value. *)
 
-val app_fun1 : ('a, 'b) fun1 -> 'a repr -> 'b repr -> 'a -> 'b Proofview.tactic
+val to_fun1 : ('a -> valexpr) -> (valexpr -> 'r) -> valexpr -> 'a -> 'r Proofview.tactic
+val of_fun1 : (valexpr -> 'a) -> ('r -> valexpr) -> ('a -> 'r Proofview.tactic) -> valexpr
+val fun1_ : 'a repr -> 'r repr -> ('a -> 'r Proofview.tactic) repr
+val fun1 : 'a repr annotated -> 'r repr annotated -> ('a -> 'r Proofview.tactic) repr annotated
 
-val to_fun1 : 'a repr -> 'b repr -> valexpr -> ('a, 'b) fun1
-val fun1 : 'a repr -> 'b repr -> ('a, 'b) fun1 repr
+val thunk : 'a repr annotated -> (unit -> 'a Proofview.tactic) repr annotated
+
+val to_fun2 : ('a -> valexpr) -> ('b -> valexpr) -> (valexpr -> 'r) -> valexpr -> 'a -> 'b -> 'r Proofview.tactic
+val of_fun2 : (valexpr -> 'a) -> (valexpr -> 'b) -> ('r -> valexpr) -> ('a -> 'b -> 'r Proofview.tactic) -> valexpr
+val fun2_ : 'a repr -> 'b repr -> 'r repr -> ('a -> 'b -> 'r Proofview.tactic) repr
+val fun2 : 'a repr annotated -> 'b repr annotated -> 'r repr annotated -> ('a -> 'b -> 'r Proofview.tactic) repr annotated
+
+val to_fun3 : ('a -> valexpr) -> ('b -> valexpr) -> ('c -> valexpr) -> (valexpr -> 'r) -> valexpr -> 'a -> 'b -> 'c -> 'r Proofview.tactic
+val of_fun3 : (valexpr -> 'a) -> (valexpr -> 'b) -> (valexpr -> 'c) -> ('r -> valexpr) -> ('a -> 'b -> 'c -> 'r Proofview.tactic) -> valexpr
+val fun3_ : 'a repr -> 'b repr -> 'c repr -> 'r repr -> ('a -> 'b -> 'c -> 'r Proofview.tactic) repr
+val fun3 : 'a repr annotated -> 'b repr annotated -> 'c repr annotated -> 'r repr annotated -> ('a -> 'b -> 'c -> 'r Proofview.tactic) repr annotated
 
 val valexpr : valexpr repr
+
+(** Most common use of valexpr is at type var 0. *)
+val valexpr_0 : valexpr repr annotated
 
 (** {5 Dynamic tags} *)
 
@@ -180,7 +263,6 @@ val val_quality : Sorts.Quality.t Val.tag
 val val_free : Id.Set.t Val.tag
 val val_uint63 : Uint63.t Val.tag
 val val_float : Float64.t Val.tag
-val val_ltac1 : Geninterp.Val.t Val.tag
 val val_pretype_flags : Pretyping.inference_flags Val.tag
 val val_expected_type : Pretyping.typing_constraint Val.tag
 

--- a/plugins/ltac2/tac2globals.ml
+++ b/plugins/ltac2/tac2globals.ml
@@ -1,0 +1,96 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+
+let s2l s = Label.of_id (Id.of_string s)
+
+let mk file modules label =
+  let dp = DirPath.make (List.map Id.of_string [file; "Ltac2"]) in
+  let mp = List.fold_left (fun mp modname -> MPdot (mp, s2l modname)) (MPfile dp) modules in
+  KerName.make mp (s2l label)
+
+let mk_init n = mk "Init" [] n
+
+let mk_std n = mk "Std" [] n
+
+module Types = struct
+  let unit = mk_init "unit"
+  let list = mk_init "list"
+  let int = mk_init "int"
+  let string = mk_init "string"
+  let char = mk_init "char"
+  let ident = mk_init "ident"
+  let uint63 = mk_init "uint63"
+  let float = mk_init "float"
+  let meta = mk_init "meta"
+  let evar = mk_init "evar"
+  let sort = mk_init "sort"
+  let cast = mk_init "cast"
+  let instance = mk_init "instance"
+  let constant = mk_init "constant"
+  let inductive = mk_init "inductive"
+  let constructor = mk_init "constructor"
+  let projection = mk_init "projection"
+  let pattern = mk_init "pattern"
+  let constr = mk_init "constr"
+  let preterm = mk_init "preterm"
+  let binder = mk_init "binder"
+  let message = mk_init "message"
+  let format = mk_init "format"
+  let exn = mk_init "exn"
+  let array = mk_init "array"
+  let option = mk_init "option"
+  let bool = mk_init "bool"
+  let result = mk_init "result"
+  let err = mk_init "err"
+  let exninfo = mk_init "exninfo"
+
+  let reference = mk_std "reference"
+  let occurrences = mk_std "occurrences"
+  let intro_pattern = mk_std "intro_pattern"
+  let bindings = mk_std "bindings"
+  let assertion = mk_std "assertion"
+  let clause = mk_std "clause"
+  let induction_clause = mk_std "induction_clause"
+  let red_flags = mk_std "red_flags"
+  let rewriting = mk_std "rewriting"
+  let inversion_kind = mk_std "inversion_kind"
+  let destruction_arg = mk_std "destruction_arg"
+  let move_location = mk_std "move_location"
+  let hypothesis = mk_std "hypothesis"
+  let std_debug = mk_std "debug"
+  let std_strategy = mk_std "strategy"
+  let orientation = mk_std "orientation"
+
+  let transparent_state = mk "TransparentState" [] "t"
+
+  let relevance = mk "Constr" ["Binder"] "relevance"
+
+  let constr_kind = mk "Constr" ["Unsafe"] "kind"
+  let constr_case = mk "Constr" ["Unsafe"] "case"
+
+  let pretype_flags = mk "Constr" ["Pretype";"Flags"] "t"
+
+  let pretype_expected_type = mk "Constr" ["Pretype"] "expected_type"
+
+  let matching_context = mk "Pattern" [] "context"
+
+  let match_kind = mk "Pattern" [] "match_kind"
+
+  let free = mk "Fresh" ["Free"] "t"
+
+  let ind_data = mk "Ind" [] "data"
+
+  let map_tag = mk "FSet" ["Tags"] "tag"
+
+  let fset = mk "FSet" [] "t"
+  let fmap = mk "FMap" [] "t"
+end

--- a/plugins/ltac2/tac2globals.mli
+++ b/plugins/ltac2/tac2globals.mli
@@ -1,0 +1,88 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Tac2expr
+
+(** Names of ltac2 objects the plugin expects to exist. *)
+
+(* Maybe we should use some sort of Register-like indirection layer to provide this stuff? *)
+
+module Types : sig
+  val unit : type_constant
+  val list : type_constant
+  val int : type_constant
+  val string : type_constant
+  val char : type_constant
+  val ident : type_constant
+  val uint63 : type_constant
+  val float : type_constant
+  val meta : type_constant
+  val evar : type_constant
+  val sort : type_constant
+  val cast : type_constant
+  val instance : type_constant
+  val constant : type_constant
+  val inductive : type_constant
+  val constructor : type_constant
+  val projection : type_constant
+  val pattern : type_constant
+  val constr : type_constant
+  val preterm : type_constant
+  val binder : type_constant
+  val message : type_constant
+  val format : type_constant
+  val exn  : type_constant
+  val array : type_constant
+  val option : type_constant
+  val bool : type_constant
+  val result  : type_constant
+  val err : type_constant
+  val exninfo  : type_constant
+
+  val reference : type_constant
+  val occurrences : type_constant
+  val intro_pattern : type_constant
+  val bindings : type_constant
+  val assertion : type_constant
+  val clause : type_constant
+  val induction_clause : type_constant
+  val red_flags : type_constant
+  val rewriting : type_constant
+  val inversion_kind : type_constant
+  val destruction_arg : type_constant
+  val move_location : type_constant
+  val hypothesis : type_constant
+  val std_debug : type_constant
+  val std_strategy : type_constant
+  val orientation : type_constant
+
+  val transparent_state : type_constant
+
+  val constr_kind : type_constant
+  val constr_case : type_constant
+
+  val pretype_flags : type_constant
+  val pretype_expected_type : type_constant
+
+  val relevance : type_constant
+
+  val matching_context : type_constant
+
+  val match_kind : type_constant
+
+  val free : type_constant
+
+  val ind_data : type_constant
+
+  val map_tag : type_constant
+
+  val fset : type_constant
+  val fmap : type_constant
+end

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -41,7 +41,7 @@ val split_with_bindings : evars_flag -> bindings -> unit tactic
 
 val specialize : constr_with_bindings -> intro_pattern option -> unit tactic
 
-val change : Pattern.constr_pattern option -> (constr array, constr) Tac2ffi.fun1 -> clause -> unit tactic
+val change : Pattern.constr_pattern option -> (constr array -> constr Proofview.tactic) -> clause -> unit tactic
 
 val rewrite :
   evars_flag -> rewriting list -> clause -> unit thunk option -> unit tactic

--- a/plugins/ltac2/tac2types.mli
+++ b/plugins/ltac2/tac2types.mli
@@ -17,7 +17,7 @@ open Proofview
 type evars_flag = bool
 type advanced_flag = bool
 
-type 'a thunk = (unit, 'a) Tac2ffi.fun1
+type 'a thunk = unit -> 'a Proofview.tactic
 
 type quantified_hypothesis = Tactypes.quantified_hypothesis =
 | AnonHyp of int

--- a/plugins/ltac2_ltac1/tac2ltac1_ffi.ml
+++ b/plugins/ltac2_ltac1/tac2ltac1_ffi.ml
@@ -8,6 +8,18 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Standard tactics sharing their implementation with Ltac1 *)
+open Ltac2_plugin
+open Tac2dyn
+open Tac2ffi
+open Names
 
-val intro_pattern : Tac2types.intro_pattern Tac2ffi.repr Tac2ffi.annotated
+let ltac1_t =
+  KerName.make (MPfile (DirPath.make (List.map Id.of_string ["Ltac1";"Ltac2"])))
+    (Label.of_id (Id.of_string "t"))
+
+let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
+
+let ltac1_ = repr_ext val_ltac1
+let of_ltac1 = repr_of ltac1_
+let to_ltac1 = repr_to ltac1_
+let ltac1 = typed ltac1_ Types.(!! ltac1_t)

--- a/plugins/ltac2_ltac1/tac2ltac1_ffi.mli
+++ b/plugins/ltac2_ltac1/tac2ltac1_ffi.mli
@@ -8,6 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Standard tactics sharing their implementation with Ltac1 *)
+open Ltac2_plugin
+open Tac2ffi
+open Tac2val
 
-val intro_pattern : Tac2types.intro_pattern Tac2ffi.repr Tac2ffi.annotated
+val to_ltac1 : valexpr -> Geninterp.Val.t
+val of_ltac1 : Geninterp.Val.t -> valexpr
+val ltac1 : Geninterp.Val.t repr annotated

--- a/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
@@ -17,14 +17,13 @@ open Tac2ffi
 open Tac2expr
 open Proofview.Notations
 open Tac2externals
+open Tac2ltac1_ffi
 
 let ltac2_ltac1_plugin = "coq-core.plugins.ltac2_ltac1"
 
 let pname ?(plugin=ltac2_ltac1_plugin) s = { mltac_plugin = plugin; mltac_tactic = s }
 
 let define ?plugin s = define (pname ?plugin s)
-
-let ltac1 = Tac2ffi.repr_ext Tac2ffi.val_ltac1
 
 let val_tag wit = match val_tag wit with
 | Base t -> t
@@ -69,7 +68,7 @@ and to_intro_pattern_action : Tactypes.delayed_open_constr Tactypes.intro_patter
       Proofview.Unsafe.tclEVARS sigma >>= fun () ->
       tclUNIT (of_constr c)
     in
-    let c = to_fun1 unit constr (mk_closure_val arity_one (fun _ -> c)) in
+    let c = to_fun1 of_unit to_constr (mk_closure_val arity_one (fun _ -> c)) in
     IntroApplyOn (c, to_intro_pattern ipat)
   | IntroRewrite b -> IntroRewrite b
 

--- a/user-contrib/Ltac2/FMap.v
+++ b/user-contrib/Ltac2/FMap.v
@@ -29,7 +29,7 @@ Ltac2 @ external find_opt : 'k -> ('k, 'v) t -> 'v option := "coq-core.plugins.l
 
 Ltac2 @ external mapi : ('k -> 'v -> 'r) -> ('k, 'v) t -> ('k, 'r) t := "coq-core.plugins.ltac2" "fmap_mapi".
 
-Ltac2 @ external fold : ('k -> 'v -> 'acc) -> ('k, 'v) t -> 'acc -> 'acc := "coq-core.plugins.ltac2" "fmap_fold".
+Ltac2 @ external fold : ('k -> 'v -> 'acc -> 'acc) -> ('k, 'v) t -> 'acc -> 'acc := "coq-core.plugins.ltac2" "fmap_fold".
 
 Ltac2 @ external cardinal : ('k, 'v) t -> int := "coq-core.plugins.ltac2" "fmap_cardinal".
 


### PR DESCRIPTION

Fix #18553
Fix #18635

This PR enforces types as strictly as possible. We could also do a less strict version enforcing only the arity of the external, which would not require changing the tac2externals API, but that would not catch https://github.com/coq/coq/issues/18635 or https://github.com/coq/coq/pull/18551#discussion_r1465268467

We could also merge `repr` and `repr annotated` ie add an optional type field to `repr`. This would mean ocaml typechecking doesn't tell us when we forget to annotate a type though.