### PR TITLE
close_proof: merge side effects univs when not keep_body_ucst_separate

### DIFF
--- a/test-suite/bugs/bug_18642.v
+++ b/test-suite/bugs/bug_18642.v
@@ -1,0 +1,7 @@
+
+Set Warnings "+failed-abstract-certificate".
+Goal True.
+Proof.
+  do 2 assert True by abstract (pose proof Type;exact I).
+  exact I.
+Qed.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1960,14 +1960,6 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
   cb, ce.proof_entry_type, ce.proof_entry_universes, status, uctx
 
 let declare_abstract ~name ~poly ~kind ~sign ~secsign ~opaque ~solve_tac sigma concl =
-  let sigma, concl =
-    (* FIXME: should be done only if the tactic succeeds *)
-    (* XXX maybe we can fix now that we support evars
-       if close_proof stops caring about is_empty_private_constants we can remove the minimization
-       see #18636 *)
-    let sigma = Evd.minimize_universes sigma in
-    sigma, Evarutil.nf_evar sigma concl
-  in
   let (const, safe, sigma') =
     try build_constant_by_tactic ~warn_incomplete:false ~name ~opaque:Vernacexpr.Transparent ~poly ~sigma ~sign:secsign concl solve_tac
     with Logic_monad.TacticFailure e as src ->


### PR DESCRIPTION
Morally we consider them part of the body univs.

This makes it so we don't need to disregard keep_body_ucst_separate
when there are side effects.

Fix #18636 (alternative to #18640, but this probably isn't as good a candidate for backporting)
