### PR TITLE
Ltac2: Make refine notation take preterm so that the expected type can be used

### DIFF
--- a/doc/changelog/06-Ltac2-language/18650-ltac2-refine.rst
+++ b/doc/changelog/06-Ltac2-language/18650-ltac2-refine.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  `Ltac2.Notations.refine` is a full notation taking an argument
+  in constr syntax scope instead of an alias
+  (`#18650 <https://github.com/coq/coq/pull/18650>`_,
+  fixes `#18522 <https://github.com/coq/coq/issues/18522>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/ltac2/binder.v
+++ b/test-suite/ltac2/binder.v
@@ -9,7 +9,7 @@ match Constr.Unsafe.kind t with
   let b := Constr.Binder.make na u in
   let c := Constr.Unsafe.make (Constr.Unsafe.Prod b t) in
   pose (v := $c);
-  refine '(_ : &v);
+  refine (_ : &v);
   unfold &v
 | _ => fail
 end.

--- a/test-suite/ltac2/control_tests.v
+++ b/test-suite/ltac2/control_tests.v
@@ -147,7 +147,7 @@ Goal 3 = 3 -> 1 = 1 /\ 2 = 2.
   | _ => throw Error
   end.
 
-  refine (fun () => '(eq_refl &X)).
+  Control.refine (fun () => '(eq_refl &X)).
 Qed.
 
 Goal True.

--- a/test-suite/ltac2/example1.v
+++ b/test-suite/ltac2/example1.v
@@ -22,6 +22,6 @@ Print Ltac2 get_hyp_by_name.
 
 Goal forall n m, n + m = 0 -> n = 0.
 Proof.
-refine (fun () => '(fun n m H => _)).
+Control.refine (fun () => '(fun n m H => _)).
 let t := get_hyp_by_name @H in Message.print (Message.of_constr t).
 Abort.

--- a/test-suite/ltac2/example2.v
+++ b/test-suite/ltac2/example2.v
@@ -212,7 +212,7 @@ Qed.
 
 Goal exists x y : nat, x = y.
 Proof.
-refine '(let x := 0 in _).
+refine (let x := 0 in _).
 eexists; exists &x; reflexivity.
 Qed.
 

--- a/test-suite/ltac2/notations.v
+++ b/test-suite/ltac2/notations.v
@@ -12,7 +12,7 @@ Ltac2 Notation "ex" arg(constr(nat,Z)) := arg.
 Check (1 + 1)%nat%Z = 1%nat.
 
 Lemma two : nat.
-  refine (ex (1 + 1)).
+  Control.refine (fun () => ex (1 + 1)).
 Qed.
 
 Import ListNotations.
@@ -22,7 +22,7 @@ Ltac2 Notation "sl" arg(constr(string,list)) := arg.
 
 Lemma maybe : list bool.
 Proof.
-  refine (sl ["left" =? "right"]).
+  Control.refine (fun () => sl ["left" =? "right"]).
 Qed.
 
 Lemma Z_add_bounds {amin a amax bmin b bmax : Z}:

--- a/test-suite/ltac2/term_notations.v
+++ b/test-suite/ltac2/term_notations.v
@@ -19,7 +19,7 @@ Section Bar.
 (* Have fun with context capture *)
 Notation "[ x ]" := ltac2:(
   let c () := Constr.pretype x in
-  refine constr:(forall n : nat, n = ltac2:(Notations.exact0 true c))
+  refine (forall n : nat, n = ltac2:(Notations.exact0 true c))
 ).
 
 Goal forall n : nat, [ n ].

--- a/test-suite/success/unshelve.v
+++ b/test-suite/success/unshelve.v
@@ -23,8 +23,7 @@ Require Import Ltac2.Ltac2.
 
 Goal True.
 Proof.
-(* Ltac2 refine is more like simple_refine *)
-unshelve (refine '(F _ _ _ _); Control.shelve_unifiable ()).
+unshelve (refine (F _ _ _ _)).
 + exact true.
 + exact tt.
 + exact (@eq_refl bool true).

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -520,7 +520,27 @@ Ltac2 Notation "clear" ids(list0(ident)) := clear0 ids.
 Ltac2 Notation "clear" "-" ids(list1(ident)) := Std.keep ids.
 Ltac2 Notation clear := clear.
 
-Ltac2 Notation refine := Control.refine.
+Ltac2 refine0 simple with_classes c :=
+  Control.enter (fun () =>
+    Control.refine (fun () =>
+      let flags :=
+        if with_classes then Constr.Pretype.Flags.open_constr_flags_with_tc
+        else Constr.Pretype.Flags.open_constr_flags_no_tc
+      in
+      Constr.Pretype.pretype flags (Constr.Pretype.expected_oftype (Control.goal()))
+        c);
+    if simple then ()
+    else
+      (* ltac1 does lazy beta iota before shelve_unifiable, should we? *)
+      Control.shelve_unifiable ()).
+
+Ltac2 Notation "refine" c(preterm) := refine0 false true c.
+
+Ltac2 Notation "simple" "refine" c(preterm) := refine0 true true c.
+
+Ltac2 Notation "notypeclasses" "refine" c(preterm) := refine0 false false c.
+
+Ltac2 Notation "simple" "notypeclasses" "refine" c(preterm) := refine0 true false c.
 
 (** extratactics *)
 


### PR DESCRIPTION

Those who want the old behaviour can use Control.refine with a manual thunk.

Close #18522

