### PR TITLE
Fix doc about Extraction AutoInline

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -180,11 +180,14 @@ and commands:
 
 .. flag:: Extraction AutoInline
 
-   Default is on. The extraction mechanism inlines the :term:`bodies <body>` of
+   Default is off. When enabled, the extraction mechanism inlines the :term:`bodies <body>` of
    some defined :term:`constants <constant>`, according to some heuristics
    like size of bodies, uselessness of some arguments, etc.
-   Those heuristics are not always perfect; if you want to disable
-   this feature, turn this :term:`flag` off.
+
+   Even when this flag is off, recursors (`_rect` and `_rec` schemes, such as `nat_rect`), projections, and a few
+   specific constants such as `andb` and `orb` (for the lazy
+   behaviour) and well founded recursion combinators are still
+   automatically inlined.
 
 .. cmd:: Extraction Inline {+ @qualid }
 


### PR DESCRIPTION
It has been default off since 9a69dd9a3f0b4ffe94d5ef4670858f7a7e99f405
