### PR TITLE
Reduce reliance on global enviromnents in Prettyp.

### DIFF
--- a/dev/ci/user-overlays/18652-ppedrot-prettyp-explicit-env.sh
+++ b/dev/ci/user-overlays/18652-ppedrot-prettyp-explicit-env.sh
@@ -1,0 +1,1 @@
+overlay vscoq https://github.com/ppedrot/vscoq prettyp-explicit-env 18652

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -601,7 +601,7 @@ let () =
   }
 
 let print_located_tactic qid =
-  Feedback.msg_notice (Prettyp.print_located_other locatable_ltac qid)
+  Feedback.msg_notice (Prettyp.print_located_other (Global.env ()) locatable_ltac qid)
 
 let print_ltac id =
  try

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1154,7 +1154,7 @@ let () =
   }
 
 let print_located_tactic qid =
-  Feedback.msg_notice (Prettyp.print_located_other locatable_ltac2 qid)
+  Feedback.msg_notice (Prettyp.print_located_other (Global.env ()) locatable_ltac2 qid)
 
 let print_ltac2 qid =
   if Tac2env.is_constructor qid then

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -52,7 +52,7 @@ val print_abbreviation : env -> Evd.evar_map -> KerName.t -> Pp.t
 
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.full_name_list option -> Pp.t
-val print_impargs : GlobRef.t -> Pp.t
+val print_impargs : env -> GlobRef.t -> Pp.t
 
 (** Pretty-printing functions for classes and coercions *)
 val print_graph : unit -> Pp.t
@@ -92,7 +92,7 @@ val register_locatable : string -> 'a locatable_info -> unit
     name describing the kind of objects considered and that is added as a
     grammar command prefix for vernacular commands Locate. *)
 
-val print_located_qualid : qualid -> Pp.t
-val print_located_term : qualid -> Pp.t
-val print_located_module : qualid -> Pp.t
-val print_located_other : string -> qualid -> Pp.t
+val print_located_qualid : env -> qualid -> Pp.t
+val print_located_term : env -> qualid -> Pp.t
+val print_located_module : env -> qualid -> Pp.t
+val print_located_other : env -> string -> qualid -> Pp.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2017,7 +2017,7 @@ let vernac_print ~pstate =
     Notation.pr_visibility (Constrextern.without_symbols (pr_glob_constr_env env sigma)) s
   | PrintAbout (ref_or_by_not,udecl,glnumopt) ->
     print_about_hyp_globs ~pstate ref_or_by_not udecl glnumopt
-  | PrintImplicit qid -> Prettyp.print_impargs (smart_global qid)
+  | PrintImplicit qid -> Prettyp.print_impargs env (smart_global qid)
   | PrintAssumptions (o,t,r) ->
     (* Prints all the axioms and section variables used by a term *)
       let env = Global.env () in
@@ -2045,17 +2045,19 @@ let vernac_search ~pstate ~atts s gopt r =
   in
   interp_search env sigma s r
 
-let vernac_locate ~pstate = let open Constrexpr in function
-  | LocateAny {v=AN qid}  -> Prettyp.print_located_qualid qid
-  | LocateTerm {v=AN qid} -> Prettyp.print_located_term qid
+let vernac_locate ~pstate query =
+  let open Constrexpr in
+  let sigma, env = get_current_or_global_context ~pstate in
+  match query with
+  | LocateAny {v=AN qid}  -> Prettyp.print_located_qualid env qid
+  | LocateTerm {v=AN qid} -> Prettyp.print_located_term env qid
   | LocateAny {v=ByNotation (ntn, sc)} (* TODO : handle Ltac notations *)
   | LocateTerm {v=ByNotation (ntn, sc)} ->
-    let sigma, env = get_current_or_global_context ~pstate in
     Notation.locate_notation
       (Constrextern.without_symbols (pr_glob_constr_env env sigma)) ntn sc
   | LocateLibrary qid -> print_located_library qid
-  | LocateModule qid -> Prettyp.print_located_module qid
-  | LocateOther (s, qid) -> Prettyp.print_located_other s qid
+  | LocateModule qid -> Prettyp.print_located_module env qid
+  | LocateOther (s, qid) -> Prettyp.print_located_other env s qid
   | LocateFile f -> locate_file f
 
 let vernac_register qid r =


### PR DESCRIPTION
We also remove a call to canonical equality this way.

Overlays:
- https://github.com/coq-community/vscoq/pull/722