### PR TITLE
Primitive int and float notations: use Register instead of hardcoded paths

### DIFF
--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -424,17 +424,17 @@ let locate_global_inductive_or_int63_or_float env allow_params qid =
   with Not_found ->
     let int63n = "num.int63.type" in
     let int63c = "num.int63.wrap_int" in
-    let int63w = "Coq.Numbers.Cyclic.Int63.PrimInt63.int_wrapper" in
+    let int63w = "num.int63.int_wrapper" in
     let floatn = "num.float.type" in
     let floatc = "num.float.wrap_float" in
-    let floatw = "Coq.Floats.PrimFloat.float_wrapper" in
+    let floatw = "num.float.float_wrapper" in
     if allow_params && Coqlib.has_ref int63n
        && Environ.QGlobRef.equal env (Smartlocate.global_with_alias qid) (Coqlib.lib_ref int63n)
-    then TargetPrim (cref (qualid_of_string int63w), [Coqlib.lib_ref int63c],
+    then TargetPrim (cref (qualid_of_ref int63w), [Coqlib.lib_ref int63c],
                      (Nametab.path_of_global (Coqlib.lib_ref int63n), []))
     else if allow_params && Coqlib.has_ref floatn
        && Environ.QGlobRef.equal env (Smartlocate.global_with_alias qid) (Coqlib.lib_ref floatn)
-    then TargetPrim (cref (qualid_of_string floatw), [Coqlib.lib_ref floatc],
+    then TargetPrim (cref (qualid_of_ref floatw), [Coqlib.lib_ref floatc],
                      (Nametab.path_of_global (Coqlib.lib_ref floatn), []))
     else TargetInd (Smartlocate.global_inductive_with_alias qid, [])
 

--- a/theories/Floats/PrimFloat.v
+++ b/theories/Floats/PrimFloat.v
@@ -28,6 +28,7 @@ Primitive float := #float64_type.
 Register float as num.float.type.
 
 Record float_wrapper := wrap_float { float_wrap : float }.
+Register float_wrapper as num.float.float_wrapper.
 Register wrap_float as num.float.wrap_float.
 Definition printer (x : float_wrapper) : float := float_wrap x.
 Definition parser (x : float) : float := x.

--- a/theories/Numbers/Cyclic/Int63/PrimInt63.v
+++ b/theories/Numbers/Cyclic/Int63/PrimInt63.v
@@ -22,6 +22,7 @@ Register pos_neg_int63 as num.int63.pos_neg_int63.
 Declare Scope uint63_scope.
 Definition id_int : int -> int := fun x => x.
 Record int_wrapper := wrap_int {int_wrap : int}.
+Register int_wrapper as num.int63.int_wrapper.
 Register wrap_int as num.int63.wrap_int.
 Definition printer (x : int_wrapper) : pos_neg_int63 := Pos (int_wrap x).
 Definition parser (x : pos_neg_int63) : option int :=


### PR DESCRIPTION

Fix #18510
