### PR TITLE
Remove high-level patterns in extraction plugin.

### DIFF
--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -233,9 +233,7 @@ and pp_cons_pat par r ppl =
     (pp_global Cons r ++ space_if (not (List.is_empty ppl)) ++ prlist_with_sep spc identity ppl)
 
 and pp_gen_pat par ids env = function
-  | Pcons (r,l) -> pp_cons_pat par r (List.map (pp_gen_pat true ids env) l)
   | Pusual r -> pp_cons_pat par r (List.map Id.print ids)
-  | Ptuple l -> pp_boxed_tuple (pp_gen_pat false ids env) l
   | Pwild -> str "_"
   | Prel n -> Id.print (get_db_name n env)
 

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -179,12 +179,7 @@ and json_one_pat env (ids,p,t) =
   ]
 
 and json_gen_pat ids env = function
-  | Pcons (r, l) -> json_cons_pat r (List.map (json_gen_pat ids env) l)
   | Pusual r -> json_cons_pat r (List.map json_id ids)
-  | Ptuple l -> json_dict [
-      ("what", json_str "pat:tuple");
-      ("items", json_list (List.map (json_gen_pat ids env) l))
-    ]
   | Pwild -> json_dict [("what", json_str "pat:wild")]
   | Prel n -> json_dict [
       ("what", json_str "pat:rel");

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -131,11 +131,9 @@ and ml_ast =
   | MLparray of ml_ast array * ml_ast
 
 and ml_pattern =
-  | Pcons   of GlobRef.t * ml_pattern list
-  | Ptuple  of ml_pattern list
   | Prel    of int (** Cf. the idents in the branch. [Prel 1] is the last one. *)
   | Pwild
-  | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
+  | Pusual  of GlobRef.t (** Eta-expanded constructor **)
 
 (*s ML declarations. *)
 

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -131,11 +131,9 @@ and ml_ast =
   | MLparray of ml_ast array * ml_ast
 
 and ml_pattern =
-  | Pcons   of GlobRef.t * ml_pattern list
-  | Ptuple  of ml_pattern list
   | Prel    of int (** Cf. the idents in the branch. [Prel 1] is the last one. *)
   | Pwild
-  | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
+  | Pusual  of GlobRef.t (** Eta-expanded constructor **)
 
 (*s ML declarations. *)
 

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -118,8 +118,6 @@ val normalize : ml_ast -> ml_ast
 val optimize_fix : ml_ast -> ml_ast
 val inline : GlobRef.t -> ml_ast -> bool
 
-val is_basic_pattern : ml_pattern -> bool
-val has_deep_pattern : ml_branch array -> bool
 val is_regular_match : ml_branch array -> bool
 
 exception Impossible

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -89,10 +89,8 @@ let type_iter_references do_type t =
   in iter t
 
 let patt_iter_references do_cons p =
-  let rec iter = function
-    | Pcons (r,l) -> do_cons r; List.iter iter l
+  let iter = function
     | Pusual r -> do_cons r
-    | Ptuple l -> List.iter iter l
     | Prel _ | Pwild -> ()
   in iter p
 

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -146,8 +146,7 @@ and pp_cons_args env = function
 and pp_one_pat env (ids,p,t) =
   let r = match p with
     | Pusual r -> r
-    | Pcons (r,l) -> r (* cf. the check [is_regular_match] above *)
-    | _ -> assert false
+    | Prel _ | Pwild -> assert false
   in
   let ids,env' = push_vars (List.rev_map id_of_mlid ids) env in
   let args =

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -831,8 +831,7 @@ let indref_of_match pv =
   let (_,pat,_) = pv.(0) in
   match pat with
     | Pusual (GlobRef.ConstructRef (ip,_)) -> GlobRef.IndRef ip
-    | Pcons (GlobRef.ConstructRef (ip,_),_) -> GlobRef.IndRef ip
-    | _ -> raise Not_found
+    | Pusual _ | Prel _ | Pwild -> raise Not_found
 
 let is_custom_match pv =
   try Refmap'.mem (indref_of_match pv) !custom_matchs


### PR DESCRIPTION
This was introduced by 4f523e7d25ed22b6e41cabf1c2bd091afc0fde7f to support what seems to have been an external extraction plugin, but this was dead code in Coq. Since we have no code in the CI that tests this API anyways, it is simply better to just remove it.