### PR TITLE
Use Coqlib primitives to check for reference equality in extraction.

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -40,11 +40,12 @@ let get_lib_refs () =
 
 let has_ref s = CString.Map.mem s !table
 
-let check_ind_ref s ind =
+let check_ref s gr =
   match CString.Map.find s !table with
-  | GlobRef.IndRef r -> Ind.UserOrd.equal r ind
-  | _ -> false
+  | r -> GlobRef.UserOrd.equal r gr
   | exception Not_found -> false
+
+let check_ind_ref s ind = check_ref s (GlobRef.IndRef ind)
 
 exception NotFoundRef of string
 

--- a/library/coqlib.mli
+++ b/library/coqlib.mli
@@ -44,8 +44,11 @@ val lib_ref_opt : string -> GlobRef.t option
     For any name [n], if [has_ref n] returns [true], [lib_ref n] will succeed. *)
 val has_ref : string -> bool
 
+(** Checks whether a name is bound to a known reference. *)
+val check_ref : string -> GlobRef.t -> bool
+
 (** Checks whether a name is bound to a known inductive. *)
-val check_ind_ref : string -> inductive -> bool
+val check_ind_ref : string -> inductive -> bool [@@ocaml.deprecated "Use Coqlib.check_ref"]
 
 (** List of all currently bound names. *)
 val get_lib_refs : unit -> (string * GlobRef.t) list

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -638,7 +638,6 @@ let is_ascii_registered () =
   && Coqlib.has_ref ascii_constructor_name
 
 let ascii_type_ref () = Coqlib.lib_ref ascii_type_name
-let ascii_constructor_ref () = Coqlib.lib_ref ascii_constructor_name
 
 let check_extract_ascii () =
   try
@@ -656,7 +655,7 @@ let is_list_cons l =
 let is_native_char = function
   | MLcons(_,gr,l) ->
     is_ascii_registered ()
-    && GlobRef.CanOrd.equal gr (ascii_constructor_ref ())
+    && Coqlib.check_ref ascii_constructor_name gr
     && check_extract_ascii ()
     && is_list_cons l
   | _ -> false
@@ -686,8 +685,6 @@ let is_string_registered () =
   && Coqlib.has_ref string_constructor_name
 
 let string_type_ref () = Coqlib.lib_ref string_type_name
-let empty_string_ref () = Coqlib.lib_ref empty_string_name
-let string_constructor_ref () = Coqlib.lib_ref string_constructor_name
 
 let check_extract_string () =
   try
@@ -705,10 +702,10 @@ let check_extract_string () =
 
 let rec is_native_string_rec empty_string_ref string_constructor_ref = function
   (* "EmptyString" constructor *)
-  | MLcons(_, gr, []) -> GlobRef.CanOrd.equal gr empty_string_ref
+  | MLcons(_, gr, []) -> Coqlib.check_ref empty_string_ref gr
   (* "String" constructor *)
   | MLcons(_, gr, [hd; tl]) ->
-      GlobRef.CanOrd.equal gr string_constructor_ref
+      Coqlib.check_ref string_constructor_ref gr
       && is_native_char hd
       && is_native_string_rec empty_string_ref string_constructor_ref tl
   (* others *)
@@ -723,9 +720,9 @@ let is_native_string c =
   match c with
   | MLcons(_, GlobRef.ConstructRef(ind, j), l) ->
       is_string_registered ()
-      && GlobRef.CanOrd.equal (GlobRef.IndRef ind) (string_type_ref ())
+      && Coqlib.check_ref string_type_name (GlobRef.IndRef ind)
       && check_extract_string ()
-      && is_native_string_rec (empty_string_ref ()) (string_constructor_ref ()) c
+      && is_native_string_rec empty_string_name string_constructor_name c
   | _ -> false
 
 (* Extract the underlying string. *)
@@ -734,10 +731,10 @@ let get_native_string c =
   let buf = Buffer.create 64 in
   let rec get = function
     (* "EmptyString" constructor *)
-    | MLcons(_, gr, []) when GlobRef.CanOrd.equal gr (empty_string_ref ()) ->
+    | MLcons(_, gr, []) when Coqlib.check_ref empty_string_name gr ->
         Buffer.contents buf
     (* "String" constructor *)
-    | MLcons(_, gr, [hd; tl]) when GlobRef.CanOrd.equal gr (string_constructor_ref ()) ->
+    | MLcons(_, gr, [hd; tl]) when Coqlib.check_ref string_constructor_name gr ->
         Buffer.add_char buf (get_native_char hd);
         get tl
     (* others *)
@@ -751,4 +748,4 @@ let pp_native_string c =
 
 (* Registered sig type *)
 
-let sig_type_ref () = Coqlib.lib_ref "core.sig.type"
+let sig_type_name = "core.sig.type"

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -90,4 +90,4 @@ val get_native_string : ml_ast -> string
 val pp_native_string : ml_ast -> Pp.t
 
 (* Registered sig type *)
-val sig_type_ref : unit -> GlobRef.t
+val sig_type_name : string

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -117,7 +117,7 @@ let rec pp_type par vl t =
        with Failure _ -> (str "a" ++ int i))
     | Tglob (r,[]) -> pp_global Type r
     | Tglob (gr,l)
-        when not (keep_singleton ()) && GlobRef.CanOrd.equal gr (sig_type_ref ()) ->
+        when not (keep_singleton ()) && Coqlib.check_ref sig_type_name gr ->
           pp_type true vl (List.hd l)
     | Tglob (r,l) ->
           pp_par par

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -176,7 +176,7 @@ let pp_type par vl t =
         pp_par par (pp_rec true a1 ++ str (get_infix r) ++ pp_rec true a2)
     | Tglob (r,[]) -> pp_global Type r
     | Tglob (gr,l)
-        when not (keep_singleton ()) && GlobRef.CanOrd.equal gr (sig_type_ref ()) ->
+        when not (keep_singleton ()) && Coqlib.check_ref sig_type_name gr ->
         pp_tuple_light pp_rec l
     | Tglob (r,l) ->
         pp_tuple_light pp_rec l ++ spc () ++ pp_global Type r

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1306,7 +1306,7 @@ let tclOPTION o d =
 let tacIS_INJECTION_CASE ?ty t = begin
   tclOPTION ty (tacTYPEOF t) >>= fun ty ->
   tacEVAL_TO_QUANTIFIED_IND ty >>= fun (mind,_) ->
-  tclUNIT (Coqlib.check_ind_ref "core.eq.type" mind)
+  tclUNIT (Coqlib.check_ref "core.eq.type" (GlobRef.IndRef mind))
 end
 
 let tclWITHTOP tac = Goal.enter begin fun gl ->

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -572,7 +572,7 @@ let injectl2rtac sigma c = match EConstr.kind sigma c with
 let is_injection_case env sigma c =
   let sigma, cty = Typing.type_of env sigma c in
   let (mind,_) = Tacred.eval_to_quantified_ind env sigma cty in
-  Coqlib.check_ind_ref "core.eq.type" mind
+  Coqlib.check_ref "core.eq.type" (GlobRef.IndRef mind)
 
 let perform_injection c =
   let open Proofview.Notations in

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -291,13 +291,14 @@ let match_with_equation env sigma t =
   match EConstr.kind sigma hdapp with
   | Ind (ind,u) ->
     (try
-       if Coqlib.check_ind_ref "core.eq.type" ind then
+      let gr = GlobRef.IndRef ind in
+       if Coqlib.check_ref "core.eq.type" gr then
          Some (build_coq_eq_data()),hdapp,
          PolymorphicLeibnizEq(args.(0),args.(1),args.(2))
-       else if Coqlib.check_ind_ref "core.identity.type" ind then
+       else if Coqlib.check_ref "core.identity.type" gr then
          Some (build_coq_identity_data()),hdapp,
          PolymorphicLeibnizEq(args.(0),args.(1),args.(2))
-       else if Coqlib.check_ind_ref "core.JMeq.type" ind then
+       else if Coqlib.check_ref "core.JMeq.type" gr then
          Some (build_coq_jmeq_data()),hdapp,
          HeterogenousEq(args.(0),args.(1),args.(2),args.(3))
        else


### PR DESCRIPTION
This is a slight change of semantics because the new version compares user rather than canonical names. We argue that this is the expected behaviour, since we are comparing w.r.t. user-declared references through the Register mechanism.