### PR TITLE
Remove notation-related API

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1292,6 +1292,16 @@ let fresh_string_of =
   let count = ref 0 in
   fun root -> count := !count+1; (string_of_int !count)^"_"^root
 
+let glob_prim_constr_key c = match DAst.get c with
+  | GRef (ref, _) -> Some (canonical_gr ref)
+  | GApp (c, _) ->
+    begin match DAst.get c with
+    | GRef (ref, _) -> Some (canonical_gr ref)
+    | _ -> None
+    end
+  | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
+  | _ -> None
+
 let declare_numeral_interpreter ?(local=false) sc dir interp (patl,uninterp,b) =
   let uid = fresh_string_of sc in
   register_bignumeral_interpretation uid (interp,uninterp);

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1288,10 +1288,6 @@ let enable_prim_token_interpretation infos =
     (the latter inside a [Mltop.declare_cache_obj]).
 *)
 
-let fresh_string_of =
-  let count = ref 0 in
-  fun root -> count := !count+1; (string_of_int !count)^"_"^root
-
 let glob_prim_constr_key c = match DAst.get c with
   | GRef (ref, _) -> Some (canonical_gr ref)
   | GApp (c, _) ->
@@ -1301,28 +1297,6 @@ let glob_prim_constr_key c = match DAst.get c with
     end
   | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
   | _ -> None
-
-let declare_numeral_interpreter ?(local=false) sc dir interp (patl,uninterp,b) =
-  let uid = fresh_string_of sc in
-  register_bignumeral_interpretation uid (interp,uninterp);
-  enable_prim_token_interpretation
-    { pt_local = local;
-      pt_scope = sc;
-      pt_interp_info = Uid uid;
-      pt_required = dir;
-      pt_refs = List.map_filter glob_prim_constr_key patl;
-      pt_in_match = b }
-let declare_string_interpreter ?(local=false) sc dir interp (patl,uninterp,b) =
-  let uid = fresh_string_of sc in
-  register_string_interpretation uid (interp,uninterp);
-  enable_prim_token_interpretation
-    { pt_local = local;
-      pt_scope = sc;
-      pt_interp_info = Uid uid;
-      pt_required = dir;
-      pt_refs = List.map_filter glob_prim_constr_key patl;
-      pt_in_match = b }
-
 
 let check_required_module ?loc sc (sp,d) =
   try let _ = Nametab.global_of_path sp in ()

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -207,20 +207,6 @@ type prim_token_infos = {
 
 val enable_prim_token_interpretation : prim_token_infos -> unit
 
-(** Compatibility.
-    Avoid the next two functions, they will now store unnecessary
-    objects in the library segment. Instead, combine
-    [register_*_interpretation] and [enable_prim_token_interpretation]
-    (the latter inside a [Mltop.declare_cache_obj]).
-*)
-
-val declare_numeral_interpreter : ?local:bool -> scope_name -> required_module ->
-  Z.t prim_token_interpreter ->
-  glob_constr list * Z.t prim_token_uninterpreter * bool -> unit
-val declare_string_interpreter : ?local:bool -> scope_name -> required_module ->
-  string prim_token_interpreter ->
-  glob_constr list * string prim_token_uninterpreter * bool -> unit
-
 (** Return the [term]/[cases_pattern] bound to a primitive token in a
    given scope context*)
 

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -144,16 +144,6 @@ let notations_key_table = Summary.ref
     ~name:"notation_uninterpretation"
     (KeyMap.empty : notation_rule list KeyMap.t)
 
-let glob_prim_constr_key c = match DAst.get c with
-  | GRef (ref, _) -> Some (canonical_gr ref)
-  | GApp (c, _) ->
-    begin match DAst.get c with
-    | GRef (ref, _) -> Some (canonical_gr ref)
-    | _ -> None
-    end
-  | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
-  | _ -> None
-
 let glob_constr_keys c = match DAst.get c with
   | GApp (c, _) ->
     begin match DAst.get c with

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -59,8 +59,6 @@ type notation_applicative_status =
 
 type notation_rule = interp_rule * interpretation * notation_applicative_status
 
-val glob_prim_constr_key : 'a Glob_term.glob_constr_g -> Names.GlobRef.t option
-
 (** Return the possible notations for a given term *)
 val uninterp_notations : 'a glob_constr_g -> notation_rule list
 val uninterp_cases_pattern_notations : 'a cases_pattern_g -> notation_rule list

--- a/interp/notationextern.mli
+++ b/interp/notationextern.mli
@@ -59,12 +59,7 @@ type notation_applicative_status =
 
 type notation_rule = interp_rule * interpretation * notation_applicative_status
 
-(** Return printing key *)
-type key
 val glob_prim_constr_key : 'a Glob_term.glob_constr_g -> Names.GlobRef.t option
-val glob_constr_keys : glob_constr -> key list
-val cases_pattern_key : cases_pattern -> key
-val notation_constr_key : Notation_term.notation_constr -> key * notation_applicative_status
 
 (** Return the possible notations for a given term *)
 val uninterp_notations : 'a glob_constr_g -> notation_rule list


### PR DESCRIPTION
We remove several functions from Notations and friends that are either not usable or have been discouraged for more than half a decade.