### PR TITLE
Fix misplaced attributes.

### DIFF
--- a/kernel/float64.mli
+++ b/kernel/float64.mli
@@ -57,13 +57,11 @@ val le : t -> t -> bool
 (** The IEEE 754 float comparison.
  * NotComparable is returned if there is a NaN in the arguments *)
 val compare : t -> t -> float_comparison
-[@@ocaml.inline always]
 
 type float_class =
   | PNormal | NNormal | PSubn | NSubn | PZero | NZero | PInf | NInf | NaN
 
 val classify : t -> float_class
-[@@ocaml.inline always]
 
 val mul : t -> t -> t
 
@@ -77,19 +75,15 @@ val sqrt : t -> t
 
 (** Link with integers *)
 val of_uint63 : Uint63.t -> t
-[@@ocaml.inline always]
 
 val normfr_mantissa : t -> Uint63.t
-[@@ocaml.inline always]
 
 (** Shifted exponent extraction *)
 val eshift : int
 
 val frshiftexp : t -> t * Uint63.t (* float remainder, shifted exponent *)
-[@@ocaml.inline always]
 
 val ldshiftexp : t -> Uint63.t -> t
-[@@ocaml.inline always]
 
 val next_up : t -> t
 
@@ -98,7 +92,6 @@ val next_down : t -> t
 (** Return true if two floats are equal.
  * All NaN values are considered equal. *)
 val equal : t -> t -> bool
-[@@ocaml.inline always]
 
 val hash : t -> int
 
@@ -106,4 +99,3 @@ val hash : t -> int
 val total_compare : t -> t -> int
 
 val is_float64 : Obj.t -> bool
-[@@ocaml.inline always]

--- a/kernel/float64_common.mli
+++ b/kernel/float64_common.mli
@@ -57,29 +57,23 @@ val le : t -> t -> bool
 (** The IEEE 754 float comparison.
  * NotComparable is returned if there is a NaN in the arguments *)
 val compare : t -> t -> float_comparison
-[@@ocaml.inline always]
 
 type float_class =
   | PNormal | NNormal | PSubn | NSubn | PZero | NZero | PInf | NInf | NaN
 
 val classify : t -> float_class
-[@@ocaml.inline always]
 
 (** Link with integers *)
 val of_uint63 : Uint63.t -> t
-[@@ocaml.inline always]
 
 val normfr_mantissa : t -> Uint63.t
-[@@ocaml.inline always]
 
 (** Shifted exponent extraction *)
 val eshift : int
 
 val frshiftexp : t -> t * Uint63.t (* float remainder, shifted exponent *)
-[@@ocaml.inline always]
 
 val ldshiftexp : t -> Uint63.t -> t
-[@@ocaml.inline always]
 
 val next_up : t -> t
 
@@ -88,7 +82,6 @@ val next_down : t -> t
 (** Return true if two floats are equal.
  * All NaN values are considered equal. *)
 val equal : t -> t -> bool
-[@@ocaml.inline always]
 
 val hash : t -> int
 
@@ -96,4 +89,3 @@ val hash : t -> int
 val total_compare : t -> t -> int
 
 val is_float64 : Obj.t -> bool
-[@@ocaml.inline always]

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -630,6 +630,7 @@ let fabs accu x =
 
 let no_check_feq x y =
   mk_bool (Float64.eq (to_float x) (to_float y))
+[@@ocaml.inline always]
 
 let feq accu x y =
   if is_float x && is_float y then no_check_feq x y
@@ -637,6 +638,7 @@ let feq accu x y =
 
 let no_check_flt x y =
   mk_bool (Float64.lt (to_float x) (to_float y))
+[@@ocaml.inline always]
 
 let flt accu x y =
   if is_float x && is_float y then no_check_flt x y
@@ -644,6 +646,7 @@ let flt accu x y =
 
 let no_check_fle x y =
   mk_bool (Float64.le (to_float x) (to_float y))
+[@@ocaml.inline always]
 
 let fle accu x y =
   if is_float x && is_float y then no_check_fle x y
@@ -667,6 +670,7 @@ let fcompare accu x y =
 
 let no_check_fequal x y =
   mk_bool (Float64.equal (to_float x) (to_float y))
+[@@ocaml.inline always]
 
 let fequal accu x y =
   if is_float x && is_float y then no_check_fequal x y
@@ -794,6 +798,7 @@ let of_parray t = Obj.magic t
 
 let no_check_arraymake n def =
   of_parray (Parray.make (to_uint n) def)
+[@@ocaml.inline always]
 
 let arraymake accu vA n def =
   if is_int n then

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -100,16 +100,12 @@ val mk_block : tag -> t array -> t
 val mk_prod : Name.t -> t -> t -> t
 
 val mk_bool : bool -> t
-[@@ocaml.inline always]
 
 val mk_int : int -> t
-[@@ocaml.inline always]
 
 val mk_uint : Uint63.t -> t
-[@@ocaml.inline always]
 
 val mk_float : Float64.t -> t
-[@@ocaml.inline always]
 
 val napply : t -> t array -> t
 (* Functions over accumulators *)
@@ -120,7 +116,6 @@ val args_of_accu : accumulator -> t list
 val accu_nargs : accumulator -> int
 
 val cast_accu : t -> accumulator
-[@@ocaml.inline always]
 
 (* Functions over block: i.e constructors *)
 
@@ -144,7 +139,6 @@ val str_decode : string -> 'a
 val val_to_int : t -> int
 
 val is_int : t -> bool
-[@@ocaml.inline always]
 
 (* function with check *)
 val head0 : t -> t -> t
@@ -188,88 +182,60 @@ val print : t -> t
 
 (* Function without check *)
 val no_check_head0 : t -> t
-[@@ocaml.inline always]
 
 val no_check_tail0 : t -> t
-[@@ocaml.inline always]
 
 val no_check_add : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_sub : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_mul : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_div : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_rem : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_divs : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_rems : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_l_sr  : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_l_sl  : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_a_sr  : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_l_and : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_l_xor : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_l_or  : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_addc      : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_subc      : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_addCarryC : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_subCarryC : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_mulc    : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_diveucl : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_div21     : t -> t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_addMulDiv : t -> t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_eq      : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_lt      : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_le      : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_lts     : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_les     : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_compare : t -> t -> t
 
@@ -278,7 +244,6 @@ val no_check_compares : t -> t -> t
 (** Support for machine floating point values *)
 
 val is_float : t -> bool
-[@@ocaml.inline always]
 
 val fopp : t -> t -> t
 val fabs : t -> t -> t
@@ -302,61 +267,42 @@ val next_down : t -> t -> t
 
 (* Function without check *)
 val no_check_fopp : t -> t
-[@@ocaml.inline always]
 
 val no_check_fabs : t -> t
-[@@ocaml.inline always]
 
 val no_check_feq : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_flt : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fle : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fcompare : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fequal : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fclassify : t -> t
-[@@ocaml.inline always]
 
 val no_check_fadd : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fsub : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fmul : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fdiv : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_fsqrt : t -> t
-[@@ocaml.inline always]
 
 val no_check_float_of_int : t -> t
-[@@ocaml.inline always]
 
 val no_check_normfr_mantissa : t -> t
-[@@ocaml.inline always]
 
 val no_check_frshiftexp : t -> t
-[@@ocaml.inline always]
 
 val no_check_ldshiftexp : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_next_up : t -> t
-[@@ocaml.inline always]
 
 val no_check_next_down : t -> t
-[@@ocaml.inline always]
 
 (** Support for arrays *)
 
@@ -371,19 +317,13 @@ val arraycopy : t -> t -> t -> t (* accu A t *)
 val arraylength : t -> t -> t -> t (* accu A t *)
 
 val no_check_arraymake : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_arrayget : t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_arraydefault : t -> t
-[@@ocaml.inline always]
 
 val no_check_arrayset : t -> t -> t -> t
-[@@ocaml.inline always]
 
 val no_check_arraycopy : t -> t
-[@@ocaml.inline always]
 
 val no_check_arraylength : t -> t
-[@@ocaml.inline always]

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -20,7 +20,7 @@ module G = AcyclicGraph.Make(struct
     let compare = Level.compare
 
     let raw_pr = Level.raw_pr
-  end) [@@inlined] (* without inline, +1% ish on HoTT, compcert. See jenkins 594 vs 596 *)
+  end)
 (* Do not include G to make it easier to control universe specific
    code (eg add_universe with a constraint vs G.add with no
    constraint) *)

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -197,7 +197,7 @@ val add_hints : locality:hint_locality -> hint_db_name list -> hints_entry -> un
 val hint_globref : GlobRef.t -> hint_term
 
 val hint_constr : constr * UnivGen.sort_context_set option -> hint_term
-[@ocaml.deprecated "Declare a hint constant instead"]
+[@@ocaml.deprecated "Declare a hint constant instead"]
 
 (** A constr which is Hint'ed will be:
    - (1) used as an Exact, if it does not start with a product


### PR DESCRIPTION
These trigger warnings on OCaml 5.2.0~alpha1.

Also, my understanding is that inlining attributes in ".mli" files were always entirely ignored (see https://github.com/ocaml/ocaml/issues/12972 and [this zulip thread](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Entirely.20useless.20inlining.20annotations)).