### PR TITLE
Make "Found no matching notation to enable or disable." a warning

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -557,7 +557,7 @@ Enabling and disabling notations
       Cannot enable or disable for parsing a notation that was
       originally defined as only printing.
 
-   .. exn:: Found no matching notation to enable or disable.
+   .. warn:: Found no matching notation to enable or disable.
 
       No previously defined notation satisfies the given constraints.
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2671,6 +2671,11 @@ let toggle_abbreviations ~on found ntn_pattern =
     Abbreviation.toggle_abbreviations ~on ~use:ntn_pattern.use_pattern test
   with Exit -> ()
 
+let warn_nothing_to_enable_or_disable =
+  CWarnings.create ~name:"no-notation-to-enable-or-disable"
+    ~category:CWarnings.CoreCategories.syntax
+    (fun () -> strbrk "Found no matching notation to enable or disable.")
+
 let toggle_notations ~on ~all ?(verbose=true) prglob ntn_pattern =
   let found = ref [] in
   (* Deal with (parsing) notations *)
@@ -2688,8 +2693,7 @@ let toggle_notations ~on ~all ?(verbose=true) prglob ntn_pattern =
   (* Deal with abbreviations *)
   toggle_abbreviations ~on found ntn_pattern;
   match !found with
-  | [] ->
-    user_err (strbrk "Found no matching notation to enable or disable.")
+  | [] -> warn_nothing_to_enable_or_disable ()
   | _::_::_ when not all ->
     user_err (strbrk "More than one interpretation bound to this notation, confirm with the \"all\" modifier.")
   | _ ->

--- a/test-suite/output/activation.out
+++ b/test-suite/output/activation.out
@@ -5,12 +5,13 @@ modifier.
 File "./output/activation.v", line 12, characters 0-22:
 The command has indeed failed with message:
 No notation provided.
-File "./output/activation.v", line 15, characters 0-24:
+File "./output/activation.v", line 16, characters 0-24:
 The command has indeed failed with message:
 Found no matching notation to enable or disable.
+[no-notation-to-enable-or-disable,syntax,default]
 a
      : Type
-File "./output/activation.v", line 24, characters 11-12:
+File "./output/activation.v", line 26, characters 11-12:
 The command has indeed failed with message:
 The reference a was not found in the current environment.
 Prop
@@ -25,6 +26,7 @@ x
      : bool
 0
      : nat
-File "./output/activation.v", line 44, characters 0-49:
+File "./output/activation.v", line 47, characters 0-49:
 The command has indeed failed with message:
 Found no matching notation to enable or disable.
+[no-notation-to-enable-or-disable,syntax,default]

--- a/test-suite/output/activation.v
+++ b/test-suite/output/activation.v
@@ -12,7 +12,9 @@ Disable Notation (all) : nat_scope.
 Fail Disable Notation.
 
 Module Abbrev.
+Set Warnings "+no-notation-to-enable-or-disable".
 Fail Disable Notation f. (* no abbreviation with such suffix *)
+Set Warnings "no-notation-to-enable-or-disable".
 Notation f w := (S w).
 Disable Notation f w := (S w).
 Enable Notation := (S _).
@@ -41,6 +43,8 @@ End Abbrev.
 Module Bug17782.
 
 Declare Custom Entry trm.
+Set Warnings "+no-notation-to-enable-or-disable".
 Fail Disable Notation "'foo' _"  (in custom trm).
+Set Warnings "no-notation-to-enable-or-disable".
 
 End Bug17782.


### PR DESCRIPTION
instead of an error

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
