### PR TITLE
[Experiment] Hack a global fixpoint expansion in conversion.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -378,8 +378,8 @@ end = struct
     | Primitive p -> raise (NotEvaluableConst (IsPrimitive (u,p)))
 
   let expand_global_fixpoint info cst c = match info.i_cache.i_mode with
-  | Reduction -> None
-  | Conversion ->
+  | Conversion -> None
+  | Reduction ->
     let ctx, body = Term.decompose_lambda c in
     match destFix body with
     | fix ->

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -24,6 +24,8 @@ type fconstr
 
 type finvert
 
+type gfix
+
 type evar_repack
 
 type usubs = fconstr subs UVars.puniverses
@@ -40,7 +42,7 @@ type fterm =
   | FConstruct of pconstructor
   | FApp of fconstr * fconstr array
   | FProj of Projection.t * Sorts.relevance * fconstr
-  | FFix of fixpoint * usubs
+  | FFix of fixpoint * usubs * gfix
   | FCoFix of cofixpoint * usubs
   | FCaseT of case_info * UVars.Instance.t * constr array * case_return * fconstr * case_branch array * usubs (* predicate and branches are closures *)
   | FCaseInvert of case_info * UVars.Instance.t * constr array * case_return * finvert * fconstr * case_branch array * usubs

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -650,7 +650,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
          in convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
        with Not_found -> raise NotConvertible)
 
-    | (FFix (((op1, i1),(na1,tys1,cl1)),e1), FFix(((op2, i2),(_,tys2,cl2)),e2)) ->
+    | (FFix (((op1, i1),(na1,tys1,cl1)),e1, _), FFix(((op2, i2),(_,tys2,cl2)),e2, _)) ->
         if Int.equal i1 i2 && Array.equal Int.equal op1 op2
         then
           let n = Array.length cl1 in

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -232,7 +232,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
       infer_constructor_instance_eq (info_env (fst infos)) variances ctor nargs u
     in
     infer_stack infos variances stk
-  | FFix ((_,(na,tys,cl)),e) | FCoFix ((_,(na,tys,cl)),e) ->
+  | FFix ((_,(na,tys,cl)),e,_) | FCoFix ((_,(na,tys,cl)),e) ->
     let n = Array.length cl in
     let variances = infer_vect infos variances (Array.map (mk_clos e) tys) in
     let le = CClosure.usubs_liftn n e in

--- a/test-suite/output/reduction.out
+++ b/test-suite/output/reduction.out
@@ -6,12 +6,7 @@
      : nat
      = S (1 + 2)
      : nat
-     = S
-         ((fix add (n m : nat) {struct n} : nat :=
-             match n with
-             | 0 => m
-             | S p => S (add p m)
-             end) 1 2)
+     = S (1 + 2)
      : nat
      = 4
      : nat


### PR DESCRIPTION
Quick and dirty experiment following the Coq call. Rather than implementing a full-blown refolding of fixpoint everywhere, we experiment with refolding when converting only.