### PR TITLE
Extension of the [FMap] Ltac2 module

### DIFF
--- a/clib/cSig.mli
+++ b/clib/cSig.mli
@@ -76,7 +76,9 @@ sig
     val cardinal: 'a t -> int
     val bindings: 'a t -> (key * 'a) list
     val min_binding: 'a t -> (key * 'a)
+    val min_binding_opt: 'a t -> (key * 'a) option
     val max_binding: 'a t -> (key * 'a)
+    val max_binding_opt: 'a t -> (key * 'a) option
     val choose: 'a t -> (key * 'a)
     val choose_opt: 'a t -> (key * 'a) option
     val split: key -> 'a t -> 'a t * 'a option * 'a t

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -343,7 +343,11 @@ struct
 
   let min_binding _ = assert false (** Cannot be implemented efficiently *)
 
+  let min_binding_opt _ = assert false (** Cannot be implemented efficiently *)
+
   let max_binding _ = assert false (** Cannot be implemented efficiently *)
+
+  let max_binding_opt _ = assert false (** Cannot be implemented efficiently *)
 
   let fold_left _ _ _ = assert false (** Cannot be implemented efficiently *)
 

--- a/doc/changelog/06-Ltac2-language/18673-more-ltac2-fmap.rst
+++ b/doc/changelog/06-Ltac2-language/18673-more-ltac2-fmap.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Functions `FMap.min_binding` and `FMap.max_binding`
+  (`#18673 <https://github.com/coq/coq/pull/18673>`_,
+  by Rodolphe Lepigre).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1308,9 +1308,11 @@ module type MapType = sig
   val repr : S.elt Tac2ffi.repr
 end
 
+type ('a,'set,'map) map =
+  (module MapType with type S.elt = 'a and type S.t = 'set and type valmap = 'map)
+
 module MapTypeV = struct
-  type _ t = Map : (module MapType with type S.elt = 't and type S.t = 'set and type valmap = 'map)
-    -> ('t * 'set * 'map) t
+  type _ t = Map : ('t, 'set, 'map) map -> ('t * 'set * 'map) t
 end
 
 module MapMap = MapTagDyn.Map(MapTypeV)

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1528,6 +1528,22 @@ let () =
   let Refl = V.valmap_eq in
   tag_set tag (V.M.domain m)
 
+let () =
+  define "fmap_min_binding" (map_repr @-> ret valexpr)
+    @@ fun (TaggedMap (tag,m)) ->
+  let (module V) = get_map tag in
+  let Refl = V.valmap_eq in
+  let o = V.M.min_binding_opt m in
+  Tac2ffi.(of_option (of_pair (repr_of V.repr) identity)) o
+
+let () =
+  define "fmap_max_binding" (map_repr @-> ret valexpr)
+    @@ fun (TaggedMap (tag,m)) ->
+  let (module V) = get_map tag in
+  let Refl = V.valmap_eq in
+  let o = V.M.max_binding_opt m in
+  Tac2ffi.(of_option (of_pair (repr_of V.repr) identity)) o
+
 (** ML types *)
 
 (** Embed all Ltac2 data into Values *)

--- a/plugins/ltac2/tac2core.mli
+++ b/plugins/ltac2/tac2core.mli
@@ -55,12 +55,16 @@ val map_tag_repr : any_map_tag Tac2ffi.repr
 val set_repr : tagged_set Tac2ffi.repr
 val map_repr : tagged_map Tac2ffi.repr
 
+type ('a,'set,'map) map =
+  (module MapType with type S.elt = 'a and type S.t = 'set and type valmap = 'map)
+
 val register_map : ?plugin:string -> tag_name:string
-  -> (module MapType with type S.elt = 'a and type S.t = 'set and type valmap = 'map)
-  -> ('a,'set,'map) map_tag
+  -> ('a,'set,'map) map -> ('a,'set,'map) map_tag
 (** Register a type on which we can use finite sets and maps.
     [tag_name] is the name used for the external to make the
     [Ltac2.FSet.Tags.tag] available. *)
+
+val get_map : ('a,'set,'map) map_tag -> ('a,'set,'map) map
 
 (** Default registered maps *)
 

--- a/test-suite/ltac2/map.v
+++ b/test-suite/ltac2/map.v
@@ -33,8 +33,24 @@ Ltac2 Notation "sprintf" fmt(format) := Message.Format.kfprintf (fun m => Messag
 
 Ltac2 Eval
   let m := FMap.empty FSet.Tags.string_tag in
+  match FMap.min_binding m with
+  | None => ()
+  | Some _ => ensure false
+  end;
+  match FMap.max_binding m with
+  | None => ()
+  | Some _ => ensure false
+  end;
   let m := FMap.add "one" 1 m in
   let m := FMap.add "two" 2 m in
+  match FMap.min_binding m with
+  | None => ensure false
+  | Some (k, v) => ensure (String.equal k "one"); ensure (Int.equal v 1)
+  end;
+  match FMap.max_binding m with
+  | None => ensure false
+  | Some (k, v) => ensure (String.equal k "two"); ensure (Int.equal v 2)
+  end;
   let m := FMap.add "three" 3 m in
   let m := FMap.add "four" 4 m in
   let m := FMap.mapi (fun s i => sprintf "%s=%i" s i) m in

--- a/user-contrib/Ltac2/FMap.v
+++ b/user-contrib/Ltac2/FMap.v
@@ -35,4 +35,10 @@ Ltac2 @ external cardinal : ('k, 'v) t -> int := "coq-core.plugins.ltac2" "fmap_
 
 Ltac2 @ external bindings : ('k, 'v) t -> ('k * 'v) list := "coq-core.plugins.ltac2" "fmap_bindings".
 
+(** Not supported on maps created with tag [Ltac2.FSet.Tags.constant_tag]. *)
+Ltac2 @ external min_binding : ('k, 'v) t -> ('k * 'v) option := "coq-core.plugins.ltac2" "fmap_min_binding".
+
+(** Not supported on maps created with tag [Ltac2.FSet.Tags.constant_tag]. *)
+Ltac2 @ external max_binding : ('k, 'v) t -> ('k * 'v) option := "coq-core.plugins.ltac2" "fmap_max_binding".
+
 Ltac2 @ external domain : ('k, 'v) t -> 'k FSet.t := "coq-core.plugins.ltac2" "fmap_domain".


### PR DESCRIPTION
This also exposes the `Tac2core.get_map` function, without which it is not possible to add new `set/map` functions from a plugin.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.