### PR TITLE
Fix `unfold` tactic not unfolding compatibility constants.

### DIFF
--- a/test-suite/success/primitiveproj.v
+++ b/test-suite/success/primitiveproj.v
@@ -250,3 +250,24 @@ Fail Check (@eq_refl _ 0 <: 0 = snd (pair 0 1)).
 
 Check (@eq_refl _ 0 <<: 0 = fst (pair 0 1)).
 Fail Check (@eq_refl _ 0 <<: 0 = snd (pair 0 1)).
+
+(* [unfold] tactic *)
+Module Unfold.
+  Record rec (P: Prop) := REC { v: unit }.
+  Set Printing All.
+  Set Printing Unfolded Projection As Match.
+
+  (* Testing that [unfold] can unfold compatibility constants. *)
+  Goal forall r: rec True, @v True r = tt.
+  Proof.
+    intros.
+    lazymatch goal with
+    | |- context C [@v _ ?r] =>
+        (* Carefully construct a term that definitely contains the compatibility constant. *)
+        let t := constr:(@v True) in
+        let g := context C [t r] in
+        change g
+    end.
+    progress unfold v.
+  Abort.
+End Unfold.


### PR DESCRIPTION
#18327 introduced a regression in `unfold` that made it not unfold compatibility constants.