### PR TITLE
Add support for inserting a table of contents inside each file for coqdoc

### DIFF
--- a/tools/coqdoc/common.mli
+++ b/tools/coqdoc/common.mli
@@ -25,7 +25,7 @@ type otype = Dvi | Ps | Pdf
 
 (* Globals *************************************************************************)
 val page_title : string ref
-val out_channel : out_channel ref
+val out_channel : Buffer.t option ref
 (* End globals *********************************************************************)
 
 (** User-setable options from command line [coqdoc] arugments **********************)
@@ -72,5 +72,10 @@ val prefs : t ref
 val (/) : string -> string -> string
 val coqdoc_out : string -> string
 val open_out_file : string -> unit
+val set_header_output : unit -> unit
+val set_toc_output : unit -> unit
+val set_main_output : unit -> unit
 val close_out_file : unit -> unit
+val set_stdout : unit -> unit
+val flush_stdout : unit -> unit
 (* End little helpers **************************************************************)

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -1473,8 +1473,10 @@ and st_subtitle = parse
     let lb = { lb with lex_curr_p = { lb.lex_curr_p with pos_fname = f };
                        lex_start_p = { lb.lex_start_p with pos_fname = f } } in
       (Index.current_library := m;
+       Common.set_header_output ();
        Output.initialize ();
        Output.start_module ();
+       Common.set_main_output ();
        Output.start_coq (); coq_bol' f lb; Output.end_coq ();
        close_in c)
 

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -104,4 +104,5 @@ val inf_rule :  (int * string) list
 
 val make_multi_index : unit -> unit
 val make_index : unit -> unit
-val make_toc : unit -> unit
+val make_local_toc : unit -> unit
+val make_global_toc : unit -> unit


### PR DESCRIPTION
The PR makes that the `-toc` option of `coqdoc` for html output inserts a table of contents at the beginning of each file, and not only in a separate file `toc.html`. The difficulty is that the table of contents is known only after having processed the file.

TODO:
- check what it gives in LaTeX
- wonder whether there should not rather be a `(** tableofcontents *)` coqdoc tag that insert the table of contents at a place chosen by the write of the file
- check it is not slower
- check if other extensions of coqdoc provide it

- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.