### PR TITLE
add Trakt to Coq's CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -857,6 +857,12 @@ library:ci-http:
   - library:ci-itree_io
   - plugin:ci-quickchick
 
+library:ci-trakt:
+  extends: .ci-template-flambda
+  needs:
+  - build:edge+flambda
+  - plugin:ci-elpi_hb
+
 # Plugins are by definition the projects that depend on Coq's ML API
 
 plugin:ci-aac_tactics:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -92,6 +92,7 @@ CI_TARGETS= \
     ci-stdlib2 \
     ci-tactician \
     ci-tlc \
+    ci-trakt \
     ci-unimath \
     ci-unicoq \
     ci-verdi_raft \
@@ -144,6 +145,8 @@ ci-hb: ci-elpi
 
 ci-elpi_test: ci-elpi_hb
 ci-hb_test: ci-elpi_hb
+
+ci-trakt: ci-elpi
 
 ci-jasmin: ci-mathcomp_word
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -530,3 +530,9 @@ project waterproof "https://github.com/impermeable/coq-waterproof" "coq-master"
 ########################################################################
 project autosubst_ocaml "https://github.com/uds-psl/autosubst-ocaml" "master"
 # Contact @yforster on github
+
+########################################################################
+# Trakt
+########################################################################
+project trakt "https://github.com/ecranceMERCE/trakt" "coq-master"
+# Contact @ckeller, @louiseddp on github

--- a/dev/ci/ci-trakt.sh
+++ b/dev/ci/ci-trakt.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download trakt
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+( cd "${CI_BUILD_DIR}/trakt"
+  make
+  make install
+)


### PR DESCRIPTION
This PR adds the Trakt plugin to Coq's CI
This plugin allows automatic translation between goals about equivalent datatypes (such as `N` and `nat`), in addition to translation between goals in `Prop` and in `bool`

This plugin was developped by @ecranceMERCE and is now maintained by myself and @ckeller. 
