### PR TITLE
Remove all uses of the functional induction tactic from the stdlib.

### DIFF
--- a/theories/FSets/FMapFullAVL.v
+++ b/theories/FSets/FMapFullAVL.v
@@ -142,7 +142,7 @@ Qed.
 Lemma bal_avl : forall l x e r, avl l -> avl r ->
  -(3) <= height l - height r <= 3 -> avl (bal l x e r).
 Proof.
- intros l x e r; functional induction (bal l x e r); intros; clearf;
+ intros l x e r; induction elt, l, x, e, r, (bal l x e r) using bal_ind; intros; clearf;
  inv avl; simpl in *;
  match goal with |- avl (assert_false _ _ _ _) => avl_nns
   | _ => repeat apply create_avl; simpl in *; auto
@@ -153,7 +153,7 @@ Lemma bal_height_1 : forall l x e r, avl l -> avl r ->
  -(3) <= height l - height r <= 3 ->
  0 <= height (bal l x e r) - max (height l) (height r) <= 1.
 Proof.
- intros l x e r; functional induction (bal l x e r); intros; clearf;
+ intros l x e r; induction elt, l, x, e, r, (bal l x e r) using bal_ind; intros; clearf;
  inv avl; avl_nns; simpl in *; omega_max.
 Qed.
 
@@ -161,7 +161,7 @@ Lemma bal_height_2 :
  forall l x e r, avl l -> avl r -> -(2) <= height l - height r <= 2 ->
  height (bal l x e r) == max (height l) (height r) +1.
 Proof.
- intros l x e r; functional induction (bal l x e r); intros; clearf;
+ intros l x e r; induction elt, l, x, e, r, (bal l x e r) using bal_ind; intros; clearf;
  inv avl; avl_nns; simpl in *; omega_max.
 Qed.
 
@@ -176,7 +176,7 @@ Ltac omega_bal := match goal with
 Lemma add_avl_1 :  forall m x e, avl m ->
  avl (add x e m) /\ 0 <= height (add x e m) - height m <= 1.
 Proof.
- intros m x e; functional induction (add x e m); intros; inv avl; simpl in *.
+ intros m x e; induction elt, x, e, m, (add x e m) using add_ind; clearf; intros; inv avl; simpl in *.
  - intuition; try constructor; simpl; auto; try omega_max.
  - (* LT *)
    destruct IHt; auto.
@@ -205,7 +205,7 @@ Lemma remove_min_avl_1 : forall l x e r h, avl (Node l x e r h) ->
  avl (remove_min l x e r)#1 /\
  0 <= height (Node l x e r h) - height (remove_min l x e r)#1 <= 1.
 Proof.
- intros l x e r; functional induction (remove_min l x e r); simpl in *; intros.
+ intros l x e r; induction elt, l, x, e, r, (remove_min l x e r) using remove_min_ind; clearf; simpl in *; intros.
  - inv avl; simpl in *; split; auto.
    avl_nns; omega_max.
  - inversion_clear H.
@@ -228,7 +228,7 @@ Lemma merge_avl_1 : forall m1 m2, avl m1 -> avl m2 ->
  avl (merge m1 m2) /\
  0<= height (merge m1 m2) - max (height m1) (height m2) <=1.
 Proof.
- intros m1 m2; functional induction (merge m1 m2); intros;
+ intros m1 m2; induction elt, m1, m2, (merge m1 m2) using merge_ind; clearf; intros;
  try factornode _x _x0 _x1 _x2 _x3 as m1.
  - simpl; split; auto; avl_nns; omega_max.
  - simpl; split; auto; avl_nns; omega_max.
@@ -252,7 +252,7 @@ Qed.
 Lemma remove_avl_1 : forall m x, avl m ->
  avl (remove x m) /\ 0 <= height m - height (remove x m) <= 1.
 Proof.
- intros m x; functional induction (remove x m); intros.
+ intros m x; induction elt, x, m, (remove x m) using remove_ind; clearf; intros.
  - split; auto; omega_max.
  - (* LT *)
    inv avl.
@@ -343,7 +343,7 @@ Hint Resolve join_avl : core.
 
 Lemma concat_avl : forall m1 m2, avl m1 -> avl m2 -> avl (concat m1 m2).
 Proof.
- intros m1 m2; functional induction (concat m1 m2); auto.
+ intros m1 m2; induction elt, m1, m2, (concat m1 m2) using concat_ind; clearf; auto.
  intros; apply join_avl; auto.
  generalize (remove_min_avl H0); rewrite e1; simpl; auto.
 Qed.
@@ -355,7 +355,7 @@ Hint Resolve concat_avl : core.
 Lemma split_avl : forall m x, avl m ->
   avl (split x m)#l /\ avl (split x m)#r.
 Proof.
- intros m x; functional induction (split x m); simpl; auto.
+ intros m x; induction elt, x, m, (split x m) using split_ind; clearf; simpl; auto.
  - rewrite e1 in IHt;simpl in IHt;inversion_clear 1; intuition.
  - simpl; inversion_clear 1; auto.
  - rewrite e1 in IHt;simpl in IHt;inversion_clear 1; intuition.
@@ -424,7 +424,7 @@ Notation map2_opt := (map2_opt f mapl mapr).
 Lemma map2_opt_avl : forall m1 m2, avl m1 -> avl m2 ->
  avl (map2_opt m1 m2).
 Proof.
-intros m1 m2; functional induction (map2_opt m1 m2); auto;
+intros m1 m2; induction elt, elt', elt'', f, mapl, mapr, m1, m2, (map2_opt m1 m2) using map2_opt_ind; clearf; auto;
 factornode _x0 _x1 _x2 _x3 _x4 as r2; intros;
 destruct (split_avl x1 H0); rewrite e1 in *; simpl in *; inv avl;
 auto using join_avl, concat_avl.
@@ -728,7 +728,7 @@ Module IntMake_ord (I:Int)(X: OrderedType)(D : OrderedType) <:
   Lemma compare_aux_Cmp : forall e,
    Cmp (compare_aux e) (flatten_e (fst e)) (flatten_e (snd e)).
   Proof.
-  intros e; functional induction (compare_aux e); simpl in *;
+  intros e; induction e, (compare_aux e) using compare_aux_ind; clearf; simpl in *;
    auto; intros; try clear e0; try clear e3; try MX.elim_comp; auto.
   rewrite 2 cons_1 in IHc; auto.
   Qed.

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -381,7 +381,7 @@ Qed.
 Lemma bal_spec : forall l x r y,
  InT y (bal l x r) <-> X.eq y x \/ InT y l \/ InT y r.
 Proof.
- intros l x r; functional induction bal l x r; intros; try clear e0;
+ intros l x r; induction l, x, r, (bal l x r) using bal_ind; subst; intros; try clear e0;
  rewrite !create_spec; intuition_in.
 Qed.
 
@@ -389,7 +389,7 @@ Qed.
 Instance bal_ok l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r) :
  Ok (bal l x r).
 Proof.
- functional induction bal l x r; intros;
+ induction l, x, r, (bal l x r) using bal_ind; subst; intros;
  inv; repeat apply create_ok; auto; unfold create;
  (apply lt_tree_node || apply gt_tree_node); auto;
  (eapply lt_tree_trans || eapply gt_tree_trans); eauto.
@@ -469,7 +469,7 @@ Lemma remove_min_spec : forall l x r y h,
  InT y (Node h l x r) <->
   X.eq y (remove_min l x r)#2 \/ InT y (remove_min l x r)#1.
 Proof.
- intros l x r; functional induction (remove_min l x r); simpl in *; intros.
+ intros l x r; induction l, x, r, (remove_min l x r) using remove_min_ind; subst; simpl in *; intros.
  - intuition_in.
  - rewrite bal_spec, In_node_iff, IHp, e0; simpl; intuition.
 Qed.
@@ -478,7 +478,7 @@ Qed.
 Instance remove_min_ok l x r : forall h `(Ok (Node h l x r)),
  Ok (remove_min l x r)#1.
 Proof.
- functional induction (remove_min l x r); simpl; intros.
+ induction l, x, r, (remove_min l x r) using remove_min_ind; subst; simpl; intros.
  - inv; auto.
  - assert (O : Ok (Node _x ll lx lr)) by (inv; auto).
    assert (L : lt_tree x (Node _x ll lx lr)) by (inv; auto).
@@ -493,7 +493,7 @@ Qed.
 Lemma remove_min_gt_tree : forall l x r h `{Ok (Node h l x r)},
  gt_tree (remove_min l x r)#2 (remove_min l x r)#1.
 Proof.
- intros l x r; functional induction (remove_min l x r); simpl; intros.
+ intros l x r; induction l, x, r, (remove_min l x r) using remove_min_ind; subst; simpl; intros.
  - inv; auto.
  - assert (O : Ok (Node _x ll lx lr)) by (inv; auto).
    assert (L : lt_tree x (Node _x ll lx lr)) by (inv; auto).
@@ -510,7 +510,7 @@ Local Hint Resolve remove_min_gt_tree : core.
 Lemma merge_spec : forall s1 s2 y,
  InT y (merge s1 s2) <-> InT y s1 \/ InT y s2.
 Proof.
- intros s1 s2; functional induction (merge s1 s2); intros;
+ intros s1 s2; induction s1, s2, (merge s1 s2) using merge_ind; subst; intros;
   try factornode s1.
  - intuition_in.
  - intuition_in.
@@ -522,7 +522,7 @@ Instance merge_ok s1 s2 : forall `(Ok s1, Ok s2)
  `(forall y1 y2 : elt, InT y1 s1 -> InT y2 s2 -> X.lt y1 y2),
  Ok (merge s1 s2).
 Proof.
- functional induction (merge s1 s2); intros; auto;
+ induction s1, s2, (merge s1 s2) using merge_ind; subst; intros; auto;
   try factornode s1.
  apply bal_ok; auto.
  - change s2' with ((s2',m)#1); rewrite <-e1; eauto with *.
@@ -568,7 +568,7 @@ Qed.
 Lemma concat_spec : forall s1 s2 y,
  InT y (concat s1 s2) <-> InT y s1 \/ InT y s2.
 Proof.
- intros s1 s2; functional induction (concat s1 s2); intros;
+ intros s1 s2; induction s1, s2, (concat s1 s2) using concat_ind; subst; intros;
   try factornode s1.
  - intuition_in.
  - intuition_in.
@@ -580,7 +580,7 @@ Instance concat_ok s1 s2 : forall `(Ok s1, Ok s2)
  `(forall y1 y2 : elt, InT y1 s1 -> InT y2 s2 -> X.lt y1 y2),
  Ok (concat s1 s2).
 Proof.
- functional induction (concat s1 s2); intros; auto;
+  induction s1, s2, (concat s1 s2) using concat_ind; subst; intros; auto;
   try factornode s1.
  apply join_ok; auto.
  - change (Ok (s2',m)#1); rewrite <-e1; eauto with *.
@@ -665,7 +665,7 @@ Ltac destruct_split := match goal with
 Lemma inter_spec_ok : forall s1 s2 `{Ok s1, Ok s2},
  Ok (inter s1 s2) /\ (forall y, InT y (inter s1 s2) <-> InT y s1 /\ InT y s2).
 Proof.
- intros s1 s2; functional induction inter s1 s2; intros B1 B2;
+ intros s1 s2; induction s1, s2, (inter s1 s2) using inter_ind; subst; intros B1 B2;
  [intuition_in|intuition_in | | ]; factornode s2;
  destruct_split; inv;
  destruct IHt0 as (IHo1,IHi1), IHt1 as (IHo2,IHi2); auto with *;
@@ -700,7 +700,7 @@ Proof. intros; destruct (@inter_spec_ok s1 s2); auto. Qed.
 Lemma diff_spec_ok : forall s1 s2 `{Ok s1, Ok s2},
  Ok (diff s1 s2) /\ (forall y, InT y (diff s1 s2) <-> InT y s1 /\ ~InT y s2).
 Proof.
- intros s1 s2; functional induction diff s1 s2; intros B1 B2;
+ intros s1 s2; induction s1, s2, (diff s1 s2) using diff_ind; subst; intros B1 B2;
  [intuition_in|intuition_in | | ]; factornode s2;
  destruct_split; inv;
  destruct IHt0 as (IHb1,IHi1), IHt1 as (IHb2,IHi2); auto with *;
@@ -736,7 +736,7 @@ Proof. intros; destruct (@diff_spec_ok s1 s2); auto. Qed.
 Lemma union_spec : forall s1 s2 y `{Ok s1, Ok s2},
  (InT y (union s1 s2) <-> InT y s1 \/ InT y s2).
 Proof.
- intros s1 s2; functional induction union s1 s2; intros y B1 B2.
+ intros s1 s2; induction s1, s2, (union s1 s2) using union_ind; subst; intros y B1 B2.
  - intuition_in.
  - intuition_in.
  - factornode s2; destruct_split; inv.
@@ -747,7 +747,7 @@ Qed.
 #[global]
 Instance union_ok s1 s2 : forall `(Ok s1, Ok s2), Ok (union s1 s2).
 Proof.
- functional induction union s1 s2; intros B1 B2; auto.
+ induction s1, s2, (union s1 s2) using union_ind; subst; intros B1 B2; auto.
  factornode s2; destruct_split; inv.
  apply join_ok; auto with *.
  - intro y; rewrite union_spec, split_spec1; intuition_in; exact _.


### PR DESCRIPTION
This reduces the reliance of the stdlib on the plugin whose name must not be uttered. The diff is so trivial I do not really understand why we have a spaghetti wrapper around induction except for adding fragility. It should be the job of induction to perform the administrative task of finding the parameters.
