### PR TITLE
[ci] [docker] Bump edge Dune version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2024-01-08-011994e15c"
-  EDGE_CACHEKEY: "edge_ubuntu-V2024-02-08-93cae959db"
+  EDGE_CACHEKEY: "edge_ubuntu-V2024-02-08-3ed9c93d7c"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -39,7 +39,7 @@ ENV NJOBS="2" \
 ENV COMPILER="4.14.1" \
     BASE_OPAM="zarith.1.13 ounit2.2.2.6" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
-    BASE_OPAM_EDGE="dune.3.12.1 dune-build-info.3.12.1 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.3.1" \
+    BASE_OPAM_EDGE="dune.3.14.0 dune-build-info.3.14.0 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.3.1" \
     CI_OPAM_EDGE="elpi.1.18.1 ppx_import.1.10.0 cmdliner.1.1.1 sexplib.v0.15.1 ppx_sexp_conv.v0.15.1 ppx_hash.v0.15.0 ppx_compare.v0.15.0 ppx_deriving_yojson.3.7.0 yojson.2.1.0 uri.4.2.0 ppx_yojson_conv.v0.15.1 ppx_inline_test.v0.15.1 ppx_assert.v0.15.0 ppx_optcomp.v0.15.0 lsp.1.16.2 sel.0.4.0" \
     COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.3"
 


### PR DESCRIPTION
This version fixes a few bugs, but moreover it finally supports including generated dune files.

Thus, we can start to experiment with removal of the `dunestrap` step in the build setup.
