### PR TITLE
Remove the Lforce node from the generic lambda AST.

### DIFF
--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -41,7 +41,6 @@ type 'v lambda =
 | Lval          of 'v
 | Lsort         of Sorts.t
 | Lind          of pinductive
-| Lforce
 
 and 'v lam_branches =
   { constant_branches : 'v lambda array;
@@ -91,7 +90,6 @@ module type S =
 sig
   type value
   val as_value : int -> value lambda array -> value option
-  val get_constant : pconstant -> Declarations.constant_body -> value lambda
   val check_inductive : inductive -> Declarations.mutual_inductive_body -> unit
 end
 

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -52,6 +52,11 @@ let fresh_lname n =
   incr lname_ctr;
   { lname = n; luid = !lname_ctr }
 
+let is_lazy t =
+  match Constr.kind t with
+  | App _ | LetIn _ | Case _ | Proj _ -> true
+  | _ -> false
+
 type prefix = string
 
 (* Linked code location utilities *)
@@ -66,6 +71,12 @@ let get_const_prefix env c =
    match !nameref with
    | NotLinked -> ""
    | Linked s -> s
+
+let get_const_lazy env c =
+  let cb = Environ.lookup_constant c env in
+  match cb.const_body with
+  | Def body -> is_lazy body
+  | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> false
 
 (** Global names **)
 type gname =
@@ -865,16 +876,18 @@ type env =
       env_named : (Id.t * mllambda) list ref;
       env_univ : lname option;
       env_const_prefix : Constant.t -> prefix;
+      env_const_lazy : Constant.t -> bool;
       env_mind_prefix : MutInd.t -> prefix;
     }
 
-let empty_env univ get_const get_mind =
+let empty_env univ get_const const_lazy get_mind =
   { env_rel = [];
     env_bound = 0;
     env_urel = ref [];
     env_named = ref [];
     env_univ = univ;
     env_const_prefix = get_const;
+    env_const_lazy = const_lazy;
     env_mind_prefix = get_mind;
   }
 
@@ -1225,7 +1238,9 @@ let compile_prim env decl cond paux =
   | Lconst (c, u) ->
      let prefix = env.env_const_prefix c in
      let args = ml_of_instance env.env_univ u in
-     mkMLapp (MLglobal(Gconstant (prefix, c))) args
+     let ans = mkMLapp (MLglobal(Gconstant (prefix, c))) args in
+     if env.env_const_lazy c then MLapp (MLglobal (Ginternal "Lazy.force"), [|ans|])
+     else ans
   | Lproj (p, c) ->
     let ind = Projection.Repr.inductive p in
     let i = Projection.Repr.arg p in
@@ -1252,14 +1267,14 @@ let compile_prim env decl cond paux =
           asw_finite = knd <> CoFinite;
           asw_prefix = env.env_mind_prefix (fst ci.ci_ind);
       } in
-      let env_p = empty_env env.env_univ env.env_const_prefix env.env_mind_prefix in
+      let env_p = empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix in
       let pn = fresh_gpred l in
       let mlp = ml_of_lam env_p l p in
       let mlp = generalize_fv env_p mlp in
       let (pfvn,pfvr) = !(env_p.env_named), !(env_p.env_urel) in
       let pn = push_global_let pn mlp in
       (* Compilation of the case *)
-      let env_c = empty_env env.env_univ env.env_const_prefix env.env_mind_prefix in
+      let env_c = empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix in
       let a_uid = fresh_lname Anonymous in
       let la_uid = MLlocal a_uid in
       (* compilation of branches *)
@@ -1313,7 +1328,7 @@ let compile_prim env decl cond paux =
            start
       *)
       (* Compilation of type *)
-      let env_t = empty_env env.env_univ env.env_const_prefix env.env_mind_prefix in
+      let env_t = empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix in
       let ml_t = Array.map (ml_of_lam env_t l) tt in
       let params_t = fv_params env_t in
       let args_t = fv_args env !(env_t.env_named) !(env_t.env_urel) in
@@ -1322,7 +1337,7 @@ let compile_prim env decl cond paux =
       let mk_type = MLapp(MLglobal gft, args_t) in
       (* Compilation of norm_i *)
       let ndef = Array.length ids in
-      let lf,env_n = push_rels (empty_env env.env_univ env.env_const_prefix env.env_mind_prefix) ids in
+      let lf,env_n = push_rels (empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix) ids in
       let t_params = Array.make ndef [||] in
       let t_norm_f = Array.make ndef (Gnorm (l,-1)) in
       let mk_let _envi (id,def) t = MLlet (id,def,t) in
@@ -1380,7 +1395,7 @@ let compile_prim env decl cond paux =
       MLletrec(Array.mapi mkrec lf, lf_args.(start))
   | Lcofix (start, (ids, tt, tb)) ->
       (* Compilation of type *)
-      let env_t = empty_env env.env_univ env.env_const_prefix env.env_mind_prefix in
+      let env_t = empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix in
       let ml_t = Array.map (ml_of_lam env_t l) tt in
       let params_t = fv_params env_t in
       let args_t = fv_args env !(env_t.env_named) !(env_t.env_urel) in
@@ -1389,7 +1404,7 @@ let compile_prim env decl cond paux =
       let mk_type = MLapp(MLglobal gft, args_t) in
       (* Compilation of norm_i *)
       let ndef = Array.length ids in
-      let lf,env_n = push_rels (empty_env env.env_univ env.env_const_prefix env.env_mind_prefix) ids in
+      let lf,env_n = push_rels (empty_env env.env_univ env.env_const_prefix env.env_const_lazy env.env_mind_prefix) ids in
       let t_params = Array.make ndef [||] in
       let t_norm_f = Array.make ndef (Gnorm (l,-1)) in
       let ml_of_fix i body =
@@ -1473,10 +1488,9 @@ let compile_prim env decl cond paux =
      let prefix = env.env_mind_prefix (fst ind) in
      let uargs = ml_of_instance env.env_univ u in
      mkMLapp (MLglobal (Gind (prefix, ind))) uargs
-  | Lforce -> MLglobal (Ginternal "Lazy.force")
 
-let mllambda_of_lambda univ constpref mindpref auxdefs l t =
-  let env = empty_env univ constpref mindpref in
+let mllambda_of_lambda univ constpref constlazy mindpref auxdefs l t =
+  let env = empty_env univ constpref constlazy mindpref in
   global_stack := auxdefs;
   let ml = ml_of_lam env l t in
   let fv_rel = !(env.env_urel) in
@@ -2008,8 +2022,9 @@ let pp_global fmt g =
 (** Compilation of elements in environment **)
 let rec compile_with_fv ?(wrap = fun t -> t) env sigma univ auxdefs l t =
   let const_prefix c = get_const_prefix env c in
+  let const_lazy = get_const_lazy env in
   let mind_prefix c = get_mind_prefix env c in
-  let (auxdefs,(fv_named,fv_rel),ml) = mllambda_of_lambda univ const_prefix mind_prefix auxdefs l t in
+  let (auxdefs,(fv_named,fv_rel),ml) = mllambda_of_lambda univ const_prefix const_lazy mind_prefix auxdefs l t in
   let ml = wrap ml in
   if List.is_empty fv_named && List.is_empty fv_rel then (auxdefs,ml)
   else apply_fv env sigma univ (fv_named,fv_rel) auxdefs ml

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -52,10 +52,12 @@ let fresh_lname n =
   incr lname_ctr;
   { lname = n; luid = !lname_ctr }
 
-let is_lazy t =
-  match Constr.kind t with
-  | App _ | LetIn _ | Case _ | Proj _ -> true
-  | _ -> false
+let rec is_lazy t = match Constr.kind t with
+| App _ | LetIn _ | Case _ | Proj _ -> true
+| Cast (c,_, _) -> is_lazy c
+| Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _ | Int _
+| Float _ | Prod _ | Lambda _ | Evar _ | Fix _ | CoFix _ | Array _ ->
+  false
 
 let is_lazy_constant cb =
   (* Bound universes are turned into lambda-abstractions *)

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -10,7 +10,6 @@
 
 open Util
 open Esubst
-open Constr
 open Genlambda
 
 (** This file defines the lambda code generation phase of the native compiler *)
@@ -54,20 +53,11 @@ let as_value tag args =
     Some (Nativevalues.mk_block tag args)
   else None
 
-let is_lazy t =
-  match Constr.kind t with
-  | App _ | LetIn _ | Case _ | Proj _ -> true
-  | _ -> false
-
 module Val =
 struct
-  open Declarations
   type value = Nativevalues.t
   let as_value = as_value
   let check_inductive _ _ = ()
-  let get_constant knu cb = match cb.const_body with
-  | Def body -> if is_lazy body then mkLapp Lforce [|Lconst knu|] else Lconst knu
-  | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> assert false
 end
 
 module Lambda = Genlambda.Make(Val)

--- a/kernel/nativelambda.mli
+++ b/kernel/nativelambda.mli
@@ -7,14 +7,12 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-open Constr
+
 open Environ
 open Genlambda
 
 (** This file defines the lambda code generation phase of the native compiler *)
 
 type lambda = Nativevalues.t Genlambda.lambda
-
-val is_lazy : constr -> bool
 
 val lambda_of_constr : env -> evars -> Constr.constr -> lambda

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -809,8 +809,6 @@ let rec compile_lam env cenv lam sz cont =
       comp_args (compile_lam env) cenv args sz (Kprim(op, kn)::cont)
     end
 
-  | Lforce -> CErrors.anomaly Pp.(str "The VM should not use force")
-
 and compile_get_global env cenv (kn,u) sz cont =
   let () = set_max_stack_size cenv sz in
   if UVars.Instance.is_empty u then

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -50,7 +50,6 @@ struct
   let check_inductive (_, i) mb =
     let { mind_typename=name; mind_nb_args; mind_nb_constant; _ } = mb.mind_packets.(i) in
     Vmerrors.check_compilable_ind ~name ~mind_nb_args ~mind_nb_constant
-  let get_constant knu _ = Lconst knu
 end
 
 module Lambda = Genlambda.Make(Val)

--- a/test-suite/bugs/bug_18715.v
+++ b/test-suite/bugs/bug_18715.v
@@ -1,0 +1,22 @@
+Section Foo.
+
+Variable f : nat -> nat.
+
+Definition foo := f 0.
+
+Eval native_compute in foo.
+
+End Foo.
+
+Set Universe Polymorphism.
+
+Section Bar.
+
+Universe u.
+
+Variable f : nat -> Type@{u}.
+Definition bar := f 0.
+
+Eval native_compute in bar.
+
+End Bar.


### PR DESCRIPTION
We move the code responsible from the generation of the forcing of lazy constants in the native compiler to the second compilation phase. This also has the nice side-effect of encapsulating the code that decides to make a constant lazy behind a sealed API.

Additionally fixes the following issues discovered in the meantime.

Fixes #18715: Incorrect compilation of lazy native definitions.
Partial fix of #18703: Incorrect characterization of computational terms in native_compute.