### PR TITLE
Use Loc.raise instead of raise in Require for missing libraries

### DIFF
--- a/test-suite/output/bug_15097.out
+++ b/test-suite/output/bug_15097.out
@@ -1,7 +1,7 @@
-File "./output/bug_15097.v", line 1, characters 0-39:
+File "./output/bug_15097.v", line 1, characters 20-38:
 The command has indeed failed with message:
 Cannot find a physical path bound to logical path Coq.Does.Not.Exist.
-File "./output/bug_15097.v", line 2, characters 0-44:
+File "./output/bug_15097.v", line 2, characters 29-43:
 The command has indeed failed with message:
 Cannot find a physical path bound to logical path
 Does.Not.Exist with prefix Coq.

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -293,8 +293,8 @@ let synterp_require from export qidl =
     let open Loadpath in
     match locate_qualified_library ?root qid with
     | Ok (dir,_) -> dir
-    | Error LibUnmappedDir -> raise (UnmappedLibrary (root, qid))
-    | Error LibNotFound -> raise (NotFoundLibrary (root, qid))
+    | Error LibUnmappedDir -> Loc.raise ?loc:qid.loc (UnmappedLibrary (root, qid))
+    | Error LibNotFound -> Loc.raise ?loc:qid.loc (NotFoundLibrary (root, qid))
   in
   let modrefl = List.map locate qidl in
   let lib_resolver = Loadpath.try_locate_absolute_library in


### PR DESCRIPTION
This has the benefit of forwarding a loc, which is then used by vscoq-language-server to correctly display the error message.
