### PR TITLE
Declaremods collect_export: preserve strict equality

### DIFF
--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -50,6 +50,11 @@ let in_filter ~cat f =
 
 let simple_open ?cat f filter i o = if in_filter ~cat filter then f i o
 
+let filter_eq f1 f2 = match f1, f2 with
+  | Unfiltered, Unfiltered -> true
+  | Unfiltered, _ | _, Unfiltered -> false
+  | Filtered f1, Filtered f2 -> CString.Pred.equal f1 f2
+
 let filter_and f1 f2 = match f1, f2 with
   | Unfiltered, f | f, Unfiltered -> Some f
   | Filtered f1, Filtered f2 ->

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -109,6 +109,8 @@ val simple_open : ?cat:category -> ('i -> 'a -> unit) ->
    behaviour. When [cat:None], can be opened by Unfiltered, but also
    by Filtered with a negative set. *)
 
+val filter_eq : open_filter -> open_filter -> bool
+
 val filter_and : open_filter -> open_filter -> open_filter option
 (** Returns [None] when the intersection is empty. *)
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -465,15 +465,12 @@ and collect_export f (f',mp) (exports,objs as acc) =
   | Some f ->
     let exports' = MPmap.update mp (function
         | None -> Some f
-        | Some f0 -> Some (filter_or f f0))
+        | Some f0 ->
+          let f' = filter_or f f0 in
+          if filter_eq f' f0 then Some f0 else Some f')
         exports
     in
-    (* If the map doesn't change there is nothing new to export.
-
-       It's possible that [filter_and] or [filter_or] mangled precise
-       filters such that we repeat uselessly, but the important
-       [Unfiltered] case is handled correctly.
-    *)
+    (* If the map doesn't change there is nothing new to export. *)
     if exports == exports' then acc
     else
       collect_module (f,mp) (exports', objs)


### PR DESCRIPTION
Fix #18697

We could fix filter_or to avoid breaking physical equality instead but assuming the bench does't complain I think using semantic equality is nicer.
