### PR TITLE
More explicit error message for NotAllowedCaseAnalysis

### DIFF
--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -55,8 +55,7 @@ type ('constr, 'types) ptype_error =
   | NotAType of ('constr, 'types) punsafe_judgment
   | BadAssumption of ('constr, 'types) punsafe_judgment
   | ReferenceVariables of Id.t * GlobRef.t
-  | ElimArity of pinductive * 'constr *
-    (('constr, 'types) punsafe_judgment * Sorts.t) option
+  | ElimArity of pinductive * 'constr * Sorts.t option
   | CaseNotInductive of ('constr, 'types) punsafe_judgment
   | CaseOnPrivateInd of inductive
   | WrongCaseInfo of pinductive * case_info
@@ -213,8 +212,7 @@ let map_ptype_error f = function
 | ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ as e -> e
 | NotAType j -> NotAType (on_judgment f j)
 | BadAssumption j -> BadAssumption (on_judgment f j)
-| ElimArity (pi, c, ar) ->
-  ElimArity (pi, f c, Option.map (fun (j, s1) -> (on_judgment f j, s1)) ar)
+| ElimArity (pi, c, ar) -> ElimArity (pi, f c, ar)
 | CaseNotInductive j -> CaseNotInductive (on_judgment f j)
 | WrongCaseInfo (pi, ci) -> WrongCaseInfo (pi, ci)
 | NumberBranches (j, n) -> NumberBranches (on_judgment f j, n)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -57,8 +57,7 @@ type ('constr, 'types) ptype_error =
   | NotAType of ('constr, 'types) punsafe_judgment
   | BadAssumption of ('constr, 'types) punsafe_judgment
   | ReferenceVariables of Id.t * GlobRef.t
-  | ElimArity of pinductive * 'constr *
-      (('constr, 'types) punsafe_judgment * Sorts.t) option
+  | ElimArity of pinductive * 'constr * Sorts.t option
   | CaseNotInductive of ('constr, 'types) punsafe_judgment
   | CaseOnPrivateInd of inductive
   | WrongCaseInfo of pinductive * case_info
@@ -119,8 +118,7 @@ val error_assumption : env -> unsafe_judgment -> 'a
 val error_reference_variables : env -> Id.t -> GlobRef.t -> 'a
 
 val error_elim_arity :
-  env -> pinductive -> constr ->
-    (unsafe_judgment * Sorts.t) option -> 'a
+  env -> pinductive -> constr -> Sorts.t option -> 'a
 
 val error_case_not_inductive : env -> unsafe_judgment -> 'a
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -551,8 +551,7 @@ let type_of_case env (mib, mip as specif) ci u pms (pctx, pnas, p, rp, pt) iv c 
     then error_bad_invert env
   in
   let () = if not (is_allowed_elimination (specif,u) sp) then begin
-    let pj = make_judge (it_mkLambda_or_LetIn p pctx) (it_mkProd_or_LetIn pt pctx) in
-    let kinds = Some (pj, sp) in
+    let kinds = Some sp in
     error_elim_arity env (ind, u') c kinds
   end
   in

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -120,7 +120,7 @@ let error_ill_typed_rec_body ?loc env sigma i na jl tys =
 
 let error_elim_arity ?loc env sigma pi c a =
   (* XXX type_errors should have a 'sort type parameter *)
-  let a = Option.map (fun (x,s) -> x, EConstr.Unsafe.to_sorts s) a in
+  let a = Option.map EConstr.Unsafe.to_sorts a in
   raise_type_error ?loc
     (env, sigma, ElimArity (pi, c, a))
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -115,8 +115,7 @@ val error_ill_typed_rec_body :
 
 val error_elim_arity :
   ?loc:Loc.t -> env -> Evd.evar_map ->
-      pinductive -> constr ->
-      (unsafe_judgment * ESorts.t) option -> 'b
+      pinductive -> constr -> ESorts.t option -> 'b
 
 val error_not_a_type :
   ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'b

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -267,7 +267,7 @@ let check_allowed_sort env sigma ind c p =
   if Inductiveops.is_allowed_elimination sigma (specif,(snd ind)) sort then
     ESorts.relevance_of_sort sigma sort
   else
-    error_elim_arity env sigma ind c (Some (pj, sort))
+    error_elim_arity env sigma ind c (Some sort)
 
 let check_actual_type env sigma cj t =
   try Evarconv.unify_leq_delay env sigma cj.uj_type t

--- a/test-suite/output/SchemeNames.out
+++ b/test-suite/output/SchemeNames.out
@@ -1,12 +1,24 @@
 File "./output/SchemeNames.v", line 14, characters 2-47:
 The command has indeed failed with message:
-Induction on sort Prop is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Prop" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Prop"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 15, characters 2-46:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Set" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Set"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 16, characters 2-47:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Type" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type"
+because strict proofs can be eliminated only to build strict proofs.
 fooSProp_inds :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
 
@@ -16,13 +28,25 @@ fooSProp_inds is transparent
 Expands to: Constant SchemeNames.fooSProp_inds
 File "./output/SchemeNames.v", line 23, characters 2-48:
 The command has indeed failed with message:
-Induction on sort Prop is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Prop" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Prop"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 24, characters 2-47:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Set" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Set"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 25, characters 2-48:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Type" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type"
+because strict proofs can be eliminated only to build strict proofs.
 fooSProp_inds_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
 fooSProp_inds_nodep is not universe polymorphic
@@ -31,13 +55,25 @@ fooSProp_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_inds_nodep
 File "./output/SchemeNames.v", line 32, characters 2-49:
 The command has indeed failed with message:
-Induction on sort Prop is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Prop" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Prop"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 33, characters 2-48:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Set" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Set"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 34, characters 2-49:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Type" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type"
+because strict proofs can be eliminated only to build strict proofs.
 fooSProp_cases :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
 
@@ -47,13 +83,25 @@ fooSProp_cases is transparent
 Expands to: Constant SchemeNames.fooSProp_cases
 File "./output/SchemeNames.v", line 41, characters 2-42:
 The command has indeed failed with message:
-Induction on sort Prop is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Prop" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Prop"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 42, characters 2-41:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Set" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Set"
+because strict proofs can be eliminated only to build strict proofs.
 File "./output/SchemeNames.v", line 43, characters 2-42:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooSProp.
+Incorrect elimination in the inductive type "fooSProp":
+the return type has sort "Type" while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type"
+because strict proofs can be eliminated only to build strict proofs.
 fooSProp_cases_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
 fooSProp_cases_nodep is not universe polymorphic
@@ -66,10 +114,18 @@ Cannot extract computational content from proposition
 "fooSProp".
 File "./output/SchemeNames.v", line 61, characters 2-45:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Set" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Set"
+because proofs can be eliminated only to build proofs.
 File "./output/SchemeNames.v", line 62, characters 2-46:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Type" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type"
+because proofs can be eliminated only to build proofs.
 fooProp_inds_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
 
@@ -86,10 +142,18 @@ fooProp_ind_dep is transparent
 Expands to: Constant SchemeNames.fooProp_ind_dep
 File "./output/SchemeNames.v", line 71, characters 2-46:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Set" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Set"
+because proofs can be eliminated only to build proofs.
 File "./output/SchemeNames.v", line 72, characters 2-47:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Type" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type"
+because proofs can be eliminated only to build proofs.
 fooProp_inds : forall P : SProp, P -> P -> fooProp -> P
 
 fooProp_inds is not universe polymorphic
@@ -104,10 +168,18 @@ fooProp_ind is transparent
 Expands to: Constant SchemeNames.fooProp_ind
 File "./output/SchemeNames.v", line 81, characters 2-47:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Set" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Set"
+because proofs can be eliminated only to build proofs.
 File "./output/SchemeNames.v", line 82, characters 2-48:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Type" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type"
+because proofs can be eliminated only to build proofs.
 fooProp_cases_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
 
@@ -124,10 +196,18 @@ fooProp_case_dep is transparent
 Expands to: Constant SchemeNames.fooProp_case_dep
 File "./output/SchemeNames.v", line 91, characters 2-40:
 The command has indeed failed with message:
-Induction on sort Set is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Set" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Set"
+because proofs can be eliminated only to build proofs.
 File "./output/SchemeNames.v", line 92, characters 2-41:
 The command has indeed failed with message:
-Induction on sort Type is not allowed for inductive definition fooProp.
+Incorrect elimination in the inductive type "fooProp":
+the return type has sort "Type" while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type"
+because proofs can be eliminated only to build proofs.
 fooProp_cases : forall P : SProp, P -> P -> fooProp -> P
 
 fooProp_cases is not universe polymorphic

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -227,7 +227,7 @@ let explain_elim_arity env sigma ind c okinds =
   let pc = pr_leconstr_env env sigma c in
   let msg = match okinds with
     | None -> str "ill-formed elimination predicate."
-    | Some (pj, sp) ->
+    | Some sp ->
       let ppt ?(ppunivs=false) () =
         let pp () = pr_leconstr_env env sigma (mkSort (ESorts.make sp)) in
         if ppunivs then Flags.with_option Constrextern.print_universes pp ()

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -306,7 +306,7 @@ let warning_or_error ~info flags indsp err =
            strbrk " not defined.")
     | BadTypedProj (fi,env,te) ->
       let err = match te with
-        | ElimArity (_, _, Some (_, s)) ->
+        | ElimArity (_, _, Some s) ->
           error_elim_explain (Sorts.family s)
             (Inductiveops.elim_sort (Global.lookup_inductive indsp))
         | _ -> None


### PR DESCRIPTION

Fix #5342

This makes `destruct` and `Scheme` use the same error message as `match`.
