### PR TITLE
Ltac2: importing a mutable definition does not undo its mutations

### DIFF
--- a/doc/changelog/06-Ltac2-language/18713-ltac2-original-redef-no-import.rst
+++ b/doc/changelog/06-Ltac2-language/18713-ltac2-original-redef-no-import.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :cmd:`Import`\ing a module containing a mutable Ltac2 definition
+  does not undo its mutations. Replace `Ltac2 mutable foo := some_expr.`
+  with `Ltac2 mutable foo := some_expr. Ltac2 Set foo := some_expr.`
+  to recover the previous behaviour
+  (`#18713 <https://github.com/coq/coq/pull/18713>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -319,6 +319,12 @@ Ltac2 Definitions
    The previous value of the binding can be optionally accessed using the `as`
    binding syntax.
 
+   The effect of this command is limited to the current section or module.
+   When not in a section, importing the module containing this command
+   applies the redefinition again.
+   In other words it acts according to :attr:`local` in sections and
+   :attr:`export` otherwise (but explicit locality is not supported).
+
    .. example:: Dynamic nature of mutable cells
 
       .. coqtop:: all


### PR DESCRIPTION
cf #10556

The previous behaviour can be gotten by doing eg

~~~coq
(* auxiliary definition to avoid repeating it, if it's a simple expression it can also be inlined *)
Ltac2 original_def := ...

Ltac2 mutable the_def := original_def.

Ltac2 Set the_def := original_def.
~~~

instead of `Ltac2 mutable the_def := ...`.

Also add test for Ltac2 mutable definitions vs Import/Export.

This exposes some complex behaviour around repeated imports when using `Set as`.
