### PR TITLE
Ltac2 `assert` scope: intern and typecheck types as types

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -164,6 +164,8 @@ let ensure_scope scope = check_scope ~tolerant:true scope
 
 let find_scope scope = find_scope scope
 
+let scope_delimiters scope = scope.delimiters
+
 (* [sc] might be here a [scope_name] or a [delimiter]
    (now allowed after Open Scope) *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -60,6 +60,8 @@ val push_scope : scope_name -> scopes -> scopes
 
 val find_scope : scope_name -> scope
 
+val scope_delimiters : scope -> delimiters option
+
 (** Declare delimiters for printing *)
 
 val declare_delimiters : scope_name -> delimiters -> unit

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -33,6 +33,7 @@ let prefix_gen n =
 let control_prefix = prefix_gen "Control"
 let pattern_prefix = prefix_gen "Pattern"
 let array_prefix = prefix_gen "Array"
+let constr_prefix = prefix_gen "Constr"
 let format_prefix = MPdot (prefix_gen "Message", Label.make "Format")
 
 let kername prefix n = KerName.make prefix (Label.of_id (Id.of_string_soft n))
@@ -40,6 +41,13 @@ let std_core n = kername Tac2env.std_prefix n
 let coq_core n = kername Tac2env.coq_prefix n
 let control_core n = kername control_prefix n
 let pattern_core n = kername pattern_prefix n
+
+let in_constr mods n =
+  let mp = List.fold_left (fun mp mod_ -> MPdot (mp, Label.of_id @@ Id.of_string mod_))
+      constr_prefix
+      mods
+  in
+  kername mp n
 
 let global_ref ?loc kn =
   CAst.make ?loc @@ CTacRef (AbsKn (TacConstant kn))
@@ -100,13 +108,12 @@ let of_anti f = function
 
 let of_ident {loc;v=id} = inj_wit ?loc wit_ident id
 
-let quote_constr ?delimiters c =
+let quote_constr ?(delimiters=[]) c =
   let loc = Constrexpr_ops.constr_loc c in
-  Option.cata
-    (List.fold_left (fun c d ->
-          CAst.make ?loc @@ Constrexpr.(CDelimiters(DelimUnboundedScope, Id.to_string d, c)))
-        c)
-    c delimiters
+  List.fold_left (fun c d ->
+      CAst.make ?loc @@ Constrexpr.(CDelimiters(DelimUnboundedScope, Id.to_string d, c)))
+    c
+    delimiters
 
 let of_constr ?delimiters c =
   let loc = Constrexpr_ops.constr_loc c in
@@ -122,6 +129,27 @@ let of_preterm ?delimiters c =
   let loc = Constrexpr_ops.constr_loc c in
   let c = quote_constr ?delimiters c in
   inj_wit ?loc wit_preterm c
+
+let of_open_constr_expected_istype ?delimiters c =
+  let {loc} as c = quote_constr ?delimiters c in
+  let mk e = CAst.make ?loc e in
+  let c =
+    let sc = Notation.current_type_scope_names () in
+    let delim = List.filter_map (fun sc -> Notation.scope_delimiters (Notation.find_scope sc)) sc in
+    (* Not sure if this puts the delimiters in the correct order, usually we have just "type" *)
+    List.fold_left (fun c delim ->
+        mk @@ Constrexpr.CDelimiters (DelimOnlyTmpScope, delim, c))
+      c
+      delim
+  in
+  let c = inj_wit ?loc wit_preterm c in
+  let gref n = global_ref ?loc n in
+  mk @@ CTacApp
+    (gref @@ in_constr ["Pretype"] "pretype",
+     [mk @@ CTacApp (gref @@ in_constr ["Pretype";"Flags"] "open_constr_flags_with_tc_kn",
+                     [of_tuple ?loc []]);
+      gref @@ in_constr ["Pretype"] "expected_istype";
+      c])
 
 let of_bool ?loc b =
   let c = if b then coq_core "true" else coq_core "false" in
@@ -532,7 +560,7 @@ let of_pose p =
 let of_assertion {loc;v=ast} = match ast with
 | QAssertType (ipat, c, tac) ->
   let ipat = of_option of_intro_pattern ipat in
-  let c = of_constr c in
+  let c = of_open_constr_expected_istype c in
   let tac = of_option thunk tac in
   std_constructor ?loc "AssertType" [ipat; c; tac]
 | QAssertValue (id, c) ->

--- a/test-suite/ltac2/std_tactics.v
+++ b/test-suite/ltac2/std_tactics.v
@@ -118,3 +118,21 @@ Goal bool -> 2 = 2.
   intros b%lem'.
   destruct b.
 Qed.
+
+(* assert interns and typechecks the type as a type
+   (bug #15094) *)
+
+Inductive my_type :=
+| my_el : my_type.
+
+Definition my_coercion (_ : my_type) := True.
+
+Coercion my_coercion : my_type >-> Sortclass.
+
+Goal False.
+  (* expected type is sortclass -> coercion inserted *)
+  assert my_el by exact I.
+
+  (* interned as with type scope locally open *)
+  assert (H' : nat * (0 * 0 = 0)) by (split; first [exact 0 | reflexivity]).
+Abort.

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -171,6 +171,9 @@ Module Pretype.
     Ltac2 Notation open_constr_flags_with_tc :=
       set_nf_evars false (set_allow_evars true constr_flags).
 
+    Local Ltac2 open_constr_flags_with_tc_kn () := open_constr_flags_with_tc.
+    (** Code generation uses this as using the notation is not convenient. *)
+
     Ltac2 Notation open_constr_flags_no_tc :=
       set_use_typeclasses false open_constr_flags_with_tc.
     (** The flags used by open_constr:() and its alias [']. *)


### PR DESCRIPTION
Fix #15094