### PR TITLE
Always set `Sys.catch_break true`, not just when interactive

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -383,7 +383,6 @@ let parse_args argv =
 (* XXX: At some point we need to either port the checker to use the
    feedback system or to remove its use completely. *)
 let init_with_argv argv =
-  Sys.catch_break false; (* Ctrl-C is fatal during the initialisation *)
   let _fhandle = Feedback.(add_feeder (console_feedback_listener Format.err_formatter)) in
   try
     parse_args argv;

--- a/doc/changelog/09-cli-tools/18716-catch-break.rst
+++ b/doc/changelog/09-cli-tools/18716-catch-break.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  signal `SIGINT` interrupts the process with " "user interrupt" error
+  instead of aborting. This is intended to produce better messages when interrupting Coq
+  (`#18716 <https://github.com/coq/coq/pull/18716>`_,
+  by Gaëtan Gilbert).

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -78,7 +78,8 @@ let init_gc () =
 let init_ocaml () =
   CProfile.init_profile ();
   init_gc ();
-  Sys.catch_break false (* Ctrl-C is fatal during the initialisation *)
+  (* Get error message (and backtrace if enabled) on Ctrl-C instead of just exiting the process *)
+  Sys.catch_break true
 
 let init_coqlib opts = match opts.Coqargs.config.Coqargs.coqlib with
   | None -> ()

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -519,7 +519,6 @@ let loop ~opts ~state =
   (* We initialize the console only if we run the toploop_run *)
   let tl_feed = Feedback.add_feeder coqloop_feed in
   (* Initialize buffer *)
-  Sys.catch_break true;
   reset_input_buffer state.Vernac.State.doc stdin top_buffer;
   (* Call the main loop *)
   let _ : Vernac.State.t = vernac_loop ~state in


### PR DESCRIPTION
When debugging it can be nice to run coqc and try to get a backtrace from interrupting it.

eg https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Debugging.20hangs

OTOH if we're hanging in such a way that we can't process signals this
may be a bad idea so maybe we should only enable it with backtraces in
non interactive mode?
