### PR TITLE
CoqIDE: Improve menu items and accelerators

### DIFF
--- a/doc/changelog/10-coqide/18717-coqide.rst
+++ b/doc/changelog/10-coqide/18717-coqide.rst
@@ -9,13 +9,13 @@
   The Edit/Undo key binding was changed from Ctrl-U to Ctrl-Z to
   be more consistent with common conventions.  `View/Previous Tab`
   and `View/Next Tab` were changed from `Alt-Left/Right` to
-  `Ctrl-Left/Right` (`Alt-Left/Right` on macOS).  To change key
+  `Ctrl-PgUp/PgDn` (`Cmd-PgUp/PgDn` on macOS).  To change key
   bindings on your system (e.g. back to Ctrl-U), see :ref:`key_bindings`
   (`#18717 <https://github.com/coq/coq/pull/18717>`_,
   by Sylvain Chiron).
 - **Changed:**
   Changing modifiers for the View menu only applies
-  to toggleable items; View/Show Proof was changed to Shift F2
+  to toggleable items; View/Show Proof was changed to Shift-F2
   (`#18717 <https://github.com/coq/coq/pull/18717>`_,
   by Sylvain Chiron).
 - **Added:**

--- a/doc/changelog/10-coqide/18717-coqide.rst
+++ b/doc/changelog/10-coqide/18717-coqide.rst
@@ -1,16 +1,25 @@
 - **Changed:**
-  Some default key bindings were changed, notably Alt
-  is now the default modifier for navigation (except on macOS)
-  just like with VsCoq
+  The default key binding modifier for the Navigation menu
+  was changed to Alt on non-macOS systems.  The previous default,
+  Ctrl, hid some conventional cursor movement bindings such as Ctrl-Left,
+  Ctrl-Right, Ctrl-Home and Ctrl-End.  The new default generally
+  has no effect if you've previously installed Coq on your
+  system.  See :ref:`Shortcuts<shortcuts>` to change the default.
+
+  The Edit/Undo key binding was changed from Ctrl-U to Ctrl-Z to
+  be more consistent with common conventions.  `View/Previous Tab`
+  and `View/Next Tab` were changed from `Alt-Left/Right` to
+  `Ctrl-Left/Right` (`Alt-Left/Right` on macOS).  To change key
+  bindings on your system (e.g. back to Ctrl-U), see :ref:`key_bindings`
   (`#18717 <https://github.com/coq/coq/pull/18717>`_,
   by Sylvain Chiron).
 - **Changed:**
   Changing modifiers for the View menu only applies
-  to togglable items
+  to toggleable items; View/Show Proof was changed to Shift F2
   (`#18717 <https://github.com/coq/coq/pull/18717>`_,
   by Sylvain Chiron).
 - **Added:**
-  “Select All” menu item in the Edit menu
+  Edit/Select All and Navigation/Fully Check menu items
   (`#18717 <https://github.com/coq/coq/pull/18717>`_,
   fixes `#16141 <https://github.com/coq/coq/issues/16141>`_,
   by Sylvain Chiron).

--- a/doc/changelog/10-coqide/18717-coqide.rst
+++ b/doc/changelog/10-coqide/18717-coqide.rst
@@ -1,0 +1,16 @@
+- **Changed:**
+  Some default key bindings were changed, notably Alt
+  is now the default modifier for navigation (except on macOS)
+  just like with VsCoq
+  (`#18717 <https://github.com/coq/coq/pull/18717>`_,
+  by Sylvain Chiron).
+- **Changed:**
+  Changing modifiers for the View menu only applies
+  to togglable items
+  (`#18717 <https://github.com/coq/coq/pull/18717>`_,
+  by Sylvain Chiron).
+- **Added:**
+  “Select All” menu item in the Edit menu
+  (`#18717 <https://github.com/coq/coq/pull/18717>`_,
+  fixes `#16141 <https://github.com/coq/coq/issues/16141>`_,
+  by Sylvain Chiron).

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -58,11 +58,12 @@ reopen the file to see your changes.  Also note:
 - Undo is also available as ``Ctrl-Z`` (`Cmd-Z` on macOS).  Redo is `Ctrl-Shift-Z`
   (`Shift-Cmd-Z` on macOS).
 - Select all is `Ctrl-A` (`Cmd-A` on macOS).
-- `Home` and `End` move the cursor to the beginning or end of the current line.
-- If you remove the default bindings for `Ctrl-Home` and `Ctrl-End`, these keys
-  will move the cursor to the beginning or end of the buffer.
-- `Ctrl-Delete` deletes a word of text after the cursor
-- `Ctrl-Backspace` deletes a word of text before the cursor
+- `Home` and `End` move the cursor to the beginning or end of the current line
+  (`Cmd-Left` and `Cmd-Right` on macOS).
+- `Ctrl-Home` and `Ctrl-End` move the cursor to the beginning or end of the buffer
+  (`Cmd-Up` and `Cmd-Down` on macOS).
+- `Ctrl-Delete` deletes a word of text after the cursor.
+- `Ctrl-Backspace` deletes a word of text before the cursor (`Alt-Backspace` on macOS).
 - Commenting and uncommenting the current line or selected text is available in
   the *Tools* menu.  If some text is selected, exactly that text is commented out;
   otherwise the line containing the cursor is commented out.  To uncomment, position
@@ -86,15 +87,23 @@ Running Coq scripts
 Operations for running the script are available in the *Navigation* menu,
 from the toolbar and from the keyboard.  These include:
 
-- Forward (`Ctrl-Down`) to run one command or tactic
-- Backward (`Ctrl-Up`) undo one command or tactic
-- Run to cursor (`Ctrl-Right`) to run commands up to the cursor
-- Run to end (`Ctrl-End`) to run commands to the end of the buffer
-- Reset Coq (`Ctrl-Home`) to restart the Coq process
+- Forward (`Alt-Down`) to run one command or tactic
+- Backward (`Alt-Up`) undo one command or tactic
+- Run to cursor (`Alt-Right`) to run commands up to the cursor
+- Run to end (`Alt-End`) to run commands to the end of the buffer
+- Reset Coq (`Alt-Home`) to restart the Coq process
 - Interrupt to stop processing commands after the current command completes.
   (Note: on Windows but not on WSL, Interrupt doesn't work if you start CoqIDE
   as a background process, e.g. `coqide &` in bash.  See Coq issue
   `#16142 <https://github.com/coq/coq/pull/16142>`_).
+
+On macOS, use `Cmd-Ctrl` instead of `Alt` for these operations.
+
+Note about the change of modifier: the modifier for Navigation was previously
+`Ctrl` (except on macOS). It was changed so that the hotkeys for moving the
+cursor in the editor (`Ctrl-Right`, `Ctrl-Home`, `Ctrl-End`) are supported by
+default. To restore the previous behavior, go to *Edit/Preferences/Shortcuts*
+and change the modifier for Navigation.
 
 Tooltips identify the action associated with each toolbar icon.
 
@@ -202,7 +211,7 @@ A *query* is any command that does not change the current state, such as
 :cmd:`About`, :cmd:`Check`, :cmd:`Print`, :cmd:`Search`, etc.  The *query pane*
 lets you run such commands
 interactively without modifying your script. The query pane is accessible from
-the *View* menu, or using the shortcut ``F1``.
+the *View* menu, or using the shortcut ``F2``.
 You can also do queries by selecting some text, then choosing an
 item from the *Queries* menu. The response will appear in the message panel.
 The image above shows the result after selecting
@@ -264,10 +273,10 @@ Preferences
 You may customize your environment with the *Preferences* dialog, which is
 accessible from *Edit/Preferences* on the menu. There are several sections:
 
-The `Fonts` section is for selecting the text font used for scripts,
+The *Fonts* section is for selecting the text font used for scripts,
 goal and message panels.
 
-The `Colors` and `Tags` sections are for controlling colors and style of
+The *Colors* and *Tags* sections are for controlling colors and style of
 the three main buffers. A predefined Coq highlighting style as well
 as standard |GtkSourceView| styles are available. Other styles can be
 added e.g. in ``$HOME/.local/share/gtksourceview-3.0/styles/`` (see
@@ -280,12 +289,12 @@ governed by files such as ``settings.ini`` and ``gtk.css`` in
 variable ``GTK_THEME`` (search the internet for the various
 possibilities).
 
-The `Editor` section is for customizing the editor. It includes in
+The *Editor* section is for customizing the editor. It includes in
 particular the ability to activate an Emacs mode named
 micro-Proof-General (use the Help menu to know more about the
 available bindings).
 
-The `Files` section is devoted to file management: you may configure
+The *Files* section is devoted to file management: you may configure
 automatic saving of files, by periodically saving the contents into
 files named `#f#` for each opened file `f`. You may also activate the
 *revert* feature: in case a opened file is modified on the disk by a
@@ -294,18 +303,27 @@ you edited that same file, you will be prompted to choose to either
 discard your changes or not. The File charset encoding choice is
 described below in :ref:`character-encoding-saved-files`.
 
-`Project`
+*Project*
 
-`Appearance`
+*Appearance*
 
-The `Externals` section allows customizing the external commands for
+The *Externals* section allows customizing the external commands for
 compilation, printing, web browsing. In the browser command, you may
 use `%s` to denote the URL to open, for example:
 `firefox -remote "OpenURL(%s)"`.
 
-`Shortcuts`
+The *Shortcuts* section contains buttons that allow you to change the
+modifiers (`Ctrl`, `Alt`, `Cmd`, `Shift`) used for the key bindings of
+all items of a menu (except the View menu in which only the togglable
+items are concerned). To make the interface cleaner, all available
+modifiers are presented at the top. You may toggle some of them to be
+able to use them as modifiers.
+Once you apply your changes, you will see in the menus how accelerators
+have changed. Note that, in case of conflict between menu items,
+accelerators will be removed and you will need to use one of the methods
+described in the next section to get them back.
 
-`Misc`
+*Misc*
 
 .. _user-configuration-directory:
 
@@ -317,6 +335,9 @@ Preferences are in the file "coqiderc" and key bindings are in the file "coqide.
 
 Key bindings
 ~~~~~~~~~~~~
+
+As explained just above, the *Edit/Preferences/Shortcuts* panel
+offers buttons to modify in a few clicks the key bindings for a whole menu.
 
 Each menu item in the GUI shows its key binding, if one has been defined,
 on the right-hand side.  Typing the key binding is equivalent to selecting
@@ -359,8 +380,6 @@ The end of
 gives the names of the keys.
 
 Some menu entries can be changed as a group from the Edit/Preferences/Shortcuts panel.
-Key bindings that don't appear in the file such as `Ctrl-A` (Select All) can't be
-changed with this mechanism.  (At the moment, `Ctrl-A` does not work on Windows.)
 
 .. todo: list common rebindings?
 

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -53,21 +53,21 @@ for menu items are shown on the right of each item.  If you need more complex ed
 commands, you can launch an external text editor on the current buffer, using the
 *Edit/External Editor* menu. (Use `Edit/Preferences/Externals/External Editor` to
 specify the external text editor.)  When you're done editing, you currently must
-reopen the file to see your changes.  Also note:
+reopen the file to see your changes.  Also note these key bindings that are not
+shown in menus:
 
-- Undo is also available as ``Ctrl-Z`` (`Cmd-Z` on macOS).  Redo is `Ctrl-Shift-Z`
-  (`Shift-Cmd-Z` on macOS).
-- Select all is `Ctrl-A` (`Cmd-A` on macOS).
 - `Home` and `End` move the cursor to the beginning or end of the current line
   (`Cmd-Left` and `Cmd-Right` on macOS).
 - `Ctrl-Home` and `Ctrl-End` move the cursor to the beginning or end of the buffer
   (`Cmd-Up` and `Cmd-Down` on macOS).
-- `Ctrl-Delete` deletes a word of text after the cursor.
-- `Ctrl-Backspace` deletes a word of text before the cursor (`Alt-Backspace` on macOS).
-- Commenting and uncommenting the current line or selected text is available in
-  the *Tools* menu.  If some text is selected, exactly that text is commented out;
-  otherwise the line containing the cursor is commented out.  To uncomment, position
-  the cursor between `(*` and `*)` or select any text between them.
+- `Ctrl-Left` and `Ctrl-Right` move the cursor to the next beginning or end of a word
+- `Ctrl-Delete` (`Alt-Backspace` on macOS) and `Ctrl-Backspace` delete characters
+  from the cursor to the next beginning or end of a word.
+
+Commenting and uncommenting the current line or selected text is available in
+the *Tools* menu.  If some text is selected, exactly that text is commented out;
+otherwise the line containing the cursor is commented out.  To uncomment, position
+the cursor between `(*` and `*)` or select any text between them.
 
 Files are automatically saved periodically to a recovery file.  For example,
 `foo.v` is saved to `#foo.v#` every 10 seconds by default.  You can change the
@@ -312,16 +312,20 @@ compilation, printing, web browsing. In the browser command, you may
 use `%s` to denote the URL to open, for example:
 `firefox -remote "OpenURL(%s)"`.
 
-The *Shortcuts* section contains buttons that allow you to change the
-modifiers (`Ctrl`, `Alt`, `Cmd`, `Shift`) used for the key bindings of
-all items of a menu (except the View menu in which only the togglable
-items are concerned). To make the interface cleaner, all available
-modifiers are presented at the top. You may toggle some of them to be
-able to use them as modifiers.
-Once you apply your changes, you will see in the menus how accelerators
-have changed. Note that, in case of conflict between menu items,
-accelerators will be removed and you will need to use one of the methods
-described in the next section to get them back.
+.. _shortcuts:
+
+The *Shortcuts* section lets you change the modifiers (e.g. `Ctrl`, `Alt`
+and `Shift`) used in all the menu entry key bindings for the selected menu
+(for the View menu, only the checkbox items will be changed).
+Current key bindings are shown at the right side of each menu entry.
+
+If any of the new key bindings are already assigned, the existing binding
+will be removed.  You can then rebind one of the menu entries as described
+in the next section.
+
+The top of the *Shortcuts* section lets you select the allowed modifiers
+that can be selected for the listed menus.  (The changes won't appear until
+you close and reopen the Preferences dialog.)
 
 *Misc*
 
@@ -333,11 +337,10 @@ is set.  If the variable isn't set, the directory is ``~/.config/coq`` on Linux
 and `C:\\Users\\<USERNAME>\\AppData\\Local\\coq` on Windows.
 Preferences are in the file "coqiderc" and key bindings are in the file "coqide.keys".
 
+.. _key_bindings:
+
 Key bindings
 ~~~~~~~~~~~~
-
-As explained just above, the *Edit/Preferences/Shortcuts* panel
-offers buttons to modify in a few clicks the key bindings for a whole menu.
 
 Each menu item in the GUI shows its key binding, if one has been defined,
 on the right-hand side.  Typing the key binding is equivalent to selecting
@@ -362,7 +365,8 @@ The file contains lines such as:
      (gtk_accel_path "<Actions>/Edit/Find Next" "F4")
 
 The first line corresponds to the menu item for the Queries/About menu item,
-which was bound by default to `Shift-Ctrl-A`.  "<Primary>" indicates `Ctrl`.
+which was bound by default to `Shift-Ctrl-A`.  "<Primary>" indicates `Cmd` on macOS
+and otherwise `Ctrl`.
 The second line is for a menu item that has no key binding.
 
 Lines that begin with semicolons are comments created by CoqIDE.  CoqIDE uses
@@ -379,7 +383,8 @@ The end of
 `this file <https://github.com/linuxmint/gtk/blob/master/gdk/keyname-table.h#:~:text=NC_(%22keyboard%20label%22%2C%20%22BackSpace%22)>`_
 gives the names of the keys.
 
-Some menu entries can be changed as a group from the Edit/Preferences/Shortcuts panel.
+Modifers (e.g. Alt, Ctrl) for some menus can be can be changed as a group from the
+Edit/Preferences/Shortcuts panel.  See :ref:`Shortcuts<shortcuts>`.
 
 .. todo: list common rebindings?
 

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -99,12 +99,6 @@ from the toolbar and from the keyboard.  These include:
 
 On macOS, use `Cmd-Ctrl` instead of `Alt` for these operations.
 
-Note about the change of modifier: the modifier for Navigation was previously
-`Ctrl` (except on macOS). It was changed so that the hotkeys for moving the
-cursor in the editor (`Ctrl-Right`, `Ctrl-Home`, `Ctrl-End`) are supported by
-default. To restore the previous behavior, go to *Edit/Preferences/Shortcuts*
-and change the modifier for Navigation.
-
 Tooltips identify the action associated with each toolbar icon.
 
 Commands may:
@@ -383,7 +377,7 @@ The end of
 `this file <https://github.com/linuxmint/gtk/blob/master/gdk/keyname-table.h#:~:text=NC_(%22keyboard%20label%22%2C%20%22BackSpace%22)>`_
 gives the names of the keys.
 
-Modifers (e.g. Alt, Ctrl) for some menus can be can be changed as a group from the
+Modifiers (e.g. Alt, Ctrl) for some menus can be can be changed as a group from the
 Edit/Preferences/Shortcuts panel.  See :ref:`Shortcuts<shortcuts>`.
 
 .. todo: list common rebindings?

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -110,7 +110,7 @@ let rec filter_coq_opts args =
 
 and asks_for_coqtop args =
   let pb_mes = GWindow.message_dialog
-    ~message:"Failed to load coqidetop. Reset the preference to default ?"
+    ~message:"Failed to load coqidetop. Reset the preference to default?"
     ~message_type:`QUESTION ~buttons:GWindow.Buttons.yes_no () in
   match pb_mes#run () with
     | `YES ->
@@ -672,7 +672,7 @@ struct
     { opts = [universes]; init = false; label = "Display _universe levels" };
     { opts = [all_basic;existential;universes]; init = false;
       label = "Display all _low-level contents" };
-    { opts = [unfocused]; init = false; label = "Display _unfocused goals" };
+    { opts = [unfocused]; init = false; label = "Display un_focused goals" };
     { opts = [goal_names]; init = false; label = "Display _goal names" };
     { opts = [record]; init = true; label = "Use _record syntax" };
     { opts = [synth]; init = true; label = "Hide _synthesizable types" }

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1444,6 +1444,12 @@ let build_ui () =
       ~callback:(cb_on_current_term (fun t -> t.script#undo ()));
     item "Redo" ~accel:"<Primary><Shift>z" ~stock:`REDO
       ~callback:(cb_on_current_term (fun t -> t.script#redo ()));
+    item "Select All" ~accel:"<Primary>a" ~stock:`SELECT_ALL
+      ~callback:(cb_on_current_term (fun t ->
+         t.script#select_all ();
+         t.proof#select_all ();
+         t.messages#select_all ();
+         t.debugger#select_all ()));
     item "Cut" ~stock:`CUT
       ~callback:(fun _ -> emit_to_focus w GtkText.View.S.cut_clipboard);
     item "Copy" ~stock:`COPY

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1622,13 +1622,13 @@ let build_ui () =
 
   menu help_menu [
     item "Help" ~label:"_Help";
-    item "Browse Coq Manual" ~label:"Browse Coq _Manual"
+    item "Browse Coq Manual" ~label:"Browse Coq _Manual" ~accel:"<Shift>F1" ~stock:`HELP
       ~callback:(fun _ ->
         browse notebook#current_term.messages#default_route#add_string Coq_config.wwwrefman);
-    item "Browse Coq Library" ~label:"Browse Coq _Library"
+    item "Browse Coq Library" ~label:"Browse Coq _Library" ~accel:"<Primary><Shift>F1" ~stock:`HELP
       ~callback:(fun _ ->
         browse notebook#current_term.messages#default_route#add_string Coq_config.wwwstdlib);
-    item "Help for keyword" ~label:"Help for _keyword" ~stock:`HELP
+    item "Help for keyword" ~label:"Help for _keyword" ~accel:"F1"
       ~callback:(fun _ -> on_current_term (fun sn ->
         browse_keyword sn.messages#default_route#add_string (get_current_word sn)));
     item "Help for μPG mode" ~label:"Help for μPG mode"

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1605,13 +1605,13 @@ let build_ui () =
 
   menu debug_menu [
     item "Debug" ~label:"_Debug";
-    item "Toggle breakpoint" ~label:"_Toggle breakpoint" ~accel:"F8"
+    item "Toggle breakpoint" ~label:"_Toggle breakpoint" ~accel:"F8" ~stock:`MEDIA_RECORD
       ~callback:MiscMenu.toggle_breakpoint;
-    item "Continue" ~label:"_Continue" ~accel:"F9" ~callback:Nav.continue;
-    item "Step in" ~label:"Step in" ~accel:"F10" ~callback:Nav.step_in;
-    item "Step out" ~label:"Step out" ~accel:"<Shift>F10" ~callback:Nav.step_out;
+    item "Continue" ~label:"_Continue" ~accel:"F9" ~stock:`MEDIA_NEXT ~callback:Nav.continue;
+    item "Step in" ~label:"Step in" ~accel:"F10" ~stock:`MEDIA_PLAY ~callback:Nav.step_in;
+    item "Step out" ~label:"Step out" ~accel:"<Shift>F10" ~stock:`MEDIA_FORWARD ~callback:Nav.step_out;
     (* todo: consider other names for Break and Interrupt to be clearer to users *)
-    item "Break" ~label:"Break" ~accel:"F11" ~callback:Nav.break;
+    item "Break" ~label:"Break" ~accel:"F11" ~stock:`MEDIA_PAUSE ~callback:Nav.break;
     item "Show debug panel" ~label:"Show debug panel" ~callback:Nav.show_debugger;
   ];
 

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1416,33 +1416,33 @@ let build_ui () =
   menu file_menu [
     item "File" ~label:"_File";
     item "New" ~callback:File.newfile ~stock:`NEW;
-    item "Open" ~callback:(File.load ~parent:w) ~stock:`OPEN;
+    item "Open" ~callback:(File.load ~parent:w) ~stock:`OPEN ~tooltip:"Open file";
     item "Save" ~callback:(File.save ~parent:w) ~stock:`SAVE ~tooltip:"Save current buffer";
-    item "Save as" ~label:"S_ave as" ~stock:`SAVE_AS ~callback:(File.saveas ~parent:w);
+    item "Save as" ~stock:`SAVE_AS ~callback:(File.saveas ~parent:w);
     item "Save all" ~label:"Sa_ve all" ~callback:File.saveall;
     item "Close buffer" ~label:"_Close buffer" ~stock:`CLOSE
       ~callback:(File.close_buffer ~parent:w) ~tooltip:"Close current buffer";
-    item "Print..." ~label:"_Print..."
-      ~callback:File.print ~stock:`PRINT ~accel:"<Ctrl>p";
-    item "Rehighlight" ~label:"Reh_ighlight" ~accel:"<Ctrl>l"
+    item "Print..." ~label:"_Print..." ~accel:"<Primary>p"
+      ~callback:File.print ~stock:`PRINT;
+    item "Rehighlight" ~label:"Re_highlight" ~accel:"<Primary>l"
       ~callback:File.highlight ~stock:`REFRESH;
     item "Quit" ~stock:`QUIT ~callback:(File.quit ~parent:w);
   ];
 
   menu export_menu [
     item "Export to" ~label:"E_xport to";
-    item "Html" ~label:"_Html" ~callback:(File.export "html");
+    item "Html" ~label:"_HTML" ~callback:(File.export "html");
     item "Latex" ~label:"_LaTeX" ~callback:(File.export "latex");
-    item "Dvi" ~label:"_Dvi" ~callback:(File.export "dvi");
-    item "Pdf" ~label:"_Pdf" ~callback:(File.export "pdf");
-    item "Ps" ~label:"_Ps" ~callback:(File.export "ps");
+    item "Dvi" ~label:"_DVI" ~callback:(File.export "dvi");
+    item "Pdf" ~label:"_PDF" ~callback:(File.export "pdf");
+    item "Ps" ~label:"_PostScript" ~callback:(File.export "ps");
   ];
 
   menu edit_menu [
     item "Edit" ~label:"_Edit";
-    item "Undo" ~accel:"<Primary>u" ~stock:`UNDO
+    item "Undo" ~accel:"<Primary>z" ~stock:`UNDO
       ~callback:(cb_on_current_term (fun t -> t.script#undo ()));
-    item "Redo" ~stock:`REDO
+    item "Redo" ~accel:"<Primary><Shift>z" ~stock:`REDO
       ~callback:(cb_on_current_term (fun t -> t.script#redo ()));
     item "Cut" ~stock:`CUT
       ~callback:(fun _ -> emit_to_focus w GtkText.View.S.cut_clipboard);
@@ -1471,39 +1471,36 @@ let build_ui () =
 
   menu view_menu [
     item "View" ~label:"_View";
-    item "Previous tab" ~label:"_Previous tab" ~accel:"<Alt>Left"
+    item "Previous tab" ~label:"_Previous tab" ~accel:"<Primary>Page_Up"
       ~stock:`GO_BACK
       ~callback:(fun _ -> notebook#previous_page ());
-    item "Next tab" ~label:"_Next tab" ~accel:"<Alt>Right"
+    item "Next tab" ~label:"_Next tab" ~accel:"<Primary>Page_Down"
       ~stock:`GO_FORWARD
       ~callback:(fun _ -> notebook#next_page ());
-    item "Zoom in" ~label:"_Zoom in" ~accel:("<Primary>plus")
+    item "Zoom in" ~accel:("<Primary>plus")
         ~stock:`ZOOM_IN ~callback:(fun _ ->
           let ft = Pango.Font.from_string text_font#get in
           Pango.Font.set_size ft (Pango.Font.get_size ft + Pango.scale);
           text_font#set (Pango.Font.to_string ft);
           save_pref ());
-    item "Zoom out" ~label:"_Zoom out" ~accel:("<Primary>minus")
+    item "Zoom out" ~accel:("<Primary>minus")
         ~stock:`ZOOM_OUT ~callback:(fun _ ->
           let ft = Pango.Font.from_string text_font#get in
           Pango.Font.set_size ft (Pango.Font.get_size ft - Pango.scale);
           text_font#set (Pango.Font.to_string ft);
           save_pref ());
-    item "Zoom fit" ~label:"_Zoom fit" ~accel:("<Primary>0")
+    item "Zoom fit" ~accel:("<Primary>0")
         ~stock:`ZOOM_FIT ~callback:(cb_on_current_term MiscMenu.zoom_fit);
     toggle_item "Show Toolbar" ~label:"Show _Toolbar"
       ~active:(show_toolbar#get)
       ~callback:(fun _ -> show_toolbar#set (not show_toolbar#get));
-    item "Query Pane" ~label:"_Query Pane"
-      ~accel:"F1"
+    item "Query Pane" ~label:"_Query Pane" ~accel:"F2"
       ~callback:(cb_on_current_term MiscMenu.show_hide_query_pane);
     GAction.group_radio_actions
       ~init_value:(
         let v = diffs#get in
         List.iter (fun o -> Opt.set o v) Opt.diff_item.Opt.opts;
-        if v = "on" then 1
-        else if v = "removed" then 2
-        else 0)
+        match v with "on" -> 1 | "removed" -> 2 | _ -> 0)
       ~callback:begin fun n ->
         (match n with
         | 0 -> List.iter (fun o -> Opt.set o "off"; diffs#set "off") Opt.diff_item.Opt.opts
@@ -1517,7 +1514,7 @@ let build_ui () =
         radio "Set diff" 1 ~label:"Show diffs: only _added";
         radio "Set removed diff" 2 ~label:"Show diffs: added and _removed";
       ];
-    item "Show Proof Diffs" ~label:"_Show Proof (with diffs, if set)" ~accel:(modifier_for_display#get ^ "S")
+    item "Show Proof Diffs" ~label:"_Show Proof (with diffs, if set)" ~accel:"<Shift>F2"
       ~callback:MiscMenu.show_proof_diffs;
   ];
   toggle_items view_menu Coq.PrintOpt.bool_items;
@@ -1533,16 +1530,18 @@ let build_ui () =
     ("Forward", "_Forward", `GO_DOWN, Nav.forward_one, "Forward one command", "Down");
     ("Backward", "_Backward", `GO_UP, Nav.backward_one, "Backward one command", "Up");
     ("Run to cursor", "Run to _cursor", `JUMP_TO, Nav.run_to_cursor, "Run to cursor", "Right");
-    ("Run to end", "_Run to end", `GOTO_BOTTOM, Nav.run_to_end, "Run to end", "End");
-    ("Interrupt", "_Interrupt", `STOP, Nav.interrupt, "Interrupt computations", "Break");
     ("Reset", "_Reset", `GOTO_TOP, Nav.restart, "Reset Coq", "Home");
+    ("Run to end", "_Run to end", `GOTO_BOTTOM, Nav.run_to_end, "Run to end", "End");
+    ("Fully check", "_Fully check", `EXECUTE, Nav.join_document, "Fully check the document", "Return");
+    ("Interrupt", "_Interrupt", `STOP, Nav.interrupt, "Interrupt computations", "Break");
     (* wait for this available in GtkSourceView !
     ("Hide", "_Hide", `MISSING_IMAGE,
         ~callback:(fun _ -> let sess = notebook#current_term in
           toggle_proof_visibility sess.buffer sess.analyzed_view#get_insert), "Hide proof", "h"); *)
-    ("Previous", "_Previous", `GO_BACK, Nav.previous_occ, "Previous occurrence", "less");
-    ("Next", "_Next", `GO_FORWARD, Nav.next_occ, "Next occurrence", "greater");
-    ("Force", "_Force", `EXECUTE, Nav.join_document, "Fully check the document", "f");
+    ("Previous", "_Previous occurrence", `GO_BACK, Nav.previous_occ,
+        "Previous occurrence of word under cursor", "less");
+    ("Next", "_Next occurrence", `GO_FORWARD, Nav.next_occ,
+        "Next occurrence of word under cursor", "greater");
   ] end;
 
   menu templates_menu [
@@ -1578,9 +1577,9 @@ let build_ui () =
 
   menu tools_menu [
     item "Tools" ~label:"_Tools";
-    item "Comment" ~label:"_Comment" ~accel:"<CTRL>D"
+    item "Comment" ~label:"_Comment" ~accel:"<Primary>D"
       ~callback:(cb_on_current_term (fun t -> t.script#comment ()));
-    item "Uncomment" ~label:"_Uncomment" ~accel:"<CTRL><SHIFT>D"
+    item "Uncomment" ~label:"_Uncomment" ~accel:"<Primary><Shift>D"
       ~callback:(cb_on_current_term (fun t -> t.script#uncomment ()));
     item "Coqtop arguments" ~label:"Coqtop _arguments"
       ~callback:MiscMenu.coqtop_arguments;

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1279,13 +1279,13 @@ let get_shortcut s =
 
 module Opt = Coq.PrintOpt
 
-let toggle_items menu_name l =
-  let f d =
-    let label = d.Opt.label in
+let printopts_items menu_name l =
+  let f Opt.{ label; init; opts } =
     let k, name = get_shortcut label in
     let accel = Option.map ((^) modifier_for_display#get) k in
-    toggle_item name ~label ?accel ~active:d.Opt.init
-      ~callback:(printopts_callback d.Opt.opts)
+    printopts_item_names := name :: !printopts_item_names;
+    toggle_item name ~label ?accel ~active:init
+      ~callback:(printopts_callback opts)
       menu_name
   in
   List.iter f l
@@ -1523,7 +1523,7 @@ let build_ui () =
     item "Show Proof Diffs" ~label:"_Show Proof (with diffs, if set)" ~accel:"<Shift>F2"
       ~callback:MiscMenu.show_proof_diffs;
   ];
-  toggle_items view_menu Coq.PrintOpt.bool_items;
+  printopts_items view_menu Coq.PrintOpt.bool_items;
 
   let navitem (text, label, stock, callback, tooltip, accel) =
     let accel = modifier_for_navigation#get ^ accel in

--- a/ide/coqide/coqide_main.ml
+++ b/ide/coqide/coqide_main.ml
@@ -68,5 +68,5 @@ let () =
     GMain.main ();
     failwith "Gtk loop ended"
   with e ->
-    Minilib.log ("CoqIDE unexpected error:" ^ Printexc.to_string e);
+    Minilib.log ("CoqIDE unexpected error: " ^ Printexc.to_string e);
     Coqide.crash_save 127

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -98,9 +98,11 @@ let init () =
 \n    <menuitem action='Forward' />\
 \n    <menuitem action='Backward' />\
 \n    <menuitem action='Run to cursor' />\
-\n    <menuitem action='Run to end' />\
-\n    <menuitem action='Interrupt' />\
 \n    <menuitem action='Reset' />\
+\n    <menuitem action='Run to end' />\
+\n    <menuitem action='Fully check' />\
+\n    <menuitem action='Interrupt' />\
+\n    <separator/>\
 \n    <menuitem action='Previous' />\
 \n    <menuitem action='Next' />\
 \n  </menu>\
@@ -160,15 +162,18 @@ let init () =
 \n  </menu>\
 \n</menubar>\
 \n<toolbar name='CoqIDE ToolBar'>\
+\n  <toolitem action='Open' />\
 \n  <toolitem action='Save' />\
 \n  <toolitem action='Close buffer' />\
+\n  <separator />\
 \n  <toolitem action='Forward' />\
 \n  <toolitem action='Backward' />\
 \n  <toolitem action='Run to cursor' />\
-\n  <toolitem action='Run to end' />\
-\n  <toolitem action='Force' />\
-\n  <toolitem action='Interrupt' />\
 \n  <toolitem action='Reset' />\
+\n  <toolitem action='Run to end' />\
+\n  <toolitem action='Fully check' />\
+\n  <toolitem action='Interrupt' />\
+\n  <separator/>\
 \n  <toolitem action='Previous' />\
 \n  <toolitem action='Next' />\
 \n</toolbar>\

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -52,6 +52,7 @@ let init () =
 \n    <menuitem action='Undo' />\
 \n    <menuitem action='Redo' />\
 \n    <separator />\
+\n    <menuitem action='Select All' />\
 \n    <menuitem action='Cut' />\
 \n    <menuitem action='Copy' />\
 \n    <menuitem action='Paste' />\

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -148,6 +148,7 @@ let init () =
 \n    <menuitem action='Step in' />\
 \n    <menuitem action='Step out' />\
 \n    <menuitem action='Break' />\
+\n    <separator/>\
 \n    <menuitem action='Show debug panel' />\
 \n  </menu>\
 \n  <menu action='Windows'>\

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -564,7 +564,7 @@ let show_line_number =
   new preference ~name:["show_line_number"] ~init:false ~repr:Repr.(bool)
 
 let auto_indent =
-  new preference ~name:["auto_indent"] ~init:false ~repr:Repr.(bool)
+  new preference ~name:["auto_indent"] ~init:true ~repr:Repr.(bool)
 
 let show_spaces =
   new preference ~name:["show_spaces"] ~init:true ~repr:Repr.(bool)
@@ -582,7 +582,7 @@ let tab_length =
   new preference ~name:["tab_length"] ~init:2 ~repr:Repr.(int)
 
 let highlight_current_line =
-  new preference ~name:["highlight_current_line"] ~init:false ~repr:Repr.(bool)
+  new preference ~name:["highlight_current_line"] ~init:true ~repr:Repr.(bool)
 
 let microPG =
   (* Legacy name in preference is "nanoPG" *)

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -321,21 +321,20 @@ let attach_modifiers (pref : string preference) ?(filter = Fun.const true) prefi
   in
   pref#connect#changed ~callback:cb
 
+let select_arch m m_mac =
+  (* Gtk's <Primary> maps to <Meta> (i.e. "Command") on Darwin (i.e. Mac),
+    <Control> on other architectures; but sometimes, we want more distinction *)
+  if Coq_config.arch = "Darwin" then m_mac else m
+
 let modifier_for_navigation =
   new preference ~name:["modifier_for_navigation"]
-    (* Note: on Darwin, this will give "<Control><Meta>", i.e. Ctrl and Command; on other
-    architectures, "<Primary>" binds to "<Control>" so it will give "<Control>" alone *)
-    ~init:"<Control><Primary>" ~repr:Repr.(string)
+    ~init:(select_arch "<Alt>" "<Control><Primary>") ~repr:Repr.(string)
 
 let modifier_for_templates =
   new preference ~name:["modifier_for_templates"] ~init:"<Control><Shift>" ~repr:Repr.(string)
 
-let select_arch m m_osx =
-  if Coq_config.arch = "Darwin" then m_osx else m
-
 let modifier_for_display =
   new preference ~name:["modifier_for_display"]
-   (* Note: <Primary> (i.e. <Meta>, i.e. "Command") on Darwin, i.e. MacOS X, but <Alt> elsewhere *)
     ~init:(select_arch "<Alt><Shift>" "<Primary><Shift>")~repr:Repr.(string)
 
 let modifier_for_queries =

--- a/ide/coqide/preferences.mli
+++ b/ide/coqide/preferences.mli
@@ -50,6 +50,7 @@ val list_tags : unit -> tag preference Util.String.Map.t
 val get_unicode_bindings_local_file : unit -> string option
 val get_unicode_bindings_default_file : unit -> string option
 
+val printopts_item_names : string list ref
 
 val cmd_coqtop : string option preference
 val cmd_coqc : string preference

--- a/ide/coqide/wg_Debugger.ml
+++ b/ide/coqide/wg_Debugger.ml
@@ -23,6 +23,7 @@ class type debugger_view =
     method set_forward_db_vars : (int -> unit) -> unit
     method set_forward_paned_pos : (int -> unit) -> unit
     method set_forward_get_basename : (unit -> string) -> unit
+    method select_all : unit -> unit
   end
 
 let forward_keystroke = ref ((fun x -> failwith "forward_keystroke (db)")
@@ -350,6 +351,10 @@ let debugger title sid =
     method set_forward_db_vars f = forward_db_vars := f
     method set_forward_paned_pos f = forward_set_paned_pos := f
     method set_forward_get_basename f = forward_get_basename := f
+
+    method select_all () =
+      if stack_view#is_focus then
+        stack_buffer#select_range stack_buffer#start_iter stack_buffer#end_iter
   end
   in
   debugger

--- a/ide/coqide/wg_Debugger.mli
+++ b/ide/coqide/wg_Debugger.mli
@@ -23,6 +23,7 @@ class type debugger_view =
     method set_forward_db_vars : (int -> unit) -> unit
     method set_forward_paned_pos : (int -> unit) -> unit
     method set_forward_get_basename : (unit -> string) -> unit
+    method select_all : unit -> unit
   end
 
 val debugger : string -> int -> debugger_view

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -40,6 +40,7 @@ class type message_view =
     (** Callback for the Ltac debugger *)
     method debug_prompt : Pp.t -> unit
 
+    method select_all : unit -> unit
     method has_selection : bool
     method get_selected_text : string
     method editable2 : bool
@@ -257,6 +258,9 @@ let message_view sid : message_view =
 
     method set msg = self#clear; self#add msg
 
+    method select_all () =
+      if view#is_focus then
+        self#source_buffer#select_range self#source_buffer#start_iter self#source_buffer#end_iter;
     method has_selection = buffer#has_selection
     method get_selected_text =
       if buffer#has_selection then

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -28,6 +28,7 @@ class type message_view =
       (** same as [add], but with an explicit level instead of [Notice] *)
 
     method debug_prompt : Pp.t -> unit
+    method select_all : unit -> unit
     method has_selection : bool
     method get_selected_text : string
     method editable2 : bool

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -26,6 +26,7 @@ class type proof_view =
     inherit GObj.widget
     method source_buffer : GSourceView3.source_buffer
     method buffer : GText.buffer
+    method select_all : unit -> unit
     method refresh : force:bool -> unit
     method clear : unit -> unit
     method set_goals : goals -> unit
@@ -218,6 +219,10 @@ let proof_view () =
     method source_buffer = buffer
 
     method buffer = text_buffer
+
+    method select_all () =
+      if self#is_focus then
+        self#buffer#select_range self#buffer#start_iter self#buffer#end_iter;
 
     method clear () = buffer#set_text ""
 

--- a/ide/coqide/wg_ProofView.mli
+++ b/ide/coqide/wg_ProofView.mli
@@ -22,6 +22,7 @@ class type proof_view =
     inherit GObj.widget
     method source_buffer : GSourceView3.source_buffer
     method buffer : GText.buffer
+    method select_all : unit -> unit
     method refresh : force:bool -> unit
     method clear : unit -> unit
     method set_goals : goals -> unit

--- a/ide/coqide/wg_RoutedMessageViews.ml
+++ b/ide/coqide/wg_RoutedMessageViews.ml
@@ -12,6 +12,7 @@ class type message_views_router = object
   method route : int -> Wg_MessageView.message_view
   method default_route : Wg_MessageView.message_view
 
+  method select_all : unit -> unit
   method has_selection : bool
   method get_selected_text : string
 
@@ -34,6 +35,8 @@ object
   method register_route i mv = Hashtbl.add route_table i mv
 
   method delete_route i = Hashtbl.remove route_table i
+
+  method select_all () = Hashtbl.iter (fun _ v -> v#select_all ()) route_table
 
   method has_selection =
     Hashtbl.fold (fun _ v -> (||) v#has_selection) route_table false

--- a/ide/coqide/wg_RoutedMessageViews.mli
+++ b/ide/coqide/wg_RoutedMessageViews.mli
@@ -12,6 +12,7 @@ class type message_views_router = object
   method route : int -> Wg_MessageView.message_view
   method default_route : Wg_MessageView.message_view
 
+  method select_all : unit -> unit
   method has_selection : bool
   method get_selected_text : string
 

--- a/ide/coqide/wg_ScriptView.ml
+++ b/ide/coqide/wg_ScriptView.ml
@@ -361,6 +361,10 @@ object (self)
     } in
     Gobject.set prop obj show
 
+  method select_all () =
+    if self#is_focus then
+      self#buffer#select_range self#buffer#start_iter self#buffer#end_iter;
+
   method comment () =
     let rec get_line_start iter =
       if iter#starts_line then iter

--- a/ide/coqide/wg_ScriptView.mli
+++ b/ide/coqide/wg_ScriptView.mli
@@ -24,6 +24,7 @@ object
   method set_right_margin_position : int -> unit
   method show_right_margin : bool
   method set_show_right_margin : bool -> unit
+  method select_all : unit -> unit
   method comment : unit -> unit
   method uncomment : unit -> unit
   method apply_unicode_binding : unit -> unit


### PR DESCRIPTION
Here is a bunch of small improvements to menu items and accelerators.

- Add “Open” to the toolbar
- Add “Fully check” to the Navigation menu
- Avoid overlapping accelerators
- Use more common accelerators (for Undo/Redo and changing tab)
- Add “Select All” item in the Edit menu
- Add icons to Debug menu items
- Put icon at a better place in Help menu
- Apply View modifiers changes to the “Coq.PrintOpt” menu items only
- Provide Alt as default modifier for navigation
- Set auto indent and highlight current line enabled by default

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #16141

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.