### PR TITLE
Reduce dependencies on ltac_plugin + stricter type for vernac_argument extend

### DIFF
--- a/dev/ci/user-overlays/18719-SkySkimmer-less-ltac-plugin.sh
+++ b/dev/ci/user-overlays/18719-SkySkimmer-less-ltac-plugin.sh
@@ -1,0 +1,1 @@
+overlay serapi https://github.com/SkySkimmer/coq-serapi less-ltac-plugin 18719

--- a/plugins/derive/dune
+++ b/plugins/derive/dune
@@ -2,6 +2,6 @@
  (name derive_plugin)
  (public_name coq-core.plugins.derive)
  (synopsis "Coq's derive plugin")
- (libraries coq-core.plugins.ltac))
+ (libraries coq-core.vernac))
 
 (coq.pp (modules g_derive))

--- a/plugins/extraction/dune
+++ b/plugins/extraction/dune
@@ -2,6 +2,6 @@
  (name extraction_plugin)
  (public_name coq-core.plugins.extraction)
  (synopsis "Coq's extraction plugin")
- (libraries coq-core.plugins.ltac))
+ (libraries coq-core.vernac))
 
 (coq.pp (modules g_extraction))

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -20,19 +20,17 @@ DECLARE PLUGIN "coq-core.plugins.extraction"
 
 (* ML names *)
 
-open Ltac_plugin
 open Stdarg
 open Pp
 open Names
 open Table
 open Extract_env
 
-let pr_mlname _ _ _ s = spc () ++ qs s
+let pr_mlname s = spc () ++ qs s
 
 }
 
-ARGUMENT EXTEND mlname
-  TYPED AS string
+VERNAC ARGUMENT EXTEND mlname
   PRINTED BY { pr_mlname }
 | [ preident(id) ] -> { id }
 | [ string(s) ] -> { s }
@@ -40,13 +38,13 @@ END
 
 {
 
-let pr_int_or_id _ _ _ = function
+let pr_int_or_id = function
   | ArgInt i -> int i
   | ArgId id -> Id.print id
 
 }
 
-ARGUMENT EXTEND int_or_id
+VERNAC ARGUMENT EXTEND int_or_id
   PRINTED BY { pr_int_or_id }
 | [ preident(id) ] -> { ArgId (Id.of_string id) }
 | [ integer(i) ] -> { ArgInt i }

--- a/plugins/extraction/g_extraction.mli
+++ b/plugins/extraction/g_extraction.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val wit_int_or_id: (Table.int_or_id, Table.int_or_id, Table.int_or_id) Genarg.genarg_type
+val wit_int_or_id: (Table.int_or_id, unit, unit) Genarg.genarg_type
 val wit_language: (Table.lang, unit, unit) Genarg.genarg_type
-val wit_mlname: (string, string, string) Genarg.genarg_type
+val wit_mlname: (string, unit, unit) Genarg.genarg_type

--- a/plugins/extraction/g_extraction.mli
+++ b/plugins/extraction/g_extraction.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val wit_int_or_id: (Table.int_or_id, unit, unit) Genarg.genarg_type
-val wit_language: (Table.lang, unit, unit) Genarg.genarg_type
-val wit_mlname: (string, unit, unit) Genarg.genarg_type
+val wit_int_or_id: Table.int_or_id Genarg.vernac_genarg_type
+val wit_language: Table.lang Genarg.vernac_genarg_type
+val wit_mlname: string Genarg.vernac_genarg_type

--- a/plugins/funind/dune
+++ b/plugins/funind/dune
@@ -2,6 +2,6 @@
  (name funind_plugin)
  (public_name coq-core.plugins.funind)
  (synopsis "Coq's functional induction plugin")
- (libraries coq-core.plugins.extraction))
+ (libraries coq-core.plugins.ltac coq-core.plugins.extraction))
 
 (coq.pp (modules g_indfun))

--- a/plugins/funind/g_indfun.mli
+++ b/plugins/funind/g_indfun.mli
@@ -48,8 +48,7 @@ val function_fix_definition :
   Vernacexpr.fixpoint_expr Loc.located Pcoq.Entry.t
 
 val wit_fun_scheme_arg :
-  (Names.Id.t * Libnames.qualid * Sorts.family, unit, unit)
-  Genarg.genarg_type
+  (Names.Id.t * Libnames.qualid * Sorts.family) Genarg.vernac_genarg_type
 
 val fun_scheme_arg :
   (Names.Id.t * Libnames.qualid * Sorts.family) Pcoq.Entry.t

--- a/plugins/funind/g_indfun.mli
+++ b/plugins/funind/g_indfun.mli
@@ -20,7 +20,7 @@ val fun_ind_using :
 val wit_with_names :
   (Constrexpr.constr_expr Tactypes.intro_pattern_expr CAst.t option,
    Genintern.glob_constr_and_expr Tactypes.intro_pattern_expr CAst.t option,
-   Ltac_plugin.Tacexpr.intro_pattern option)
+   Tactypes.intro_pattern option)
   Genarg.genarg_type
 
 val with_names :

--- a/plugins/funind/indfun.mli
+++ b/plugins/funind/indfun.mli
@@ -12,5 +12,5 @@ val functional_induction :
      bool
   -> EConstr.constr
   -> (EConstr.constr * EConstr.constr Tactypes.bindings) option
-  -> Ltac_plugin.Tacexpr.or_and_intro_pattern option
+  -> Tactypes.or_and_intro_pattern option
   -> unit Proofview.tactic

--- a/plugins/ltac/g_auto.mli
+++ b/plugins/ltac/g_auto.mli
@@ -22,8 +22,7 @@ val wit_auto_using :
 val auto_using : Constrexpr.constr_expr list Pcoq.Entry.t
 
 val wit_hints_path :
-  (Libnames.qualid Hints.hints_path_gen, unit, unit)
-  Genarg.genarg_type
+  Libnames.qualid Hints.hints_path_gen Genarg.vernac_genarg_type
 
 val hints_path : Libnames.qualid Hints.hints_path_gen Pcoq.Entry.t
 

--- a/plugins/ltac/g_ltac.mli
+++ b/plugins/ltac/g_ltac.mli
@@ -31,37 +31,36 @@ val classic_proof_mode : Pvernac.proof_mode
 
 val hint : Vernacexpr.hints_expr Pcoq.Entry.t
 
-val wit_ltac_selector : (Goal_select.t, unit, unit) Genarg.genarg_type
+val wit_ltac_selector : Goal_select.t Genarg.vernac_genarg_type
 
 val ltac_selector : Goal_select.t Pcoq.Entry.t
 
-val wit_ltac_info : (int, unit, unit) Genarg.genarg_type
+val wit_ltac_info : int Genarg.vernac_genarg_type
 
 val ltac_info : int Pcoq.Entry.t
 
-val wit_ltac_use_default : (bool, unit, unit) Genarg.genarg_type
+val wit_ltac_use_default : bool Genarg.vernac_genarg_type
 
 val ltac_use_default : bool Pcoq.Entry.t
 
-val wit_ltac_tactic_level : (int, unit, unit) Genarg.genarg_type
+val wit_ltac_tactic_level : int Genarg.vernac_genarg_type
 
 val ltac_tactic_level : int Pcoq.Entry.t
 
-val wit_ltac_production_sep : (string, unit, unit) Genarg.genarg_type
+val wit_ltac_production_sep : string Genarg.vernac_genarg_type
 
 val ltac_production_sep : string Pcoq.Entry.t
 
 val wit_ltac_production_item :
-  ((string * string option)
-   Tacentries.grammar_tactic_prod_item_expr, unit, unit)
-  Genarg.genarg_type
+  (string * string option) Tacentries.grammar_tactic_prod_item_expr
+    Genarg.vernac_genarg_type
 
 val ltac_production_item :
   (string * string option)
   Tacentries.grammar_tactic_prod_item_expr Pcoq.Entry.t
 
 val wit_ltac_tacdef_body :
-  (Tacexpr.tacdef_body, unit, unit) Genarg.genarg_type
+  Tacexpr.tacdef_body Genarg.vernac_genarg_type
 
 val ltac_tacdef_body : Tacexpr.tacdef_body Pcoq.Entry.t
 

--- a/plugins/ltac2/g_ltac2.mli
+++ b/plugins/ltac2/g_ltac2.mli
@@ -50,23 +50,20 @@ val tac2mode : Vernacexpr.vernac_expr Pcoq.Entry.t
 val tac2expr_in_env :
   (Names.Id.t CAst.t list * Tac2expr.raw_tacexpr) Pcoq.Entry.t
 
-val wit_ltac2_entry :
-  (Tac2expr.strexpr, unit, unit) Genarg.genarg_type
+val wit_ltac2_entry : Tac2expr.strexpr Genarg.vernac_genarg_type
 
 val ltac2_entry : Tac2expr.strexpr Pcoq.Entry.t
 
 val wit_ltac2def_syn :
-  (Tac2expr.sexpr list * int option *
-   Tac2expr.raw_tacexpr, unit, unit)
-  Genarg.genarg_type
+  (Tac2expr.sexpr list * int option * Tac2expr.raw_tacexpr)
+    Genarg.vernac_genarg_type
 
 val ltac2def_syn :
   (Tac2expr.sexpr list * int option *
    Tac2expr.raw_tacexpr)
   Pcoq.Entry.t
 
-val wit_ltac2_expr :
-  (Tac2expr.raw_tacexpr, unit, unit) Genarg.genarg_type
+val wit_ltac2_expr : Tac2expr.raw_tacexpr Genarg.vernac_genarg_type
 
 val ltac2_expr : Tac2expr.raw_tacexpr Pcoq.Entry.t
 

--- a/plugins/ring/g_ring.mli
+++ b/plugins/ring/g_ring.mli
@@ -9,29 +9,25 @@
 (************************************************************************)
 
 val wit_ring_mod :
-  (Constrexpr.constr_expr Ring_ast.ring_mod, unit, unit)
-  Genarg.genarg_type
+  Constrexpr.constr_expr Ring_ast.ring_mod Genarg.vernac_genarg_type
 
 val ring_mod :
   Constrexpr.constr_expr Ring_ast.ring_mod Pcoq.Entry.t
 
 val wit_ring_mods :
-  (Constrexpr.constr_expr Ring_ast.ring_mod list, unit, unit)
-  Genarg.genarg_type
+  Constrexpr.constr_expr Ring_ast.ring_mod list Genarg.vernac_genarg_type
 
 val ring_mods :
   Constrexpr.constr_expr Ring_ast.ring_mod list Pcoq.Entry.t
 
 val wit_field_mod :
-  (Constrexpr.constr_expr Ring_ast.field_mod, unit, unit)
-  Genarg.genarg_type
+  Constrexpr.constr_expr Ring_ast.field_mod Genarg.vernac_genarg_type
 
 val field_mod :
   Constrexpr.constr_expr Ring_ast.field_mod Pcoq.Entry.t
 
 val wit_field_mods :
-  (Constrexpr.constr_expr Ring_ast.field_mod list, unit, unit)
-  Genarg.genarg_type
+  Constrexpr.constr_expr Ring_ast.field_mod list Genarg.vernac_genarg_type
 
 val field_mods :
   Constrexpr.constr_expr Ring_ast.field_mod list Pcoq.Entry.t

--- a/plugins/syntax/g_number_string.mli
+++ b/plugins/syntax/g_number_string.mli
@@ -8,40 +8,27 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Number
+
 val wit_number_string_mapping :
-  (bool * Libnames.qualid * Libnames.qualid, unit, unit) Genarg.genarg_type
+  (bool * Libnames.qualid * Libnames.qualid) Genarg.vernac_genarg_type
 
 val number_string_mapping :
   (bool * Libnames.qualid * Libnames.qualid) Pcoq.Entry.t
 
-val wit_number_string_via :
-  (Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list,
-   unit, unit)
-  Genarg.genarg_type
+val wit_number_string_via : number_string_via Genarg.vernac_genarg_type
 
-val number_string_via :
-  (Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list)
-  Pcoq.Entry.t
+val number_string_via : number_string_via Pcoq.Entry.t
 
-val wit_number_modifier :
-  (Number.number_option, unit, unit)
-  Genarg.genarg_type
+val wit_number_modifier : Number.number_option Genarg.vernac_genarg_type
 
-val number_modifier :
-  Number.number_option Pcoq.Entry.t
+val number_modifier : Number.number_option Pcoq.Entry.t
 
-val wit_number_options :
-  (Number.number_option list, unit, unit)
-  Genarg.genarg_type
+val wit_number_options : Number.number_option list Genarg.vernac_genarg_type
 
 val number_options :
   Number.number_option list Pcoq.Entry.t
 
-val wit_string_option :
-  (Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list,
-   unit, unit)
-  Genarg.genarg_type
+val wit_string_option : number_string_via Genarg.vernac_genarg_type
 
-val string_option :
-  (Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list)
-  Pcoq.Entry.t
+val string_option : number_string_via Pcoq.Entry.t

--- a/pretyping/genarg.ml
+++ b/pretyping/genarg.ml
@@ -80,6 +80,8 @@ let pr_argument_type (ArgumentType t) = pr_genarg_type t
 type 'a uniform_genarg_type = ('a, 'a, 'a) genarg_type
 (** Alias for concision *)
 
+type 'a vernac_genarg_type = ('a, Util.Empty.t, Util.Empty.t) genarg_type
+
 (* Dynamics but tagged by a type expression *)
 
 type rlevel = [ `rlevel ]

--- a/pretyping/genarg.mli
+++ b/pretyping/genarg.mli
@@ -68,6 +68,9 @@ type (_, _, _) genarg_type =
 type 'a uniform_genarg_type = ('a, 'a, 'a) genarg_type
 (** Alias for concision when the three types agree. *)
 
+type 'a vernac_genarg_type = ('a, Util.Empty.t, Util.Empty.t) genarg_type
+(** Produced  by VERNAC ARGUMENT EXTEND *)
+
 val make0 : string -> ('raw, 'glob, 'top) genarg_type
 (** Create a new generic type of argument: force to associate
     unique ML types at each of the three levels. *)

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -146,7 +146,7 @@ type 'a vernac_argument = {
 }
 
 val vernac_argument_extend : plugin:string -> name:string -> 'a vernac_argument ->
-  ('a, unit, unit) Genarg.genarg_type * 'a Pcoq.Entry.t
+  'a Genarg.vernac_genarg_type * 'a Pcoq.Entry.t
 
 (** {5 STM classifiers} *)
 val get_vernac_classifier : Vernacexpr.extend_name -> classifier


### PR DESCRIPTION
Derive didn't actually use it.
Extraction used it for ARGUMENT EXTEND but VERNAC ARGUMENT EXTEND is
enough.

The other plugins with a ltac_plugin dependency really interact with
ltac.

NB: funind depends on extraction to declare some generated function
Extraction Inline. Not sure this is actually useful.

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/394