### PR TITLE
Towards having only folded primitive projections

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -931,7 +931,7 @@ struct
 
   type t = Repr.t * bool
 
-  let make c b = (c, b)
+  let make c _b = (c, false)
 
   let mind (c,_) = Repr.mind c
   let inductive (c,_) = Repr.inductive c
@@ -941,7 +941,6 @@ struct
   let label (c,_) = Repr.label c
   let repr = fst
   let unfolded = snd
-  let unfold (c, b as p) = if b then p else (c, true)
 
   let equal (c, b) (c', b') = Repr.equal c c' && b == b'
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -621,7 +621,6 @@ module Projection : sig
   val arg : t -> int
   val label : t -> Label.t
   val unfolded : t -> bool
-  val unfold : t -> t
 
   val equal : t -> t -> bool
   [@@ocaml.deprecated "(8.13) Use QProjection.equal"]

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -400,9 +400,10 @@ let rec extract_type env sg db j c args =
         extract_type_app env sg db (GlobRef.IndRef (kn,i),s) args
     | Proj (p,r,t) ->
        (* Let's try to reduce, if it hasn't already been done. *)
-       if Projection.unfolded p then Tunknown
-       else
-         extract_type env sg db j (EConstr.mkProj (Projection.unfold p, r, t)) args
+       let c, args = Reductionops.whd_stack_gen RedFlags.(red_add betaiotazeta (fPROJ (Projection.repr p))) env sg (EConstr.applist (c,args)) in
+       (match EConstr.kind sg c with
+       | Proj (p',_,_) when QProjection.equal env p p' -> Tunknown
+       | _ -> extract_type env sg db j c args)
     | Case _ | Fix _ | CoFix _ -> Tunknown
     | Evar _ | Meta _ -> Taxiom (* only possible during Show Extraction *)
     | Var v ->

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -525,13 +525,7 @@ let rec norm_head info env t stack =
   | Case (ci,u,pms,p,iv,c,v) -> norm_head info env c (CASE(u,pms,p,v,iv,ci,env,stack))
   | Cast (ct,_,_) -> norm_head info env ct stack
 
-  | Proj (p, r, c) ->
-    let p' =
-      if red_set info.reds (fPROJ (Projection.repr p))
-      then Projection.unfold p
-      else p
-    in
-      norm_head info env c (PROJ (p', r, stack))
+  | Proj (p, r, c) -> norm_head info env c (PROJ (p, r, stack))
 
   (* constants, axioms
    * the first pattern is CRUCIAL, n=0 happens very often:

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -79,11 +79,11 @@ let unfold_projection env evd ts p r c =
 (* [unfold_projection_under_eta env evd ts n c] checks if [c] is the eta
    expanded, folded primitive projection of name [n] and unfolds the primitive
    projection. It respects projection transparency of [ts]. *)
-let unfold_projection_under_eta env evd ts n c =
+let unfold_projection_under_eta env evd ts cst c =
   let rec go c lams =
     match EConstr.kind evd c with
     | Lambda (b, t, c) -> go c ((b,t)::lams)
-    | Proj (p, r, c) when QConstant.equal env n (Projection.constant p) ->
+    | Proj (p, r, c) when QConstant.equal env cst (Projection.constant p) ->
       let c = unfold_projection env evd ts p r c in
       begin
         match c with

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1696,6 +1696,15 @@ let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
   | Proj (p,r,c) -> whrec (c, Stack.Proj (p,r) :: stack)
   | _ -> whrec s
 
+let whd_betaiotazeta_proj env sigma c =
+  let (c, args as s) = whd_beta_stack env sigma c in
+  let stack = Stack.(append_app_list args empty) in
+  let s =
+    match kind sigma c with
+    | Proj (p,r,c) -> (c, Stack.(Proj (p,r) :: stack))
+    | _ -> (c, stack) in
+  Stack.zip sigma (whd_betaiotazeta_state env sigma s)
+
 let find_conclusion env sigma =
   let rec decrec env c =
     let t = whd_all env sigma c in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1690,7 +1690,11 @@ let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
         end
       |_, ((Stack.App _|Stack.Primitive _) :: _|[]) -> s
   in
-  whrec s
+  let (t, stack) = s in
+  let (t, stack) = apply_subst [] sigma t stack in
+  match kind sigma t with
+  | Proj (p,r,c) -> whrec (c, Stack.Proj (p,r) :: stack)
+  | _ -> whrec s
 
 let find_conclusion env sigma =
   let rec decrec env c =

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -309,6 +309,9 @@ exception PatternFailure
 val apply_rules : (state -> state) -> env -> evar_map -> EInstance.t ->
   Declarations.rewrite_rule list -> Stack.t -> econstr * Stack.t
 
+val whd_betaiotazeta_proj :
+  reduction_function
+
 val is_head_evar : env -> evar_map -> constr -> bool
 
 (** {6 Meta-related reduction functions } *)

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -619,10 +619,6 @@ let match_eval_ref_value env sigma constr stack =
       Some (EConstr.of_constr (constant_value_in env (sp, u)))
     else
       None
-  | Proj (p, r, c) when not (Projection.unfolded p) ->
-     if is_evaluable env (EvalProjectionRef (Projection.repr p)) then
-       Some (mkProj (Projection.unfold p, r, c))
-     else None
   | Var id when is_evaluable env (EvalVarRef id) ->
      env |> lookup_named id |> NamedDecl.get_value
   | Rel n ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -488,7 +488,7 @@ let use_metas_pattern_unification sigma flags nb l =
 (* [unfold_projection_under_eta env ts n c] checks if [c] is the eta
    expanded, folded primitive projection of name [n] and unfolds the primitive
    projection. It respects projection transparency of [ts]. *)
-let unfold_projection_under_eta env ts n c =
+let unfold_projection_under_eta env ts cst c =
   let unfold_projection env ts p r c =
     if TransparentState.is_transparent_projection ts (Projection.repr p) then
       Some (Constr.mkProj (Projection.unfold p, r, c))
@@ -497,7 +497,7 @@ let unfold_projection_under_eta env ts n c =
   let rec go c lams =
     match Constr.kind c with
     | Lambda (b, t, c) -> go c ((b,t)::lams)
-    | Proj (p, r, c) when QConstant.equal env n (Projection.constant p) ->
+    | Proj (p, r, c) when QConstant.equal env cst (Projection.constant p) ->
       let c = unfold_projection env ts p r c in
       begin
         match c with

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1145,24 +1145,24 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
             (match expand_key flags.modulo_delta curenv sigma l1 cf1 with
             | Some c_l1 ->
                 unirec_rec curenvnb pb opt substn
-                  (whd_betaiotazeta curenv sigma (mkApp c_l1)) cN
+                  (whd_betaiotazeta_proj curenv sigma (mkApp c_l1)) cN
             | None ->
                 (match expand_key flags.modulo_delta curenv sigma l2 cf2 with
                 | Some c_l2 ->
                     unirec_rec curenvnb pb opt substn cM
-                      (whd_betaiotazeta curenv sigma (mkApp c_l2))
+                      (whd_betaiotazeta_proj curenv sigma (mkApp c_l2))
                 | None ->
                     error_cannot_unify curenv sigma (cM,cN)))
         | Some false ->
             (match expand_key flags.modulo_delta curenv sigma l2 cf2 with
             | Some c_l2 ->
                 unirec_rec curenvnb pb opt substn cM
-                  (whd_betaiotazeta curenv sigma (mkApp c_l2))
+                  (whd_betaiotazeta_proj curenv sigma (mkApp c_l2))
             | None ->
                 (match expand_key flags.modulo_delta curenv sigma l1 cf1 with
                 | Some c_l1 ->
                     unirec_rec curenvnb pb opt substn
-                      (whd_betaiotazeta curenv sigma (mkApp c_l1)) cN
+                      (whd_betaiotazeta_proj curenv sigma (mkApp c_l1)) cN
                 | None ->
                     error_cannot_unify curenv sigma (cM,cN)))
 

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -164,3 +164,20 @@ exact _H.
 Qed.
 
 End Wildcard.
+
+Module SimplNever.
+
+Fixpoint arrow n X :=
+  match n with
+  | 0 => X
+  | S n => X -> arrow n X
+  end.
+
+Arguments arrow : simpl never.
+
+Goal arrow 1 False.
+intro H.
+exact H.
+Qed.
+
+End SimplNever.


### PR DESCRIPTION
This is an experimental PR going in the direction of manipulating only folded primitive projections. Both fMATCH/fCOFIX and fPROJ are required to reduce the projection of a record value and the unfolded/folded status is not anymore observable.

- [ ] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
 