### PR TITLE
About and Print inform about projections

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18725-HEAD.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18725-HEAD.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  When a name is a projection, :cmd:`About` and :cmd:`Print` now indicate it
+  (`#18725 <https://github.com/coq/coq/pull/18725>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/InductiveMainName.out
+++ b/test-suite/output/InductiveMainName.out
@@ -1,18 +1,21 @@
 bar : foo -> nat
 
 bar is not universe polymorphic
+bar is a projection of foo
 Arguments bar id
 bar is transparent
 Expands to: Constant InductiveMainName.bar
 bar' : foo' -> nat
 
 bar' is not universe polymorphic
+bar' is a projection of foo'
 Arguments bar' {id'}
 bar' is transparent
 Expands to: Constant InductiveMainName.bar'
 bar'' : foo'' -> foo''
 
 bar'' is not universe polymorphic
+bar'' is a projection of foo''
 Arguments bar'' id''
 bar'' is transparent
 Expands to: Constant InductiveMainName.bar''

--- a/test-suite/output/InductiveMainName.out
+++ b/test-suite/output/InductiveMainName.out
@@ -19,3 +19,8 @@ bar'' is a projection of foo''
 Arguments bar'' id''
 bar'' is transparent
 Expands to: Constant InductiveMainName.bar''
+Record foo''' : Set := Build_foo''' { bar''' : nat } as id.
+
+foo''' has primitive projections with eta conversion.
+Arguments Build_foo''' bar'''%nat_scope
+Arguments bar''' id

--- a/test-suite/output/InductiveMainName.v
+++ b/test-suite/output/InductiveMainName.v
@@ -4,3 +4,6 @@ Class foo' := { bar' : nat } as id'.
 About bar'.
 CoInductive foo'' := { bar'' : foo'' } as id''.
 About bar''.
+Set Primitive Projections.
+Record foo''' := { bar''' : nat } as id.
+Print bar'''.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -122,3 +122,17 @@ Arguments Alias.eq_ind [A]%type_scope x P%function_scope f y e
 Alias.eq_ind is transparent
 Expands to: Constant PrintInfos.Alias.eq_ind (syntactically equal to
 Coq.Init.Logic.eq_ind)
+fst : forall A B : Type, prod A B -> A
+
+fst is not universe polymorphic
+fst is a projection of prod
+Arguments fst (A B)%type_scope p
+fst is transparent
+Expands to: Constant PrintInfos.AboutProj.fst
+fst : forall A B : Type, prod A B -> A
+
+fst is not universe polymorphic
+fst is a primitive projection of prod
+Arguments fst (A B)%type_scope p
+fst is transparent
+Expands to: Constant PrintInfos.AboutPrimProj.fst

--- a/test-suite/output/PrintInfos.v
+++ b/test-suite/output/PrintInfos.v
@@ -52,3 +52,14 @@ Module Alias := Logic.
 About Alias.eq.
 About Alias.eq_refl.
 About Alias.eq_ind.
+
+Module AboutProj.
+Record prod A B := { fst:A ; snd:B }.
+About fst.
+End AboutProj.
+
+Module AboutPrimProj.
+Set Primitive Projections.
+Record prod A B := { fst:A ; snd:B }.
+About fst.
+End AboutPrimProj.

--- a/test-suite/output/Projections.out
+++ b/test-suite/output/Projections.out
@@ -7,11 +7,14 @@ let B := A in fun (C : Type) (u : U A C) => (A, B, C, c _ _ u)
        let B := A in
        forall C : Type, U A C -> Type * Type * Type * (B * A * C)
 
+a is a projection of U
 Arguments a (A C)%type_scope u
-b =
-fun A : Type => let B := A in fun (C : Type) (u : U A C) => b _ _ u
-     : forall A : Type,
-       let B := A in
-       forall (C : Type) (u : U A C), (A, B, C, c _ _ u) = (A, B, C, c _ _ u)
+Record U (A : Type) (B : Type := A) (C : Type) : Type := Build_U
+  { c : (B * A * C)%type;  a := (A, B, C, c);  b : a = a }.
 
+U has primitive projections with eta conversion.
+Arguments U (A C)%type_scope
+Arguments Build_U (A C)%type_scope c b
+Arguments c (A C)%type_scope u
+Arguments a (A C)%type_scope u
 Arguments b (A C)%type_scope u

--- a/test-suite/output/RecordProjParameter.out
+++ b/test-suite/output/RecordProjParameter.out
@@ -1,36 +1,42 @@
 t1 : Atype -> forall a : Type, a
 
 t1 is not universe polymorphic
+t1 is a projection of Atype
 Arguments t1 a0 a%type_scope
 t1 is transparent
 Expands to: Constant RecordProjParameter.t1
 t3 : forall a0 : Atype, t2 a0
 
 t3 is not universe polymorphic
+t3 is a projection of Atype
 Arguments t3 a0
 t3 is transparent
 Expands to: Constant RecordProjParameter.t3
 u1 : Btype -> forall b b0 : Type, b * b0
 
 u1 is not universe polymorphic
+u1 is a projection of Btype
 Arguments u1 b1 (b b0)%type_scope
 u1 is transparent
 Expands to: Constant RecordProjParameter.u1
 u3 : forall b1 : Btype, u2 b1
 
 u3 is not universe polymorphic
+u3 is a projection of Btype
 Arguments u3 b1
 u3 is transparent
 Expands to: Constant RecordProjParameter.u3
 v1 : Ctype -> forall c0 : Type, c0
 
 v1 is not universe polymorphic
+v1 is a projection of Ctype
 Arguments v1 c c0%type_scope
 v1 is transparent
 Expands to: Constant RecordProjParameter.v1
 v3 : forall c : Ctype, v2 c
 
 v3 is not universe polymorphic
+v3 is a projection of Ctype
 Arguments v3 c
 v3 is transparent
 Expands to: Constant RecordProjParameter.v3

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -7,11 +7,14 @@ Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%type_scope
 Arguments pwrap A%type_scope punwrap
-punwrap@{uu} =
-fun (A : Type@{uu}) (p : PWrap@{uu} A) => punwrap _ p
-     : forall A : Type@{uu}, PWrap@{uu} A -> A
+Arguments punwrap A%type_scope p
+Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
+  { punwrap : A }.
 (* uu |=  *)
 
+PWrap has primitive projections with eta conversion.
+Arguments PWrap A%type_scope
+Arguments pwrap A%type_scope punwrap
 Arguments punwrap A%type_scope p
 Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
   { runwrap : A }.
@@ -19,11 +22,13 @@ Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
 
 Arguments RWrap A%type_scope
 Arguments rwrap A%type_scope runwrap
+Arguments runwrap A%type_scope r
 runwrap@{uu} =
 fun (A : Type@{uu}) (r : RWrap@{uu} A) => let (runwrap) := r in runwrap
      : forall A : Type@{uu}, RWrap@{uu} A -> A
 (* uu |=  *)
 
+runwrap is a projection of RWrap
 Arguments runwrap A%type_scope r
 Wrap@{uu} = fun A : Type@{uu} => A
      : Type@{uu} -> Type@{uu}
@@ -97,6 +102,7 @@ Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%type_scope
 Arguments pwrap A%type_scope punwrap
+Arguments punwrap A%type_scope p
 punwrap@{K} : forall A : Type@{K}, PWrap@{K} A -> A
 (* K |=  *)
 
@@ -194,8 +200,10 @@ Inductive MutualR1@{u} (A : Type@{u}) : Prop :=
 
 Arguments MutualR1 A%type_scope
 Arguments Build_MutualR1 A%type_scope p1
+Arguments p1 A%type_scope m
 Arguments MutualR2 A%type_scope
 Arguments Build_MutualR2 A%type_scope p2
+Arguments p2 A%type_scope m
 Inductive MutualI1@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1 : MutualI2@{u u0} A -> MutualI1@{u u0} A
   with MutualI2@{u u0} (A : Type@{u}) : Type@{u0} :=
@@ -214,8 +222,10 @@ CoInductive MutualR1'@{u} (A : Type@{u}) : Prop :=
 
 Arguments MutualR1' A%type_scope
 Arguments Build_MutualR1' A%type_scope p1'
+Arguments p1' A%type_scope m
 Arguments MutualR2' A%type_scope
 Arguments Build_MutualR2' A%type_scope p2'
+Arguments p2' A%type_scope m
 CoInductive MutualI1'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1' : MutualI2'@{u u0} A -> MutualI1'@{u u0} A
   with MutualI2'@{u u0} (A : Type@{u}) : Type@{u0} :=

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -101,6 +101,7 @@ punwrap@{K} : forall A : Type@{K}, PWrap@{K} A -> A
 (* K |=  *)
 
 punwrap is universe polymorphic
+punwrap is a primitive projection of PWrap
 Arguments punwrap A%type_scope p
 punwrap is transparent
 Expands to: Constant UnivBinders.punwrap

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -396,6 +396,7 @@ let print_name_infos env ref =
     else
       [] in
   print_type_in_type env ref @
+  print_projection env ref @
   print_primitive env ref @
   type_info_for_implicit @
   print_arguments env ref @
@@ -443,12 +444,23 @@ let assumptions_for_print lna =
 (*********************)
 (* *)
 
-let print_inductive_args env mind mipv =
+let print_inductive_args env mind mib =
   let flatmapi f v = List.flatten (Array.to_list (Array.mapi f v)) in
+  let mips =
+    (* We don't use the PrimRecord field as it misses the projections corresponding to local definition *)
+    try
+      Array.mapi (fun i mip ->
+          let projs = Option.List.flatten (Structures.Structure.find_projections (mind,i)) in
+          (mip.mind_consnames, Array.of_list projs)) mib.mind_packets
+    with
+      Not_found (* find_projections *) ->
+      Array.map (fun mip -> (mip.mind_consnames,[||])) mib.mind_packets in
   flatmapi
-    (fun i mip -> print_arguments env (GlobRef.IndRef (mind,i)) @
-                  flatmapi (fun j _ -> print_arguments env (GlobRef.ConstructRef ((mind,i),j+1)))
-                    mip.mind_consnames) mipv
+    (fun i (constructs, projs) ->
+       print_arguments env (GlobRef.IndRef (mind,i)) @
+       flatmapi (fun j _ -> print_arguments env (GlobRef.ConstructRef ((mind,i),j+1))) constructs @
+       flatmapi (fun _ cst -> print_arguments env (GlobRef.ConstRef cst)) projs)
+    mips
 
 let print_inductive env mind udecl =
   let mib = Environ.lookup_mind mind env in
@@ -460,7 +472,7 @@ let print_inductive_with_infos env mind udecl =
   Printmod.pr_mutual_inductive_body env mind mib udecl ++
   with_line_skip
     (print_primitive_record mib.mind_finite mipv mib.mind_record @
-     print_inductive_args env mind mipv)
+     print_inductive_args env mind mib)
 
 let print_section_variable_with_infos env sigma id =
   print_named_decl env sigma true id ++
@@ -517,7 +529,10 @@ let print_constant_with_infos env cst udecl =
 let print_global_reference env sigma gref udecl =
   let open GlobRef in
   match gref with
-  | ConstRef cst -> print_constant_with_infos env cst udecl
+  | ConstRef cst ->
+    (match Structures.PrimitiveProjections.find_opt cst with
+     | Some p -> print_inductive_with_infos env (fst (Projection.Repr.inductive p)) udecl
+     | None -> print_constant_with_infos env cst udecl)
   | IndRef (mind,_) -> print_inductive_with_infos env mind udecl
   | ConstructRef ((mind,_),_) -> print_inductive_with_infos env mind udecl
   | VarRef id -> print_section_variable_with_infos env sigma id
@@ -920,7 +935,6 @@ let print_about_global_reference ?loc env ref udecl =
   pr_infos_list
    (print_ref env false ref udecl :: blankline ::
     print_polymorphism env ref @
-    print_projection env ref @
     print_name_infos env ref @
     print_reduction_behaviour ref @
     print_opacity env ref @

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -208,6 +208,22 @@ let print_polymorphism env ref =
          ++ if !Detyping.print_universes then h (pr_template_variables template_variables) else mt()
        else str "not universe polymorphic") ]
 
+(** Print projection status *)
+
+let print_projection env ref =
+  match ref with
+  | GlobRef.ConstRef cst ->
+    begin
+      match Structures.PrimitiveProjections.find_opt cst with
+      | Some p -> [pr_global ref ++ str " is a primitive projection of " ++ pr_global (IndRef (Projection.Repr.inductive p))]
+      | None ->
+      try
+        let ind = (Structures.Structure.find_from_projection cst).name in
+        [pr_global ref ++ str " is a projection of " ++ pr_global (IndRef ind)]
+      with Not_found -> []
+    end
+  | _ -> []
+
 (** Printing type-in-type status *)
 
 let print_type_in_type env ref =
@@ -904,6 +920,7 @@ let print_about_global_reference ?loc env ref udecl =
   pr_infos_list
    (print_ref env false ref udecl :: blankline ::
     print_polymorphism env ref @
+    print_projection env ref @
     print_name_infos env ref @
     print_reduction_behaviour ref @
     print_opacity env ref @

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -119,7 +119,7 @@ let print_one_inductive env sigma isrecord mib ((_,i) as ind) =
   let args = Context.Rel.instance_list mkRel 0 params in
   let arity = hnf_prod_applist_decls env nparamdecls (build_ind_type ((mib,mip),u)) args in
   let cstrtypes = Inductive.type_of_constructors (ind,u) (mib,mip) in
-  let cstrtypes = Array.map (fun c -> hnf_prod_applist_decls env nparamdecls c args) cstrtypes in
+  let cstrtypes = Array.map (fun c -> snd (Term.decompose_prod_n_decls nparamdecls c)) cstrtypes in
   if isrecord then assert (Array.length cstrtypes = 1);
   let inst =
     if Declareops.inductive_is_polymorphic mib then

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -89,6 +89,8 @@ val interp_structure
 
 val declare_existing_class : GlobRef.t -> unit
 
+val canonical_inhabitant_id : isclass:bool -> Id.t -> Id.t
+
 (* Implementation internals, consult Coq developers before using;
    current user Elpi, see https://github.com/LPCIC/coq-elpi/pull/151 *)
 module Internal : sig


### PR DESCRIPTION
The PR adds the following:
- if `x` is a projection, `About x` indicates it
- if `x` is a projection, `Print x` prints the whole record to which this projection refers, as it would do for the constructor of the record
- for `Record`, prints the name of the `as` variable (so that the names used in `Arguments` make sense)

Examples:
```coq
Set Primitive Projections.
Record prod (A B : Type) : Type := Build_prod { fst : A; snd : B }.
About fst.
(*
fst : forall A B : Type, prod A B -> A

fst is not universe polymorphic
fst is a primitive projection of prod <-------- new information
Arguments fst (A B)%type_scope p
fst is transparent
Expands to: Top.fst
*)
```
```coq
Record prod (A B : Type) : Type := Build_prod { fst : A; snd : B }.
About fst.
(*
fst : forall A B : Type, prod A B -> A

fst is not universe polymorphic
fst is a projection of prod <-------- new information
Arguments fst (A B)%type_scope p
fst is transparent
Expands to: Top.fst
*)
```
```coq
Set Primitive Projections.
Record prod (A B : Type) : Type := Build_prod { fst : A; snd : B }.
Print fst.
(*
Record prod (A B : Type) : Type := Build_prod { fst : A;  snd : B } as p.

prod has primitive projections with eta conversion.
Arguments prod (A B)%type_scope
Arguments Build_prod (A B)%type_scope fst snd
Arguments fst (A B)%type_scope p
Arguments snd (A B)%type_scope p
*)
(* Before:
fst = fun (A B : Type) (p : prod A B) => fst _ _ p
     : forall A B : Type, prod A B -> A

Arguments fst (A B)%type_scope p
*)
```

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
