### PR TITLE
Ltac2: don't use delayed_of_tactic for apply terms

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1687,7 +1687,8 @@ and interp_atomic ist tac : unit Proofview.tactic =
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
         let l = List.map (fun (k,c) ->
-          let loc, f = interp_open_constr_with_bindings_loc ist c in
+            let loc, f = interp_open_constr_with_bindings_loc ist c in
+            let f = Tacticals.tactic_of_delayed f in
             (k,(CAst.make ?loc f))) cb
         in
         let tac = match cl with

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1131,11 +1131,7 @@ let () =
 
 let () =
   define "with_holes" (closure @-> closure @-> tac valexpr) @@ fun x f ->
-  Proofview.tclEVARMAP >>= fun sigma0 ->
-  thaw x >>= fun ans ->
-  Proofview.tclEVARMAP >>= fun sigma ->
-  Proofview.Unsafe.tclEVARS sigma0 >>= fun () ->
-  Tacticals.tclWITHHOLES false (Tac2val.apply f [ans]) sigma
+  Tacticals.tclRUNWITHHOLES false (thaw x) (fun ans -> Tac2val.apply f [ans])
 
 let () =
   define "progress" (closure @-> tac valexpr) @@ fun f ->

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -104,7 +104,7 @@ let intros_patterns ev ipat =
 let apply adv ev cb cl =
   let map c =
     let c = thaw constr_with_bindings c >>= fun p -> return (mk_with_bindings p) in
-    None, CAst.make (delayed_of_tactic c)
+    None, CAst.make c
   in
   let cb = List.map map cb in
   match cl with

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -108,12 +108,19 @@ val tclREPEAT_MAIN : unit tactic -> unit tactic
 val tclCOMPLETE : 'a tactic -> 'a tactic
 val tclSOLVE : unit tactic list -> unit tactic
 val tclPROGRESS : unit tactic -> unit tactic
+val tclRUNWITHHOLES : bool -> 'a tactic -> ('a -> 'b tactic) -> 'b tactic
+(** [tclRUNWITHHOLES b tac0 tac] is [tac0 >>= tac] if [b = false],
+    otherwise it additionally checks that evars created by [tac0] are solved after [tac]. *)
+
 val tclWITHHOLES : bool -> 'a tactic -> Evd.evar_map -> 'a tactic
 val tclDELAYEDWITHHOLES : bool -> 'a delayed_open -> ('a -> unit tactic) -> unit tactic
 val tclMAPDELAYEDWITHHOLES : bool -> 'a delayed_open list -> ('a -> unit tactic) -> unit tactic
 (* in [tclMAPDELAYEDWITHHOLES with_evars l tac] the delayed
     argument of [l] are evaluated in the possibly-updated
     environment and updated sigma of each new successive goals *)
+
+val tactic_of_delayed : 'a delayed_open -> 'a tactic
+(** Must be focused to use *)
 
 val check_evar_list : Environ.env -> evar_map -> Evar.Set.t -> evar_map -> Evar.t list
   (* [check_evar_list env sigma evars origsigma] returns the subset of

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -210,7 +210,7 @@ val apply_with_bindings_gen :
   ?with_classes:bool -> advanced_flag -> evars_flag -> (clear_flag * constr with_bindings CAst.t) list -> unit Proofview.tactic
 
 val apply_with_delayed_bindings_gen :
-  advanced_flag -> evars_flag -> (clear_flag * delayed_open_constr_with_bindings CAst.t) list -> unit Proofview.tactic
+  advanced_flag -> evars_flag -> (clear_flag * constr with_bindings Proofview.tactic CAst.t) list -> unit Proofview.tactic
 
 val apply_with_bindings   : constr with_bindings -> unit Proofview.tactic
 val eapply_with_bindings : ?with_classes:bool -> constr with_bindings -> unit Proofview.tactic
@@ -224,7 +224,7 @@ val apply_in :
 
 val apply_delayed_in :
   advanced_flag -> evars_flag -> Id.t ->
-    (clear_flag * delayed_open_constr_with_bindings CAst.t) list ->
+    (clear_flag * constr with_bindings Proofview.tactic CAst.t) list ->
     intro_pattern option -> unit Proofview.tactic -> unit Proofview.tactic
 
 (** {6 Elimination tactics. } *)

--- a/test-suite/ltac2/std_tactics.v
+++ b/test-suite/ltac2/std_tactics.v
@@ -136,3 +136,7 @@ Goal False.
   (* interned as with type scope locally open *)
   assert (H' : nat * (0 * 0 = 0)) by (split; first [exact 0 | reflexivity]).
 Abort.
+
+Goal nat.
+  Std.apply true false [fun () => Control.plus (fun () => 'I) (fun _ => '0), Std.NoBindings] None.
+Qed.


### PR DESCRIPTION
Eventually we want to get rid of all delayed_of_tactic uses but let's take it one step at a time.

This should not be particularly impactful as we need to eg pass a thunk which does backtracking to `Std.apply` to see a difference (see test).
