### PR TITLE
zify Nat.double and Nat.div2

### DIFF
--- a/doc/changelog/04-tactics/18729-zify-nat-double-halve.rst
+++ b/doc/changelog/04-tactics/18729-zify-nat-double-halve.rst
@@ -1,0 +1,4 @@
+- **Added:** support for :g:`Nat.double` and :g:`Nat.div2` to :g:`zify` and
+  :g:`lia`
+  (`#18729 <https://github.com/coq/coq/pull/18729>`_,
+  by Andres Erbsen).

--- a/test-suite/micromega/zify.v
+++ b/test-suite/micromega/zify.v
@@ -143,7 +143,13 @@ Proof.
   lia.
 Qed.
 
+Goal forall n, Nat.double n = n + n.
+Proof. lia. Qed.
+
 Open Scope Z_scope.
+
+Goal forall n, Z.of_nat (Nat.div2 n) = Z.of_nat n / 2.
+Proof. lia. Qed.
 
 Goal forall p,
     False ->

--- a/theories/Reals/Exp_prop.v
+++ b/theories/Reals/Exp_prop.v
@@ -324,10 +324,11 @@ Proof.
     apply Rmult_le_reg_l with (Rsqr (INR (Nat.div2 (S N)))).
     { apply Rsqr_pos_lt.
       apply not_O_INR; red; intro.
-      lia. }
+      PreOmega.zify; PreOmega.Z.to_euclidean_division_equations; lia. }
     repeat rewrite <- Rmult_assoc.
     rewrite Rinv_r.
-    2:{ unfold Rsqr; apply prod_neq_R0; apply not_O_INR;lia. }
+    2:{ unfold Rsqr; apply prod_neq_R0; apply not_O_INR;
+      PreOmega.zify; PreOmega.Z.to_euclidean_division_equations; lia. }
     rewrite Rmult_1_l.
     change 4 with (Rsqr 2).
     rewrite <- Rsqr_mult.

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -768,6 +768,12 @@ Proof.
  now rewrite <- !nat_N_Z, Nat2N.inj_pow, N2Z.inj_pow.
 Qed.
 
+Lemma inj_div2 n : Z.of_nat (Nat.div2 n) = Z.div2 (Z.of_nat n).
+Proof. rewrite Nat.div2_div, Z.div2_div, inj_div; trivial. Qed.
+
+Lemma inj_double n : Z.of_nat (Nat.double n) = Z.double (Z.of_nat n).
+Proof. rewrite Nat.double_twice, Z.double_spec, inj_mul; trivial. Qed.
+
 End Nat2Z.
 
 Module Z2Nat.

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -127,7 +127,7 @@ Add Zify UnOp Op_nat_div2.
 
 #[global]
 Instance Op_nat_double : UnOp Nat.double :=
-  {| TUOp := Z.double ; TUOpInj := Nat2Z.inj_double |}.
+  {| TUOp := Z.mul 2 ; TUOpInj := Nat2Z.inj_double |}.
 Add Zify UnOp Op_nat_double.
 
 (** Support for positive *)

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -119,6 +119,17 @@ Instance Op_Z_abs_nat : UnOp  Z.abs_nat :=
   { TUOp := Z.abs ; TUOpInj := Zabs2Nat.id_abs }.
 Add Zify UnOp Op_Z_abs_nat.
 
+#[global]
+Instance Op_nat_div2 : UnOp Nat.div2 :=
+  { TUOp x := x / 2 ;
+    TUOpInj x := ltac:(now rewrite Nat2Z.inj_div2, Z.div2_div) }.
+Add Zify UnOp Op_nat_div2.
+
+#[global]
+Instance Op_nat_double : UnOp Nat.double :=
+  {| TUOp := Z.double ; TUOpInj := Nat2Z.inj_double |}.
+Add Zify UnOp Op_nat_double.
+
 (** Support for positive *)
 
 #[global]


### PR DESCRIPTION
I just coached a new Coq user to work around this incompleteness; it didn't leave a good impression.


- [x] Added **changelog**.
- [x] Opened **overlay** pull requests
    - [x] ~~[cross-crypto](https://github.com/mit-plv/cross-crypto/pull/36)~~
        - [x] ~~[FCF](https://github.com/adampetcher/fcf/pull/46)~~
    - [x] ~~[tlc](https://github.com/charguer/tlc/pull/19)~~
    - [x] [flocq](https://github.com/coq/coq/pull/18729#issuecomment-2023724404)
    - [x] [neural-net-interp](https://github.com/JasonGross/neural-net-coq-interp/pull/48)

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
