### PR TITLE
Experimenting a variant of `clear -hyps` that skips dependencies in evar instance

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -827,11 +827,13 @@ let occur_in_global env id constr =
   let vars = vars_of_global env constr in
   Id.Set.mem id vars
 
-let occur_var env sigma id c =
+let occur_var env sigma ?(skip_evar=false) id c =
   let rec occur_rec c =
     match EConstr.destRef sigma c with
     | gr, _ -> if occur_in_global env id gr then raise Occur
-    | exception DestKO -> EConstr.iter sigma occur_rec c
+    | exception DestKO ->
+      if not (skip_evar && EConstr.isEvar sigma c) then
+        EConstr.iter sigma occur_rec c
   in
   try occur_rec c; false with Occur -> true
 
@@ -856,8 +858,8 @@ let occur_var_indirectly env sigma id c =
   in
   try occur_rec c; None with OccurInGlobal gr -> Some gr
 
-let occur_var_in_decl env sigma hyp decl =
-  NamedDecl.exists (occur_var env sigma hyp) decl
+let occur_var_in_decl env sigma ?skip_evar hyp decl =
+  NamedDecl.exists (occur_var env sigma ?skip_evar hyp) decl
 
 let occur_vars_in_decl env sigma hyps decl =
   NamedDecl.exists (occur_vars env sigma hyps) decl

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -98,9 +98,9 @@ val occur_existential : Evd.evar_map -> constr -> bool
 val occur_meta_or_existential : Evd.evar_map -> constr -> bool
 val occur_metavariable : Evd.evar_map -> metavariable -> constr -> bool
 val occur_evar : Evd.evar_map -> Evar.t -> constr -> bool
-val occur_var : env -> Evd.evar_map -> Id.t -> constr -> bool
+val occur_var : env -> Evd.evar_map -> ?skip_evar:bool -> Id.t -> constr -> bool
 val occur_var_indirectly : env -> Evd.evar_map -> Id.t -> constr -> GlobRef.t option
-val occur_var_in_decl : env -> Evd.evar_map -> Id.t -> named_declaration -> bool
+val occur_var_in_decl : env -> Evd.evar_map -> ?skip_evar:bool -> Id.t -> named_declaration -> bool
 val occur_vars : env -> Evd.evar_map -> Id.Set.t -> constr -> bool
 val occur_vars_in_decl : env -> Evd.evar_map -> Id.Set.t -> named_declaration -> bool
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2213,8 +2213,8 @@ let keep hyps =
       let decl = map_named_decl EConstr.of_constr decl in
       let hyp = NamedDecl.get_id decl in
       if Id.List.mem hyp hyps
-        || List.exists (occur_var_in_decl env sigma hyp) keep
-        || occur_var env sigma hyp ccl
+        || List.exists (occur_var_in_decl env sigma ~skip_evar:true hyp) keep
+        || occur_var env sigma ~skip_evar:true hyp ccl
       then (clear,decl::keep)
       else (hyp::clear,keep))
       ~init:([],[]) (Proofview.Goal.env gl)


### PR DESCRIPTION
This is to test whether the new semantics might make more sense in practice. If so, it could be an answer to the current time explosion in [#18617](https://github.com/coq/coq/pull/18617#issuecomment-1970826947).

Note: a variant would be to skip only the part of the instance which is the identity.