### PR TITLE
Ltac2 `located` scope modifier

### DIFF
--- a/doc/changelog/06-Ltac2-language/18737-ltac2-loc.rst
+++ b/doc/changelog/06-Ltac2-language/18737-ltac2-loc.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  `located` :ref:`syntactic class <syntactic_classes>` modifier.
+  `located(s)` parses the same grammar as `s` and returns the result of `s`
+  together with its location
+  (`#18737 <https://github.com/coq/coq/pull/18737>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1420,6 +1420,9 @@ Metasyntactic operations that can be applied to other syntactic classes are:
     omitting :token:`ltac2_scope`\s that are :token:`string`\s.
     `self` and `next` are not permitted within `seq`.
 
+  :n:`located(@ltac2_scope)`
+     Parses the :token:`ltac2_scope` and adds the location of what was parsed to the result.
+
 The following classes represent nonterminals with some special handling.  The
 table further down lists the classes that that are handled plainly.
 

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -29,6 +29,7 @@ let map_repr f g r = {
 
 (** Dynamic tags *)
 
+let val_loc = Val.create "loc"
 let val_exn = Val.create "exn"
 let val_exninfo = Val.create "exninfo"
 let val_constr = Val.create "constr"
@@ -184,6 +185,10 @@ let cast = repr_ext val_cast
 let of_ident c = of_ext val_ident c
 let to_ident c = to_ext val_ident c
 let ident = repr_ext val_ident
+
+let of_loc c = of_ext val_loc c
+let to_loc c = to_ext val_loc c
+let loc = repr_ext val_loc
 
 let of_pattern c = of_ext val_pattern c
 let to_pattern c = to_ext val_pattern c

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -85,6 +85,10 @@ val of_ident : Id.t -> valexpr
 val to_ident : valexpr -> Id.t
 val ident : Id.t repr
 
+val of_loc : Loc.t -> valexpr
+val to_loc : valexpr -> Loc.t
+val loc : Loc.t repr
+
 val of_closure : closure -> valexpr
 val to_closure : valexpr -> closure
 val closure : closure repr

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -858,6 +858,11 @@ let () = register_init "string" begin fun _ _ s ->
   Pp.quote (str s)
 end
 
+let () = register_init "location" begin fun _ _ loc ->
+  let loc = to_loc loc in
+  hov 2 (str "<loc:" ++ spc() ++ Loc.pr loc ++ str ">")
+end
+
 let () = register_init "ident" begin fun _ _ id ->
   let id = to_ident id in
   str "@" ++ Id.print id

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -18,6 +18,7 @@ open Tac2qexpr
 
 (** Generic arguments *)
 
+let wit_loc = Arg.create "loc"
 let wit_pattern = Arg.create "pattern"
 let wit_reference = Arg.create "reference"
 let wit_ident = Arg.create "ident"
@@ -86,6 +87,8 @@ let of_option ?loc f opt = match opt with
 
 let inj_wit ?loc wit x =
   CAst.make ?loc @@ CTacExt (wit, x)
+
+let of_loc loc = inj_wit ~loc wit_loc loc
 
 let of_variable {loc;v=id} =
   let qid = Libnames.qualid_of_ident ?loc id in

--- a/plugins/ltac2/tac2quote.mli
+++ b/plugins/ltac2/tac2quote.mli
@@ -30,6 +30,10 @@ val of_pair : ('a -> raw_tacexpr) -> ('b -> raw_tacexpr) -> ('a * 'b) CAst.t -> 
 
 val of_tuple : ?loc:Loc.t -> raw_tacexpr list -> raw_tacexpr
 
+val of_option : ?loc:Loc.t -> ('a -> raw_tacexpr) -> 'a option -> raw_tacexpr
+
+val of_loc : Loc.t -> raw_tacexpr
+
 val of_variable : Id.t CAst.t -> raw_tacexpr
 
 val of_ident : Id.t CAst.t -> raw_tacexpr
@@ -106,3 +110,5 @@ val wit_constr : (Constrexpr.constr_expr, Glob_term.glob_constr) Arg.tag
 val wit_open_constr : (Constrexpr.constr_expr, Glob_term.glob_constr) Arg.tag
 
 val wit_preterm : (Constrexpr.constr_expr, Id.Set.t * Glob_term.glob_constr) Arg.tag
+
+val wit_loc : (Loc.t, Loc.t) Arg.tag

--- a/test-suite/output/ltac2_loc_scope.out
+++ b/test-suite/output/ltac2_loc_scope.out
@@ -1,0 +1,11 @@
+- : location option * unit =
+(Some <loc: File "./output/ltac2_loc_scope.v", line 5, characters 26-28>, ())
+Ltac2 foo : unit -> location option * unit
+      foo :=
+        fun _ =>
+        let t :=
+          Some
+            <loc:
+              File "./output/ltac2_loc_scope.v", line 5, characters 26-28>,
+            () in
+        t

--- a/test-suite/output/ltac2_loc_scope.v
+++ b/test-suite/output/ltac2_loc_scope.v
@@ -1,0 +1,8 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Notation "with_loc:(" t(located(tactic)) ")" := t.
+
+Ltac2 foo () := with_loc:(()).
+
+Ltac2 Eval foo ().
+Print foo.

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -37,6 +37,9 @@ Ltac2 Type constr.
 Ltac2 Type preterm.
 Ltac2 Type binder.
 
+Ltac2 Type location.
+(** Code location in a .v file. *)
+
 Ltac2 Type message.
 Ltac2 Type ('a, 'b, 'c, 'd) format.
 Ltac2 Type exn := [ .. ].


### PR DESCRIPTION
This makes it possible to capture the location of notation arguments.

Typically `apply` wants the location of the constr argument so that it can report type mismatches at that location.

Currently printing (from Ltac2 Eval and Print Ltac2) does not reparse, instead we print `<loc: File "bla.v", line X, characters Y-Z>`.

TODO add APIs that use the loc.

See also #11181
