### PR TITLE
Fixes "where notation" clause of interactive Fixpoint

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1369,9 +1369,11 @@ let pr_optional_scope = function
   | LastLonelyNotation -> mt ()
   | NotationInScope scope -> spc () ++ strbrk "in scope" ++ spc () ++ str scope
 
+let warning_overridden_name = "notation-overridden"
+
 let w_nota_overridden =
   CWarnings.create_warning
-    ~from:[CWarnings.CoreCategories.parsing] ~name:"notation-overridden" ()
+    ~from:[CWarnings.CoreCategories.parsing] ~name:warning_overridden_name ()
 
 let warn_notation_overridden =
   CWarnings.create_in w_nota_overridden

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -229,6 +229,8 @@ val availability_of_prim_token :
 
 (** {6 Declare and interpret back and forth a notation } *)
 
+val warning_overridden_name : string
+
 type entry_coercion_kind =
   | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
   | IsEntryGlobal of string * int

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -406,3 +406,13 @@ Fixpoint f (n : nat) :=
   end.
 
 End WithLateCaseReduction.
+
+Module NtnInteractiveFixpoint.
+
+Reserved Notation "# n" (at level 2, right associativity).
+Fixpoint f (n:nat) : nat where "# n" := (f n).
+exact (match n with 0 => 0 | S n => # n end).
+Defined.
+Check eq_refl : # 0 = f 0.
+
+End NtnInteractiveFixpoint.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -289,7 +289,7 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typin
   let indexes = Option.default [] indexes in
   let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns () in
+  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
   let lemma =
     Declare.Proof.start_mutual_with_initialization ~info
       evd ~mutual_info:(cofix,indexes,init_terms) ~cinfo:thms None in
@@ -303,11 +303,11 @@ let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?use
   let fixdefs = List.map Option.get fixdefs in
   let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
   let fix_kind = Decls.IsDefinition fix_kind in
-  let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns () in
+  let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns ~ntns () in
   let cinfo = fixitems in
   let _ : GlobRef.t list =
     Declare.declare_mutually_recursive ~cinfo ~info ~opaque:false ~uctx
-      ~possible_indexes:indexes ~ntns ~rec_declaration
+      ~possible_indexes:indexes ~rec_declaration
   in
   ()
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -290,12 +290,8 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typin
   let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
   let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
-  let lemma =
-    Declare.Proof.start_mutual_with_initialization ~info
-      evd ~mutual_info:(cofix,indexes,init_terms) ~cinfo:thms None in
-  (* Declare notations *)
-  List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
-  lemma
+  Declare.Proof.start_mutual_with_initialization ~info
+    evd ~mutual_info:(cofix,indexes,init_terms) ~cinfo:thms None
 
 let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -345,8 +345,8 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
   | Declare.Obls.IsCoFixpoint -> Decls.(IsDefinition CoFixpoint)
   in
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
-  Declare.Obls.add_mutual_definitions ~pm defs ~info ~uctx ~ntns fixkind
+  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns ~ntns () in
+  Declare.Obls.add_mutual_definitions ~pm defs ~info ~uctx fixkind
 
 let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
   let g = List.map (fun { Vernacexpr.rec_order } -> rec_order) l in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -86,14 +86,15 @@ module Info = struct
     ; hook : Hook.t option
     ; typing_flags : Declarations.typing_flags option
     ; user_warns : UserWarn.t option
+    ; ntns : Metasyntax.notation_interpretation_decl list
     }
 
   (** Note that [opaque] doesn't appear here as it is not known at the
      start of the proof in the interactive case. *)
   let make ?(poly=false) ?(inline=false) ?(kind=Decls.(IsDefinition Definition))
       ?(udecl=UState.default_univ_decl) ?(scope=Locality.default_scope)
-      ?(clearbody=false) ?hook ?typing_flags ?user_warns () =
-    { poly; inline; kind; udecl; scope; hook; typing_flags; clearbody; user_warns }
+      ?(clearbody=false) ?hook ?typing_flags ?user_warns ?(ntns=[]) () =
+    { poly; inline; kind; udecl; scope; hook; typing_flags; clearbody; user_warns; ntns }
 
 end
 
@@ -744,8 +745,8 @@ let mutual_make_bodies ~typing_flags ~fixitems ~rec_declaration ~possible_indexe
     let vars = Vars.universes_of_constr (List.hd fixdecls) in
     vars, fixdecls, None
 
-let declare_mutually_recursive_core ~info ~cinfo ~opaque ~ntns ~uctx ~rec_declaration ~possible_indexes ?(restrict_ucontext=true) () =
-  let { Info.poly; udecl; scope; clearbody; kind; typing_flags; user_warns; _ } = info in
+let declare_mutually_recursive_core ~info ~cinfo ~opaque ~uctx ~rec_declaration ~possible_indexes ?(restrict_ucontext=true) () =
+  let { Info.poly; udecl; scope; clearbody; kind; typing_flags; user_warns; ntns; _ } = info in
   let vars, fixdecls, indexes =
     mutual_make_bodies ~typing_flags ~fixitems:cinfo ~rec_declaration ~possible_indexes in
   let uctx, univs =
@@ -899,13 +900,12 @@ module ProgramDecl = struct
     ; prg_obligations : obligations
     ; prg_deps : Id.t list
     ; prg_fixkind : fixpoint_kind option
-    ; prg_notations : Metasyntax.notation_interpretation_decl list
     ; prg_reduce : constr -> constr
     }
 
   open Obligation
 
-  let make ~info ~cinfo ~opaque ~ntns ~reduce ~deps ~uctx ~body ~fixpoint_kind ?obl_hook obls =
+  let make ~info ~cinfo ~opaque ~reduce ~deps ~uctx ~body ~fixpoint_kind ?obl_hook obls =
     let obls', body =
       match body with
       | None ->
@@ -942,7 +942,6 @@ module ProgramDecl = struct
     ; prg_obligations = {obls = obls'; remaining = Array.length obls'}
     ; prg_deps = deps
     ; prg_fixkind = fixpoint_kind
-    ; prg_notations = ntns
     ; prg_reduce = reduce }
 
   let show prg =
@@ -1315,7 +1314,7 @@ let declare_mutual_definition ~pm l =
   in
   (* Declare the recursive definitions *)
   let kns =
-    declare_mutually_recursive_core ~info:first.prg_info ~ntns:first.prg_notations
+    declare_mutually_recursive_core ~info:first.prg_info
       ~uctx:first.prg_uctx ~rec_declaration ~possible_indexes ~opaque:first.prg_opaque
       ~restrict_ucontext:false ~cinfo:fixitems ()
   in
@@ -2589,7 +2588,7 @@ let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
     ?tactic ?(reduce = reduce) ?(opaque = false) obls =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let prg =
-    ProgramDecl.make ~info ~cinfo ~body:term ~opaque ~uctx ~reduce ~ntns:[] ~deps:[] ~fixpoint_kind:None ?obl_hook obls
+    ProgramDecl.make ~info ~cinfo ~body:term ~opaque ~uctx ~reduce ~deps:[] ~fixpoint_kind:None ?obl_hook obls
   in
   let name = CInfo.get_name cinfo in
   let {obls;_} = Internal.get_obligations prg in
@@ -2608,7 +2607,7 @@ let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
     | _ -> pm, res
 
 let add_mutual_definitions l ~pm ~info ?obl_hook ~uctx
-    ?tactic ?(reduce = reduce) ?(opaque = false) ~ntns fixkind =
+    ?tactic ?(reduce = reduce) ?(opaque = false) fixkind =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let deps = List.map (fun (ci,_,_) -> CInfo.get_name ci) l in
   let pm =
@@ -2616,7 +2615,7 @@ let add_mutual_definitions l ~pm ~info ?obl_hook ~uctx
       (fun pm (cinfo, b, obls) ->
         let prg =
           ProgramDecl.make ~info ~cinfo ~opaque ~body:(Some b) ~uctx ~deps
-            ~fixpoint_kind:(Some fixkind) ~ntns ~reduce ?obl_hook obls
+            ~fixpoint_kind:(Some fixkind) ~reduce ?obl_hook obls
         in
         State.add pm (CInfo.get_name cinfo) prg)
       pm l

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -112,6 +112,7 @@ module Info : sig
     (** Callback to be executed after saving the constant *)
     -> ?typing_flags:Declarations.typing_flags
     -> ?user_warns : UserWarn.t
+    -> ?ntns : Metasyntax.notation_interpretation_decl list
     -> unit
     -> t
 
@@ -136,7 +137,6 @@ val declare_mutually_recursive
   : info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
-  -> ntns:Metasyntax.notation_interpretation_decl list
   -> uctx:UState.t
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:lemma_possible_guards option
@@ -568,7 +568,6 @@ val add_mutual_definitions :
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
-  -> ntns:Metasyntax.notation_interpretation_decl list
   -> fixpoint_kind
   -> OblState.t
 


### PR DESCRIPTION
The PR fixes
```coq
Fixpoint f (n:nat) : nat where "- n" := (f n).
```
which was failing with `f` not found beforehand.

- [x] Added / updated **test-suite**.
