### PR TITLE
Fixes an anomaly with interactive Fixpoint without arguments

### DIFF
--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -416,3 +416,9 @@ Defined.
 Check eq_refl : # 0 = f 0.
 
 End NtnInteractiveFixpoint.
+
+Module NoArgumentFixpoint.
+
+Fail Fixpoint f : nat. (* was an anomaly at some time *)
+
+End NoArgumentFixpoint.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -126,6 +126,7 @@ let find_rec_annot bl ctx na =
 
 let interp_fix_context ~program_mode ~cofix env sigma fix =
   let sigma, (impl_env, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma fix.Vernacexpr.binders in
+  if not cofix && Context.Rel.nhyps ctx = 0 then CErrors.user_err Pp.(str "A fixpoint needs at least one parameter.");
   let annot = Option.map (find_rec_annot fix.Vernacexpr.binders ctx) fix.Vernacexpr.rec_order in
   sigma, ((env', ctx), (impl_env, imps), annot)
 


### PR DESCRIPTION
A short PR preventing a `List.last` anomaly regression in the current situation:
```coq
Fixpoint f : nat.
```

- [x] Added / updated **test-suite**.
