### PR TITLE
Making `Theorem with` more flexible + code cleanup

### DIFF
--- a/dev/ci/user-overlays/18743-herbelin-master+more-flexible-theorem-with.sh
+++ b/dev/ci/user-overlays/18743-herbelin-master+more-flexible-theorem-with.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/herbelin/Coq-Equations main+adapt+coq-pr18743-more-flexible-theorem-with 18743 master+more-flexible-theorem-with

--- a/doc/changelog/02-specification-language/18743-master+more-flexible-theorem-with.rst
+++ b/doc/changelog/02-specification-language/18743-master+more-flexible-theorem-with.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Mutually-proved theorems with statements in different coinductive
+  types now supported
+  (`#18743 <https://github.com/coq/coq/pull/18743>`_,
+  by Hugo Herbelin).

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -426,7 +426,7 @@ end
 
 val push_rel : rel_declaration -> env -> env
 val push_rel_context : rel_context -> env -> env
-val push_rec_types : (t, t, ERelevance.t) Constr.prec_declaration -> env -> env
+val push_rec_types : rec_declaration -> env -> env
 
 val push_named : named_declaration -> env -> env
 val push_named_context : named_context -> env -> env

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -30,13 +30,31 @@ val get_bidirectionality_hint : GlobRef.t -> int option
 
 val clear_bidirectionality_hint : GlobRef.t -> unit
 
-(** An auxiliary function for searching for fixpoint guard indexes *)
+(** An auxiliary function for searching for fixpoint guard indices *)
+
+(* Tells the possible indices liable to guard a fixpoint *)
+type possible_fix_indices = int list list
+
+(* Tells if possibly a cofixpoint or a fixpoint over the given list of possible indices *)
+type possible_guard = {
+  possibly_cofix : bool;
+  possible_fix_indices : possible_fix_indices;
+} (* Note: if no fix indices are given, it has to be a cofix *)
 
 val search_guard :
-  ?loc:Loc.t -> ?evars:CClosure.evar_handler -> env -> int list list -> Constr.rec_declaration -> int array
+  ?loc:Loc.t -> ?evars:CClosure.evar_handler -> env ->
+  possible_guard -> Constr.rec_declaration -> int array option
+
+val search_fix_guard : (* For Fixpoints only *)
+  ?loc:Loc.t -> ?evars:CClosure.evar_handler -> env ->
+  possible_fix_indices -> Constr.rec_declaration -> int array
 
 val esearch_guard :
-  ?loc:Loc.t -> env -> evar_map -> int list list ->
+  ?loc:Loc.t -> env -> evar_map -> possible_guard ->
+  EConstr.rec_declaration -> int array option
+
+val esearch_fix_guard : (* For Fixpoints only *)
+  ?loc:Loc.t -> env -> evar_map -> possible_fix_indices ->
   EConstr.rec_declaration -> int array
 
 type typing_constraint =

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -564,3 +564,28 @@ match t with
 end.
 
 End Wish16040.
+
+Module TheoremWith.
+
+CoInductive Stream : Set := Cons : nat -> Stream -> Stream.
+
+(* Support for mutually recursive theorems in non-mutual types *)
+Theorem a : Stream with b : Stream.
+Proof.
+apply (Cons 0), b.
+apply (Cons 0), a.
+Defined.
+
+Theorem c (n:nat) : Stream with d (n:nat) : Stream. (* corecursive *)
+Proof.
+apply (Cons n), (d n).
+apply (Cons n), (c n).
+Defined.
+
+Theorem c' (n:nat) : Stream with d' (n:nat) : Stream. (* recursive *)
+Proof.
+destruct n as [|n']. apply a. apply (d' n').
+destruct n as [|n']. apply a. apply (c' n').
+Defined.
+
+End TheoremWith.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -260,9 +260,9 @@ let interp_fixpoint ?(check_recursivity=true) ?typing_flags ~cofix l :
   (fix,pl,uctx,info)
 
 let build_recthms ~indexes fixnames fixtypes fiximps =
-  let fix_kind, cofix = match indexes with
-    | Some indexes -> Decls.Fixpoint, false
-    | None -> Decls.CoFixpoint, true
+  let fix_kind, possible_guard = match indexes with
+    | Some possible_fix_indices -> Decls.Fixpoint, Pretyping.{possibly_cofix = false; possible_fix_indices}
+    | None -> Decls.CoFixpoint, Pretyping.{possibly_cofix = true; possible_fix_indices = List.map (fun _ -> []) fixtypes}
   in
   let thms =
     List.map3 (fun name typ (ctx,impargs,_) ->
@@ -270,20 +270,19 @@ let build_recthms ~indexes fixnames fixtypes fiximps =
         Declare.CInfo.make ~name ~typ ~args ~impargs ()
       ) fixnames fixtypes fiximps
   in
-  fix_kind, cofix, thms
+  fix_kind, possible_guard, thms
 
 let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
-  let fix_kind, cofix, thms = build_recthms ~indexes fixnames fixtypes fiximps in
-  let indexes = Option.default [] indexes in
+  let fix_kind, possible_guard, thms = build_recthms ~indexes fixnames fixtypes fiximps in
   let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
   let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
-  Declare.Proof.start_mutual_with_initialization ~info
-    evd ~mutual_info:(cofix,indexes,init_terms) ~cinfo:thms ?using None
+    Declare.Proof.start_mutual_with_initialization ~info
+      evd ~mutual_info:(possible_guard,init_terms) ~cinfo:thms ?using
 
 let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)
-  let fix_kind, cofix, fixitems = build_recthms ~indexes fixnames fixtypes fiximps in
+  let fix_kind, possible_guard, fixitems = build_recthms ~indexes fixnames fixtypes fiximps in
   let fixdefs = List.map Option.get fixdefs in
   let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
   let fix_kind = Decls.IsDefinition fix_kind in
@@ -291,7 +290,7 @@ let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?use
   let cinfo = fixitems in
   let _ : GlobRef.t list =
     Declare.declare_mutually_recursive ~cinfo ~info ~opaque:false ~uctx
-      ~possible_indexes:indexes ~rec_declaration ?using ()
+      ~possible_guard ~rec_declaration ?using ()
   in
   ()
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -274,11 +274,10 @@ let build_recthms ~indexes fixnames fixtypes fiximps =
 
 let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
   let fix_kind, possible_guard, thms = build_recthms ~indexes fixnames fixtypes fiximps in
-  let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
   let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
-    Declare.Proof.start_mutual_with_initialization ~info
-      evd ~mutual_info:(possible_guard,init_terms) ~cinfo:thms ?using
+    Declare.Proof.start_mutual_with_initialization ~info ~cinfo:thms
+      ~init_terms:fixdefs ~possible_guard ?using evd
 
 let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -612,8 +612,8 @@ let cofixpoint_message l =
   | l -> hov 0 (prlist_with_sep pr_comma Id.print l ++
                     spc () ++ str "are corecursively defined"))
 
-let recursive_message isfix i l =
-  (if isfix then fixpoint_message i else cofixpoint_message) l
+let recursive_message isfix indexes l =
+  (if isfix then fixpoint_message indexes else cofixpoint_message) l
 
 let definition_message id =
   Flags.if_verbose Feedback.msg_info (Id.print id ++ str " is defined")
@@ -731,29 +731,37 @@ let interp_proof_using_cinfo env evd cinfo using =
   let f { CInfo.name; typ; _ } = name, [EConstr.of_constr typ] in
   interp_proof_using_gen f env evd cinfo using
 
-let mutual_make_bodies env ~typing_flags ~fixitems ~rec_declaration ~possible_indexes =
-  match possible_indexes with
-  | Some possible_indexes ->
-    let env = Environ.update_typing_flags ?typing_flags env in
-    let indexes = Pretyping.search_guard env possible_indexes rec_declaration in
-    let vars = Vars.universes_of_constr (Constr.mkFix ((indexes,0),rec_declaration)) in
-    let fixdecls = CList.map_i (fun i _ -> Constr.mkFix ((indexes,i),rec_declaration)) 0 fixitems in
-    vars, fixdecls, Some indexes
-  | None ->
-    let fixdecls = CList.map_i (fun i _ -> Constr.mkCoFix (i,rec_declaration)) 0 fixitems in
-    let vars = Vars.universes_of_constr (List.hd fixdecls) in
-    vars, fixdecls, None
+let make_recursive_body env possible_guard rec_declaration =
+  let indexes = Pretyping.search_guard env possible_guard rec_declaration in
+  let body = match indexes with
+  | Some indexes -> Constr.mkFix ((indexes,0), rec_declaration)
+  | None -> Constr.mkCoFix (0, rec_declaration) in
+  body, indexes
 
 let gather_mutual_using_data =
   List.fold_left2 (fun acc CInfo.{ name; typ; _ } body ->
       let typ, body = EConstr.(of_constr typ, of_constr body) in
       (name, [typ; body]) :: acc) []
 
-let declare_mutually_recursive ~info ~cinfo ~opaque ~uctx ~rec_declaration ~possible_indexes ?using () =
+let select_body i t =
+  let open Constr in
+  match Constr.kind t with
+  | Fix ((nv,0),decls) -> mkFix ((nv,i),decls)
+  | CoFix (0,decls) -> mkCoFix (i,decls)
+  | _ -> assert false
+
+let mutual_make_bodies env ~typing_flags ~fixitems ~rec_declaration ~possible_guard =
+  let env = Environ.update_typing_flags ?typing_flags env in
+  let body, indexes = make_recursive_body env possible_guard rec_declaration in
+  let vars = Vars.universes_of_constr body in
+  let fixdecls = CList.map_i (fun i _ -> select_body i body) 0 fixitems in
+  vars, fixdecls, indexes
+
+let declare_mutually_recursive ~info ~cinfo ~opaque ~uctx ~rec_declaration ~possible_guard ?using () =
   let { Info.poly; udecl; scope; clearbody; kind; typing_flags; user_warns; ntns; _ } = info in
   let env = Global.env() in
   let vars, fixdecls, indexes =
-    mutual_make_bodies env ~typing_flags ~fixitems:cinfo ~rec_declaration ~possible_indexes in
+    mutual_make_bodies env ~typing_flags ~fixitems:cinfo ~rec_declaration ~possible_guard in
   let uctx = UState.restrict uctx vars in
   let univs = UState.check_univ_decl ~poly uctx udecl in
   let evd = Evd.from_env env in
@@ -770,7 +778,7 @@ let declare_mutually_recursive ~info ~cinfo ~opaque ~uctx ~rec_declaration ~poss
          declare_entry ~name ~scope ~clearbody ~kind ~impargs ~uctx ~typing_flags ~user_warns entry)
       cinfo fixdecls
   in
-  let isfix = Option.has_some possible_indexes in
+  let isfix = Option.has_some indexes in
   let fixnames = List.map (fun { CInfo.name } -> name) cinfo in
   recursive_message isfix indexes fixnames;
   List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
@@ -911,13 +919,13 @@ module ProgramDecl = struct
     ; prg_uctx : UState.t
     ; prg_obligations : obligations
     ; prg_deps : Id.t list
-    ; prg_fixkind : fixpoint_kind option
+    ; prg_possible_guard : Pretyping.possible_guard option (* None = not recursive *)
     ; prg_reduce : constr -> constr
     }
 
   open Obligation
 
-  let make ~info ~cinfo ~opaque ~reduce ~deps ~uctx ~body ~fixpoint_kind ?obl_hook ?using obls =
+  let make ~info ~cinfo ~opaque ~reduce ~deps ~uctx ~body ~possible_guard ?obl_hook ?using obls =
     let obls', body =
       match body with
       | None ->
@@ -954,7 +962,7 @@ module ProgramDecl = struct
     ; prg_uctx
     ; prg_obligations = {obls = obls'; remaining = Array.length obls'}
     ; prg_deps = deps
-    ; prg_fixkind = fixpoint_kind
+    ; prg_possible_guard = possible_guard
     ; prg_reduce = reduce }
 
   let show prg =
@@ -1259,24 +1267,6 @@ let declare_definition ~pm prg =
   let pm = progmap_remove pm prg in
   pm, kn
 
-let rec lam_index n t acc =
-  match Constr.kind t with
-  | Lambda ({Context.binder_name = Name n'}, _, _) when Id.equal n n' -> acc
-  | Lambda (_, _, b) -> lam_index n b (succ acc)
-  | _ -> raise Not_found
-
-let compute_possible_guardness_evidences n fixbody fixtype =
-  match n with
-  | Some {CAst.loc; v = n} -> [lam_index n fixbody 0]
-  | None ->
-    (* If recursive argument was not given by user, we try all args.
-         An earlier approach was to look only for inductive arguments,
-         but doing it properly involves delta-reduction, and it finally
-         doesn't seem to worth the effort (except for huge mutual
-         fixpoints ?) *)
-    let ctx, _ = Term.decompose_prod fixtype in
-    List.mapi (fun i _ -> i) ctx
-
 let declare_mutual_definition ~pm l =
   let len = List.length l in
   let first = List.hd l in
@@ -1316,21 +1306,15 @@ let declare_mutual_definition ~pm l =
         , (CInfo.make ~name ~typ ~impargs ()) :: a4 ))
       defs first.prg_deps ([], [], [], [])
   in
-  let fixkind = Option.get first.prg_fixkind in
+  let possible_guard = Option.get first.prg_possible_guard in
   let arrrec, recvec = (Array.of_list fixtypes, Array.of_list fixdefs) in
   let rvec = Array.of_list fixrs in
   let namevec = Array.of_list (List.map (fun x -> Name x.prg_cinfo.CInfo.name) l) in
   let rec_declaration = (Array.map2 Context.make_annot namevec rvec, arrrec, recvec) in
-  let possible_indexes =
-    match fixkind with
-    | IsFixpoint wfl ->
-      Some (List.map3 compute_possible_guardness_evidences wfl fixdefs fixtypes)
-    | IsCoFixpoint -> None
-  in
   (* Declare the recursive definitions *)
   let kns =
     declare_mutually_recursive ~info:first.prg_info
-      ~uctx:first.prg_uctx ~rec_declaration ~possible_indexes ~opaque:first.prg_opaque
+      ~uctx:first.prg_uctx ~rec_declaration ~possible_guard ~opaque:first.prg_opaque
       ~cinfo:fixitems ?using:first.prg_using ()
   in
   (* Only for the first constant *)
@@ -1511,8 +1495,6 @@ end
 (* Handling of interactive proofs                                       *)
 (************************************************************************)
 
-type lemma_possible_guards = int list list
-
 module Proof_ending = struct
 
   type t =
@@ -1539,16 +1521,16 @@ module Proof_info = struct
     ; info : Info.t
     ; proof_ending : Proof_ending.t CEphemeron.key
     (* This could be improved and the CEphemeron removed *)
-    ; compute_guard : lemma_possible_guards option (* None = not recursive *)
+    ; possible_guard : Pretyping.possible_guard option (* None = not recursive *)
     (** thms and compute guard are specific only to
        start_lemma_with_initialization + regular terminator, so we
        could make this per-proof kind *)
     }
 
-  let make ~cinfo ~info ?compute_guard ?(proof_ending=Proof_ending.Regular) () =
+  let make ~cinfo ~info ?possible_guard ?(proof_ending=Proof_ending.Regular) () =
     { cinfo
     ; info
-    ; compute_guard
+    ; possible_guard
     ; proof_ending = CEphemeron.create proof_ending
     }
 
@@ -1652,16 +1634,14 @@ let start_equations ~name ~info ~hook ~types sigma goals =
   let proof_ending = Proof_ending.End_equations {hook; i=name; types; sigma} in
   start_dependent ~name ~info ~proof_ending goals
 
-let rec_tac_initializer finite guard thms snl =
-  if finite then
+let rec_tac_initializer Pretyping.{possibly_cofix; possible_fix_indices} thms =
+  if possibly_cofix then
     match List.map (fun { CInfo.name; typ } -> name, (EConstr.of_constr typ)) thms with
     | (id,_)::l -> Tactics.mutual_cofix id l 0
     | _ -> assert false
   else
-    (* nl is dummy: it will be recomputed at Qed-time *)
-    let nl = match snl with
-     | None -> List.map succ (List.map List.last guard)
-     | Some nl -> nl
+    (* nl is set to its maximal possible value for the purpose of mutual_fix; it will then be recomputed at Qed-time *)
+    let nl = List.map succ (List.map List.last possible_fix_indices)
     in match List.map2 (fun { CInfo.name; typ } n -> (name, n, (EConstr.of_constr typ))) thms nl with
        | (id,n,_)::l -> Tactics.mutual_fix id n l 0
        | _ -> assert false
@@ -1676,13 +1656,13 @@ let start_with_initialization ~info ~cinfo ?using sigma =
   map lemma ~f:(fun p ->
       pi1 @@ Proof.run_tactic Global.(env ()) init_tac p)
 
-type mutual_info = (bool * lemma_possible_guards * Constr.t option list option)
+type mutual_info = Pretyping.possible_guard * Constr.t option list option
 
-let start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using sigma snl =
+let start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using sigma =
   let intro_tac { CInfo.args; _ } = Tactics.auto_intros_tac args in
-  let init_tac, compute_guard =
-    let (finite,guard,init_terms) = mutual_info in
-    let rec_tac = rec_tac_initializer finite guard cinfo snl in
+  let init_tac, possible_guard =
+    let (possible_guard,init_terms) = mutual_info in
+    let rec_tac = rec_tac_initializer possible_guard cinfo in
     let term_tac =
       match init_terms with
       | None ->
@@ -1693,12 +1673,12 @@ let start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using sigma snl 
         let tacl = List.map (Option.cata (EConstr.of_constr %> Tactics.exact_no_check) Tacticals.tclIDTAC) init_terms in
         List.map2 (fun tac thm -> Tacticals.tclTHEN tac (intro_tac thm)) tacl cinfo
     in
-    Tacticals.tclTHENS rec_tac term_tac, guard
+    Tacticals.tclTHENS rec_tac term_tac, possible_guard
   in
   match cinfo with
   | [] -> CErrors.anomaly (Pp.str "No proof to start.")
   | { CInfo.name; typ; _} :: thms ->
-    let pinfo = Proof_info.make ~cinfo ~info ~compute_guard () in
+    let pinfo = Proof_info.make ~cinfo ~info ~possible_guard () in
     (* start_lemma has the responsibility to add (name, impargs, typ)
        to thms, once Info.t is more refined this won't be necessary *)
     let typ = EConstr.of_constr typ in
@@ -1747,7 +1727,7 @@ let set_used_variables ps ~using =
 
 (* Interprets the expression in the current proof context, from vernacentries *)
 let get_recnames pf =
-  if Option.has_some pf.pinfo.Proof_info.compute_guard then
+  if Option.has_some pf.pinfo.Proof_info.possible_guard then
     List.map (fun c -> c.CInfo.name) pf.pinfo.Proof_info.cinfo
   else
     []
@@ -2118,41 +2098,31 @@ module MutualEntry : sig
 end = struct
 
   (* XXX: Refactor this with the code in [Declare.declare_mutdef] *)
-  let guess_decreasing env possible_indexes ((body, ctx), eff) =
+  let guess_decreasing env possible_guard ((body, ctx), eff) =
     let open Constr in
     match Constr.kind body with
-    | Fix ((nv,0),(_,_,fixdefs as fixdecls)) ->
+    | Fix (_,(_,_,fixdefs as fixdecls)) | CoFix (_,(_,_,fixdefs as fixdecls)) ->
       let env = Safe_typing.push_private_constants env eff.Evd.seff_private in
-      let indexes = Pretyping.search_guard env possible_indexes fixdecls in
-      (mkFix ((indexes,0),fixdecls), ctx), eff
-    | _ -> (body, ctx), eff
-
-  let select_body i t =
-    let open Constr in
-    match Constr.kind t with
-    | Fix ((nv,0),decls) -> mkFix ((nv,i),decls)
-    | CoFix (0,decls) -> mkCoFix (i,decls)
-    | _ ->
-      CErrors.anomaly
-        Pp.(str "Not a proof by induction: " ++
-            Constr.debug_print t ++ str ".")
+      let body, _ = make_recursive_body env possible_guard fixdecls in
+      (body, ctx), eff
+    | _ -> assert false
 
   let declare_mutdef ~uctx ~pinfo pe i CInfo.{ name; impargs; typ; _} =
-    let { Proof_info.info; compute_guard; _ } = pinfo in
+    let { Proof_info.info; possible_guard; _ } = pinfo in
     let { Info.hook; scope; clearbody; kind; typing_flags; user_warns; _ } = info in
     (* if i = 0 , we don't touch the type; this is for compat
        but not clear it is the right thing to do.
     *)
     let pe, ubind =
-      if i > 0 && Option.has_some compute_guard
+      if i > 0 && Option.has_some possible_guard
       then
         let typ = UState.nf_universes uctx typ in
         Internal.map_entry_type pe ~f:(fun _ -> Some typ), UnivNames.empty_binders
       else pe, UState.universe_binders uctx
     in
-    (* We when compute_guard was [] in the previous step we should not
+    (* We when possible_guard was [] in the previous step we should not
        substitute the body *)
-    let pe = match compute_guard with
+    let pe = match possible_guard with
       | None -> pe
       | _ ->
         Internal.map_entry_body pe
@@ -2161,7 +2131,7 @@ end = struct
     declare_entry ~name ~scope ~clearbody ~kind ?hook ~impargs ~typing_flags ~user_warns ~uctx pe
 
   let declare_mutdef ~pinfo ~uctx ~entry =
-    let pe = match pinfo.Proof_info.compute_guard with
+    let pe = match pinfo.Proof_info.possible_guard with
     | None ->
       (* Not a recursive statement *)
       entry
@@ -2670,7 +2640,7 @@ let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
     ?tactic ?(reduce = reduce) ?(opaque = false) ?using obls =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let prg =
-    ProgramDecl.make ~info ~cinfo ~body:term ~opaque ~uctx ~reduce ~deps:[] ~fixpoint_kind:None ?obl_hook ?using obls
+    ProgramDecl.make ~info ~cinfo ~body:term ~opaque ~uctx ~reduce ~deps:[] ~possible_guard:None ?obl_hook ?using obls
   in
   let name = CInfo.get_name cinfo in
   let {obls;_} = Internal.get_obligations prg in
@@ -2688,8 +2658,8 @@ let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
       pm, res
     | _ -> pm, res
 
-let add_mutual_definitions l ~pm ~info ?obl_hook ~uctx
-    ?tactic ?(reduce = reduce) ?(opaque = false) ?using fixkind =
+let add_mutual_definitions ~pm ~info ?obl_hook ~uctx
+    ?tactic ?(reduce = reduce) ?(opaque = false) ?using ~possible_guard l =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let deps = List.map (fun (ci,_,_) -> CInfo.get_name ci) l in
   let pm =
@@ -2700,7 +2670,7 @@ let add_mutual_definitions l ~pm ~info ?obl_hook ~uctx
       (fun pm (cinfo, b, obls) ->
         let prg =
           ProgramDecl.make ~info ~cinfo ~opaque ~body:(Some b) ~uctx ~deps
-            ~fixpoint_kind:(Some fixkind) ~reduce ?obl_hook ?using obls
+            ~possible_guard:(Some possible_guard) ~reduce ?obl_hook ?using obls
         in
         State.add pm (CInfo.get_name cinfo) prg)
       pm l

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1656,12 +1656,9 @@ let start_with_initialization ~info ~cinfo ?using sigma =
   map lemma ~f:(fun p ->
       pi1 @@ Proof.run_tactic Global.(env ()) init_tac p)
 
-type mutual_info = Pretyping.possible_guard * Constr.t option list option
-
-let start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using sigma =
+let start_mutual_with_initialization ~info ~cinfo ?init_terms ~possible_guard ?using sigma =
   let intro_tac { CInfo.args; _ } = Tactics.auto_intros_tac args in
-  let init_tac, possible_guard =
-    let (possible_guard,init_terms) = mutual_info in
+  let init_tac =
     let rec_tac = rec_tac_initializer possible_guard cinfo in
     let term_tac =
       match init_terms with
@@ -1673,7 +1670,7 @@ let start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using sigma =
         let tacl = List.map (Option.cata (EConstr.of_constr %> Tactics.exact_no_check) Tacticals.tclIDTAC) init_terms in
         List.map2 (fun tac thm -> Tacticals.tclTHEN tac (intro_tac thm)) tacl cinfo
     in
-    Tacticals.tclTHENS rec_tac term_tac, possible_guard
+    Tacticals.tclTHENS rec_tac term_tac
   in
   match cinfo with
   | [] -> CErrors.anomaly (Pp.str "No proof to start.")

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -212,13 +212,12 @@ module Proof : sig
     -> Evd.evar_map
     -> t
 
-  type mutual_info = Pretyping.possible_guard * Constr.t option list option
-
   (** Pretty much internal, used by mutual Lemma / Fixpoint vernaculars *)
   val start_mutual_with_initialization
     :  info:Info.t
     -> cinfo:Constr.t CInfo.t list
-    -> mutual_info:mutual_info
+    -> ?init_terms:Constr.t option list
+    -> possible_guard:Pretyping.possible_guard
     -> ?using:Vernacexpr.section_subset_expr
     -> Evd.evar_map
     -> t

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -131,15 +131,13 @@ val declare_definition
   -> Evd.evar_map
   -> GlobRef.t
 
-type lemma_possible_guards = int list list
-
 val declare_mutually_recursive
   : info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
   -> uctx:UState.t
   -> rec_declaration:Constr.rec_declaration
-  -> possible_indexes:lemma_possible_guards option
+  -> possible_guard:Pretyping.possible_guard
   -> ?using:Vernacexpr.section_subset_expr
   -> unit
   -> Names.GlobRef.t list
@@ -214,7 +212,7 @@ module Proof : sig
     -> Evd.evar_map
     -> t
 
-  type mutual_info = (bool * lemma_possible_guards * Constr.t option list option)
+  type mutual_info = Pretyping.possible_guard * Constr.t option list option
 
   (** Pretty much internal, used by mutual Lemma / Fixpoint vernaculars *)
   val start_mutual_with_initialization
@@ -223,7 +221,6 @@ module Proof : sig
     -> mutual_info:mutual_info
     -> ?using:Vernacexpr.section_subset_expr
     -> Evd.evar_map
-    -> int list option
     -> t
 
   (** Qed a proof  *)
@@ -556,8 +553,7 @@ val add_definition :
 (** Start a [Program Fixpoint] declaration, similar to the above,
    except it takes a list now. *)
 val add_mutual_definitions :
-     (Constr.t CInfo.t * Constr.t * RetrieveObl.obligation_info) list
-  -> pm:OblState.t
+     pm:OblState.t
   -> info:Info.t
   -> ?obl_hook: OblState.t Hook.g
   -> uctx:UState.t
@@ -565,7 +561,8 @@ val add_mutual_definitions :
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
   -> ?using:Vernacexpr.section_subset_expr
-  -> fixpoint_kind
+  -> possible_guard:Pretyping.possible_guard
+  -> (Constr.t CInfo.t * Constr.t * RetrieveObl.obligation_info) list
   -> OblState.t
 
 (** Implementation of the [Obligation] command *)

--- a/vernac/recLemmas.ml
+++ b/vernac/recLemmas.ml
@@ -63,11 +63,11 @@ let find_mutually_recursive_statements sigma thms =
       CErrors.user_err Pp.(str
          ("Cannot find common (mutual) inductive premises or coinductive" ^
           " conclusions in the statements."));
-    (Pretyping.{possibly_cofix; possible_fix_indices}, None)
+    Pretyping.{possibly_cofix; possible_fix_indices}
 
 type mutual_info =
   | NonMutual of EConstr.t Declare.CInfo.t
-  | Mutual of Declare.Proof.mutual_info
+  | Mutual of Pretyping.possible_guard
 
 let look_for_possibly_mutual_statements sigma thms : mutual_info =
   match thms with

--- a/vernac/recLemmas.mli
+++ b/vernac/recLemmas.mli
@@ -10,10 +10,7 @@
 
 type mutual_info =
   | NonMutual of EConstr.t Declare.CInfo.t
-  | Mutual of
-      { mutual_info : Declare.Proof.mutual_info
-      ; cinfo : EConstr.t Declare.CInfo.t list
-      }
+  | Mutual of Declare.Proof.mutual_info
 
 val look_for_possibly_mutual_statements
   :  Evd.evar_map

--- a/vernac/recLemmas.mli
+++ b/vernac/recLemmas.mli
@@ -13,7 +13,6 @@ type mutual_info =
   | Mutual of
       { mutual_info : Declare.Proof.mutual_info
       ; cinfo : EConstr.t Declare.CInfo.t list
-      ; possible_guards : int list
       }
 
 val look_for_possibly_mutual_statements

--- a/vernac/recLemmas.mli
+++ b/vernac/recLemmas.mli
@@ -10,7 +10,7 @@
 
 type mutual_info =
   | NonMutual of EConstr.t Declare.CInfo.t
-  | Mutual of Declare.Proof.mutual_info
+  | Mutual of Pretyping.possible_guard
 
 val look_for_possibly_mutual_statements
   :  Evd.evar_map

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -631,8 +631,8 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
     let thm = Declare.CInfo.to_constr evd thm in
     let evd = post_check_evd ~udecl ~poly evd in
     Declare.Proof.start_with_initialization ~info ~cinfo:thm ?using evd
-  | RecLemmas.Mutual { mutual_info; cinfo } ->
-    let cinfo = List.map (Declare.CInfo.to_constr evd) cinfo in
+  | RecLemmas.Mutual mutual_info ->
+    let cinfo = List.map (Declare.CInfo.to_constr evd) thms in
     let evd = post_check_evd ~udecl ~poly evd in
     Declare.Proof.start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using evd
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -631,10 +631,10 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
     let thm = Declare.CInfo.to_constr evd thm in
     let evd = post_check_evd ~udecl ~poly evd in
     Declare.Proof.start_with_initialization ~info ~cinfo:thm ?using evd
-  | RecLemmas.Mutual { mutual_info; cinfo ; possible_guards } ->
+  | RecLemmas.Mutual { mutual_info; cinfo } ->
     let cinfo = List.map (Declare.CInfo.to_constr evd) cinfo in
     let evd = post_check_evd ~udecl ~poly evd in
-    Declare.Proof.start_mutual_with_initialization ~info ~cinfo evd ~mutual_info ?using (Some possible_guards)
+    Declare.Proof.start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using evd
 
 let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let open Decls in function
 | Coercion ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -631,10 +631,10 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
     let thm = Declare.CInfo.to_constr evd thm in
     let evd = post_check_evd ~udecl ~poly evd in
     Declare.Proof.start_with_initialization ~info ~cinfo:thm ?using evd
-  | RecLemmas.Mutual mutual_info ->
+  | RecLemmas.Mutual possible_guard ->
     let cinfo = List.map (Declare.CInfo.to_constr evd) thms in
     let evd = post_check_evd ~udecl ~poly evd in
-    Declare.Proof.start_mutual_with_initialization ~info ~cinfo ~mutual_info ?using evd
+    Declare.Proof.start_mutual_with_initialization ~info ~cinfo ~possible_guard ?using evd
 
 let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let open Decls in function
 | Coercion ->


### PR DESCRIPTION
The PR simplifies `Theorem with` and makes it more flexible:
- We accept, if coinductive, that the conclusions have the same or different coinductive types in any order.
- When the conclusions are coinductive and enough hypotheses are inductive, we postpone the decision between fix and cofix to Qed-time.
- We simplify and reorganize the code. For instance, `mutual_info` had two redundant copies of the possible recursion indices.

Depends on PR #18741 (merged) ~~and #18742~~.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.


Overlay: mattam82/Coq-Equations#584
