### PR TITLE
Rely on evar rather than metas in canonical structure resolution.

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1192,9 +1192,8 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
             if match n with Some n -> Int.equal m n | None -> false then
                 (evd,t2::ks, m-1)
             else
-              let mv = new_meta () in
-              let evd' = meta_declare mv (substl ks b) evd in
-              (evd', mkMeta mv :: ks, m - 1))
+              let evd', ev = Evarutil.new_evar (fst curenvnb) evd (substl ks b) in
+              (evd', ev :: ks, m - 1))
           (sigma,[],List.length bs) bs
       in
       try


### PR DESCRIPTION
I am not sure how critical this is for unification heuristics, e.g. when considering HO vs FO algorithms. This piece of code was problematic because before this patch it was the only one in the whole code base that created dangling metas not well-scoped within a clausenv. The alternative is to try to prune these freshly generated metas after resolution has run, but this is probably too dangerous and unsound in practice.