### PR TITLE
Put evar counter in the evar map instead of summary

### DIFF
--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -748,10 +748,6 @@ type unsolvability_explanation = SeveralInstancesFound of int
 
 (** {5 Summary names} *)
 
-(* This stuff is internal and should not be used. Currently a hack in
-   the STM relies on it. *)
-val evar_counter_summary_tag : int Summary.Dyn.tag
-
 (** {5 Deprecated functions} *)
 val create_evar_defs : evar_map -> evar_map
 (* XXX: This is supposed to be deprecated by used by ssrmatching, what

--- a/test-suite/output-coqtop/DependentEvars.out
+++ b/test-suite/output-coqtop/DependentEvars.out
@@ -66,7 +66,7 @@ goal 3 is:
 goal 4 is:
  ?P
 
-(dependent evars: ?X4:?P, ?X5:?Q; in current goal: ?X5)
+(dependent evars: ?X2:?P, ?X3:?Q; in current goal: ?X3)
 
 p14 < 3 focused goals (shelved: 2)
   
@@ -82,7 +82,7 @@ goal 2 is:
 goal 3 is:
  ?P
 
-(dependent evars: ?X4:?P, ?X5 using ?X10 ?X11, ?X10 using ?X11, ?X11:?P0; in current goal: ?X4 ?X5 ?X10 ?X11)
+(dependent evars: ?X2:?P, ?X3 using ?X8 ?X9, ?X8 using ?X9, ?X9:?P0; in current goal: ?X2 ?X3 ?X8 ?X9)
 
 p14 < 
 Coq < 

--- a/test-suite/output-coqtop/DependentEvars2.out
+++ b/test-suite/output-coqtop/DependentEvars2.out
@@ -68,7 +68,7 @@ goal 3 is:
 goal 4 is:
  ?P
 
-(dependent evars: ?X4:?P, ?X5:?Q; in current goal: ?X5)
+(dependent evars: ?X2:?P, ?X3:?Q; in current goal: ?X3)
 
 p14 < 1 focused goal (shelved: 2)
   
@@ -79,7 +79,7 @@ p14 < 1 focused goal (shelved: 2)
   ============================
   ?Q -> P4
 
-(dependent evars: ?X4:?P, ?X5:?Q; in current goal: ?X5)
+(dependent evars: ?X2:?P, ?X3:?Q; in current goal: ?X3)
 
 p14 < This subproof is complete, but there are some unfocused goals.
 Try unfocusing with "}".
@@ -93,7 +93,7 @@ goal 2 is:
 goal 3 is:
  ?P
 
-(dependent evars: ?X4:?P, ?X5 using ?X10 ?X11, ?X10 using ?X11, ?X11:?P0; in current goal:)
+(dependent evars: ?X2:?P, ?X3 using ?X8 ?X9, ?X8 using ?X9, ?X9:?P0; in current goal:)
 
 p14 < 3 focused goals (shelved: 2)
   
@@ -109,7 +109,7 @@ goal 2 is:
 goal 3 is:
  ?P
 
-(dependent evars: ?X4:?P, ?X5 using ?X10 ?X11, ?X10 using ?X11, ?X11:?P0; in current goal: ?X4 ?X5 ?X10 ?X11)
+(dependent evars: ?X2:?P, ?X3 using ?X8 ?X9, ?X8 using ?X9, ?X9:?P0; in current goal: ?X2 ?X3 ?X8 ?X9)
 
 p14 < 
 Coq < 

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -294,17 +294,15 @@ module Stm = struct
      for evar / metas to be global among proofs *)
   type nonrec pstate =
     LemmaStack.t option *
-    int *                                   (* Evarutil.meta_counter_summary_tag *)
-    int                                     (* Evd.evar_counter_summary_tag *)
+    int                                    (* Evarutil.meta_counter_summary_tag *)
 
   (* Parts of the system state that are morally part of the proof state *)
   let pstate { interp = { lemmas; system }} =
     let st = System.Interp.Stm.summary system in
     lemmas,
-    Summary.Interp.project_from_summary st Evarutil.meta_counter_summary_tag,
-    Summary.Interp.project_from_summary st Evd.evar_counter_summary_tag
+    Summary.Interp.project_from_summary st Evarutil.meta_counter_summary_tag
 
-  let set_pstate ({ interp = { lemmas; system } } as s) (pstate,c1,c2) =
+  let set_pstate ({ interp = { lemmas; system } } as s) (pstate,c1) =
     { s with interp = { s.interp with
       lemmas =
         Declare_.copy_terminators ~src:s.interp.lemmas ~tgt:pstate
@@ -313,7 +311,6 @@ module Stm = struct
           begin
             let st = System.Interp.Stm.summary s.interp.system in
             let st = Summary.Interp.modify_summary st Evarutil.meta_counter_summary_tag c1 in
-            let st = Summary.Interp.modify_summary st Evd.evar_counter_summary_tag c2 in
             st
           end
       }
@@ -324,7 +321,6 @@ module Stm = struct
     let system = interp.system in
     let st = System.Interp.Stm.summary system in
     let st = Summary.Interp.remove_from_summary st Evarutil.meta_counter_summary_tag in
-    let st = Summary.Interp.remove_from_summary st Evd.evar_counter_summary_tag in
     System.Synterp.Stm.summary synterp.system, System.Synterp.Stm.lib synterp.system,
       st, System.Interp.Stm.lib system
 


### PR DESCRIPTION
This should make it less a footgun when resetting summaries such as in https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/When.20does.20.60new_type_evar.60.20return.20an.20instantiated.20evar.3F

We could perhaps do the same for the meta counter but not sure if worth doing.

NB: the original use of summary was in
81429f879fa76ac24c25d89a6ada2073ea8361e2

>Registering universe and meta/evar counters as summaries so as to
eventually get the same numbers when replaying

Because universes escape `par:` and vio they ended up having to be treated specially but this should not be a problem for evars.