### PR TITLE
Adding full support for attributes bypass_guard, clearbody, deprecated/warn in CoFixpoint (and sometimes in Program Fixpoint)

### DIFF
--- a/doc/changelog/02-specification-language/18754-HEAD.rst
+++ b/doc/changelog/02-specification-language/18754-HEAD.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`CoFixpoint` supports attributes `bypass_guard`, `clearbody`,
+  `deprecated` and `warn`
+  (`#18754 <https://github.com/coq/coq/pull/18754>`_,
+  by Hugo Herbelin).

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -466,3 +466,18 @@ exact
 Defined.
 
 End FixpointRelevance.
+
+Module ClearFixBody.
+
+CoInductive Stream : Set := Cons : nat -> Stream -> Stream.
+
+Section S.
+#[clearbody] Let CoFixpoint f : Stream := Cons 1 f.
+#[clearbody] Let Fixpoint g n := match n with 0 => 0 | S n => g n end.
+Goal True.
+Fail Check eq_refl : f = cofix f := Cons 1 f.
+Fail Check eq_refl : g = fix g n := match n with 0 => 0 | S n => g n end.
+Abort.
+End S.
+
+End ClearFixBody.

--- a/test-suite/success/typing_flags.v
+++ b/test-suite/success/typing_flags.v
@@ -88,3 +88,8 @@ Inductive Box :=
 | box : forall n, f n = n -> g 2 -> Box.
 
 Print Assumptions Box.
+
+(** CoFixpoint *)
+
+CoInductive Stream : Type :=  Cons : nat -> Stream -> Stream.
+#[bypass_check(guard)] CoFixpoint f2 : Stream := f2.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -356,11 +356,11 @@ let do_cofixpoint_common (fixl : Vernacexpr.cofixpoint_expr list) =
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
   interp_fixpoint ~cofix:true fixl, ntns
 
-let do_cofixpoint_interactive ~scope ~poly ?user_warns l =
+let do_cofixpoint_interactive ~scope ?clearbody ~poly ?typing_flags ?user_warns l =
   let cofix, ntns = do_cofixpoint_common l in
-  let lemma = declare_fixpoint_interactive_generic ~scope ~poly ?user_warns cofix ntns in
+  let lemma = declare_fixpoint_interactive_generic ~scope ?clearbody ~poly ?typing_flags ?user_warns cofix ntns in
   lemma
 
-let do_cofixpoint ~scope ~poly ?user_warns ?using l =
+let do_cofixpoint ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
   let cofix, ntns = do_cofixpoint_common l in
-  declare_fixpoint_generic ~scope ~poly ?user_warns ?using cofix ntns
+  declare_fixpoint_generic ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using cofix ntns

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -36,14 +36,18 @@ val do_fixpoint
 
 val do_cofixpoint_interactive
   : scope:Locality.definition_scope
+  -> ?clearbody:bool
   -> poly:bool
+  -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> cofixpoint_expr list
   -> Declare.Proof.t
 
 val do_cofixpoint
   : scope:Locality.definition_scope
+  -> ?clearbody:bool
   -> poly:bool
+  -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -367,7 +367,7 @@ let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
           user_err Pp.(str"Measure takes only two arguments in Program Fixpoint.")
         | _, _ -> r
       in
-        build_wellfounded pm (id, univs, binders, rtype, out_def body_def) poly ?typing_flags ?using
+        build_wellfounded pm (id, univs, binders, rtype, out_def body_def) poly ?typing_flags ?user_warns ?using
           (Option.default (CAst.make @@ CRef (lt_ref,None)) r) m notations
 
     | _, _ when List.for_all (fun ro -> match ro with None | Some { CAst.v = CStructRec _} -> true | _ -> false) g ->
@@ -375,11 +375,11 @@ let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
           Vernacexpr.(ComFixpoint.adjust_rec_order ~structonly:true fix.binders fix.rec_order)) l in
       let fixkind = Declare.Obls.IsFixpoint annots in
       let l = List.map2 (fun fix rec_order -> { fix with Vernacexpr.rec_order }) l annots in
-      do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?using fixkind l
+      do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using fixkind l
     | _, _ ->
       CErrors.user_err
         (str "Well-founded fixpoints not allowed in mutually recursive blocks.")
 
-let do_cofixpoint ~pm ~scope ~poly ?user_warns ?using fixl =
+let do_cofixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using fixl =
   let fixl = List.map (fun fix -> { fix with Vernacexpr.rec_order = None }) fixl in
-  do_program_recursive ~pm ~scope ~poly ?user_warns ?using Declare.Obls.IsCoFixpoint fixl
+  do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using Declare.Obls.IsCoFixpoint fixl

--- a/vernac/comProgramFixpoint.mli
+++ b/vernac/comProgramFixpoint.mli
@@ -25,7 +25,9 @@ val do_fixpoint :
 val do_cofixpoint :
      pm:Declare.OblState.t
   -> scope:Locality.definition_scope
+  -> ?clearbody:bool
   -> poly:bool
+  -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1094,10 +1094,13 @@ let vernac_cofixpoint_interactive ~atts discharge l =
 let vernac_cofixpoint ~atts ~pm discharge l =
   let open DefAttributes in
   let scope = vernac_cofixpoint_common ~atts discharge l in
+  let typing_flags = atts.typing_flags in
   if atts.program then
-    ComProgramFixpoint.do_cofixpoint ~pm ~scope ~poly:atts.polymorphic ?using:atts.using l
+    ComProgramFixpoint.do_cofixpoint ~pm ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic
+      ?typing_flags ?user_warns:atts.user_warns ?using:atts.using l
   else
-    let () = ComFixpoint.do_cofixpoint ~scope ~poly:atts.polymorphic ?using:atts.using l in
+    let () = ComFixpoint.do_cofixpoint ~scope ?clearbody:atts.clearbody ~poly:atts.polymorphic
+        ?typing_flags ?user_warns:atts.user_warns ?using:atts.using l in
     pm
 
 let vernac_scheme l =


### PR DESCRIPTION
`CoFixpoint` was apparently missing support for the attributes `bypass_guard`, `clearbody` and `deprecated`/`warn` (compared to `Fixpoint`).

For `deprecated`/`warn`, it was also not propagated to all different defining parts in `Program Fixpoint` (I hope what I did is ok...).

Maybe the clearbody part is relevant for 8.19.2?

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Note: I'm working on merging the executation paths for Fixpoint and CoFixpoint, so the test coverage will mechanically increase later and is thus not so important at this stage.