### PR TITLE
Check that the universe binders of each component of a "Theorem with" are consistent + code factorization.

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -227,3 +227,8 @@ val interp_cumul_univ_decl_opt : Environ.env -> cumul_univ_decl_expr option ->
   Evd.evar_map * UState.universe_decl * Entries.variance_entry
 (** BEWARE the variance entry needs to be adjusted by
    [ComInductive.variance_of_entry] if the instance is extensible. *)
+
+val interp_mutual_univ_decl_opt : Environ.env -> universe_decl_expr option list ->
+  Evd.evar_map * UState.universe_decl
+(** Check that all defined udecls of a list of udecls associated to a mutual definition
+    are the same and interpret this common udecl *)

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -481,3 +481,17 @@ Abort.
 End S.
 
 End ClearFixBody.
+
+Module TheoremWithUnivs.
+
+Fail Fixpoint f@{u} (n:nat) : nat with g@{v} (n:nat) : nat.
+Fail Theorem f@{u} (n:nat) : nat with g@{v} (n:nat) : nat.
+Fail CoFixpoint f@{u} (n:nat) : Stream 0 with g@{v} (n:nat) : Stream 0.
+Succeed Fixpoint f@{u} (n:nat) : nat with g@{u} (n:nat) : nat.
+Succeed Theorem f@{u} (n:nat) : nat with g@{u} (n:nat) : nat.
+Succeed CoFixpoint f@{u} (n:nat) : Stream 0 with g@{u} (n:nat) : Stream 0.
+Succeed Fixpoint f@{u} (n:nat) : nat with g (n:nat) : nat. (* Accepted *)
+Succeed Theorem f@{u} (n:nat) : nat with g (n:nat) : nat. (* Accepted *)
+Succeed CoFixpoint f@{u} (n:nat) : Stream 0 with g (n:nat) : Stream 0. (* Accepted *)
+
+End TheoremWithUnivs.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -181,18 +181,7 @@ let interp_recursive env ~program_mode ~cofix (fixl : 'a Vernacexpr.fix_expr_gen
   let fixnames = List.map (fun fix -> fix.Vernacexpr.fname.CAst.v) fixl in
 
   (* Interp arities allowing for unresolved types *)
-  let all_universes =
-    List.fold_right (fun sfe acc ->
-        match sfe.Vernacexpr.univs , acc with
-        | None , acc -> acc
-        | x , None -> x
-        | Some ls , Some us ->
-          let open UState in
-          let lsu = ls.univdecl_instance and usu = us.univdecl_instance in
-           if not (CList.for_all2eq (fun x y -> Id.equal x.CAst.v y.CAst.v) lsu usu) then
-             CErrors.user_err Pp.(str "(co)-recursive definitions should all have the same universe binders");
-           Some us) fixl None in
-  let sigma, decl = interp_univ_decl_opt env all_universes in
+  let sigma, decl = interp_mutual_univ_decl_opt env (List.map (fun Vernacexpr.{univs} -> univs) fixl) in
   let sigma, (fixctxs, fiximppairs, fixannots) =
     on_snd List.split3 @@
       List.fold_left_map (fun sigma -> interp_fix_context ~program_mode env sigma ~cofix) sigma fixl in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -625,8 +625,8 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
   let env0 = Global.env () in
   let env0 = Environ.update_typing_flags ?typing_flags env0 in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
-  let decl = fst (List.hd thms) in
-  let evd, udecl = Constrintern.interp_univ_decl_opt env0 (snd decl) in
+  let udecls = List.map (fun ((_,univs),_) -> univs) thms in
+  let evd, udecl = Constrintern.interp_mutual_univ_decl_opt env0 udecls in
   let evd, thms = interp_lemma ~program_mode ~flags ~scope env0 evd thms in
   let mut_analysis = RecLemmas.look_for_possibly_mutual_statements evd thms in
   let evd = Evd.minimize_universes evd in


### PR DESCRIPTION
In `Theorem with`, only the universe declaration of the first component was taken into account, leading to behaviors such as
```coq
Theorem f@{u} (n:nat) : Type@{u} with g@{v} (n:nat) : Type@{v}.
(* raises "Undeclared universe: v." about `Type@{v}.` *)
```
or
```coq
Set Universe Polymorphism.
Theorem f@{u} (n:nat) : nat with g@{v w} (n:nat) : nat.
Proof.
exact (match n with 0 => 0 | S n => g n end).
exact (match n with 0 => 0 | S n => f n end).
Defined.
(* About g reports about u but not v and w *)
```
The PR applies the same policy as in `Fixpoint`, that is checking that all components have the same universe declarations.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
