### PR TITLE
Subtraction in NatInt

### DIFF
--- a/doc/changelog/11-standard-library/18761-subtraction-in-NatInt.rst
+++ b/doc/changelog/11-standard-library/18761-subtraction-in-NatInt.rst
@@ -1,0 +1,42 @@
+-- **Added:**
+   functor types :g:`IsNatInt`, :g:`NatIntOrderProp`, :g:`NatIntAddOrderProp`
+
+   lemmas :g:`sub_succ`,
+   :g:`add_add_simpl_l_l`,
+   :g:`add_add_simpl_l_r`,
+   :g:`add_add_simpl_r_l`,
+   :g:`add_add_simpl_r_r`,
+   :g:`add_simpl_l`,
+   :g:`add_simpl_r`,
+   :g:`le_lt_sub_lt`,
+   :g:`lt_0_sub`,
+   :g:`lt_exists_sub`
+   :g:`mul_pred_l`,
+   :g:`add_sub_eq_l`,
+   :g:`add_sub_eq_r`,
+   :g:`add_sub`,
+   :g:`add_simpl_l`,
+   :g:`sub_add_distr`,
+   :g:`le_sub_le_add_r`,
+   :g:`le_sub_le_add_l`,
+   :g:`lt_add_lt_sub_r`,
+   :g:`lt_add_lt_sub_l`,
+   :g:`le_lt_sub_lt`,
+   :g:`mul_pred_r`,
+   :g:`mul_pred_l`,
+   :g:`mul_sub_distr_r`,
+   :g:`mul_sub_distr_l` in :g:`NatIntOrderProp` which is
+   included in :g:`Zbase` and :g:`NBase`. As a result, any of these
+   lemmas is now included in :g:`BinInt`, :g:`BinNat` and :g:`PeanoNat`
+
+-- **Removed:**
+   functor types :g:`NZAxiomsSig` and :g:`NZAxiomsSig'` which were
+   aliases for :g:`NZBasicFunsSig` and :g:`NZBasicFunsSig'`
+
+-- **Changed:**
+   the order of the parameters in :g:`mul_sub_distr_l` in :g:`PeanoNat` and :g:`BinNat`, for consistency; the parameters are now the same
+   as in `BinInt`. One can recover the previous order with
+   `fun n m p => mul_sub_distr_l p n m`
+
+(`#18761 <https://github.com/coq/coq/pull/18761>`_,
+by Pierre Rousselin).

--- a/theories/Numbers/Cyclic/Abstract/NZCyclic.v
+++ b/theories/Numbers/Cyclic/Abstract/NZCyclic.v
@@ -25,7 +25,7 @@ Require Import Lia.
     a power of 2.
 *)
 
-Module NZCyclicAxiomsMod (Import Cyclic : CyclicType) <: NZAxiomsSig.
+Module NZCyclicAxiomsMod (Import Cyclic : CyclicType) <: NZBasicFunsSig.
 
 Local Open Scope Z_scope.
 

--- a/theories/Numbers/Integer/Abstract/ZAdd.v
+++ b/theories/Numbers/Integer/Abstract/ZAdd.v
@@ -66,13 +66,6 @@ rewrite <- (succ_pred n) at 2.
 rewrite opp_succ. now rewrite succ_pred.
 Qed.
 
-Theorem sub_diag n : n - n == 0.
-Proof.
-nzinduct n.
-- now nzsimpl.
-- intro n. rewrite sub_succ_r, sub_succ_l; now rewrite pred_succ.
-Qed.
-
 Theorem add_opp_diag_l n : - n + n == 0.
 Proof.
 now rewrite add_comm, add_opp_r, sub_diag.
@@ -132,12 +125,6 @@ Qed.
 Theorem eq_opp_r n m : n == - m <-> - n == m.
 Proof.
 symmetry; apply eq_opp_l.
-Qed.
-
-Theorem sub_add_distr n m p : n - (m + p) == (n - m) - p.
-Proof.
-rewrite <- add_opp_r, opp_add_distr, add_assoc.
-now rewrite 2 add_opp_r.
 Qed.
 
 Theorem sub_sub_distr n m p : n - (m - p) == (n - m) + p.
@@ -230,16 +217,6 @@ Qed.
     terms. The name includes the first operator and the position of
     the term being canceled. *)
 
-Theorem add_simpl_l n m : n + m - n == m.
-Proof.
-now rewrite add_sub_swap, sub_diag, add_0_l.
-Qed.
-
-Theorem add_simpl_r n m : n + m - m == n.
-Proof.
-now rewrite <- add_sub_assoc, sub_diag, add_0_r.
-Qed.
-
 Theorem sub_simpl_l n m : - n - m + n == - m.
 Proof.
 now rewrite <- add_sub_swap, add_opp_diag_l, sub_0_l.
@@ -257,27 +234,6 @@ Qed.
 
 (** Now we have two sums or differences; the name includes the two
     operators and the position of the terms being canceled *)
-
-Theorem add_add_simpl_l_l n m p : (n + m) - (n + p) == m - p.
-Proof.
-now rewrite (add_comm n m), <- add_sub_assoc,
-sub_add_distr, sub_diag, sub_0_l, add_opp_r.
-Qed.
-
-Theorem add_add_simpl_l_r n m p : (n + m) - (p + n) == m - p.
-Proof.
-rewrite (add_comm p n); apply add_add_simpl_l_l.
-Qed.
-
-Theorem add_add_simpl_r_l n m p : (n + m) - (m + p) == n - p.
-Proof.
-rewrite (add_comm n m); apply add_add_simpl_l_l.
-Qed.
-
-Theorem add_add_simpl_r_r n m p : (n + m) - (p + m) == n - p.
-Proof.
-rewrite (add_comm p m); apply add_add_simpl_r_l.
-Qed.
 
 Theorem sub_add_simpl_r_l n m p : (n - m) + (m + p) == n + p.
 Proof.

--- a/theories/Numbers/Integer/Abstract/ZAddOrder.v
+++ b/theories/Numbers/Integer/Abstract/ZAddOrder.v
@@ -40,11 +40,6 @@ Qed.
 
 (** Sub and order *)
 
-Theorem lt_0_sub : forall n m, 0 < m - n <-> n < m.
-Proof.
-intros n m. now rewrite (add_lt_mono_r _ _ n), add_0_l, sub_simpl_r.
-Qed.
-
 Notation sub_pos := lt_0_sub (only parsing).
 
 Theorem le_0_sub : forall n m, 0 <= m - n <-> n <= m.
@@ -151,37 +146,22 @@ apply le_lt_trans with (m - p);
 [now apply sub_le_mono_r | now apply sub_lt_mono_l].
 Qed.
 
-Theorem le_lt_sub_lt : forall n m p q, n <= m -> p - n < q - m -> p < q.
-Proof.
-intros n m p q H1 H2. apply (le_lt_add_lt (- m) (- n));
-[now apply -> opp_le_mono | now rewrite 2 add_opp_r].
-Qed.
-
 Theorem lt_le_sub_lt : forall n m p q, n < m -> p - n <= q - m -> p < q.
 Proof.
 intros n m p q H1 H2. apply (lt_le_add_lt (- m) (- n));
 [now apply -> opp_lt_mono | now rewrite 2 add_opp_r].
 Qed.
 
+(* TODO: fix name *)
 Theorem le_le_sub_lt : forall n m p q, n <= m -> p - n <= q - m -> p <= q.
 Proof.
 intros n m p q H1 H2. apply (le_le_add_le (- m) (- n));
 [now apply -> opp_le_mono | now rewrite 2 add_opp_r].
 Qed.
 
-Theorem lt_add_lt_sub_r : forall n m p, n + p < m <-> n < m - p.
-Proof.
-intros n m p. now rewrite (sub_lt_mono_r _ _ p), add_simpl_r.
-Qed.
-
 Theorem le_add_le_sub_r : forall n m p, n + p <= m <-> n <= m - p.
 Proof.
 intros n m p. now rewrite (sub_le_mono_r _ _ p), add_simpl_r.
-Qed.
-
-Theorem lt_add_lt_sub_l : forall n m p, n + p < m <-> p < m - n.
-Proof.
-intros n m p. rewrite add_comm; apply lt_add_lt_sub_r.
 Qed.
 
 Theorem le_add_le_sub_l : forall n m p, n + p <= m <-> p <= m - n.
@@ -194,19 +174,9 @@ Proof.
 intros n m p. now rewrite (add_lt_mono_r _ _ p), sub_simpl_r.
 Qed.
 
-Theorem le_sub_le_add_r : forall n m p, n - p <= m <-> n <= m + p.
-Proof.
-intros n m p. now rewrite (add_le_mono_r _ _ p), sub_simpl_r.
-Qed.
-
 Theorem lt_sub_lt_add_l : forall n m p, n - m < p <-> n < m + p.
 Proof.
 intros n m p. rewrite add_comm; apply lt_sub_lt_add_r.
-Qed.
-
-Theorem le_sub_le_add_l : forall n m p, n - m <= p <-> n <= m + p.
-Proof.
-intros n m p. rewrite add_comm; apply le_sub_le_add_r.
 Qed.
 
 Theorem lt_sub_lt_add : forall n m p q, n - m < p - q <-> n + q < m + p.

--- a/theories/Numbers/Integer/Abstract/ZAxioms.v
+++ b/theories/Numbers/Integer/Abstract/ZAxioms.v
@@ -16,7 +16,7 @@ Require Import Bool NZParity NZPow NZSqrt NZLog NZGcd NZDiv NZBits.
 (** We obtain integers by postulating that successor of predecessor
     is identity. *)
 
-Module Type ZAxiom (Import Z : NZAxiomsSig').
+Module Type ZAxiom (Import Z : NZBasicFunsSig').
  Axiom succ_pred : forall n, S (P n) == n.
 End ZAxiom.
 
@@ -34,14 +34,14 @@ End OppNotation.
 
 Module Type Opp' (T:Typ) := Opp T <+ OppNotation T.
 
-Module Type IsOpp (Import Z : NZAxiomsSig')(Import O : Opp' Z).
+Module Type IsOpp (Import Z : NZBasicFunsSig')(Import O : Opp' Z).
 #[global]
  Declare Instance opp_wd : Proper (eq==>eq) opp.
  Axiom opp_0 : - 0 == 0.
  Axiom opp_succ : forall n, - (S n) == P (- n).
 End IsOpp.
 
-Module Type OppCstNotation (Import A : NZAxiomsSig)(Import B : Opp A).
+Module Type OppCstNotation (Import A : NZBasicFunsSig)(Import B : Opp A).
  Notation "- 1" := (opp one).
  Notation "- 2" := (opp two).
 End OppCstNotation.

--- a/theories/Numbers/Integer/Abstract/ZBase.v
+++ b/theories/Numbers/Integer/Abstract/ZBase.v
@@ -17,6 +17,14 @@ Require Import NZMulOrder.
 Module ZBaseProp (Import Z : ZAxiomsMiniSig').
 Include NZMulOrderProp Z.
 
+Lemma Private_succ_pred n : n ~= 0 -> S (P n) == n.
+Proof. intros _; exact (succ_pred _). Qed.
+
+Lemma le_pred_l n : P n <= n.
+Proof. rewrite <-(succ_pred n), pred_succ; exact (le_succ_diag_r _). Qed.
+
+Include NZAddOrder.NatIntAddOrderProp Z.
+
 (* Theorems that are true for integers but not for natural numbers *)
 
 Theorem pred_inj : forall n m, P n == P m -> n == m.

--- a/theories/Numbers/Integer/Abstract/ZLt.v
+++ b/theories/Numbers/Integer/Abstract/ZLt.v
@@ -47,11 +47,6 @@ Proof.
 intro n; rewrite <- (succ_pred n) at 2; apply lt_succ_diag_r.
 Qed.
 
-Theorem le_pred_l : forall n, P n <= n.
-Proof.
-intro; apply lt_le_incl; apply lt_pred_l.
-Qed.
-
 Theorem lt_le_pred : forall n m, n < m <-> n <= P m.
 Proof.
 intros n m; rewrite <- (succ_pred m); rewrite pred_succ. apply lt_succ_r.

--- a/theories/Numbers/Integer/Abstract/ZMul.v
+++ b/theories/Numbers/Integer/Abstract/ZMul.v
@@ -27,18 +27,6 @@ Include ZAddProp Z.
 (** Theorems that are either not valid on N or have different proofs
     on N and Z *)
 
-Theorem mul_pred_r : forall n m, n * (P m) == n * m - n.
-Proof.
-intros n m.
-rewrite <- (succ_pred m) at 2.
-now rewrite mul_succ_r, <- add_sub_assoc, sub_diag, add_0_r.
-Qed.
-
-Theorem mul_pred_l : forall n m, (P n) * m == n * m - m.
-Proof.
-intros n m; rewrite (mul_comm (P n) m), (mul_comm n m). apply mul_pred_r.
-Qed.
-
 Theorem mul_opp_l : forall n m, (- n) * m == - (n * m).
 Proof.
 intros n m. apply add_move_0_r.
@@ -58,18 +46,6 @@ Qed.
 Theorem mul_opp_comm : forall n m, (- n) * m == n * (- m).
 Proof.
 intros n m. now rewrite mul_opp_l, <- mul_opp_r.
-Qed.
-
-Theorem mul_sub_distr_l : forall n m p, n * (m - p) == n * m - n * p.
-Proof.
-intros n m p. do 2 rewrite <- add_opp_r. rewrite mul_add_distr_l.
-now rewrite mul_opp_r.
-Qed.
-
-Theorem mul_sub_distr_r : forall n m p, (n - m) * p == n * p - m * p.
-Proof.
-intros n m p; rewrite (mul_comm (n - m) p), (mul_comm n p), (mul_comm m p);
-now apply mul_sub_distr_l.
 Qed.
 
 End ZMulProp.

--- a/theories/Numbers/NatInt/NZAddOrder.v
+++ b/theories/Numbers/NatInt/NZAddOrder.v
@@ -17,6 +17,9 @@ This file defines the [NZAddOrderProp] functor type, meant to be [Include]d
 in a module implementing [NZOrdAxiomsSig'] (see [Coq.Numbers.NatInt.NZAxioms]).
 
 This gives important basic compatibility lemmas between [add] and [lt], [le].
+
+In the second part of this file, we further assume [IsNatInt] and prove
+results about subtraction which are shared between integers and natural numbers.
 *)
 From Coq.Numbers.NatInt Require Import NZAxioms NZBase NZMul NZOrder.
 
@@ -159,9 +162,6 @@ Qed.
 
 (** Subtraction *)
 
-(** We can prove the existence of a subtraction of any number by
-    a smaller one *)
-
 Lemma le_exists_sub : forall n m, n<=m -> exists p, m == p+n /\ 0<=p.
 Proof.
   intros n m H. apply le_ind with (4:=H). - solve_proper.
@@ -170,9 +170,242 @@ Proof.
     split. + nzsimpl. now f_equiv. + now apply le_le_succ_r.
 Qed.
 
-(** For the moment, it doesn't seem possible to relate
-    this existing subtraction with [sub].
-*)
+Lemma lt_exists_sub : forall n m, n<m -> exists p, m == p+n /\ 0<p.
+Proof.
+  intros n m I; pose proof (lt_le_incl _ _ I) as [p [E Ip]]%le_exists_sub.
+  exists p; split; [exact E |].
+  apply le_lteq in Ip as [Ip | Ep]; [exact Ip | exfalso].
+  apply (lt_irrefl m); rewrite E at 1; rewrite <-Ep, add_0_l; exact I.
+Qed.
 
 End NZAddOrderProp.
 
+Module Type NatIntAddOrderProp
+  (Import NZ : NZOrdAxiomsSig')
+  (Import NI : IsNatInt NZ)
+  (Import NZA : NZAddOrderProp NZ).
+
+Include NatIntOrderProp NZ NI NZA NZA.
+
+Lemma Private_nat_sub_0_l : P 0 == 0 -> forall n, 0 - n == 0.
+Proof.
+  intros isNat; apply (Private_nat_induction isNat); [now intros x y -> | |].
+  - rewrite sub_0_r; reflexivity.
+  - intros n IH; rewrite sub_succ_r, IH; exact isNat.
+Qed.
+
+Lemma Private_int_sub_succ_l :
+  (forall n, S (P n) == n) -> forall n m, S n - m == S (n - m).
+Proof.
+  intros isInt n. nzinduct m.
+  - rewrite 2!sub_0_r; reflexivity.
+  - intros m; rewrite 2!sub_succ_r, isInt; split; intros IH;
+      [rewrite IH, pred_succ | rewrite <-IH, isInt]; reflexivity.
+Qed.
+
+Lemma sub_succ : forall n m, S n - S m == n - m.
+Proof.
+  destruct (Private_int_or_nat) as [isInt | isNat].
+  - intros n m; rewrite Private_int_sub_succ_l, sub_succ_r, isInt
+      by (exact isInt); reflexivity.
+  - intros n; apply (Private_nat_induction isNat); [now intros x y -> | |].
+    + rewrite sub_succ_r, 2!sub_0_r, pred_succ; reflexivity.
+    + intros m IH; rewrite sub_succ_r, IH, sub_succ_r; reflexivity.
+Qed.
+
+Lemma sub_diag : forall n, n - n == 0.
+Proof.
+  nzinduct n; [rewrite sub_0_r | intros n; rewrite sub_succ]; reflexivity.
+Qed.
+
+Lemma add_simpl_r : forall n m, n + m - m == n.
+Proof.
+  intros n; nzinduct m.
+  - rewrite add_0_r, sub_0_r; reflexivity.
+  - intros m; rewrite add_succ_r, sub_succ; reflexivity.
+Qed.
+
+(* add_sub was in Natural, add_simpl_r in Integer *)
+(* TODO: should we keep both? *)
+Lemma add_sub : forall n m, n + m - m == n.
+Proof. exact add_simpl_r. Qed.
+
+Theorem add_simpl_l n m : n + m - n == m.
+Proof. rewrite add_comm; exact (add_simpl_r _ _). Qed.
+
+Theorem sub_add_distr n m p : n - (m + p) == (n - m) - p.
+Proof.
+  destruct Private_int_or_nat as [isInt | isNat].
+  - nzinduct p; [rewrite sub_0_r, add_0_r; reflexivity |].
+    intros p; rewrite add_succ_r, 2!sub_succ_r.
+    symmetry; exact (Private_int_pred_inj isInt _ _).
+  - revert p; apply (Private_nat_induction isNat); [now intros x y -> | |].
+    + rewrite add_0_r, sub_0_r; reflexivity.
+    + intros p; rewrite add_succ_r, 2!sub_succ_r; intros ->; reflexivity.
+Qed.
+
+Theorem add_add_simpl_l_l n m p : (n + m) - (n + p) == m - p.
+Proof. rewrite sub_add_distr, add_simpl_l; reflexivity. Qed.
+
+Theorem add_add_simpl_l_r n m p : (n + m) - (p + n) == m - p.
+Proof. rewrite (add_comm p n), add_add_simpl_l_l; reflexivity. Qed.
+
+Theorem add_add_simpl_r_l n m p : (n + m) - (m + p) == n - p.
+Proof. rewrite (add_comm n m), add_add_simpl_l_l; reflexivity. Qed.
+
+Theorem add_add_simpl_r_r n m p : (n + m) - (p + m) == n - p.
+Proof. rewrite (add_comm p m), add_add_simpl_r_l; reflexivity. Qed.
+
+Theorem add_sub_eq_l : forall n m p, m + p == n -> n - m == p.
+Proof. intros n m p <-; exact (add_simpl_l _ _). Qed.
+
+Theorem add_sub_eq_r : forall n m p, m + p == n -> n - p == m.
+Proof. intros n m p; rewrite add_comm; exact (add_sub_eq_l _ _ _). Qed.
+
+Lemma Private_nat_sub_0_le : P 0 == 0 -> forall n m, n - m == 0 <-> n <= m.
+Proof.
+  intros isNat; apply (Private_nat_induction isNat (fun n => forall m, _)).
+  - intros x y H; split; intros H' n; [rewrite <-H | rewrite H]; exact (H' _).
+  - intros m; rewrite (Private_nat_sub_0_l isNat); split; intros _;
+      [exact (Private_nat_le_0_l isNat _) | reflexivity].
+  - intros n IH m; destruct (Private_nat_zero_or_succ isNat m) as [-> | [m' ->]].
+    + rewrite sub_0_r; split; intros H; exfalso.
+      * apply (Private_nat_neq_succ_0 isNat n); exact H.
+      * apply (Private_nat_nle_succ_0 isNat n); exact H.
+    + rewrite sub_succ, <-succ_le_mono; exact (IH _).
+Qed.
+
+Lemma Private_int_add_pred_l : (forall n, S (P n) == n) ->
+  forall n m, P n + m == P (n + m).
+Proof.
+  intros isInt n m; rewrite <-(isInt n) at 2; now rewrite add_succ_l, pred_succ.
+Qed.
+
+Lemma Private_int_sub_add :
+  (forall n, S (P n) == n) -> forall m n, m - n + n == m.
+Proof.
+  intros isInt m n; nzinduct n.
+  - rewrite sub_0_r, add_0_r; reflexivity.
+  - now intros n; rewrite add_succ_r, sub_succ_r, Private_int_add_pred_l, isInt.
+Qed.
+
+Theorem lt_0_sub : forall n m, 0 < m - n <-> n < m.
+Proof.
+  destruct Private_int_or_nat as [isInt | isNat].
+  - intros n m; rewrite (add_lt_mono_r 0 (m - n) n), add_0_l.
+    rewrite (Private_int_sub_add isInt); reflexivity.
+  - intros n m; rewrite <-(Private_nat_neq_0_lt_0 isNat), lt_nge; split;
+      intros H1 H2%(Private_nat_sub_0_le isNat); apply H1; exact H2.
+Qed.
+
+Lemma Private_sub_add : forall n m, n <= m -> (m - n) + n == m.
+Proof.
+  destruct Private_int_or_nat as [isInt | isNat]. {
+    intros n m _; rewrite (Private_int_sub_add isInt); reflexivity.
+  }
+  apply (Private_nat_induction isNat (fun n => forall m, _ -> _)).
+  - now intros x y E; split; intros H m; [rewrite <-E | rewrite E]; apply H.
+  - intros m _; rewrite add_0_r, sub_0_r; reflexivity.
+  - intros n IH m H; destruct (Private_nat_zero_or_succ isNat m) as [E | [k E]].
+    + rewrite E in H; exfalso; exact (Private_nat_nle_succ_0 isNat n H).
+    + rewrite E, sub_succ, add_succ_r, IH; [reflexivity |].
+      apply succ_le_mono; rewrite E in H; exact H.
+Qed.
+
+Lemma Private_sub_add_le : forall n m, n <= n - m + m.
+Proof.
+  destruct Private_int_or_nat as [isInt | isNat]. {
+    intros n m; rewrite (Private_int_sub_add isInt); reflexivity.
+  }
+  intros n m; destruct (lt_ge_cases m n) as [I | I].
+  - apply lt_exists_sub in I as [p [-> I]]; rewrite add_simpl_r.
+    exact (le_refl _).
+  - apply (Private_nat_sub_0_le isNat) in I as E; rewrite E, add_0_l; exact I.
+Qed.
+
+Theorem le_sub_le_add_r : forall n m p, n - p <= m <-> n <= m + p.
+Proof.
+  intros n m p; split; intros H.
+  - apply (add_le_mono_r _ _ p) in H; apply le_trans with (2 := H).
+    exact (Private_sub_add_le _ _).
+  - destruct Private_int_or_nat as [isInt | isNat]. {
+      now apply (add_le_mono_r _ _ p); rewrite (Private_int_sub_add isInt).
+    }
+    destruct (le_ge_cases n p) as [I | I].
+    + apply (Private_nat_sub_0_le isNat) in I as ->;
+        exact (Private_nat_le_0_l isNat _).
+    + apply le_exists_sub in I as [k [Ek Ik]]; rewrite Ek, add_simpl_r.
+      apply (add_le_mono_r _ _ p); rewrite <-Ek; exact H.
+Qed.
+
+Theorem le_sub_le_add_l : forall n m p, n - m <= p <-> n <= m + p.
+Proof. intros n m p; rewrite add_comm; exact (le_sub_le_add_r _ _ _). Qed.
+
+Theorem lt_add_lt_sub_r : forall n m p, n + p < m <-> n < m - p.
+Proof.
+  intros n m p; split; intros H.
+  - apply (add_lt_mono_r _ _ p), lt_le_trans with (1 := H).
+    exact (Private_sub_add_le _ _).
+  - destruct Private_int_or_nat as [isInt | isNat].
+    + apply (add_lt_mono_r _ _ p) in H.
+      rewrite (Private_int_sub_add isInt) in H; exact H.
+    + assert (p <= m) as I. {
+        apply lt_le_incl, lt_0_sub, le_lt_trans with (2 := H).
+        exact (Private_nat_le_0_l isNat _).
+      }
+      apply (add_lt_mono_r _ _ p) in H.
+      rewrite Private_sub_add in H by (exact I); exact H.
+Qed.
+
+Theorem lt_add_lt_sub_l : forall n m p, n + p < m <-> p < m - n.
+Proof. intros n m p; rewrite add_comm; exact (lt_add_lt_sub_r _ _ _). Qed.
+
+Theorem le_lt_sub_lt : forall n m p q, n <= m -> p - n < q - m -> p < q.
+Proof.
+  intros n m p q I H; apply add_le_lt_mono with (1 := I) in H as H'.
+  rewrite (add_comm n), (add_comm m) in H'.
+  assert (q - m + m == q) as Eq. {
+    destruct Private_int_or_nat as [isInt | isNat];
+      [exact (Private_int_sub_add isInt _ _) |].
+    apply Private_sub_add, lt_le_incl, lt_0_sub, le_lt_trans with (2 := H).
+    exact (Private_nat_le_0_l isNat _).
+  }
+  rewrite Eq in H'; apply le_lt_trans with (2 := H').
+  exact (Private_sub_add_le _ _).
+Qed.
+
+Theorem mul_pred_r : forall n m, n * (P m) == n * m - n.
+Proof.
+  intros n m; destruct (eq_decidable m 0) as [-> | H%Private_succ_pred].
+  - destruct Private_int_or_nat as [isInt | isNat].
+    + rewrite <-(isInt 0) at 2; rewrite mul_succ_r, add_sub; reflexivity.
+    + rewrite isNat, mul_0_r, Private_nat_sub_0_l by (exact isNat); reflexivity.
+  - rewrite <-H at 2; rewrite mul_succ_r, add_sub; reflexivity.
+Qed.
+
+Theorem mul_pred_l : forall n m, P n * m == n * m - m.
+Proof. intros n m; rewrite mul_comm, mul_pred_r, mul_comm; reflexivity. Qed.
+
+Theorem mul_sub_distr_r : forall n m p, (n - m) * p == n * p - m * p.
+Proof.
+  intros n m p; destruct Private_int_or_nat as [isInt | isNat].
+  - nzinduct m; [| intros m'; split].
+    + rewrite mul_0_l, 2!sub_0_r; reflexivity.
+    + now intros H; rewrite sub_succ_r, mul_pred_l, H, mul_succ_l, sub_add_distr.
+    + intros H; rewrite <-(Private_int_sub_add isInt ((n - m') * p) p).
+      rewrite sub_succ_r, mul_pred_l, mul_succ_l, sub_add_distr in H.
+      rewrite H, Private_int_sub_add by (exact isInt); reflexivity.
+  - revert m; apply (Private_nat_induction isNat).
+    + intros x y ->; reflexivity.
+    + rewrite mul_0_l, 2!sub_0_r; reflexivity.
+    + intros m H; rewrite sub_succ_r, mul_pred_l, mul_succ_l, sub_add_distr, H.
+      reflexivity.
+Qed.
+
+Theorem mul_sub_distr_l : forall n m p, n * (m - p) == n * m - n * p.
+Proof.
+  intros n m p; rewrite (mul_comm n (m - p)), (mul_comm n m), (mul_comm n p).
+  exact (mul_sub_distr_r _ _ _).
+Qed.
+
+End NatIntAddOrderProp.

--- a/theories/Numbers/NatInt/NZDomain.v
+++ b/theories/Numbers/NatInt/NZDomain.v
@@ -329,7 +329,7 @@ End NZOfNatOrd.
 (** For basic operations, we can prove correspondence with
     their counterpart in [nat]. *)
 
-Module NZOfNatOps (Import NZ:NZAxiomsSig').
+Module NZOfNatOps (Import NZ:NZBasicFunsSig').
 Include NZOfNat NZ.
 Local Open Scope ofnat.
 

--- a/theories/Numbers/NatInt/NZParity.v
+++ b/theories/Numbers/NatInt/NZParity.v
@@ -12,7 +12,7 @@ Require Import Bool NZAxioms NZMulOrder.
 
 (** Parity functions *)
 
-Module Type NZParity (Import A : NZAxiomsSig').
+Module Type NZParity (Import A : NZBasicFunsSig').
  Parameter Inline even odd : t -> bool.
  Definition Even n := exists m, n == 2*m.
  Definition Odd n := exists m, n == 2*m+1.

--- a/theories/Numbers/Natural/Abstract/NOrder.v
+++ b/theories/Numbers/Natural/Abstract/NOrder.v
@@ -26,7 +26,7 @@ setoid_replace lt with (fun n m => 0 <= n < m).
   + now intros [_ H].
 Defined.
 
-(* "le_0_l : forall n : N, 0 <= n" was proved in NBase.v *)
+(** Note that [le_0_l : forall n, 0 <= n] is already proved in [NBase]. *)
 
 Theorem nlt_0_r : forall n, ~ n < 0.
 Proof.
@@ -162,12 +162,7 @@ intros n H; apply succ_pred; intro H1; rewrite H1 in H.
 false_hyp H lt_irrefl.
 Qed.
 
-Theorem le_pred_l : forall n, P n <= n.
-Proof.
-intro n; cases n.
-- rewrite pred_0; now apply eq_le_incl.
-- intros; rewrite pred_succ;  apply le_succ_diag_r.
-Qed.
+(** The lemma [le_pred_l] is proved in NBase. *)
 
 Theorem lt_pred_l : forall n, n ~= 0 -> P n < n.
 Proof.


### PR DESCRIPTION
We add two axioms in NatInt to restrict the models to exactly the integers and the natural numbers (with `pred 0 = 0`). This allows us to prove lemmas such as `sub_succ` and then prove many properties of `sub` which are shared between the natural numbers and the integers.

The Natural and Integer parts of Numbers are modified in consequence. The result should be completely compatible except for `mul_sub_distr_l` which had different variable names in Integers and Natural (we chose to keep it as it was in Integers).

We also remove references to old NZAxiomsSig modules.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes a part of Coq/Coq#18462 (TODO be more precise about which new lemmas are visible for the user)


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
