### PR TITLE
Strictly unique classes can be resolved independently.

### DIFF
--- a/doc/changelog/02-specification-language/18762-janno-strictly-unique.rst
+++ b/doc/changelog/02-specification-language/18762-janno-strictly-unique.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Typeclasses queries of classes that are declared with the options
+  `Typeclasses Strict Resolution` and `Typeclasses Unique Instances`
+  enabled are resolved independently of other queries, allowing them
+  to succeed even when the remaining queries fail
+  (`#18762 <https://github.com/coq/coq/pull/18762>`_,
+  by Jan-Oliver Kaiser).

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1137,7 +1137,7 @@ let split_evars pred env evm =
   in
   let fn evs =
     let (strictly_uniques, rest) = Evar.Set.partition is_strictly_unique evs in
-    rest :: (List.map Evar.Set.singleton (Evar.Set.elements strictly_uniques))
+    List.rev_append (List.rev_map Evar.Set.singleton (Evar.Set.elements strictly_uniques)) [rest]
   in
   List.concat_map fn part
 

--- a/test-suite/success/eauto.v
+++ b/test-suite/success/eauto.v
@@ -221,3 +221,37 @@ not_in_list ((p, q) :: l) n -> not_in_list l n.
   intros.
   eauto with essai.
 Qed.
+
+Module StrictlyUnique.
+  Inductive thing := | List.
+  Module Problem.
+    Class WhatIsThis (T : Type) (t : T) : Type := what_is : thing.
+    Arguments what_is {T} t _.
+    Instance WhatIsThis_list {X} ls : @WhatIsThis (list X) ls := List.
+
+    Class DynamicType := { dyn_type : Type }.
+
+    (* [WhatIsThis ls] cannot be resolved despite having a clear answer. The
+       fact that the [DynamicType] instance cannot be found makes Coq abandon
+       the search for [WhatIsThis] entirely. *)
+    Fail Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
+  End Problem.
+
+  Module Solution.
+    (* Inform Coq that [WhatIsThis] will not/must not instantiate evars. *)
+    #[local] Set Typeclasses Strict Resolution.
+    (* Inform Coq that [WhatIsThis] should not backtrack. *)
+    #[local] Set Typeclasses Unique Instances.
+    Class WhatIsThis (T : Type) (t : T) : Type := what_is : thing.
+    Arguments what_is {T} t _.
+    #[local] Unset Typeclasses Strict Resolution.
+    #[local] Unset Typeclasses Unique Instances.
+
+    Instance WhatIsThis_list {X} ls : @WhatIsThis (list X) ls := List.
+
+    Class DynamicType := { dyn_type : Type }.
+
+    (* We can now resolve [WhatIsThis] even though we don't have a [DynamicType] *)
+    Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
+  End Solution.
+End StrictlyUnique.

--- a/test-suite/success/eauto.v
+++ b/test-suite/success/eauto.v
@@ -254,4 +254,25 @@ Module StrictlyUnique.
     (* We can now resolve [WhatIsThis] even though we don't have a [DynamicType] *)
     Example test := Eval lazy in (fun (ls : list dyn_type) => what_is ls _) _.
   End Solution.
+
+  Module Dependencies.
+    (* Other evars can still depend on strictly unique evars by using them
+       directly in their type. We must make sure to not forget those dependencies. *)
+
+    #[local] Set Typeclasses Strict Resolution.
+    #[local] Set Typeclasses Unique Instances.
+    Class SU : Type := su : unit.
+    Arguments su : clear implicits.
+    #[local] Unset Typeclasses Strict Resolution.
+    #[local] Unset Typeclasses Unique Instances.
+
+    Instance SU_inst : SU := tt.
+
+    Class Depends (t : unit) := {}.
+    Hint Mode Depends + : typeclass_instances.
+
+    Instance Depends_inst {t} : Depends t := {}.
+
+    Example test := Eval lazy in (fun (s : SU) (d : Depends (su s)) => d) _ _.
+  End Dependencies.
 End StrictlyUnique.


### PR DESCRIPTION
Classes with unique instances are forbidden from changing their chosen answer when other goals make progress. Classes with strict resolution cannot contribute to other classes progress since they are forbidden from instantiating evars. Classes that have both unique instances and strict resolution do not need their existing progress invalidated when other goals that share evars get stuck since they cannot switch to a different solution.

Taken together, this means that they can be resolved completely independently except for the fact that they might be blocked (e.g. through Hint Modes) on  shared evars that could be instantiated by other goals. We thus create singleton groups for strictly unique goals and insert these  groups after their original equivalence group to maximize the chance that  shared evars are already instantiated.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
