### PR TITLE
Ltac2 add APIs to customize pretype flags

### DIFF
--- a/doc/changelog/06-Ltac2-language/18765-ltac2-pretype-flags-2.rst
+++ b/doc/changelog/06-Ltac2-language/18765-ltac2-pretype-flags-2.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  `Ltac2.Constr.Pretype.Flags.open_constr_flags` whose name is misleading
+  as it runs typeclass inference unlike `open_constr:()`
+  (`#18765 <https://github.com/coq/coq/pull/18765>`_,
+  by Gaëtan Gilbert).

--- a/doc/changelog/06-Ltac2-language/18765-ltac2-pretype-flags.rst
+++ b/doc/changelog/06-Ltac2-language/18765-ltac2-pretype-flags.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  APIs in `Ltac2.Constr.Pretype.Flags` to customize pretyping flags.
+  (`#18765 <https://github.com/coq/coq/pull/18765>`_,
+  by Gaëtan Gilbert).

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -145,10 +145,38 @@ Module Pretype.
     Ltac2 Type t.
 
     Ltac2 @ external constr_flags : t := "coq-core.plugins.ltac2" "constr_flags".
-    (** Does not allow new unsolved evars. *)
+    (** The flags used by constr:(). *)
 
-    Ltac2 @ external open_constr_flags : t := "coq-core.plugins.ltac2" "open_constr_flags".
-    (** Allows new unsolved evars. *)
+    Ltac2 @external set_use_coercions : bool -> t -> t
+      := "coq-core.plugins.ltac2" "pretype_flags_set_use_coercions".
+    (** Use coercions during pretyping. [true] in [constr_flags]. *)
+
+    Ltac2 @external set_use_typeclasses : bool -> t -> t
+      := "coq-core.plugins.ltac2" "pretype_flags_set_use_typeclasses".
+    (** Run typeclass inference at the end of pretyping and when
+        needed according to flag "Typeclass Resolution For Conversion".
+        [true] in [constr_flags]. *)
+
+    Ltac2 @external set_allow_evars : bool -> t -> t
+      := "coq-core.plugins.ltac2" "pretype_flags_set_allow_evars".
+    (** Allow pretyping to produce new unresolved evars.
+        [false] in [constr_flags]. *)
+
+    Ltac2 @external set_nf_evars : bool -> t -> t
+      := "coq-core.plugins.ltac2" "pretype_flags_set_nf_evars".
+    (** Evar-normalize the result of pretyping. This should not impact
+        anything other than performance.
+        [true] in [constr_flags]. *)
+
+    Ltac2 Notation open_constr_flags_with_tc :=
+      set_nf_evars false (set_allow_evars true constr_flags).
+
+    Ltac2 Notation open_constr_flags_no_tc :=
+      set_use_typeclasses false open_constr_flags_with_tc.
+    (** The flags used by open_constr:() and its alias [']. *)
+
+    #[deprecated(since="8.20", note="use open_constr_flags_with_tc (or no_tc as desired)")]
+    Ltac2 Notation open_constr_flags := open_constr_flags_with_tc.
   End Flags.
 
   Ltac2 Type expected_type.

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -479,7 +479,7 @@ Ltac2 exact1 ev c :=
   Control.enter (fun () =>
     let c :=
       Constr.Pretype.pretype
-        (if ev then Constr.Pretype.Flags.open_constr_flags else Constr.Pretype.Flags.constr_flags)
+        (if ev then Constr.Pretype.Flags.open_constr_flags_with_tc else Constr.Pretype.Flags.constr_flags)
         (Constr.Pretype.expected_oftype (Control.goal()))
         c
     in


### PR DESCRIPTION
Deprecate the `open_constr_flags` definition to make it clear when using typeclasses unlike `open_constr:()`.

The deprecated `open_constr_flags` is also changed as it stops evar normalizing.
