### PR TITLE
Ltac2 #[abstract] attribute for types

### DIFF
--- a/doc/changelog/06-Ltac2-language/18766-ltac2-abstract-type.rst
+++ b/doc/changelog/06-Ltac2-language/18766-ltac2-abstract-type.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :attr:`abstract` attribute for :cmd:`Ltac2 Type` to turn types abstract at the end of the current module
+  (`#18766 <https://github.com/coq/coq/pull/18766>`_,
+  fixes `#18656 <https://github.com/coq/coq/issues/18656>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -192,6 +192,28 @@ One can define new types with the following commands.
    Records are product types with named fields and eliminated by projection.
    Likewise they can be recursive if the `rec` flag is set.
 
+.. attr:: abstract
+   :name: abstract
+
+   Types declared with this attribute are made abstract at the end of
+   the current module. This makes it possible to enforce invariants.
+
+   .. example::
+
+      .. coqtop:: in
+
+         Module PositiveInt.
+           #[abstract] Ltac2 Type t := int.
+
+           Ltac2 make (x:int) : t := if Int.le 0 x then x else Control.throw (Invalid_argument None).
+           Ltac2 get (x:t) : int := x.
+         End PositiveInt.
+
+      .. coqtop:: all
+
+         Ltac2 Eval PositiveInt.get (PositiveInt.make 3).
+         Fail Ltac2 Eval PositiveInt.get (PositiveInt.make -1).
+
 .. cmd:: Ltac2 @ external @ident : @ltac2_type := @string__plugin @string__function
    :name: Ltac2 external
 

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -17,7 +17,7 @@ open Tac2expr
 val register_ltac : ?deprecation:Deprecation.t -> ?local:bool -> ?mut:bool -> rec_flag ->
   (Names.lname * raw_tacexpr) list -> unit
 
-val register_type : ?local:bool -> rec_flag ->
+val register_type : ?local:bool -> ?abstract:bool -> rec_flag ->
   (qualid * redef_flag * raw_quant_typedef) list -> unit
 
 val register_primitive : ?deprecation:Deprecation.t -> ?local:bool ->

--- a/test-suite/output/ltac2_abstract.out
+++ b/test-suite/output/ltac2_abstract.out
@@ -1,0 +1,56 @@
+File "./output/ltac2_abstract.v", line 20, characters 27-28:
+The command has indeed failed with message:
+This expression has type int but an expression was expected of type 
+M.t
+- : M.t = <abstr>
+File "./output/ltac2_abstract.v", line 28, characters 27-28:
+The command has indeed failed with message:
+This expression has type int but an expression was expected of type 
+t
+- : int = 2
+Ltac2 foo : t -> t
+      foo := fun x => Int.add x 1
+Ltac2 three : t
+      three := 3
+- : t = <abstr>
+File "./output/ltac2_abstract.v", line 47, characters 18-21:
+The command has indeed failed with message:
+Unbound constructor M.A
+File "./output/ltac2_abstract.v", line 49, characters 40-43:
+The command has indeed failed with message:
+Unbound constructor M.A
+- : M.t = <abstr>
+- : bool = false
+Ltac2 M.a : M.t
+      M.a := <abstr>
+Ltac2 M.is_b : M.t -> bool
+      M.is_b := fun x => match x with
+                         <abstr>
+                         end
+Ltac2 M.get_b : int -> M.t -> int
+      M.get_b := fun def x => match x with
+                              | <abstr> => x
+                              | _ => def
+                              end
+- : int M.t = <abstr>
+File "./output/ltac2_abstract.v", line 73, characters 20-21:
+The command has indeed failed with message:
+p is not a projection
+File "./output/ltac2_abstract.v", line 75, characters 30-31:
+The command has indeed failed with message:
+p is not a projection
+- : int t = <abstr>
+- : int = 42
+File "./output/ltac2_abstract.v", line 81, characters 27-40:
+The command has indeed failed with message:
+This expression has type bool but an expression was expected of type 
+int
+Ltac2 make : 'a -> 'a t
+      make := fun x => <abstr>
+Ltac2 p : 'a t -> 'a
+      p := fun x => <abstr>
+Ltac2 set : 'a t -> 'a -> unit
+      set := fun x v => <abstr>
+File "./output/ltac2_abstract.v", line 91, characters 32-33:
+The command has indeed failed with message:
+Open types currently do not support #[abstract].

--- a/test-suite/output/ltac2_abstract.v
+++ b/test-suite/output/ltac2_abstract.v
@@ -1,0 +1,110 @@
+Require Import Ltac2.Ltac2.
+
+Module AbstractType.
+  (* redundant, maybe should be an error? *)
+  #[abstract] Ltac2 Type t.
+End AbstractType.
+
+Module DefinedType.
+  Module M.
+    #[abstract] Ltac2 Type t := int.
+
+    Ltac2 foo (x:t) : t := Int.add x 1.
+
+    Ltac2 make (x:int) : t := x.
+    Ltac2 repr (x:t) : int := x.
+
+    Ltac2 three : t := 3.
+  End M.
+
+  Fail Ltac2 nope : M.t := 0.
+
+  Ltac2 ok () : M.t := M.make 0.
+
+  Ltac2 Eval ok ().
+
+  Import M.
+
+  Fail Ltac2 nope : M.t := 0.
+
+  Ltac2 Eval repr (foo (make 1)).
+
+  Print foo.
+  Print three.
+
+  Ltac2 Eval three.
+End DefinedType.
+
+Module AlgebraicType.
+  Module M.
+    #[abstract] Ltac2 Type t := [ A | B (int option) ].
+
+    Ltac2 a := A.
+    Ltac2 is_b x := match x with B _ => true | _ => false end.
+    Ltac2 get_b def x := match x with B (Some x) => x | _ => def end.
+  End M.
+
+  Fail Ltac2 Eval M.A.
+
+  Fail Ltac2 Eval fun x => match x with M.A => true | _ => false end.
+
+  Ltac2 Eval M.a.
+
+  Ltac2 Eval M.is_b M.a.
+
+  Print M.a.
+  Print M.is_b.
+  Print M.get_b.
+End AlgebraicType.
+
+Module RecordType.
+  Module M.
+    #[abstract] Ltac2 Type 'a t := { mutable p : 'a }.
+
+    Ltac2 make x := { p := x }.
+    Ltac2 set x v := x.(p) := v.
+    Ltac2 p x := x.(p).
+  End M.
+
+  Ltac2 Eval M.make 0.
+
+  Import M.
+
+  Fail Ltac2 Eval { p := 0 }.
+
+  Fail Ltac2 Eval fun x => x.(p).
+
+  Ltac2 Eval make 42.
+
+  Ltac2 Eval p (make 42).
+
+  Fail Ltac2 Eval Int.add (p (make true)) 0.
+
+  Print make.
+  Print p.
+  Print set.
+End RecordType.
+
+Module ExtensibleType.
+  Module M.
+    (* TODO figure out what this should do, error until then. *)
+    Fail #[abstract] Ltac2 Type t := [ .. ].
+
+    (* Ltac2 Type t ::= [ E | E' ]. *)
+
+    (* Fail #[abstract] Ltac2 Type t ::= [ F ]. *)
+
+    (* Ltac2 e := E. *)
+
+    (* Ltac2 is_e x := match x with E => true | _ => false end. *)
+  End M.
+
+  (* Import M. *)
+  (* Ltac2 Eval E. *)
+
+  (* Ltac2 Eval match E with E => true | _ => false end. *)
+
+  (* Fail Ltac2 Type t ::= [ F ]. *)
+
+  (* add more tests once we have something to test *)
+End ExtensibleType.


### PR DESCRIPTION
Fix #18656

Printing of glb_expr is a bit awkward. We don't have access to the type so we don't know when we cross an abstraction barrier. OTOH constructors and projections are not in the environment / nametab so we still print <abstr> in some places.

The attribute is disabled for open types as the naive implementation produces not necessarily expected results.
