### PR TITLE
Protect debugger printer from failing on genargs

### DIFF
--- a/printing/genprint.ml
+++ b/printing/genprint.ml
@@ -118,7 +118,7 @@ struct
   let name = "printer"
   let default wit = match wit with
   | ExtraArg tag ->
-    let name = ArgT.repr tag in
+    let name = try ArgT.repr tag with Assert_failure _ when !Flags.in_debugger -> "UNKNOWN" in
     let printer = {
       raw = (fun _ -> PrinterBasic (fun env sigma -> str "<genarg:" ++ str name ++ str ">"));
       glb = (fun _ -> PrinterBasic (fun env sigma -> str "<genarg:" ++ str name ++ str ">"));


### PR DESCRIPTION
Allow the debugger not to fail when printing values such as `ltac2:(binder open_constr:($preterm:x))` (taken from #18762).
