### PR TITLE
Try to preserve physical equality in genarg ntn subst

### DIFF
--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -101,6 +101,6 @@ let generic_intern_pat ?loc ist (GenArg (Rawwit wit, v)) =
 let substitute_notation = NtnSubst.obj
 let register_ntn_subst0 = NtnSubst.register0
 
-let generic_substitute_notation avoid env (GenArg (Glbwit wit, v)) =
-  let v = substitute_notation wit avoid env v in
-  in_gen (glbwit wit) v
+let generic_substitute_notation avoid env (GenArg (Glbwit wit, v) as orig) =
+  let v' = substitute_notation wit avoid env v in
+  if v' == v then orig else in_gen (glbwit wit) v'

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1837,7 +1837,11 @@ let warn_missing_notation_variable =
         str ", if used in Ltac2 code in the notation an error will be produced.")
 
 let () =
-  let subs avoid globs (ids, tac) =
+  let subs avoid globs (ids, tac as orig) =
+    if Id.Set.is_empty ids then
+      (* closed tactic *)
+      orig
+    else
     (* Let-bind the notation terms inside the tactic *)
     let fold id c (rem, accu) =
       let c = GTacExt (Tac2quote.wit_preterm, (avoid, c)) in

--- a/test-suite/ltac2/ltac2_recursive_nota.v
+++ b/test-suite/ltac2/ltac2_recursive_nota.v
@@ -1,0 +1,9 @@
+Require Import Ltac2.Ltac2.
+Notation binder_act := ltac2:(exact eq_refl) (only parsing).
+Notation binder x := (binder_act :> x = x) (only parsing).
+
+#[local] Notation "'test{' x .. y } P" :=
+  ((fun x => .. ((fun y => P), binder (fun y => I)) ..), binder (fun x => I))
+    (at level 0, x binder, y binder, only parsing).
+
+Check (test{(aa : nat) (bb : bool)} True).


### PR DESCRIPTION
This allows to use a restricted set of genargs in recursive notations.

(specifically ltac2:() from a notation that has no bound variables)
