### PR TITLE
Fix #18769: Recompute stored projection constant 

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -921,7 +921,9 @@ struct
       let ind = fst p.proj_ind in
       let ind' = f ind in
       if ind == ind' then p
-      else {p with proj_ind = (ind',snd p.proj_ind)}
+      else
+        let proj_name = KerPair.change_label ind' (label p) in
+        {p with proj_ind = (ind',snd p.proj_ind); proj_name}
 
     let to_string p = Constant.to_string (constant p)
     let print p = Constant.print (constant p)

--- a/test-suite/bugs/bug_18769.v
+++ b/test-suite/bugs/bug_18769.v
@@ -1,0 +1,11 @@
+Module Type T.
+  #[projections(primitive)]
+  Record t := of_unit { to_unit : unit }.
+End T.
+
+Module M.
+  Include T.
+  Print to_unit.
+  Definition foo x := to_unit x.
+  Print foo.
+End M.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #18769


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.


<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
