### PR TITLE
Refactor timelog2html 

### DIFF
--- a/dev/bench/benchUtil.ml
+++ b/dev/bench/benchUtil.ml
@@ -23,9 +23,6 @@ type source_loc = {
 
 let same_char_locs a b = a.start_char = b.start_char && a.stop_char = b.stop_char
 
-(* [line] and [text] are derived data using the same [source] so no need to check them *)
-let same_source_locs a b = same_char_locs a.chars b.chars
-
 let combine_related_data data =
   let nvals = Array.length (snd (data.(0))) in
   let fname0, data0 = data.(0) in
@@ -39,7 +36,7 @@ let combine_related_data data =
       let loc0, _ = data0.(i) in
       let data = data |> Array.map (fun (fname, fdata) ->
           let floc, v = fdata.(i) in
-          if same_source_locs loc0 floc then v
+          if same_char_locs loc0 floc then v
           else die "Mismatch between %s and %s (measurement %d)\n" fname0 fname (i+1))
       in
       loc0, data)

--- a/dev/bench/benchUtil.ml
+++ b/dev/bench/benchUtil.ml
@@ -23,6 +23,10 @@ type source_loc = {
 
 let same_char_locs a b = a.start_char = b.start_char && a.stop_char = b.stop_char
 
+type measure = { str: string; q: Q.t; }
+
+let dummy_measure = { str="0"; q=Q.zero; }
+
 let combine_related_data data =
   let nvals = Array.length (snd (data.(0))) in
   let fname0, data0 = data.(0) in

--- a/dev/bench/benchUtil.ml
+++ b/dev/bench/benchUtil.ml
@@ -43,3 +43,10 @@ let combine_related_data data =
           else die "Mismatch between %s and %s (measurement %d)\n" fname0 fname (i+1))
       in
       loc0, data)
+
+let read_whole_file f =
+  let sourcelen = (Unix.stat f).st_size in
+  let ch = try open_in f with Sys_error e -> die "Could not open %s: %s" f e in
+  let s = really_input_string ch sourcelen in
+  close_in ch;
+  s

--- a/dev/bench/benchUtil.ml
+++ b/dev/bench/benchUtil.ml
@@ -1,0 +1,45 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
+
+type char_loc = {
+  start_char : int;
+  stop_char : int;
+}
+
+type source_loc = {
+  chars : char_loc;
+  line : int;
+  text : string;
+}
+
+let same_char_locs a b = a.start_char = b.start_char && a.stop_char = b.stop_char
+
+(* [line] and [text] are derived data using the same [source] so no need to check them *)
+let same_source_locs a b = same_char_locs a.chars b.chars
+
+let combine_related_data data =
+  let nvals = Array.length (snd (data.(0))) in
+  let fname0, data0 = data.(0) in
+  let () =
+    Array.iter (fun (fname, v) ->
+        if nvals <> Array.length v
+        then die "Mismatch between %s and %s: different measurement counts\n" fname0 fname)
+      data
+  in
+  Array.init nvals (fun i ->
+      let loc0, _ = data0.(i) in
+      let data = data |> Array.map (fun (fname, fdata) ->
+          let floc, v = fdata.(i) in
+          if same_source_locs loc0 floc then v
+          else die "Mismatch between %s and %s (measurement %d)\n" fname0 fname (i+1))
+      in
+      loc0, data)

--- a/dev/bench/benchUtil.mli
+++ b/dev/bench/benchUtil.mli
@@ -13,17 +13,13 @@ type char_loc = {
   stop_char : int;
 }
 
-val same_char_locs : char_loc -> char_loc -> bool
-
 type source_loc = {
   chars : char_loc;
   line : int;
   text : string;
 }
 
-val same_source_locs : source_loc -> source_loc -> bool
-
-val combine_related_data : (string * (source_loc * 'a) array) array -> (source_loc * 'a array) array
+val combine_related_data : (string * (char_loc * 'a) array) array -> (char_loc * 'a array) array
 (** Combine data from multiple files about the same source, ensuring
     that the locations do not have inconsistencies. *)
 

--- a/dev/bench/benchUtil.mli
+++ b/dev/bench/benchUtil.mli
@@ -19,6 +19,11 @@ type source_loc = {
   text : string;
 }
 
+(** A measurement, with the original printed string and an exact rational representation *)
+type measure = { str: string; q: Q.t; }
+
+val dummy_measure : measure
+
 val combine_related_data : (string * (char_loc * 'a) array) array -> (char_loc * 'a array) array
 (** Combine data from multiple files about the same source, ensuring
     that the locations do not have inconsistencies. *)

--- a/dev/bench/benchUtil.mli
+++ b/dev/bench/benchUtil.mli
@@ -1,0 +1,28 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type char_loc = {
+  start_char : int;
+  stop_char : int;
+}
+
+val same_char_locs : char_loc -> char_loc -> bool
+
+type source_loc = {
+  chars : char_loc;
+  line : int;
+  text : string;
+}
+
+val same_source_locs : source_loc -> source_loc -> bool
+
+val combine_related_data : (string * (source_loc * 'a) array) array -> (source_loc * 'a array) array
+(** Combine data from multiple files about the same source, ensuring
+    that the locations do not have inconsistencies. *)

--- a/dev/bench/dune
+++ b/dev/bench/dune
@@ -23,4 +23,4 @@
  (public_name coqtimelog2html)
  (package coq-core)
  (modules timelog2html)
- (libraries unix str clib zarith benchlib))
+ (libraries benchlib))

--- a/dev/bench/dune
+++ b/dev/bench/dune
@@ -13,9 +13,14 @@
  (modules render_line_results)
  (libraries unix table str clib))
 
+(library
+ (name benchlib)
+ (modules benchUtil sourcehandler timelogparser)
+ (libraries unix str clib zarith))
+
 (executable
  (name timelog2html)
  (public_name coqtimelog2html)
  (package coq-core)
  (modules timelog2html)
- (libraries unix str clib zarith))
+ (libraries unix str clib zarith benchlib))

--- a/dev/bench/dune
+++ b/dev/bench/dune
@@ -15,7 +15,7 @@
 
 (library
  (name benchlib)
- (modules benchUtil sourcehandler timelogparser)
+ (modules benchUtil sourcehandler timelogparser htmloutput)
  (libraries unix str clib zarith))
 
 (executable

--- a/dev/bench/htmloutput.ml
+++ b/dev/bench/htmloutput.ml
@@ -1,0 +1,157 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let colors = [|"#F08080"; "#EEE8AA"; "#98FB98"|]
+
+let max_data_count = Array.length colors
+
+let htmlescape =
+  let r = Str.regexp "[&<>\"]" in
+  let subst s = match Str.matched_string s with
+    | "&" -> "&amp;"
+    | "<" -> "&lt;"
+    | ">" -> "&gt;"
+    | "\"" -> "&quot;"
+    | _ -> assert false
+  in
+  fun s -> Str.global_substitute r subst s
+
+type measure = { str: string; q: Q.t; }
+
+let percentage ~max:m v =
+  Q.to_float Q.(v * of_int 100 / m)
+
+let output ch ~vname ~data_files all_data =
+
+let out fmt = Printf.fprintf ch fmt in
+let ndata = Array.length data_files in
+
+let maxq =
+  Array.fold_left (fun max (_,data) ->
+      Array.fold_left (fun max d ->
+          let dq = d.q in
+          if Q.lt max dq then dq
+          else max)
+        max
+        data)
+    Q.zero all_data
+in
+
+let () =
+  out
+{|<html>
+<head>
+<title>%s</title>
+<style>
+|} vname
+in
+
+let () = data_files |> Array.iteri (fun i _ ->
+    let color = colors.(i) in
+    out
+{|.time%d {
+  background-color: %s;
+  height: %d%%;
+  top: %d%%;
+  z-index: -1;
+  position: absolute;
+  opacity: 50%%;
+}
+|} (i+1) color (100 / ndata) (100 / ndata * i))
+in
+
+let () =
+  out
+{|.code {
+  z-index: 0;
+  position: relative;
+  border-style: solid;
+  border-color: transparent;
+  border-width: 1px;
+}
+.code:hover {
+  border-color: black;
+}
+code::before {
+    content:  attr(data-line);
+    right: 0.5em;
+    position: absolute;
+    text-align: right;
+}
+</style>
+</head>
+<body>
+|}
+in
+
+let () = out "<h1>Timings for %s</h1>\n" vname in
+
+let () = out "<ol>\n" in
+
+let () = data_files |> Array.iteri (fun i data_file ->
+    out "<li style=\"background-color: %s\">%s</li>\n" colors.(i) data_file)
+in
+
+let () = out "</ol>\n" in
+
+let () = out "<pre>" in
+
+let last_seen_line = ref 0 in
+
+let line_id fmt l =
+  if l > !last_seen_line then begin
+    last_seen_line := l;
+    Printf.fprintf fmt "id=\"L%d\" " l
+  end
+in
+
+let () = all_data |> Array.iteri (fun j ((loc:BenchUtil.source_loc),time) ->
+    let () = out {|<div class="code" title="File: %s
+Line: %d
+
+|} vname loc.line
+    in
+    let () = time |> Array.iteri (fun k d ->
+        out "Time%d: %ss\n" (k+1) d.str)
+    in
+    let () = out {|">|} in
+
+    let () = time |> Array.iteri (fun k d ->
+        out {|<div class="time%d" style="width: %f%%"></div>|}
+          (k+1)
+          (percentage d.q ~max:maxq))
+    in
+
+    let text = loc.text in
+    let text = if text <> "" && text.[0] = '\n'
+      then String.sub text 1 (String.length text  - 1)
+      else text
+    in
+    let sublines = String.split_on_char '\n' text in
+    let () = sublines |> List.iteri (fun i line ->
+        let lnum = loc.line + i in
+        out "<code %adata-line=\"%d\">%s</code>\n" line_id lnum lnum (htmlescape line))
+    in
+
+    let () = out "</div>" in
+    ())
+in
+
+let () =
+  out
+{|
+</pre>
+
+</body>
+</html>
+|}
+in
+
+()

--- a/dev/bench/htmloutput.ml
+++ b/dev/bench/htmloutput.ml
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open BenchUtil
+
 let colors = [|"#F08080"; "#EEE8AA"; "#98FB98"|]
 
 let max_data_count = Array.length colors
@@ -22,8 +24,6 @@ let htmlescape =
     | _ -> assert false
   in
   fun s -> Str.global_substitute r subst s
-
-type measure = { str: string; q: Q.t; }
 
 let percentage ~max:m v =
   Q.to_float Q.(v * of_int 100 / m)
@@ -112,7 +112,7 @@ let line_id fmt l =
   end
 in
 
-let () = all_data |> Array.iteri (fun j ((loc:BenchUtil.source_loc),time) ->
+let () = all_data |> Array.iteri (fun j (loc,time) ->
     let () = out {|<div class="code" title="File: %s
 Line: %d
 

--- a/dev/bench/htmloutput.mli
+++ b/dev/bench/htmloutput.mli
@@ -8,23 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type char_loc = {
-  start_char : int;
-  stop_char : int;
-}
+(** A measurement, with the original printed string and an exact rational representation *)
+type measure = { str: string; q: Q.t; }
 
-val same_char_locs : char_loc -> char_loc -> bool
+val output : out_channel -> vname:string ->
+  data_files:string array ->
+  (BenchUtil.source_loc * measure array) array -> unit
 
-type source_loc = {
-  chars : char_loc;
-  line : int;
-  text : string;
-}
-
-val same_source_locs : source_loc -> source_loc -> bool
-
-val combine_related_data : (string * (source_loc * 'a) array) array -> (source_loc * 'a array) array
-(** Combine data from multiple files about the same source, ensuring
-    that the locations do not have inconsistencies. *)
-
-val read_whole_file : string -> string
+val max_data_count : int
+(** Max length supported for the inner [measure array]. *)

--- a/dev/bench/htmloutput.mli
+++ b/dev/bench/htmloutput.mli
@@ -8,12 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** A measurement, with the original printed string and an exact rational representation *)
-type measure = { str: string; q: Q.t; }
-
 val output : out_channel -> vname:string ->
   data_files:string array ->
-  (BenchUtil.source_loc * measure array) array -> unit
+  (BenchUtil.source_loc * BenchUtil.measure array) array -> unit
 
 val max_data_count : int
 (** Max length supported for the inner [measure array]. *)

--- a/dev/bench/sourcehandler.ml
+++ b/dev/bench/sourcehandler.ml
@@ -1,0 +1,90 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open BenchUtil
+
+module Compat = struct
+
+  (* stdlib version needs ocaml >= 4.13 *)
+  let str_fold_left f x a =
+    let open String in
+    let r = ref x in
+    for i = 0 to length a - 1 do
+      r := f !r (unsafe_get a i)
+    done;
+    !r
+
+  (* stdlib version needs ocaml >= 4.13 *)
+  let str_for_all p s =
+    let open String in
+    let n = length s in
+    let rec loop i =
+      if i = n then true
+      else if p (unsafe_get s i) then loop (succ i)
+      else false in
+    loop 0
+
+end
+open Compat
+
+let source_substring source start stop =
+  (* substring from start to stop inclusive, both 1-based *)
+  (* start=0 is the same as start=1 *)
+  let start = if start = 0 then 1 else start in
+  let len = stop - start + 1 (* +1 for inclusive *) in
+  String.sub source (start-1) len
+
+let count_newlines s = str_fold_left (fun n c -> if c = '\n' then n+1 else n) 0 s
+
+let is_white_char = function ' '|'\n'|'\t' -> true | _ -> false
+
+let rec join_loop ~dummy ~source ~last_end ~lines acc = function
+  | [] ->
+    let sourcelen = String.length source in
+    let acc = if last_end + 1 <= sourcelen then
+        let text = source_substring source (last_end+1) sourcelen in
+        if str_for_all is_white_char text then acc
+        else
+          ({ chars = { start_char = last_end+1; stop_char = sourcelen; };
+             line = lines+1; text}, dummy)
+          :: acc
+      else
+        acc
+    in
+    List.rev acc
+  | (loc,v) :: rest ->
+    let acc, lines, last_end =
+      if loc.start_char > last_end + 1 then
+        let text = source_substring source (last_end + 1) (loc.start_char - 1) in
+        (* if only spaces since last command, include them in the next command
+           typically "Module Foo.\n  Cmd." *)
+        if not (str_for_all is_white_char text) then
+          let n = count_newlines text in
+          let acc =
+            ({ chars = { start_char = last_end + 1; stop_char = loc.start_char - 1; };
+               line = lines; text }, dummy)
+            :: acc
+          in
+          acc, (lines+n), loc.start_char - 1
+        else acc, lines, last_end
+      else acc, lines, last_end
+    in
+    let text = source_substring source (last_end+1) loc.stop_char in
+    let lines, n = if text <> "" && text.[0] = '\n' then lines+1, 1 else lines, 0 in
+    let n = count_newlines text - n in
+    let acc =
+      ({ chars = { start_char = last_end + 1; stop_char = loc.stop_char; };
+         line = lines; text }, v)
+      :: acc
+    in
+    join_loop ~dummy ~source ~last_end:loc.stop_char ~lines:(lines + n) acc rest
+
+let join_to_source ~dummy ~source vals =
+  join_loop ~dummy ~source ~last_end:(-1) ~lines:1 [] vals

--- a/dev/bench/sourcehandler.mli
+++ b/dev/bench/sourcehandler.mli
@@ -1,0 +1,20 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open BenchUtil
+
+val join_to_source : dummy:'a -> source:string -> (char_loc * 'a) list -> (source_loc * 'a) list
+(** Given a list of values ordered by locations with no overlaps but
+    maybe gaps, associate them to substrings of the source and fill in
+    the gaps using [dummy].
+
+    When a gap is all whitespace in the source, it is merged to the
+    next value (dropped if at the end).
+*)

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -25,20 +25,22 @@ let data_files = Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
 
 let source = BenchUtil.read_whole_file vfile
 
-let dummy = { Htmloutput.str="0"; q=Q.zero; }
-
 let file_data data_file =
   let data = Timelogparser.parse ~file:data_file in
   let data = data |> List.map (fun (loc,{Timelogparser.timestr}) ->
       loc, { Htmloutput.str = timestr; q = Q.of_string timestr })
   in
-  (* XXX should we join_to_source after combine_related_data? *)
-  let data = Sourcehandler.join_to_source ~dummy ~source data in
   data_file, CArray.of_list data
 
 let all_data = Array.map file_data data_files
 
 let all_data = BenchUtil.combine_related_data all_data
+
+let dummy_measure = { Htmloutput.str="0"; q=Q.zero; }
+
+let dummy = Array.make (Array.length data_files) dummy_measure
+
+let all_data = Array.of_list (Sourcehandler.join_to_source ~dummy ~source (Array.to_list all_data))
 
 let vname = Filename.basename vfile
 

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -12,49 +12,25 @@ open Benchlib
 
 let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
 
-let colors = [|"#F08080"; "#EEE8AA"; "#98FB98"|]
-
 let usage () = die "Usage: %s VFILE TIMEFILES\n\n%a\n" Sys.argv.(0)
     (fun fmt len -> Printf.fprintf fmt "(Only up to %d time files are supported.)" len)
-    (Array.length colors)
+    Htmloutput.max_data_count
 
 let () = if Array.length Sys.argv < 3 ||
-            Array.length Sys.argv > 2 + Array.length colors
+            Array.length Sys.argv > 2 + Htmloutput.max_data_count
   then  usage ()
 
 let vfile = Sys.argv.(1)
 let data_files = Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
-let ndata = Array.length data_files
 
-let htmlescape =
-  let r = Str.regexp "[&<>\"]" in
-  let subst s = match Str.matched_string s with
-    | "&" -> "&amp;"
-    | "<" -> "&lt;"
-    | ">" -> "&gt;"
-    | "\"" -> "&quot;"
-    | _ -> assert false
-  in
-  fun s -> Str.global_substitute r subst s
+let source = BenchUtil.read_whole_file vfile
 
-let sourcelen = (Unix.stat vfile).st_size
-let source =
-  let ch = try open_in vfile with Sys_error e -> die "Could not open %s: %s" vfile e in
-  let s = really_input_string ch sourcelen in
-  close_in ch;
-  s
-
-(* A measurement, with the original printed string and an exact rational representation *)
-type measure = { str: string; q: Q.t; }
-
-let dummy = { str="0"; q=Q.zero; }
-
-type 'a one_command = BenchUtil.source_loc * 'a
+let dummy = { Htmloutput.str="0"; q=Q.zero; }
 
 let file_data data_file =
   let data = Timelogparser.parse ~file:data_file in
   let data = data |> List.map (fun (loc,{Timelogparser.timestr}) ->
-      loc, { str = timestr; q = Q.of_string timestr })
+      loc, { Htmloutput.str = timestr; q = Q.of_string timestr })
   in
   (* XXX should we join_to_source after combine_related_data? *)
   let data = Sourcehandler.join_to_source ~dummy ~source data in
@@ -62,127 +38,8 @@ let file_data data_file =
 
 let all_data = Array.map file_data data_files
 
-let all_data : measure array one_command array =
-  BenchUtil.combine_related_data all_data
-
-let percentage ~max:m v =
-  Q.to_float Q.(v * of_int 100 / m)
-
-let maxq =
-  Array.fold_left (fun max (_,data) ->
-      Array.fold_left (fun max d ->
-          let dq = d.q in
-          if Q.lt max dq then dq
-          else max)
-        max
-        data)
-    Q.zero all_data
+let all_data = BenchUtil.combine_related_data all_data
 
 let vname = Filename.basename vfile
 
-let out fmt = Printf.fprintf stdout fmt
-
-let () =
-  out
-{|<html>
-<head>
-<title>%s</title>
-<style>
-|} vname
-
-(* NB: lua "ipairs" is 1-based, ocaml "iteri" is 0-based *)
-let () = data_files |> Array.iteri (fun i _ ->
-    let color = colors.(i) in
-    out
-{|.time%d {
-  background-color: %s;
-  height: %d%%;
-  top: %d%%;
-  z-index: -1;
-  position: absolute;
-  opacity: 50%%;
-}
-|} (i+1) color (100 / ndata) (100 / ndata * i))
-
-let () =
-  out
-{|.code {
-  z-index: 0;
-  position: relative;
-  border-style: solid;
-  border-color: transparent;
-  border-width: 1px;
-}
-.code:hover {
-  border-color: black;
-}
-code::before {
-    content:  attr(data-line);
-    right: 0.5em;
-    position: absolute;
-    text-align: right;
-}
-</style>
-</head>
-<body>
-|}
-
-let () = out "<h1>Timings for %s</h1>\n" vname
-
-let () = out "<ol>\n"
-
-let () = data_files |> Array.iteri (fun i data_file ->
-    out "<li style=\"background-color: %s\">%s</li>\n" colors.(i) data_file)
-
-let () = out "</ol>\n"
-
-let () = out "<pre>"
-
-let last_seen_line = ref 0
-
-let line_id fmt l =
-  if l > !last_seen_line then begin
-    last_seen_line := l;
-    Printf.fprintf fmt "id=\"L%d\" " l
-  end
-
-
-let () = all_data |> Array.iteri (fun j ((loc:BenchUtil.source_loc),time) ->
-    let () = out {|<div class="code" title="File: %s
-Line: %d
-
-|} vname loc.line
-    in
-    let () = time |> Array.iteri (fun k d ->
-        out "Time%d: %ss\n" (k+1) d.str)
-    in
-    let () = out {|">|} in
-
-    let () = time |> Array.iteri (fun k d ->
-        out {|<div class="time%d" style="width: %f%%"></div>|}
-          (k+1)
-          (percentage d.q ~max:maxq))
-    in
-
-    let text = loc.text in
-    let text = if text <> "" && text.[0] = '\n'
-      then String.sub text 1 (String.length text  - 1)
-      else text
-    in
-    let sublines = String.split_on_char '\n' text in
-    let () = sublines |> List.iteri (fun i line ->
-        let lnum = loc.line + i in
-        out "<code %adata-line=\"%d\">%s</code>\n" line_id lnum lnum (htmlescape line))
-    in
-
-    let () = out "</div>" in
-    ())
-
-let () =
-  out
-{|
-</pre>
-
-</body>
-</html>
-|}
+let () = Htmloutput.output stdout ~vname ~data_files all_data

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Benchlib
+
 let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
 
 let colors = [|"#F08080"; "#EEE8AA"; "#98FB98"|]
@@ -19,30 +21,6 @@ let usage () = die "Usage: %s VFILE TIMEFILES\n\n%a\n" Sys.argv.(0)
 let () = if Array.length Sys.argv < 3 ||
             Array.length Sys.argv > 2 + Array.length colors
   then  usage ()
-
-module Compat = struct
-
-  (* stdlib version needs ocaml >= 4.13 *)
-  let str_fold_left f x a =
-    let open String in
-    let r = ref x in
-    for i = 0 to length a - 1 do
-      r := f !r (unsafe_get a i)
-    done;
-    !r
-
-  (* stdlib version needs ocaml >= 4.13 *)
-  let str_for_all p s =
-    let open String in
-    let n = length s in
-    let rec loop i =
-      if i = n then true
-      else if p (unsafe_get s i) then loop (succ i)
-      else false in
-    loop 0
-
-end
-open Compat
 
 let vfile = Sys.argv.(1)
 let data_files = Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
@@ -66,119 +44,43 @@ let source =
   close_in ch;
   s
 
-let source_substring start stop =
-  (* substring from start to stop inclusive, both 1-based *)
-  (* start=0 is the same as start=1 *)
-  let start = if start = 0 then 1 else start in
-  let len = stop - start + 1 (* +1 for inclusive *) in
-  String.sub source (start-1) len
-
-type loc = { start: int; stop: int; line: int; text: string; }
-
-(* [line] and [text] are derived data using the same [source] so no need to check them *)
-let same_loc a b = a.start = b.start && a.stop = b.stop
-
 (* A measurement, with the original printed string and an exact rational representation *)
 type measure = { str: string; q: Q.t; }
 
 let dummy = { str="0"; q=Q.zero; }
 
-type 'a one_command = {
-  loc: loc;
-  time: 'a;
-}
-
-let time_regex = Str.regexp {|^Chars \([0-9]+\) - \([0-9]+\) [^ ]+ \([0-9.]+\) secs|}
-
-let count_newlines s = str_fold_left (fun n c -> if c = '\n' then n+1 else n) 0 s
-
-let is_white_char = function ' '|'\n'|'\t' -> true | _ -> false
-
-let rec file_loop filech ~last_end ~lines acc : measure one_command array =
-  match input_line filech with
-  | exception End_of_file ->
-    let acc = if last_end + 1 <= sourcelen then
-        let text = source_substring (last_end+1) sourcelen in
-        if str_for_all is_white_char text then acc
-        else
-          { loc = { start = last_end+1; stop = sourcelen; line = lines+1; text; };
-            time = dummy;
-          } :: acc
-      else acc
-    in
-    CArray.rev_of_list acc
-  | l ->
-    if not (Str.string_match time_regex l 0) then
-      file_loop filech ~last_end ~lines acc
-    else
-      let b = int_of_string @@ Str.matched_group 1 l
-      and e = int_of_string @@ Str.matched_group 2 l
-      and t = Str.matched_group 3 l in
-      let acc, lines, last_end = if b > last_end + 1 then
-          let text = source_substring (last_end + 1) (b - 1) in
-          (* if only spaces since last command, include them in the next command
-             typically "Module Foo.\n  Cmd." *)
-          if not (str_for_all is_white_char text) then
-            let n = count_newlines text in
-            let acc =
-              { loc = { start = last_end + 1; stop = b-1; line = lines; text };
-                time = dummy;
-              } :: acc
-            in
-            acc, (lines+n), b-1
-          else acc, lines, last_end
-        else acc, lines, last_end
-      in
-      let text = source_substring (last_end+1) e in
-      let lines, n = if text <> "" && text.[0] = '\n' then lines+1, 1 else lines, 0 in
-      let n = count_newlines text - n in
-      (* lua script has "eoln" but unused *)
-      let acc =
-        { loc = { start = last_end+1; stop = e; line = lines; text; };
-          time = { str=t; q = Q.of_string t; };
-        } :: acc
-      in
-      let lines = lines + n in
-      let last_end = e in
-      file_loop filech ~last_end ~lines acc
+type 'a one_command = BenchUtil.source_loc * 'a
 
 let file_data data_file =
-  file_loop (open_in data_file) ~last_end:(-1) ~lines:1 []
+  let data = Timelogparser.parse ~file:data_file in
+  let data = data |> List.map (fun (loc,{Timelogparser.timestr}) ->
+      loc, { str = timestr; q = Q.of_string timestr })
+  in
+  (* XXX should we join_to_source after combine_related_data? *)
+  let data = Sourcehandler.join_to_source ~dummy ~source data in
+  data_file, CArray.of_list data
 
 let all_data = Array.map file_data data_files
 
-let () =
-  data_files |> Array.iteri (fun fidx fname ->
-      if Array.length all_data.(0) <> Array.length all_data.(fidx)
-      then die "Mismatch between %s and %s: different measurement counts\n" data_files.(0) fname)
-
 let all_data : measure array one_command array =
-  all_data.(0) |> Array.mapi (fun i d ->
-      let times = data_files |> Array.mapi (fun fidx fname ->
-          let fdata = all_data.(fidx).(i) in
-          if same_loc d.loc fdata.loc
-          then fdata.time
-          else die "Mismatch between %s and %s at line %d\n" data_files.(0) fname (i+1))
-      in
-      { loc = d.loc;
-        time = times; })
+  BenchUtil.combine_related_data all_data
 
 let percentage ~max:m v =
   Q.to_float Q.(v * of_int 100 / m)
 
 let maxq =
-  Array.fold_left (fun max data ->
+  Array.fold_left (fun max (_,data) ->
       Array.fold_left (fun max d ->
           let dq = d.q in
           if Q.lt max dq then dq
           else max)
         max
-        data.time)
+        data)
     Q.zero all_data
 
 let vname = Filename.basename vfile
 
-let out fmt = Printf.kfprintf (fun _ -> ()) stdout fmt
+let out fmt = Printf.fprintf stdout fmt
 
 let () =
   out
@@ -245,31 +147,31 @@ let line_id fmt l =
   end
 
 
-let () = all_data |> Array.iteri (fun j d ->
+let () = all_data |> Array.iteri (fun j ((loc:BenchUtil.source_loc),time) ->
     let () = out {|<div class="code" title="File: %s
 Line: %d
 
-|} vname d.loc.line
+|} vname loc.line
     in
-    let () = d.time |> Array.iteri (fun k d ->
+    let () = time |> Array.iteri (fun k d ->
         out "Time%d: %ss\n" (k+1) d.str)
     in
     let () = out {|">|} in
 
-    let () = d.time |> Array.iteri (fun k d ->
+    let () = time |> Array.iteri (fun k d ->
         out {|<div class="time%d" style="width: %f%%"></div>|}
           (k+1)
           (percentage d.q ~max:maxq))
     in
 
-    let text = d.loc.text in
+    let text = loc.text in
     let text = if text <> "" && text.[0] = '\n'
       then String.sub text 1 (String.length text  - 1)
       else text
     in
     let sublines = String.split_on_char '\n' text in
     let () = sublines |> List.iteri (fun i line ->
-        let lnum = d.loc.line + i in
+        let lnum = loc.line + i in
         out "<code %adata-line=\"%d\">%s</code>\n" line_id lnum lnum (htmlescape line))
     in
 

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -27,18 +27,13 @@ let source = BenchUtil.read_whole_file vfile
 
 let file_data data_file =
   let data = Timelogparser.parse ~file:data_file in
-  let data = data |> List.map (fun (loc,{Timelogparser.timestr}) ->
-      loc, { Htmloutput.str = timestr; q = Q.of_string timestr })
-  in
   data_file, CArray.of_list data
 
 let all_data = Array.map file_data data_files
 
 let all_data = BenchUtil.combine_related_data all_data
 
-let dummy_measure = { Htmloutput.str="0"; q=Q.zero; }
-
-let dummy = Array.make (Array.length data_files) dummy_measure
+let dummy = Array.make (Array.length data_files) BenchUtil.dummy_measure
 
 let all_data = Array.of_list (Sourcehandler.join_to_source ~dummy ~source (Array.to_list all_data))
 

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -13,7 +13,7 @@ open Benchlib
 let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
 
 let usage () = die "Usage: %s VFILE TIMEFILES\n\n%a\n" Sys.argv.(0)
-    (fun fmt len -> Printf.fprintf fmt "(Only up to %d time files are supported.)" len)
+    (fun fmt len -> Printf.fprintf fmt "(1 to %d time files are supported.)" len)
     Htmloutput.max_data_count
 
 let () = if Array.length Sys.argv < 3 ||

--- a/dev/bench/timelogparser.ml
+++ b/dev/bench/timelogparser.ml
@@ -10,8 +10,6 @@
 
 open BenchUtil
 
-type raw_time = { timestr : string }
-
 let time_regex = Str.regexp {|^Chars \([0-9]+\) - \([0-9]+\) [^ ]+ \([0-9.]+\) secs|}
 
 let rec parse_loop filech acc =
@@ -25,7 +23,7 @@ let rec parse_loop filech acc =
       let b = int_of_string @@ Str.matched_group 1 l
       and e = int_of_string @@ Str.matched_group 2 l
       and t = Str.matched_group 3 l in
-      let v = { start_char = b; stop_char = e; }, { timestr = t } in
+      let v = { start_char = b; stop_char = e; }, { str = t; q = Q.of_string t } in
       parse_loop filech (v :: acc)
 
 let parse ~file =

--- a/dev/bench/timelogparser.ml
+++ b/dev/bench/timelogparser.ml
@@ -1,0 +1,35 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open BenchUtil
+
+type raw_time = { timestr : string }
+
+let time_regex = Str.regexp {|^Chars \([0-9]+\) - \([0-9]+\) [^ ]+ \([0-9.]+\) secs|}
+
+let rec parse_loop filech acc =
+  match input_line filech with
+  | exception End_of_file ->
+    List.rev acc
+  | l ->
+    if not (Str.string_match time_regex l 0) then
+      parse_loop filech acc
+    else
+      let b = int_of_string @@ Str.matched_group 1 l
+      and e = int_of_string @@ Str.matched_group 2 l
+      and t = Str.matched_group 3 l in
+      let v = { start_char = b; stop_char = e; }, { timestr = t } in
+      parse_loop filech (v :: acc)
+
+let parse ~file =
+  let ch = open_in file in
+  let v = parse_loop ch [] in
+  close_in ch;
+  v

--- a/dev/bench/timelogparser.mli
+++ b/dev/bench/timelogparser.mli
@@ -1,0 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type raw_time = { timestr : string }
+
+val parse : file:string -> (BenchUtil.char_loc * raw_time) list

--- a/dev/bench/timelogparser.mli
+++ b/dev/bench/timelogparser.mli
@@ -8,6 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type raw_time = { timestr : string }
-
-val parse : file:string -> (BenchUtil.char_loc * raw_time) list
+val parse : file:string -> (BenchUtil.char_loc * BenchUtil.measure) list

--- a/test-suite/misc/bench-render.sh
+++ b/test-suite/misc/bench-render.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 set -o pipefail
 
 export COQBIN=$BIN
@@ -11,18 +11,18 @@ cd misc/bench-render
 
 coqtimelog2html foo.v foo.v.time1 foo.v.time2 > result.html.real
 
-diff result.html result.html.real
+diff -u result.html result.html.real
 
 if coqtimelog2html foo.v foo.v.time1 foo.v.time3 > bad1v3.html.real 2>stderr1v3.real
 then >&2 echo "Should have failed!"; exit 1
 fi
 
-diff /dev/null bad1v3.html.real
-diff stderr1v3 stderr1v3.real
+diff -u /dev/null bad1v3.html.real
+diff -u stderr1v3 stderr1v3.real
 
 if coqtimelog2html foo.v foo.v.time1 foo.v.time4 > bad1v4.html.real 2>stderr1v4.real
 then >&2 echo "Should have failed!"; exit 1
 fi
 
-diff /dev/null bad1v4.html.real
-diff stderr1v4 stderr1v4.real
+diff -u /dev/null bad1v4.html.real
+diff -u stderr1v4 stderr1v4.real

--- a/test-suite/misc/bench-render/stderr1v4
+++ b/test-suite/misc/bench-render/stderr1v4
@@ -1,1 +1,1 @@
-Mismatch between foo.v.time1 and foo.v.time4 (measurement 2)
+Mismatch between foo.v.time1 and foo.v.time4 (measurement 1)

--- a/test-suite/misc/bench-render/stderr1v4
+++ b/test-suite/misc/bench-render/stderr1v4
@@ -1,1 +1,1 @@
-Mismatch between foo.v.time1 and foo.v.time4 at line 2
+Mismatch between foo.v.time1 and foo.v.time4 (measurement 2)


### PR DESCRIPTION
The goal is to make it easy to read the timing info from the json -profile files instead of the -time files, then we can also read memory info and any other data we add from the json files.

For this PR behaviour change should be minimal (error messages are slightly improved).