### PR TITLE
Add some profiling calls around functions used in initialization

### DIFF
--- a/lib/newProfile.ml
+++ b/lib/newProfile.ml
@@ -92,6 +92,8 @@ let gettimeopt = function
 let prtime t =
   Format.sprintf "%.0f" (t *. 1E6)
 
+(* NewProfile should be fairly early in the linking order so we
+   probably don't miss much before this gettime call *)
 let global_start = gettime()
 let global_start_stat = Gc.quick_stat()
 let global_start_count = Ok Int64.zero
@@ -214,14 +216,14 @@ let init { output } =
   accu := Some { ch = output; sums = [] };
   f "{ \"traceEvents\": [\n";
   enter ~time:global_start "process" ();
-  enter ~time:global_start "init" ();
+  enter ~time:global_start "before_profiler_init" ();
   let iend = Instr.read_counter () in
   let mend = Gc.quick_stat () in
   let args =
     make_instr_diff ~istart:global_start_count ~iend @
     make_mem_diff ~mstart:global_start_stat ~mend
   in
-  leave "init" ~args ()
+  leave "before_profiler_init" ~args ()
 
 let pause () =
   let v = !accu in

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -682,10 +682,12 @@ let end_compilation dir =
 
 (** Compatibility layer *)
 let init () =
+  NewProfile.profile "Lib.init" (fun () ->
   Synterp.init ();
   Interp.init ();
   Summary.Synterp.init_summaries ();
-  Summary.Interp.init_summaries ()
+  Summary.Interp.init_summaries ())
+    ()
 
 let open_section id =
   Synterp.open_section id;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -142,7 +142,10 @@ let init_load_paths opts =
   let env_ocamlpath = ml_path @ env_ocamlpath in
   let ocamlpathsep = if Sys.unix then ":" else ";" in
   let env_ocamlpath = String.concat ocamlpathsep env_ocamlpath in
-  Findlib.init ~env_ocamlpath ()
+  NewProfile.profile "Findlib.init" (fun () -> Findlib.init ~env_ocamlpath ()) ()
+
+let init_load_paths opts =
+  NewProfile.profile "init_load_paths" (fun () -> init_load_paths opts) ()
 
 let init_profile ~file =
   let ch = open_out file in
@@ -186,7 +189,9 @@ let require_file ~prefix ~lib ~export =
   let mp = Libnames.qualid_of_string lib in
   let mfrom = Option.map Libnames.qualid_of_string prefix in
   let exp = Option.map (fun e -> e, None) export in
-  Flags.silently (Vernacentries.vernac_require mfrom exp) [mp,Vernacexpr.ImportAll]
+  NewProfile.profile "injection require" (fun () ->
+      Flags.silently (Vernacentries.vernac_require mfrom exp) [mp,Vernacexpr.ImportAll])
+    ()
 
 let warn_no_native_compiler =
   CWarnings.create_in Nativeconv.w_native_disabled

--- a/sysinit/coqloadpath.ml
+++ b/sysinit/coqloadpath.ml
@@ -89,3 +89,8 @@ let init_load_path ~coqenv =
     List.concat misc_vo
   in
   ml_loadpath, vo_loadpath
+
+let init_load_path ~coqenv =
+  NewProfile.profile "Coqloadpath.init_load_path" (fun () ->
+      init_load_path ~coqenv)
+    ()

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1473,13 +1473,14 @@ let register_library dir (objs:library_objects) =
   SynterpVisitor.do_module SynterpVisitor.load_objects 1 dir mp ([],Objs sobjs) keepobjs
 
 let import_modules ~export mpl =
+NewProfile.profile "Synterp.import" (fun () ->
   let _,objs = SynterpVisitor.collect_modules mpl (MPmap.empty, []) in
   List.iter (fun (f,o) -> SynterpVisitor.open_object f 1 o) objs;
   match export with
   | Lib.Import -> ()
   | Lib.Export ->
     let entry = ExportObject { mpl } in
-    Lib.Synterp.add_leaf_entry entry
+    Lib.Synterp.add_leaf_entry entry) ()
 
 let import_module f ~export mp =
   import_modules ~export [f,mp]
@@ -1565,13 +1566,14 @@ let register_library dir cenv (objs:library_objects) digest univ vmtab =
   InterpVisitor.do_module InterpVisitor.load_objects 1 dir mp ([],Objs sobjs) keepobjs
 
 let import_modules ~export mpl =
+NewProfile.profile "Interp.import" (fun () ->
   let _,objs = InterpVisitor.collect_modules mpl (MPmap.empty, []) in
   List.iter (fun (f,o) -> InterpVisitor.open_object f 1 o) objs;
   match export with
   | Lib.Import -> ()
   | Lib.Export ->
     let entry = ExportObject { mpl } in
-    Lib.Interp.add_leaf_entry entry
+    Lib.Interp.add_leaf_entry entry) ()
 
 let import_module f ~export mp =
   import_modules ~export [f,mp]

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -293,6 +293,12 @@ let intern_from_file ?loc lib_resolver dir =
   Library_info.warn_library_info ~transitive:true lsd.md_name lsd.md_info;
   lsd, lmd, digest_lmd, univs, digest_u, del_opaque, vmlib
 
+let intern_from_file ?loc reso dir =
+  NewProfile.profile "intern_from_file"
+    ~args:(fun () -> ["dp", `String (DirPath.to_string dir)]) (fun () ->
+      intern_from_file ?loc reso dir)
+    ()
+
 let rec intern_library ~intern (needed, contents as acc) dir =
   (* Look if in the current logical environment *)
   try find_library dir, acc
@@ -352,6 +358,8 @@ let native_name_from_filename f =
 *)
 
 let register_library m =
+  NewProfile.profile "register_library"
+    ~args:(fun () -> ["libname", `String (DirPath.to_string m.library_name)]) (fun () ->
   let l = m.library_data in
   Declaremods.Interp.register_library
     m.library_name
@@ -361,14 +369,17 @@ let register_library m =
     m.library_extra_univs
     m.library_vm
   ;
-  register_native_library m.library_name
+  register_native_library m.library_name) ()
 
 let register_library_syntax m =
+  NewProfile.profile "register_library_syntax"
+    ~args:(fun () -> ["libname", `String (DirPath.to_string m.library_name)]) (fun () ->
   let l = m.library_data in
   Declaremods.Synterp.register_library
     m.library_name
     l.md_syntax_objects;
-  register_loaded_library (mk_summary m)
+  register_loaded_library (mk_summary m))
+    ()
 
 (* Follow the semantics of Anticipate object:
    - called at module or module type closing when a Require occurs in

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -272,6 +272,11 @@ let locate_qualified_library ?root qid :
       Ok (library, file)
     | Error _ as e -> e
 
+let locate_qualified_library ?root qid =
+  NewProfile.profile "locate_qualified_library" (fun () ->
+      locate_qualified_library ?root qid)
+    ()
+
 let error_unmapped_dir qid =
   let prefix, _ = Libnames.repr_qualid qid in
   CErrors.user_err
@@ -360,3 +365,15 @@ let add_vo_path lp =
     add_load_path root unix_path ~implicit lp.coq_path
   else
     warn_cannot_open_path unix_path
+
+let json_path p = [
+  "unix_path", `String p.unix_path;
+  "implicit", `String (string_of_bool p.implicit);
+  "has_ml", `String (string_of_bool p.has_ml);
+  "recursive", `String (string_of_bool p.recursive);
+]
+
+let add_vo_path p =
+  NewProfile.profile "add_vo_path" ~args:(fun () -> json_path p) (fun () ->
+      add_vo_path p)
+    ()

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -257,10 +257,12 @@ let load_module x = match !load with
 
 (* Adds a path to the ML paths *)
 let add_ml_dir s =
+  NewProfile.profile "add_ml_dir" (fun () ->
   match !load with
     | WithTop t -> t.add_dir s; keep_copy_mlpath s
     | WithoutTop when has_dynlink -> keep_copy_mlpath s
-    | _ -> ()
+    | _ -> ())
+    ()
 
 (** Is the ML code of the standard library placed into loadable plugins
     or statically compiled into coqtop ? For the moment this choice is

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -307,6 +307,11 @@ let synterp_require from export qidl =
     export;
     filenames, List.map snd modrefl
 
+let synterp_require from export qidl =
+  NewProfile.profile "synterp_require" (fun () ->
+      synterp_require from export qidl)
+    ()
+
 (*****************************)
 (* Auxiliary file management *)
 


### PR DESCRIPTION
Not sure how useful it is, but it shouldn't be costly.

Looks like this on an empty file:
![prof_empty](https://github.com/coq/coq/assets/2461932/48f560f4-97d5-41b4-9eca-07c2144e4fad)
