### PR TITLE
[CI] Remove allow_failure from fiat-crypto-legacy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -667,7 +667,6 @@ library:ci-fiat_crypto:
 
 library:ci-fiat_crypto_legacy:
   extends: .ci-template-flambda
-  allow_failure: true # See https://github.com/coq/coq/wiki/Coq-Call-2020-06-24#adding-back-fiat-crypto-legacy
   timeout: 1h 30min
 
 # We cannot use flambda due to


### PR DESCRIPTION
The [original justification](https://github.com/coq/coq/wiki/Coq-Call-2020-06-24#adding-back-fiat-crypto-legacy) was:
> Jason is willing to put in the time to maintain it, and help understanding failures in the proof automation part.
>
> Maxime suggests adding it to the allow_failure pipeline, but Théo mentions it does not report back this information very well. A coqbot change can allow that, pinging Jason in case of failure. Théo is on it. Emilio raises the point that we still need to investigate regressions in developments. We agree but see the cost/benefit for f-c-l to have been too high in the past (partly due to our inability to quickly debug the Ltac code there). Hence we compromise on this tradeoff of putting it in allow-failure for now.

However, there hasn't been an issue with the Ltac code in fiat-crypto-legacy in a long time, the brief stint of time when f-c-l was failing on master resulted in a bug in Coq being missed (see https://github.com/coq/coq/issues/18239), and there is no longer any backwards compatibility that we are trying to maintain with f-c-l, insofar as we are moving towards Ltac2 and away from Ltac1, I expect that there shouldn't be too many semantics changes in Ltac1, and so I think it may be time to remove the allow_failure.

This PR is a request to put f-c-l back in the normal category.  If this is contentious, we should perhaps discuss during an upcoming coq call.

