### PR TITLE
coqchk: add marshal checking for `Module with` and VM data

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -354,7 +354,7 @@ let intern_from_file ~intern_mode (dir, f) =
       let opaque_csts = marshal_in_segment ~validate ~value:Values.v_univopaques ~segment:seg_univs f ch in
       let tasks = marshal_in_segment ~validate ~value:Values.(Opt Any) ~segment:seg_tasks f ch in
       let table = marshal_in_segment ~validate ~value:Values.v_opaquetable ~segment:seg_opaque f ch in
-      let vmlib = marshal_in_segment ~validate ~value:Any ~segment:seg_vmlib f ch in
+      let vmlib = marshal_in_segment ~validate ~value:Values.v_vmlib ~segment:seg_vmlib f ch in
       (* Verification of the final checksum *)
       let () = close_in ch in
       let ch = open_in_bin f in

--- a/checker/check.ml
+++ b/checker/check.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Pp
-open CErrors
 open Util
 open Names
 
@@ -149,7 +148,7 @@ let find_logical_path phys_dir =
   match List.filter2 (fun p d -> p = phys_dir) physical logical with
   | _,[dir] -> dir
   | _,[] -> default_root_prefix
-  | _,l -> anomaly (Pp.str ("Two logical paths are associated to "^phys_dir^"."))
+  | _,l -> CErrors.anomaly (Pp.str ("Two logical paths are associated to "^phys_dir^"."))
 
 let remove_load_path dir =
   let physical, logical = !load_paths in
@@ -181,7 +180,7 @@ let add_load_path (phys_path,coq_path) =
             end
       | _,[] ->
           load_paths := (phys_path :: fst !load_paths, coq_path :: snd !load_paths)
-      | _ -> anomaly (Pp.str ("Two logical paths are associated to "^phys_path^"."))
+      | _ -> CErrors.anomaly (Pp.str ("Two logical paths are associated to "^phys_path^"."))
 
 let load_paths_of_dir_path dir =
   let physical, logical = !load_paths in
@@ -227,13 +226,13 @@ let locate_qualified_library qid =
 
 let error_unmapped_dir qid =
   let prefix = qid.dirpath in
-  user_err
+  CErrors.user_err
     (str "Cannot load " ++ pr_path qid ++ str ":" ++ spc () ++
      str "no physical path bound to" ++ spc () ++ pr_dirlist prefix
      ++ str "." ++ fnl ())
 
 let error_lib_not_found qid =
-  user_err
+  CErrors.user_err
     (str "Cannot find library " ++ pr_path qid ++ str " in loadpath.")
 
 let try_locate_absolute_library dir =
@@ -317,7 +316,7 @@ let marshal_in_segment (type a) ~validate ~value ~(segment : a ObjFile.segment) 
         let () = if not (String.equal digest segment.ObjFile.hash) then raise_notrace Exit in
         v
       with _ ->
-        user_err (str "Corrupted file " ++ quote (str f))
+        CErrors.user_err (str "Corrupted file " ++ quote (str f))
     in
     let () = Validate.validate value v in
     let v = Analyze.instantiate v in
@@ -361,15 +360,15 @@ let intern_from_file ~intern_mode (dir, f) =
       let () = close_in ch in
       let () = System.check_caml_version ~caml:sd.md_ocaml ~file:f in
       if dir <> sd.md_name then
-        user_err
+        CErrors.user_err
           (name_clash_message dir sd.md_name f);
       if tasks <> None then
-        user_err
+        CErrors.user_err
           (str "The file "++str f++str " contains unfinished tasks");
       if opaque_csts <> None then begin
        Flags.if_verbose chk_pp (str " (was a vio file) ");
       Option.iter (fun (_,b) -> if not b then
-        user_err
+        CErrors.user_err
           (str "The file "++str f++str " is still a .vio"))
         opaque_csts;
       end;

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -254,13 +254,64 @@ let v_typing_flags =
 
 let v_univs = v_sum "universes" 1 [|[|v_abs_context|]|]
 
+let v_vm_reloc_table = Array (v_pair Int Int)
+
+let v_vm_annot_switch = v_tuple "vm_annot_switch" [|v_vm_reloc_table; v_bool; Int|]
+
+let v_vm_structured_constant = v_sum "vm_structured_constant" 0 [|
+    [|v_sort|];
+    [|v_ind|];
+    [|Fail "Const_evar"|];
+    [|Int|];
+    [|v_quality|];
+    [|v_level|];
+    [|v_instance|];
+    [|Any|]; (* contains a Vmvalues.value *)
+    [|v_uint63|];
+    [|Float64|];
+  |]
+
+let v_vm_caml_prim = v_enum "vm_caml_prim" 6
+
+let v_reloc_info = v_sum "vm_reloc_info" 0 [|
+    [|v_vm_annot_switch|];
+    [|v_vm_structured_constant|];
+    [|v_cst|];
+    [|v_vm_caml_prim|];
+  |]
+
+let v_vm_patches = v_tuple "vm_patches" [|Array v_reloc_info|]
+
+let v_vm_pbody_code index =
+  v_sum "pbody_code" 1 [|
+    [|v_pair index v_vm_patches|];
+    [|v_cst|];
+  |]
+
+let v_vm_index = v_pair v_dp Int
+
+let v_vm_indirect_code = v_vm_pbody_code v_vm_index
+
+let v_vm_emitcodes = String
+
+let v_vm_fv_elem = v_sum "vm_fv_elem" 0 [|
+    [|v_id|];
+    [|Int|]
+  |]
+
+let v_vm_fv = Array v_vm_fv_elem
+
+let v_vm_positions = String
+
+let v_vm_to_patch = v_tuple "vm_to_patch" [|v_vm_emitcodes; v_vm_fv; v_vm_positions|]
+
 let v_cb = v_tuple "constant_body"
   [|v_section_ctxt;
     v_instance;
     v_cst_def;
     v_constr;
     v_relevance;
-    Any;
+    Opt v_vm_indirect_code;
     v_univs;
     v_bool;
     v_typing_flags|]
@@ -301,7 +352,7 @@ let v_one_ind = v_tuple "one_inductive_body"
     v_relevance;
     Int;
     Int;
-    Any|]
+    v_vm_reloc_table|]
 
 let v_finite = v_enum "recursivity_kind" 3
 
@@ -466,3 +517,5 @@ let v_delayed_universes =
 let v_opaquetable = Array (Opt (v_pair v_constr v_delayed_universes))
 let v_univopaques =
   Opt (Tuple ("univopaques",[|v_context_set;v_bool|]))
+
+let v_vmlib = v_tuple "vmlibrary" [|v_dp; Array v_vm_to_patch|]

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -378,11 +378,16 @@ let v_rewrule = v_tuple "rewrite_rule"
 let v_rrb = v_tuple "rewrite_rules_body"
   [| List (v_pair v_cst v_rewrule) |]
 
+let v_module_with_decl = v_sum "with_declaration" 0 [|
+    [|List v_id; v_mp|];
+    [|List v_id; v_pair v_constr (Opt v_abs_context)|];
+  |]
+
 let rec v_mae =
   Sum ("module_alg_expr",0,
   [|[|v_mp|];         (* SEBident *)
     [|v_mae;v_mp|];   (* SEBapply *)
-    [|v_mae; Any|]  (* SEBwith *)
+    [|v_mae; v_module_with_decl|]  (* SEBwith *)
   |])
 
 let rec v_sfb =

--- a/checker/values.mli
+++ b/checker/values.mli
@@ -49,3 +49,4 @@ val v_libsum : value
 val v_lib : value
 val v_opaquetable : value
 val v_stm_seg : value
+val v_vmlib : value


### PR DESCRIPTION

With this PR the only remaining Any
should be for ignored values (eg libobject stuff), except for the
Const_val case of structured_constant as it's an arbitrary
value.
