### PR TITLE
Restore ability to make primitive projections hint opaque.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18785-janno-fix-dnet-proj.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18785-janno-fix-dnet-proj.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`Hint Projections` command that sets the transparency flag for projections
+  for the specified hint databases
+  (`#18785 <https://github.com/coq/coq/pull/18785>`_,
+  by Jan-Oliver Kaiser and Rodolphe Lepigre).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -505,10 +505,10 @@ Creating Hints
       .. exn:: Cannot coerce @qualid to an evaluable reference.
          :undocumented:
 
-   .. cmd:: Hint {| Constants | Variables } {| Transparent | Opaque } {? : {+ @ident } }
-      :name: Hint Constants; Hint Variables
+   .. cmd:: Hint {| Constants | Projections | Variables } {| Transparent | Opaque } {? : {+ @ident } }
+      :name: Hint Constants; Hint Projections; Hint Variables
 
-      Sets the transparency flag for constants or variables for the specified hint
+      Sets the transparency flag for constants, projections or variables for the specified hint
       databases.
       These flags affect the unification of hints in the database.
       We advise using this just after a :cmd:`Create HintDb` command.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -23,10 +23,12 @@ hint: [
 | WITH "Resolve" [ "->" | "<-" ] LIST1 global OPT natural
 | DELETE "Resolve" "<-" LIST1 global OPT natural
 | REPLACE "Variables" "Transparent"
-| WITH [ "Constants" | "Variables" ] [ "Transparent" | "Opaque" ]
+| WITH [ "Constants" | "Projections" | "Variables" ] [ "Transparent" | "Opaque" ]
 | DELETE "Variables" "Opaque"
 | DELETE "Constants" "Transparent"
 | DELETE "Constants" "Opaque"
+| DELETE "Projections" "Transparent"
+| DELETE "Projections" "Opaque"
 | REPLACE "Transparent" LIST1 global
 | WITH [ "Transparent" | "Opaque" ] LIST1 global
 | DELETE "Opaque" LIST1 global

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -721,6 +721,8 @@ hint: [
 | "Variables" "Opaque"
 | "Constants" "Transparent"
 | "Constants" "Opaque"
+| "Projections" "Transparent"
+| "Projections" "Opaque"
 | "Transparent" LIST1 global
 | "Opaque" LIST1 global
 | "Mode" global mode

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -991,7 +991,7 @@ command: [
 | "Hint" "Resolve" LIST1 [ qualid | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
 | "Hint" "Resolve" [ "->" | "<-" ] LIST1 qualid OPT natural OPT ( ":" LIST1 ident )
 | "Hint" "Immediate" LIST1 [ qualid | one_term ] OPT ( ":" LIST1 ident )
-| "Hint" [ "Constants" | "Variables" ] [ "Transparent" | "Opaque" ] OPT ( ":" LIST1 ident )
+| "Hint" [ "Constants" | "Projections" | "Variables" ] [ "Transparent" | "Opaque" ] OPT ( ":" LIST1 ident )
 | "Hint" [ "Transparent" | "Opaque" ] LIST1 qualid OPT ( ":" LIST1 ident )
 | "Hint" "Mode" qualid LIST1 [ "+" | "!" | "-" ] OPT ( ":" LIST1 ident )
 | "Hint" "Unfold" LIST1 qualid OPT ( ":" LIST1 ident )

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -516,9 +516,12 @@ let pr_cpred p =
 
 let pr_idpred p = pr_predicate Id.print (Id.Pred.elements p)
 
+let pr_prpred p = pr_predicate Projection.Repr.print (PRpred.elements p)
+
 let pr_transparent_state ts =
   hv 0 (str"VARIABLES: " ++ pr_idpred ts.TransparentState.tr_var ++ fnl () ++
-        str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl ())
+        str"CONSTANTS: " ++ pr_cpred ts.TransparentState.tr_cst ++ fnl () ++
+        str"PROJECTIONS: " ++ pr_prpred ts.TransparentState.tr_prj ++ fnl ())
 
 let goal_repr sigma g =
   let EvarInfo evi = Evd.find sigma g in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -189,6 +189,7 @@ val pr_context_of          : env -> evar_map -> Pp.t
 val pr_predicate           : ('a -> Pp.t) -> (bool * 'a list) -> Pp.t
 val pr_cpred               : Cpred.t -> Pp.t
 val pr_idpred              : Id.Pred.t -> Pp.t
+val pr_prpred              : PRpred.t -> Pp.t
 val pr_transparent_state   : TransparentState.t -> Pp.t
 
 (** Proofs, these functions obey [Hyps Limit] and [Compact contexts]. *)

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -21,13 +21,20 @@ let dnet_depth = ref 8
 
 type term_label =
 | GRLabel of GlobRef.t
-| ProjLabel of Projection.t
+| ProjLabel of Projection.Repr.t * int
+ (** [ProjLabel (p, n)] represents a possibly partially applied projection [p]
+     with [n] arguments missing to be fully applied. [n] is always zero for
+     labels derived from [Proj] terms but can be greater than zero for labels
+     derived from compatibility constants. *)
 | ProdLabel
 | SortLabel
 
 let compare_term_label t1 t2 = match t1, t2 with
 | GRLabel gr1, GRLabel gr2 -> GlobRef.UserOrd.compare gr1 gr2
-| ProjLabel p1, ProjLabel p2 -> Projection.UserOrd.compare p1 p2
+| ProjLabel (p1, n1), ProjLabel (p2, n2) ->
+  let c = Int.compare n1 n2 in
+  if c <> 0 then c else
+    (Projection.Repr.UserOrd.compare p1 p2)
 | _ -> Stdlib.compare t1 t2 (** OK *)
 
 type 'res lookup_res = 'res Dn.lookup_res = Label of 'res | Nothing | Everything
@@ -70,6 +77,16 @@ let evaluable_named id env ts =
 let evaluable_projection p _env ts =
   (match ts with None -> true | Some ts -> TransparentState.is_transparent_projection ts (Projection.repr p))
 
+let label_of_opaque_constant c stack =
+  match Structures.PrimitiveProjections.find_opt c with
+  | None -> (GRLabel (ConstRef c), stack)
+  | Some p ->
+    let n_args_needed = Structures.Structure.projection_nparams c + 1 in (* +1 for the record value itself *)
+    let n_args_given = List.length stack in
+    let n_args_missing = max (n_args_needed - n_args_given) 0 in
+    let n_args_drop = min (n_args_needed - 1) n_args_given in (* we do not drop the record value from the stack *)
+    (ProjLabel (p, n_args_missing), List.skipn n_args_drop stack)
+
 (* The pattern view functions below try to overapproximate βι-neutral terms up
    to η-conversion. Some historical design choices are still incorrect w.r.t. to
    this specification. TODO: try to make them follow the spec. *)
@@ -81,12 +98,12 @@ let constr_val_discr env sigma ts t =
     match EConstr.kind sigma t with
     | App (f,l) -> decomp (Array.fold_right (fun a l -> a::l) l stack) f
     | Proj (p,_,c) when evaluable_projection p env ts -> Everything
-    | Proj (p,_,c) -> Label(ProjLabel p, c :: stack)
+    | Proj (p,_,c) -> Label(ProjLabel (Projection.repr p, 0), c :: stack)
     | Cast (c,_,_) -> decomp stack c
     | Const (c,_) when evaluable_constant c env ts -> Everything
     | Const (c,_) ->
       let c = Environ.QConstant.canonize env c in
-      Label(GRLabel (ConstRef c), stack)
+      Label (label_of_opaque_constant c stack)
     | Ind (ind_sp,_) ->
       let ind_sp = Environ.QInd.canonize env ind_sp in
       Label(GRLabel (IndRef ind_sp), stack)
@@ -112,7 +129,7 @@ let constr_pat_discr env ts p =
     match p with
     | PApp (f,args) -> decomp (Array.to_list args @ stack) f
     | PProj (p,c) when evaluable_projection p env ts -> None
-    | PProj (p,c) -> Some (ProjLabel p, c :: stack)
+    | PProj (p,c) -> Some (ProjLabel (Projection.repr p, 0), c :: stack)
     | PRef ((IndRef _) as ref)
     | PRef ((ConstructRef _ ) as ref) ->
       let ref = Environ.QGlobRef.canonize env ref in
@@ -120,9 +137,9 @@ let constr_pat_discr env ts p =
     | PRef (VarRef v) when evaluable_named v env ts -> None
     | PRef ((VarRef _) as ref) -> Some (GRLabel ref, stack)
     | PRef (ConstRef c) when evaluable_constant c env ts -> None
-    | PRef ((ConstRef _) as ref) ->
-      let ref = Environ.QGlobRef.canonize env ref in
-      Some (GRLabel ref, stack)
+    | PRef (ConstRef c) ->
+      let c = Environ.QConstant.canonize env c in
+      Some (label_of_opaque_constant c stack)
     | PVar v when evaluable_named v env ts -> None
     | PVar v -> Some (GRLabel (VarRef v), stack)
     | PProd (_,d,c) when stack = [] -> Some (ProdLabel, [d ; c])

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1298,12 +1298,15 @@ let discharge_autohint obj =
       let grefs = match grefs with
       | HintsVariables | HintsConstants -> grefs
       | HintsReferences grs ->
-        let filter = function
-        | Evaluable.EvalConstRef c -> true
-        | Evaluable.EvalProjectionRef p -> true
-        | Evaluable.EvalVarRef id -> not @@ Lib.is_in_section (GlobRef.VarRef id)
+        let filter e = match e with
+        | Evaluable.EvalConstRef c -> Some e
+        | Evaluable.EvalProjectionRef p ->
+          let p = Lib.discharge_proj_repr p in
+          Some (Evaluable.EvalProjectionRef p)
+        | Evaluable.EvalVarRef id ->
+          if Lib.is_in_section (GlobRef.VarRef id) then None else Some e
         in
-        let grs = List.filter filter grs in
+        let grs = List.filter_map filter grs in
         HintsReferences grs
       in
       AddTransparency { grefs; state }

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1712,12 +1712,15 @@ let pr_hint_db_env env sigma db =
     in
     Hint_db.fold fold db (mt ())
   in
-  let { TransparentState.tr_var = ids; tr_cst = csts } = Hint_db.transparent_state db in
+  let { TransparentState.tr_var = ids; tr_cst = csts; tr_prj = ps } =
+    Hint_db.transparent_state db
+  in
   hov 0
     ((if Hint_db.use_dn db then str"Discriminated database"
       else str"Non-discriminated database")) ++ fnl () ++
   hov 2 (str"Unfoldable variable definitions: " ++ pr_idpred ids) ++ fnl () ++
   hov 2 (str"Unfoldable constant definitions: " ++ pr_cpred csts) ++ fnl () ++
+  hov 2 (str"Unfoldable projection definitions: " ++ pr_prpred ps) ++ fnl () ++
   hov 2 (str"Cut: " ++ pp_hints_path (Hint_db.cut db)) ++ fnl () ++
   content
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -78,6 +78,7 @@ type hint_mode =
 type 'a hints_transparency_target =
   | HintsVariables
   | HintsConstants
+  | HintsProjections
   | HintsReferences of 'a list
 
 type 'a hints_path_gen =

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -98,7 +98,9 @@ let classify_strategy (local,_) =
 let disch_ref ref =
   match ref with
   | Evaluable.EvalConstRef c -> Some ref
-  | Evaluable.EvalProjectionRef p -> Some ref
+  | Evaluable.EvalProjectionRef p ->
+    let p = Lib.discharge_proj_repr p in
+    Some (Evaluable.EvalProjectionRef p)
   | Evaluable.EvalVarRef id -> if Lib.is_in_section (GlobRef.VarRef id) then None else Some ref
 
 let discharge_strategy (local,obj) =

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -1,6 +1,7 @@
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -9,6 +10,7 @@ For S (modes !) ->
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -17,6 +19,7 @@ For S (modes !) ->
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -25,28 +28,7 @@ For S (modes !) ->
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
-Cut: _
-For any goal ->   
-For nat ->   
-For S (modes !) ->   
-
-Non-discriminated database
-Unfoldable variable definitions: all
-Unfoldable constant definitions: all
-Cut: emp
-For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
-
-Non-discriminated database
-Unfoldable variable definitions: all
-Unfoldable constant definitions: all
-Cut: emp
-For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
-
-Non-discriminated database
-Unfoldable variable definitions: all
-Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -55,6 +37,15 @@ For S (modes !) ->
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all
+Unfoldable projection definitions: all
+Cut: emp
+For any goal ->   
+For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all
+Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
 For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
@@ -62,6 +53,24 @@ For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0)
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
+Cut: _
+For any goal ->   
+For nat ->   
+For S (modes !) ->   
+
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all
+Unfoldable projection definitions: all
+Cut: emp
+For any goal ->   
+For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -73,6 +82,7 @@ This command does not support the global attribute in sections.
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   
@@ -81,6 +91,7 @@ For S (modes !) ->
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all except: id
+Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
 For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
@@ -101,6 +112,7 @@ disappear when the section is closed.
 Non-discriminated database
 Unfoldable variable definitions: all
 Unfoldable constant definitions: all
+Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
 For refl (modes - !) ->   

--- a/test-suite/success/primitive_tc.v
+++ b/test-suite/success/primitive_tc.v
@@ -1,0 +1,81 @@
+Create HintDb test discriminated.
+
+(* Testing that projections can be made hint opaque. *)
+Module ProjOpaque.
+  #[projections(primitive)]
+  Record bla := { x : unit }.
+
+  Definition bli := {| x := tt |}.
+
+  Class C (p : unit) := {}.
+  Definition I  : C (x bli) := Build_C _.
+
+  #[local] Hint Resolve I : test.
+  #[local] Hint Opaque x : test.
+
+  Goal C tt.
+  Proof.
+    Fail typeclasses eauto with test.
+  Abort.
+End ProjOpaque.
+
+(* Testing that compatibility constants are equated with their projections in
+   the bnet. *)
+Module CompatConstants.
+  Class T (p : Prop) : Prop := {}.
+
+  Axiom prod : Prop -> Prop -> Prop.
+  Axiom T_prod : forall p1 p2, T p1 -> T p2 -> T (prod p1 p2).
+  Axiom T_True : T True.
+
+  Class F (f : unit -> Prop) : Prop := { F_T :: forall u, T (f u) }.
+
+  #[projections(primitive)]
+  Record R (useless : unit) : Type :=
+    { v : unit -> Prop;
+      v_F : F (v);
+    }.
+  Hint Opaque v : test.
+  Hint Resolve v_F F_T T_prod T_True : test.
+
+  (* Notation constant := (@v tt). *)
+
+  Goal forall (a : R tt) q, T (prod (v _ a q) (True)).
+  Proof.
+    intros a.
+    (* [v _ a] gets turned into its compatibility constant by the application
+       of [T_prod]. The application of [v_F] after [F_T] only works if the
+       bnet correctly equates the compatibility constant with the projection
+       used in the type and pattern of [v_F] *)
+    typeclasses eauto with test.
+  Qed.
+End CompatConstants.
+
+(* Testing that projection opacity settings are properly discharged at the end
+   of sections. *)
+Module Sections.
+  #[local] Hint Constants Opaque : test.
+  #[local] Hint Projections Opaque : test.
+  Class C (u : unit) := {}.
+  Definition i : C tt := Build_C _.
+  #[global] Hint Resolve i : test.
+
+  Section S.
+    Context (P : Prop).  (* Load bearing [Context] but content does not matter! *)
+    #[projections(primitive)]
+    Record r := R { v : unit; prf : P }. (* Load bearing use of the [Context] *)
+    #[global] Hint Transparent v : test.
+    Definition x (p: P) := {| v := tt; prf := p|}.
+    #[global] Hint Transparent x : test.
+    Print HintDb test. (* [v] is transparent *)
+    Goal forall p, C (v (x p)).
+    Proof. intros.
+      typeclasses eauto with test. (* [i] is a candidate, [v] must be transparent *)
+    Qed.
+  End S.
+  Print HintDb test. (* [v] is reportedly transparent *)
+  Goal forall P (p : P), C (v P (x P p)).
+  Proof. intros.
+    typeclasses eauto with test. (* This will fail if [Hint Transparent v] is improperly discharged. *)
+  Qed.
+End Sections.

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -134,6 +134,7 @@ let interp_hints ~poly h =
   let ft = function
     | HintsVariables -> HintsVariables
     | HintsConstants -> HintsConstants
+    | HintsProjections -> HintsProjections
     | HintsReferences lhints -> HintsReferences (List.map fr lhints)
   in
   let fp = Constrintern.intern_constr_pattern (Global.env ()) in

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -122,6 +122,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Variables"; IDENT "Opaque" -> { HintsTransparency (HintsVariables, false) }
       | IDENT "Constants"; IDENT "Transparent" -> { HintsTransparency (HintsConstants, true) }
       | IDENT "Constants"; IDENT "Opaque" -> { HintsTransparency (HintsConstants, false) }
+      | IDENT "Projections"; IDENT "Transparent" -> { HintsTransparency (HintsProjections, true) }
+      | IDENT "Projections"; IDENT "Opaque" -> { HintsTransparency (HintsProjections, false) }
       | IDENT "Transparent"; lc = LIST1 global -> { HintsTransparency (HintsReferences lc, true) }
       | IDENT "Opaque"; lc = LIST1 global -> { HintsTransparency (HintsReferences lc, false) }
       | IDENT "Mode"; l = global; m = mode -> { HintsMode (l, m) }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -318,6 +318,7 @@ let pr_hints db h pr_c pr_pat =
       ++ (match l with
           | HintsVariables -> keyword "Variables"
           | HintsConstants -> keyword "Constants"
+          | HintsProjections -> keyword "Projections"
           | HintsReferences l -> prlist_with_sep sep pr_qualid l)
     | HintsMode (m, l) ->
       keyword "Mode"


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

#18327 accidentally broke the ability to make primitive projections hint opaque. This MR fixes it.

The code below shows the problem but I don't know how to turn it into a test case.

```coq
#[projections(primitive)]
Record bla := { x : unit }.

Class C (p : unit) := {}.
(* Definition B1 : bla 1 := {|x := tt |}. *)
Definition I {b} : C (x b) := Build_C _.

Create HintDb test discriminated.
Hint Resolve I : test.
Hint Opaque x : test.

Goal C tt.
Proof.
  Set Typeclasses Debug Verbosity 3.
  Fail typeclasses eauto with test. (* tries to apply instance [I] despite [x] being hint opaque *)
Abort.
```
