### PR TITLE
Fixes ltac2 term printer in debugger

### DIFF
--- a/dev/db
+++ b/dev/db
@@ -26,6 +26,7 @@ load_printer stm.cma
 load_printer toplevel.cma
 
 load_printer ltac_plugin.cma
+load_printer ltac2_plugin.cma
 load_printer top_printers.cma
 
 source top_printers.dbg

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1869,7 +1869,7 @@ let () =
   let pr_glb (ids, e) =
     let ids =
       if List.is_empty ids then mt ()
-      else pr_sequence Id.print ids ++ str " |- "
+      else hov 0 (pr_sequence Id.print ids ++ str " |- ")
     in
     Genprint.PrinterBasic Pp.(fun _env _sigma -> ids ++ Tac2print.pr_glbexpr ~avoid:Id.Set.empty e)
   in
@@ -1886,7 +1886,7 @@ let () =
     let ids =
       let ids = Id.Set.elements ids in
       if List.is_empty ids then mt ()
-      else pr_sequence Id.print ids ++ str " |- "
+      else hov 0 (pr_sequence Id.print ids ++ str " |- ")
     in
     (* FIXME avoid set
        eg "Ltac2 bla foo := constr:(ltac2:(foo X.foo))"

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -16,10 +16,10 @@ open Tac2env
 
 let pr_tacref avoid kn =
   try Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac avoid (TacConstant kn))
-  with Not_found when KNmap.mem kn (Tac2env.globals()) ->
+  with Not_found when !Flags.in_debugger || KNmap.mem kn (Tac2env.globals()) ->
     str (ModPath.to_string (KerName.modpath kn))
     ++ str"." ++ Label.print (KerName.label kn)
-    ++ str " (* local *)"
+    ++ if !Flags.in_debugger then mt() else str " (* local *)"
 
 (** Utils *)
 


### PR DESCRIPTION
 Add support for printing`ltac2:in-constr` genarg in debugger. We do as suggested [here](https://github.com/coq/coq/pull/18767#discussion_r1523251810). Additionally, we prefer line breaks after printing of contexts than before.