### PR TITLE
Towards a more uniform API for declare.ml (part declaring mutual statements)

### DIFF
--- a/dev/ci/user-overlays/18795-herbelin-master+uniform-API-declare.ml.sh
+++ b/dev/ci/user-overlays/18795-herbelin-master+uniform-API-declare.ml.sh
@@ -1,0 +1,2 @@
+overlay metacoq https://github.com/herbelin/template-coq main+adapt-coq-pr18795-more-uniform-declare.ml 18795 master+uniform-API-declare.ml
+overlay equations https://github.com/herbelin/Coq-Equations main+adapt-coq-pr18795-more-uniform-declare.ml 18795 master+uniform-API-declare.ml

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -337,14 +337,14 @@ let declare_instance_program pm env sigma ~locality ~poly name pri impargs udecl
     let sigma = Evd.from_env env in
     declare_instance env sigma (Some pri) locality (GlobRef.ConstRef cst)
   in
-  let obls, _, term, typ = RetrieveObl.retrieve_obligations env name sigma 0 term termtype in
+  let obls, _, body, typ = RetrieveObl.retrieve_obligations env name sigma 0 term termtype in
   let hook = Declare.Hook.make hook in
   let uctx = Evd.evar_universe_context sigma in
   let kind = Decls.IsDefinition Decls.Instance in
   let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
   let info = Declare.Info.make  ~udecl ~poly ~kind ~hook () in
   let pm, _ =
-    Declare.Obls.add_definition ~pm ~cinfo ~info ~term ~uctx obls
+    Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~uctx ~body obls
   in pm
 
 let declare_instance_open sigma ?hook ~tac ~locality ~poly id pri impargs udecl ids term termtype =

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -143,9 +143,9 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
   let evd, (body, types), impargs =
     interp_definition ~program_mode:true env evd empty_internalization_env bl red_option c ctypopt
   in
-  let term, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
+  let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
   let pm, _ =
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
-    Declare.Obls.add_definition ~pm ~cinfo ~info ~term ~uctx ?using obls
+    Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls
   in pm

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -145,11 +145,6 @@ let interp_fix_body ~program_mode env_rec sigma impls (_,ctx) fix ccl =
 
 let build_fix_type (_,ctx) ccl = EConstr.it_mkProd_or_LetIn ccl ctx
 
-let prepare_recursive_declaration fixnames fixrs fixtypes fixdefs =
-  let defs = List.map (Vars.subst_vars (List.rev fixnames)) fixdefs in
-  let names = List.map2 (fun id r -> Context.make_annot (Name id) r) fixnames fixrs in
-  (Array.of_list names, Array.of_list fixtypes, Array.of_list defs)
-
 (* Jump over let-bindings. *)
 
 let compute_possible_guardness_evidences (ctx,_,recindex) =
@@ -283,13 +278,12 @@ let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?use
   (* We shortcut the proof process *)
   let fix_kind, possible_guard, fixitems = build_recthms ~indexes fixnames fixtypes fiximps in
   let fixdefs = List.map Option.get fixdefs in
-  let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
   let fix_kind = Decls.IsDefinition fix_kind in
   let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns ~ntns () in
   let cinfo = fixitems in
   let _ : GlobRef.t list =
     Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx
-      ~possible_guard ~rec_declaration ?using ()
+      ~possible_guard ~bodies:(fixdefs,fixrs) ?using ()
   in
   ()
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -271,8 +271,8 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typin
   let fix_kind, possible_guard, thms = build_recthms ~indexes fixnames fixtypes fiximps in
   let evd = Evd.from_ctx ctx in
   let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
-    Declare.Proof.start_mutual_with_initialization ~info ~cinfo:thms
-      ~init_terms:fixdefs ~possible_guard ?using evd
+    Declare.Proof.start_mutual_definitions ~info ~cinfo:thms
+      ~bodies:fixdefs ~possible_guard ?using evd
 
 let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
   (* We shortcut the proof process *)

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -288,7 +288,7 @@ let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?use
   let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns ~ntns () in
   let cinfo = fixitems in
   let _ : GlobRef.t list =
-    Declare.declare_mutually_recursive ~cinfo ~info ~opaque:false ~uctx
+    Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx
       ~possible_guard ~rec_declaration ?using ()
   in
   ()

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -203,7 +203,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
   let kind = Decls.(IsDefinition Fixpoint) in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ~hook ?typing_flags ?user_warns ~ntns () in
   let pm, _ =
-    Declare.Obls.add_definition ~pm ~cinfo ~info ~term:evars_def ~uctx ?using evars in
+    Declare.Obls.add_definition ~pm ~cinfo ~info ~opaque:false ~body:evars_def ~uctx ?using evars in
   pm
 
 let out_def = function
@@ -234,11 +234,11 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
     let evars, _, def, typ =
       RetrieveObl.retrieve_obligations env name evd
         (List.length rec_sign) ~deps def typ in
-    (def, evars), typ
+    (def, evars, typ)
   in
   let fiximps = List.map pi2 info in
   let fixdefs = List.map out_def fixdefs in
-  let defs, typs = List.split (List.map4 collect_evars fixnames fixdefs fixtypes fiximps) in
+  let bodies, obls, typs = List.split3 (List.map4 collect_evars fixnames fixdefs fixtypes fiximps) in
   let cinfo = List.map3 (fun name typ impargs -> Declare.CInfo.make ~name ~typ ~impargs ()) fixnames typs fiximps in
   let possible_guard =
     if cofix then Pretyping.{possibly_cofix = true; possible_fix_indices = List.map (fun _ -> []) info}
@@ -256,7 +256,7 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
   let kind = Decls.(IsDefinition kind) in
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
   let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns ~ntns () in
-  Declare.Obls.add_mutual_definitions ~pm ~info ~cinfo ~uctx ?using ~possible_guard defs
+  Declare.Obls.add_mutual_definitions ~pm ~info ~cinfo ~opaque:false ~uctx ~bodies ~possible_guard ?using obls
 
 let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
   let g = List.map (fun { Vernacexpr.rec_order } -> rec_order) l in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -228,8 +228,8 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
   let (fixnames,fixrs,fixdefs,fixtypes) = fix in
   let collect_evars name def typ impargs =
     (* Generalize by the recursive prototypes  *)
-    let def = nf_evar evd (EConstr.it_mkNamedLambda_or_LetIn evd def rec_sign) in
-    let typ = nf_evar evd (EConstr.it_mkNamedProd_or_LetIn evd typ rec_sign) in
+    let def = nf_evar evd def in
+    let typ = nf_evar evd typ in
     let deps = collect_evars_of_term evd def typ in
     let evars, _, def, typ =
       RetrieveObl.retrieve_obligations env name evd

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1319,23 +1319,10 @@ let declare_mutual_definition ~pm l =
     let oblsubst = List.map (fun (id, (_, c)) -> (id, c)) oblsubst in
     (def, oblsubst)
   in
-  let defs, obls =
-    List.fold_right
-      (fun x (defs, obls) ->
-        let xdef, xobls = defobl x in
-        (xdef :: defs, xobls @ obls))
-      l ([], [])
-  in
-  (*   let fixdefs = List.map reduce_fix fixdefs in *)
-  let fixdefs, fixrs, fixtypes, fixitems =
-    List.fold_right2
-      (fun (d, r, typ, impargs) name (a1, a2, a3, a4) ->
-        ( d :: a1
-        , r :: a2
-        , typ :: a3
-        , (CInfo.make ~name ~typ ~impargs ()) :: a4 ))
-      defs first.prg_deps ([], [], [], [])
-  in
+  let defs, obls = List.split (List.map defobl l) in
+  let obls = List.flatten obls in
+  let fixitems = List.map2 (fun (d, r, typ, impargs) name -> CInfo.make ~name ~typ ~impargs ()) defs first.prg_deps in
+  let fixdefs, fixrs, fixtypes, _ = List.split4 defs in
   let possible_guard = Option.get first.prg_possible_guard in
   let arrrec, recvec = (Array.of_list fixtypes, Array.of_list fixdefs) in
   let rvec = Array.of_list fixrs in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2627,7 +2627,7 @@ let msg_generating_obl name obls =
        info ++ str ", generating " ++ int len ++
        str (String.plural len " obligation"))
 
-let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
+let add_definition ~pm ~info ~cinfo ?obl_hook ?term ~uctx
     ?tactic ?(reduce = reduce) ?(opaque = false) ?using obls =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let prg =
@@ -2649,22 +2649,22 @@ let add_definition ~pm ~cinfo ~info ?obl_hook ?term ~uctx
       pm, res
     | _ -> pm, res
 
-let add_mutual_definitions ~pm ~info ?obl_hook ~uctx
+let add_mutual_definitions ~pm ~info ~cinfo ?obl_hook ~uctx
     ?tactic ?(reduce = reduce) ?(opaque = false) ?using ~possible_guard l =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
-  let deps = List.map (fun (ci,_,_) -> CInfo.get_name ci) l in
+  let deps = List.map CInfo.get_name cinfo in
   let pm =
     (* EJGA: Note that here we duplicate the using declaration for all
        the new entries in the obligation map, that seems the right
        thing to do? *)
-    List.fold_left
-      (fun pm (cinfo, b, obls) ->
+    List.fold_left2
+      (fun pm cinfo (body, obls) ->
         let prg =
-          ProgramDecl.make ~info ~cinfo ~opaque ~body:(Some b) ~uctx ~deps
+          ProgramDecl.make ~info ~cinfo ~opaque ~body:(Some body) ~uctx ~deps
             ~possible_guard:(Some possible_guard) ~reduce ?obl_hook ?using obls
         in
         State.add pm (CInfo.get_name cinfo) prg)
-      pm l
+      pm cinfo l
   in
   let pm, _defined =
     List.fold_left

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -757,7 +757,7 @@ let mutual_make_bodies env ~typing_flags ~fixitems ~rec_declaration ~possible_gu
   let fixdecls = CList.map_i (fun i _ -> select_body i body) 0 fixitems in
   vars, fixdecls, indexes
 
-let declare_mutually_recursive ~info ~cinfo ~opaque ~uctx ~rec_declaration ~possible_guard ?using () =
+let declare_mutual_definitions ~info ~cinfo ~opaque ~uctx ~rec_declaration ~possible_guard ?using () =
   let { Info.poly; udecl; scope; clearbody; kind; typing_flags; user_warns; ntns; _ } = info in
   let env = Global.env() in
   let vars, fixdecls, indexes =
@@ -1297,7 +1297,7 @@ let declare_definition ~pm prg =
   let pm = progmap_remove pm prg in
   pm, kn
 
-let declare_mutual_definition ~pm l =
+let declare_mutual_definitions ~pm l =
   let len = List.length l in
   let first = List.hd l in
   let defobl x =
@@ -1330,7 +1330,7 @@ let declare_mutual_definition ~pm l =
   let rec_declaration = (Array.map2 Context.make_annot namevec rvec, arrrec, recvec) in
   (* Declare the recursive definitions *)
   let kns =
-    declare_mutually_recursive ~info:first.prg_info
+    declare_mutual_definitions ~info:first.prg_info
       ~uctx:first.prg_uctx ~rec_declaration ~possible_guard ~opaque:first.prg_opaque
       ~cinfo:fixitems ?using:first.prg_using ()
   in
@@ -1361,7 +1361,7 @@ let update_obls ~pm prg obls rem =
         List.map (fun x -> CEphemeron.get (ProgMap.find x pm)) prg'.prg_deps
       in
       if List.for_all (fun x -> obligations_solved x) progs then
-        let pm, kn = declare_mutual_definition ~pm progs in
+        let pm, kn = declare_mutual_definitions ~pm progs in
         pm, Defined kn
       else pm, Dependent
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1306,7 +1306,6 @@ let declare_definition ~pm prg =
   pm, kn
 
 let declare_mutual_definitions ~pm l =
-  let len = List.length l in
   let first = List.hd l in
   let defobl x =
     let oblsubst = obligation_substitution true x in
@@ -1314,12 +1313,8 @@ let declare_mutual_definitions ~pm l =
     let env = Global.env () in
     let sigma = Evd.from_ctx x.prg_uctx in
     let r = Retyping.relevance_of_type env sigma (EConstr.of_constr typ) in
-    let term =
-      snd (Reductionops.whd_decompose_lambda_n env sigma len (EConstr.of_constr subs))
-    in
-    let typ =
-      snd (Reductionops.whd_decompose_prod_n env sigma len (EConstr.of_constr typ))
-    in
+    let term = EConstr.of_constr subs in
+    let typ = EConstr.of_constr typ in
     let term = EConstr.to_constr sigma term in
     let typ = EConstr.to_constr sigma typ in
     let r = EConstr.ERelevance.kind sigma r in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2097,12 +2097,12 @@ end = struct
     (* if i = 0 , we don't touch the type; this is for compat
        but not clear it is the right thing to do.
     *)
-    let pe, ubind =
+    let pe =
       if i > 0 && Option.has_some possible_guard
       then
         let typ = UState.nf_universes uctx typ in
-        Internal.map_entry_type pe ~f:(fun _ -> Some typ), UnivNames.empty_binders
-      else pe, UState.universe_binders uctx
+        Internal.map_entry_type pe ~f:(fun _ -> Some typ)
+      else pe
     in
     (* We when possible_guard was [] in the previous step we should not
        substitute the body *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2622,11 +2622,11 @@ let msg_generating_obl name obls =
        info ++ str ", generating " ++ int len ++
        str (String.plural len " obligation"))
 
-let add_definition ~pm ~info ~cinfo ?obl_hook ?term ~uctx
-    ?tactic ?(reduce = reduce) ?(opaque = false) ?using obls =
+let add_definition ~pm ~info ~cinfo ~opaque ~uctx ?body
+    ?tactic ?(reduce = reduce) ?using ?obl_hook obls =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let prg =
-    ProgramDecl.make ~info ~cinfo ~body:term ~opaque ~uctx ~reduce ~deps:[] ~possible_guard:None ?obl_hook ?using obls
+    ProgramDecl.make ~info ~cinfo ~body ~opaque ~uctx ~reduce ~deps:[] ~possible_guard:None ?obl_hook ?using obls
   in
   let name = CInfo.get_name cinfo in
   let {obls;_} = Internal.get_obligations prg in
@@ -2644,22 +2644,19 @@ let add_definition ~pm ~info ~cinfo ?obl_hook ?term ~uctx
       pm, res
     | _ -> pm, res
 
-let add_mutual_definitions ~pm ~info ~cinfo ?obl_hook ~uctx
-    ?tactic ?(reduce = reduce) ?(opaque = false) ?using ~possible_guard l =
+let add_mutual_definitions ~pm ~info ~cinfo ~opaque ~uctx ~bodies ~possible_guard
+    ?tactic ?(reduce = reduce) ?using ?obl_hook obls =
   let obl_hook = Option.map (fun h -> State.PrgHook h) obl_hook in
   let deps = List.map CInfo.get_name cinfo in
   let pm =
-    (* EJGA: Note that here we duplicate the using declaration for all
-       the new entries in the obligation map, that seems the right
-       thing to do? *)
-    List.fold_left2
-      (fun pm cinfo (body, obls) ->
+    List.fold_left3
+      (fun pm cinfo body obls ->
         let prg =
           ProgramDecl.make ~info ~cinfo ~opaque ~body:(Some body) ~uctx ~deps
             ~possible_guard:(Some possible_guard) ~reduce ?obl_hook ?using obls
         in
         State.add pm (CInfo.get_name cinfo) prg)
-      pm cinfo l
+      pm cinfo bodies obls
   in
   let pm, _defined =
     List.fold_left

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -131,7 +131,7 @@ val declare_definition
   -> Evd.evar_map
   -> GlobRef.t
 
-val declare_mutually_recursive
+val declare_mutual_definitions
   : info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -132,7 +132,7 @@ val declare_definition
   -> GlobRef.t
 
 val declare_mutual_definitions
-  : info:Info.t
+  :  info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
   -> uctx:UState.t
@@ -538,13 +538,13 @@ val add_definition :
      pm:OblState.t
   -> info:Info.t
   -> cinfo:Constr.types CInfo.t
-  -> ?obl_hook: OblState.t Hook.g
-  -> ?term:Constr.t
+  -> opaque:bool
   -> uctx:UState.t
+  -> ?body:Constr.t
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
-  -> ?opaque:bool
   -> ?using:Vernacexpr.section_subset_expr
+  -> ?obl_hook: OblState.t Hook.g
   -> RetrieveObl.obligation_info
   -> OblState.t * progress
 
@@ -556,14 +556,15 @@ val add_mutual_definitions :
      pm:OblState.t
   -> info:Info.t
   -> cinfo:Constr.types CInfo.t list
-  -> ?obl_hook: OblState.t Hook.g
+  -> opaque:bool
   -> uctx:UState.t
+  -> bodies:Constr.t list
+  -> possible_guard:Pretyping.possible_guard
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
-  -> ?opaque:bool
   -> ?using:Vernacexpr.section_subset_expr
-  -> possible_guard:Pretyping.possible_guard
-  -> (Constr.t * RetrieveObl.obligation_info) list
+  -> ?obl_hook: OblState.t Hook.g
+  -> RetrieveObl.obligation_info list
   -> OblState.t
 
 (** Implementation of the [Obligation] command *)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -536,8 +536,8 @@ val prepare_obligations
    also register [c] with the kernel. *)
 val add_definition :
      pm:OblState.t
-  -> cinfo:Constr.types CInfo.t
   -> info:Info.t
+  -> cinfo:Constr.types CInfo.t
   -> ?obl_hook: OblState.t Hook.g
   -> ?term:Constr.t
   -> uctx:UState.t
@@ -555,6 +555,7 @@ val add_definition :
 val add_mutual_definitions :
      pm:OblState.t
   -> info:Info.t
+  -> cinfo:Constr.types CInfo.t list
   -> ?obl_hook: OblState.t Hook.g
   -> uctx:UState.t
   -> ?tactic:unit Proofview.tactic
@@ -562,7 +563,7 @@ val add_mutual_definitions :
   -> ?opaque:bool
   -> ?using:Vernacexpr.section_subset_expr
   -> possible_guard:Pretyping.possible_guard
-  -> (Constr.t CInfo.t * Constr.t * RetrieveObl.obligation_info) list
+  -> (Constr.t * RetrieveObl.obligation_info) list
   -> OblState.t
 
 (** Implementation of the [Obligation] command *)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -205,7 +205,7 @@ module Proof : sig
     -> t
 
   (** Pretty much internal, used by the Lemma vernaculars *)
-  val start_with_initialization
+  val start_definition
     :  info:Info.t
     -> cinfo:Constr.t CInfo.t
     -> ?using:Vernacexpr.section_subset_expr
@@ -213,10 +213,10 @@ module Proof : sig
     -> t
 
   (** Pretty much internal, used by mutual Lemma / Fixpoint vernaculars *)
-  val start_mutual_with_initialization
+  val start_mutual_definitions
     :  info:Info.t
     -> cinfo:Constr.t CInfo.t list
-    -> ?init_terms:Constr.t option list
+    -> ?bodies:Constr.t option list
     -> possible_guard:Pretyping.possible_guard
     -> ?using:Vernacexpr.section_subset_expr
     -> Evd.evar_map

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -12,7 +12,7 @@ open Names
 
 (** This module provides the functions to declare new
    variables, parameters, constants and inductive types in the global
-   environment. It also updates some accesory tables such as [Nametab]
+   environment. It also updates some accessory tables such as [Nametab]
    (name resolution), [Impargs], and [Notations]. *)
 
 (** We provide three main entry points:

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -136,7 +136,7 @@ val declare_mutual_definitions
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
   -> uctx:UState.t
-  -> rec_declaration:Constr.rec_declaration
+  -> bodies:(Constr.t list * Sorts.relevance list)
   -> possible_guard:Pretyping.possible_guard
   -> ?using:Vernacexpr.section_subset_expr
   -> unit

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -630,11 +630,11 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
   | RecLemmas.NonMutual thm ->
     let thm = Declare.CInfo.to_constr evd thm in
     let evd = post_check_evd ~udecl ~poly evd in
-    Declare.Proof.start_with_initialization ~info ~cinfo:thm ?using evd
+    Declare.Proof.start_definition ~info ~cinfo:thm ?using evd
   | RecLemmas.Mutual possible_guard ->
     let cinfo = List.map (Declare.CInfo.to_constr evd) thms in
     let evd = post_check_evd ~udecl ~poly evd in
-    Declare.Proof.start_mutual_with_initialization ~info ~cinfo ~possible_guard ?using evd
+    Declare.Proof.start_mutual_definitions ~info ~cinfo ~possible_guard ?using evd
 
 let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let open Decls in function
 | Coercion ->


### PR DESCRIPTION
The purpose of this PR is to present some uniformity in the API of `declare.ml` so that it is clearer to compare the different functions. It should not change the semantics.

Depends on ~~#18742 and~~ #18743 (merged).

It has an impact on the exact API though with the following API changes:
- function renamings
  - `declare_mutually_recursive` -> `declare_mutual_definition` (+ label `rec_declaration` -> `bodies`), consistently with `declare_definition`
  - `start_with_initialization` -> `start_definition`
  - `start_mutual_with_initialization` -> `start_mutual_definition` (+ label `init_term` -> `bodies`)
- other labels renaming
  - in `add_definition`: `term` -> `body`, and `opaque` made mandatory
  - in `add_mutual_definitions`: argument (cinfo,bodies,obls) -> labels `cinfo` and `bodies` + obls kept as unnamed argument

- [ ] TODO, pending question: mutual_definition or mutual_definitions?

Overlays (due to opaque made mandatory)
- MetaCoq/metacoq#1083
- mattam82/Coq-Equations#599