### PR TITLE
Include tactic grammars in Print Grammar

### DIFF
--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -66,7 +66,7 @@ module type S = sig
     val is_empty : 'a t -> bool with_estate
 
     type any_t = Any : 'a t -> any_t
-    val accumulate_in : 'a t -> any_t list CString.Map.t with_estate
+    val accumulate_in : any_t list -> any_t list CString.Map.t with_estate
   end
 
   module rec Symbol : sig

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -88,7 +88,14 @@ let is_known = let open Pcoq.Entry in function
     | [] -> None
     | entries -> Some entries
 
-let full_grammar () = Pcoq.Entry.accumulate_in [Any Pvernac.Vernac_.vernac_control]
+let full_grammar () =
+  let open Pvernac.Vernac_ in
+  let open Pcoq.Entry in
+  let proof_modes = List.map (fun (_,e) -> Any e)
+      (CString.Map.bindings (Pvernac.list_proof_modes()))
+  in
+  let entries = (Any vernac_control) :: (Any noedit_mode) :: proof_modes in
+  Pcoq.Entry.accumulate_in entries
 
 let same_entry (Pcoq.Entry.Any e) (Pcoq.Entry.Any e') = (Obj.magic e) == (Obj.magic e')
 

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -88,7 +88,7 @@ let is_known = let open Pcoq.Entry in function
     | [] -> None
     | entries -> Some entries
 
-let full_grammar () = Pcoq.Entry.accumulate_in Pvernac.Vernac_.vernac_control
+let full_grammar () = Pcoq.Entry.accumulate_in [Any Pvernac.Vernac_.vernac_control]
 
 let same_entry (Pcoq.Entry.Any e) (Pcoq.Entry.Any e') = (Obj.magic e) == (Obj.magic e')
 

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -13,7 +13,7 @@ open Pcoq
 type proof_mode = string
 
 (* Tactic parsing modes *)
-let register_proof_mode, find_proof_mode, lookup_proof_mode =
+let register_proof_mode, find_proof_mode, lookup_proof_mode, list_proof_modes =
   let proof_mode : (string, Vernacexpr.vernac_expr Entry.t) Hashtbl.t =
     Hashtbl.create 19 in
   let register_proof_mode ename e = Hashtbl.add proof_mode ename e; ename in
@@ -25,7 +25,10 @@ let register_proof_mode, find_proof_mode, lookup_proof_mode =
     if Hashtbl.mem proof_mode name then Some name
     else None
   in
-  register_proof_mode, find_proof_mode, lookup_proof_mode
+  let list_proof_modes () =
+    Hashtbl.fold CString.Map.add proof_mode CString.Map.empty
+  in
+  register_proof_mode, find_proof_mode, lookup_proof_mode, list_proof_modes
 
 let proof_mode_to_string name = name
 

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -53,3 +53,4 @@ val main_entry : proof_mode option -> vernac_control option Entry.t
 val register_proof_mode : string -> Vernacexpr.vernac_expr Entry.t -> proof_mode
 val lookup_proof_mode : string -> proof_mode option
 val proof_mode_to_string : proof_mode -> string
+val list_proof_modes : unit -> Vernacexpr.vernac_expr Entry.t CString.Map.t


### PR DESCRIPTION
They are behind a dynamic indirection so searching for entries from
vernac_control would not find them.

(ltac_expr would still be found through constr ltac:() but the command
level entries with toplevel selectors etc would not)
