### PR TITLE
Add attribute [@@immediate64] to Uint63.t

### DIFF
--- a/kernel/uint63.mli
+++ b/kernel/uint63.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type t
+type t [@@immediate64]
 
 val uint_size : int
 val maxuint31 : t


### PR DESCRIPTION
OCaml 4.09 ignores it but it may unlock some optimizations on >=4.10.
