### PR TITLE
[CI] Directly exclude .git directories

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,6 +192,8 @@ before_script:
     name: "$CI_JOB_NAME"
     paths:
       - _build_ci
+    exclude: # reduce artifact size
+      - _build_ci/**/.git/**/*
     when: always
   needs:
     - build:base

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -95,7 +95,6 @@ set -x
 # useful when building locally).
 # Note: when there is an overlay, $WITH_SUBMODULES is set to 1 or $CI is unset or empty
 # (local build), it uses git clone to perform the download.
-# If $CI is nonempty it then removes the .git (to reduce artifact size)
 git_download()
 {
   local project=$1
@@ -135,9 +134,6 @@ git_download()
     fi
     if [ "$WITH_SUBMODULES" = 1 ]; then
         git submodule update --init --recursive
-    fi
-    if [ "$CI" ]; then
-        rm -rf .git
     fi
     popd
   else # When possible, we download tarballs to reduce bandwidth and latency


### PR DESCRIPTION
This simplifies the logic in `dev/ci/ci-common.sh`.  This doesn't matter much on its own, but drastically simplifies the request at https://github.com/coq/coq/pull/18736#discussion_r1530708213

We should check that I got the syntax right, i.e., that the artifacts in fact exclude the .git directories

