### PR TITLE
Vernactypes: use record instead of multiple arguments and tuples

### DIFF
--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1373,19 +1373,19 @@ let vernac_end_segment ~pm ~proof ({v=id} as lid) =
   | _ -> assert false
 
 let vernac_end_segment lid =
-  Vernactypes.typed_vernac Pop ReadOpt
-    (fun ~pm ~proof ->
-       let () = vernac_end_segment ~pm ~proof lid in
-       (), ())
+  Vernactypes.typed_vernac { prog=Pop; proof=ReadOpt; }
+    (fun {proof; prog} ->
+       let () = vernac_end_segment ~pm:prog ~proof lid in
+       Vernactypes.no_state)
 
 let vernac_begin_segment ~interactive f =
   let open Vernactypes in
   let proof = Proof.(if interactive then Reject else Ignore) in
   let prog = Prog.(if interactive then Push else Ignore) in
-  typed_vernac prog proof
-    (fun ~pm ~proof ->
+  typed_vernac { prog; proof; }
+    (fun (_:no_state) ->
        let () = f () in
-       (), ())
+       no_state)
 
 (* Libraries *)
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -119,7 +119,8 @@ let rec interp_expr ?loc ~atts ~st c =
     let fv = Vernacentries.translate_vernac ?loc ~atts v in
     let stack = st.Vernacstate.interp.lemmas in
     let program = st.Vernacstate.interp.program in
-    interp_typed_vernac ~pm:program ~stack fv
+    let {Vernactypes.prog; proof} = interp_typed_vernac fv { prog=program; proof=stack; } in
+    proof, prog
 
 and vernac_load ~verbosely entries =
   (* Note that no proof should be open here, so the state here is just token for now *)

--- a/vernac/vernactypes.mli
+++ b/vernac/vernactypes.mli
@@ -34,21 +34,32 @@ module Proof : sig
     | Open : (unit, state) t
 end
 
+type ('prog,'proof) state_gen = {
+  prog : 'prog;
+  proof : 'proof;
+}
+
+type no_state = (unit, unit) state_gen
+val no_state : no_state
+(** Useful for patterns like [{ no_state with proof = newproof }] when
+    modifying a subset of the state. *)
+
+val ignore_state : ((unit, unit) Prog.t, (unit, unit) Proof.t) state_gen
+
 type typed_vernac =
     TypedVernac : {
-      prog : ('in1, 'out1) Prog.t;
-      proof : ('in2, 'out2) Proof.t;
-      run : pm:'in1 -> proof:'in2 -> 'out1 * 'out2;
+      spec : (('inprog, 'outprog) Prog.t, ('inproof, 'outproof) Proof.t) state_gen;
+      run : ('inprog, 'inproof) state_gen -> ('outprog, 'outproof) state_gen;
     } -> typed_vernac
 
 val typed_vernac
-  : ('in1, 'out1) Prog.t
-  -> ('in2, 'out2) Proof.t
-  -> (pm:'in1 -> proof:'in2 -> 'out1 * 'out2)
+  : (('inprog, 'outprog) Prog.t, ('inproof, 'outproof) Proof.t) state_gen
+  -> (('inprog, 'inproof) state_gen -> ('outprog, 'outproof) state_gen)
   -> typed_vernac
 
-val run : typed_vernac -> pm:Prog.stack -> stack:Vernacstate.LemmaStack.t option
-  -> Vernacstate.LemmaStack.t option * Prog.stack
+type full_state = (Prog.stack,Vernacstate.LemmaStack.t option) state_gen
+
+val run : typed_vernac -> full_state -> full_state
 
 (** Some convenient typed_vernac constructors. Used by coqpp. *)
 


### PR DESCRIPTION
This should make it easier to add states (eg opaque tables).
