### PR TITLE
Use implicit status of further arguments in measure/wf-like Program Fixpoint

### DIFF
--- a/doc/changelog/02-specification-language/18834-master+use-extra-impargs-program-fixpoint-wf.rst
+++ b/doc/changelog/02-specification-language/18834-master+use-extra-impargs-program-fixpoint-wf.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  `Program Fixpoint` with `measure` or `wf` (see
+  :ref:`program_fixpoint`) now supports the `where` clause for
+  notations, the `local` and `clearbody` attributes, as well as
+  non-atomic conclusions
+  (`#18834 <https://github.com/coq/coq/pull/18834>`_,
+  by Hugo Herbelin, fixes in particular
+  `#13812 <https://github.com/coq/coq/issues/13812>`_ and
+  `#14841 <https://github.com/coq/coq/issues/14841>`_).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -179,8 +179,15 @@ let compute_internalization_env env sigma ?(impls=empty_internalization_env) ty 
     (fun map id typ impl -> Id.Map.add id (compute_internalization_data env sigma id ty typ impl) map)
     impls
 
-let extend_internalization_data (r, impls, scopes, uid) impl scope =
-  (r, impls@[impl], scopes@[scope], uid)
+let set_obligation_internalization_data recname (r, impls, scopes, uid) =
+  let f =
+    function {impl_pos=(na,_,_)} as impl ->
+      if Name.equal na (Name recname)
+      then {impl with impl_force = false}
+      else impl
+  in
+  let impls = List.map (Option.map f) impls in
+  (r, impls, scopes, uid)
 
 let implicits_of_decl_in_internalization_env id (int_env:internalization_env) =
   let (_, impls, _, _) = Id.Map.find id int_env in impls

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -62,8 +62,8 @@ val compute_internalization_env : env -> evar_map -> ?impls:internalization_env 
   Id.t list -> types list -> Impargs.manual_implicits list ->
   internalization_env
 
-val extend_internalization_data :
-  var_internalization_data -> Impargs.implicit_status -> scope_name list -> var_internalization_data
+val set_obligation_internalization_data :
+  Id.t -> var_internalization_data -> var_internalization_data
 
 val implicits_of_decl_in_internalization_env :
   Id.t -> internalization_env -> Impargs.implicit_status list

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -118,3 +118,29 @@ Program Fixpoint f n {B} (b:B) {measure n} : forall {A}, A -> A * B :=
   end.
 
 End FurtherArguments.
+
+Module Notations.
+
+Reserved Notation "[ x ]".
+Program Fixpoint zero (n : nat) {measure n} : nat -> nat :=
+  match n with
+    | 0 => fun _ => 0
+    | S n' => [ n' ]
+  end
+
+where "[ n ]" := (zero n).
+
+Check eq_refl : ([ 0 ] 0) = 0.
+
+Reserved Notation "[[ x | y ]]".
+Program Fixpoint zero' (n : nat) {measure n} : nat -> nat :=
+  match n with
+    | 0 => fun _ => 0
+    | S n' => fun a => [[ n' | a ]]
+  end
+
+where "[[ n | p ]]" := (zero' n p).
+
+Check eq_refl : [[ 0 | 0 ]] = 0.
+
+End Notations.

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -103,3 +103,18 @@ Qed.
 Program Fixpoint check_n'  (n : nat) (m : {m:nat | m = n}) (p : nat) (q:{q : nat | q = p})
   {measure (p - n)} : nat :=
   _.
+Module FurtherArguments.
+
+Program Fixpoint zero (n : nat) {measure n} : nat -> nat :=
+  match n with
+    | 0 => fun _ => 0
+    | S n' => zero n'
+  end.
+
+Program Fixpoint f n {B} (b:B) {measure n} : forall {A}, A -> A * B :=
+  match n with
+  | 0 => fun A a => (a, b)
+  | S n => fun A a => f n b a
+  end.
+
+End FurtherArguments.

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -66,8 +66,8 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?user_wa
   let sigma, (_, ((env', binders_rel), impls)) = interp_context_evars ~program_mode:true env sigma bl in
   let len = List.length binders_rel in
   let top_env = push_rel_context binders_rel env in
-  let sigma, top_arity = interp_type_evars ~program_mode:true top_env sigma arityc in
-  let full_arity = it_mkProd_or_LetIn top_arity binders_rel in
+  let flags = Pretyping.{ all_no_fail_flags with program_mode = true } in
+  let sigma, (top_arity, arityimpls) = interp_type_evars_impls ~flags top_env sigma arityc in
   let sigma, letbinders, { telescope_type = argtyp; telescope_value = make } =
     telescope env sigma binders_rel in
   let argname = Id.of_string "recarg" in
@@ -114,13 +114,14 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?user_wa
   let intern_fun_arity_prod = it_mkProd_or_LetIn intern_arity [wfa] in
   let intern_fun_binder = LocalAssum (make_annot (Name (add_suffix recname "'")) Sorts.Relevant,
                                       intern_fun_arity_prod) in
+  let recproofid = Id.of_string "recproof" in
   let sigma, curry_fun =
     let wfpred = mkLambda (make_annot (Name argid') Sorts.Relevant, argtyp, wf_rel_fun (mkRel 1) (mkRel (2 * len + 4))) in
     let sigma, intro = Evd.fresh_global (Global.env ()) sigma (delayed_force build_sigma).Coqlib.intro in
     let arg = mkApp (intro, [| argtyp; wfpred; lift 1 make; mkRel 1 |]) in
     let app = mkApp (mkRel (2 * len + 2 (* recproof + orig binders + current binders *)), [| arg |]) in
     let rcurry = mkApp (rel, [| measure; lift len measure |]) in
-    let lam = LocalAssum (make_annot (Name (Id.of_string "recproof")) Sorts.Relevant, rcurry) in
+    let lam = LocalAssum (make_annot (Name recproofid) Sorts.Relevant, rcurry) in
     let body = it_mkLambda_or_LetIn app (lam :: binders_rel) in
     let ty = it_mkProd_or_LetIn (lift 1 top_arity) (lam :: binders_rel) in
     sigma, LocalDef (make_annot (Name recname) Sorts.Relevant, body, ty)
@@ -129,18 +130,19 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?user_wa
   let lift_lets = lift_rel_context 1 letbinders in
   let sigma, intern_body =
     let ctx = LocalAssum (make_annot (Name recname) Sorts.Relevant, get_type curry_fun) :: binders_rel in
+    let impl = CAst.make (Some (Name recproofid, true)) in
+    let newimpls = impls @ impl :: arityimpls in
+    let dummy_decl =
+      (* Ensure the measure argument does not contribute to the computation of automatic implicit arguments *)
+      LocalAssum (make_annot (Name recproofid) Sorts.Relevant, mkProp) in
+    let full_arity = it_mkProd_or_LetIn top_arity (dummy_decl :: binders_rel) in
     let interning_data =
       Constrintern.compute_internalization_data env sigma recname
-        Constrintern.Recursive full_arity impls
-    in
-    let impl = Some Impargs.{
-      impl_pos = (Name (Id.of_string "recproof"), 1, None);
-      impl_expl = Manual;
-      impl_max = true;
-      impl_force = false;
-    } in
-    let newimpls = Id.Map.singleton recname
-        (Constrintern.extend_internalization_data interning_data impl []) in
+        Constrintern.Recursive full_arity newimpls in
+    let interning_data =
+      (* Force the obligation status of "recproof" *)
+      set_obligation_internalization_data recproofid interning_data in
+    let newimpls = Id.Map.singleton recname interning_data in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -819,8 +819,10 @@ let prepare_definition ~info ~opaque ?using ~body ~typ sigma =
 let declare_definition_core ~info ~cinfo ~opaque ~obls ~body sigma =
   let { CInfo.name; impargs; typ; using; _ } = cinfo in
   let entry, uctx = prepare_definition ~info ~opaque ?using ~body ~typ sigma in
-  let { Info.scope; clearbody; kind; hook; typing_flags; user_warns; _ } = info in
-  declare_entry_core ~name ~scope ~clearbody ~kind ~impargs ~typing_flags ~user_warns ~obls ?hook ~uctx entry, uctx
+  let { Info.scope; clearbody; kind; hook; typing_flags; user_warns; ntns; _ } = info in
+  let gref = declare_entry_core ~name ~scope ~clearbody ~kind ~impargs ~typing_flags ~user_warns ~obls ?hook ~uctx entry in
+  List.iter (Metasyntax.add_notation_interpretation ~local:(info.scope=Locality.Discharge) (Global.env ())) ntns;
+  gref, uctx
 
 let declare_definition ~info ~cinfo ~opaque ~body sigma =
   declare_definition_core ~obls:[] ~info ~cinfo ~opaque ~body sigma |> fst


### PR DESCRIPTION
The purpose of the PR is to align the behavior of `measure`/`wf`-like `Program Fixpoint` on what is done for `Fixpoint` in general. This includes:
- taking into account the presence of `forall` and of implicit arguments in the conclusion of the fixpoint
- supporting the `where` clause for notations
- supporting the `Local` modifier / `local` attribute
- supporting the `clearbody` attribute

For instance, the PR makes that the following does not fail anymore:
```coq
Require Import Program.
Program Fixpoint zero (n : nat) {measure n} : nat -> nat :=
  match n with
    | 0 => fun _ => 0
    | S n' => zero n'
  end.

Program Fixpoint f n {B} (b:B) {measure n} : forall {A}, A -> A * B :=
  match n with
  | 0 => fun A a => (a, b)
  | S n => fun A a => f n b a
  end.
```

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Fixes #14841 (regarding the `where` clause)
Fixes #13812 (regarding further arguments)

Note: it does not fix #13697, which would require hacking recursive calls made with `@` (see #18878 instead).