### PR TITLE
[ssr] Backports from mathcomp following merge of https://github.com/math-comp/math-comp/pull/1193

### DIFF
--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -834,6 +834,17 @@ move=> iPQ []// notPQ; apply/notPQ=> /iPQ-cQ.
 by case: notF; apply: cQ => hQ; apply: notPQ.
 Qed.
 
+Lemma classic_sigW T (P : T -> Prop) :
+  classically (exists x, P x) <-> classically ({x | P x}).
+Proof. by split; apply: classic_bind => -[x Px]; apply/classicW; exists x. Qed.
+
+Lemma classic_ex T (P : T -> Prop) :
+  ~ (forall x, ~ P x) -> classically (exists x, P x).
+Proof.
+move=> NfNP; apply/classicP => exPF; apply: NfNP => x Px.
+by apply: exPF; exists x.
+Qed.
+
 (**
  List notations for wider connectives; the Prop connectives have a fixed
  width so as to avoid iterated destruction (we go up to width 5 for /\, and


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Adds `classic_sigW` and `classic_ex`, that come from the math-comp/Abel repository




<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->


<!-- If this breaks external libraries or plugins in CI: -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
