### PR TITLE
Use correct relevance in inversion

### DIFF
--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -137,10 +137,11 @@ let make_inv_predicate env evd indf realargs id status concl =
         let eq_term = eqdata.Coqlib.eq in
         let eq = evd_comb1 (Evd.fresh_global env) evd eq_term in
         let eqn = applist (eq,[eqnty;lhs;rhs]) in
-        let eqns = (make_annot Anonymous Sorts.Relevant, lift n eqn) :: eqns in
         let refl_term = eqdata.Coqlib.refl in
         let refl_term = evd_comb1 (Evd.fresh_global env) evd refl_term in
         let refl = mkApp (refl_term, [|eqnty; rhs|]) in
+        let r = Retyping.relevance_of_term env !evd refl in
+        let eqns = (make_annot Anonymous r, lift n eqn) :: eqns in
         let _ = evd_comb1 (Typing.type_of env) evd refl in
         let args = refl :: args in
         build_concl eqns args (succ n) restlist


### PR DESCRIPTION
Fix #18839

but not sure this is really useful, eg
~~~coq
Inductive SFalse : SProp :=.

Inductive eq (A : Type) (a : A) : forall (b : A), SProp :=
| eq_refl : eq A a a.

Register eq as core.eq.type.
Register eq_refl as core.eq.refl.

Lemma inversion_le   : forall _:eq nat 1 0 , SFalse.
Proof.
  inversion 1.
~~~
fails because it wants to eliminate eq to some Prop (Equality.discrimination_pf)
