### PR TITLE
Remove all instances of `== Sorts.Irrelevant`

### DIFF
--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -648,6 +648,9 @@ val restrict_universe_context : evar_map -> Univ.Level.Set.t -> evar_map
 val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 val quality_of_name : evar_map -> Id.t -> Sorts.QVar.t
 
+val is_relevance_irrelevant : evar_map -> Sorts.relevance -> bool
+(** Whether the relevance is irrelevant modulo qstate *)
+
 val universe_binders : evar_map -> UnivNames.universe_binders
 
 val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -418,7 +418,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let m = reloc_rel m el2 in
         let rn = Range.get (info_relevances infos.cnv_inf) (n - 1) in
         let rm = Range.get (info_relevances infos.cnv_inf) (m - 1) in
-        if rn == Sorts.Irrelevant && rm == Sorts.Irrelevant then
+        if is_irrelevant infos.cnv_inf rn && is_irrelevant infos.cnv_inf rm then
           let v1 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
           let v2 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
@@ -731,7 +731,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FRel n1, FIrrelevant) ->
       let n1 = reloc_rel n1 (el_stack lft1 v1) in
       let r1 = Range.get (info_relevances infos.cnv_inf) (n1 - 1) in
-      if r1 == Sorts.Irrelevant then
+      if is_irrelevant infos.cnv_inf r1 then
         let v1 = CClosure.skip_irrelevant_stack infos.cnv_inf v1 in
         convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
       else raise NotConvertible
@@ -739,7 +739,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FIrrelevant, FRel n2) ->
       let n2 = reloc_rel n2 (el_stack lft2 v2) in
       let r2 = Range.get (info_relevances infos.cnv_inf) (n2 - 1) in
-      if r2 == Sorts.Irrelevant then
+      if is_irrelevant infos.cnv_inf r2 then
         let v2 = CClosure.skip_irrelevant_stack infos.cnv_inf v2 in
         convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
       else raise NotConvertible

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -629,8 +629,8 @@ let rec evar_conv_x flags env evd pbty term1 term2 =
             (whd_nored_state env evd (term2,Stack.empty))
         with
         | UnifFailure _ as x ->
-           if Retyping.relevance_of_term env evd term1 == Sorts.Irrelevant ||
-              Retyping.relevance_of_term env evd term2 == Sorts.Irrelevant
+           if Retyping.is_term_irrelevant env evd term1 ||
+              Retyping.is_term_irrelevant env evd term2
            then Success evd
            else x
         | Success _ as x -> x

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -364,6 +364,10 @@ let relevance_of_term env sigma c =
     aux Range.empty c
   else Sorts.Relevant
 
+let is_term_irrelevant env sigma c =
+  let r = relevance_of_term env sigma c in
+  Evd.is_relevance_irrelevant sigma r
+
 let relevance_of_type env sigma t =
   let s = get_sort_of env sigma t in
   ESorts.relevance_of_sort sigma s

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -61,3 +61,5 @@ val relevance_of_term : env -> evar_map -> constr -> Sorts.relevance
 val relevance_of_type : env -> evar_map -> types -> Sorts.relevance
 val relevance_of_sort : evar_map -> ESorts.t -> Sorts.relevance
 val relevance_of_sort_family : evar_map -> Sorts.family -> Sorts.relevance
+
+val is_term_irrelevant : env -> Evd.evar_map -> Evd.econstr -> bool

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -736,8 +736,8 @@ let eta_constructor_app env sigma f l1 term =
 
 (* If the terms are irrelevant, check that they have the same type. *)
 let careful_infer_conv ~pb ~ts env sigma m n =
-  if Retyping.relevance_of_term env sigma m == Sorts.Irrelevant &&
-     Retyping.relevance_of_term env sigma n == Sorts.Irrelevant
+  if Retyping.is_term_irrelevant env sigma m &&
+     Retyping.is_term_irrelevant env sigma n
   then
     let tm = Retyping.get_type_of env sigma m in
     let tn = Retyping.get_type_of env sigma n in

--- a/test-suite/bugs/bug_18845.v
+++ b/test-suite/bugs/bug_18845.v
@@ -1,0 +1,9 @@
+Set Universe Polymorphism.
+
+Inductive Box@{s|u|} (A:Type@{s|u}) := box (_:A).
+
+Definition t1@{s|u|} (A:Type@{s|u}) (x y : A) := box _ x.
+Definition t2@{s|u|} (A:Type@{s|u}) (x y : A) := box _ y.
+
+Check fun A:SProp => eq_refl : t1 A = t2 A. (* What is in "test-suite/success/sort_polymorphism.v" *)
+Check fun (A : SProp) => (fun (x : t1 A = t2 A) => x) eq_refl. (* Slight variation *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #18845

I'm quite unsure of what I did, please review carefully.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
