### PR TITLE
 Remove all `nf_evar` from `cases.ml` and `pretyping.ml` if they affected the elaborated term

### DIFF
--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -589,6 +589,7 @@ let resolve_and_replace_implicits exptyp env sigma rt =
       resolve_tc = true;
       undeclared_evars_patvars = false;
       patvars_abstract = false;
+      expand_evars = true;
     } in
     let vars = Evarutil.VarSet.variables (Global.env ()) in
     let hypnaming = RenameExistingBut vars in

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -44,7 +44,7 @@ val irrefutable : env -> cases_pattern -> bool
 (** {6 Compilation primitive. } *)
 
 val compile_cases :
-  ?loc:Loc.t -> program_mode:bool -> case_style ->
+  ?loc:Loc.t -> program_mode:bool -> expand_evars:bool -> case_style ->
   (type_constraint -> GlobEnv.t -> evar_map -> glob_constr -> evar_map * unsafe_judgment) * evar_map ->
   type_constraint ->
   GlobEnv.t -> glob_constr option * tomatch_tuples * cases_clauses ->
@@ -116,10 +116,10 @@ type 'a pattern_matching_problem =
       casestyle : case_style;
       typing_function: type_constraint -> GlobEnv.t -> evar_map -> 'a option -> evar_map * unsafe_judgment }
 
-val compile : program_mode:bool -> evar_map -> 'a pattern_matching_problem ->
+val compile : program_mode:bool -> expand_evars:bool -> evar_map -> 'a pattern_matching_problem ->
   (int option * Names.Id.t CAst.t list) list * evar_map * unsafe_judgment
 
-val prepare_predicate : ?loc:Loc.t -> program_mode:bool ->
+val prepare_predicate : ?loc:Loc.t -> program_mode:bool -> expand_evars:bool ->
            (type_constraint ->
             GlobEnv.t -> Evd.evar_map -> glob_constr -> Evd.evar_map * unsafe_judgment) ->
            GlobEnv.t ->

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -157,6 +157,7 @@ type pretype_flags = {
   use_coercions : bool;
   undeclared_evars_patvars : bool;
   patvars_abstract : bool;
+  expand_evars : bool;
 }
 
 type 'a pretype_fun = ?loc:Loc.t -> flags:pretype_flags -> Evardefine.type_constraint -> GlobEnv.t -> evar_map -> evar_map * 'a


### PR DESCRIPTION
Test for removing instances of `nf_evar` during pretyping.

Needs PR #18847