### PR TITLE
A few more list, context and term combinators

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -492,7 +492,13 @@ let rec fold_left4 f accu l1 l2 l3 l4 =
   match (l1, l2, l3, l4) with
   | ([], [], [], []) -> accu
   | (a1 :: l1, a2 :: l2, a3 :: l3, a4 :: l4) -> fold_left4 f (f accu a1 a2 a3 a4) l1 l2 l3 l4
-  | (_,_, _, _) -> invalid_arg "List.fold_left4"
+  | (_, _, _, _) -> invalid_arg "List.fold_left4"
+
+let rec fold_left5 f accu l1 l2 l3 l4 l5 =
+  match (l1, l2, l3, l4, l5) with
+  | ([], [], [], [], []) -> accu
+  | (a1 :: l1, a2 :: l2, a3 :: l3, a4 :: l4, a5 :: l5) -> fold_left5 f (f accu a1 a2 a3 a4 a5) l1 l2 l3 l4 l5
+  | (_, _, _, _, _) -> invalid_arg "List.fold_left5"
 
 (* [fold_right_and_left f [a1;...;an] hd =
    f (f (... (f (f hd
@@ -567,6 +573,10 @@ let fold_left3_map f e l l' l'' =
 let fold_left4_map f e l1 l2 l3 l4 =
   on_snd List.rev @@
   fold_left4 (fun (e,l) x1 x2 x3 x4 -> let (e,y) = f e x1 x2 x3 x4 in (e,y::l)) (e,[]) l1 l2 l3 l4
+
+let fold_left5_map f e l1 l2 l3 l4 l5 =
+  on_snd List.rev @@
+  fold_left5 (fun (e,l) x1 x2 x3 x4 x5 -> let (e,y) = f e x1 x2 x3 x4 x5 in (e,y::l)) (e,[]) l1 l2 l3 l4 l5
 
 (** {6 Splitting} *)
 

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -186,6 +186,10 @@ val fold_left3 : ('a -> 'b -> 'c -> 'd -> 'a) -> 'a -> 'b list -> 'c list -> 'd 
 (** Like [List.fold_left] but for 3 lists; raise [Invalid_argument _] if
     not all lists of the same size *)
 
+val fold_left4 : ('a -> 'b -> 'c -> 'd -> 'e -> 'a) -> 'a -> 'b list -> 'c list -> 'd list -> 'e list -> 'a
+(** Like [List.fold_left] but for 4 lists; raise [Invalid_argument _] if
+    not all lists of the same size *)
+
 val fold_left2_set : exn -> ('a -> 'b -> 'c -> 'b list -> 'c list -> 'a) -> 'a -> 'b list -> 'c list -> 'a
 (** Fold sets, i.e. lists up to order; the folding function tells
     when elements match by returning a value and raising the given
@@ -211,6 +215,9 @@ val fold_left3_map : ('a -> 'b -> 'c -> 'd -> 'a * 'e) -> 'a -> 'b list -> 'c li
 
 val fold_left4_map : ('a -> 'b -> 'c -> 'd -> 'e -> 'a * 'r) -> 'a -> 'b list -> 'c list -> 'd list -> 'e list -> 'a * 'r list
 (** Same with four lists, folding on the left *)
+
+val fold_left5_map : ('a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'a * 'r) -> 'a -> 'b list -> 'c list -> 'd list -> 'e list -> 'f list -> 'a * 'r list
+(** Same with five lists, folding on the left *)
 
 (** {6 Splitting} *)
 

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -457,9 +457,13 @@ val of_named_decl : (Constr.t, Constr.types) Context.Named.Declaration.pt -> (t,
 val of_rel_decl : (Constr.t, Constr.types) Context.Rel.Declaration.pt -> (t, types) Context.Rel.Declaration.pt
 
 val to_rel_decl : Evd.evar_map -> (t, types) Context.Rel.Declaration.pt -> (Constr.t, Constr.types) Context.Rel.Declaration.pt
+val to_named_decl : Evd.evar_map -> (t, types) Context.Named.Declaration.pt -> (Constr.t, Constr.types) Context.Named.Declaration.pt
 
 val of_named_context : Constr.named_context -> named_context
 val of_rel_context : Constr.rel_context -> rel_context
+
+val to_named_context : Evd.evar_map -> (t, types) Context.Named.pt -> (Constr.t, Constr.types) Context.Named.pt
+val to_rel_context : Evd.evar_map -> (t, types) Context.Rel.pt -> (Constr.t, Constr.types) Context.Rel.pt
 
 val of_case_invert : Constr.case_invert -> case_invert
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -78,10 +78,10 @@ let nf_relevance sigma r =
   UState.nf_relevance (Evd.evar_universe_context sigma) r
 
 let nf_named_context_evar sigma ctx =
-  Context.Named.map (nf_evars_universes sigma) ctx
+  Context.Named.map_with_relevance (nf_relevance sigma) (nf_evars_universes sigma) ctx
 
 let nf_rel_context_evar sigma ctx =
-  Context.Rel.map (nf_evar sigma) ctx
+  Context.Rel.map_with_relevance (nf_relevance sigma) (nf_evar sigma) ctx
 
 let nf_env_evar sigma env =
   let nc' = nf_named_context_evar sigma (Environ.named_context env) in

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1854,12 +1854,15 @@ module MiniEConstr = struct
 
   let of_named_decl d = d
   let unsafe_to_named_decl d = d
+  let to_named_decl sigma d = NamedDecl.map_constr_het_with_relevance (UState.nf_relevance sigma.universes) (to_constr sigma) d
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
   let to_rel_decl sigma d = RelDecl.map_constr_het_with_relevance (UState.nf_relevance sigma.universes) (to_constr sigma) d
 
   let of_named_context d = d
+  let to_named_context sigma l = List.map (to_named_decl sigma) l
   let of_rel_context d = d
+  let to_rel_context sigma l = List.map (to_rel_decl sigma) l
 
   let unsafe_to_case_invert x = x
   let of_case_invert x = x

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1856,13 +1856,7 @@ module MiniEConstr = struct
   let unsafe_to_named_decl d = d
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
-  let to_rel_decl sigma d = match d with
-  | RelDecl.LocalAssum (na, t) ->
-    let na = UnivSubst.nf_binder_annot (fun r -> UState.nf_relevance sigma.universes r) na in
-    RelDecl.LocalAssum (na, to_constr sigma t)
-  | RelDecl.LocalDef (na, c, t) ->
-    let na = UnivSubst.nf_binder_annot (fun r -> UState.nf_relevance sigma.universes r) na in
-    RelDecl.LocalDef (na, to_constr sigma c, to_constr sigma t)
+  let to_rel_decl sigma d = RelDecl.map_constr_het_with_relevance (UState.nf_relevance sigma.universes) (to_constr sigma) d
 
   let of_named_context d = d
   let of_rel_context d = d

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -806,18 +806,23 @@ module MiniEConstr : sig
   val unsafe_eq : (t, Constr.t) eq
 
   val of_named_decl : (Constr.t, Constr.types) Context.Named.Declaration.pt ->
-    (t, t) Context.Named.Declaration.pt
-  val unsafe_to_named_decl : (t, t) Context.Named.Declaration.pt ->
+    (t, etypes) Context.Named.Declaration.pt
+  val unsafe_to_named_decl : (t, etypes) Context.Named.Declaration.pt ->
     (Constr.t, Constr.types) Context.Named.Declaration.pt
-  val unsafe_to_rel_decl : (t, t) Context.Rel.Declaration.pt ->
+  val to_named_decl : evar_map -> (t, etypes) Context.Named.Declaration.pt ->
+    (Constr.t, Constr.types) Context.Named.Declaration.pt
+  val unsafe_to_rel_decl : (t, etypes) Context.Rel.Declaration.pt ->
     (Constr.t, Constr.types) Context.Rel.Declaration.pt
-  val of_case_invert : constr pcase_invert -> econstr pcase_invert
-  val unsafe_to_case_invert : econstr pcase_invert -> constr pcase_invert
   val of_rel_decl : (Constr.t, Constr.types) Context.Rel.Declaration.pt ->
-    (t, t) Context.Rel.Declaration.pt
-  val to_rel_decl : evar_map -> (t, t) Context.Rel.Declaration.pt ->
+    (t, etypes) Context.Rel.Declaration.pt
+  val to_rel_decl : evar_map -> (t, etypes) Context.Rel.Declaration.pt ->
     (Constr.t, Constr.types) Context.Rel.Declaration.pt
 
-  val of_named_context : (Constr.t, Constr.types) Context.Named.pt -> (t, t) Context.Named.pt
-  val of_rel_context : (Constr.t, Constr.types) Context.Rel.pt -> (t, t) Context.Rel.pt
+  val of_case_invert : constr pcase_invert -> econstr pcase_invert
+  val unsafe_to_case_invert : econstr pcase_invert -> constr pcase_invert
+
+  val of_named_context : (Constr.t, Constr.types) Context.Named.pt -> (t, etypes) Context.Named.pt
+  val to_named_context : evar_map -> (t, etypes) Context.Named.pt -> (Constr.t, Constr.types) Context.Named.pt
+  val of_rel_context : (Constr.t, Constr.types) Context.Rel.pt -> (t, etypes) Context.Rel.pt
+  val to_rel_context : evar_map -> (t, etypes) Context.Rel.pt -> (Constr.t, Constr.types) Context.Rel.pt
 end

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -162,17 +162,11 @@ let subst_univs_fn_puniverses f (c, u as cu) =
   let u' = Instance.subst_fn f u in
     if u' == u then cu else (c, u')
 
-let nf_binder_annot frel na =
-  let open Context in
-  let rel' = frel na.binder_relevance in
-  if rel' == na.binder_relevance then na
-  else { binder_name = na.binder_name; binder_relevance = rel' }
-
 let map_universes_opt_subst_with_binders next aux fqual funiv k c =
   let frel = Sorts.relevance_subst_fn fqual in
   let flevel = fqual, level_subst_of funiv in
   let aux_rec ((nas, tys, bds) as rc) =
-    let nas' = Array.Smart.map (fun na -> nf_binder_annot frel na) nas in
+    let nas' = Array.Smart.map (Context.map_binder_relevance frel) nas in
     let tys' = Array.Fun1.Smart.map aux k tys in
     let k' = iterate next (Array.length tys') k in
     let bds' = Array.Fun1.Smart.map aux k' bds in
@@ -180,7 +174,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     else (nas', tys', bds')
   in
   let aux_ctx ((nas, c) as p) =
-    let nas' = Array.Smart.map (fun na -> nf_binder_annot frel na) nas in
+    let nas' = Array.Smart.map (Context.map_binder_relevance frel) nas in
     let k' = iterate next (Array.length nas) k in
     let c' = aux k' c in
     if nas' == nas && c' == c then p
@@ -217,19 +211,19 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     if u == u' && elems == elems' && def == def' && ty == ty' then c
     else mkArray (u',elems',def',ty')
   | Prod (na, t, u) ->
-    let na' = nf_binder_annot frel na in
+    let na' = Context.map_binder_relevance frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkProd (na', t', u')
   | Lambda (na, t, u) ->
-    let na' = nf_binder_annot frel na in
+    let na' = Context.map_binder_relevance frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkLambda (na', t', u')
   | LetIn (na, b, t, u) ->
-    let na' = nf_binder_annot frel na in
+    let na' = Context.map_binder_relevance frel na in
     let b' = aux k b in
     let t' = aux k t in
     let u' = aux (next k) u in

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -25,9 +25,6 @@ val level_subst_of : universe_subst_fn -> universe_level_subst_fn
 
 val subst_univs_constraints : universe_subst_fn -> Constraints.t -> Constraints.t
 
-val nf_binder_annot : (Sorts.relevance -> Sorts.relevance) ->
-  'a Context.binder_annot -> 'a Context.binder_annot
-
 (** Full universes substitutions into terms *)
 
 val map_universes_opt_subst_with_binders

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -44,6 +44,9 @@ let map_annot f {binder_name=na;binder_relevance} =
 
 let make_annot x r = {binder_name=x;binder_relevance=r}
 
+let map_binder_relevance f {binder_name=na;binder_relevance=r} =
+  {binder_name=na;binder_relevance=f r}
+
 let binder_name x = x.binder_name
 let binder_relevance x = x.binder_relevance
 
@@ -169,6 +172,18 @@ struct
           let ty' = f ty in
           if v == v' && ty == ty' then decl else LocalDef (na, v', ty')
 
+    (** Map all terms in a given declaration. *)
+    let map_constr_with_relevance g f = function
+      | LocalAssum (na, ty) as decl ->
+          let na' = map_binder_relevance g na in
+          let ty' = f ty in
+          if na == na' && ty == ty' then decl else LocalAssum (na', ty')
+      | LocalDef (na, v, ty) as decl ->
+          let na' = map_binder_relevance g na in
+          let v' = f v in
+          let ty' = f ty in
+          if na == na' && v == v' && ty == ty' then decl else LocalDef (na', v', ty')
+
     let map_constr_het f = function
       | LocalAssum (na, ty) ->
           let ty' = f ty in
@@ -177,6 +192,17 @@ struct
           let v' = f v in
           let ty' = f ty in
           LocalDef (na, v', ty')
+
+    let map_constr_het_with_relevance g f = function
+      | LocalAssum (na, ty) ->
+          let na' = map_binder_relevance g na in
+          let ty' = f ty in
+          LocalAssum (na', ty')
+      | LocalDef (na, v, ty) ->
+          let na' = map_binder_relevance g na in
+          let v' = f v in
+          let ty' = f ty in
+          LocalDef (na', v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -236,6 +262,8 @@ struct
 
   (** Map all terms in a given rel-context. *)
   let map f = List.Smart.map (Declaration.map_constr f)
+
+  let map_with_relevance g f = List.Smart.map (Declaration.map_constr_with_relevance g f)
 
   let map_het f = List.map (Declaration.map_constr_het f)
 
@@ -414,6 +442,18 @@ struct
           let ty' = f ty in
           if v == v' && ty == ty' then decl else LocalDef (id, v', ty')
 
+    (** Map all terms in a given declaration. *)
+    let map_constr_with_relevance g f = function
+      | LocalAssum (id, ty) as decl ->
+          let id' = map_binder_relevance g id in
+          let ty' = f ty in
+          if id == id' && ty == ty' then decl else LocalAssum (id', ty')
+      | LocalDef (id, v, ty) as decl ->
+          let id' = map_binder_relevance g id in
+          let v' = f v in
+          let ty' = f ty in
+          if id == id' && v == v' && ty == ty' then decl else LocalDef (id', v', ty')
+
     let map_constr_het f = function
       | LocalAssum (id, ty) ->
           let ty' = f ty in
@@ -422,6 +462,17 @@ struct
           let v' = f v in
           let ty' = f ty in
           LocalDef (id, v', ty')
+
+    let map_constr_het_with_relevance g f = function
+      | LocalAssum (id, ty) ->
+          let id' = map_binder_relevance g id in
+          let ty' = f ty in
+          LocalAssum (id', ty')
+      | LocalDef (id, v, ty) ->
+          let id' = map_binder_relevance g id in
+          let v' = f v in
+          let ty' = f ty in
+          LocalDef (id', v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -487,6 +538,8 @@ struct
 
   (** Map all terms in a given named-context. *)
   let map f = List.Smart.map (Declaration.map_constr f)
+
+  let map_with_relevance g f = List.Smart.map (Declaration.map_constr_with_relevance g f)
 
   let map_het f = List.map (Declaration.map_constr_het f)
 

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -33,6 +33,8 @@ val map_annot : ('a -> 'b) -> 'a binder_annot -> 'b binder_annot
 
 val make_annot : 'a -> Sorts.relevance -> 'a binder_annot
 
+val map_binder_relevance : (Sorts.relevance -> Sorts.relevance) -> 'a binder_annot -> 'a binder_annot
+
 val binder_name : 'a binder_annot -> 'a
 val binder_relevance : 'a binder_annot -> Sorts.relevance
 
@@ -108,8 +110,14 @@ sig
     (** Map all terms in a given declaration. *)
     val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
+    (** Map all terms in a given declaration. *)
+    val map_constr_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+
     (** Map all terms, with an heterogeneous function. *)
     val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
+
+    (** Map all terms, with an heterogeneous function. *)
+    val map_constr_het_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
 
     (** Perform a given action on all terms in a given declaration. *)
     val iter_constr : ('c -> unit) -> ('c, 'c) pt -> unit
@@ -149,6 +157,9 @@ sig
 
   (** Map all terms in a given rel-context. *)
   val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+
+  (** Map all terms in a given rel-context. *)
+  val map_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
   (** Map all terms in a given named-context. *)
   val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt
@@ -262,8 +273,14 @@ sig
     (** Map all terms in a given declaration. *)
     val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
+    (** Map all terms in a given declaration. *)
+    val map_constr_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+
     (** Map all terms, with an heterogeneous function. *)
     val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
+
+    (** Map all terms, with an heterogeneous function. *)
+    val map_constr_het_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
 
     (** Perform a given action on all terms in a given declaration. *)
     val iter_constr : ('c -> unit) -> ('c, 'c) pt -> unit
@@ -309,6 +326,9 @@ sig
 
   (** Map all terms in a given named-context. *)
   val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+
+  (** Map all terms in a given rel-context. *)
+  val map_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
   (** Map all terms in a given named-context. *)
   val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -286,6 +286,20 @@ let decompose_prod_n_decls n =
   in
   prodec_rec Context.Rel.empty n
 
+let decompose_lambda_prod_n_decls n =
+  if n < 0 then
+    anomaly (str "decompose_lambda_prod_n_decls: integer parameter must be positive.");
+  let rec lamprodec_rec l n c t =
+    if Int.equal n 0 then (l, c, t)
+    else
+      let open Context.Rel.Declaration in
+      match kind c, kind t with
+      | Lambda (na, u, c), Prod (_, _, t) -> lamprodec_rec (LocalAssum (na, u) :: l) (n-1) c t
+      | LetIn (na, b, u, c), LetIn (_, _, _, t) -> lamprodec_rec (LocalDef (na, b, u) :: l) (n-1) c t
+      | _ -> anomaly (str "decompose_lambda_prod_n_decls: not same form.")
+  in
+  lamprodec_rec Context.Rel.empty n
+
 (** Given a positive integer n, decompose a lambda term [fun
    (x1:T1)..(xn:Tn) => T] (possibly with let-ins before xn) into the pair of the
    abstracted context [(xn,None,Tn);...;(x1,None,T1)] and of the inner body [T]. *)

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -139,6 +139,9 @@ val decompose_lambda_decls : constr -> Constr.rel_context * constr
 (** Idem but extract the first [n] premisses, counting let-ins. *)
 val decompose_prod_n_decls : int -> types -> Constr.rel_context * types
 
+(** Idem but extracting simultaneously the first [n] premisses, counting let-ins, in a term and its type. *)
+val decompose_lambda_prod_n_decls : int -> constr -> types -> Constr.rel_context * constr * types
+
 (** Idem for lambdas, including let-ins but _not_ counting them;
     This is typically the function to use to extract the context of a Fix
     up to and including the decreasing argument, counting as many lambda's

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -23,8 +23,6 @@ open Evarutil
 open Context.Rel.Declaration
 open ComFixpoint
 
-module RelDecl = Context.Rel.Declaration
-
 (* Wellfounded definition *)
 
 open Coqlib
@@ -41,15 +39,6 @@ let mkSubset sigma name typ prop =
 
 let make_qref s = qualid_of_string s
 let lt_ref = make_qref "Init.Peano.lt"
-
-let nf_evar_context sigma ctx =
-  let nf c = Evarutil.nf_evar sigma c in
-  let nfa na = UnivSubst.nf_binder_annot (fun r -> Evarutil.nf_relevance sigma r) na in
-  let map = function
-  | RelDecl.LocalAssum (na, t) -> RelDecl.LocalAssum (nfa na, nf t)
-  | RelDecl.LocalDef (na, c, t) -> RelDecl.LocalDef (nfa na, nf c, nf t)
-  in
-  List.map map ctx
 
 let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typing_flags ?user_warns ?using r measure notations =
   let open EConstr in
@@ -167,8 +156,8 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
   let sigma, def = Typing.solve_evars env sigma def in
   let sigma = Evarutil.nf_evar_map sigma in
   let def = mkApp (def, [|intern_body_lam|]) in
-  let binders_rel = nf_evar_context sigma binders_rel in
-  let binders = nf_evar_context sigma binders in
+  let binders_rel = Evarutil.nf_rel_context_evar sigma binders_rel in
+  let binders = Evarutil.nf_rel_context_evar sigma binders in
   let top_arity = Evarutil.nf_evar sigma top_arity in
   let make = Evarutil.nf_evar sigma make in
   let hook, recname, typ =

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -640,17 +640,6 @@ module Internal = struct
   let set_opacity ~opaque entry =
     { entry with proof_entry_opaque = opaque }
 
-  let rec decompose len c t accu =
-    let open Constr in
-    let open Context.Rel.Declaration in
-    if len = 0 then (c, t, accu)
-    else match kind c, kind t with
-      | Lambda (na, u, c), Prod (_, _, t) ->
-        decompose (pred len) c t (LocalAssum (na, u) :: accu)
-      | LetIn (na, b, u, c), LetIn (_, _, _, t) ->
-        decompose (pred len) c t (LocalDef (na, b, u) :: accu)
-      | _ -> assert false
-
   let rec shrink ctx sign c t accu =
     let open Constr in
     let open Vars in
@@ -677,7 +666,7 @@ module Internal = struct
       | Some t -> t
     in
     let ((body, uctx), eff) = const.proof_entry_body in
-    let (body, typ, ctx) = decompose (List.length sign) body typ [] in
+    let (ctx, body, typ) = Term.decompose_lambda_prod_n_decls (List.length sign) body typ in
     let (body, typ, args) = shrink ctx sign body typ [] in
     { const with
       proof_entry_body = ((body, uctx), eff)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -255,10 +255,7 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
       c
     in
     let nf_rel r = Evarutil.nf_relevance sigma r in
-    let map_decl = function
-    | LocalAssum (na, t) -> LocalAssum (UnivSubst.nf_binder_annot nf_rel na, nf t)
-    | LocalDef (na, c, t) -> LocalDef (UnivSubst.nf_binder_annot nf_rel na, nf c, nf t)
-    in
+    let map_decl = RelDecl.map_constr_het_with_relevance nf_rel nf in
     let newps = List.map map_decl newps in
     let map (implfs, fields) typ =
       let fields = List.map map_decl fields in


### PR DESCRIPTION
We add extra iterators on lists and contexts:
- `List.fold_left4` and `List.fold_left5_map`
- `Context.map_binder_relevance`, `Context.Rel.Declaration.map_constr_with_relevance`, `Context.Rel.Declaration.map_constr_het_with_relevance`,`Context.Rel.map_with_relevance`  (not fully sure about the names, maybe relying on word `annot` would be better?)
- we give a proper status to `decompose_lambda_prod_n_decls` (extracted from `declare.ml`)

This will be useful in particular to clean the executation paths for `CoFixpoint`/`Fixpoint` in #18811.

Following @SkySkimmer, we also include by default `nf_relevance` in `nf_rel_context_evar` and `nf_named_context_evar`.