### PR TITLE
Rename variable to avoid future ocaml reserved keyword [effect].

### DIFF
--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -44,8 +44,8 @@ let effect_table = ref String.Map.empty
 let reduction_effect_hook env sigma con c =
   try
     let funkey = Cmap.find con !constant_effect_table in
-    let effect = String.Map.find funkey !effect_table in
-    effect env sigma (Lazy.force c)
+    let effect_function = String.Map.find funkey !effect_table in
+    effect_function env sigma (Lazy.force c)
   with Not_found -> ()
 
 let cache_reduction_effect (con,funkey) =


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Future versions of Ocaml will include new syntax for effects. 
In particular, "effect" with become a reserved keyword.

This PR renames the only variable called "effect" to "effect_function".

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
