### PR TITLE
Don't make Prop inductives template to control eliminator generation

### DIFF
--- a/dev/ci/user-overlays/18867-SkySkimmer-non-prop-template.sh
+++ b/dev/ci/user-overlays/18867-SkySkimmer-non-prop-template.sh
@@ -1,0 +1,3 @@
+overlay metacoq https://github.com/SkySkimmer/metacoq non-prop-template 18867
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi non-prop-template 18867

--- a/doc/changelog/08-vernac-commands-and-options/18867-non-prop-template.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18867-non-prop-template.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  inductives declared with `: Type` or no annotation and automatically put in `Prop`
+  are not declared template polymorphic
+  (`#18867 <https://github.com/coq/coq/pull/18867>`_,
+  by Gaëtan Gilbert).

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -1010,7 +1010,7 @@ let it_mkNamedProd_wo_LetIn sigma t ctx = List.fold_left (fun c d -> mkNamedProd
 let rec isArity sigma c =
   match kind sigma c with
   | Prod (_,_,c)    -> isArity sigma c
-  | LetIn (_,b,_,c) -> isArity sigma (Vars.subst1 b c)
+  | LetIn (_,_,_,c) -> isArity sigma c
   | Cast (c,_,_)      -> isArity sigma c
   | Sort _          -> true
   | _               -> false

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -304,12 +304,6 @@ let abstract_constructor_type_relatively_to_inductive_types_context ntyps mind t
 
 (* Get type of inductive, with parameters instantiated *)
 
-(* XXX questionable for sort poly inductives *)
-let inductive_sort_family mip =
-  match mip.mind_arity with
-  | RegularArity s -> Sorts.family s.mind_sort
-  | TemplateArity _ -> Sorts.InType
-
 let quality_leq q q' =
   let open Sorts.Quality in
   match q, q' with

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -137,9 +137,6 @@ val build_branches_type :
   pinductive -> mutual_inductive_body * one_inductive_body ->
     constr list -> constr -> types array
 
-(** Return the arity of an inductive type *)
-val inductive_sort_family : one_inductive_body -> Sorts.family
-
 (** Check a [case_info] actually correspond to a Case expression on the
    given inductive type. *)
 val check_case_info : env -> pinductive -> case_info -> unit

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -363,7 +363,7 @@ let mkArity (sign,s) = it_mkProd_or_LetIn (mkSort s) sign
 let rec isArity c =
   match kind c with
   | Prod (_,_,c)    -> isArity c
-  | LetIn (_,b,_,c) -> isArity (subst1 b c)
+  | LetIn (_,_,_,c) -> isArity c
   | Cast (c,_,_)      -> isArity c
   | Sort _          -> true
   | _               -> false

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -605,14 +605,37 @@ let build_case_analysis_scheme env sigma pity dep kind =
   let specif = lookup_mind_specif env (fst pity) in
   mis_make_case_com dep env sigma pity specif kind
 
+let prop_but_default_dependent_elim =
+  Summary.ref ~name:"prop_but_default_dependent_elim" Indset_env.empty
+
+let inPropButDefaultDepElim : inductive -> Libobject.obj =
+  Libobject.declare_object @@
+  Libobject.superglobal_object "prop_but_default_dependent_elim"
+    ~cache:(fun i ->
+        prop_but_default_dependent_elim := Indset_env.add i !prop_but_default_dependent_elim)
+    ~subst:(Some (fun (subst,i) -> Mod_subst.subst_ind subst i))
+    ~discharge:(fun i -> Some i)
+
+let declare_prop_but_default_dependent_elim i =
+  Lib.add_leaf (inPropButDefaultDepElim i)
+
+let is_prop_but_default_dependent_elim i = Indset_env.mem i !prop_but_default_dependent_elim
+
+let pseudo_sort_family_for_elim ind mip =
+  match mip.mind_arity with
+  | RegularArity s when Sorts.is_prop s.mind_sort && is_prop_but_default_dependent_elim ind -> InType
+  | RegularArity s -> Sorts.family s.mind_sort
+  | TemplateArity _ -> InType
+
 let is_in_prop mip =
-  match inductive_sort_family mip with
-  | InProp -> true
-  | _ -> false
+  match mip.mind_arity with
+  | RegularArity s -> Sorts.is_prop s.mind_sort
+  | TemplateArity _ -> false
 
 let default_case_analysis_dependence env ind =
   let _, mip as specif = lookup_mind_specif env ind in
-  not (is_in_prop mip || not (Inductiveops.has_dependent_elim specif))
+  Inductiveops.has_dependent_elim specif
+  && (not (is_in_prop mip) || is_prop_but_default_dependent_elim ind)
 
 let build_case_analysis_scheme_default env sigma pity kind =
   let dep = default_case_analysis_dependence env (fst pity) in

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -70,3 +70,11 @@ val elimination_suffix : Sorts.family -> string
 val make_elimination_ident : Id.t -> Sorts.family -> Id.t
 
 val case_suffix : string
+
+(** Default dependence of eliminations for Prop inductives *)
+
+val declare_prop_but_default_dependent_elim : inductive -> unit
+
+val is_prop_but_default_dependent_elim : inductive -> bool
+
+val pseudo_sort_family_for_elim : inductive -> Declarations.one_inductive_body -> Sorts.family

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -288,9 +288,12 @@ let is_allowed_elimination sigma ((mib,_),_ as specifu) s =
       end
     | Some (SquashToQuality indq) -> quality_leq (EConstr.ESorts.quality sigma s) indq
 
+(* XXX questionable for sort poly inductives *)
 let elim_sort (_,mip) =
   if Option.is_empty mip.mind_squashed then Sorts.InType
-  else Inductive.inductive_sort_family mip
+  else match mip.mind_arity with
+    | TemplateArity _ -> assert false (* never squashed *)
+    | RegularArity s -> Sorts.family s.mind_sort
 
 let top_allowed_sort env (kn,i as ind) =
   let specif = Inductive.lookup_mind_specif env ind in

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -200,7 +200,7 @@ let build_sym_scheme env _handle ind =
     get_sym_eq_data env indu in
   let cstr n =
     mkApp (mkConstructUi(indu,1),Context.Rel.instance mkRel n mib.mind_params_ctxt) in
-  let inds = inductive_sort_family mip in
+  let inds = Indrec.pseudo_sort_family_for_elim ind mip in
   let varH,_ = fresh env (default_id_of_sort inds) Id.Set.empty in
   let applied_ind = build_dependent_inductive indu specif in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
@@ -263,7 +263,7 @@ let build_sym_involutive_scheme env handle ind =
   let eq,eqrefl,ctx = get_coq_eq env ctx in
   let sym, ctx = const_of_scheme sym_scheme_kind env handle ind ctx in
   let cstr n = mkApp (mkConstructUi (indu,1),Context.Rel.instance mkRel n paramsctxt) in
-  let inds = inductive_sort_family mip in
+  let inds = Indrec.pseudo_sort_family_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,_ = fresh env (default_id_of_sort inds) Id.Set.empty in
   let applied_ind = build_dependent_inductive indu specif in
@@ -379,7 +379,7 @@ let build_l2r_rew_scheme dep env handle ind kind =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.instance mkRel n paramsctxt1;
                     rel_vect p nrealargs]) in
-  let inds = inductive_sort_family mip in
+  let inds = Indrec.pseudo_sort_family_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
@@ -497,7 +497,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.instance mkRel n paramsctxt1;
                     rel_vect p nrealargs]) in
-  let inds = inductive_sort_family mip in
+  let inds = Indrec.pseudo_sort_family_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
@@ -592,7 +592,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
   let cstr n =
     mkApp (mkConstructUi(indu,1),Context.Rel.instance mkRel n mib.mind_params_ctxt) in
   let constrargs_cstr = constrargs@[cstr 0] in
-  let inds = inductive_sort_family mip in
+  let inds = Indrec.pseudo_sort_family_for_elim ind mip in
   let indr = Sorts.relevance_of_sort_family inds in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -593,7 +593,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
     mkApp (mkConstructUi(indu,1),Context.Rel.instance mkRel n mib.mind_params_ctxt) in
   let constrargs_cstr = constrargs@[cstr 0] in
   let inds = Indrec.pseudo_sort_family_for_elim ind mip in
-  let indr = Sorts.relevance_of_sort_family inds in
+  let indr = Inductive.relevance_of_ind_body mip u in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
   let varP,_ = fresh env (Id.of_string "P") avoid in

--- a/test-suite/output/PrimitiveProjectionsAttribute_Records.out
+++ b/test-suite/output/PrimitiveProjectionsAttribute_Records.out
@@ -11,5 +11,6 @@ Expands to: Inductive PrimitiveProjectionsAttribute_Records.C
 G : Prop
 
 G is not universe polymorphic
+G is in Prop but its eliminators are declared dependent by default
 G has primitive projections without eta conversion.
 Expands to: Inductive PrimitiveProjectionsAttribute_Records.G

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -417,7 +417,7 @@ let warn_no_template_universe =
   CWarnings.create ~name:"no-template-universe"
     (fun () -> Pp.str "This inductive type has no template universes.")
 
-let compute_template_inductive ~user_template ~env_ar_params ~ctx_params ~univ_entry entry concl =
+let compute_template_inductive ~user_template ~ctx_params ~univ_entry entry concl =
 match user_template, univ_entry with
 | Some false, UState.Monomorphic_entry uctx ->
   Monomorphic_ind_entry, uctx
@@ -437,7 +437,7 @@ match user_template, univ_entry with
       arity, but inference has decided to lower it to Prop. *)
   let lowered_prop =
     if Term.isArity entry.mind_entry_arity then
-      let (_, s) = Reduction.dest_arity env_ar_params entry.mind_entry_arity in
+      let (_, s) = Term.destArity entry.mind_entry_arity in
       if Sorts.is_prop s then match concl with
       | None | Some (Type _ | Set) -> true
       | Some Prop -> false
@@ -521,7 +521,7 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
   in
   let univ_entry, ctx = match entries, arityconcl with
   | [entry], [concl] ->
-    compute_template_inductive ~user_template:template ~env_ar_params ~ctx_params ~univ_entry entry concl
+    compute_template_inductive ~user_template:template ~ctx_params ~univ_entry entry concl
   | _ ->
     let () = match template with
     | Some true -> user_err Pp.(str "Template-polymorphism not allowed with mutual inductives.")

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -120,6 +120,8 @@ let rec make_anonymous_conclusion_flexible ind =
     end
   | _ -> None
 
+type syntax_allows_template_poly = SyntaxAllowsTemplatePoly | SyntaxNoTemplatePoly
+
 let intern_ind_arity env sigma ind =
   let c = intern_gen IsType env sigma ind.ind_arity in
   let impls = Implicit_quantifiers.implicits_of_glob_constr ~with_products:true c in
@@ -127,16 +129,16 @@ let intern_ind_arity env sigma ind =
     | None -> check_type_conclusion c, c
     | Some c -> true, c
   in
-  (constr_loc ind.ind_arity, c, impls, pseudo_poly)
+  let template_syntax = if pseudo_poly then SyntaxAllowsTemplatePoly else SyntaxNoTemplatePoly in
+  (constr_loc ind.ind_arity, c, impls, template_syntax)
 
-let pretype_ind_arity env sigma (loc, c, impls, pseudo_poly) =
+let pretype_ind_arity env sigma (loc, c, impls, template_syntax) =
   let sigma,t = understand_tcc env sigma ~expected_type:IsType c in
   match Reductionops.sort_of_arity env sigma t with
   | exception Reduction.NotArity ->
     user_err ?loc (str "Not an arity")
   | s ->
-    let concl = if pseudo_poly then Some s else None in
-    sigma, (t, Retyping.relevance_of_sort sigma s, concl, impls)
+    sigma, (t, Retyping.relevance_of_sort sigma s, template_syntax, impls)
 
 (* ind_rel is the Rel for this inductive in the context without params.
    n is how many arguments there are in the constructor. *)
@@ -381,24 +383,27 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt u =
   let univs = Univ.Level.Set.filter (fun l -> check_level l) univs in
   univs
 
-let template_polymorphism_candidate uctx params entry concl = match concl with
-| None -> Univ.Level.Set.empty
-| Some (Set | SProp | Prop) -> Univ.Level.Set.empty
-| Some (Type u) ->
-  let ctor_levels =
-    let add_levels c levels = Univ.Level.Set.union levels (CVars.universes_of_constr c) in
-    let param_levels =
-      List.fold_left (fun levels d -> match d with
-          | LocalAssum _ -> levels
-          | LocalDef (_,b,t) -> add_levels b (add_levels t levels))
-        Univ.Level.Set.empty params
+let template_polymorphism_candidate uctx params entry template_syntax = match template_syntax with
+| SyntaxNoTemplatePoly -> Univ.Level.Set.empty
+| SyntaxAllowsTemplatePoly ->
+  let _, concl = Term.destArity entry.mind_entry_arity in
+  match concl with
+  | Set | SProp | Prop -> Univ.Level.Set.empty
+  | Type u ->
+    let ctor_levels =
+      let add_levels c levels = Univ.Level.Set.union levels (CVars.universes_of_constr c) in
+      let param_levels =
+        List.fold_left (fun levels d -> match d with
+            | LocalAssum _ -> levels
+            | LocalDef (_,b,t) -> add_levels b (add_levels t levels))
+          Univ.Level.Set.empty params
+      in
+      List.fold_left (fun levels c -> add_levels c levels)
+        param_levels entry.mind_entry_lc
     in
-    List.fold_left (fun levels c -> add_levels c levels)
-      param_levels entry.mind_entry_lc
-  in
-  let univs = template_polymorphic_univs ~ctor_levels uctx params u in
-  univs
-| Some (QSort _) -> assert false
+    let univs = template_polymorphic_univs ~ctor_levels uctx params u in
+    univs
+  | QSort _ -> assert false
 
 let split_universe_context subset (univs, csts) =
   let subfilter (l, _, r) =
@@ -417,14 +422,14 @@ let warn_no_template_universe =
   CWarnings.create ~name:"no-template-universe"
     (fun () -> Pp.str "This inductive type has no template universes.")
 
-let compute_template_inductive ~user_template ~ctx_params ~univ_entry entry concl =
+let compute_template_inductive ~user_template ~ctx_params ~univ_entry entry template_syntax =
 match user_template, univ_entry with
 | Some false, UState.Monomorphic_entry uctx ->
   Monomorphic_ind_entry, uctx
 | Some false, UState.Polymorphic_entry uctx ->
   Polymorphic_ind_entry uctx, Univ.ContextSet.empty
 | Some true, UState.Monomorphic_entry uctx ->
-  let template_universes = template_polymorphism_candidate uctx ctx_params entry concl in
+  let template_universes = template_polymorphism_candidate uctx ctx_params entry template_syntax in
   let template, global = split_universe_context template_universes uctx in
   let () = if Univ.Level.Set.is_empty (fst template) then warn_no_template_universe () in
   Template_ind_entry template, global
@@ -433,29 +438,13 @@ match user_template, univ_entry with
 | None, UState.Polymorphic_entry uctx ->
   Polymorphic_ind_entry uctx, Univ.ContextSet.empty
 | None, UState.Monomorphic_entry uctx ->
-  (* Heuristic: the user has not written Prop explicitly in the return
-      arity, but inference has decided to lower it to Prop. *)
-  let lowered_prop =
-    if Term.isArity entry.mind_entry_arity then
-      let (_, s) = Term.destArity entry.mind_entry_arity in
-      if Sorts.is_prop s then match concl with
-      | None | Some (Type _ | Set) -> true
-      | Some Prop -> false
-      | Some SProp | Some (QSort _) -> assert false
-      else false
-    else false
-  in
-  if lowered_prop then
-    (* here concl = Type@{u} so can't yet remove this branch *)
-    Monomorphic_ind_entry, uctx
-  else
-    let template_candidate = template_polymorphism_candidate uctx ctx_params entry concl in
-    let has_template = not @@ Univ.Level.Set.is_empty template_candidate in
-    let template = should_auto_template entry.mind_entry_typename has_template in
-    if template then
-      let template, global = split_universe_context template_candidate uctx in
-      Template_ind_entry template, global
-    else Monomorphic_ind_entry, uctx
+  let template_candidate = template_polymorphism_candidate uctx ctx_params entry template_syntax in
+  let has_template = not @@ Univ.Level.Set.is_empty template_candidate in
+  let template = should_auto_template entry.mind_entry_typename has_template in
+  if template then
+    let template, global = split_universe_context template_candidate uctx in
+    Template_ind_entry template, global
+  else Monomorphic_ind_entry, uctx
 
 let check_param = function
 | CLocalDef (na, _, _, _) -> check_named na
@@ -492,7 +481,7 @@ let variance_of_entry ~cumulative ~variances uctx =
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 
-let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities ~arityconcl ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
+let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
   (* Compute renewed arities *)
   let ctor_args =  List.map (fun (_,tys) ->
       List.map (fun ty ->
@@ -506,7 +495,6 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
   let arities = List.map EConstr.(to_constr sigma) arities in
   let constructors = List.map (on_snd (List.map (EConstr.to_constr sigma))) constructors in
   let ctx_params = List.map (fun d -> EConstr.to_rel_decl sigma d) ctx_params in
-  let arityconcl = List.map (Option.map (fun s -> ESorts.kind sigma s)) arityconcl in
   let sigma = restrict_inductive_universes sigma ctx_params arities constructors in
   let univ_entry, binders = Evd.check_univ_decl ~poly sigma udecl in
 
@@ -519,9 +507,9 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
       })
       indnames arities constructors
   in
-  let univ_entry, ctx = match entries, arityconcl with
-  | [entry], [concl] ->
-    compute_template_inductive ~user_template:template ~ctx_params ~univ_entry entry concl
+  let univ_entry, ctx = match entries, template_syntax with
+  | [entry], [template_syntax] ->
+    compute_template_inductive ~user_template:template ~ctx_params ~univ_entry entry template_syntax
   | _ ->
     let () = match template with
     | Some true -> user_err Pp.(str "Template-polymorphism not allowed with mutual inductives.")
@@ -603,7 +591,7 @@ let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) not
   let arities = List.map (intern_ind_arity env_params sigma) indl in
 
   let sigma, arities = List.fold_left_map (pretype_ind_arity env_params) sigma arities in
-  let arities, relevances, arityconcl, indimpls = List.split4 arities in
+  let arities, relevances, template_syntax, indimpls = List.split4 arities in
 
   let lift_ctx n ctx =
     let t = EConstr.it_mkProd_or_LetIn EConstr.mkProp ctx in
@@ -673,7 +661,7 @@ let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) not
             userimpls @ impls) cimpls)
       indimpls cimpls
   in
-  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~template ~sigma ~ctx_params ~udecl ~variances ~arities ~arityconcl ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
+  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~template ~sigma ~ctx_params ~udecl ~variances ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
   (default_dep_elim, mie, binders, impls, ctx)
 
 

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -46,7 +46,7 @@ module Mind_decl : sig
 (** inductive_expr at the constr level *)
 type t = {
   mie : Entries.mutual_inductive_entry;
-  default_dep_elim : DeclareInd.default_dep_elim;
+  default_dep_elim : DeclareInd.default_dep_elim list;
   nuparams : int option;
   univ_binders : UnivNames.universe_binders;
   implicits : DeclareInd.one_inductive_impls list;
@@ -90,7 +90,7 @@ val interp_mutual_inductive_constr
   -> poly:bool
   -> private_ind:bool
   -> finite:Declarations.recursivity_kind
-  -> DeclareInd.default_dep_elim * Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
+  -> DeclareInd.default_dep_elim list * Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
 
 (************************************************************************)
 (** Internal API, exported for Record                                   *)
@@ -103,7 +103,7 @@ val compute_template_inductive
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry
   -> Sorts.t option
-  -> DeclareInd.default_dep_elim * Entries.inductive_universes_entry * Univ.ContextSet.t
+  -> Entries.inductive_universes_entry * Univ.ContextSet.t
 (** [compute_template_inductive] computes whether an inductive can be template
     polymorphic. *)
 
@@ -134,5 +134,5 @@ sig
     (* arities *)
     -> EConstr.rel_context list list
     (* constructors *)
-    -> Evd.evar_map * EConstr.t list
+    -> Evd.evar_map * (DeclareInd.default_dep_elim list * EConstr.t list)
 end

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -98,7 +98,6 @@ val interp_mutual_inductive_constr
 
 val compute_template_inductive
   : user_template:bool option
-  -> env_ar_params:Environ.env
   -> ctx_params:(Constr.constr, Constr.constr) Context.Rel.Declaration.pt list
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -72,6 +72,8 @@ val interp_mutual_inductive
   -> Declarations.recursivity_kind
   -> Mind_decl.t
 
+type syntax_allows_template_poly = SyntaxAllowsTemplatePoly | SyntaxNoTemplatePoly
+
 (** the post-elaboration part of interp_mutual_inductive, mainly dealing with
     universe levels *)
 val interp_mutual_inductive_constr
@@ -82,7 +84,7 @@ val interp_mutual_inductive_constr
   -> ctx_params:(EConstr.t, EConstr.t) Context.Rel.Declaration.pt list
   -> indnames:Names.Id.t list
   -> arities:EConstr.t list
-  -> arityconcl:EConstr.ESorts.t option list
+  -> template_syntax:syntax_allows_template_poly list
   -> constructors:(Names.Id.t list * EConstr.constr list) list
   -> env_ar_params:Environ.env
   (** Environment with the inductives and parameters in the rel_context *)
@@ -101,7 +103,7 @@ val compute_template_inductive
   -> ctx_params:(Constr.constr, Constr.constr) Context.Rel.Declaration.pt list
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry
-  -> Sorts.t option
+  -> syntax_allows_template_poly
   -> Entries.inductive_universes_entry * Univ.ContextSet.t
 (** [compute_template_inductive] computes whether an inductive can be template
     polymorphic. *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -46,6 +46,7 @@ module Mind_decl : sig
 (** inductive_expr at the constr level *)
 type t = {
   mie : Entries.mutual_inductive_entry;
+  default_dep_elim : DeclareInd.default_dep_elim;
   nuparams : int option;
   univ_binders : UnivNames.universe_binders;
   implicits : DeclareInd.one_inductive_impls list;
@@ -89,7 +90,7 @@ val interp_mutual_inductive_constr
   -> poly:bool
   -> private_ind:bool
   -> finite:Declarations.recursivity_kind
-  -> Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
+  -> DeclareInd.default_dep_elim * Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
 
 (************************************************************************)
 (** Internal API, exported for Record                                   *)
@@ -102,7 +103,7 @@ val compute_template_inductive
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry
   -> Sorts.t option
-  -> Entries.inductive_universes_entry * Univ.ContextSet.t
+  -> DeclareInd.default_dep_elim * Entries.inductive_universes_entry * Univ.ContextSet.t
 (** [compute_template_inductive] computes whether an inductive can be template
     polymorphic. *)
 

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -147,7 +147,7 @@ type one_inductive_impls =
 
 type default_dep_elim = DefaultElim | PropButDepElim
 
-let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags ?(indlocs=[]) ?(default_dep_elim=DefaultElim) mie ubinders impls =
+let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags ?(indlocs=[]) ?default_dep_elim mie ubinders impls =
   (* spiwack: raises an error if the structure is supposed to be non-recursive,
         but isn't *)
   begin match mie.mind_entry_finite with
@@ -179,13 +179,15 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
         constrimpls)
     impls;
   let () = match default_dep_elim with
-    | DefaultElim -> ()
-    | PropButDepElim ->
-      List.iteri (fun i _ ->
-          (* XXX maybe the API should have a default_dep_elim per inductive
-             instead of for the whole block *)
-          Indrec.declare_prop_but_default_dependent_elim (mind,i))
-        mie.mind_entry_inds
+    | None -> ()
+    | Some defaults ->
+      List.iteri (fun i -> function
+          | DefaultElim -> ()
+          | PropButDepElim ->
+            (* XXX maybe the API should have a default_dep_elim per inductive
+               instead of for the whole block *)
+            Indrec.declare_prop_but_default_dependent_elim (mind,i))
+        defaults
   in
   Flags.if_verbose Feedback.msg_info (minductive_message names);
   let locmap = Ind_tables.Locmap.make mind indlocs in

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -145,7 +145,9 @@ type one_inductive_impls =
   Impargs.manual_implicits (* for inds *) *
   Impargs.manual_implicits list (* for constrs *)
 
-let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags ?(indlocs=[]) mie ubinders impls =
+type default_dep_elim = DefaultElim | PropButDepElim
+
+let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typing_flags ?(indlocs=[]) ?(default_dep_elim=DefaultElim) mie ubinders impls =
   (* spiwack: raises an error if the structure is supposed to be non-recursive,
         but isn't *)
   begin match mie.mind_entry_finite with
@@ -176,6 +178,15 @@ let declare_mutual_inductive_with_eliminations ?(primitive_expected=false) ?typi
              (GlobRef.ConstructRef (ind, succ j)) impls)
         constrimpls)
     impls;
+  let () = match default_dep_elim with
+    | DefaultElim -> ()
+    | PropButDepElim ->
+      List.iteri (fun i _ ->
+          (* XXX maybe the API should have a default_dep_elim per inductive
+             instead of for the whole block *)
+          Indrec.declare_prop_but_default_dependent_elim (mind,i))
+        mie.mind_entry_inds
+  in
   Flags.if_verbose Feedback.msg_info (minductive_message names);
   let locmap = Ind_tables.Locmap.make mind indlocs in
   if mie.mind_entry_private == None

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -15,10 +15,13 @@ type one_inductive_impls =
   Impargs.manual_implicits (* for inds *) *
   Impargs.manual_implicits list (* for constrs *)
 
+type default_dep_elim = DefaultElim | PropButDepElim
+
 val declare_mutual_inductive_with_eliminations
   : ?primitive_expected:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?indlocs:Loc.t option list (* Inductive type locs, for .glob *)
+  -> ?default_dep_elim:default_dep_elim
   -> Entries.mutual_inductive_entry (* Inductive types declaration *)
   -> UState.named_universes_entry
   -> one_inductive_impls list (* Implicit arguments *)

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -21,7 +21,7 @@ val declare_mutual_inductive_with_eliminations
   : ?primitive_expected:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?indlocs:Loc.t option list (* Inductive type locs, for .glob *)
-  -> ?default_dep_elim:default_dep_elim
+  -> ?default_dep_elim:default_dep_elim list
   -> Entries.mutual_inductive_entry (* Inductive types declaration *)
   -> UState.named_universes_entry
   -> one_inductive_impls list (* Implicit arguments *)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -198,7 +198,7 @@ let declare_beq_scheme ?locmap mi = declare_beq_scheme_with ?locmap [] mi
 (* Case analysis schemes *)
 let declare_one_case_analysis_scheme ?loc ind =
   let (mib, mip) as specif = Global.lookup_inductive ind in
-  let kind = Inductive.inductive_sort_family mip in
+  let kind = Indrec.pseudo_sort_family_for_elim ind mip in
   let dep, suff =
     if kind == InProp then case_nodep, Some "case"
     else if not (Inductiveops.has_dependent_elim specif) then
@@ -221,7 +221,7 @@ let declare_one_case_analysis_scheme ?loc ind =
 
 let declare_one_induction_scheme ?loc ind =
   let (mib,mip) as specif = Global.lookup_inductive ind in
-  let kind = Inductive.inductive_sort_family mip in
+  let kind = Indrec.pseudo_sort_family_for_elim ind mip in
   let from_prop = kind == InProp in
   let depelim = Inductiveops.has_dependent_elim specif in
   let kelim = Inductiveops.sorts_below (Inductiveops.elim_sort (mib,mip)) in
@@ -373,7 +373,7 @@ let rec name_and_process_schemes env l =
 (* If no name has been provided, we build one from the types of the ind requested *)
   | (None, ({sch_type; sch_qualid; sch_sort} as sch)) :: q
    -> let ind = smart_ind sch_qualid in
-      let sort_of_ind = Inductive.inductive_sort_family (snd (Inductive.lookup_mind_specif env ind)) in
+      let sort_of_ind = Indrec.pseudo_sort_family_for_elim ind (snd (Inductive.lookup_mind_specif env ind)) in
       let suffix = scheme_suffix_gen sch sort_of_ind in
       let newid = Nameops.add_suffix (Nametab.basename_of_global (Names.GlobRef.IndRef ind)) suffix in
       let newref = CAst.make newid in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -208,6 +208,14 @@ let print_polymorphism env ref =
          ++ if !Detyping.print_universes then h (pr_template_variables template_variables) else mt()
        else str "not universe polymorphic") ]
 
+let print_prop_but_default_dep_elim ref =
+  match ref with
+  | GlobRef.IndRef ind ->
+    if Indrec.is_prop_but_default_dependent_elim ind
+    then [pr_global ref ++ str " is in Prop but its eliminators are declared dependent by default"]
+    else []
+  | _ -> []
+
 (** Print projection status *)
 
 let print_projection env ref =
@@ -396,6 +404,7 @@ let print_name_infos env ref =
     else
       [] in
   print_type_in_type env ref @
+  print_prop_but_default_dep_elim ref @
   print_projection env ref @
   print_primitive env ref @
   type_info_for_implicit @

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -795,7 +795,7 @@ let interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj i
     let env_ar_params = Environ.push_rel_context params (Global.env ()) in
     let concl = Some (snd (Reduction.dest_arity env_ar_params data.rdata.arity)) in
     ComInductive.compute_template_inductive ~user_template:template
-      ~env_ar_params ~ctx_params:params ~univ_entry:univs entry concl
+      ~ctx_params:params ~univ_entry:univs entry concl
   | _ ->
     begin match template with
     | Some true -> user_err Pp.(str "Template-polymorphism not allowed with mutual records.")

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -792,10 +792,9 @@ let interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj i
   let blocks = List.mapi mk_block data in
   let ind_univs, global_univ_decls = match blocks, data with
   | [entry], [data] ->
-    let env_ar_params = Environ.push_rel_context params (Global.env ()) in
-    let concl = Some (snd (Reduction.dest_arity env_ar_params data.rdata.arity)) in
     ComInductive.compute_template_inductive ~user_template:template
-      ~ctx_params:params ~univ_entry:univs entry concl
+      ~ctx_params:params ~univ_entry:univs entry
+      (if Term.isArity entry.mind_entry_arity then SyntaxAllowsTemplatePoly else SyntaxNoTemplatePoly)
   | _ ->
     begin match template with
     | Some true -> user_err Pp.(str "Template-polymorphism not allowed with mutual records.")

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -60,6 +60,7 @@ val definition_structure
   module Record_decl : sig
     type t = {
       mie : Entries.mutual_inductive_entry;
+      default_dep_elim : DeclareInd.default_dep_elim;
       records : Data.t list;
       (* TODO: this part could be factored in mie *)
       primitive_proj : bool;

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -60,7 +60,7 @@ val definition_structure
   module Record_decl : sig
     type t = {
       mie : Entries.mutual_inductive_entry;
-      default_dep_elim : DeclareInd.default_dep_elim;
+      default_dep_elim : DeclareInd.default_dep_elim list;
       records : Data.t list;
       (* TODO: this part could be factored in mie *)
       primitive_proj : bool;


### PR DESCRIPTION
Instead we register those Prop inductives which should have dependent eliminators in a table.

Next:
- ~separate the code from compute_template_inductive~ done
- provide a way for users to declare explicit Prop inductives with default dependent elim (eg `#[dep_elim] Inductive foo : Prop := .` and/or some option)
- stop automatically putting inductives in Prop when declared with explicit Type (with deprecation phase)

Overlays:
- https://github.com/MetaCoq/metacoq/pull/1073
- https://github.com/LPCIC/coq-elpi/pull/617