### PR TITLE
Move from deprecated find_reference to lib_ref in the plugin tutorial

### DIFF
--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -1,8 +1,6 @@
 open Pp
 open Context
 
-let find_reference = Coqlib.find_reference [@ocaml.warning "-3"]
-
 let example_sort sigma =
 (* creating a new sort requires that universes should be recorded
   in the evd datastructure, so this datastructure also needs to be
@@ -14,11 +12,9 @@ let example_sort sigma =
 let c_one env sigma =
 (* In the general case, global references may refer to universe polymorphic
    objects, and their universe has to be made afresh when creating an instance. *)
-  let gr_S =
-    find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
-(* the long name of "S" was found with the command "About S." *)
-  let gr_O =
-    find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
+  let gr_S = Coqlib.lib_ref "num.nat.S" in
+  (* the long name of "S" was found with the command "Print Registered." *)
+  let gr_O = Coqlib.lib_ref "num.nat.O" in
   let sigma, c_O = Evd.fresh_global env sigma gr_O in
   let sigma, c_S = Evd.fresh_global env sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
@@ -66,43 +62,43 @@ let example_sort_app_lambda () =
 
 
 let c_S env sigma =
-  let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
+  let gr = Coqlib.lib_ref "num.nat.S" in
   Evd.fresh_global env sigma gr
 
 let c_O env sigma =
-  let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
+  let gr = Coqlib.lib_ref "num.nat.O" in
   Evd.fresh_global env sigma gr
 
 let c_E env sigma =
-  let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
+  let gr = Coqlib.lib_ref "Tuto3.EvenNat" in
   Evd.fresh_global env sigma gr
 
 let c_D env sigma =
-  let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
+  let gr = Coqlib.lib_ref "Tuto3.tuto_div2" in
   Evd.fresh_global env sigma gr
 
 let c_Q env sigma =
-  let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
+  let gr = Coqlib.lib_ref "core.eq.type" in
   Evd.fresh_global env sigma gr
 
 let c_R env sigma =
-  let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
+  let gr = Coqlib.lib_ref "core.eq.eq_refl" in
   Evd.fresh_global env sigma gr
 
 let c_N env sigma =
-  let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
+  let gr = Coqlib.lib_ref "num.nat.type" in
   Evd.fresh_global env sigma gr
 
 let c_C env sigma =
-  let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
+  let gr = Coqlib.lib_ref "Tuto3.C" in
   Evd.fresh_global env sigma gr
 
 let c_F env sigma =
-  let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
+  let gr = Coqlib.lib_ref "Tuto3.S_ev" in
   Evd.fresh_global env sigma gr
 
 let c_P env sigma =
-  let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
+  let gr = Coqlib.lib_ref "Tuto3.s_half_proof" in
   Evd.fresh_global env sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant

--- a/doc/plugin_tutorial/tuto3/theories/Data.v
+++ b/doc/plugin_tutorial/tuto3/theories/Data.v
@@ -16,6 +16,7 @@ Notation "!!!" := (pack _) (at level 0, only printing).
 Class EvenNat the_even := {half : nat; half_prop : 2 * half = the_even}.
 
 #[export] Instance EvenNat0 : EvenNat 0 := {half := 0; half_prop := eq_refl}.
+Register EvenNat as Tuto3.EvenNat.
 
 Lemma even_rec n h : 2 * h = n -> 2 * S h = S (S n).
 Proof.
@@ -28,6 +29,7 @@ Qed.
  {half := S (@half _ p); half_prop := even_rec n (@half _ p) (@half_prop _ p)}.
 
 Definition tuto_div2 n (p : EvenNat n) := @half _ p.
+Register tuto_div2 as Tuto3.tuto_div2.
 
 (* to be used in the following examples
 Compute (@half 8 _).
@@ -42,9 +44,11 @@ and in command Tuto3_3 8. *)
   based on canonical structures. *)
 
 Record S_ev n := Build_S_ev {double_of : nat; _ : 2 * n = double_of}.
+Register S_ev as Tuto3.S_ev.
 
 Definition s_half_proof n (r : S_ev n) : 2 * n = double_of n r :=
   match r with Build_S_ev _ _ h => h end.
+Register s_half_proof as Tuto3.s_half_proof.
 
 Canonical Structure can_ev_default n d (Pd : 2 * n = d) : S_ev n :=
   Build_S_ev n d Pd.
@@ -63,6 +67,7 @@ Canonical Structure can_ev_rec.
 
 Record cmp (n : nat) (k : nat) :=
   C {h : S_ev k; _ : double_of k h = n}.
+Register C as Tuto3.C.
 
 (* To be used in, e.g.,
 


### PR DESCRIPTION
I noticed tuto3 was using find_reference, which is marked as deprecated in favor of lib_ref.