### PR TITLE
Make the usage of Ftactic in Tacinterp more consistent

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1088,9 +1088,8 @@ let rec val_interp_f ist ?(appl=UnnamedAppl) (tac:glob_tactic_expr) : Val.t Ftac
      [VFun]. Otherwise a [Ltac t := let x := .. in tac] would never
      register its name since it is syntactically a let, not a
      function.  *)
-  let (loc,tac2) = CAst.(tac.loc, tac.v) in
   let aux ist =
-  match tac2 with
+  match tac.v with
   | TacFun (it, body) ->
     Ftactic.return (of_tacvalue (VFun (UnnamedAppl, extract_trace ist, extract_loc ist, ist.lfun, it, body)))
   | TacLetIn (true,l,u) -> interp_letrec ist l u
@@ -1122,8 +1121,8 @@ and interp_tactic ist tac : unit Proofview.tactic =
   val_interp ist tac (fun v -> tactic_of_value ist v)
 
 and eval_tactic_ist ist tac : unit Proofview.tactic =
-  let (loc, tac2) = CAst.(tac.loc, tac.v) in
-  match tac2 with
+  let loc = tac.loc in
+  match tac.v with
   | TacAtom t ->
       let call = LtacAtomCall t in
       let (stack, _) = push_trace(loc,call) ist in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -173,7 +173,7 @@ let ensure_loc loc ist =
     | None -> { ist with extra = TacStore.set ist.extra f_loc loc }
     | Some _ -> ist
 
-let print_top_val env v = Pptactic.pr_value Pptactic.ltop v
+let print_top_val v = Pptactic.pr_value Pptactic.ltop v
 
 let catching_error call_trace fail (e, info) =
   let inner_trace =
@@ -1207,7 +1207,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       in
       let tac =
         Ftactic.with_env interp_vars >>= fun (env, lr) ->
-        let name () = Pptactic.pr_alias (fun v -> print_top_val env v) 0 s lr in
+        let name () = Pptactic.pr_alias print_top_val 0 s lr in
         Proofview.Trace.name_tactic name (tac lr)
       (* spiwack: this use of name_tactic is not robust to a
          change of implementation of [Ftactic]. In such a situation,
@@ -1231,7 +1231,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       let tac = Tacenv.interp_ml_tactic opn in
       let args = Ftactic.List.map_right (fun a -> interp_tacarg ist a) l in
       let tac args =
-        let name () = Pptactic.pr_extend (fun v -> print_top_val () v) 0 opn args in
+        let name () = Pptactic.pr_extend print_top_val 0 opn args in
         let (stack, _) = trace in
         Proofview.Trace.name_tactic name (catch_error_tac_loc loc stack (tac args ist))
       in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1123,8 +1123,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
   let loc = tac.loc in
   match tac.v with
   | TacAtom t ->
-      let call = LtacAtomCall t in
-      let (stack, _) = push_trace(loc,call) ist in
+      let (stack, _) = push_trace (loc, LtacAtomCall t) ist in
       do_profile stack
         (catch_error_tac_loc loc stack (interp_atomic ist t))
   | TacFun _ | TacLetIn _ | TacMatchGoal _ | TacMatch _ -> interp_tactic ist tac
@@ -1149,8 +1148,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       interp_message ist s k
   | TacProgress tac -> Tacticals.tclPROGRESS (interp_tactic ist tac)
   | TacAbstract (t,ido) ->
-      let call = LtacMLCall tac in
-      let (stack,_) = push_trace(None,call) ist in
+      let (stack, _) = push_trace (None, LtacMLCall tac) ist in
       do_profile stack
         (catch_error_tac stack begin
       Proofview.Goal.enter begin fun gl -> Abstract.tclABSTRACT
@@ -1263,9 +1261,8 @@ and interp_ltac_reference ?loc' mustbetac ist r : Val.t Ftactic.t =
   | ArgArg (loc,r) ->
       Proofview.tclProofInfo [@ocaml.warning "-3"] >>= fun (_name, poly) ->
       let ids = extract_ids [] ist.lfun Id.Set.empty in
-      let loc_info = (Option.default loc loc',LtacNameCall r) in
       let extra = TacStore.set ist.extra f_avoid_ids ids in
-      let trace = push_trace loc_info ist in
+      let trace = push_trace (Option.default loc loc', LtacNameCall r) ist in
       let extra = TacStore.set extra f_trace trace in
       let ist = { lfun = Id.Map.empty; poly; extra } in
       let appl = GlbAppl[r,[]] in


### PR DESCRIPTION
This file uses a lot shadowing, which makes it hard to understand.

Suffix top-level functions that return `_ Ftactic.t` with "_ftactic" instead of using shadowing (this way the external interface is preserved).

Also clean up control flow and local shadowing in `eval_tactic_ist`, `interp_tacarg_ftactic` and `interp_message_ftactic`.

Make the usage of `Ftactic.bind` consistent, factorize the usage of `Ftactic.run` as much as possible.