### PR TITLE
Fixes #3889: anomaly instead of error when no more obligation of some name are pending

### DIFF
--- a/test-suite/bugs/bug_3889.v
+++ b/test-suite/bugs/bug_3889.v
@@ -1,0 +1,15 @@
+Require Import Program.
+
+Inductive Even : nat -> Prop :=
+| evenO : Even O
+| evenS : forall n, Odd n -> Even (S n)
+with Odd : nat -> Prop :=
+| oddS : forall n, Even n -> Odd (S n).
+Axiom admit : forall {T}, T.
+Program Fixpoint doubleE {n} (e : Even n) : Even (2 * n)
+  := admit
+with doubleO {n} (o : Odd n) : Odd (S (2 * n))
+     := _.
+Fail Next Obligation of doubleE.
+Next Obligation.
+Admitted.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2684,7 +2684,10 @@ let next_obligation ~pm ?(final=false) n tac =
   let is_open _ x = Option.is_empty x.obl_body && List.is_empty (deps_remaining obls x.obl_deps) in
   let i = match Array.findi is_open obls with
     | Some i -> i
-    | None -> CErrors.anomaly (Pp.str "Could not find a solvable obligation.")
+    | None ->
+      match n with
+      | None -> CErrors.anomaly (Pp.str "Could not find a solvable obligation.")
+      | Some n -> CErrors.user_err (str "No more obligations for " ++ Id.print n ++ str ".")
   in
   let check_final = if not final then None
     else match n with


### PR DESCRIPTION
Fixes / closes #3889 

Additionally, we improve the message used to check that all pending obligations are solved.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
