### PR TITLE
Ignore universes of inlined side effects in build_by_tactic

### DIFF
--- a/test-suite/bugs/bug_13271.v
+++ b/test-suite/bugs/bug_13271.v
@@ -1,0 +1,19 @@
+Require Program.Tactics.
+
+Definition PeanoWithMax (maxValue : nat) : Set := { value : nat | value <= maxValue }.
+
+Polymorphic Definition NonEmptyList (elementType : Type) : Type :=
+  { list : list elementType | list <> nil }.
+
+Axiom n : nat.
+Axiom ListFromPeano : forall (value : nat), list (PeanoWithMax n).
+
+Polymorphic Program Definition FromPeano (value : nat) : NonEmptyList (PeanoWithMax n) :=
+  match value with
+  | 0 => exist _ (cons (exist _ 0 _) nil) _
+  | S _ => exist _ (ListFromPeano value) _
+  end.
+Next Obligation.
+Admitted.
+Next Obligation.
+Admitted.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1958,6 +1958,10 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
   let sigma = Evd.from_ctx uctx in
   let ce, status, sigma = build_constant_by_tactic ~name ~sigma ~sign ~poly typ tac in
   let uctx = Evd.evar_universe_context sigma in
+  (* ignore side effect universes:
+     we don't reset the global env in this code path so the side effects are still present
+     cf #13271 and discussion in #18874
+     (but due to #13324 we still want to inline them) *)
   let cb, _uctx = inline_private_constants ~uctx env ce in
   cb, ce.proof_entry_type, ce.proof_entry_universes, status, uctx
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1958,7 +1958,7 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
   let sigma = Evd.from_ctx uctx in
   let ce, status, sigma = build_constant_by_tactic ~name ~sigma ~sign ~poly typ tac in
   let uctx = Evd.evar_universe_context sigma in
-  let cb, uctx = inline_private_constants ~uctx env ce in
+  let cb, _uctx = inline_private_constants ~uctx env ce in
   cb, ce.proof_entry_type, ce.proof_entry_universes, status, uctx
 
 let declare_abstract ~name ~poly ~kind ~sign ~secsign ~opaque ~solve_tac sigma concl =


### PR DESCRIPTION
If the typo is confirmed, this fixes / closes #13271 (regression from 8.11 to 8.12)

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
