### PR TITLE
Checking freshness of definition name at the time of initial declaration

### DIFF
--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -120,7 +120,7 @@ Universe instance length is 0 but should be 1.
 File "./output/UnivBinders.v", line 106, characters 0-30:
 The command has indeed failed with message:
 This object does not support universe names.
-File "./output/UnivBinders.v", line 110, characters 0-49:
+File "./output/UnivBinders.v", line 110, characters 0-50:
 The command has indeed failed with message:
 Cannot enforce v < u because u < gU < gV < v
 insec@{v} = Type@{uu} -> Type@{v}

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -107,7 +107,7 @@ Fail Print Coq.Init.Logic@{E}.
 
 (* Nice error when constraints are impossible. *)
 Monomorphic Universes gU gV. Monomorphic Constraint gU < gV.
-Fail Lemma foo@{u v|u < gU, gV < v, v < u} : nat.
+Fail Lemma foo'@{u v|u < gU, gV < v, v < u} : nat.
 
 Section SomeSec.
   Universe uu.

--- a/test-suite/success/freshness.v
+++ b/test-suite/success/freshness.v
@@ -1,0 +1,13 @@
+Definition bar := 0.
+
+Section S.
+Let bar := bar.
+Definition foo := 0.
+Let foo := foo.
+End S.
+
+Section S'.
+Let bar : nat. exact 0. Defined.
+Definition foo' := 0.
+Let foo' : nat. exact 0. Defined.
+End S'.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -552,7 +552,8 @@ let vernac_enable_notation ~module_local on rule interp flags scope =
 
 let check_name_freshness locality {CAst.loc;v=id} : unit =
   (* We check existence here: it's a bit late at Qed time *)
-  if Nametab.exists_cci (Lib.make_path id) || Termops.is_section_variable (Global.env ()) id ||
+  if Termops.is_section_variable (Global.env ()) id ||
+     locality <> Locality.Discharge && Nametab.exists_cci (Lib.make_path id) ||
      locality <> Locality.Discharge && Nametab.exists_cci (Lib.make_path_except_section id)
   then
     user_err ?loc  (Id.print id ++ str " already exists.")
@@ -604,7 +605,6 @@ let interp_lemma ~program_mode ~flags ~scope env0 evd thms =
       let flags = Pretyping.{ all_and_fail_flags with program_mode } in
       let evd = Pretyping.solve_remaining_evars ?hook:inference_hook flags env evd in
       let ids = List.map Context.Rel.Declaration.get_name ctx in
-      check_name_freshness scope id;
       let thm = Declare.CInfo.make ~name:id.CAst.v ~typ:(EConstr.it_mkProd_or_LetIn t' ctx)
           ~args:ids ~impargs:(imps @ imps') () in
       evd, thm)
@@ -669,6 +669,7 @@ let vernac_definition_name lid local =
     | { v = Name.Anonymous; loc } ->
          CAst.make ?loc (fresh_name_for_anonymous_theorem ())
     | { v = Name.Name n; loc } -> CAst.make ?loc n in
+  check_name_freshness local lid;
   let () =
     match local with
     | Discharge -> Dumpglob.dump_definition lid true "var"
@@ -719,6 +720,7 @@ let vernac_start_proof ~atts kind l =
   let scope = enforce_locality_exp atts.locality NoDischarge in
   if Dumpglob.dump () then
     List.iter (fun ((id, _), _) -> Dumpglob.dump_definition id false "prf") l;
+  List.iter (fun ((id, _), _) -> check_name_freshness scope id) l;
   start_lemma_com
     ~typing_flags:atts.typing_flags
     ~program_mode:atts.program
@@ -1048,7 +1050,9 @@ let preprocess_inductive_decl ~atts kind indl =
 let vernac_fixpoint_common ~atts discharge l =
   if Dumpglob.dump () then
     List.iter (fun { fname } -> Dumpglob.dump_definition fname false "def") l;
-  enforce_locality_exp atts.DefAttributes.locality discharge
+  let scope = enforce_locality_exp atts.DefAttributes.locality discharge in
+  List.iter (fun { fname } -> check_name_freshness scope fname) l;
+  scope
 
 let vernac_fixpoint_interactive ~atts discharge l =
   let open DefAttributes in
@@ -1075,7 +1079,9 @@ let vernac_fixpoint ~atts ~pm discharge l =
 let vernac_cofixpoint_common ~atts discharge l =
   if Dumpglob.dump () then
     List.iter (fun { fname } -> Dumpglob.dump_definition fname false "def") l;
-  enforce_locality_exp atts.DefAttributes.locality discharge
+  let scope = enforce_locality_exp atts.DefAttributes.locality discharge in
+  List.iter (fun { fname } -> check_name_freshness scope fname) l;
+  scope
 
 let vernac_cofixpoint_interactive ~atts discharge l =
   let open DefAttributes in


### PR DESCRIPTION
Previously, this was the case for `Theorem` but not for `Program Definition` or the different variants of `Co`/`Fixpoint`.

This is part of making the different execution paths for `Co`/`Fixpoint`, `Theorem`/`Definition` (and optionally `Program` of them) similar.

This might changes some habits, and, maybe, checking the name after the type-checking is done might also be preferable?