### PR TITLE
[replaced] Fixes #13697: insertion of non-forced implicit arguments even with explicit application

### DIFF
--- a/test-suite/bugs/bug_13697.v
+++ b/test-suite/bugs/bug_13697.v
@@ -1,0 +1,39 @@
+From Coq Require micromega.Lia Lists.List Program.Program.
+
+Set Implicit Arguments.
+Set Strict Implicit. Set Strongly Strict Implicit.
+Set Maximal Implicit Insertion.
+
+Section Context.
+
+Import Lia List Tactics.
+Import ListNotations.
+
+Obligation Tactic := idtac.
+
+Program Fixpoint merge (A : Type) (f : A -> A -> bool) (l0 l1 : list A)
+  {measure (length l0 + length l1)} : list A :=
+  match l0, l1 with
+  | [], _ => l1
+  | _, [] => l0
+  | n0 :: k0, n1 :: k1 => if f n0 n1 then
+    n0 :: merge f k0 l1 else
+    n1 :: @merge _ f l0 k1
+  end.
+Next Obligation. intros; subst; cbn in *; lia. Qed.
+Next Obligation. intros; subst; cbn in *; lia. Qed.
+Next Obligation. program_simplify. Qed.
+Next Obligation. program_solve_wf. Defined.
+
+End Context.
+
+Section Context.
+
+Import List NArith.
+Import ListNotations N.
+
+Open Scope N_scope.
+
+Compute merge leb [7; 13; 42] [18; 69; 420].
+
+End Context.

--- a/test-suite/bugs/bug_4725.v
+++ b/test-suite/bugs/bug_4725.v
@@ -34,6 +34,6 @@ Program Fixpoint nubV' `{eqDecV : @EqDec V eqV equivV} (l : list V)
         {  measure (@length V l) lt } :=
     match l with
       | nil => nil
-      | x::xs => x :: @nubV' V eqV equivV eqDecV (removeV x xs) _
+      | x::xs => x :: @nubV' V eqV equivV eqDecV (removeV x xs)
     end.
 Next Obligation. apply remove_le. Defined.


### PR DESCRIPTION
We start from the empirical observation that non-"force" implicit arguments are used in `Program Fixpoint` to refer to the  implicit extra argument associated to the decreasing of the measure. We then adopt the policy that such implicit argument is not supposed to be given, even in explicit mode (which may be disputable in some sense).

Otherwise said, #13697 is asking whether the need for an explicit `_` in anticipation of the extra argument for the measure is a bug or a feature and this PR is adopting the point of view that it is a bug.

Conversely, if we adopted the point of view that it is a feature, we should document it.

Fixes / closes #13697

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.

Depends on #18877 (merged)