### PR TITLE
Prevent side effect temporary global env entries from leaking

### DIFF
--- a/test-suite/bugs/bug_13271.v
+++ b/test-suite/bugs/bug_13271.v
@@ -1,0 +1,11 @@
+Require Import Program.Tactics.
+Set Printing Universes.
+
+Local Obligation Tactic := idtac.
+
+Polymorphic Program Definition foo (n m : nat) (H : n = m) : H = H := _.
+Solve Obligations with (intros ? ? H; rewrite H; reflexivity).
+(* rewrite generates a side effect with a monomorphic universe *)
+
+Polymorphic Program Definition foo' (n m : nat) (H : n = m) : H = H := _.
+Next Obligation. intros ? ? H; rewrite H; reflexivity. Qed.

--- a/test-suite/bugs/bug_18879_1.v
+++ b/test-suite/bugs/bug_18879_1.v
@@ -1,0 +1,4 @@
+
+Section S.
+  Definition foo := ltac:(abstract exact I).
+End S.

--- a/test-suite/output-coqchk/bug_13324.out
+++ b/test-suite/output-coqchk/bug_13324.out
@@ -1,0 +1,16 @@
+
+CONTEXT SUMMARY
+===============
+
+* Theory: Set is predicative
+  
+* Theory: Rewrite rules are not allowed
+  
+* Axioms: <none>
+  
+* Constants/Inductives relying on type-in-type: <none>
+  
+* Constants/Inductives relying on unsafe (co)fixpoints: <none>
+  
+* Inductives whose positivity is assumed: <none>
+  

--- a/test-suite/output-coqchk/bug_13324.v
+++ b/test-suite/output-coqchk/bug_13324.v
@@ -1,0 +1,7 @@
+Require Import Coq.Program.Tactics.
+
+Local Obligation Tactic := abstract exact I.
+
+Program Definition foo : True := _.
+
+Definition bar : True := ltac:(abstract exact I).


### PR DESCRIPTION

Fix #13324
Also fix #13271

The bug occurs in 2 code paths so there are 2 changes
- Proof.refine_by_tactic for ltac:() / ltac2:() / whatever rewrite.ml is doing
- Declare.solve_by_tac sor Solve Obligations / automatic obligation solving.

We might have wrapped Declare.build_by_tactic in state protection
everywhere instead of just the solve_by_tac call, but this makes
funind fail. Not sure if funind could be changed to make it work.

There is also a use of inline_private_constants in
obligation_terminator, but the state reset is handled by the stm for
this AFAICT.
