### PR TITLE
program_inference_hook: use refine_by_tactic instead of build_by_tactic

### DIFF
--- a/dev/ci/user-overlays/18881-SkySkimmer-program-ref-by-tactic.sh
+++ b/dev/ci/user-overlays/18881-SkySkimmer-program-ref-by-tactic.sh
@@ -1,0 +1,1 @@
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 program-ref-by-tactic 18881

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2200,7 +2200,7 @@ let _ =
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
     let (c, sigma) = Proof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma ty tac in
-    let j = { Environ.uj_val = EConstr.of_constr c; uj_type = ty } in
+    let j = { Environ.uj_val = c; uj_type = ty } in
     (j, sigma)
   in
   GlobEnv.register_constr_interp0 wit_tactic eval

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1747,7 +1747,7 @@ let () =
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
     let c, sigma = Proof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma concl tac in
-    let j = { Environ.uj_val = EConstr.of_constr c; Environ.uj_type = concl } in
+    let j = { Environ.uj_val = c; Environ.uj_type = concl } in
     (j, sigma)
   in
   GlobEnv.register_constr_interp0 wit_ltac2_constr interp

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -542,7 +542,7 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
      this hack will work in most cases. *)
   let neff = neff.Evd.seff_private in
   let (ans, _) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
-  ans, sigma
+  EConstr.of_constr ans, sigma
 
 let get_goal_context_gen pf i =
   let { sigma; goals } = data pf in

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -214,7 +214,7 @@ val refine_by_tactic
   -> Evd.evar_map
   -> EConstr.types
   -> unit Proofview.tactic
-  -> Constr.constr * Evd.evar_map
+  -> EConstr.constr * Evd.evar_map
 (** A variant of the above function that handles open terms as well.
     Caveat: all effects are purged in the returned term at the end, but other
     evars solved by side-effects are NOT purged, so that unexpected failures may

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -653,7 +653,7 @@ let solve_remaining_by env sigma holes by =
         let ty = Evd.evar_concl evi in
         let name, poly = Id.of_string "rewrite", false in
         let c, sigma = Proof.refine_by_tactic ~name ~poly env sigma ty solve_tac in
-        Evd.define evk (EConstr.of_constr c) sigma
+        Evd.define evk c sigma
     in
     List.fold_left solve sigma indep
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -578,10 +578,11 @@ let program_inference_hook env sigma ev =
             Evarutil.is_ground_term sigma concl)
     then None
     else
-      let c, _, _, _, ctx =
-        Declare.build_by_tactic ~poly:false env ~uctx:(Evd.evar_universe_context sigma) ~typ:concl tac
+      let c, sigma =
+        Proof.refine_by_tactic ~name:(Id.of_string "program_subproof")
+          ~poly:false env sigma concl (Tacticals.tclSOLVE [tac])
       in
-      Some (Evd.set_universe_context sigma ctx, EConstr.of_constr c)
+      Some (sigma, c)
   with
   | Logic_monad.TacticFailure e when noncritical e ->
     user_err Pp.(str "The statement obligations could not be resolved \


### PR DESCRIPTION
refine_by_tactic is more appropriate AFAICT (program_inference_hook is
similar to an implicit ltac:() which is refine_by_tactic).

This would also allow us to call it on non evar free goals (ie remove
the is_ground checks just above) but not sure we want to.

Overlays:
- https://github.com/Mtac2/Mtac2/pull/401
