### PR TITLE
Use gitlab.inria.fr shared runners for docker boot

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -282,8 +282,8 @@ docker-boot:
   except:
     variables:
       - $SKIP_DOCKER == "true"
-  tags:
-    - docker
+  extends: .auto-use-docker-tags
+  timeout: 2h
 
 build:base:
   extends: .build-template

--- a/dev/ci/gitlab-modes/tagged-runners.yml
+++ b/dev/ci/gitlab-modes/tagged-runners.yml
@@ -1,3 +1,11 @@
 .auto-use-tags:
   tags:
     - $TAGGED_RUNNERS
+
+# making this configurable is too annoying if we want to support > 1 tag
+# and not sure small is enough
+# so just hardcode ci.inria.fr && medium
+.auto-use-docker-tags:
+  tags:
+    - ci.inria.fr
+    - medium

--- a/dev/ci/gitlab-modes/untagged-runners.yml
+++ b/dev/ci/gitlab-modes/untagged-runners.yml
@@ -1,2 +1,6 @@
 .auto-use-tags:
   tags: []
+
+.auto-use-docker-tags:
+  tags:
+    - docker


### PR DESCRIPTION
Thanks to Guillaume Melquiond for telling us this is possible.

Behind the scenes to avoid using the ci.inria.fr workers for other jobs I retagged the ci-coq workers adding the `ci-coq` tag and modified variable TAGGED_RUNNERS := ci-coq in the project settings.

Once the pipelines started before this change have finished we can enable the shared runners and test this commit.

As mentioned in the comments making the tags for the docker job configurable by variable seems too annoying to be worth doing so I hardcoded them.
