### PR TITLE
[declare] Consolidate `Proof Using` handling.

### DIFF
--- a/dev/ci/user-overlays/18890-ejgallego-no_using_cinfo.sh
+++ b/dev/ci/user-overlays/18890-ejgallego-no_using_cinfo.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/ejgallego/coq-elpi no_using_cinfo 18890
+
+overlay vscoq https://github.com/ejgallego/vscoq no_using_cinfo 18890

--- a/test-suite/success/definition_using.v
+++ b/test-suite/success/definition_using.v
@@ -80,3 +80,43 @@ End B.
 Check c8 : forall a, c1 a = true -> bogus.
 Check c9 : forall a, c1 a = true -> bogus.
 Check c10: bogus -> bogus.
+
+Module TypeBehavior.
+
+Section S.
+Variables a : nat.
+#[using="Type", warning="-non-recursive"]
+Program Fixpoint b1 (n:nat) : nat := (fun _ => 0) a.
+Program Fixpoint b2 (n:nat) : (fun X _ => X) nat a := 0.
+Program Fixpoint b3 (n:nat) : (fun X _ => X) nat a := (fun _ => 0) a.
+Program Definition c1 : nat := (fun _ => 0) a.
+Program Definition c2 : (fun X _ => X) nat a := 0.
+Program Definition c3 : (fun X _ => X) nat a := (fun _ => 0) a.
+Fixpoint d1 (n:nat) : nat := (fun _ => 0) a.
+Fixpoint d2 (n:nat) : (fun X _ => X) nat a := 0.
+Fixpoint d3 (n:nat) : (fun X _ => X) nat a := (fun _ => 0) a.
+Definition e1 : nat := (fun _ => 0) a.
+Definition e2 : (fun X _ => X) nat a := 0.
+Definition e3 : (fun X _ => X) nat a := (fun _ => 0) a.
+End S.
+(* Not clear what is most expected below... *)
+
+(* Dependency in a with Program Fixpoint: the body is not reduced. *)
+(* As of now, we don't seem to have such a case. *)
+(* No dependency in a with Program Fixpoint, because both body and type are beta-reduced *)
+Check b1 0 : nat.
+Check b2 0 : nat.
+Check b3 0 : nat.
+(* With Program Definition, type is beta-reduced but not the body *)
+Check c1 0 : nat.
+Check c2 : nat.
+Check c3 0 : nat.
+(* With Definition/Fixpoint, neither body nor type are beta-reduced *)
+Check d1 0 0 : nat.
+Check d2 0 0 : nat.
+Check d3 0 0 : nat.
+Check e1 0 : nat.
+Check e2 0 : nat.
+Check e3 0 : nat.
+
+End TypeBehavior.

--- a/test-suite/success/proof_using.v
+++ b/test-suite/success/proof_using.v
@@ -195,4 +195,61 @@ Qed.
 End Clear.
 *)
 
+Module InteractiveUsing.
 
+Section S.
+
+Variable m : nat.
+Variable e : m = m.
+
+#[using="e"]
+Definition a := 0.
+
+#[using="e"]
+Definition a' : nat.
+exact 0.
+Defined.
+
+#[using="e"]
+Fixpoint f (n:nat) : nat :=
+ match n with 0 => 0 | S n => f n end.
+
+#[using="e"]
+Fixpoint f' (n:nat) : nat.
+exact (match n with 0 => 0 | S n => f n end).
+Defined.
+
+#[using="Type"]
+Fixpoint f1 (n:nat) : nat :=
+  match n with 0 => 0 | S n => match f2 n with eq_refl => n end end
+with f2 (n:nat) : m = m :=
+  match n with 0 => eq_refl | S n => match f1 n with 0 => eq_refl | S _ => eq_refl end end.
+
+#[using="Type"]
+Fixpoint f1' (n:nat) : nat with f2' (n:nat) : m = m.
+exact (match n with 0 => 0 | S n => match f2' n with eq_refl => n end end).
+exact (match n with 0 => eq_refl | S n => match f1' n with 0 => eq_refl | S _ => eq_refl end end).
+Defined.
+
+CoInductive Stream : Set := Cons : Stream -> Stream.
+
+#[using="e"]
+CoFixpoint g : Stream := Cons g.
+
+#[using="e"]
+CoFixpoint g' : Stream.
+exact (Cons g).
+Defined.
+
+End S.
+
+Check eq_refl : a 0 (eq_refl 0) = 0.
+Check eq_refl : a' 0 (eq_refl 0) = 0.
+Check eq_refl : f 10 (eq_refl 10) 2 = 0.
+Check eq_refl : f' 10 (eq_refl 10) 2 = 0.
+Check eq_refl : f1 10 2 = 1.
+Check eq_refl : f1' 10 2 = 1.
+Check g 0 eq_refl : Stream.
+Check g' 0 eq_refl : Stream.
+
+End InteractiveUsing.

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -21,6 +21,7 @@ val do_fixpoint_interactive
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
+  -> ?using:Vernacexpr.section_subset_expr
   -> fixpoint_expr list
   -> Declare.Proof.t
 
@@ -40,6 +41,7 @@ val do_cofixpoint_interactive
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
+  -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list
   -> Declare.Proof.t
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -79,7 +79,6 @@ module CInfo : sig
     -> typ:'constr
     -> ?args:Name.t list
     -> ?impargs:Impargs.manual_implicits
-    -> ?using:Proof_using.t
     -> unit
     -> 'constr t
 
@@ -128,6 +127,7 @@ val declare_definition
   -> cinfo:EConstr.t option CInfo.t
   -> opaque:bool
   -> body:EConstr.t
+  -> ?using:Vernacexpr.section_subset_expr
   -> Evd.evar_map
   -> GlobRef.t
 
@@ -140,6 +140,8 @@ val declare_mutually_recursive
   -> uctx:UState.t
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:lemma_possible_guards option
+  -> ?using:Vernacexpr.section_subset_expr
+  -> unit
   -> Names.GlobRef.t list
 
 (** {2 Declaration of interactive constants }  *)
@@ -183,6 +185,7 @@ module Proof : sig
   val start
     :  info:Info.t
     -> cinfo:EConstr.t CInfo.t
+    -> ?using:Id.Set.t
     -> Evd.evar_map
     -> t
 
@@ -207,6 +210,7 @@ module Proof : sig
   val start_with_initialization
     :  info:Info.t
     -> cinfo:Constr.t CInfo.t
+    -> ?using:Vernacexpr.section_subset_expr
     -> Evd.evar_map
     -> t
 
@@ -217,6 +221,7 @@ module Proof : sig
     :  info:Info.t
     -> cinfo:Constr.t CInfo.t list
     -> mutual_info:mutual_info
+    -> ?using:Vernacexpr.section_subset_expr
     -> Evd.evar_map
     -> int list option
     -> t
@@ -260,7 +265,7 @@ module Proof : sig
 
   (** Sets the section variables assumed by the proof, returns its closure
    * (w.r.t. type dependencies and let-ins covered by it) *)
-  val set_used_variables : t -> using:Proof_using.t -> Constr.named_context * t
+  val set_proof_using : t -> Vernacexpr.section_subset_expr -> Constr.named_context * t
 
   (** Gets the set of variables declared to be used by the proof. None means
       no "Proof using" or #[using] was given *)
@@ -276,9 +281,6 @@ module Proof : sig
   val update_sigma_univs : UGraph.t -> t -> t
 
   val get_open_goals : t -> int
-
-  (** Gets the set of mutual theorem names being currently built, if any *)
-  val get_recnames : t -> Id.t list
 
   (** Helpers to obtain proof state when in an interactive proof *)
 
@@ -545,6 +547,7 @@ val add_definition :
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
+  -> ?using:Vernacexpr.section_subset_expr
   -> RetrieveObl.obligation_info
   -> OblState.t * progress
 
@@ -561,6 +564,7 @@ val add_mutual_definitions :
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
+  -> ?using:Vernacexpr.section_subset_expr
   -> fixpoint_kind
   -> OblState.t
 


### PR DESCRIPTION
This is an old to-do from the times of `declare.ml` refactoring;
thanks to Hugo Herbelin for trying first with #18742 , which this PR
could replace.

We adopt the following convention:

- we remove the per-constant `using` field from `CInfo.t` (as in #18742)

- interactive commands pass their using attribute down to the proof
  initialization, where the parameter is interpreted properly in declare.ml

-  ̶f̶o̶r̶ ̶n̶o̶w̶ ̶w̶e̶ ̶c̶h̶o̶o̶s̶e̶ ̶t̶o̶ ̶w̶a̶r̶n̶ ̶o̶n̶ ̶p̶l̶a̶c̶e̶s̶ ̶w̶h̶e̶r̶e̶ ̶u̶s̶i̶n̶g̶ ̶a̶t̶t̶r̶i̶b̶u̶t̶e̶s̶ ̶a̶r̶e̶ ̶n̶o̶t̶
̶ ̶ ̶u̶s̶e̶d̶ ̶(̶t̶r̶a̶n̶s̶p̶a̶r̶e̶n̶t̶ ̶d̶e̶f̶i̶n̶i̶t̶i̶o̶n̶ ̶n̶o̶t̶ ̶i̶n̶s̶i̶d̶e̶ ̶a̶ ̶s̶e̶c̶t̶i̶o̶n̶)̶

We add tests from #18742, written by Hugo.

cc: @herbelin 

Overlays:
- https://github.com/coq-community/vscoq/pull/767
- https://github.com/LPCIC/coq-elpi/pull/628