### PR TITLE
Fix a broken hint declaration in a test from the test-suite.

### DIFF
--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -74,7 +74,7 @@ Module Backtracking.
 End Backtracking.
 
 
-#[export] Hint Resolve 100 eq_sym eq_trans : core.
+#[export] Hint Resolve eq_sym eq_trans | 100 : core.
 #[export] Hint Cut [(_)* eq_sym eq_sym] : core.
 #[export] Hint Cut [_* eq_trans eq_trans] : core.
 #[export] Hint Cut [_* eq_trans eq_sym eq_trans] : core.


### PR DESCRIPTION
The hint priority was written as part of the list of hints, leading to its intepretation as the constr numeral "100" rather than the actual priority of the given hints. Needless to say, this was not the intended behaviour.