### PR TITLE
Set the warning for raw constr hints default to error.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18895-hint-constr-warning-default-error.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18895-hint-constr-warning-default-error.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The "fragile-hint-constr" warning is now an error by default,
+  as the corresponding feature will be removed in a later version
+  (`#18895 <https://github.com/coq/coq/pull/18895>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -455,9 +455,9 @@ Creating Hints
 
       :n:`@one_term`
         Permits declaring a hint without declaring a new
-        constant first, but this is not recommended.
+        constant first. This is deprecated.
 
-         .. warn:: Declaring arbitrary terms as hints is fragile; it is recommended to declare a toplevel constant instead
+         .. warn:: Declaring arbitrary terms as hints is fragile and deprecated; it is recommended to declare a toplevel constant instead
             :undocumented:
 
       .. exn:: @qualid cannot be used as a hint

--- a/lib/deprecation.ml
+++ b/lib/deprecation.ml
@@ -73,5 +73,6 @@ module Version = struct
   let v8_17 = get_generic_cat "8.17"
   let v8_18 = get_generic_cat "8.18"
   let v8_19 = get_generic_cat "8.19"
+  let v8_20 = get_generic_cat "8.20"
 
 end

--- a/lib/deprecation.mli
+++ b/lib/deprecation.mli
@@ -27,4 +27,5 @@ module Version : sig
   val v8_17 : CWarnings.category
   val v8_18 : CWarnings.category
   val v8_19 : CWarnings.category
+  val v8_20 : CWarnings.category
 end

--- a/test-suite/bugs/bug_4450.v
+++ b/test-suite/bugs/bug_4450.v
@@ -21,7 +21,8 @@ Goal (forall U, f U) -> (*(f unit -> False) ->  *)False /\ False.
   eauto using (fapp unit funi). (* The two fapp's have different universes *)
 Qed.
 
-#[export] Hint Resolve (fapp unit funi) : mylems.
+Definition fapp0 := fapp unit funi.
+#[export] Hint Resolve fapp0 : mylems.
 
 Goal (forall U, f U) -> (*(f unit -> False) ->  *)False /\ False.
   eauto with mylems. (* Forces the two fapps at the same level *)

--- a/test-suite/ssr/absevarprop.v
+++ b/test-suite/ssr/absevarprop.v
@@ -85,7 +85,7 @@ Definition R1 := fun (x : nat) (p : P x) m (q : P (x+1)) (r : Q x p) => m > 0.
 Inductive myEx1 : Type :=
   ExI1 : forall n (pn : P n) pn' (q : Q n pn), R1 n pn n pn' q -> myEx1.
 
-#[export] Hint Resolve (Q1 P1) : SSR.
+#[export] Hint Extern 0 (Q 1 P1) => apply (Q1 P1) : SSR.
 
 (* tests that goals in prop are solved in the right order, propagating instantiations,
    thus the goal Q 1 ?p1 is faced by trivial after ?p1, and is thus evar free *)

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -65,7 +65,7 @@ let project_hint ~poly pri l2r r =
   (info, true, Hints.hint_globref (GlobRef.ConstRef c))
 
 let warn_deprecated_hint_constr =
-  CWarnings.create ~name:"fragile-hint-constr" ~category:CWarnings.CoreCategories.automation
+  CWarnings.create ~name:"fragile-hint-constr" ~default:AsError ~category:CWarnings.CoreCategories.automation
     (fun () ->
       Pp.strbrk
         "Declaring arbitrary terms as hints is fragile; it is recommended to \

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -64,12 +64,15 @@ let project_hint ~poly pri l2r r =
   let info = {Typeclasses.hint_priority = pri; hint_pattern = None} in
   (info, true, Hints.hint_globref (GlobRef.ConstRef c))
 
+let warning_deprecated_hint_constr =
+  CWarnings.create_warning ~from:[CWarnings.CoreCategories.automation; Deprecation.Version.v8_20] ~name:"fragile-hint-constr" ~default:AsError ()
+
 let warn_deprecated_hint_constr =
-  CWarnings.create ~name:"fragile-hint-constr" ~default:AsError ~category:CWarnings.CoreCategories.automation
+  CWarnings.create_in warning_deprecated_hint_constr
     (fun () ->
       Pp.strbrk
-        "Declaring arbitrary terms as hints is fragile; it is recommended to \
-         declare a toplevel constant instead")
+        "Declaring arbitrary terms as hints is fragile and deprecated; it is \
+         recommended to declare a toplevel constant instead")
 
 (* Only error when we have to (axioms may be instantiated if from functors)
    XXX maybe error if not from a functor argument?

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -76,6 +76,15 @@ let warn_deprecated_hint_constr =
  *)
 let soft_evaluable = Tacred.soft_evaluable_of_global_reference
 
+(* Slightly more lenient global hint syntax for backwards compatibility *)
+let rectify_hint_constr h = match h with
+| Vernacexpr.HintsReference _ -> h
+| Vernacexpr.HintsConstr c ->
+  let open Constrexpr in
+  match c.CAst.v with
+  | CAppExpl ((qid, None), []) -> Vernacexpr.HintsReference qid
+  | _ -> Vernacexpr.HintsConstr c
+
 let interp_hints ~poly h =
   let env = Global.env () in
   let sigma = Evd.from_env env in
@@ -88,7 +97,7 @@ let interp_hints ~poly h =
   let fi c =
     let open Hints in
     let open Vernacexpr in
-    match c with
+    match rectify_hint_constr c with
     | HintsReference c ->
       let gr = Smartlocate.global_with_alias c in
       (hint_globref gr)


### PR DESCRIPTION
This feature has been triggering a warning for quite a while (since 8.12 to be exact). This PR proceeds to the next step, i.e. an error by default, with the perspective that we'll remove it in the next version.

We also tweak a bit the warning message and a category so that it is now explicit that this is a deprecation. Before that the deprecation qualification was only internal. We also enhance backwards compatibility by tolerating constants with explicit application `@foo`. Some devs rely on that because it used to be the case that `@foo` and `foo` didn't have the same semantics for hint declarations, although it's also been a while that they behave the same.