### PR TITLE
Remove essentially unused wrappers from Auto

### DIFF
--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -36,7 +36,7 @@ let { Goptions.get = ground_depth } =
     ()
 
 let default_intuition_tac =
-  let tac _ _ = Auto.h_auto None [] (Some []) in
+  let tac _ _ = Auto.gen_auto None [] (Some []) in
   let name = { Tacexpr.mltac_plugin = "coq-core.plugins.firstorder"; mltac_tactic = "auto_with"; } in
   let entry = { Tacexpr.mltac_name = name; mltac_index = 0 } in
   Tacenv.register_ml_tactic name [| tac |];

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -34,7 +34,6 @@ open Constrintern
 open Tactypes
 open Genredexpr
 open Equality
-open Auto
 open Eauto
 open Indfun_common
 open Context.Rel.Declaration
@@ -563,6 +562,9 @@ let rec prove_lt hyple =
                 str "assumption: "
                 ++ Printer.Debug.pr_goal g)
               assumption ])
+
+let default_full_auto =
+  Auto.gen_auto (Some Auto.default_search_depth) [] None
 
 let rec destruct_bounds_aux infos (bound, hyple, rechyps) lbounds =
   let open Tacticals in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1472,7 +1472,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
           let sigma = project gl in
           match EConstr.kind sigma (pf_concl gl) with
           | App (f, _) when EConstr.eq_constr sigma f (well_founded ()) ->
-            Auto.h_auto None [] (Some [])
+            Auto.gen_auto None [] (Some [])
           | _ ->
             incr h_num;
             tclCOMPLETE

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -99,17 +99,17 @@ END
 
 TACTIC EXTEND auto
 | [ "auto" nat_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    { Auto.h_auto n (eval_uconstrs ist lems) db }
+    { Auto.gen_auto n (eval_uconstrs ist lems) db }
 END
 
 TACTIC EXTEND info_auto
 | [ "info_auto" nat_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    { Auto.h_auto ~debug:Info n (eval_uconstrs ist lems) db }
+    { Auto.gen_auto ~debug:Info n (eval_uconstrs ist lems) db }
 END
 
 TACTIC EXTEND debug_auto
 | [ "debug" "auto" nat_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    { Auto.h_auto ~debug:Debug n (eval_uconstrs ist lems) db }
+    { Auto.gen_auto ~debug:Debug n (eval_uconstrs ist lems) db }
 END
 
 (** Eauto *)

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -84,17 +84,17 @@ END
 
 TACTIC EXTEND trivial
 | [ "trivial" auto_using(lems) hintbases(db) ] ->
-    { Auto.h_trivial (eval_uconstrs ist lems) db }
+    { Auto.gen_trivial (eval_uconstrs ist lems) db }
 END
 
 TACTIC EXTEND info_trivial
 | [ "info_trivial" auto_using(lems) hintbases(db) ] ->
-    { Auto.h_trivial ~debug:Info (eval_uconstrs ist lems) db }
+    { Auto.gen_trivial ~debug:Info (eval_uconstrs ist lems) db }
 END
 
 TACTIC EXTEND debug_trivial
 | [ "debug" "trivial" auto_using(lems) hintbases(db) ] ->
-    { Auto.h_trivial ~debug:Debug (eval_uconstrs ist lems) db }
+    { Auto.gen_trivial ~debug:Debug (eval_uconstrs ist lems) db }
 END
 
 TACTIC EXTEND auto

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -388,7 +388,7 @@ let autorewrite ~all by ids cl =
 let trivial debug lems dbs =
   let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
-  Auto.h_trivial ~debug lems dbs
+  Auto.gen_trivial ~debug lems dbs
 
 let auto debug n lems dbs =
   let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -393,7 +393,7 @@ let trivial debug lems dbs =
 let auto debug n lems dbs =
   let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
-  Auto.h_auto ~debug n lems dbs
+  Auto.gen_auto ~debug n lems dbs
 
 let eauto debug n lems dbs =
   let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -77,7 +77,7 @@ let ssrautoprop =
       with Not_found -> Tacenv.locate_tactic (ssrqid "ssrautoprop") in
     let tacexpr = CAst.make @@ Tacexpr.Reference (ArgArg (Loc.tag @@ tacname)) in
     eval_tactic (CAst.make @@ Tacexpr.TacArg CAst.(tacexpr.v))
-  with Not_found -> Auto.full_trivial []
+  with Not_found -> Auto.gen_trivial [] None
   end
 
 let () = ssrautoprop_tac := ssrautoprop

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -365,8 +365,6 @@ let gen_trivial ?(debug=Off) lems dbnames =
     tclTRY_dbg d (trivial_fail_db d db_list local_db)
   end
 
-let full_trivial ?(debug=Off) lems = gen_trivial ~debug lems None
-
 (**************************************************************************)
 (*                       The classical Auto tactic                        *)
 (**************************************************************************)

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -441,5 +441,3 @@ let auto ?(debug=Off) n lems dbnames = gen_auto ~debug (Some n) lems (Some dbnam
 let default_auto = auto default_search_depth [] []
 
 let full_auto ?(debug=Off) n lems = gen_auto ~debug (Some n) lems None
-
-let default_full_auto = full_auto default_search_depth []

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -443,5 +443,3 @@ let default_auto = auto !default_search_depth [] []
 let full_auto ?(debug=Off) n lems = gen_auto ~debug (Some n) lems None
 
 let default_full_auto = full_auto !default_search_depth []
-
-let h_auto ?(debug=Off) n lems l = gen_auto ~debug n lems l

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -439,5 +439,3 @@ let gen_auto ?(debug=Off) n lems dbnames =
 let auto ?(debug=Off) n lems dbnames = gen_auto ~debug (Some n) lems (Some dbnames)
 
 let default_auto = auto default_search_depth [] []
-
-let full_auto ?(debug=Off) n lems = gen_auto ~debug (Some n) lems None

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -421,12 +421,12 @@ let search d n db_list lems =
     search d n (make_local_db gl)
   end
 
-let default_search_depth = ref 5
+let default_search_depth = 5
 
 let gen_auto ?(debug=Off) n lems dbnames =
   Hints.wrap_hint_warning @@
     Proofview.Goal.enter begin fun gl ->
-    let n = match n with None -> !default_search_depth | Some n -> n in
+    let n = match n with None -> default_search_depth | Some n -> n in
     let db_list =
       match dbnames with
       | Some dbnames -> make_db_list dbnames
@@ -438,8 +438,8 @@ let gen_auto ?(debug=Off) n lems dbnames =
 
 let auto ?(debug=Off) n lems dbnames = gen_auto ~debug (Some n) lems (Some dbnames)
 
-let default_auto = auto !default_search_depth [] []
+let default_auto = auto default_search_depth [] []
 
 let full_auto ?(debug=Off) n lems = gen_auto ~debug (Some n) lems None
 
-let default_full_auto = full_auto !default_search_depth []
+let default_full_auto = full_auto default_search_depth []

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -369,8 +369,6 @@ let trivial ?(debug=Off) lems dbnames = gen_trivial ~debug lems (Some dbnames)
 
 let full_trivial ?(debug=Off) lems = gen_trivial ~debug lems None
 
-let h_trivial ?(debug=Off) lems dbnames = gen_trivial ~debug lems dbnames
-
 (**************************************************************************)
 (*                       The classical Auto tactic                        *)
 (**************************************************************************)

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -365,8 +365,6 @@ let gen_trivial ?(debug=Off) lems dbnames =
     tclTRY_dbg d (trivial_fail_db d db_list local_db)
   end
 
-let trivial ?(debug=Off) lems dbnames = gen_trivial ~debug lems (Some dbnames)
-
 let full_trivial ?(debug=Off) lems = gen_trivial ~debug lems None
 
 (**************************************************************************)

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -46,9 +46,6 @@ val default_auto : unit Proofview.tactic
 val full_auto : ?debug:debug ->
   int -> delayed_open_constr list -> unit Proofview.tactic
 
-(** auto with default search depth and with all hint databases *)
-val default_full_auto : unit Proofview.tactic
-
 (** The generic form of auto (second arg [None] means all bases) *)
 val gen_auto : ?debug:debug ->
   int option -> delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -68,5 +68,3 @@ val gen_trivial : ?debug:debug ->
   delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
 val full_trivial : ?debug:debug ->
   delayed_open_constr list -> unit Proofview.tactic
-val h_trivial : ?debug:debug ->
-  delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -37,9 +37,6 @@ val conclPattern : constr -> constr_pattern option -> Genarg.glob_generic_argume
 (** The use of the "core" database can be de-activated by passing
     "nocore" amongst the databases. *)
 
-val auto : ?debug:debug ->
-  int -> delayed_open_constr list -> hint_db_name list -> unit Proofview.tactic
-
 (** Auto with more delta. *)
 
 (** auto with default search depth and with the hint database "core" *)

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -56,10 +56,6 @@ val default_full_auto : unit Proofview.tactic
 val gen_auto : ?debug:debug ->
   int option -> delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
 
-(** The hidden version of auto *)
-val h_auto   : ?debug:debug ->
-  int option -> delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
-
 (** Trivial *)
 
 val trivial : ?debug:debug ->

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -50,5 +50,3 @@ val gen_auto : ?debug:debug ->
 
 val gen_trivial : ?debug:debug ->
   delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
-val full_trivial : ?debug:debug ->
-  delayed_open_constr list -> unit Proofview.tactic

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -48,8 +48,6 @@ val gen_auto : ?debug:debug ->
 
 (** Trivial *)
 
-val trivial : ?debug:debug ->
-  delayed_open_constr list -> hint_db_name list -> unit Proofview.tactic
 val gen_trivial : ?debug:debug ->
   delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
 val full_trivial : ?debug:debug ->

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -42,10 +42,6 @@ val conclPattern : constr -> constr_pattern option -> Genarg.glob_generic_argume
 (** auto with default search depth and with the hint database "core" *)
 val default_auto : unit Proofview.tactic
 
-(** auto with all hint databases *)
-val full_auto : ?debug:debug ->
-  int -> delayed_open_constr list -> unit Proofview.tactic
-
 (** The generic form of auto (second arg [None] means all bases) *)
 val gen_auto : ?debug:debug ->
   int option -> delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -18,7 +18,7 @@ open Tactypes
 
 val compute_secvars : Proofview.Goal.t -> Id.Pred.t
 
-val default_search_depth : int ref
+val default_search_depth : int
 
 val auto_flags_of_state : TransparentState.t -> Unification.unify_flags
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -349,7 +349,7 @@ let make_initial_state evk dbg n localdb =
 
 let e_search_auto ?(debug = Off) ?depth lems db_list =
   Proofview.Goal.enter begin fun gl ->
-  let p = Option.default !default_search_depth depth in
+  let p = Option.default default_search_depth depth in
   let local_db env sigma = make_local_hint_db env sigma ~ts:TransparentState.full true lems in
   let d = mk_eauto_dbg debug in
   let debug = match d with Debug -> true | Info | Off -> false in

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -170,7 +170,7 @@ let diseqCase hyps eqonleft =
   (intro_using_then absurd (fun absurd ->
   tclTHEN  (Simple.apply (mkVar diseq))
   (tclTHEN  (injHyp absurd)
-            (full_trivial []))))))))
+            (Auto.gen_trivial [] None))))))))
 
 open Proofview.Notations
 


### PR DESCRIPTION
We had a bunch of historical wrappers that were either not used at all, or used once or twice for no good reason.