### PR TITLE
Slightly tweak the interpretation of using clause for eauto tactics.

### DIFF
--- a/doc/changelog/04-tactics/18909-hint-using-strict-globref.rst
+++ b/doc/changelog/04-tactics/18909-hint-using-strict-globref.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  syntactic global references passed through the `using` clauses of :tacn:`auto`-like
+  tactics are now handled as plain references rather than interpreted terms. In
+  particular, their typeclass arguments will not be inferred. In general, the previous
+  behaviour can be emulated by replacing `auto using foo` with `pose proof foo; auto`
+  (`#18909 <https://github.com/coq/coq/pull/18909>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/bugs/bug_4354.v
+++ b/test-suite/bugs/bug_4354.v
@@ -5,7 +5,7 @@ Create HintDb core.
 Lemma closed_monotonic T (H : Lift T) : True.
 Proof.
   Set Printing Universes.
-  auto using closed_increment. Show Universes.
+  eauto using closed_increment. Show Universes.
 Qed.
 (* also fails with -nois, so the content of the hint database does not matter
 *)

--- a/test-suite/bugs/bug_4450.v
+++ b/test-suite/bugs/bug_4450.v
@@ -39,10 +39,10 @@ Polymorphic Axiom maketype@{i} : MyType@{i}.
 
 Goal MyType@{l}.
 Proof.
-  Fail solve [ eauto using maketype@{m} ].
+  Fail solve [ pose (mk := maketype@{m}); eauto using mk ].
   eauto using maketype.
   Undo.
-  eauto using maketype@{n}.
+  pose (mk := maketype@{n}); eauto using mk.
 Qed.
 
 Axiom foo : forall (A : Type), list A.

--- a/test-suite/bugs/bug_5501.v
+++ b/test-suite/bugs/bug_5501.v
@@ -18,5 +18,6 @@ Global Instance Pred_All_instance (A : Pred_All) : All A := P'_All A.
 
 Definition Pred_All_proof {A : Pred_All} (a : A) : P A a.
 Proof.
-solve[auto using proof].
+Fail solve[auto using proof]. (* Do not implicitly rely on TC resolution *)
+solve[auto using proof, Pred_All_instance].
 Abort.

--- a/theories/Sorting/PermutSetoid.v
+++ b/theories/Sorting/PermutSetoid.v
@@ -236,7 +236,7 @@ Lemma permut_remove_hd :
   forall l l1 l2 a,
     permutation (a :: l) (l1 ++ a :: l2) -> permutation l (l1 ++ l2).
 Proof.
-  eauto using permut_remove_hd_eq, Equivalence_Reflexive.
+  eauto using permut_remove_hd_eq, (Equivalence_Reflexive (R := eqA)).
 Qed.
 
 Fact if_eqA_else : forall a a' (B:Type)(b b':B),
@@ -499,7 +499,7 @@ Proof.
   - apply permut_cons; auto using Equivalence_Reflexive.
   - change (x :: y :: l) with ([x] ++ y :: l);
       apply permut_add_cons_inside; simpl;
-      apply permut_cons_eq; auto using Equivalence_Reflexive, permut_refl.
+      apply permut_cons_eq; auto using (Equivalence_Reflexive (R := eqA)), permut_refl.
   - apply permut_trans with l'; trivial.
 Qed.
 


### PR DESCRIPTION
We intercept the definition of terms that look like global reference and generate a true global reference instead.

This exposes what is arguably a bug in the interpretation of using clauses, namely that typeclass resolution can be run to fill in some arguments of global references from the using clauses. At least this contradicts the documentation, [which states the following](https://coq.inria.fr/doc/V8.19.0/refman/proofs/automatic-tactics/auto.html?highlight=auto#coq:tacn.auto):
> hints passed through the using clause are used in the same way as if they were passed through a hint database