### PR TITLE
Set some basic rewriting primitives in Type opaque for TC search.

### DIFF
--- a/doc/changelog/11-standard-library/18910-setoid-type-core-tc-opaque.rst
+++ b/doc/changelog/11-standard-library/18910-setoid-type-core-tc-opaque.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  ``Coq.CRelationClasses.arrow``, ``Coq.CRelationClasses.iffT`` and
+  ``Coq.CRelationClasses.flip`` are now :cmd:`Typeclasses Opaque`
+  (`#18910 <https://github.com/coq/coq/pull/18910>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/bugs/bug_7675_3.v
+++ b/test-suite/bugs/bug_7675_3.v
@@ -58,19 +58,15 @@ Ltac test S b1 b2 b3 b4 :=
     unfold arrow, Basics.arrow; now rewrite <- HR | clear Ht ].
 
 Goal True.
-test Ri   true  true  true  true.
+Proof.
 test Ra   true  true  true  true.
 test Rb   false false false false.
-test RBi  true  true  true  true.
 test RBa  true  true  true  true.
 test RBb  false false false false.
-test RTi  true  true  true  true.
 test RTa  true  true  true  true.
 test RTb  false false false false.
-test RRBi true  true  true  true.
 test RRBa true  true  true  true.
 test RRBb false false false false.
-test RRTi true  true  true  true.
 test RRTa true  true  true  true.
 test RRTb false false false false.
 apply I.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -33,6 +33,8 @@ Definition flip {A B C : Type} (f : A -> B -> C) := fun x y => f y x.
 
 Definition iffT (A B : Type) := ((A -> B) * (B -> A))%type.
 
+Global Typeclasses Opaque flip arrow iffT.
+
 (** We allow to unfold the [crelation] definition while doing morphism search. *)
 
 Section Defs.


### PR DESCRIPTION
The corresponding Prop primitives are already set opaque in Classes.Init, hence I think this is an oversight. These low-level primitives being transparent mean that TC search when setoid rewriting in Type fires off a crapload of search branches that should not be there to begin with. Hopefully nobody relies on that in the wild.

cc @mattam82 

Backward compatible overlay:
- https://github.com/jwiegley/category-theory/pull/143
- https://github.com/MetaCoq/metacoq/pull/1076