### PR TITLE
Do not expose API relying on kernel instance substitution in EConstr.

### DIFF
--- a/dev/ci/user-overlays/18911-ppedrot-econstr-einstance-api.sh
+++ b/dev/ci/user-overlays/18911-ppedrot-econstr-einstance-api.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/Coq-Equations econstr-einstance-api 18911

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -875,9 +875,11 @@ let subst_univs_level_constr subst c =
   of_constr (Vars.subst_univs_level_constr subst (to_constr c))
 
 let subst_instance_context subst ctx =
+  let subst = EInstance.unsafe_to_instance subst in
   cast_rel_context (sym unsafe_eq) (Vars.subst_instance_context subst (cast_rel_context unsafe_eq ctx))
 
 let subst_instance_constr subst c =
+  let subst = EInstance.unsafe_to_instance subst in
   of_constr (Vars.subst_instance_constr subst (to_constr c))
 
 let subst_ainstance_constr subst c =

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -377,8 +377,8 @@ val closedn : Evd.evar_map -> int -> t -> bool
 val closed0 : Evd.evar_map -> t -> bool
 
 val subst_univs_level_constr : UVars.sort_level_subst -> t -> t
-val subst_instance_context : UVars.Instance.t -> rel_context -> rel_context
-val subst_instance_constr : UVars.Instance.t -> t -> t
+val subst_instance_context : EInstance.t -> rel_context -> rel_context
+val subst_instance_constr : EInstance.t -> t -> t
 
 val subst_ainstance_constr : UVars.AInstance.t -> t -> t
 

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -103,7 +103,7 @@ let eval_flexible_term ts env evd c sk =
         let cb = lookup_constant c env in
         match cb.const_body with
         | Def l_body ->
-            let def = subst_instance_constr (EInstance.kind evd u) (EConstr.of_constr l_body) in
+            let def = subst_instance_constr u (EConstr.of_constr l_body) in
             (* If we are unfolding a compatibility constant we want to return the
                unfolded primitive projection directly since we would like to pretend
                that the compatibility constant itself does not count as an unfolding

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -352,6 +352,7 @@ let find env sigma (proj,pat) =
   let us = List.map EConstr.of_constr us in
   let params = List.map EConstr.of_constr params in
   let u, ctx' = UnivGen.fresh_instance_from ctx None in
+  let u = EConstr.EInstance.make u in
   let c = EConstr.of_constr c in
   let c' = EConstr.Vars.subst_instance_constr u c in
   let t' = EConstr.of_constr t' in


### PR DESCRIPTION
This defeats the purpose of EConstr.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/588