### PR TITLE
[Experiment] Skip normalization of instances in projection-related code.

### DIFF
--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -623,7 +623,7 @@ let find_rectype env sigma c =
         if mib.mind_nparams > List.length l then raise Not_found;
         let l = List.map EConstr.Unsafe.to_constr l in
         let (par,rargs) = List.chop mib.mind_nparams l in
-        let indu = (ind, EInstance.kind sigma u) in
+        let indu = (ind, EConstr.Unsafe.to_instance u) in
         IndType((indu, par),List.map EConstr.of_constr rargs)
     | _ -> raise Not_found
 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -331,7 +331,7 @@ let judge_of_projection env sigma p cj =
     try find_mrectype env sigma cj.uj_type
     with Not_found -> error_case_not_inductive env sigma cj
   in
-  let u = EInstance.kind sigma u in
+  let u = EConstr.Unsafe.to_instance u in
   let pr = UVars.subst_instance_relevance u pr in
   let ty = EConstr.of_constr (CVars.subst_instance_constr u pty) in
   let ty = substl (cj.uj_val :: List.rev args) ty in


### PR DESCRIPTION
This is a hackish subset of another cleanup PR extracted out so that it is easy to bench as it keeps the API unchanged.