### PR TITLE
Fixes #13979: share universe instance in measure-based Program Fixpoint auxiliary constant

### DIFF
--- a/test-suite/bugs/bug_13979.v
+++ b/test-suite/bugs/bug_13979.v
@@ -1,0 +1,22 @@
+From Coq Require Import Lia Lists.List Program.Wf.
+
+Import ListNotations Nat.
+
+Set Universe Polymorphism.
+
+(* Check that merge_by calls merge_by_func with the identity instance *)
+
+Program Fixpoint merge_by {A : Type} (f : A -> nat) (l0 l1 : list A)
+  {measure (length l0 + length l1)} : list A :=
+  match l0, l1 with
+  | [], _ => l1
+  | _, [] => l0
+  | n0 :: k0, n1 :: k1 => if f n0 <=? f n1 then
+    n0 :: merge_by f k0 l1 else
+    n1 :: merge_by f l0 k1
+  end.
+Next Obligation.
+  intros.
+  subst;cbn.
+  lia.
+Qed.


### PR DESCRIPTION
The fix is short but maybe not so robust as it makes the assumption that the `uctx` received by the hook is the same as the one used to build the `universe_entry` of the constant it defined. It would probably be more robust to let the hook returns the `universe_entry` it computed (or return the canonical polymorphic instance of the constant it defined). At least, this is a working fix while more general decisions are taken about the hook (such as e.g. returning a full sigma, etc.).

Fixes / closes #13979 (the issue was that we regenerated a fresh instance instead of sharing the existing one).

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
