### PR TITLE
Fixes #11030, #11586: pattern-matching bugs in program mode or when using the program-style return predicate

### DIFF
--- a/dev/ci/user-overlays/18921-herbelin-master+fix11030-bugs-program-pattern-matching.sh
+++ b/dev/ci/user-overlays/18921-herbelin-master+fix11030-bugs-program-pattern-matching.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/herbelin/template-coq main+adapt-coq-pr18921-program-return-clause 18921 master+fix11030-bugs-program-pattern-matching

--- a/doc/changelog/02-specification-language/18921-master+fix11030-bugs-program-pattern-matching.rst
+++ b/doc/changelog/02-specification-language/18921-master+fix11030-bugs-program-pattern-matching.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  Anomaly `assertion failed` in pattern-matching compilation, with
+  `Program` mode or with let-ins in the arity of an inductive type
+  (`#18921 <https://github.com/coq/coq/pull/18921>`_,
+  fixes `#5777 <https://github.com/coq/coq/issues/5777>`_
+  and `#11030 <https://github.com/coq/coq/issues/11030>`_
+  and `#11586 <https://github.com/coq/coq/issues/11586>`_,
+  by Hugo Herbelin).

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2032,7 +2032,7 @@ let prepare_predicate_from_arsign_tycon ~program_mode env sigma loc tomatchs ars
   let nar = List.fold_left (fun n sign -> Context.Rel.nhyps sign + n) 0 arsign in
   let (rel_subst,var_subst), len =
     List.fold_right2 (fun (tm, tmtype) sign (subst, len) ->
-      let signlen = List.length sign in
+      let signlen = Context.Rel.nhyps sign in
         match EConstr.kind sigma tm with
           | Rel _ | Var _ when Int.equal signlen 1 && dependent_rel_or_var sigma tm c
             (* The term to match is not of a dependent type itself *) ->
@@ -2412,7 +2412,7 @@ let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
              (fun (sigma, idents, newpatterns, pats) pat arsign ->
                 let sigma, pat', cpat, idents = constr_of_pat !!env sigma arsign pat idents in
                   (sigma, idents, pat' :: newpatterns, cpat :: pats))
-              (sigma, Id.Set.empty, [], []) eqn.patterns sign
+              (sigma, Id.Set.empty, [], []) eqn.patterns (List.rev sign)
          in
          let newpatterns = List.rev newpatterns and opats = List.rev pats in
          let rhs_rels, pats, signlen =
@@ -2616,9 +2616,8 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
             pred slift, (arsign' :: []) :: arsigns))
       (sigma, [], 0, [], nar, []) tomatchs arsign
   in
-  let arsign'' = List.rev arsign' in
-    assert(Int.equal slift 0); (* we must have folded over all elements of the arity signature *)
-    sigma, arsign'', allnames, nar, eqs, neqs, refls
+  assert (Int.equal slift 0); (* we must have folded over all elements of the arity signature *)
+  sigma, arsign', allnames, nar, eqs, neqs, refls
 
 let context_of_arsign l =
   let (x, _) = List.fold_right

--- a/test-suite/bugs/bug_11030.v
+++ b/test-suite/bugs/bug_11030.v
@@ -1,0 +1,29 @@
+Inductive I : let z := 0 in Set := C : I.
+Check match C with C => true end.
+(* Was failing due to prepare_predicate_from_arsign_tycon not robust to let-in *)
+
+From Coq Require Import Arith Program.
+
+Module Bug11586.
+
+Inductive vector (A : Type) : nat -> Type :=
+  | nil : vector A O
+  | cons : forall {n : nat}, A -> vector A n -> vector A (S n).
+
+Arguments vector A n.
+Arguments nil {A}.
+Arguments cons {A n} x xs.
+
+(** Program was failing due to a List.rev issue *)
+
+Program Fixpoint nth'' {A : Type} {m : nat}
+  (xs : vector A m) (n : {i : nat | i < m}) : A :=
+  match xs, n with
+  | nil, i => !
+  | cons y ys, O => y
+  | cons y ys, (S q) => nth'' ys (exist _ q _)
+  end.
+Next Obligation. Admitted.
+Next Obligation. Admitted.
+
+End Bug11586.


### PR DESCRIPTION
This addresses two issues in `prepare_predicate_from_arsign_tycon`:
- the possibility of let-in was not taken into account in inductive types
- some contexts were inverted

Fixes #11030 
Fixes #11586 
This also fixes the anomaly part of #5777.

This does not solve the typing part of #5777 (presumably a de Bruijn lifting bug).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Overlay: MetaCoq/metacoq#1078