### PR TITLE
Fix printing of out-of-scope rels in rel_context debugging printer

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1561,7 +1561,7 @@ let extern_constr_pattern env sigma pat =
     (glob_of_pat Id.Set.empty env sigma pat)
 
 let extern_rel_context where env sigma sign =
-  let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
+  let a = detype_rel_context Detyping.Later where Id.Set.empty ([],env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
   pi3 (extern_local_binder ((constr_some_level,None),([],[])) vars a)


### PR DESCRIPTION
The variables were registered twice, so that unbound rels were picking a name as a cycle (e.g. `Rel 1`, `Rel 2`, `Rel 3`, `Rel 4` and `Rel 5` in `x:A;y:B` were printed `x`, `y`, `x`, `y` and `_UNBOUND_REL_5`).
