### PR TITLE
Make some VM allocations more robust

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -940,16 +940,21 @@ value coq_interprete
         print_instr("MAKEBLOCK, tag=");
         if (wosize == 0) {
           accu = Atom(tag);
-        } else {
+        } else if (wosize <= Max_young_wosize) {
           Coq_alloc_small(block, wosize, tag);
           Field(block, 0) = accu;
           for (i = 1; i < wosize; i++) Field(block, i) = *sp++;
           accu = block;
+        } else {
+          block = caml_alloc_shr(wosize, tag);
+          caml_initialize(&Field(block, 0), accu);
+          for (i = 1; i < wosize; i++) caml_initialize(&Field(block, i), *sp++);
+          accu = block;
         }
         Next;
       }
-      Instruct(MAKEBLOCK1) {
 
+      Instruct(MAKEBLOCK1) {
         tag_t tag = *pc++;
         value block;
         print_instr("MAKEBLOCK1, tag=");

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1243,12 +1243,19 @@ value coq_interprete
             *--sp=Field(coq_global_data, annot);
             /* We save the stack */
             if (sz == 0) accu = Atom(0);
-            else {
+            else if (sz <= Max_young_wosize) {
               Coq_alloc_small(accu, sz, Default_tag);
               if (Is_tailrec_switch(*sp)) {
                 for (i = 0; i < sz; i++) Field(accu, i) = sp[i+2];
               }else{
                 for (i = 0; i < sz; i++) Field(accu, i) = sp[i+5];
+              }
+            } else {
+              accu = caml_alloc_shr(sz, Default_tag);
+              if (Is_tailrec_switch(*sp)) {
+                for (i = 0; i < sz; i++) caml_initialize(&Field(accu, i), sp[i+2]);
+              }else{
+                for (i = 0; i < sz; i++) caml_initialize(&Field(accu, i), sp[i+5]);
               }
             }
             *--sp = accu;


### PR DESCRIPTION
A few commits fixing several instances of the same issue:

1. Now that `MAKEBLOCK` is also used for allocating universe blocks, and since those can grow larger than 256 words (one known instance of size 888 in non-malicious user code), it needs to be made more robust.
2. When it encounters an accumulator, `MAKESWITCHBLOCK` copies the whole stack frame of the current function, so that the code of the pattern-matching branches can be replayed later, during strong normalization. There is no reason why the stack frame could not exceed 256 words, even in a non-malicious function, so it needs to be taken into account.

Note that an actual buffer overflow would only happen when there is a conjunction of two events: the minor heap being almost full, and the subsequent minor collection giving up early instead of freeing a good chunk of the minor heap (I am looking at you, OCaml 5). So, it is unlikely. But better safe than sorry.