### PR TITLE
Pass the number of binders crossed in Find_subterm matching function.

### DIFF
--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -59,7 +59,7 @@ let map_named_declaration_with_hyploc f hyploc acc decl =
 exception SubtermUnificationError of subterm_unification_error
 
 type ('a, 'b) testing_function = {
-  match_fun : 'a -> EConstr.constr -> ('b, unit) Result.t;
+  match_fun : int -> 'a -> EConstr.constr -> ('b, unit) Result.t;
   merge_fun : 'b -> 'a -> ('a, unit) Result.t;
   mutable testing_state : 'a;
   mutable last_found : position_reporting option
@@ -74,7 +74,7 @@ let replace_term_occ_gen_modulo env sigma like_first test bywhat cl count t =
   let count = ref count in
   let rec substrec (nested, k) t =
     if Locusops.occurrences_done !count then t else
-    match test.match_fun test.testing_state t with
+    match test.match_fun k test.testing_state t with
     | Result.Ok subst ->
       let selected, count' = Locusops.update_occurrence_counter !count in
       let () = count := count' in
@@ -128,7 +128,7 @@ let replace_term_occ_decl_modulo env evd occs test bywhat d =
 (** Finding an exact subterm *)
 
 let make_eq_univs_test env evd c =
-  { match_fun = (fun evd c' ->
+  { match_fun = (fun k evd c' ->
     match EConstr.eq_constr_universes_proj env evd c c' with
     | None -> Result.Error ()
     | Some cst ->

--- a/pretyping/find_subterm.mli
+++ b/pretyping/find_subterm.mli
@@ -26,7 +26,7 @@ exception SubtermUnificationError of subterm_unification_error
     with None. *)
 
 type ('a, 'b) testing_function = {
-  match_fun : 'a -> constr -> ('b, unit) Result.t;
+  match_fun : int -> 'a -> constr -> ('b, unit) Result.t;
   merge_fun : 'b -> 'a -> ('a, unit) Result.t;
   mutable testing_state : 'a;
   mutable last_found : position_reporting option

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1711,9 +1711,9 @@ let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
   let n = Array.length (snd (decompose_app sigma c)) in
   let cgnd = if occur_meta_or_undefined_evar sigma c then NotGround else Ground in
   let exception NotUnifiable in
-  let matching_fun _ t =
+  let matching_fun k _ t =
     (* make_pattern_test is only ever called with an empty rel context *)
-    if not (EConstr.Vars.closed0 sigma t) then Result.Error ()
+    if 0 < k && not (EConstr.Vars.closed0 sigma t) then Result.Error ()
     else try
       let t',l2 =
         if from_prefix_of_ind then


### PR DESCRIPTION
We use it as a fast-path for closedness checking in Unification. We could do better by propagating the closedness status in the term data structure used by the matching function itself, but it would be way more invasive.