### PR TITLE
Fixes coq-elpi#618: remove synterp code from add_instance_base

### DIFF
--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -86,11 +86,11 @@ let add_instance_base inst =
     (* i.e. in a section, declare the hint as local since discharge is managed
        by rebuild_instance which calls again add_instance_hint; don't ask hints
        to take discharge into account itself *)
-    if Lib.sections_are_opened () then Local
+    if Global.sections_are_opened () then Local
     else SuperGlobal
   | Export ->
     (* Same as above for export *)
-    if Lib.sections_are_opened () then Local
+    if Global.sections_are_opened () then Local
     else Export
   in
   add_instance_hint inst.instance ~locality


### PR DESCRIPTION
Fixes anomaly encountered in elpi LPCIC/coq-elpi#618, see the discussion there.

I'm not really familiar with this part of the codebase, so I'm just acting on guidance from @gares:
>The code below should use Global.sections_are_opened () instead of Lib.sections_are_open () since add_instance_base is interp code (not synterp code).

I wasn't able to reproduce anomaly without elpi, so I'm not sure if we can add something to the testsuite.