### PR TITLE
Map opaque definitions to lossy accumulators in the VM (variant)

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -399,7 +399,9 @@ let init_with_argv argv =
   with e ->
     fatal_error (str "Error during initialization :" ++ (explain_exn e)) (is_anomaly e)
 
-let init() = init_with_argv Sys.argv
+let init () =
+  Vmsymtable.expensive_bytecode := true;
+  init_with_argv Sys.argv
 
 let run senv =
   try

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -847,6 +847,16 @@ to tell the kernel which reduction engine to use.
    full evaluation of algebraic objects. This includes the case of
    reflection-based tactics.
 
+   .. flag:: Expensive Bytecode
+
+      By default, :tacn:`vm_compute` eagerly drops sub-terms involving declarations
+      without body, so as to reduce the memory footprint. If this causes completeness
+      issues, enable this :term:`flag`.
+
+   .. exn:: vm_compute reduction has produced an incomplete term.
+
+      Some of the dropped sub-terms were actually meaningful in the reduced term.
+
 .. tacn:: native_compute {? {| @reference_occs | @pattern_occs } } {? @occurrences }
 
    Evaluates the goal by compilation to OCaml as described

--- a/kernel/byterun/coq_values.h
+++ b/kernel/byterun/coq_values.h
@@ -29,6 +29,7 @@
 
 #define Is_double(v) (Tag_val(v) == Double_tag)
 #define Is_tailrec_switch(v) (Field(v,1) == Val_true)
+#define Is_const_accu(v) (Tag_val(v) == ATOM_ID_TAG && Tag_val(Field(v, 0)) == 0)
 
 /* coq values for primitive operations */
 #define coq_tag_C1 2

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -127,7 +127,7 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
     else raise NotConvertible
   | Asort s1, Asort s2 ->
     sort_cmp_universes env pb s1 s2 cu
-  | Asort _ , _ | Aind _, _ | Aid _, _ -> raise NotConvertible
+  | Asort _ , _ | Aind _, _ | Aid _, _ | Ahole, _ -> raise NotConvertible
 
 and conv_stack env k stk1 stk2 cu =
   match stk1, stk2 with

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -26,6 +26,8 @@ open Vmbytegen
 module NamedDecl = Context.Named.Declaration
 module RelDecl = Context.Rel.Declaration
 
+let expensive_bytecode = ref false
+
 type vm_global = values array
 
 (* interpreter *)
@@ -321,7 +323,7 @@ and eval_to_patch env sigma code envcache table =
     a
   in
   let global = get_global_data !table in
-  let lossy = true in
+  let lossy = not !expensive_bytecode in
   coq_interprete tc crazy_val (get_atom_rel ()) global (inj_env vm_env) 0 lossy
 
 and val_of_constr env sigma c envcache table =

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -29,7 +29,7 @@ module RelDecl = Context.Rel.Declaration
 type vm_global = values array
 
 (* interpreter *)
-external coq_interprete : tcode -> values -> atom array -> vm_global -> Vmvalues.vm_env -> int -> values =
+external coq_interprete : tcode -> values -> atom array -> vm_global -> Vmvalues.vm_env -> int -> bool -> values =
   "coq_interprete_byte" "coq_interprete_ml"
 
 (* table for structured constants and switch annotations *)
@@ -321,8 +321,8 @@ and eval_to_patch env sigma code envcache table =
     a
   in
   let global = get_global_data !table in
-  let v = coq_interprete tc crazy_val (get_atom_rel ()) global (inj_env vm_env) 0 in
-  v
+  let lossy = true in
+  coq_interprete tc crazy_val (get_atom_rel ()) global (inj_env vm_env) 0 lossy
 
 and val_of_constr env sigma c envcache table =
   match compile ~fail_on_error:true env sigma c with
@@ -350,4 +350,4 @@ let val_of_constr env sigma c =
   v
 
 let vm_interp code v env k =
-  coq_interprete code v (get_atom_rel ()) (get_global_data !global_table) env k
+  coq_interprete code v (get_atom_rel ()) (get_global_data !global_table) env k false

--- a/kernel/vmsymtable.mli
+++ b/kernel/vmsymtable.mli
@@ -17,3 +17,5 @@ open Vmvalues
 val val_of_constr : env -> Genlambda.evars -> constr -> Vmvalues.values
 
 val vm_interp : tcode -> values -> vm_env -> int -> values
+
+val expensive_bytecode : bool ref

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -275,6 +275,7 @@ type atom =
   | Aid of id_key
   | Aind of inductive
   | Asort of Sorts.t
+  | Ahole
 
 (* Zippers *)
 
@@ -312,6 +313,8 @@ let rec whd_accu a stk =
     else Zapp (Obj.obj a) :: stk in
   let at = Obj.field a 2 in
   match Obj.tag at with
+  | i when Int.equal i Obj.int_tag ->
+      Vaccu (Ahole, [])
   | i when Int.equal i type_atom_tag ->
      begin match stk with
      | [] -> Vaccu (Obj.magic at, stk)
@@ -650,7 +653,8 @@ let rec pr_atom a =
                             | RelKey i -> str "#" ++ int i
                             | _ -> str "...") ++ str ")"
   | Aind (mi,i) -> str "Aind(" ++ MutInd.print mi ++ str "#" ++ int i ++ str ")"
-  | Asort _ -> str "Asort(")
+  | Asort _ -> str "Asort"
+  | Ahole -> str "?")
 and pr_kind w =
   let open Pp in
   match w with

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -104,6 +104,7 @@ type atom =
   | Aid of id_key
   | Aind of inductive
   | Asort of Sorts.t
+  | Ahole
 
 val get_atom_rel : unit -> atom array
 (** Global table of rels *)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -197,6 +197,8 @@ and nf_whd env sigma whd typ =
      nf_univ_args ~nb_univs mk env sigma stk
   | Vaccu (Asort s, stk) ->
     assert (List.is_empty stk); mkSort s
+  | Vaccu (Ahole, _) ->
+      CErrors.user_err Pp.(str "vm_compute reduction has produced an incomplete term.");
 
 and nf_univ_args ~nb_univs mk env sigma stk =
   let u =

--- a/test-suite/bugs/bug_4203.v
+++ b/test-suite/bugs/bug_4203.v
@@ -11,6 +11,8 @@ Proof.
   split. cbn. apply eq_refl.
 Qed.
 
+Set Expensive Bytecode.
+
 Definition t := Eval lazy in constant_ok nat_ops nat_ops_ok.
 Definition t' := Eval vm_compute in constant_ok nat_ops nat_ops_ok.
 Definition t'' := Eval native_compute in constant_ok nat_ops nat_ops_ok.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1760,6 +1760,14 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
+      optkey   = ["Expensive";"Bytecode"];
+      optread  = (fun () -> !Vmsymtable.expensive_bytecode);
+      optwrite = (:=) Vmsymtable.expensive_bytecode }
+
+let () =
+  declare_bool_option
+    { optstage = Summary.Stage.Interp;
+      optdepr  = None;
       optkey   = ["Dump";"Lambda"];
       optread  = (fun () -> !Vmlambda.dump_lambda);
       optwrite = (:=) Vmlambda.dump_lambda }


### PR DESCRIPTION
This pull request introduces a new kind of accumulator that discards its arguments. If this accumulator is still present at the end of the reduction, the conversion check fails with an error message, because we do not have enough information to conclude. This accumulator is used for opaque definitions (i.e., `Qed`) and axioms. This obviously breaks completeness when such definitions are not eliminated during computations. This behavior can be disabled using `Set Expensive Bytecode`, which is the main difference with #18917.

On the following testcase, memory consumption is reduced by 2.1 GB, no major GC is needed, and time is divided by 5.

```coq
Require Import List Program BinPos.

Section Rev.
Variable T : Type.
Record vec n := { list_of_vec : list T; vec_spec : length list_of_vec = n }.

Definition build l := Build_vec (length l) l eq_refl.

Lemma length_rev' l : @length T (rev' l) = length l.
Proof. unfold rev'. rewrite <- rev_alt. apply rev_length. Qed.

Program Definition rev {n} (v : vec n) :=
  Build_vec n (rev' (list_of_vec _ v)) _.
Next Obligation. rewrite length_rev'. apply vec_spec. Qed.
End Rev.

(*Set Expensive Bytecode.*)

Definition l := 0::1::2::3::4::5::nil.

Goal list_of_vec _ _ (Pos.iter (rev _) (build _ l) 10000000) = l.
Proof. vm_cast_no_check (eq_refl l). Time Qed.
```

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [x] Added / updated **documentation**.
- [ ] Opened **overlay** pull requests.