### PR TITLE
Indent body and type when printing local definitions over several lines

### DIFF
--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -102,11 +102,11 @@ Arguments lem3 k
   n, n0 := match x + 0 with
            | 0 | S _ => 0
            end : nat
-  e,
-  e0 := match x + 0 as y return (y = y) with
-        | 0 => eq_refl
-        | S n => eq_refl
-        end : x + 0 = x + 0
+  e, e0 :=
+    match x + 0 as y return (y = y) with
+    | 0 => eq_refl
+    | S n => eq_refl
+    end : x + 0 = x + 0
   n1, n2 := match x with
             | 0 | S _ => 0
             end : nat
@@ -119,14 +119,14 @@ Arguments lem3 k
 1 goal
   
   p : nat
-  a,
-  a0 := match eq_refl as y in (_ = e) return (y = y /\ e = e) with
-        | eq_refl => conj eq_refl eq_refl
-        end : eq_refl = eq_refl /\ p = p
-  a1,
-  a2 := match eq_refl in (_ = e) return (p = p /\ e = e) with
-        | eq_refl => conj eq_refl eq_refl
-        end : p = p /\ p = p
+  a, a0 :=
+    match eq_refl as y in (_ = e) return (y = y /\ e = e) with
+    | eq_refl => conj eq_refl eq_refl
+    end : eq_refl = eq_refl /\ p = p
+  a1, a2 :=
+    match eq_refl in (_ = e) return (p = p /\ e = e) with
+    | eq_refl => conj eq_refl eq_refl
+    end : p = p /\ p = p
   ============================
   eq_refl = eq_refl
 fun x : comparison => match x with

--- a/test-suite/output/DebugRelevances.out
+++ b/test-suite/output/DebugRelevances.out
@@ -26,13 +26,13 @@ Arguments boz (A B)%type_scope a b
 1 goal
   
   f := fun (A : (* Relevant *) Type) (_ : (* α8 *) A) => A
-   : forall (A : (* Relevant *) Type) (_ : (* α8 *) A), Type
+    : forall (A : (* Relevant *) Type) (_ : (* α8 *) A), Type
   ============================
   True
 1 goal
   
   f := fun (A : (* Relevant *) Type) (_ : (* Relevant *) A) => A
-   : forall (A : (* Relevant *) Type) (_ : (* Relevant *) A), Type
+    : forall (A : (* Relevant *) Type) (_ : (* Relevant *) A), Type
   ============================
   True
 let x := 0 in x

--- a/test-suite/output/Naming.out
+++ b/test-suite/output/Naming.out
@@ -39,18 +39,20 @@
 1 goal
   
   x3, x, x1, x4, x0 : nat
-  H : forall x x3 : nat,
-      x + x1 = x4 + x3 ->
-      forall x0 x4 x5 S0 : nat, x0 + S0 = x4 + x5 + (S x + x1)
+  H :
+    forall x x3 : nat,
+    x + x1 = x4 + x3 ->
+    forall x0 x4 x5 S0 : nat, x0 + S0 = x4 + x5 + (S x + x1)
   H0 : x + x1 = x4 + x0
   ============================
   forall x5 x6 x7 S : nat, x5 + S = x6 + x7 + Datatypes.S x
 1 goal
   
   x3, x, x1, x4, x0 : nat
-  H : forall x x3 : nat,
-      x + x1 = x4 + x3 ->
-      forall x0 x4 x5 S0 : nat, x0 + S0 = x4 + x5 + (Datatypes.S x + x1)
+  H :
+    forall x x3 : nat,
+    x + x1 = x4 + x3 ->
+    forall x0 x4 x5 S0 : nat, x0 + S0 = x4 + x5 + (Datatypes.S x + x1)
   H0 : x + x1 = x4 + x0
   x5, x6, x7, S : nat
   ============================

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -135,8 +135,9 @@ match x with
 end
      : list ?T -> option (list ?T)
 where
-?T : [x : list ?T  x1 : list ?T  x0 := x1 : list ?T |- Type] (x, x1,
-     x0 cannot be used)
+?T :
+  [x : list ?T  x1 : list ?T  x0 := x1 : list ?T |- Type] (x, x1,
+  x0 cannot be used)
 s
      : s
 10

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -44,22 +44,28 @@ fun y : nat => # (x, z) |-> y & y
      : forall y : nat,
        (?T1 * ?T2 -> ?T1 * ?T2 * nat) * (?T * ?T0 -> ?T * ?T0 * nat)
 where
-?T : [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0
-     |- Type] (pat, p0, p cannot be used)
-?T0 : [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0
-      |- Type] (pat, p0, p cannot be used)
-?T1 : [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
-      |- Type] (pat, p0, p cannot be used)
-?T2 : [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
-      |- Type] (pat, p0, p cannot be used)
+?T :
+  [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0 |- Type] (pat,
+  p0, p cannot be used)
+?T0 :
+  [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0 |- Type] (pat,
+  p0, p cannot be used)
+?T1 :
+  [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
+  |- Type] (pat, p0, p cannot be used)
+?T2 :
+  [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
+  |- Type] (pat, p0, p cannot be used)
 fun y : nat => # (x, z) |-> (x + y) & (y + z)
      : forall y : nat,
        (nat * ?T -> nat * ?T * nat) * (?T0 * nat -> ?T0 * nat * nat)
 where
-?T : [y : nat  pat : nat * ?T  p0 : nat * ?T  p := p0 : nat * ?T
-     |- Type] (pat, p0, p cannot be used)
-?T0 : [y : nat  pat : ?T0 * nat  p0 : ?T0 * nat  p := p0 : ?T0 * nat
-      |- Type] (pat, p0, p cannot be used)
+?T :
+  [y : nat  pat : nat * ?T  p0 : nat * ?T  p := p0 : nat * ?T |- Type] (pat,
+  p0, p cannot be used)
+?T0 :
+  [y : nat  pat : ?T0 * nat  p0 : ?T0 * nat  p := p0 : ?T0 * nat
+  |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
 File "./output/Notations4.v", line 149, characters 82-85:

--- a/test-suite/output/PrintAssumptions.out
+++ b/test-suite/output/PrintAssumptions.out
@@ -9,17 +9,17 @@ bli : Type
 Axioms:
 seq relies on definitional UIP.
 Axioms:
-extensionality
-  : forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
+extensionality :
+  forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
 Axioms:
-extensionality
-  : forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
+extensionality :
+  forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
 Axioms:
-extensionality
-  : forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
+extensionality :
+  forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
 Axioms:
-extensionality
-  : forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
+extensionality :
+  forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g
 Closed under the global context
 Closed under the global context
 Axioms:


### PR DESCRIPTION
Assume:
```coq
Theorem T (long_long_long_long_long_long_long_long_ident := fun x : nat => x) : True.
```
Before the PR, it is printed
```coq
  long_long_long_long_long_long_long_long_ident :=
  fun x : nat => x : nat -> nat
  ============================
  True
```
After, it is printed:
```coq
  long_long_long_long_long_long_long_long_ident :=
    fun x : nat => x : nat -> nat
  ============================
  True
```
The PR also applies this indentation to other similar places.

#### Overlays (to be merged before the current PR)

* [x] https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/549
