### PR TITLE
Fix support of Program-style pattern-matching for multiple arguments in inductive families

### DIFF
--- a/doc/changelog/02-specification-language/18929-master+program-equality-wrapper-multiple-inductive-families.rst
+++ b/doc/changelog/02-specification-language/18929-master+program-equality-wrapper-multiple-inductive-families.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Support for `Program`-style pattern-matching on more than one
+  argument in an inductive family
+  (`#18929 <https://github.com/coq/coq/pull/18929>`_,
+  fixes `#1956 <https://github.com/coq/coq/issues/1956>`_
+  and `#5777 <https://github.com/coq/coq/issues/5777>`_,
+  by Hugo Herbelin).

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2518,7 +2518,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
   let nar = List.fold_left (fun n names -> List.length names + n) 0 allnames in
   let sigma, eqs, neqs, refls, slift, arsign' =
     List.fold_left2
-      (fun (sigma, eqs, neqs, refl_args, slift, arsigns) (tm, ty) arsign ->
+      (fun (sigma, eqs, neqs, refls, slift, arsigns) (tm, ty) arsign ->
          (* The accumulator:
             previous eqs,
             number of previous eqs,
@@ -2585,7 +2585,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
              let previd, id = make_prime avoid appn in
                (sigma, (LocalAssum (make_annot (Name (eq_id avoid previd)) ERelevance.relevant, eq) :: argeqs) :: eqs,
                 succ nargeqs,
-                refl_eq :: refl_args,
+                refl_eq :: refl_args @ refls,
                 pred slift,
                 ((RelDecl.set_name (Name id) app_decl :: argsign') :: arsigns))
 
@@ -2603,7 +2603,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
             let na = make_annot (Name (eq_id avoid previd)) ERelevance.relevant in
             (sigma,
             [LocalAssum (na, eq)] :: eqs, succ neqs,
-            refl :: refl_args,
+            refl :: refls,
             pred slift, (arsign' :: []) :: arsigns))
       (sigma, [], 0, [], nar, []) tomatchs arsign
   in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2544,15 +2544,15 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
                       if Reductionops.is_conv env sigma argt t then
                         let sigma, eq =
                           mk_eq env sigma (lift (nargeqs + slift) argt)
-                            (mkRel (nargeqs + slift))
+                            (mkRel nar)
                             (lift (nargeqs + nar) arg)
                         in
                         let sigma, refl = mk_eq_refl env sigma argt arg in
                         sigma, eq, refl
                       else
                         let sigma, eq =
-                          mk_JMeq env sigma (lift (nargeqs + slift) t)
-                            (mkRel (nargeqs + slift))
+                          mk_JMeq env sigma (lift nar t)
+                            (mkRel nar)
                             (lift (nargeqs + nar) argt)
                             (lift (nargeqs + nar) arg)
                         in
@@ -2576,8 +2576,8 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
              in
               let sigma, eq =
                 mk_JMeq env sigma
-                  (lift (nargeqs + slift) appt)
-                  (mkRel (nargeqs + slift))
+                  (lift nar appt)
+                  (mkRel nar)
                   (lift (nargeqs + nar) ty)
                   (lift (nargeqs + nar) tm)
              in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2428,7 +2428,6 @@ let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
          in
          let sigma, ineqs = build_ineqs !!env sigma prevpatterns pats signlen in
          let rhs_rels' = rels_of_patsign sigma rhs_rels in
-         let _signenv,_ = push_rel_context ~hypnaming sigma rhs_rels' env in
          let arity =
            let args, nargs =
              List.fold_right (fun (sign, c, (_, args), _) (allargs,n) ->
@@ -2646,7 +2645,8 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
       (sigma, [], 0, [], nar, []) tomatchs arsign
   in
   assert (Int.equal slift 0); (* we must have folded over all elements of the arity signature *)
-  sigma, arsign', allnames, nar, eqs, neqs, refls
+  assert (neqs = nar);
+  sigma, arsign', nar, eqs, refls
 
 let context_of_arsign l =
   (* From a family of [env, arsign |- ctx_i]] to [env, arsign |- ctx_1, ..., ctx_n] *)
@@ -2674,7 +2674,7 @@ let compile_program_cases ?loc style (typing_function, sigma) tycon env
   let tomatchs, tomatchs_lets, tycon' = abstract_tomatch env sigma tomatchs tycon in
   let _,env = push_rel_context ~hypnaming sigma tomatchs_lets env in
   let len = List.length eqns in
-  let sigma, sign, allnames, signlen, eqs, neqs, args =
+  let sigma, sign, signlen, eqs, args =
     (* The arity signature *)
     let arsign = extract_arity_signature ~dolift:false !!env tomatchs tomatchl in
       (* Build the dependent arity signature, the equalities which makes

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2242,7 +2242,7 @@ let constr_of_pat env sigma arsign pat avoid =
         let r = ERelevance.relevant in (* TODO relevance *)
           (sigma, (DAst.make ?loc @@ PatVar name), [LocalAssum (make_annot name r, ty)] @ realargs, mkRel 1, lift 1 ty,
            rel_list 1 (List.length realargs), 1, avoid)
-    | PatCstr (((_, i) as cstr),args,alias) ->
+    | PatCstr (((_, i) as cstr),patargs,alias) ->
         let cind = inductive_of_constructor cstr in
         let IndType (indf, _) =
           try find_rectype env sigma (lift (-(List.length realargs)) ty)
@@ -2254,19 +2254,19 @@ let constr_of_pat env sigma arsign pat avoid =
         let cstrs = get_constructors env indf in
         let ci = cstrs.(i-1) in
         let nb_args_constr = ci.cs_nargs in
-        assert (Int.equal nb_args_constr (List.length args));
+        assert (Int.equal nb_args_constr (List.length patargs));
         let sigma, patargs, args, sign, env, n, m, avoid =
           List.fold_right2
-            (fun decl ua (sigma, patargs, args, sign, env, n, m, avoid)  ->
+            (fun decl pat (sigma, patargs, pats_c, sign, env, n, m, avoid)  ->
                let t = RelDecl.get_type decl in
-               let sigma, pat', sign', arg', typ', argtypargs, n', avoid =
-                 let liftt = liftn (List.length sign) (succ (List.length args)) t in
-                   typ env sigma (substl args liftt, []) ua avoid
+               let sigma, patarg', sign', pat_c', typ', argtypargs, n', avoid =
+                 let liftt = liftn (List.length sign) (succ (List.length pats_c)) t in
+                   typ env sigma (substl pats_c liftt, []) pat avoid
                in
-               let args' = arg' :: List.map (lift n') args in
+               let pats_c = pat_c' :: List.map (lift n') pats_c in
                let env' = EConstr.push_rel_context sign' env in
-                 (sigma, pat' :: patargs, args', sign' @ sign, env', n' + n, succ m, avoid))
-            ci.cs_args (List.rev args) (sigma, [], [], [], env, 0, 0, avoid)
+                 (sigma, patarg' :: patargs, pats_c, sign' @ sign, env', n' + n, succ m, avoid))
+            ci.cs_args (List.rev patargs) (sigma, [], [], [], env, 0, 0, avoid)
         in
         let args = List.rev args in
         let patargs = List.rev patargs in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2239,6 +2239,7 @@ let constr_of_pat env sigma arsign pat avoid =
               let id = next_ident_away wildcard_id avoid in
                 Name id, Id.Set.add id avoid
         in
+        let realargs = List.map (map_name (fun _ -> Anonymous)) realargs in (* Hack to force their instantiation as evars *)
         let r = ERelevance.relevant in (* TODO relevance *)
           (sigma, (DAst.make ?loc @@ PatVar name), [LocalAssum (make_annot name r, ty)] @ realargs, mkRel 1, lift 1 ty,
            rel_list 1 (List.length realargs), 1, avoid)
@@ -2333,7 +2334,7 @@ let vars_of_ctx sigma ctx =
                    [hole na.binder_name; DAst.make @@ GVar prev])) :: vars
         | _ ->
             match RelDecl.get_name decl with
-                Anonymous -> invalid_arg "vars_of_ctx"
+                Anonymous -> prev, (DAst.make @@ GHole GInternalHole) :: vars (* Hack, see constr_of_pat *)
               | Name n -> n, (DAst.make @@ GVar n) :: vars)
       ctx (Id.of_string "vars_of_ctx_error", [])
   in List.rev y

--- a/test-suite/bugs/bug_1956.v
+++ b/test-suite/bugs/bug_1956.v
@@ -1,0 +1,15 @@
+Require Import Program.
+
+Inductive exp_raw : nat -> Set :=
+| exp_raw_bvar : forall n i, i < n -> exp_raw n
+| exp_raw_fvar : forall n, nat -> exp_raw n
+| exp_raw_abs : forall n, exp_raw (S n) -> exp_raw n
+| exp_raw_app : forall n, exp_raw n -> exp_raw n -> exp_raw n.
+
+(* The following definition is not accepted. *)
+
+Program Definition is_abs (n : nat) (e : exp_raw n) : bool :=
+  match e with
+    | exp_raw_abs _ _ => true
+    | _ => false
+   end.

--- a/test-suite/bugs/bug_5777.v
+++ b/test-suite/bugs/bug_5777.v
@@ -1,0 +1,29 @@
+Require Import Coq.Program.Tactics.
+Require Import Coq.Program.Utils JMeq Lia.
+
+#[local]
+Open Scope program_scope.
+
+Inductive vector (A: Type) : nat -> Type :=
+| vcons  {n:nat} : A -> vector A n -> vector A (S n)
+| vnil : vector A 0.
+
+Arguments vcons [A n] _ _.
+Arguments vnil {A}.
+
+#[program]
+Fixpoint drop
+         {A:   Type}
+         {n:   nat}
+         (v:   vector A n)
+         (b:   nat | b <= n)
+         {struct v}
+  : vector A (n - b) :=
+  match b, v with
+  | 0, v => v
+  | S b', vcons _ r => drop r b'
+  | _, _ => !
+  end.
+Next Obligation. lia. Qed.
+Next Obligation. lia. Qed.
+Next Obligation. Admitted. (* Can we do better? *)

--- a/test-suite/success/ProgramCases.v
+++ b/test-suite/success/ProgramCases.v
@@ -9,4 +9,25 @@ Program Definition h {A B : Type} {n1 n2 : nat} (v1 : t A n1) (v2 : t A n2) (p1 
     | cons _ _ i1 j1 k1 c1 d1 e1 a1 b1 q1 r1, cons _ _ i2 j2 k2 c2 d2 e2 a2 b2 q2 r2 => 0
   end.
 
+Program Definition h2 {A B : Type} b {n1 n2 : nat} (v1 : t A n1) (v2 : t A n2) (p1 : T A B n1 v1) (p2 : T A B n2 v2) : nat :=
+  match b, p1, p2 with
+    | true, cons _ _ i1 j1 k1 c1 d1 e1 a1 b1 q1 r1, _ => 0
+    | false, _, cons _ _ i2 j2 k2 c2 d2 e2 a2 b2 q2 r2 => 0
+  end.
+
 End T.
+
+Module U.
+
+Inductive U A B : forall n, t A n -> Type :=
+  | cons n m p c d e : A -> B -> U A B n c -> U A B m d -> U A B p e
+  | nil n c : U A B n c.
+
+Program Definition h {A B : Type} {n1 n2 : nat} (v1 : t A n1) (v2 : t A n2) (p1 : U A B n1 v1) (p2 : U A B n2 v2) : nat :=
+  match p1, p2 with
+    | cons _ _ i1 j1 k1 c1 d1 e1 a1 b1 q1 r1, _ => 0
+    | _, cons _ _ i2 j2 k2 c2 d2 e2 a2 b2 q2 r2 => 0
+    | _, _ => 0
+  end.
+
+End U.

--- a/test-suite/success/ProgramCases.v
+++ b/test-suite/success/ProgramCases.v
@@ -1,0 +1,12 @@
+Require Import Vector Program.
+
+Module T.
+
+Inductive T A B : forall n, t A n -> Type := cons n m p c d e : A -> B -> T A B n c -> T A B m d -> T A B p e.
+
+Program Definition h {A B : Type} {n1 n2 : nat} (v1 : t A n1) (v2 : t A n2) (p1 : T A B n1 v1) (p2 : T A B n2 v2) : nat :=
+  match p1, p2 with
+    | cons _ _ i1 j1 k1 c1 d1 e1 a1 b1 q1 r1, cons _ _ i2 j2 k2 c2 d2 e2 a2 b2 q2 r2 => 0
+  end.
+
+End T.


### PR DESCRIPTION
17 years after the first version of `Program`, this PR debugs the (anticipated) support for multiple patterns involving inductive families. By fixing several de Bruijn indexes bugs, by detecting heteregeneous disequalities, and by addressing a few other typing bugs, it allows for instance to support, without returning strange typing errors, basic examples such as:

```coq
Require Import Program Vector.
Program Definition h {A B : Type} {n1 n2 : nat} (v1 : t A n1) (v2 : t A n2) : nat :=
  match v1, v2 with
  | cons _ _ _ _ , _ => 0
  | _, cons _ _ _ _ => 1
  | _, _ => 2
  end.
```

In particular, it morally fixes #5777 (up to heterogeneous equality discrimination issues still not addressed).

Also fixes #1956.

[More generally, I feel that there is a nice architecture to build by combining `Program`, Equations, small inversion, which all provide crucial advanced reasoning bricks about inductive types. All of the following are somehow independent parameters that should be freely combinable: Goguen-McBride-McKinna, or Cockx, or small inversion emulation of dependent pattern-matching; adding or not equations and inequations to the typing context; failing or opening obligations or goals on existential variables.]

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Depends on #18921 (merged)
