### PR TITLE
Full EConstr-based API for Inductiveops.

### DIFF
--- a/dev/ci/user-overlays/18935-ppedrot-econstr-inductiveops-api.sh
+++ b/dev/ci/user-overlays/18935-ppedrot-econstr-inductiveops-api.sh
@@ -1,0 +1,5 @@
+overlay equations https://github.com/ppedrot/Coq-Equations econstr-inductiveops-api 18935
+
+overlay paramcoq https://github.com/ppedrot/paramcoq econstr-inductiveops-api 18935
+
+overlay lean_importer https://github.com/ppedrot/coq-lean-import econstr-inductiveops-api 18935

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -882,6 +882,10 @@ let subst_instance_constr subst c =
   let subst = EInstance.unsafe_to_instance subst in
   of_constr (Vars.subst_instance_constr subst (to_constr c))
 
+let subst_instance_relevance subst r =
+  let subst = EInstance.unsafe_to_instance subst in
+  UVars.subst_instance_relevance subst r
+
 (** Operations that dot NOT commute with evar-normalization *)
 let noccurn sigma n term =
   let rec occur_rec n c = match kind sigma c with

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -379,6 +379,7 @@ val closed0 : Evd.evar_map -> t -> bool
 val subst_univs_level_constr : UVars.sort_level_subst -> t -> t
 val subst_instance_context : EInstance.t -> rel_context -> rel_context
 val subst_instance_constr : EInstance.t -> t -> t
+val subst_instance_relevance : EInstance.t -> Sorts.relevance -> Sorts.relevance
 
 val subst_of_rel_context_instance : rel_context -> instance -> substl
 val subst_of_rel_context_instance_list : rel_context -> instance_list -> substl

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -529,7 +529,7 @@ and extract_really_ind env kn mib =
     for i = 0 to mib.mind_ntypes - 1 do
       let p,u = packets.(i) in
       if not p.ip_logical then
-        let types = arities_of_constructors env ((kn,i),u) in
+        let types = Inductive.arities_of_constructors ((kn,i),u) (mib, mib.mind_packets.(i)) in
         for j = 0 to Array.length types - 1 do
           let t = snd (decompose_prod_n_decls ndecls types.(j)) in
           let prods,head = Reduction.whd_decompose_prod epar t in
@@ -732,7 +732,6 @@ let rec extract_term env sg mle mlt c args =
         let ind = Inductiveops.find_rectype env sg (Retyping.get_type_of env sg c) in
         let indf,_ = Inductiveops.dest_ind_type ind in
         let _,indargs = Inductiveops.dest_ind_family indf in
-        let indargs = List.map EConstr.of_constr indargs in
         extract_term env sg mle mlt (beta_applist sg (EConstr.of_constr term,indargs@[c])) args
     | Rel n ->
         (* As soon as the expected [mlt] for the head is known, *)

--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -50,16 +50,17 @@ let rec nb_prod_after n c=
     | _ -> 0
 
 let construct_nhyps env ind =
+  let ind = on_snd EInstance.make ind in
   let nparams = (fst (Global.lookup_inductive (fst ind))).mind_nparams in
   let constr_types = Inductiveops.arities_of_constructors env ind in
-  let hyp = nb_prod_after nparams in
-    Array.map hyp constr_types
+  let hyp c = nb_prod_after nparams (EConstr.Unsafe.to_constr c) in
+  Array.map hyp constr_types
 
 (* indhyps builds the array of arrays of constructor hyps for (ind largs)*)
 let ind_hyps env sigma nevar ind largs =
+  let ind = on_snd EInstance.make ind in
   let types= Inductiveops.arities_of_constructors env ind in
   let myhyps t =
-    let t = EConstr.of_constr t in
     let nparam_decls = Context.Rel.length (fst (Global.lookup_inductive (fst ind))).mind_params_ctxt in
     let t1=Termops.prod_applist_decls sigma nparam_decls t largs in
     let t2=snd (decompose_prod_n_decls sigma nevar t1) in

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -210,7 +210,6 @@ let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
         let elimty = Retyping.get_type_of env sigma elim in
         sigma, elim, elimty
       else
-        let indu = (fst indu, EConstr.EInstance.kind sigma (snd indu)) in
         let sigma, case = Indrec.build_case_analysis_scheme env sigma indu true sort in
         let (ind, indty) = Indrec.eval_case_analysis case in
         (sigma, ind, indty)

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -168,7 +168,7 @@ let find_class_type env sigma t =
         let t = Retyping.get_type_of env sigma c in
         let IndType (fam,_) = find_rectype env sigma t in
         let _, params = dest_ind_family fam in
-        List.rev_map EConstr.of_constr params
+        List.rev params
       in
       CL_PROJ (Projection.repr p), EInstance.empty, (List.rev_append revparams (c :: args))
     | Ind (ind_sp,u) -> CL_IND ind_sp, u, args

--- a/pretyping/combinators.ml
+++ b/pretyping/combinators.ml
@@ -274,7 +274,7 @@ let make_selector env sigma ~pos ~special ~default c ctype =
   let cstrs = get_constructors env indf in
   let build_branch i =
     let endpt = if Int.equal i pos then special else default in
-    let args = List.map (fun d -> map_rel_decl EConstr.of_constr d) cstrs.(i-1).cs_args in
+    let args = cstrs.(i-1).cs_args in
     it_mkLambda_or_LetIn endpt args in
   let brl =
     List.map build_branch(List.interval 1 (Array.length mip.mind_consnames)) in

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -9,14 +9,14 @@
 (************************************************************************)
 
 open Names
-open Constr
+open EConstr
 open Environ
 open Evd
 
 (** Errors related to recursors building *)
 
 type recursion_scheme_error =
-  | NotAllowedCaseAnalysis of (*isrec:*) bool * Sorts.t * pinductive
+  | NotAllowedCaseAnalysis of (*isrec:*) bool * Sorts.t * Constr.pinductive
   | NotMutualInScheme of inductive * inductive
   | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
@@ -37,31 +37,31 @@ type case_analysis = private {
   case_type : EConstr.t;
 }
 
-val check_valid_elimination : env -> evar_map -> pinductive -> dep:bool -> EConstr.ESorts.t -> unit
+val check_valid_elimination : env -> evar_map -> inductive puniverses -> dep:bool -> ESorts.t -> unit
 
 val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
 
 val default_case_analysis_dependence : env -> inductive -> bool
 
-val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
-  dep_flag -> EConstr.ESorts.t -> evar_map * case_analysis
+val build_case_analysis_scheme : env -> Evd.evar_map -> inductive puniverses ->
+  dep_flag -> ESorts.t -> evar_map * case_analysis
 
 (** Build a dependent case elimination predicate unless type is in Prop
    or is a recursive record with primitive projections. *)
 
-val build_case_analysis_scheme_default : env -> evar_map -> pinductive ->
-      EConstr.ESorts.t -> evar_map * case_analysis
+val build_case_analysis_scheme_default : env -> evar_map -> inductive puniverses ->
+  ESorts.t -> evar_map * case_analysis
 
 (** Builds a recursive induction scheme (Peano-induction style) in the given sort.  *)
 
-val build_induction_scheme : env -> evar_map -> pinductive ->
-      dep_flag -> EConstr.ESorts.t -> evar_map * constr
+val build_induction_scheme : env -> evar_map -> inductive puniverses ->
+  dep_flag -> ESorts.t -> evar_map * constr
 
 (** Builds mutual (recursive) induction schemes *)
 
 val build_mutual_induction_scheme :
   env -> evar_map -> ?force_mutual:bool ->
-  (pinductive * dep_flag * EConstr.ESorts.t) list -> evar_map * constr list
+  (inductive puniverses * dep_flag * EConstr.ESorts.t) list -> evar_map * constr list
 
 (** Recursor names utilities *)
 

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -12,7 +12,7 @@ open CErrors
 open Util
 open Names
 open Term
-open Constr
+open EConstr
 open Vars
 open Context
 open Declarations
@@ -25,10 +25,11 @@ open Context.Rel.Declaration
    Inductive, but they expect an env *)
 
 let type_of_inductive env (ind,u) =
+ let u = EConstr.Unsafe.to_instance u in
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
  Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif,u) in
- Arguments_renaming.rename_type t (IndRef ind)
+ EConstr.of_constr @@ Arguments_renaming.rename_type t (IndRef ind)
 
 let e_type_of_inductive env sigma (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
@@ -38,11 +39,12 @@ let e_type_of_inductive env sigma (ind,u) =
 
 (* Return type as quoted by the user *)
 let type_of_constructor env (cstr,u) =
+ let u = EConstr.Unsafe.to_instance u in
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
  Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,u) specif in
- Arguments_renaming.rename_type t (ConstructRef cstr)
+ EConstr.of_constr @@ Arguments_renaming.rename_type t (ConstructRef cstr)
 
 let e_type_of_constructor env sigma (cstr,u) =
  let (mib,_ as specif) =
@@ -53,16 +55,18 @@ let e_type_of_constructor env sigma (cstr,u) =
 
 (* Return constructor types in user form *)
 let type_of_constructors env (ind,u as indu) =
- let specif = Inductive.lookup_mind_specif env ind in
-  Inductive.type_of_constructors indu specif
+  let indu = on_snd EConstr.Unsafe.to_instance indu in
+  let specif = Inductive.lookup_mind_specif env ind in
+  Array.map EConstr.of_constr (Inductive.type_of_constructors indu specif)
 
 (* Return constructor types in normal form *)
 let arities_of_constructors env (ind,u as indu) =
- let specif = Inductive.lookup_mind_specif env ind in
-  Inductive.arities_of_constructors indu specif
+  let indu = on_snd EConstr.Unsafe.to_instance indu in
+  let specif = Inductive.lookup_mind_specif env ind in
+  Array.map EConstr.of_constr (Inductive.arities_of_constructors indu specif)
 
 (* [inductive_family] = [inductive_instance] applied to global parameters *)
-type inductive_family = pinductive * constr list
+type inductive_family = inductive puniverses * constr list
 
 let make_ind_family (mis, params) = (mis,params)
 let dest_ind_family (mis,params) : inductive_family = (mis,params)
@@ -74,8 +78,12 @@ let lift_inductive_family n = liftn_inductive_family n 1
 
 let substnl_ind_family l n = map_ind_family (substnl l n)
 
-let relevance_of_inductive_family env (ind,_ : inductive_family) =
+let relevance_of_inductive env ind =
+  let ind = on_snd EConstr.Unsafe.to_instance ind in
   Inductive.relevance_of_inductive env ind
+
+let relevance_of_inductive_family env (ind,_ : inductive_family) =
+  relevance_of_inductive env ind
 
 type inductive_type = IndType of inductive_family * EConstr.constr list
 
@@ -85,8 +93,7 @@ let make_ind_type (indf, realargs) = IndType (indf,realargs)
 let dest_ind_type (IndType (indf,realargs)) = (indf,realargs)
 
 let map_inductive_type f (IndType (indf, realargs)) =
-  let f' c = EConstr.Unsafe.to_constr (f (EConstr.of_constr c)) in
-  IndType (map_ind_family f' indf, List.map f realargs)
+  IndType (map_ind_family f indf, List.map f realargs)
 
 let liftn_inductive_type n d = map_inductive_type (EConstr.Vars.liftn n d)
 let lift_inductive_type n = liftn_inductive_type n 1
@@ -97,9 +104,7 @@ let relevance_of_inductive_type env (IndType (indf, _)) =
   relevance_of_inductive_family env indf
 
 let mkAppliedInd (IndType ((ind,params), realargs)) =
-  let open EConstr in
-  let ind = on_snd EInstance.make ind in
-  applist (mkIndU ind, (List.map EConstr.of_constr params)@realargs)
+  applist (mkIndU ind, params @ realargs)
 
 (* Does not consider imbricated or mutually recursive types *)
 let mis_is_recursive_subset listind rarg =
@@ -120,7 +125,7 @@ let mis_nf_constructor_type ((_,j),u) (mib,mip) =
   let nconstr = Array.length mip.mind_consnames in
   if j > nconstr then user_err Pp.(str "Not enough constructors in the type.");
   let (ctx, cty) = mip.mind_nf_lc.(j - 1) in
-  subst_instance_constr u (Term.it_mkProd_or_LetIn cty ctx)
+  subst_instance_constr u (EConstr.it_mkProd_or_LetIn (EConstr.of_constr cty) (EConstr.of_rel_context ctx))
 
 (* Number of constructors *)
 
@@ -203,12 +208,13 @@ let inductive_nalldecls env ind =
 (* Others *)
 
 let inductive_paramdecls env (ind,u) =
+  let u = EConstr.Unsafe.to_instance u in
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
-    Inductive.inductive_paramdecls (mib,u)
+  EConstr.of_rel_context @@ Inductive.inductive_paramdecls (mib,u)
 
 let inductive_alldecls env (ind,u) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
-    Vars.subst_instance_context u mip.mind_arity_ctxt
+  Vars.subst_instance_context u (EConstr.of_rel_context mip.mind_arity_ctxt)
 
 let inductive_alltags env ind =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
@@ -254,6 +260,7 @@ let is_squashed sigma ((_,mip),u) =
     match mip.mind_squashed with
     | None -> None
     | Some squash ->
+      let u = EConstr.Unsafe.to_instance u in
       let indq = EConstr.ESorts.quality sigma
           (EConstr.ESorts.make @@ UVars.subst_instance_sort u a.mind_sort)
       in
@@ -325,8 +332,8 @@ let make_case_info env ind style =
     Array.map2 (fun (d, _) n ->
       Context.Rel.to_tags (List.firstn n d))
       mip.mind_nf_lc mip.mind_consnrealdecls in
-  let print_info = { ind_tags; cstr_tags; style } in
-  { ci_ind     = ind;
+  let print_info = { Constr.ind_tags; cstr_tags; style } in
+  { Constr.ci_ind     = ind;
     ci_npar    = mib.mind_nparams;
     ci_cstr_ndecls = mip.mind_consnrealdecls;
     ci_cstr_nargs = mip.mind_consnrealargs;
@@ -335,10 +342,10 @@ let make_case_info env ind style =
 (*s Useful functions *)
 
 type constructor_summary = {
-  cs_cstr : pconstructor;
+  cs_cstr : constructor puniverses;
   cs_params : constr list;
   cs_nargs : int;
-  cs_args : Constr.rel_context;
+  cs_args : EConstr.rel_context;
   cs_concl_realargs : constr array
 }
 
@@ -355,26 +362,27 @@ let instantiate_params t params sign =
   let nnonrecpar = Context.Rel.nhyps sign - List.length params in
   (* Adjust the signature if recursively non-uniform parameters are not here *)
   let _,sign = Context.Rel.chop_nhyps nnonrecpar sign in
-  let _,t = decompose_prod_n_decls (Context.Rel.length sign) t in
+  let _,t = Term.decompose_prod_n_decls (Context.Rel.length sign) t in
   let subst = subst_of_rel_context_instance_list sign params in
-  substl subst t
+  substl subst (EConstr.of_constr t)
 
 let instantiate_constructor_params (_,u as cstru) (mib,_ as mind_specif) params =
   let typi = mis_nf_constructor_type cstru mind_specif in
-  let ctx = Vars.subst_instance_context u mib.mind_params_ctxt in
-  instantiate_params typi params ctx
+  let ctx = Vars.subst_instance_context u (EConstr.of_rel_context mib.mind_params_ctxt) in
+  instantiate_params (EConstr.Unsafe.to_constr typi) params ctx
 
 let get_constructor ((ind,u),mib,mip,params) j =
   assert (j <= Array.length mip.mind_consnames);
   let typi = instantiate_constructor_params ((ind,j),u) (mib,mip) params in
-  let (args,ccl) = decompose_prod_decls typi in
-  let (_,allargs) = decompose_app_list ccl in
+  let typi = EConstr.Unsafe.to_constr typi in
+  let (args,ccl) = Term.decompose_prod_decls typi in
+  let (_,allargs) = Constr.decompose_app_list ccl in
   let vargs = List.skipn (List.length params) allargs in
   { cs_cstr = (ith_constructor_of_inductive ind j,u);
     cs_params = params;
     cs_nargs = Context.Rel.length args;
-    cs_args = args;
-    cs_concl_realargs = Array.of_list vargs }
+    cs_args = EConstr.of_rel_context args;
+    cs_concl_realargs = Array.map_of_list EConstr.of_constr vargs }
 
 let get_constructors env (ind,params) =
   let (mib,mip) = Inductive.lookup_mind_specif env (fst ind) in
@@ -385,11 +393,10 @@ let get_projections = Environ.get_projections
 
 let make_case_invert env (IndType (((ind,u),params),indices)) ~case_relevance:r ci =
   if Typeops.should_invert_case env r ci
-  then CaseInvert {indices=Array.of_list indices}
-  else NoInvert
+  then Constr.CaseInvert {indices=Array.of_list indices}
+  else Constr.NoInvert
 
 let make_project env sigma ind pred c branches ps =
-  let open EConstr in
   assert(Array.length branches == 1);
   let na, ty, t = destLambda sigma pred in
   let mib, mip as specif = Inductive.lookup_mind_specif env ind in
@@ -410,7 +417,7 @@ let make_project env sigma ind pred c branches ps =
     mkProj (Projection.make p true, r, c)
   in
   let proj = match EConstr.destRel sigma br with
-    | exception DestKO -> None
+    | exception Constr.DestKO -> None
     | i ->
       begin match List.skipn (i-1) ctx with
       | exception Failure _ -> None
@@ -442,15 +449,13 @@ let make_project env sigma ind pred c branches ps =
   mkLetIn (na, c, ty, it_mkLambda_or_LetIn (Vars.liftn 1 (Array.length ps + 1) br) ctx)
 
 let simple_make_case_or_project env sigma ci pred invert c branches =
-  let open EConstr in
-  let ind = ci.ci_ind in
+  let ind = ci.Constr.ci_ind in
   let projs = get_projections env ind in
   match projs with
   | None -> mkCase (EConstr.contract_case env sigma (ci, pred, invert, c, branches))
   | Some ps -> make_project env sigma ind (fst pred) c branches ps
 
 let make_case_or_project env sigma indt ci pred c branches =
-  let open EConstr in
   let IndType (((ind,_),_),_) = indt in
   let projs = get_projections env ind in
   match projs with
@@ -475,6 +480,7 @@ let get_arity env ((ind,u),params) =
     (* Dynamically detect if called with an instance of recursively
        uniform parameter only or also of recursively non-uniform
        parameters *)
+    let u = EConstr.Unsafe.to_instance u in
     let nparams = List.length params in
     if Int.equal nparams mib.mind_nparams then
       Inductive.inductive_paramdecls (mib,u)
@@ -482,8 +488,10 @@ let get_arity env ((ind,u),params) =
       assert (Int.equal nparams mib.mind_nparams_rec);
       snd (Inductive.inductive_nonrec_rec_paramdecls (mib,u))
     end in
+  let parsign = EConstr.of_rel_context parsign in
   let arproperlength = List.length mip.mind_arity_ctxt - List.length parsign in
   let arsign,_ = List.chop arproperlength mip.mind_arity_ctxt in
+  let arsign = EConstr.of_rel_context arsign in
   let subst = subst_of_rel_context_instance_list parsign params in
   let arsign = Vars.subst_instance_context u arsign in
   substl_rel_context subst arsign
@@ -506,20 +514,18 @@ let build_dependent_inductive env ((ind, params) as indf) =
 
 let make_arity_signature env sigma dep (ind, _ as indf) =
   let arsign = get_arity env indf in
-  let r = Inductive.relevance_of_inductive env ind in
+  let r = relevance_of_inductive env ind in
   let anon = make_annot Anonymous r in
-  let arsign = List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) arsign in
   if dep then
     (* We need names everywhere *)
     Namegen.name_context env sigma
-      ((LocalAssum (anon,EConstr.of_constr (build_dependent_inductive env indf)))::arsign)
+      ((LocalAssum (anon, build_dependent_inductive env indf)) :: arsign)
       (* Costly: would be better to name once for all at definition time *)
   else
     (* No need to enforce names *)
     arsign
 
 let make_arity env sigma dep indf s =
-  let open EConstr in
   it_mkProd_or_LetIn (mkSort s) (make_arity_signature env sigma dep indf)
 
 (**************************************************)
@@ -529,9 +535,9 @@ let make_arity env sigma dep indf s =
     The term built is expecting to be substituted first by
     a substitution of the form [params, x : ind params] *)
 let compute_projections env (kn, i as ind) =
-  let open Term in
   let mib = Environ.lookup_mind kn env in
   let u = UVars.make_abstract_instance (Declareops.inductive_polymorphic_context mib) in
+  let u = EInstance.make u in
   let x = match mib.mind_record with
   | NotRecord | FakeRecord ->
     anomaly Pp.(str "Trying to build primitive projections for a non-primitive record")
@@ -541,8 +547,10 @@ let compute_projections env (kn, i as ind) =
   in
   let pkt = mib.mind_packets.(i) in
   let { mind_nparams = nparamargs; mind_params_ctxt = params } = mib in
+  let params = EConstr.of_rel_context params in
   let ctx, _ = pkt.mind_nf_lc.(0) in
   let ctx, paramslet = List.chop pkt.mind_consnrealdecls.(0) ctx in
+  let ctx = EConstr.of_rel_context ctx in
   (* We build a substitution smashing the lets in the record parameters so
      that typechecking projections requires just a substitution and not
      matching with a parameter context. *)
@@ -621,10 +629,9 @@ let find_rectype env sigma c =
     | Ind (ind,u) ->
         let (mib,mip) = Inductive.lookup_mind_specif env ind in
         if mib.mind_nparams > List.length l then raise Not_found;
-        let l = List.map EConstr.Unsafe.to_constr l in
         let (par,rargs) = List.chop mib.mind_nparams l in
-        let indu = (ind, EInstance.kind sigma u) in
-        IndType((indu, par),List.map EConstr.of_constr rargs)
+        let indu = (ind, u) in
+        IndType ((indu, par), rargs)
     | _ -> raise Not_found
 
 let find_inductive env sigma c =
@@ -633,7 +640,6 @@ let find_inductive env sigma c =
   match EConstr.kind sigma t with
     | Ind ind
         when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite <> CoFinite ->
-        let l = List.map EConstr.Unsafe.to_constr l in
         (ind, l)
     | _ -> raise Not_found
 
@@ -643,7 +649,6 @@ let find_coinductive env sigma c =
   match EConstr.kind sigma t with
     | Ind ind
         when (fst (Inductive.lookup_mind_specif env (fst ind))).mind_finite == CoFinite ->
-        let l = List.map EConstr.Unsafe.to_constr l in
         (ind, l)
     | _ -> raise Not_found
 
@@ -651,10 +656,10 @@ let find_coinductive env sigma c =
 (* Type of Case predicates *)
 let arity_of_case_predicate env (ind,params) dep k =
   let arsign = get_arity env (ind,params) in
-  let r = Inductive.relevance_of_inductive env ind in
+  let r = relevance_of_inductive env ind in
   let mind = build_dependent_inductive env (ind,params) in
   let concl = if dep then mkArrow mind r (mkSort k) else mkSort k in
-  Term.it_mkProd_or_LetIn concl arsign
+  it_mkProd_or_LetIn concl arsign
 
 (***********************************************)
 (* Inferring the sort of parameters of a polymorphic inductive type
@@ -670,9 +675,9 @@ let univ_level_mem l s = match s with
    conclusion, and the other ones by fresh universes. *)
 let rec instantiate_universes env evdref scl is = function
   | (LocalDef _ as d)::sign, exp ->
-      d :: instantiate_universes env evdref scl is (sign, exp)
+    EConstr.of_rel_decl d :: instantiate_universes env evdref scl is (sign, exp)
   | d::sign, None::exp ->
-      d :: instantiate_universes env evdref scl is (sign, exp)
+    EConstr.of_rel_decl d :: instantiate_universes env evdref scl is (sign, exp)
   | (LocalAssum (na,ty))::sign, Some l::exp ->
       let ctx,_ = Reduction.dest_arity env ty in
       let u = Univ.Universe.make l in
@@ -687,14 +692,14 @@ let rec instantiate_universes env evdref scl is = function
           let evm = Evd.set_leq_sort env evm s (EConstr.ESorts.make (Sorts.sort_of_univ u)) in
             evdref := evm; s
       in
-      let s = EConstr.ESorts.kind !evdref s in
-      (LocalAssum (na,mkArity(ctx,s))) :: instantiate_universes env evdref scl is (sign, exp)
-  | sign, [] -> sign (* Uniform parameters are exhausted *)
+      let ctx = EConstr.of_rel_context ctx in
+      (LocalAssum (na, mkArity (ctx, s))) :: instantiate_universes env evdref scl is (sign, exp)
+  | sign, [] -> EConstr.of_rel_context sign (* Uniform parameters are exhausted *)
   | [], _ -> assert false
 
 let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
   match mip.mind_arity with
-  | RegularArity s -> sigma, EConstr.of_constr (subst_instance_constr u s.mind_user_arity)
+  | RegularArity s -> sigma, subst_instance_constr u (EConstr.of_constr s.mind_user_arity)
   | TemplateArity ar ->
     let templ = match mib.mind_template with
     | None -> assert false
@@ -706,8 +711,7 @@ let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
     let ctx =
       instantiate_universes
         env evdref scl ar.template_level (ctx,templ.template_param_levels) in
-    let scl = EConstr.ESorts.kind !evdref scl in
-      !evdref, EConstr.of_constr (mkArity (List.rev ctx,scl))
+    !evdref, mkArity (List.rev ctx, scl)
 
 let type_of_projection_constant env (p,u) =
   let _, pty = lookup_projection p env in
@@ -721,9 +725,7 @@ let type_of_projection_knowing_arg env sigma p c ty =
       raise (Invalid_argument "type_of_projection_knowing_arg_type: not an inductive type")
   in
   let (_,u), pars = dest_ind_family pars in
-  let u = EConstr.EInstance.make u in
-  let pars = List.rev_map EConstr.of_constr pars in
-  substl (c :: pars) (type_of_projection_constant env (p,u))
+  substl (c :: List.rev pars) (type_of_projection_constant env (p,u))
 
 (***********************************************)
 (* Guard condition *)
@@ -737,7 +739,7 @@ let control_only_guard env sigma c =
   let check_fix_cofix e c =
     (* [c] has already been normalized upfront *)
     let c = EConstr.Unsafe.to_constr c in
-    match kind c with
+    match Constr.kind c with
     | CoFix (_,(_,_,_) as cofix) ->
       Inductive.check_cofix ~evars e cofix
     | Fix fix ->

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -711,17 +711,19 @@ let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
 
 let type_of_projection_constant env (p,u) =
   let _, pty = lookup_projection p env in
-  Vars.subst_instance_constr u pty
+  EConstr.Vars.subst_instance_constr u (EConstr.of_constr pty)
 
 let type_of_projection_knowing_arg env sigma p c ty =
-  let c = EConstr.Unsafe.to_constr c in
+  let open EConstr.Vars in
   let IndType(pars,realargs) =
     try find_rectype env sigma ty
     with Not_found ->
       raise (Invalid_argument "type_of_projection_knowing_arg_type: not an inductive type")
   in
   let (_,u), pars = dest_ind_family pars in
-  substl (c :: List.rev pars) (type_of_projection_constant env (p,u))
+  let u = EConstr.EInstance.make u in
+  let pars = List.rev_map EConstr.of_constr pars in
+  substl (c :: pars) (type_of_projection_constant env (p,u))
 
 (***********************************************)
 (* Guard condition *)

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -141,7 +141,7 @@ val has_dependent_elim : mind_specif -> bool
 
 (** Primitive projections *)
 val type_of_projection_knowing_arg : env -> evar_map -> Projection.t ->
-                                     EConstr.t -> EConstr.types -> types
+                                     EConstr.t -> EConstr.types -> EConstr.types
 
 (** Extract information from an inductive family *)
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -121,6 +121,7 @@ let error_ill_typed_rec_body ?loc env sigma i na jl tys =
 let error_elim_arity ?loc env sigma pi c a =
   (* XXX type_errors should have a 'sort type parameter *)
   let a = Option.map EConstr.Unsafe.to_sorts a in
+  let pi = Util.on_snd EConstr.Unsafe.to_instance pi in
   raise_type_error ?loc
     (env, sigma, ElimArity (pi, c, a))
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -115,7 +115,7 @@ val error_ill_typed_rec_body :
 
 val error_elim_arity :
   ?loc:Loc.t -> env -> Evd.evar_map ->
-      pinductive -> constr -> ESorts.t option -> 'b
+      inductive puniverses -> constr -> ESorts.t option -> 'b
 
 val error_not_a_type :
   ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'b

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -220,8 +220,7 @@ let retype ?(polyprop=true) sigma =
         (Inductive.type_of_inductive_knowing_parameters
            ~polyprop (mip, u) paramtyps)
     | Construct (cstr, u) ->
-      let u = EInstance.kind sigma u in
-      EConstr.of_constr (type_of_constructor env (cstr, u))
+      type_of_constructor env (cstr, u)
     | _ -> assert false
 
   and make_param_univs env sigma indu args =
@@ -266,12 +265,12 @@ let type_of_global_reference_knowing_conclusion env sigma c conclty =
   match EConstr.kind sigma c with
     | Ind (ind,u) ->
         let spec = Inductive.lookup_mind_specif env ind in
-          type_of_inductive_knowing_conclusion env sigma (spec, EInstance.kind sigma u) conclty
+          type_of_inductive_knowing_conclusion env sigma (spec, u) conclty
     | Const (cst, u) ->
         let t = constant_type_in env (cst, EInstance.kind sigma u) in
           sigma, EConstr.of_constr t
     | Var id -> sigma, type_of_var env id
-    | Construct (cstr, u) -> sigma, EConstr.of_constr (type_of_constructor env (cstr, EInstance.kind sigma u))
+    | Construct (cstr, u) -> sigma, type_of_constructor env (cstr, u)
     | _ -> assert false
 
 let get_type_of ?(polyprop=true) ?(lax=false) env sigma c =

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -180,10 +180,9 @@ let retype ?(polyprop=true) sigma =
         strip_outer_cast sigma
           (subst_type env sigma (type_of env f) (Array.to_list args))
     | Proj (p,_,c) ->
-       let ty = type_of env c in
-       EConstr.of_constr (try
-           Inductiveops.type_of_projection_knowing_arg env sigma p c ty
-         with Invalid_argument _ -> retype_error BadRecursiveType)
+      let ty = type_of env c in
+      (try Inductiveops.type_of_projection_knowing_arg env sigma p c ty
+        with Invalid_argument _ -> retype_error BadRecursiveType)
     | Cast (c,_, t) -> t
     | Sort _ | Prod _ -> mkSort (sort_of env cstr)
     | Int _ -> EConstr.of_constr (Typeops.type_of_int env)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -184,8 +184,9 @@ let type_case_branches env sigma (ind,largs) specif pj c =
   let nparams = inductive_params specif in
   let (params,realargs) = List.chop nparams largs in
   let p = pj.uj_val in
-  let params = List.map EConstr.Unsafe.to_constr params in
   let sigma, ps = is_correct_arity env sigma c pj ind specif params in
+  let ind = on_snd EConstr.Unsafe.to_instance ind in
+  let params = List.map EConstr.Unsafe.to_constr params in
   let lc = build_branches_type ind specif params (EConstr.to_constr ~abort_on_undefined_evars:false sigma p) in
   let lc = Array.map EConstr.of_constr lc in
   let n = (snd specif).Declarations.mind_nrealdecls in
@@ -224,7 +225,7 @@ let judge_of_case env sigma case ci (pj,rp) iv cj lfj =
     with Not_found -> error_case_not_inductive env sigma cj in
   let specif = lookup_mind_specif env ind in
   let () = if Inductive.is_private specif then Type_errors.error_case_on_private_ind env ind in
-  let indspec = ((ind, EInstance.kind sigma u), spec) in
+  let indspec = ((ind, u), spec) in
   let sigma, (bty,rslty,rci) = type_case_branches env sigma indspec specif pj cj.uj_val in
   (* should we have evar map aware should_invert_case? *)
   let sigma, rp =
@@ -234,8 +235,9 @@ let judge_of_case env sigma case ci (pj,rp) iv cj lfj =
       raise_type_error (env,sigma,Type_errors.BadCaseRelevance (rp, mkCase case))
     | Some sigma -> sigma, rci
   in
-  let () = check_case_info env (fst indspec) ci in
-  let sigma = check_branch_types env sigma (fst indspec) cj (lfj,bty) in
+  let ind = on_snd (EInstance.kind sigma) (fst indspec) in
+  let () = check_case_info env ind ci in
+  let sigma = check_branch_types env sigma ind cj (lfj,bty) in
   let () = if (match iv with | NoInvert -> false | CaseInvert _ -> true)
               != should_invert_case env rp ci
     then Type_errors.error_bad_invert env
@@ -264,7 +266,7 @@ let check_allowed_sort env sigma ind c p =
     | Sort s -> s
     | _ -> error_elim_arity env sigma ind c None
   in
-  if Inductiveops.is_allowed_elimination sigma (specif,(snd ind)) sort then
+  if Inductiveops.is_allowed_elimination sigma (specif, (snd ind)) sort then
     ESorts.relevance_of_sort sigma sort
   else
     error_elim_arity env sigma ind c (Some sort)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module CVars = Vars
-
 open Pp
 open CErrors
 open Util
@@ -333,9 +331,8 @@ let judge_of_projection env sigma p cj =
     try find_mrectype env sigma cj.uj_type
     with Not_found -> error_case_not_inductive env sigma cj
   in
-  let u = EInstance.kind sigma u in
-  let pr = UVars.subst_instance_relevance u pr in
-  let ty = EConstr.of_constr (CVars.subst_instance_constr u pty) in
+  let pr = Vars.subst_instance_relevance u pr in
+  let ty = Vars.subst_instance_constr u (EConstr.of_constr pty) in
   let ty = substl (cj.uj_val :: List.rev args) ty in
   {uj_val = EConstr.mkProj (p,pr,cj.uj_val);
    uj_type = ty}

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -38,7 +38,7 @@ val solve_evars : env -> evar_map -> constr -> evar_map * constr
 
 (** Raise an error message if incorrect elimination for this inductive
     (first constr is term to match, second is return predicate) *)
-val check_allowed_sort : env -> evar_map -> pinductive -> constr -> constr ->
+val check_allowed_sort : env -> evar_map -> inductive puniverses -> constr -> constr ->
   Sorts.relevance
 
 (** Raise an error message if bodies have types not unifiable with the

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -27,9 +27,10 @@ open Ind_tables
 let build_induction_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let sigma, pind = Evd.fresh_inductive_instance ~rigid:UState.univ_rigid env sigma ind in
+  let pind = Util.on_snd EConstr.EInstance.make pind in
   let sigma, sort = Evd.fresh_sort_in_family ~rigid:UnivRigid sigma sort in
   let sigma, c = build_induction_scheme env sigma pind dep sort in
-    c, Evd.evar_universe_context sigma
+  EConstr.to_constr sigma c, Evd.evar_universe_context sigma
 
 (**********************************************************************)
 (* [modify_sort_scheme s rec] replaces the sort of the scheme
@@ -149,6 +150,7 @@ let elim_scheme ~dep ~to_kind =
 let build_case_analysis_scheme_in_type env dep sort ind =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
+  let indu = Util.on_snd EConstr.EInstance.make indu in
   let sigma, sort = Evd.fresh_sort_in_family ~rigid:UnivRigid sigma sort in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep sort in
   let (c, _) = Indrec.eval_case_analysis c in

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -690,6 +690,7 @@ let fix_r2l_forward_rew_scheme env (c, ctx') =
 let build_r2l_rew_scheme dep env ind k =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
+  let indu = on_snd EConstr.EInstance.make indu in
   let sigma, k = Evd.fresh_sort_in_family ~rigid:UnivRigid sigma k in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep k in
   let (c, _) = Indrec.eval_case_analysis c in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -787,8 +787,6 @@ let find_positions env sigma ~keep_proofs ~no_discr t1 t2 =
             let params1,rargs1 = List.chop nparams args1 in
             let _,rargs2 = List.chop nparams args2 in
             let (mib,mip) = lookup_mind_specif env ind1 in
-            let params1 = List.map EConstr.Unsafe.to_constr params1 in
-            let u1 = EInstance.kind sigma u1 in
             let ctxt = (get_constructor ((ind1,u1),mib,mip,params1) i1).cs_args in
             let adjust i = CVars.adjust_rel_to_rel_context ctxt (i+1) - 1 in
             List.flatten
@@ -893,7 +891,7 @@ let descend_then env sigma head dirn =
   let (mib,mip) = lookup_mind_specif env ind in
   let cstr = get_constructors env indf in
   let dirn_nlams = cstr.(dirn-1).cs_nargs in
-  let dirn_env = Environ.push_rel_context cstr.(dirn-1).cs_args env in
+  let dirn_env = EConstr.push_rel_context cstr.(dirn-1).cs_args env in
   (dirn_nlams,
    dirn_env,
    (fun sigma dirnval (dfltval,resty) ->
@@ -902,7 +900,7 @@ let descend_then env sigma head dirn =
         it_mkLambda_or_LetIn (lift (mip.mind_nrealargs+1) resty) deparsign in
       let build_branch i =
         let result = if Int.equal i dirn then dirnval else dfltval in
-        let cs_args = List.map (fun d -> map_rel_decl EConstr.of_constr d) cstr.(i-1).cs_args in
+        let cs_args = cstr.(i-1).cs_args in
         let args = name_context env sigma cs_args in
         it_mkLambda_or_LetIn result args in
       let brl =

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -86,7 +86,6 @@ let make_inv_predicate env evd indf realargs id status concl =
       | NoDep ->
           (* We push the arity and leave concl unchanged *)
           let hyps_arity = get_arity env indf in
-          let hyps_arity = List.map (fun d -> map_rel_decl EConstr.of_constr d) hyps_arity in
             (hyps_arity,concl)
       | Dep dflt_concl ->
           if not (occur_var env !evd id concl) then

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1702,7 +1702,7 @@ let make_projection env sigma params cstr sign elim i n c (ind, u) =
   let elim = match elim with
   | NotADefinedRecordUseScheme ->
       (* bugs: goes from right to left when i increases! *)
-      let cs_args = List.map (fun d -> map_rel_decl EConstr.of_constr d) cstr.cs_args in
+      let cs_args = cstr.cs_args in
       let decl = List.nth cs_args i in
       let t = RelDecl.get_type decl in
       let b = match decl with LocalAssum _ -> mkRel (i+1) | LocalDef (_,b,_) -> b in
@@ -1764,7 +1764,6 @@ let descend_in_conjunctions avoid tac (err, info) c =
         let n = (constructors_nrealargs env ind).(0) in
         let IndType (indf,_) = find_rectype env sigma ccl in
         let (_,inst), params = dest_ind_family indf in
-        let params = List.map EConstr.of_constr params in
         let cstr = (get_constructors env indf).(0) in
         let elim =
           try DefinedRecord (Structures.Structure.find_projections ind)

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -738,8 +738,8 @@ let build_beq_scheme env handle kn =
     let rci = Sorts.Relevant in (* returning a boolean, hence relevant *)
     let open Inductiveops in
     let constrs =
-      let params = Context.Rel.instance_list mkRel 0 params_ctx in
-      get_constructors env (make_ind_family (indu, params))
+      let params = Context.Rel.instance_list EConstr.mkRel 0 params_ctx in
+      get_constructors env (make_ind_family (on_snd EConstr.EInstance.make indu, params))
     in
     let make_andb_list = function
       | [] -> tt ()
@@ -751,6 +751,7 @@ let build_beq_scheme env handle kn =
         (* A primitive record *)
         let nb_cstr_args = List.length constrs.(0).cs_args in
         let _,_,eqs = List.fold_right (fun decl (ndx,env_lift,l) ->
+          let decl = EConstr.Unsafe.to_rel_decl decl in
           let env_lift' = push_env_lift decl env_lift in
           match decl with
           | RelDecl.LocalDef (na,b,t) -> (ndx-1,env_lift',l)
@@ -784,6 +785,7 @@ let build_beq_scheme env handle kn =
             let cc =
               if Int.equal i j then
                 let _,_,eqs = List.fold_right (fun decl (ndx,env_lift,l) ->
+                   let decl = EConstr.Unsafe.to_rel_decl decl in
                    let env_lift' = push_env_lift decl env_lift in
                    match decl with
                    | RelDecl.LocalDef (na,b,t) -> (ndx-1,env_lift',l)
@@ -804,7 +806,7 @@ let build_beq_scheme env handle kn =
               else
                 ff ()
             in
-            let cs_argsj = translate_context env_lift_recparams_fix_nonrecparams_tomatch_csargsi constrs.(j).cs_args in
+            let cs_argsj = translate_context env_lift_recparams_fix_nonrecparams_tomatch_csargsi (EConstr.Unsafe.to_rel_context constrs.(j).cs_args) in
             Term.it_mkLambda_or_LetIn cc cs_argsj)
           in
           let predj = EConstr.of_constr (translate_term env_lift_recparams_fix_nonrecparams_tomatch_csargsi pred) in
@@ -813,7 +815,7 @@ let build_beq_scheme env handle kn =
               ci (predj,rci) NoInvert (EConstr.mkRel (nb_cstr_args + 1))
               (EConstr.of_constr_array ar2)
           in
-          let cs_argsi = translate_context env_lift_recparams_fix_nonrecparams_tomatch constrs.(i).cs_args in
+          let cs_argsi = translate_context env_lift_recparams_fix_nonrecparams_tomatch (EConstr.Unsafe.to_rel_context constrs.(i).cs_args) in
           Term.it_mkLambda_or_LetIn (EConstr.Unsafe.to_constr case) cs_argsi)
         in
         let predi = EConstr.of_constr (translate_term env_lift_recparams_fix_nonrecparams_tomatch pred) in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -390,6 +390,7 @@ let do_mutual_induction_scheme ?(force_mutual=false) env l =
          | None ->
             let _, ctx = Typeops.type_of_global_in_context env (Names.GlobRef.IndRef ind) in
             let u, ctx = UnivGen.fresh_instance_from ctx None in
+            let u = EConstr.EInstance.make u in
             let evd = Evd.from_ctx (UState.of_context_set ctx) in
               evd, (ind,u), Some u
          | Some ui -> evd, (ind, ui), inst
@@ -406,8 +407,9 @@ let do_mutual_induction_scheme ?(force_mutual=false) env l =
     Global.is_polymorphic (Names.GlobRef.IndRef ind)
   in
   let declare decl fi lrecref =
-    let decltype = Retyping.get_type_of env sigma (EConstr.of_constr decl) in
+    let decltype = Retyping.get_type_of env sigma decl in
     let decltype = EConstr.to_constr sigma decltype in
+    let decl = EConstr.to_constr sigma decl in
     let cst = define ~poly fi sigma decl (Some decltype) in
     Names.GlobRef.ConstRef cst :: lrecref
   in

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -60,7 +60,7 @@ module SearchBlacklist =
 
 let iter_constructors indsp u fn env sigma nconstr =
   for i = 1 to nconstr do
-    let typ = Inductiveops.type_of_constructor env ((indsp, i), u) in
+    let typ = Inductive.type_of_constructor ((indsp, i), u) (Inductive.lookup_mind_specif env indsp) in
     fn (GlobRef.ConstructRef (indsp, i)) None env sigma typ
   done
 
@@ -94,8 +94,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
           let iter_packet i mip =
             let ind = (mind, i) in
             let u = UVars.make_abstract_instance (Declareops.inductive_polymorphic_context mib) in
-            let i = (ind, u) in
-            let typ = Inductiveops.type_of_inductive env i in
+            let typ = Inductive.type_of_inductive (Inductive.lookup_mind_specif env ind, u) in
             let () = fn (GlobRef.IndRef ind) None env sigma typ in
             let len = Array.length mip.mind_user_lc in
             iter_constructors ind u fn env sigma len


### PR DESCRIPTION
This is both cleaner and more efficient, as it prevents back-and-forth normalizations between the data structures. This PR contains #18913 and so should bring the same speed-up. (This is not benchable as it changes the API, which was the reason for the other PR.)

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/590
- https://github.com/SkySkimmer/coq-lean-import/pull/18
- https://github.com/coq-community/paramcoq/pull/122