### PR TITLE
Add EConstr.ERelevance abstraction barrier to force normalizing relevances

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -135,7 +135,7 @@ let eq_recarg r1 r2 = match r1, r2 with
 let eq_reloc_tbl = Array.equal (fun x y -> Int.equal (fst x) (fst y) && Int.equal (snd x) (snd y))
 
 let eq_in_context (ctx1, t1) (ctx2, t2) =
-  Context.Rel.equal Constr.equal ctx1 ctx2 && Constr.equal t1 t2
+  Context.Rel.equal Sorts.relevance_equal Constr.equal ctx1 ctx2 && Constr.equal t1 t2
 
 let check_packet env mind ind
     { mind_typename; mind_arity_ctxt; mind_arity; mind_consnames; mind_user_lc;
@@ -145,7 +145,7 @@ let check_packet env mind ind
   let check = check mind in
 
   ignore mind_typename; (* passed through *)
-  check "mind_arity_ctxt" (Context.Rel.equal Constr.equal ind.mind_arity_ctxt mind_arity_ctxt);
+  check "mind_arity_ctxt" (Context.Rel.equal Sorts.relevance_equal Constr.equal ind.mind_arity_ctxt mind_arity_ctxt);
   check "mind_arity" (check_arity env ind.mind_arity mind_arity);
   ignore mind_consnames; (* passed through *)
   check "mind_user_lc" (Array.equal Constr.equal ind.mind_user_lc mind_user_lc);
@@ -206,7 +206,7 @@ let check_inductive env mind mb =
   (* module substitution can increase the real number of recursively
      uniform parameters, so be tolerant and use [<=]. *)
 
-  check "mind_params_ctxt" (Context.Rel.equal Constr.equal mb.mind_params_ctxt mind_params_ctxt);
+  check "mind_params_ctxt" (Context.Rel.equal Sorts.relevance_equal Constr.equal mb.mind_params_ctxt mind_params_ctxt);
   ignore mind_universes; (* Indtypes did the necessary checking *)
   check "mind_template" (check_template mb.mind_template mind_template);
   check "mind_variance" (Option.equal (Array.equal UVars.Variance.equal)

--- a/dev/ci/user-overlays/18938-SkySkimmer-erelevance.sh
+++ b/dev/ci/user-overlays/18938-SkySkimmer-erelevance.sh
@@ -1,0 +1,35 @@
+overlay aac_tactics https://github.com/SkySkimmer/aac-tactics erelevance 18938
+
+overlay atbr https://github.com/SkySkimmer/atbr erelevance 18938
+
+overlay coinduction https://github.com/SkySkimmer/coinduction erelevance 18938
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer erelevance 18938
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi erelevance 18938
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations erelevance 18938
+
+overlay lean_importer https://github.com/SkySkimmer/coq-lean-import erelevance 18938
+
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 erelevance 18938
+
+overlay paramcoq https://github.com/SkySkimmer/paramcoq erelevance 18938
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi erelevance 18938
+
+overlay smtcoq https://github.com/SkySkimmer/smtcoq erelevance 18938
+
+overlay stalmarck https://github.com/SkySkimmer/stalmarck erelevance 18938
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician erelevance 18938
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof erelevance 18938
+
+overlay itauto https://gitlab.inria.fr/ggilbert/itauto erelevance 18938
+
+overlay unicoq https://github.com/SkySkimmer/unicoq erelevance 18938
+
+overlay metacoq https://github.com/SkySkimmer/metacoq erelevance 18938
+
+overlay relation_algebra https://github.com/SkySkimmer/relation-algebra erelevance 18938

--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -1,12 +1,12 @@
 open Pp
-open Context
+open EConstr
 
 let example_sort sigma =
 (* creating a new sort requires that universes should be recorded
   in the evd datastructure, so this datastructure also needs to be
   passed around. *)
   let sigma, s = Evd.new_sort_variable Evd.univ_rigid sigma in
-  let new_type = EConstr.mkSort s in
+  let new_type = mkSort s in
   sigma, new_type
 
 let c_one env sigma =
@@ -18,7 +18,7 @@ let c_one env sigma =
   let sigma, c_O = Evd.fresh_global env sigma gr_O in
   let sigma, c_S = Evd.fresh_global env sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
-  sigma, EConstr.mkApp (c_S, [| c_O |])
+  sigma, mkApp (c_S, [| c_O |])
 
 let dangling_identity env sigma =
 (* I call this a dangling identity, because it is not polymorph, but
@@ -29,16 +29,16 @@ let dangling_identity env sigma =
   let sigma, arg_type = Evarutil.new_evar env sigma type_type in
 (* Notice the use of a De Bruijn index for the inner occurrence of the
   bound variable. *)
-  sigma, EConstr.mkLambda(nameR (Names.Id.of_string "x"), arg_type,
-          EConstr.mkRel 1)
+  sigma, mkLambda(nameR (Names.Id.of_string "x"), arg_type,
+          mkRel 1)
 
 let dangling_identity2 env sigma =
 (* This example uses directly a function that produces an evar that
   is meant to be a type. *)
   let sigma, (arg_type, type_type) =
     Evarutil.new_type_evar env sigma Evd.univ_rigid in
-  sigma, EConstr.mkLambda(nameR (Names.Id.of_string "x"), arg_type,
-          EConstr.mkRel 1)
+  sigma, mkLambda(nameR (Names.Id.of_string "x"), arg_type,
+          mkRel 1)
 
 let example_sort_app_lambda () =
     let env = Global.env () in
@@ -46,7 +46,7 @@ let example_sort_app_lambda () =
     let sigma, c_v = c_one env sigma in
 (* dangling_identity and dangling_identity2 can be used interchangeably here *)
     let sigma, c_f = dangling_identity2 env sigma in
-    let c_1 = EConstr.mkApp (c_f, [| c_v |]) in
+    let c_1 = mkApp (c_f, [| c_v |]) in
     let _ = Feedback.msg_notice
        (Printer.pr_econstr_env env sigma c_1) in
     (* type verification happens here.  Type verification will update
@@ -108,7 +108,7 @@ let mk_nat env sigma n =
   let sigma, c_O = c_O env sigma in
   let rec buildup = function
     | 0 -> c_O
-    | n -> EConstr.mkApp (c_S, [| buildup (n - 1) |]) in
+    | n -> mkApp (c_S, [| buildup (n - 1) |]) in
   if n <= 0 then sigma, c_O else sigma, buildup n
 
 let example_classes n =
@@ -121,16 +121,16 @@ let example_classes n =
   let sigma, c_even = c_E env sigma in
   let sigma, c_Q = c_Q env sigma in
   let sigma, c_R = c_R env sigma in
-  let arg_type = EConstr.mkApp (c_even, [| c_n |]) in
+  let arg_type = mkApp (c_even, [| c_n |]) in
   let sigma0 = sigma in
   let sigma, instance = Evarutil.new_evar env sigma arg_type in
-  let c_half = EConstr.mkApp (c_div, [|c_n; instance|]) in
+  let c_half = mkApp (c_div, [|c_n; instance|]) in
   let _ = Feedback.msg_notice (Printer.pr_econstr_env env sigma c_half) in
   let sigma, the_type = Typing.type_of env sigma c_half in
   let _ = Feedback.msg_notice (Printer.pr_econstr_env env sigma c_half) in
   let proved_equality =
-    EConstr.mkCast(EConstr.mkApp (c_R, [| c_N; c_half |]), Constr.DEFAULTcast,
-      EConstr.mkApp (c_Q, [| c_N; c_half; n_half|])) in
+    mkCast(mkApp (c_R, [| c_N; c_half |]), Constr.DEFAULTcast,
+      mkApp (c_Q, [| c_N; c_half; n_half|])) in
 (* This is where we force the system to compute with type classes. *)
 (* Question to coq developers: why do we pass two evd arguments to
    solve_remaining_evars? Is the choice of sigma0 relevant here? *)
@@ -158,25 +158,25 @@ let example_canonical n =
   let sigma, c_C = c_C env sigma in
   let sigma, c_P = c_P env sigma in
 (* the last argument of C *)
-  let refl_term = EConstr.mkApp (c_R, [|c_N; c_n |]) in
+  let refl_term = mkApp (c_R, [|c_N; c_n |]) in
 (* Now we build two existential variables, for the value of the half and for
    the "S_ev" structure that triggers the proof search. *)
   let sigma, ev1 = Evarutil.new_evar env sigma c_N in
 (* This is the type for the second existential variable *)
-  let csev = EConstr.mkApp (c_F, [| ev1 |]) in
+  let csev = mkApp (c_F, [| ev1 |]) in
   let sigma, ev2 = Evarutil.new_evar env sigma csev in
 (* Now we build the C structure. *)
-  let test_term = EConstr.mkApp (c_C, [| c_n; ev1; ev2; refl_term |]) in
+  let test_term = mkApp (c_C, [| c_n; ev1; ev2; refl_term |]) in
 (* Type-checking this term will compute values for the existential variables *)
   let sigma, final_type = Typing.type_of env sigma test_term in
 (* The computed type has two parameters, the second one is the proof. *)
-  let value = match EConstr.kind sigma final_type with
+  let value = match kind sigma final_type with
       | Constr.App(_, [| _; the_half |]) -> the_half
       | _ -> failwith "expecting the whole type to be \"cmp _ the_half\"" in
   let _ = Feedback.msg_notice (Printer.pr_econstr_env env sigma value) in
 (* I wish for a nicer way to get the value of ev2 in the evar_map *)
-  let prf_struct = EConstr.of_constr (EConstr.to_constr sigma ev2) in
-  let the_prf = EConstr.mkApp (c_P, [| ev1; prf_struct |]) in
+  let prf_struct = of_constr (to_constr sigma ev2) in
+  let the_prf = mkApp (c_P, [| ev1; prf_struct |]) in
   let sigma, the_statement = Typing.type_of env sigma the_prf in
   Feedback.msg_notice
     (Printer.pr_econstr_env env sigma the_prf ++ str " has type " ++

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -16,6 +16,17 @@ open Context
 
 module NamedDecl = Context.Named.Declaration
 
+module ERelevance = struct
+  include Evd.MiniEConstr.ERelevance
+
+  let equal sigma r1 r2 = Sorts.relevance_equal (kind sigma r1) (kind sigma r2)
+
+  let is_irrelevant = Evd.is_relevance_irrelevant
+
+  let relevant = make Relevant
+  let irrelevant = make Irrelevant
+end
+
 module ESorts = struct
   include Evd.MiniEConstr.ESorts
 
@@ -35,9 +46,9 @@ module ESorts = struct
   let super sigma s =
     make (Sorts.super (kind sigma s))
 
-  let relevance_of_sort sigma s =
+  let relevance_of_sort s =
     let r = Sorts.relevance_of_sort (unsafe_to_sorts s) in
-    UState.nf_relevance (Evd.evar_universe_context sigma) r
+    ERelevance.make r
 
   let family sigma s = Sorts.family (kind sigma s)
 
@@ -53,26 +64,33 @@ module EInstance = struct
 end
 
 include (Evd.MiniEConstr : module type of Evd.MiniEConstr
-         with module ESorts := ESorts
+         with module ERelevance := ERelevance
+          and module ESorts := ESorts
           and module EInstance := EInstance)
 
 type types = t
 type constr = t
 type existential = t pexistential
-type case_return = t pcase_return
-type case_branch = t pcase_branch
+type case_return = (t, ERelevance.t) pcase_return
+type case_branch = (t, ERelevance.t) pcase_branch
 type case_invert = t pcase_invert
-type case = (t, t, EInstance.t) pcase
-type fixpoint = (t, t) pfixpoint
-type cofixpoint = (t, t) pcofixpoint
+type case = (t, t, EInstance.t, ERelevance.t) pcase
+type rec_declaration = (t, t, ERelevance.t) prec_declaration
+type fixpoint = (t, t, ERelevance.t) pfixpoint
+type cofixpoint = (t, t, ERelevance.t) pcofixpoint
 type unsafe_judgment = (constr, types) Environ.punsafe_judgment
 type unsafe_type_judgment = (types, ESorts.t) Environ.punsafe_type_judgment
-type named_declaration = (constr, types) Context.Named.Declaration.pt
-type rel_declaration = (constr, types) Context.Rel.Declaration.pt
-type compacted_declaration = (constr, types) Context.Compacted.Declaration.pt
-type named_context = (constr, types) Context.Named.pt
+type named_declaration = (constr, types, ERelevance.t) Context.Named.Declaration.pt
+type rel_declaration = (constr, types, ERelevance.t) Context.Rel.Declaration.pt
+type compacted_declaration = (constr, types, ERelevance.t) Context.Compacted.Declaration.pt
+type named_context = (constr, types, ERelevance.t) Context.Named.pt
 type compacted_context = compacted_declaration list
-type rel_context = (constr, types) Context.Rel.pt
+type rel_context = (constr, types, ERelevance.t) Context.Rel.pt
+type 'a binder_annot = ('a, ERelevance.t) Context.pbinder_annot
+
+let annotR x = Context.make_annot x ERelevance.relevant
+let nameR x = annotR (Name x)
+let anonR = annotR Anonymous
 
 type 'a puniverses = 'a * EInstance.t
 
@@ -101,7 +119,7 @@ let mkFix f = of_kind (Fix f)
 let mkCoFix f = of_kind (CoFix f)
 let mkProj (p, r, c) = of_kind (Proj (p, r, c))
 let mkArrow t1 r t2 = of_kind (Prod (make_annot Anonymous r, t1, t2))
-let mkArrowR t1 t2 = mkArrow t1 Sorts.Relevant t2
+let mkArrowR t1 t2 = mkArrow t1 ERelevance.relevant t2
 let mkInt i = of_kind (Int i)
 let mkFloat f = of_kind (Float f)
 let mkArray (u,t,def,ty) = of_kind (Array (u,t,def,ty))
@@ -379,20 +397,36 @@ let existential_type = Evd.existential_type
 let lift n c = of_constr (Vars.lift n (unsafe_to_constr c))
 
 let of_branches : Constr.case_branch array -> case_branch array =
-  match Evd.MiniEConstr.unsafe_eq with
-  | Refl -> fun x -> x
+  match Evd.MiniEConstr.(unsafe_eq, unsafe_relevance_eq) with
+  | Refl, Refl -> fun x -> x
 
 let unsafe_to_branches : case_branch array -> Constr.case_branch array =
-  match Evd.MiniEConstr.unsafe_eq with
-  | Refl -> fun x -> x
+  match Evd.MiniEConstr.(unsafe_eq, unsafe_relevance_eq) with
+  | Refl, Refl -> fun x -> x
 
 let of_return : Constr.case_return -> case_return =
-  match Evd.MiniEConstr.unsafe_eq with
-  | Refl -> fun x -> x
+  match Evd.MiniEConstr.(unsafe_eq, unsafe_relevance_eq) with
+  | Refl, Refl -> fun x -> x
 
 let unsafe_to_return : case_return -> Constr.case_return =
-  match Evd.MiniEConstr.unsafe_eq with
+  match Evd.MiniEConstr.(unsafe_eq, unsafe_relevance_eq) with
+  | Refl, Refl -> fun x -> x
+
+let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
+  match Evd.MiniEConstr.unsafe_relevance_eq with
   | Refl -> fun x -> x
+
+let to_binder_annot sigma x = Context.map_annot_relevance (ERelevance.kind sigma) x
+
+let to_rel_decl sigma d =
+  Context.Rel.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+
+let to_rel_context sigma ctx = List.map (to_rel_decl sigma) ctx
+
+let to_named_decl sigma d =
+  Context.Named.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+
+let to_named_context sigma ctx = List.map (to_named_decl sigma) ctx
 
 let map_branches f br =
   let f c = unsafe_to_constr (f (of_constr c)) in
@@ -467,6 +501,7 @@ let expand_case env _sigma (ci, u, pms, p, iv, c, bl) =
   let bl = unsafe_to_branches bl in
   let (ci, (p,r), iv, c, bl) = Inductive.expand_case env (ci, u, pms, p, iv, c, bl) in
   let p = of_constr p in
+  let r = ERelevance.make r in
   let c = of_constr c in
   let iv = of_case_invert iv in
   let bl = of_constr_array bl in
@@ -493,12 +528,23 @@ let expand_branch env _sigma u pms (ind, i) (nas, _br) =
   let paramsubst = Vars.subst_of_rel_context_instance paramdecl pms in
   let (ctx, _) = mip.mind_nf_lc.(i - 1) in
   let (ctx, _) = List.chop mip.mind_consnrealdecls.(i - 1) ctx in
+  let nas =
+    let gen : type a b. (a,b) eq -> (_,a) Context.pbinder_annot array ->
+      (_,b) Context.pbinder_annot array =
+      fun Refl x -> x
+    in
+    gen unsafe_relevance_eq nas
+  in
   let ans = Inductive.instantiate_context u paramsubst nas ctx in
-  let ans : rel_context = match Evd.MiniEConstr.unsafe_eq with Refl -> ans in
+  let ans : rel_context =
+    match Evd.MiniEConstr.(unsafe_eq, unsafe_relevance_eq) with
+    | Refl, Refl -> ans
+  in
   ans
 
 let contract_case env _sigma (ci, (p,r), iv, c, bl) =
   let p = unsafe_to_constr p in
+  let r = ERelevance.unsafe_to_relevance r in
   let iv = unsafe_to_case_invert iv in
   let c = unsafe_to_constr c in
   let bl = unsafe_to_constr_array bl in
@@ -772,7 +818,7 @@ let fold_constr_relevance sigma f acc c =
 let add_relevance sigma (qs,us as v) r =
   let open Sorts in
   (* NB this normalizes above_prop to Relevant which makes it disappear *)
-  match UState.nf_relevance (Evd.evar_universe_context sigma) r with
+  match ERelevance.kind sigma r with
   | Irrelevant | Relevant -> v
   | RelevanceVar q -> QVar.Set.add q qs, us
 
@@ -812,24 +858,24 @@ let cast_vect : type a b. (a,b) eq -> a array -> b array =
   fun Refl x -> x
 
 let cast_rel_decl :
-  type a b. (a,b) eq -> (a, a) Rel.Declaration.pt -> (b, b) Rel.Declaration.pt =
-  fun Refl x -> x
+  type a b c d. (a,b) eq -> (c,d) eq -> (a, a, c) Rel.Declaration.pt -> (b, b, d) Rel.Declaration.pt =
+  fun Refl Refl x -> x
 
 let cast_rel_context :
-  type a b. (a,b) eq -> (a, a) Rel.pt -> (b, b) Rel.pt =
-  fun Refl x -> x
+  type a b c d. (a,b) eq -> (c,d) eq -> (a, a, c) Rel.pt -> (b, b, d) Rel.pt =
+  fun Refl Refl x -> x
 
 let cast_rec_decl :
-  type a b. (a,b) eq -> (a, a) Constr.prec_declaration -> (b, b) Constr.prec_declaration =
-  fun Refl x -> x
+  type a b c d. (a,b) eq -> (c,d) eq -> (a, a, c) Constr.prec_declaration -> (b, b, d) Constr.prec_declaration =
+  fun Refl Refl x -> x
 
 let cast_named_decl :
-  type a b. (a,b) eq -> (a, a) Named.Declaration.pt -> (b, b) Named.Declaration.pt =
-  fun Refl x -> x
+  type a b c d. (a,b) eq -> (c,d) eq -> (a, a, c) Named.Declaration.pt -> (b, b, d) Named.Declaration.pt =
+  fun Refl Refl x -> x
 
 let cast_named_context :
-  type a b. (a,b) eq -> (a, a) Named.pt -> (b, b) Named.pt =
-  fun Refl x -> x
+  type a b c d. (a,b) eq -> (c,d) eq -> (a, a, c) Named.pt -> (b, b, d) Named.pt =
+  fun Refl Refl x -> x
 
 
 module Vars =
@@ -876,7 +922,7 @@ let subst_univs_level_constr subst c =
 
 let subst_instance_context subst ctx =
   let subst = EInstance.unsafe_to_instance subst in
-  cast_rel_context (sym unsafe_eq) (Vars.subst_instance_context subst (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq) (Vars.subst_instance_context subst (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let subst_instance_constr subst c =
   let subst = EInstance.unsafe_to_instance subst in
@@ -884,7 +930,9 @@ let subst_instance_constr subst c =
 
 let subst_instance_relevance subst r =
   let subst = EInstance.unsafe_to_instance subst in
-  UVars.subst_instance_relevance subst r
+  let r = ERelevance.unsafe_to_relevance r in
+  let r = UVars.subst_instance_relevance subst r in
+  ERelevance.make r
 
 (** Operations that dot NOT commute with evar-normalization *)
 let noccurn sigma n term =
@@ -915,30 +963,30 @@ let closed0 sigma c = closedn sigma 0 c
 
 let subst_of_rel_context_instance ctx subst =
   cast_list (sym unsafe_eq)
-    (Vars.subst_of_rel_context_instance (cast_rel_context unsafe_eq ctx) (cast_vect unsafe_eq subst))
+    (Vars.subst_of_rel_context_instance (cast_rel_context unsafe_eq unsafe_relevance_eq ctx) (cast_vect unsafe_eq subst))
 let subst_of_rel_context_instance_list ctx subst =
   cast_list (sym unsafe_eq)
-    (Vars.subst_of_rel_context_instance_list (cast_rel_context unsafe_eq ctx) (cast_list unsafe_eq subst))
+    (Vars.subst_of_rel_context_instance_list (cast_rel_context unsafe_eq unsafe_relevance_eq ctx) (cast_list unsafe_eq subst))
 
 let liftn_rel_context n k ctx =
-  cast_rel_context (sym unsafe_eq)
-    (Vars.liftn_rel_context n k (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq)
+    (Vars.liftn_rel_context n k (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let lift_rel_context n ctx =
-  cast_rel_context (sym unsafe_eq)
-    (Vars.lift_rel_context n (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq)
+    (Vars.lift_rel_context n (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let substnl_rel_context subst n ctx =
-  cast_rel_context (sym unsafe_eq)
-    (Vars.substnl_rel_context (cast_list unsafe_eq subst) n (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq)
+    (Vars.substnl_rel_context (cast_list unsafe_eq subst) n (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let substl_rel_context subst ctx =
-  cast_rel_context (sym unsafe_eq)
-    (Vars.substl_rel_context (cast_list unsafe_eq subst) (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq)
+    (Vars.substl_rel_context (cast_list unsafe_eq subst) (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let smash_rel_context ctx =
-  cast_rel_context (sym unsafe_eq)
-      (Vars.smash_rel_context (cast_rel_context unsafe_eq ctx))
+  cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq)
+      (Vars.smash_rel_context (cast_rel_context unsafe_eq unsafe_relevance_eq ctx))
 
 let esubst : (int -> 'a -> t) -> 'a Esubst.subs -> t -> t =
 match unsafe_eq with
@@ -1034,26 +1082,26 @@ let destArity sigma =
   in
   prodec_rec []
 
-let push_rel d e = push_rel (cast_rel_decl unsafe_eq d) e
-let push_rel_context d e = push_rel_context (cast_rel_context unsafe_eq d) e
-let push_rec_types d e = push_rec_types (cast_rec_decl unsafe_eq d) e
-let push_named d e = push_named (cast_named_decl unsafe_eq d) e
-let push_named_context d e = push_named_context (cast_named_context unsafe_eq d) e
-let push_named_context_val d e = push_named_context_val (cast_named_decl unsafe_eq d) e
+let push_rel d e = push_rel (cast_rel_decl unsafe_eq unsafe_relevance_eq d) e
+let push_rel_context d e = push_rel_context (cast_rel_context unsafe_eq unsafe_relevance_eq d) e
+let push_rec_types d e = push_rec_types (cast_rec_decl unsafe_eq unsafe_relevance_eq d) e
+let push_named d e = push_named (cast_named_decl unsafe_eq unsafe_relevance_eq d) e
+let push_named_context d e = push_named_context (cast_named_context unsafe_eq unsafe_relevance_eq d) e
+let push_named_context_val d e = push_named_context_val (cast_named_decl unsafe_eq unsafe_relevance_eq d) e
 
-let rel_context e = cast_rel_context (sym unsafe_eq) (rel_context e)
-let named_context e = cast_named_context (sym unsafe_eq) (named_context e)
+let rel_context e = cast_rel_context (sym unsafe_eq) (sym unsafe_relevance_eq) (rel_context e)
+let named_context e = cast_named_context (sym unsafe_eq) (sym unsafe_relevance_eq) (named_context e)
 
-let val_of_named_context e = val_of_named_context (cast_named_context unsafe_eq e)
-let named_context_of_val e = cast_named_context (sym unsafe_eq) (named_context_of_val e)
+let val_of_named_context e = val_of_named_context (cast_named_context unsafe_eq unsafe_relevance_eq e)
+let named_context_of_val e = cast_named_context (sym unsafe_eq) (sym unsafe_relevance_eq) (named_context_of_val e)
 
 let of_existential : Constr.existential -> existential =
   let gen : type a b. (a,b) eq -> 'c * b SList.t -> 'c * a SList.t = fun Refl x -> x in
   gen unsafe_eq
 
-let lookup_rel i e = cast_rel_decl (sym unsafe_eq) (lookup_rel i e)
-let lookup_named n e = cast_named_decl (sym unsafe_eq) (lookup_named n e)
-let lookup_named_val n e = cast_named_decl (sym unsafe_eq) (lookup_named_ctxt n e)
+let lookup_rel i e = cast_rel_decl (sym unsafe_eq) (sym unsafe_relevance_eq) (lookup_rel i e)
+let lookup_named n e = cast_named_decl (sym unsafe_eq) (sym unsafe_relevance_eq) (lookup_named n e)
+let lookup_named_val n e = cast_named_decl (sym unsafe_eq) (sym unsafe_relevance_eq) (lookup_named_ctxt n e)
 
 let map_rel_context_in_env f env sign =
   let rec aux env acc = function
@@ -1066,8 +1114,8 @@ let map_rel_context_in_env f env sign =
 
 let match_named_context_val :
   named_context_val -> (named_declaration * named_context_val) option =
-  match unsafe_eq with
-  | Refl -> match_named_context_val
+  match unsafe_eq, unsafe_relevance_eq with
+  | Refl, Refl -> match_named_context_val
 
 let identity_subst_val : named_context_val -> t SList.t = fun ctx ->
   SList.defaultn (List.length ctx.Environ.env_named_ctx) SList.empty
@@ -1083,8 +1131,8 @@ let is_global = isRefX
 type kind_of_type =
   | SortType   of ESorts.t
   | CastType   of types * t
-  | ProdType   of Name.t Context.binder_annot * t * t
-  | LetInType  of Name.t Context.binder_annot * t * t * t
+  | ProdType   of Name.t binder_annot * t * t
+  | LetInType  of Name.t binder_annot * t * t * t
   | AtomicType of t * t array
 
 let kind_of_type sigma t = match kind sigma t with
@@ -1100,25 +1148,30 @@ let kind_of_type sigma t = match kind sigma t with
 
 module Unsafe =
 struct
+let to_relevance = ERelevance.unsafe_to_relevance
 let to_sorts = ESorts.unsafe_to_sorts
 let to_instance = EInstance.unsafe_to_instance
 let to_constr = unsafe_to_constr
 let to_constr_array = unsafe_to_constr_array
+let to_binder_annot : 'a binder_annot -> 'a Constr.binder_annot =
+  match unsafe_relevance_eq with Refl -> fun x -> x
 let to_rel_decl = unsafe_to_rel_decl
 let to_named_decl = unsafe_to_named_decl
 let to_named_context =
-  let gen : type a b. (a, b) eq -> (a,a) Context.Named.pt -> (b,b) Context.Named.pt
-    = fun Refl x -> x
+  let gen : type a b c d. (a, b) eq -> (c,d) eq -> (a,a,c) Context.Named.pt -> (b,b,d) Context.Named.pt
+    = fun Refl Refl x -> x
   in
-  gen unsafe_eq
+  gen unsafe_eq unsafe_relevance_eq
 let to_rel_context =
-  let gen : type a b. (a, b) eq -> (a,a) Context.Rel.pt -> (b,b) Context.Rel.pt
-    = fun Refl x -> x
+  let gen : type a b c d. (a, b) eq -> (c,d) eq -> (a,a,c) Context.Rel.pt -> (b,b,d) Context.Rel.pt
+    = fun Refl Refl x -> x
   in
-  gen unsafe_eq
+  gen unsafe_eq unsafe_relevance_eq
 let to_case_invert = unsafe_to_case_invert
 
 let eq = unsafe_eq
+
+let relevance_eq = unsafe_relevance_eq
 end
 
 module UnsafeMonomorphic = struct

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -17,23 +17,24 @@ type t = Evd.econstr
 (** Type of incomplete terms. Essentially a wrapper around {!Constr.t} ensuring
     that {!Constr.kind} does not observe defined evars. *)
 
-type types = t
-type constr = t
-type existential = t pexistential
-type case_return = t pcase_return
-type case_branch = t pcase_branch
-type fixpoint = (t, t) pfixpoint
-type cofixpoint = (t, t) pcofixpoint
-type unsafe_judgment = (constr, types) Environ.punsafe_judgment
-type unsafe_type_judgment = (types, Evd.esorts) Environ.punsafe_type_judgment
-type named_declaration = (constr, types) Context.Named.Declaration.pt
-type rel_declaration = (constr, types) Context.Rel.Declaration.pt
-type compacted_declaration = (constr, types) Context.Compacted.Declaration.pt
-type named_context = (constr, types) Context.Named.pt
-type compacted_context = compacted_declaration list
-type rel_context = (constr, types) Context.Rel.pt
-
 (** {5 Universe variables} *)
+
+module ERelevance :
+sig
+  type t = Evd.erelevance
+  (** Type of relevance marks up-to quality variable unification. *)
+
+  val make : Sorts.relevance -> t
+
+  val kind : Evd.evar_map -> t -> Sorts.relevance
+
+  val equal : Evd.evar_map -> t -> t -> bool
+
+  val relevant : t
+  val irrelevant : t
+
+  val is_irrelevant : Evd.evar_map -> t -> bool
+end
 
 module ESorts :
 sig
@@ -62,7 +63,7 @@ sig
 
   val super : Evd.evar_map -> t -> t
 
-  val relevance_of_sort : Evd.evar_map -> t -> Sorts.relevance
+  val relevance_of_sort : t -> ERelevance.t
 
   val family : Evd.evar_map -> t -> Sorts.family
 
@@ -82,18 +83,41 @@ sig
   val is_empty : t -> bool
 end
 
+type types = t
+type constr = t
+type existential = t pexistential
+type case_return = (t,ERelevance.t) pcase_return
+type case_branch = (t,ERelevance.t) pcase_branch
+type rec_declaration = (t, t, ERelevance.t) prec_declaration
+type fixpoint = (t, t, ERelevance.t) pfixpoint
+type cofixpoint = (t, t, ERelevance.t) pcofixpoint
+type unsafe_judgment = (constr, types) Environ.punsafe_judgment
+type unsafe_type_judgment = (types, Evd.esorts) Environ.punsafe_type_judgment
+type named_declaration = (constr, types, ERelevance.t) Context.Named.Declaration.pt
+type rel_declaration = (constr, types, ERelevance.t) Context.Rel.Declaration.pt
+type compacted_declaration = (constr, types, ERelevance.t) Context.Compacted.Declaration.pt
+type named_context = (constr, types, ERelevance.t) Context.Named.pt
+type compacted_context = compacted_declaration list
+type rel_context = (constr, types, ERelevance.t) Context.Rel.pt
+type 'a binder_annot = ('a,ERelevance.t) Context.pbinder_annot
+
+val annotR : 'a -> 'a binder_annot
+val nameR : Id.t -> Name.t binder_annot
+val anonR : Name.t binder_annot
+
 type case_invert = t pcase_invert
-type case = (t, t, EInstance.t) pcase
+type case = (t, t, EInstance.t, ERelevance.t) pcase
 
 type 'a puniverses = 'a * EInstance.t
 
 (** {5 Destructors} *)
 
-val kind : Evd.evar_map -> t -> (t, t, ESorts.t, EInstance.t) Constr.kind_of_term
+val kind : Evd.evar_map -> t -> (t, t, ESorts.t, EInstance.t, ERelevance.t) Constr.kind_of_term
 (** Same as {!Constr.kind} except that it expands evars and normalizes
     universes on the fly. *)
 
-val kind_upto : Evd.evar_map -> Constr.t -> (Constr.t, Constr.t, Sorts.t, UVars.Instance.t) Constr.kind_of_term
+val kind_upto : Evd.evar_map -> Constr.t ->
+  (Constr.t, Constr.t, Sorts.t, UVars.Instance.t, Sorts.relevance) Constr.kind_of_term
 
 val to_constr : ?abort_on_undefined_evars:bool -> Evd.evar_map -> t -> Constr.t
 (** Returns the evar-normal form of the argument. Note that this
@@ -110,15 +134,15 @@ val to_constr_opt : Evd.evar_map -> t -> Constr.t option
 type kind_of_type =
   | SortType   of ESorts.t
   | CastType   of types * t
-  | ProdType   of Name.t Context.binder_annot * t * t
-  | LetInType  of Name.t Context.binder_annot * t * t * t
+  | ProdType   of Name.t binder_annot * t * t
+  | LetInType  of Name.t binder_annot * t * t * t
   | AtomicType of t * t array
 
 val kind_of_type : Evd.evar_map -> t -> kind_of_type
 
 (** {5 Constructors} *)
 
-val of_kind : (t, t, ESorts.t, EInstance.t) Constr.kind_of_term -> t
+val of_kind : (t, t, ESorts.t, EInstance.t, ERelevance.t) Constr.kind_of_term -> t
 (** Construct a term from a view. *)
 
 val of_constr : Constr.t -> t
@@ -143,19 +167,19 @@ val mkProp : t
 val mkSet  : t
 val mkType : Univ.Universe.t -> t
 val mkCast : t * cast_kind * t -> t
-val mkProd : Name.t Context.binder_annot * t * t -> t
-val mkLambda : Name.t Context.binder_annot * t * t -> t
-val mkLetIn : Name.t Context.binder_annot * t * t * t -> t
+val mkProd : Name.t binder_annot * t * t -> t
+val mkLambda : Name.t binder_annot * t * t -> t
+val mkLetIn : Name.t binder_annot * t * t * t -> t
 val mkApp : t * t array -> t
 val mkConstU : Constant.t * EInstance.t -> t
-val mkProj : (Projection.t * Sorts.relevance * t) -> t
+val mkProj : (Projection.t * ERelevance.t * t) -> t
 val mkIndU : inductive * EInstance.t -> t
 val mkConstructU : constructor * EInstance.t -> t
 val mkConstructUi : (inductive * EInstance.t) * int -> t
 val mkCase : case -> t
-val mkFix : (t, t) pfixpoint -> t
-val mkCoFix : (t, t) pcofixpoint -> t
-val mkArrow : t -> Sorts.relevance  -> t -> t
+val mkFix : (t, t, ERelevance.t) pfixpoint -> t
+val mkCoFix : (t, t, ERelevance.t) pcofixpoint -> t
+val mkArrow : t -> ERelevance.t  -> t -> t
 val mkArrowR : t -> t -> t
 val mkInt : Uint63.t -> t
 val mkFloat : Float64.t -> t
@@ -191,8 +215,8 @@ val applistc : t -> t list -> t
     Named = binding is by name and the combinators turn it into a
             binding by index (complexity is nb(binders) * size(term)) *)
 
-val it_mkProd : t -> (Name.t Context.binder_annot * t) list -> t
-val it_mkLambda : t -> (Name.t Context.binder_annot * t) list -> t
+val it_mkProd : t -> (Name.t binder_annot * t) list -> t
+val it_mkLambda : t -> (Name.t binder_annot * t) list -> t
 
 val mkProd_or_LetIn : rel_declaration -> t -> t
 val mkLambda_or_LetIn : rel_declaration -> t -> t
@@ -204,9 +228,9 @@ val mkLambda_wo_LetIn : rel_declaration -> t -> t
 val it_mkProd_wo_LetIn : t -> rel_context -> t
 val it_mkLambda_wo_LetIn : t -> rel_context -> t
 
-val mkNamedProd : Evd.evar_map -> Id.t Context.binder_annot -> types -> types -> types
-val mkNamedLambda : Evd.evar_map -> Id.t Context.binder_annot -> types -> constr -> constr
-val mkNamedLetIn : Evd.evar_map -> Id.t Context.binder_annot -> constr -> types -> constr -> constr
+val mkNamedProd : Evd.evar_map -> Id.t binder_annot -> types -> types -> types
+val mkNamedLambda : Evd.evar_map -> Id.t binder_annot -> types -> constr -> constr
+val mkNamedLetIn : Evd.evar_map -> Id.t binder_annot -> constr -> types -> constr -> constr
 
 val mkNamedProd_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
 val mkNamedLambda_or_LetIn : Evd.evar_map -> named_declaration -> types -> types
@@ -259,18 +283,18 @@ val destMeta : Evd.evar_map -> t -> metavariable
 val destVar : Evd.evar_map -> t -> Id.t
 val destSort : Evd.evar_map -> t -> ESorts.t
 val destCast : Evd.evar_map -> t -> t * cast_kind * t
-val destProd : Evd.evar_map -> t -> Name.t Context.binder_annot * types * types
-val destLambda : Evd.evar_map -> t -> Name.t Context.binder_annot * types * t
-val destLetIn : Evd.evar_map -> t -> Name.t Context.binder_annot * t * types * t
+val destProd : Evd.evar_map -> t -> Name.t binder_annot * types * types
+val destLambda : Evd.evar_map -> t -> Name.t binder_annot * types * t
+val destLetIn : Evd.evar_map -> t -> Name.t binder_annot * t * types * t
 val destApp : Evd.evar_map -> t -> t * t array
 val destConst : Evd.evar_map -> t -> Constant.t * EInstance.t
 val destEvar : Evd.evar_map -> t -> t pexistential
 val destInd : Evd.evar_map -> t -> inductive * EInstance.t
 val destConstruct : Evd.evar_map -> t -> constructor * EInstance.t
 val destCase : Evd.evar_map -> t -> case
-val destProj : Evd.evar_map -> t -> Projection.t * Sorts.relevance * t
-val destFix : Evd.evar_map -> t -> (t, t) pfixpoint
-val destCoFix : Evd.evar_map -> t -> (t, t) pcofixpoint
+val destProj : Evd.evar_map -> t -> Projection.t * ERelevance.t * t
+val destFix : Evd.evar_map -> t -> (t, t, ERelevance.t) pfixpoint
+val destCoFix : Evd.evar_map -> t -> (t, t, ERelevance.t) pcofixpoint
 
 val destRef : Evd.evar_map -> t -> GlobRef.t * EInstance.t
 
@@ -278,7 +302,7 @@ val decompose_app : Evd.evar_map -> t -> t * t array
 val decompose_app_list : Evd.evar_map -> t -> t * t list
 
 (** Pops lambda abstractions until there are no more, skipping casts. *)
-val decompose_lambda : Evd.evar_map -> t -> (Name.t Context.binder_annot * t) list * t
+val decompose_lambda : Evd.evar_map -> t -> (Name.t binder_annot * t) list * t
 
 (** Pops lambda abstractions and letins until there are no more, skipping casts. *)
 val decompose_lambda_decls : Evd.evar_map -> t -> rel_context * t
@@ -286,7 +310,7 @@ val decompose_lambda_decls : Evd.evar_map -> t -> rel_context * t
 (** Pops [n] lambda abstractions, skipping casts.
 
     @raise UserError if the term doesn't have enough lambdas. *)
-val decompose_lambda_n : Evd.evar_map -> int -> t -> (Name.t Context.binder_annot * t) list * t
+val decompose_lambda_n : Evd.evar_map -> int -> t -> (Name.t binder_annot * t) list * t
 
 (** Pops [n] lambda abstractions, and pop letins only if needed to
    expose enough lambdas, skipping casts.
@@ -301,13 +325,13 @@ val decompose_lambda_n_decls : Evd.evar_map -> int -> t -> rel_context * t
 
 val prod_decls : Evd.evar_map -> t -> rel_context
 
-val compose_lam : (Name.t Context.binder_annot * t) list -> t -> t
+val compose_lam : (Name.t binder_annot * t) list -> t -> t
 [@@ocaml.deprecated "Use [it_mkLambda] instead."]
 
 val to_lambda : Evd.evar_map -> int -> t -> t
 
-val decompose_prod : Evd.evar_map -> t -> (Name.t Context.binder_annot * t) list * t
-val decompose_prod_n : Evd.evar_map -> int -> t -> (Name.t Context.binder_annot * t) list * t
+val decompose_prod : Evd.evar_map -> t -> (Name.t binder_annot * t) list * t
+val decompose_prod_n : Evd.evar_map -> int -> t -> (Name.t binder_annot * t) list * t
 val decompose_prod_decls : Evd.evar_map -> t -> rel_context * t
 val decompose_prod_n_decls : Evd.evar_map -> int -> t -> rel_context * t
 
@@ -379,7 +403,7 @@ val closed0 : Evd.evar_map -> t -> bool
 val subst_univs_level_constr : UVars.sort_level_subst -> t -> t
 val subst_instance_context : EInstance.t -> rel_context -> rel_context
 val subst_instance_constr : EInstance.t -> t -> t
-val subst_instance_relevance : EInstance.t -> Sorts.relevance -> Sorts.relevance
+val subst_instance_relevance : EInstance.t -> ERelevance.t -> ERelevance.t
 
 val subst_of_rel_context_instance : rel_context -> instance -> substl
 val subst_of_rel_context_instance_list : rel_context -> instance_list -> substl
@@ -402,7 +426,7 @@ end
 
 val push_rel : rel_declaration -> env -> env
 val push_rel_context : rel_context -> env -> env
-val push_rec_types : (t, t) Constr.prec_declaration -> env -> env
+val push_rec_types : (t, t, ERelevance.t) Constr.prec_declaration -> env -> env
 
 val push_named : named_declaration -> env -> env
 val push_named_context : named_context -> env -> env
@@ -435,10 +459,10 @@ val is_global : Environ.env -> Evd.evar_map -> GlobRef.t -> t -> bool
 [@@ocaml.deprecated "Use [EConstr.isRefX] instead."]
 
 val expand_case : Environ.env -> Evd.evar_map ->
-  case -> (t,t) Inductive.pexpanded_case
+  case -> (t,t,ERelevance.t) Inductive.pexpanded_case
 
 val annotate_case : Environ.env -> Evd.evar_map -> case ->
-  case_info * EInstance.t * t array * ((rel_context * t) * Sorts.relevance) * case_invert * t * (rel_context * t) array
+  case_info * EInstance.t * t array * ((rel_context * t) * ERelevance.t) * case_invert * t * (rel_context * t) array
 (** Same as above, but doesn't turn contexts into binders *)
 
 val expand_branch : Environ.env -> Evd.evar_map ->
@@ -447,26 +471,30 @@ val expand_branch : Environ.env -> Evd.evar_map ->
     constructs the typed context in which the branch lives. *)
 
 val contract_case : Environ.env -> Evd.evar_map ->
-  (t,t) Inductive.pexpanded_case -> case
+  (t,t,ERelevance.t) Inductive.pexpanded_case -> case
 
 (** {5 Extra} *)
 
 val of_existential : Constr.existential -> existential
-val of_named_decl : (Constr.t, Constr.types) Context.Named.Declaration.pt -> (t, types) Context.Named.Declaration.pt
-val of_rel_decl : (Constr.t, Constr.types) Context.Rel.Declaration.pt -> (t, types) Context.Rel.Declaration.pt
+val of_named_decl : Constr.named_declaration -> named_declaration
+val of_rel_decl : Constr.rel_declaration -> rel_declaration
 
-val to_rel_decl : Evd.evar_map -> (t, types) Context.Rel.Declaration.pt -> (Constr.t, Constr.types) Context.Rel.Declaration.pt
-val to_named_decl : Evd.evar_map -> (t, types) Context.Named.Declaration.pt -> (Constr.t, Constr.types) Context.Named.Declaration.pt
+val to_rel_decl : Evd.evar_map -> rel_declaration -> Constr.rel_declaration
+val to_named_decl : Evd.evar_map -> named_declaration -> Constr.named_declaration
 
 val of_named_context : Constr.named_context -> named_context
 val of_rel_context : Constr.rel_context -> rel_context
 
-val to_named_context : Evd.evar_map -> (t, types) Context.Named.pt -> (Constr.t, Constr.types) Context.Named.pt
-val to_rel_context : Evd.evar_map -> (t, types) Context.Rel.pt -> (Constr.t, Constr.types) Context.Rel.pt
+val to_named_context : Evd.evar_map -> named_context -> Constr.named_context
+val to_rel_context : Evd.evar_map -> rel_context -> Constr.rel_context
 
 val of_case_invert : Constr.case_invert -> case_invert
 
 val of_constr_array : Constr.t array -> t array
+
+val of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot
+
+val to_binder_annot : Evd.evar_map -> 'a binder_annot -> 'a Constr.binder_annot
 
 (** {5 Unsafe operations} *)
 
@@ -478,15 +506,21 @@ sig
   val to_constr_array : t array -> Constr.t array
   (** Physical identity. Does not care for defined evars. *)
 
-  val to_rel_decl : (t, types) Context.Rel.Declaration.pt -> (Constr.t, Constr.types) Context.Rel.Declaration.pt
+  val to_binder_annot : 'a binder_annot -> 'a Constr.binder_annot
+
+  val to_rel_decl : (t, types, ERelevance.t) Context.Rel.Declaration.pt ->
+    (Constr.t, Constr.types, Sorts.relevance) Context.Rel.Declaration.pt
   (** Physical identity. Does not care for defined evars. *)
 
-  val to_named_decl : (t, types) Context.Named.Declaration.pt -> (Constr.t, Constr.types) Context.Named.Declaration.pt
+  val to_named_decl : (t, types, ERelevance.t) Context.Named.Declaration.pt ->
+    (Constr.t, Constr.types, Sorts.relevance) Context.Named.Declaration.pt
   (** Physical identity. Does not care for defined evars. *)
 
-  val to_named_context : (t, types) Context.Named.pt -> Constr.named_context
+  val to_named_context : (t, types, ERelevance.t) Context.Named.pt -> Constr.named_context
 
-  val to_rel_context : (t, types) Context.Rel.pt -> Constr.rel_context
+  val to_rel_context : (t, types, ERelevance.t) Context.Rel.pt -> Constr.rel_context
+
+  val to_relevance : ERelevance.t -> Sorts.relevance
 
   val to_sorts : ESorts.t -> Sorts.t
   (** Physical identity. Does not care for normalization. *)
@@ -498,6 +532,8 @@ sig
 
   val eq : (t, Constr.t) eq
   (** Use for transparent cast between types. *)
+
+  val relevance_eq : (ERelevance.t, Sorts.relevance) eq
 end
 
 (** Deprecated *)
@@ -511,7 +547,7 @@ val decompose_prod_n_assum : Evd.evar_map -> int -> t -> rel_context * t
 val prod_assum : Evd.evar_map -> t -> rel_context
 [@@ocaml.deprecated "Use [prod_decls] instead."]
 
-val decompose_lam : Evd.evar_map -> t -> (Name.t Context.binder_annot * t) list * t
+val decompose_lam : Evd.evar_map -> t -> (Name.t binder_annot * t) list * t
 [@@ocaml.deprecated "Use [decompose_lambda] instead."]
 val decompose_lam_n_assum : Evd.evar_map -> int -> t -> rel_context * t
 [@@ocaml.deprecated "Use [decompose_lambda_n_assum] instead."]

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -41,7 +41,7 @@ type naming_mode =
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?relevance:Sorts.relevance ->
+  ?relevance:ERelevance.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
@@ -51,7 +51,7 @@ val new_evar :
 (** Alias of {!Evd.new_pure_evar} *)
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?relevance:Sorts.relevance ->
+  ?relevance:ERelevance.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?name:Id.t ->
   ?typeclass_candidate:bool ->
@@ -170,7 +170,7 @@ val finalize : ?abort_on_undefined_evars:bool -> evar_map ->
     as an evar [e] only if [e] is uninstantiated in [sigma]. Otherwise the
     value of [e] in [sigma] is (recursively) used. *)
 val kind_of_term_upto : evar_map -> Constr.constr ->
-  (Constr.constr, Constr.types, Sorts.t, UVars.Instance.t) kind_of_term
+  (Constr.constr, Constr.types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
 (** [eq_constr_univs_test ~evd ~extended_evd t u] tests equality of
     [t] and [u] up to existential variable instantiation and

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -17,12 +17,12 @@ open Constr
 open Vars
 open Environ
 
-module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
 type econstr = constr
 type etypes = types
 type esorts = Sorts.t
+type erelevance = Sorts.relevance
 
 (** Generic filters *)
 module Filter :
@@ -1675,6 +1675,13 @@ type unsolvability_explanation = SeveralInstancesFound of int
 
 module MiniEConstr = struct
 
+  module ERelevance = struct
+    type t = Sorts.relevance
+    let make r = r
+    let unsafe_to_relevance r = r
+    let kind sigma r = UState.nf_relevance sigma.universes r
+  end
+
   module ESorts =
   struct
     type t = Sorts.t
@@ -1730,6 +1737,7 @@ module MiniEConstr = struct
   let unsafe_to_constr c = c
   let unsafe_to_constr_array v = v
   let unsafe_eq = Refl
+  let unsafe_relevance_eq = Refl
 
   type evclos = {
     evc_map : (int * Vars.substituend Lazy.t) Id.Map.t;
@@ -1854,15 +1862,11 @@ module MiniEConstr = struct
 
   let of_named_decl d = d
   let unsafe_to_named_decl d = d
-  let to_named_decl sigma d = NamedDecl.map_constr_het_with_relevance (UState.nf_relevance sigma.universes) (to_constr sigma) d
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
-  let to_rel_decl sigma d = RelDecl.map_constr_het_with_relevance (UState.nf_relevance sigma.universes) (to_constr sigma) d
 
   let of_named_context d = d
-  let to_named_context sigma l = List.map (to_named_decl sigma) l
   let of_rel_context d = d
-  let to_rel_context sigma l = List.map (to_rel_decl sigma) l
 
   let unsafe_to_case_invert x = x
   let of_case_invert x = x

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -44,15 +44,15 @@ val id_of_name_using_hdchar : env -> evar_map -> types -> Name.t -> Id.t
 val named_hd : env -> evar_map -> types -> Name.t -> Name.t
 val head_name : evar_map -> types -> Id.t option
 
-val mkProd_name : env -> evar_map -> Name.t Context.binder_annot * types * types -> types
-val mkLambda_name : env -> evar_map -> Name.t Context.binder_annot * types * constr -> constr
+val mkProd_name : env -> evar_map -> Name.t EConstr.binder_annot * types * types -> types
+val mkLambda_name : env -> evar_map -> Name.t EConstr.binder_annot * types * constr -> constr
 
 (** Deprecated synonyms of [mkProd_name] and [mkLambda_name] *)
-val prod_name : env -> evar_map -> Name.t Context.binder_annot * types * types -> types
-val lambda_name : env -> evar_map -> Name.t Context.binder_annot * types * constr -> constr
+val prod_name : env -> evar_map -> Name.t EConstr.binder_annot * types * types -> types
+val lambda_name : env -> evar_map -> Name.t EConstr.binder_annot * types * constr -> constr
 
-val prod_create : env -> evar_map -> Sorts.relevance * types * types -> constr
-val lambda_create : env -> evar_map -> Sorts.relevance * types * constr -> constr
+val prod_create : env -> evar_map -> ERelevance.t * types * types -> constr
+val lambda_create : env -> evar_map -> ERelevance.t * types * constr -> constr
 val name_assumption : env -> evar_map -> rel_declaration -> rel_declaration
 val name_context : env -> evar_map -> rel_context -> rel_context
 

--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -518,7 +518,7 @@ sig
   val fold_right_map : (Id.t -> 'a -> Id.t * 'a) -> Name.t -> 'a -> Name.t * 'a
   val get_id : t -> Id.t
   val pick : t -> t -> t
-  val pick_annot : t Context.binder_annot -> t Context.binder_annot -> t Context.binder_annot
+  val pick_annot : (t,'r) Context.pbinder_annot -> (t,'r) Context.pbinder_annot -> (t,'r) Context.pbinder_annot
   val cons : t -> Id.t list -> Id.t list
   val to_option : Name.t -> Id.t option
 

--- a/engine/nameops.mli
+++ b/engine/nameops.mli
@@ -135,8 +135,8 @@ module Name : sig
   (** [pick na na'] returns [Anonymous] if both names are [Anonymous].
       Pick one of [na] or [na'] otherwise. *)
 
-  val pick_annot : Name.t Context.binder_annot -> Name.t Context.binder_annot ->
-    Name.t Context.binder_annot
+  val pick_annot : (Name.t,'r) Context.pbinder_annot -> (Name.t,'r) Context.pbinder_annot ->
+    (Name.t,'r) Context.pbinder_annot
 
   val cons : Name.t -> Id.t list -> Id.t list
   (** [cons na l] returns [id::l] if [na] is [Name id] and [l] otherwise. *)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -879,13 +879,14 @@ module Progress = struct
 
   (** equality function on hypothesis contexts *)
   let eq_named_context_val sigma1 sigma2 ctx1 ctx2 =
+    let r_eq _ _ = true (* ignore relevances *) in
     let c1 = EConstr.named_context_of_val ctx1 and c2 = EConstr.named_context_of_val ctx2 in
     let eq_named_declaration d1 d2 =
       match d1, d2 with
       | LocalAssum (i1,t1), LocalAssum (i2,t2) ->
-         Context.eq_annot Names.Id.equal i1 i2 && eq_constr sigma1 sigma2 t1 t2
+         Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr sigma1 sigma2 t1 t2
       | LocalDef (i1,c1,t1), LocalDef (i2,c2,t2) ->
-         Context.eq_annot Names.Id.equal i1 i2 && eq_constr sigma1 sigma2 c1 c2
+         Context.eq_annot Names.Id.equal r_eq i1 i2 && eq_constr sigma1 sigma2 c1 c2
          && eq_constr sigma1 sigma2 t1 t2
       | _ ->
          false
@@ -920,11 +921,12 @@ module Progress = struct
     | _ -> false
 
   let fast_eq_named_context_val ctx1 ctx2 =
+    let r_eq _ _ = true (* ignore relevances *) in
     let c1 = EConstr.named_context_of_val ctx1 in
     let c2 = EConstr.named_context_of_val ctx2 in
     let eq_named_declaration d1 d2 = match d1, d2 with
-    | LocalAssum (i1, _), LocalAssum (i2, _) -> Context.eq_annot Names.Id.equal i1 i2
-    | LocalDef (i1, _, _), LocalDef (i2, _, _) -> Context.eq_annot Names.Id.equal i1 i2
+    | LocalAssum (i1, _), LocalAssum (i2, _) -> Context.eq_annot Names.Id.equal r_eq i1 i2
+    | LocalDef (i1, _, _), LocalDef (i2, _, _) -> Context.eq_annot Names.Id.equal r_eq i1 i2
     | _ -> false
     in
     List.for_all2eq eq_named_declaration c1 c2

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1255,13 +1255,9 @@ let fold_named_context_both_sides f l ~init = List.fold_right_and_left f l init
 let mem_named_context_val id ctxt =
   try ignore(Environ.lookup_named_ctxt id ctxt); true with Not_found -> false
 
-let map_rel_decl f = function
-| RelDecl.LocalAssum (id, t) -> RelDecl.LocalAssum (id, f t)
-| RelDecl.LocalDef (id, b, t) -> RelDecl.LocalDef (id, f b, f t)
+let map_rel_decl = RelDecl.map_constr_het
 
-let map_named_decl f = function
-| NamedDecl.LocalAssum (id, t) -> NamedDecl.LocalAssum (id, f t)
-| NamedDecl.LocalDef (id, b, t) -> NamedDecl.LocalDef (id, f b, f t)
+let map_named_decl = NamedDecl.map_constr_het
 
 let compact_named_context sigma sign =
   let compact l decl =

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -17,11 +17,11 @@ open Environ
 open EConstr
 
 (** about contexts *)
-val push_rel_assum : Name.t Context.binder_annot * types -> env -> env
-val push_rels_assum : (Name.t Context.binder_annot * Constr.types) list -> env -> env
-val push_named_rec_types : Name.t Context.binder_annot array * Constr.types array * 'a -> env -> env
+val push_rel_assum : Name.t EConstr.binder_annot * types -> env -> env
+val push_rels_assum : (Name.t Constr.binder_annot * Constr.types) list -> env -> env
+val push_named_rec_types : Name.t Constr.binder_annot array * Constr.types array * 'a -> env -> env
 
-val lookup_rel_id : Id.t -> ('c, 't) Context.Rel.pt -> int * 'c option * 't
+val lookup_rel_id : Id.t -> ('c, 't, 'r) Context.Rel.pt -> int * 'c option * 't
 (** Associates the contents of an identifier in a [rel_context]. Raise
     [Not_found] if there is no such identifier. *)
 
@@ -39,10 +39,10 @@ val mkProd_or_LetIn : rel_declaration -> types -> types
 val mkProd_wo_LetIn : rel_declaration -> types -> types
   [@@ocaml.deprecated "Use synonymous [EConstr.mkProd_wo_LetIn]."]
 
-val it_mkProd : types -> (Name.t Context.binder_annot * types) list -> types
+val it_mkProd : types -> (Name.t EConstr.binder_annot * types) list -> types
   [@@ocaml.deprecated "Use synonymous [EConstr.it_mkProd]."]
 
-val it_mkLambda : constr -> (Name.t Context.binder_annot * types) list -> constr
+val it_mkLambda : constr -> (Name.t EConstr.binder_annot * types) list -> constr
   [@@ocaml.deprecated "Use synonymous [EConstr.it_mkLambda]."]
 
 val it_mkProd_or_LetIn : types -> rel_context -> types
@@ -199,8 +199,8 @@ val add_name : Name.t -> names_context -> names_context
 val lookup_name_of_rel : int -> names_context -> Name.t
 val lookup_rel_of_name : Id.t -> names_context -> int
 val empty_names_context : names_context
-val ids_of_rel_context : ('c, 't) Context.Rel.pt -> Id.t list
-val ids_of_named_context : ('c, 't) Context.Named.pt -> Id.t list
+val ids_of_rel_context : ('c, 't, 'r) Context.Rel.pt -> Id.t list
+val ids_of_named_context : ('c, 't, 'r) Context.Named.pt -> Id.t list
 val ids_of_context : env -> Id.t list
 val names_of_rel_context : env -> names_context
 
@@ -221,7 +221,7 @@ val add_vname : Id.Set.t -> Name.t -> Id.Set.t
 
 (** other signature iterators *)
 val process_rel_context : (rel_declaration -> env -> env) -> env -> env
-val assums_of_rel_context : ('c, 't) Context.Rel.pt -> (Name.t Context.binder_annot * 't) list
+val assums_of_rel_context : ('c, 't, 'r) Context.Rel.pt -> ((Name.t,'r) Context.pbinder_annot * 't) list
 
 val lift_rel_context : int -> Constr.rel_context -> Constr.rel_context
   [@@ocaml.deprecated "Use synonymous [Vars.lift_rel_context]."]
@@ -230,7 +230,7 @@ val substl_rel_context : Constr.constr list -> Constr.rel_context -> Constr.rel_
 val smash_rel_context : Constr.rel_context -> Constr.rel_context
   [@@ocaml.deprecated "Use synonymous [Vars.smash_rel_context]."]
 val map_rel_context_with_binders :
-  (int -> 'c -> 'c) -> ('c, 'c) Context.Rel.pt -> ('c, 'c) Context.Rel.pt
+  (int -> 'c -> 'c) -> ('c, 'c, 'r) Context.Rel.pt -> ('c, 'c, 'r) Context.Rel.pt
   [@@ocaml.deprecated "Use synonymous [Context.Rel.map_with_binders]."]
 
 val map_rel_context_in_env :
@@ -241,8 +241,11 @@ val fold_named_context_both_sides :
 val mem_named_context_val : Id.t -> named_context_val -> bool
 val compact_named_context : Evd.evar_map -> EConstr.named_context -> EConstr.compacted_context
 
-val map_rel_decl : ('a -> 'b) -> ('a, 'a) Context.Rel.Declaration.pt -> ('b, 'b) Context.Rel.Declaration.pt
-val map_named_decl : ('a -> 'b) -> ('a, 'a) Context.Named.Declaration.pt -> ('b, 'b) Context.Named.Declaration.pt
+val map_rel_decl : ('r1 -> 'r2 ) -> ('a -> 'b) -> ('a, 'a, 'r1) Context.Rel.Declaration.pt -> ('b, 'b, 'r2) Context.Rel.Declaration.pt
+[@@deprecated "Use [Context.Rel.Declaration.map_constr_het]"]
+
+val map_named_decl : ('r1 -> 'r2 ) -> ('a -> 'b) -> ('a, 'a, 'r1) Context.Named.Declaration.pt -> ('b, 'b, 'r2) Context.Named.Declaration.pt
+[@@deprecated "Use [Context.Named.Declaration.map_constr_het]"]
 
 val clear_named_body : Id.t -> env -> env
 

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -166,7 +166,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
   let frel = Sorts.relevance_subst_fn fqual in
   let flevel = fqual, level_subst_of funiv in
   let aux_rec ((nas, tys, bds) as rc) =
-    let nas' = Array.Smart.map (Context.map_binder_relevance frel) nas in
+    let nas' = Array.Smart.map (Context.map_annot_relevance frel) nas in
     let tys' = Array.Fun1.Smart.map aux k tys in
     let k' = iterate next (Array.length tys') k in
     let bds' = Array.Fun1.Smart.map aux k' bds in
@@ -174,7 +174,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     else (nas', tys', bds')
   in
   let aux_ctx ((nas, c) as p) =
-    let nas' = Array.Smart.map (Context.map_binder_relevance frel) nas in
+    let nas' = Array.Smart.map (Context.map_annot_relevance frel) nas in
     let k' = iterate next (Array.length nas) k in
     let c' = aux k' c in
     if nas' == nas && c' == c then p
@@ -211,19 +211,19 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     if u == u' && elems == elems' && def == def' && ty == ty' then c
     else mkArray (u',elems',def',ty')
   | Prod (na, t, u) ->
-    let na' = Context.map_binder_relevance frel na in
+    let na' = Context.map_annot_relevance frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkProd (na', t', u')
   | Lambda (na, t, u) ->
-    let na' = Context.map_binder_relevance frel na in
+    let na' = Context.map_annot_relevance frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkLambda (na', t', u')
   | LetIn (na, b, t, u) ->
-    let na' = Context.map_binder_relevance frel na in
+    let na' = Context.map_annot_relevance frel na in
     let b' = aux k b in
     let t' = aux k t in
     let u' = aux (next k) u in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -31,7 +31,7 @@ let whd_prod env sigma typ =
   | FProd (na, c1, c2, e) ->
     let c1 = EConstr.of_constr @@ term_of_fconstr c1 in
     let c2 = EConstr.of_constr @@ term_of_fconstr (mk_clos (CClosure.usubs_lift e) c2) in
-    Some (na, c1, c2)
+    Some (EConstr.of_binder_annot na, c1, c2)
   | _ -> None
 
 module NamedDecl = Context.Named.Declaration

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -92,9 +92,9 @@ and fterm =
   | FCoFix of cofixpoint * usubs
   | FCaseT of case_info * UVars.Instance.t * constr array * case_return * fconstr * case_branch array * usubs (* predicate and branches are closures *)
   | FCaseInvert of case_info * UVars.Instance.t * constr array * case_return * finvert * fconstr * case_branch array * usubs
-  | FLambda of int * (Name.t Context.binder_annot * constr) list * constr * usubs
-  | FProd of Name.t Context.binder_annot * fconstr * constr * usubs
-  | FLetIn of Name.t Context.binder_annot * fconstr * fconstr * constr * usubs
+  | FLambda of int * (Name.t binder_annot * constr) list * constr * usubs
+  | FProd of Name.t binder_annot * fconstr * constr * usubs
+  | FLetIn of Name.t binder_annot * fconstr * fconstr * constr * usubs
   | FEvar of Evar.t * constr list * usubs * evar_repack
   | FInt of Uint63.t
   | FFloat of Float64.t

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -44,9 +44,9 @@ type fterm =
   | FCoFix of cofixpoint * usubs
   | FCaseT of case_info * UVars.Instance.t * constr array * case_return * fconstr * case_branch array * usubs (* predicate and branches are closures *)
   | FCaseInvert of case_info * UVars.Instance.t * constr array * case_return * finvert * fconstr * case_branch array * usubs
-  | FLambda of int * (Name.t Context.binder_annot * constr) list * constr * usubs
-  | FProd of Name.t Context.binder_annot * fconstr * constr * usubs
-  | FLetIn of Name.t Context.binder_annot * fconstr * fconstr * constr * usubs
+  | FLambda of int * (Name.t binder_annot * constr) list * constr * usubs
+  | FProd of Name.t binder_annot * fconstr * constr * usubs
+  | FLetIn of Name.t binder_annot * fconstr * fconstr * constr * usubs
   | FEvar of Evar.t * constr list * usubs * evar_repack
   | FInt of Uint63.t
   | FFloat of Float64.t
@@ -94,7 +94,7 @@ val usubs_cons : fconstr -> usubs -> usubs
 (** identity if the first instance is empty *)
 val usubst_instance : 'a UVars.puniverses -> UVars.Instance.t -> UVars.Instance.t
 
-val usubst_binder : _ UVars.puniverses -> 'a Context.binder_annot -> 'a Context.binder_annot
+val usubst_binder : _ UVars.puniverses -> 'a binder_annot -> 'a binder_annot
 
 (** To lazy reduce a constr, create a [clos_infos] with
    [create_clos_infos], inject the term to reduce with [inject]; then use
@@ -117,7 +117,7 @@ val fterm_of : fconstr -> fterm
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr
 val destFLambda :
-  (usubs -> constr -> fconstr) -> fconstr -> Name.t Context.binder_annot * fconstr * fconstr
+  (usubs -> constr -> fconstr) -> fconstr -> Name.t binder_annot * fconstr * fconstr
 
 (** Global and local constant cache *)
 type clos_infos
@@ -148,8 +148,8 @@ val info_flags: clos_infos -> reds
 val info_univs : clos_infos -> UGraph.t
 val unfold_projection : clos_infos -> Projection.t -> Sorts.relevance -> stack_member option
 
-val push_relevance : clos_infos -> 'b Context.binder_annot -> clos_infos
-val push_relevances : clos_infos -> 'b Context.binder_annot array -> clos_infos
+val push_relevance : clos_infos -> 'b binder_annot -> clos_infos
+val push_relevances : clos_infos -> 'b binder_annot array -> clos_infos
 val set_info_relevances : clos_infos -> Sorts.relevance Range.t -> clos_infos
 
 val info_relevances : clos_infos -> Sorts.relevance Range.t
@@ -176,7 +176,7 @@ val whd_stack :
 
 val skip_irrelevant_stack : clos_infos -> stack -> stack
 
-val eta_expand_stack : clos_infos -> Name.t Context.binder_annot -> stack -> stack
+val eta_expand_stack : clos_infos -> Name.t binder_annot -> stack -> stack
 
 (** [eta_expand_ind_stack env ind c s t] computes stacks corresponding
     to the conversion of the eta expansion of t, considered as an inhabitant

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -103,14 +103,16 @@ type cast_kind = VMcast | NATIVEcast | DEFAULTcast
    type t{_ 2} (that means t2 is declared as the type of t1). *)
 val mkCast : constr * cast_kind * constr -> constr
 
+type 'a binder_annot = ('a,Sorts.relevance) Context.pbinder_annot
+
 (** Constructs the product [(x:t1)t2] *)
-val mkProd : Name.t Context.binder_annot * types * types -> types
+val mkProd : Name.t binder_annot * types * types -> types
 
 (** Constructs the abstraction \[x:t{_ 1}\]t{_ 2} *)
-val mkLambda : Name.t Context.binder_annot * types * constr -> constr
+val mkLambda : Name.t binder_annot * types * constr -> constr
 
 (** Constructs the product [let x = t1 : t2 in t3] *)
-val mkLetIn : Name.t Context.binder_annot * constr * types * constr -> constr
+val mkLetIn : Name.t binder_annot * constr * types * constr -> constr
 
 (** [mkApp (f, [|t1; ...; tN|]] constructs the application
     {%html:(f t<sub>1</sub> ... t<sub>n</sub>)%}
@@ -155,10 +157,10 @@ end
     [ac]{^ ith} element is ith constructor case presented as
     {e construct_args |- case_term } *)
 
-type 'constr pcase_branch = Name.t Context.binder_annot array * 'constr
+type ('constr,'r) pcase_branch = (Name.t,'r) Context.pbinder_annot array * 'constr
 (** Names bound by matching the constructor for this branch. *)
 
-type 'types pcase_return = (Name.t Context.binder_annot array * 'types) * Sorts.relevance
+type ('types,'r) pcase_return = ((Name.t,'r) Context.pbinder_annot array * 'types) * 'r
 (** Names of the indices + name of self *)
 
 type 'constr pcase_invert =
@@ -169,13 +171,13 @@ type 'constr pcase_invert =
   (** Reduce when the indices match those of the unique constructor.
       (SProp to non SProp only) *)
 
-type ('constr, 'types, 'univs) pcase =
-  case_info * 'univs * 'constr array * 'types pcase_return * 'constr pcase_invert * 'constr * 'constr pcase_branch array
+type ('constr, 'types, 'univs, 'r) pcase =
+  case_info * 'univs * 'constr array * ('types,'r) pcase_return * 'constr pcase_invert * 'constr * ('constr,'r) pcase_branch array
 
 type case_invert = constr pcase_invert
-type case_return = types pcase_return
-type case_branch = constr pcase_branch
-type case = (constr, types, UVars.Instance.t) pcase
+type case_return = (types, Sorts.relevance) pcase_return
+type case_branch = (constr, Sorts.relevance) pcase_branch
+type case = (constr, types, UVars.Instance.t, Sorts.relevance) pcase
 
 val mkCase : case -> constr
 
@@ -193,10 +195,10 @@ val mkCase : case -> constr
 
    where the length of the {% $ %}j{% $ %}th context is {% $ %}ij{% $ %}.
 *)
-type ('constr, 'types) prec_declaration =
-    Name.t Context.binder_annot array * 'types array * 'constr array
-type ('constr, 'types) pfixpoint =
-    (int array * int) * ('constr, 'types) prec_declaration
+type ('constr, 'types, 'r) prec_declaration =
+    (Name.t, 'r) Context.pbinder_annot array * 'types array * 'constr array
+type ('constr, 'types, 'r) pfixpoint =
+    (int array * int) * ('constr, 'types, 'r) prec_declaration
 (** The array of [int]'s tells for each component of the array of
    mutual fixpoints the number of lambdas to skip before finding the
    recursive argument (e.g., value is 2 in "fix f (x:A) (y:=t) (z:B)
@@ -204,14 +206,14 @@ type ('constr, 'types) pfixpoint =
    the recursive argument); The second component [int] tells which
    component of the block is returned *)
 
-type ('constr, 'types) pcofixpoint =
-    int * ('constr, 'types) prec_declaration
+type ('constr, 'types, 'r) pcofixpoint =
+    int * ('constr, 'types, 'r) prec_declaration
 (** The component [int] tells which component of the block of
    cofixpoint is returned *)
 
-type rec_declaration = (constr, types) prec_declaration
+type rec_declaration = (constr, types, Sorts.relevance) prec_declaration
 
-type fixpoint = (constr, types) pfixpoint
+type fixpoint = (constr, types, Sorts.relevance) pfixpoint
 val mkFix : fixpoint -> constr
 
 (** If [funnames = [|f1,.....fn|]]
@@ -225,7 +227,7 @@ val mkFix : fixpoint -> constr
      ...
      with       fn = bn.]
  *)
-type cofixpoint = (constr, types) pcofixpoint
+type cofixpoint = (constr, types, Sorts.relevance) pcofixpoint
 val mkCoFix : cofixpoint -> constr
 
 
@@ -235,7 +237,7 @@ val mkCoFix : cofixpoint -> constr
    the same order (i.e. last argument first) *)
 type 'constr pexistential = Evar.t * 'constr SList.t
 
-type ('constr, 'types, 'sort, 'univs) kind_of_term =
+type ('constr, 'types, 'sort, 'univs, 'r) kind_of_term =
   | Rel       of int
   (** Gallina-variable introduced by [forall], [fun], [let-in], [fix], or [cofix]. *)
   | Var       of Id.t
@@ -246,11 +248,11 @@ type ('constr, 'types, 'sort, 'univs) kind_of_term =
   | Evar      of 'constr pexistential
   | Sort      of 'sort
   | Cast      of 'constr * cast_kind * 'types
-  | Prod      of Name.t Context.binder_annot * 'types * 'types
+  | Prod      of (Name.t,'r) Context.pbinder_annot * 'types * 'types
   (** Concrete syntax ["forall A:B,C"] is represented as [Prod (A,B,C)]. *)
-  | Lambda    of Name.t Context.binder_annot * 'types * 'constr
+  | Lambda    of (Name.t,'r) Context.pbinder_annot * 'types * 'constr
   (** Concrete syntax ["fun A:B => C"] is represented as [Lambda (A,B,C)].  *)
-  | LetIn     of Name.t Context.binder_annot * 'constr * 'types * 'constr
+  | LetIn     of (Name.t,'r) Context.pbinder_annot * 'constr * 'types * 'constr
   (** Concrete syntax ["let A:C := B in D"] is represented as [LetIn (A,B,C,D)]. *)
   | App       of 'constr * 'constr array
   (** Concrete syntax ["(F P1 P2 ...  Pn)"] is represented as [App (F, [|P1; P2; ...; Pn|])].
@@ -267,7 +269,7 @@ type ('constr, 'types, 'sort, 'univs) kind_of_term =
   | Construct of (constructor * 'univs)
   (** A constructor of an inductive type defined by [Variant],
      [Inductive] or [Record] Vernacular-commands. *)
-  | Case      of case_info * 'univs * 'constr array * 'types pcase_return * 'constr pcase_invert * 'constr * 'constr pcase_branch array
+  | Case      of case_info * 'univs * 'constr array * ('types,'r) pcase_return * 'constr pcase_invert * 'constr * ('constr,'r) pcase_branch array
   (** [Case (ci,u,params,p,iv,c,brs)] is a [match c return p with brs]
      expression. [c] lives in inductive [ci.ci_ind] at universe
      instance [u] and parameters [params]. If this match has case
@@ -278,9 +280,9 @@ type ('constr, 'types, 'sort, 'univs) kind_of_term =
      inductive value (ie the [in] and [as] clauses).
 
      The names in the [brs] are the names of the variables bound in the respective branch. *)
-  | Fix       of ('constr, 'types) pfixpoint
-  | CoFix     of ('constr, 'types) pcofixpoint
-  | Proj      of Projection.t * Sorts.relevance * 'constr
+  | Fix       of ('constr, 'types, 'r) pfixpoint
+  | CoFix     of ('constr, 'types, 'r) pcofixpoint
+  | Proj      of Projection.t * 'r * 'constr
   (** The relevance is the relevance of the whole term *)
   | Int       of Uint63.t
   | Float     of Float64.t
@@ -292,13 +294,13 @@ type ('constr, 'types, 'sort, 'univs) kind_of_term =
    least one argument and the function is not itself an applicative
    term *)
 
-val kind : constr -> (constr, types, Sorts.t, UVars.Instance.t) kind_of_term
-val of_kind : (constr, types, Sorts.t, UVars.Instance.t) kind_of_term -> constr
+val kind : constr -> (constr, types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
+val of_kind : (constr, types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term -> constr
 
-val kind_nocast_gen : ('v -> ('v, 'v, 'sort, 'univs) kind_of_term) ->
-  ('v -> ('v, 'v, 'sort, 'univs) kind_of_term)
+val kind_nocast_gen : ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
+  ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term)
 
-val kind_nocast : constr -> (constr, types, Sorts.t, UVars.Instance.t) kind_of_term
+val kind_nocast : constr -> (constr, types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
 (** {6 Simple case analysis} *)
 val isRel  : constr -> bool
@@ -354,13 +356,13 @@ val destSort : constr -> Sorts.t
 val destCast : constr -> constr * cast_kind * constr
 
 (** Destructs the product {% $ %}(x:t_1)t_2{% $ %} *)
-val destProd : types -> Name.t Context.binder_annot * types * types
+val destProd : types -> Name.t binder_annot * types * types
 
 (** Destructs the abstraction {% $ %}[x:t_1]t_2{% $ %} *)
-val destLambda : constr -> Name.t Context.binder_annot * types * constr
+val destLambda : constr -> Name.t binder_annot * types * constr
 
 (** Destructs the let {% $ %}[x:=b:t_1]t_2{% $ %} *)
-val destLetIn : constr -> Name.t Context.binder_annot * constr * types * constr
+val destLetIn : constr -> Name.t binder_annot * constr * types * constr
 
 (** Destructs an application *)
 val destApp : constr -> constr * constr array
@@ -429,9 +431,9 @@ val compare : constr -> constr -> int
 
 (** {6 Extension of Context with declarations on constr} *)
 
-type rel_declaration = (constr, types) Context.Rel.Declaration.pt
-type named_declaration = (constr, types) Context.Named.Declaration.pt
-type compacted_declaration = (constr, types) Context.Compacted.Declaration.pt
+type rel_declaration = (constr, types, Sorts.relevance) Context.Rel.Declaration.pt
+type named_declaration = (constr, types, Sorts.relevance) Context.Named.Declaration.pt
+type compacted_declaration = (constr, types, Sorts.relevance) Context.Compacted.Declaration.pt
 type rel_context = rel_declaration list
 type named_context = named_declaration list
 type compacted_context = compacted_declaration list
@@ -578,8 +580,8 @@ val compare_head_gen : UVars.Instance.t instance_compare_fn ->
   constr constr_compare_fn
 
 val compare_head_gen_leq_with :
-  ('v -> ('v, 'v, 'sort, 'univs) kind_of_term) ->
-  ('v -> ('v, 'v, 'sort, 'univs) kind_of_term) ->
+  ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
+  ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
   'univs instance_compare_fn ->
   ('sort -> 'sort -> bool) ->
   ('v pexistential -> 'v pexistential -> bool) ->
@@ -592,8 +594,8 @@ val compare_head_gen_leq_with :
     is used,rather than {!kind}, to expose the immediate subterms of
     [c1] (resp. [c2]). *)
 val compare_head_gen_with :
-  ('v -> ('v, 'v, 'sort, 'univs) kind_of_term) ->
-  ('v -> ('v, 'v, 'sort, 'univs) kind_of_term) ->
+  ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
+  ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
   'univs instance_compare_fn ->
   ('sort -> 'sort -> bool) ->
   ('v pexistential -> 'v pexistential -> bool) ->
@@ -627,7 +629,7 @@ val case_info_hash : case_info -> int
 val hcons : constr -> constr
 
 val debug_print : constr -> Pp.t
-val debug_print_fix : ('a -> Pp.t) -> ('a, 'a) pfixpoint -> Pp.t
+val debug_print_fix : ('a -> Pp.t) -> ('a, 'a, 'r) pfixpoint -> Pp.t
 
 val mkConst : Constant.t -> constr
 [@@deprecated "Use [mkConstU] or if truly needed [UnsafeMonomorphic.mkConst]"]

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -24,27 +24,29 @@
 
 open Names
 
-type 'a binder_annot = { binder_name : 'a; binder_relevance : Sorts.relevance }
-val eq_annot : ('a -> 'a -> bool) -> 'a binder_annot -> 'a binder_annot -> bool
+type ('a,'r) pbinder_annot = { binder_name : 'a; binder_relevance : 'r }
 
-val hash_annot : ('a -> int) -> 'a binder_annot -> int
+val eq_annot : ('a -> 'a -> bool) -> ('r -> 'r -> bool) ->
+  ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot -> bool
 
-val map_annot : ('a -> 'b) -> 'a binder_annot -> 'b binder_annot
+val hash_annot : ('a -> int) -> ('a,Sorts.relevance) pbinder_annot -> int
 
-val make_annot : 'a -> Sorts.relevance -> 'a binder_annot
+val map_annot : ('a -> 'b) -> ('a,'r) pbinder_annot -> ('b,'r) pbinder_annot
 
-val map_binder_relevance : (Sorts.relevance -> Sorts.relevance) -> 'a binder_annot -> 'a binder_annot
+val map_annot_relevance : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
 
-val binder_name : 'a binder_annot -> 'a
-val binder_relevance : 'a binder_annot -> Sorts.relevance
+val make_annot : 'a -> 'r -> ('a,'r) pbinder_annot
 
-val annotR : 'a -> 'a binder_annot
+val binder_name : ('a,'r) pbinder_annot -> 'a
+val binder_relevance : ('a,'r) pbinder_annot -> 'r
+
+val annotR : 'a -> ('a,Sorts.relevance) pbinder_annot
 (** Always Relevant *)
 
-val nameR : Id.t -> Name.t binder_annot
+val nameR : Id.t -> (Name.t,Sorts.relevance) pbinder_annot
 (** Relevant + Name *)
 
-val anonR : Name.t binder_annot
+val anonR : (Name.t,Sorts.relevance) pbinder_annot
 (** Relevant + Anonymous *)
 
 (** Representation of contexts that can capture anonymous as well as non-anonymous variables.
@@ -54,142 +56,141 @@ sig
   module Declaration :
   sig
     (* local declaration *)
-    type ('constr, 'types) pt =
-    | LocalAssum of Name.t binder_annot * 'types            (** name, type *)
-    | LocalDef of Name.t binder_annot * 'constr * 'types   (** name, value, type *)
+    type ('constr, 'types, 'r) pt =
+    | LocalAssum of (Name.t,'r) pbinder_annot * 'types            (** name, type *)
+    | LocalDef of (Name.t,'r) pbinder_annot * 'constr * 'types   (** name, value, type *)
 
-    val get_annot : _ pt -> Name.t binder_annot
+    val get_annot : (_,_,'r) pt -> (Name.t,'r) pbinder_annot
 
     (** Return the name bound by a given declaration. *)
-    val get_name : ('c, 't) pt -> Name.t
+    val get_name : ('c, 't,'r) pt -> Name.t
 
     (** Return [Some value] for local-declarations and [None] for local-assumptions. *)
-    val get_value : ('c, 't) pt -> 'c option
+    val get_value : ('c, 't, 'r) pt -> 'c option
 
     (** Return the type of the name bound by a given declaration. *)
-    val get_type : ('c, 't) pt -> 't
+    val get_type : ('c, 't, 'r) pt -> 't
 
-    val get_relevance : ('c, 't) pt -> Sorts.relevance
+    val get_relevance : ('c, 't, 'r) pt -> 'r
 
-    val set_annot : Name.t binder_annot -> ('c, 't) pt -> ('c, 't) pt
+    val set_annot : (Name.t,'r) pbinder_annot -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Set the name that is bound by a given declaration. *)
-    val set_name : Name.t -> ('c, 't) pt -> ('c, 't) pt
+    val set_name : Name.t -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Set the type of the bound variable in a given declaration. *)
-    val set_type : 't -> ('c, 't) pt -> ('c, 't) pt
+    val set_type : 't -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Return [true] iff a given declaration is a local assumption. *)
-    val is_local_assum : ('c, 't) pt -> bool
+    val is_local_assum : ('c, 't, 'r) pt -> bool
 
     (** Return [true] iff a given declaration is a local definition. *)
-    val is_local_def : ('c, 't) pt -> bool
+    val is_local_def : ('c, 't, 'r) pt -> bool
 
     (** Check whether any term in a given declaration satisfies a given predicate. *)
-    val exists : ('c -> bool) -> ('c, 'c) pt -> bool
+    val exists : ('c -> bool) -> ('c, 'c, 'r) pt -> bool
 
     (** Check whether all terms in a given declaration satisfy a given predicate. *)
-    val for_all : ('c -> bool) -> ('c, 'c) pt -> bool
+    val for_all : ('c -> bool) -> ('c, 'c, 'r) pt -> bool
 
     (** Check whether the two given declarations are equal. *)
-    val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
+    val equal : ('r -> 'r -> bool) -> ('c -> 'c -> bool) ->
+      ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt -> bool
 
     (** Map the name bound by a given declaration. *)
-    val map_name : (Name.t -> Name.t) -> ('c, 't) pt -> ('c, 't) pt
+    val map_name : (Name.t -> Name.t) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Map the relevance *)
-    val map_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c, 't) pt -> ('c, 't) pt
+    val map_relevance : ('r -> 'r) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** For local assumptions, this function returns the original local assumptions.
         For local definitions, this function maps the value in the local definition. *)
-    val map_value : ('c -> 'c) -> ('c, 't) pt -> ('c, 't) pt
+    val map_value : ('c -> 'c) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Map the type of the name bound by a given declaration. *)
-    val map_type : ('t -> 't) -> ('c, 't) pt -> ('c, 't) pt
+    val map_type : ('t -> 't) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Map all terms in a given declaration. *)
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    val map_constr : ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
     (** Map all terms in a given declaration. *)
-    val map_constr_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    val map_constr_with_relevance : ('r -> 'r) -> ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
     (** Map all terms, with an heterogeneous function. *)
-    val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
-
-    (** Map all terms, with an heterogeneous function. *)
-    val map_constr_het_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
+    val map_constr_het : ('r1 -> 'r2) -> ('a -> 'b) -> ('a, 'a, 'r1) pt -> ('b, 'b, 'r2) pt
 
     (** Perform a given action on all terms in a given declaration. *)
-    val iter_constr : ('c -> unit) -> ('c, 'c) pt -> unit
+    val iter_constr : ('c -> unit) -> ('c, 'c, 'r) pt -> unit
 
     (** Reduce all terms in a given declaration to a single value. *)
-    val fold_constr : ('c -> 'a -> 'a) -> ('c, 'c) pt -> 'a -> 'a
+    val fold_constr : ('c -> 'a -> 'a) -> ('c, 'c, 'r) pt -> 'a -> 'a
 
-    val to_tuple : ('c, 't) pt -> Name.t binder_annot * 'c option * 't
+    val to_tuple : ('c, 't, 'r) pt -> (Name.t,'r) pbinder_annot * 'c option * 't
 
     (** Turn [LocalDef] into [LocalAssum], identity otherwise. *)
-    val drop_body : ('c, 't) pt -> ('c, 't) pt
+    val drop_body : ('c, 't, 'r) pt -> ('c, 't, 'r) pt
   end
 
   (** Rel-context is represented as a list of declarations.
       Inner-most declarations are at the beginning of the list.
       Outer-most declarations are at the end of the list. *)
-  type ('constr, 'types) pt = ('constr, 'types) Declaration.pt list
+  type ('constr, 'types, 'r) pt = ('constr, 'types, 'r) Declaration.pt list
 
   (** empty rel-context *)
-  val empty : ('c, 't) pt
+  val empty : ('c, 't, 'r) pt
 
   (** Return a new rel-context enriched by with a given inner-most declaration. *)
-  val add : ('c, 't) Declaration.pt -> ('c, 't) pt -> ('c, 't) pt
+  val add : ('c, 't, 'r) Declaration.pt -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
   (** Return the number of {e local declarations} in a given rel-context. *)
-  val length : ('c, 't) pt -> int
+  val length : ('c, 't, 'r) pt -> int
 
   (** Check whether given two rel-contexts are equal. *)
-  val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
+  val equal : ('r -> 'r -> bool) -> ('c -> 'c -> bool) ->
+    ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt -> bool
 
   (** Return the number of {e local assumptions} in a given rel-context. *)
-  val nhyps : ('c, 't) pt -> int
+  val nhyps : ('c, 't, 'r) pt -> int
 
   (** Return a declaration designated by a given de Bruijn index.
       @raise Not_found if the designated de Bruijn index outside the range. *)
-  val lookup : int -> ('c, 't) pt -> ('c, 't) Declaration.pt
+  val lookup : int -> ('c, 't, 'r) pt -> ('c, 't, 'r) Declaration.pt
 
   (** Map all terms in a given rel-context. *)
-  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  val map : ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
   (** Map all terms in a given rel-context. *)
-  val map_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  val map_with_relevance : ('r -> 'r) -> ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
   (** Map all terms in a given named-context. *)
-  val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt
+  val map_het : ('r1 -> 'r2) -> ('c -> 'd) -> ('c, 'c, 'r1) pt -> ('d, 'd, 'r2) pt
 
   (** Map all terms in a given rel-context taking into account the
       position of the binder in the context starting at 1. *)
-  val map_with_binders : (int -> 'c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  val map_with_binders : (int -> 'c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
   (** Perform a given action on every declaration in a given rel-context. *)
-  val iter : ('c -> unit) -> ('c, 'c) pt -> unit
+  val iter : ('c -> unit) -> ('c, 'c, 'r) pt -> unit
 
   (** Reduce all terms in a given rel-context to a single value.
       Innermost declarations are processed first. *)
-  val fold_inside : ('a -> ('c, 't) Declaration.pt -> 'a) -> init:'a -> ('c, 't) pt -> 'a
+  val fold_inside : ('a -> ('c, 't, 'r) Declaration.pt -> 'a) -> init:'a -> ('c, 't, 'r) pt -> 'a
 
   (** Reduce all terms in a given rel-context to a single value.
       Outermost declarations are processed first. *)
-  val fold_outside : (('c, 't) Declaration.pt -> 'a -> 'a) -> ('c, 't) pt -> init:'a -> 'a
+  val fold_outside : (('c, 't, 'r) Declaration.pt -> 'a -> 'a) -> ('c, 't, 'r) pt -> init:'a -> 'a
 
   (** Return the set of all named variables bound in a given rel-context. *)
-  val to_vars : ('c, 't) pt -> Id.Set.t
+  val to_vars : ('c, 't, 'r) pt -> Id.Set.t
 
   (** Map a given rel-context to a list where each {e local
       assumption} is mapped to [true] and each {e local definition} is
       mapped to [false]. The resulting list is in reverse order
       compared to the order of declarations in the context. *)
-  val to_tags : ('c, 't) pt -> bool list
+  val to_tags : ('c, 't, 'r) pt -> bool list
 
   (** Turn all [LocalDef] into [LocalAssum], leave [LocalAssum] unchanged. *)
-  val drop_bodies : ('c, 't) pt -> ('c, 't) pt
+  val drop_bodies : ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
   (** [chop_nhyps n Γ] returns [Γ'',Γ'] such that [Γ]=[Γ'Γ''], [Γ''] has
       [n] hypotheses (i.e. [LocalAssum]), excluding local definitions
@@ -197,21 +198,21 @@ sig
       hypothesis (i.e., [Γ''] has the form [x:A;Γ'''], i.e., local
       definitions at the junction of the [n] hypotheses are put in
       [Γ'] rather than in [Γ''] *)
-  val chop_nhyps : int -> ('c, 't) pt -> ('c, 't) pt * ('c, 't) pt
+  val chop_nhyps : int -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt * ('c, 't, 'r) pt
 
   (** [instance mk n Γ] builds an instance [args] such that [Γ,Δ ⊢ args:Γ]
       with n = |Δ| and with the {e local definitions} of [Γ] skipped in
       [args] where [mk] is used to build the corresponding variables.
       Example: for [x:T, y:=c, z:U] and [n]=2, it gives [mk 5, mk 3]. *)
-  val instance : (int -> 'r) -> int -> ('c, 't) pt -> 'r array
+  val instance : (int -> 'v) -> int -> ('c, 't, 'r) pt -> 'v array
 
   (** [instance_list] is like [instance] but returning a list. *)
-  val instance_list : (int -> 'r) -> int -> ('c, 't) pt -> 'r list
+  val instance_list : (int -> 'v) -> int -> ('c, 't, 'r) pt -> 'v list
 
-  val to_extended_vect : (int -> 'r) -> int -> ('c, 't) pt -> 'r array
+  val to_extended_vect : (int -> 'r) -> int -> ('c, 't, 'r) pt -> 'r array
     [@@ocaml.deprecated "Use synonymous [Context.Rel.instance]"]
 
-  val to_extended_list : (int -> 'r) -> int -> ('c, 't) pt -> 'r list
+  val to_extended_list : (int -> 'r) -> int -> ('c, 't, 'r) pt -> 'r list
     [@@ocaml.deprecated "Use synonymous [Context.Rel.instance_list]"]
 end
 
@@ -222,139 +223,138 @@ sig
   (** Representation of {e local declarations}. *)
   module Declaration :
   sig
-    type ('constr, 'types) pt =
-      | LocalAssum of Id.t binder_annot * 'types             (** identifier, type *)
-      | LocalDef of Id.t binder_annot * 'constr * 'types    (** identifier, value, type *)
+    type ('constr, 'types, 'r) pt =
+      | LocalAssum of (Id.t,'r) pbinder_annot * 'types             (** identifier, type *)
+      | LocalDef of (Id.t,'r) pbinder_annot * 'constr * 'types    (** identifier, value, type *)
 
-    val get_annot : _ pt -> Id.t binder_annot
+    val get_annot : (_,_,'r) pt -> (Id.t,'r) pbinder_annot
 
     (** Return the identifier bound by a given declaration. *)
-    val get_id : ('c, 't) pt -> Id.t
+    val get_id : ('c, 't, 'r) pt -> Id.t
 
     (** Return [Some value] for local-declarations and [None] for local-assumptions. *)
-    val get_value : ('c, 't) pt -> 'c option
+    val get_value : ('c, 't, 'r) pt -> 'c option
 
     (** Return the type of the name bound by a given declaration. *)
-    val get_type : ('c, 't) pt -> 't
+    val get_type : ('c, 't, 'r) pt -> 't
 
-    val get_relevance : ('c, 't) pt -> Sorts.relevance
+    val get_relevance : ('c, 't, 'r) pt -> 'r
 
     (** Set the identifier that is bound by a given declaration. *)
-    val set_id : Id.t -> ('c, 't) pt -> ('c, 't) pt
+    val set_id : Id.t -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Set the type of the bound variable in a given declaration. *)
-    val set_type : 't -> ('c, 't) pt -> ('c, 't) pt
+    val set_type : 't -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Return [true] iff a given declaration is a local assumption. *)
-    val is_local_assum : ('c, 't) pt -> bool
+    val is_local_assum : ('c, 't, 'r) pt -> bool
 
     (** Return [true] iff a given declaration is a local definition. *)
-    val is_local_def : ('c, 't) pt -> bool
+    val is_local_def : ('c, 't, 'r) pt -> bool
 
     (** Check whether any term in a given declaration satisfies a given predicate. *)
-    val exists : ('c -> bool) -> ('c, 'c) pt -> bool
+    val exists : ('c -> bool) -> ('c, 'c, 'r) pt -> bool
 
     (** Check whether all terms in a given declaration satisfy a given predicate. *)
-    val for_all : ('c -> bool) -> ('c, 'c) pt -> bool
+    val for_all : ('c -> bool) -> ('c, 'c, 'r) pt -> bool
 
     (** Check whether the two given declarations are equal. *)
-    val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
+    val equal : ('r -> 'r -> bool) -> ('c -> 'c -> bool) ->
+      ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt -> bool
 
     (** Map the identifier bound by a given declaration. *)
-    val map_id : (Id.t -> Id.t) -> ('c, 't) pt -> ('c, 't) pt
+    val map_id : (Id.t -> Id.t) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** For local assumptions, this function returns the original local assumptions.
         For local definitions, this function maps the value in the local definition. *)
-    val map_value : ('c -> 'c) -> ('c, 't) pt -> ('c, 't) pt
+    val map_value : ('c -> 'c) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Map the type of the name bound by a given declaration. *)
-    val map_type : ('t -> 't) -> ('c, 't) pt -> ('c, 't) pt
+    val map_type : ('t -> 't) -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Map all terms in a given declaration. *)
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    val map_constr : ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
     (** Map all terms in a given declaration. *)
-    val map_constr_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    val map_constr_with_relevance : ('r -> 'r) -> ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
     (** Map all terms, with an heterogeneous function. *)
-    val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
-
-    (** Map all terms, with an heterogeneous function. *)
-    val map_constr_het_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
+    val map_constr_het : ('r1 -> 'r2) -> ('a -> 'b) -> ('a, 'a, 'r1) pt -> ('b, 'b, 'r2) pt
 
     (** Perform a given action on all terms in a given declaration. *)
-    val iter_constr : ('c -> unit) -> ('c, 'c) pt -> unit
+    val iter_constr : ('c -> unit) -> ('c, 'c, 'r) pt -> unit
 
     (** Reduce all terms in a given declaration to a single value. *)
-    val fold_constr : ('c -> 'a -> 'a) -> ('c, 'c) pt -> 'a -> 'a
+    val fold_constr : ('c -> 'a -> 'a) -> ('c, 'c, 'r) pt -> 'a -> 'a
 
-    val to_tuple : ('c, 't) pt -> Id.t binder_annot * 'c option * 't
-    val of_tuple : Id.t binder_annot * 'c option * 't -> ('c, 't) pt
+    val to_tuple : ('c, 't, 'r) pt -> (Id.t,'r) pbinder_annot * 'c option * 't
+    val of_tuple : (Id.t,'r) pbinder_annot * 'c option * 't -> ('c, 't, 'r) pt
 
     (** Turn [LocalDef] into [LocalAssum], identity otherwise. *)
-    val drop_body : ('c, 't) pt -> ('c, 't) pt
+    val drop_body : ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
     (** Convert [Rel.Declaration.t] value to the corresponding [Named.Declaration.t] value.
         The function provided as the first parameter determines how to translate "names" to "ids". *)
-    val of_rel_decl : (Name.t -> Id.t) -> ('c, 't) Rel.Declaration.pt -> ('c, 't) pt
+    val of_rel_decl : (Name.t -> Id.t) -> ('c, 't, 'r) Rel.Declaration.pt -> ('c, 't, 'r) pt
 
     (** Convert [Named.Declaration.t] value to the corresponding [Rel.Declaration.t] value. *)
     (* TODO: Move this function to [Rel.Declaration] module and rename it to [of_named]. *)
-    val to_rel_decl : ('c, 't) pt -> ('c, 't) Rel.Declaration.pt
+    val to_rel_decl : ('c, 't, 'r) pt -> ('c, 't, 'r) Rel.Declaration.pt
   end
 
   (** Named-context is represented as a list of declarations.
       Inner-most declarations are at the beginning of the list.
       Outer-most declarations are at the end of the list. *)
-  type ('constr, 'types) pt = ('constr, 'types) Declaration.pt list
+  type ('constr, 'types, 'r) pt = ('constr, 'types, 'r) Declaration.pt list
 
   (** empty named-context *)
-  val empty : ('c, 't) pt
+  val empty : ('c, 't, 'r) pt
 
   (** Return a new named-context enriched by with a given inner-most declaration. *)
-  val add : ('c, 't) Declaration.pt -> ('c, 't) pt -> ('c, 't) pt
+  val add : ('c, 't, 'r) Declaration.pt -> ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
   (** Return the number of {e local declarations} in a given named-context. *)
-  val length : ('c, 't) pt -> int
+  val length : ('c, 't, 'r) pt -> int
 
   (** Return a declaration designated by an identifier of the variable bound in that declaration.
       @raise Not_found if the designated identifier is not bound in a given named-context. *)
-  val lookup : Id.t -> ('c, 't) pt -> ('c, 't) Declaration.pt
+  val lookup : Id.t -> ('c, 't, 'r) pt -> ('c, 't, 'r) Declaration.pt
 
   (** Check whether given two named-contexts are equal. *)
-  val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
+  val equal : ('r -> 'r -> bool) -> ('c -> 'c -> bool) ->
+    ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt -> bool
 
   (** Map all terms in a given named-context. *)
-  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  val map : ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
   (** Map all terms in a given rel-context. *)
-  val map_with_relevance : (Sorts.relevance -> Sorts.relevance) -> ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  val map_with_relevance : ('r -> 'r) -> ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
 
   (** Map all terms in a given named-context. *)
-  val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt
+  val map_het : ('r1 -> 'r2) -> ('c -> 'd) -> ('c, 'c, 'r1) pt -> ('d, 'd, 'r2) pt
 
   (** Perform a given action on every declaration in a given named-context. *)
-  val iter : ('c -> unit) -> ('c, 'c) pt -> unit
+  val iter : ('c -> unit) -> ('c, 'c, 'r) pt -> unit
 
   (** Reduce all terms in a given named-context to a single value.
       Innermost declarations are processed first. *)
-  val fold_inside : ('a -> ('c, 't) Declaration.pt -> 'a) -> init:'a -> ('c, 't) pt -> 'a
+  val fold_inside : ('a -> ('c, 't, 'r) Declaration.pt -> 'a) -> init:'a -> ('c, 't, 'r) pt -> 'a
 
   (** Reduce all terms in a given named-context to a single value.
       Outermost declarations are processed first. *)
-  val fold_outside : (('c, 't) Declaration.pt -> 'a -> 'a) -> ('c, 't) pt -> init:'a -> 'a
+  val fold_outside : (('c, 't, 'r) Declaration.pt -> 'a -> 'a) -> ('c, 't, 'r) pt -> init:'a -> 'a
 
   (** Return the set of all identifiers bound in a given named-context. *)
-  val to_vars : ('c, 't) pt -> Id.Set.t
+  val to_vars : ('c, 't, 'r) pt -> Id.Set.t
 
   (** Turn all [LocalDef] into [LocalAssum], leave [LocalAssum] unchanged. *)
-  val drop_bodies : ('c, 't) pt -> ('c, 't) pt
+  val drop_bodies : ('c, 't, 'r) pt -> ('c, 't, 'r) pt
 
   (** [to_instance Ω] builds an instance [args] in reverse order such
       that [Ω ⊢ args:Ω] where [Ω] is a named-context and with the local
       definitions of [Ω] skipped. Example: for [id1:T,id2:=c,id3:U], it
       gives [Var id1, Var id3]. All [idj] are supposed distinct. *)
-  val to_instance : (Id.t -> 'r) -> ('c, 't) pt -> 'r list
+  val to_instance : (Id.t -> 'v) -> ('c, 't, 'r) pt -> 'v list
     [@@ocaml.deprecated "[to_instance] was missing a [List.rev] to comply to its specification; rely on [instance] for the correct specification or use [List.rev (instance ...)] for strict compatibility"]
 
   (** [instance Ω] builds an instance [args] such
@@ -363,26 +363,26 @@ sig
       [id1:T,id2:=c,id3:U] (which is internally represented by a list
       with [id3] at the head), it gives [Var id1, Var id3]. All [idj]
       are supposed distinct. *)
-  val instance : (Id.t -> 'r) -> ('c, 't) pt -> 'r array
+  val instance : (Id.t -> 'v) -> ('c, 't, 'r) pt -> 'v array
 
   (** [instance_list] is like [instance] but returning a list. *)
-  val instance_list : (Id.t -> 'r) -> ('c, 't) pt -> 'r list
+  val instance_list : (Id.t -> 'v) -> ('c, 't, 'r) pt -> 'v list
 end
 
 module Compacted :
 sig
   module Declaration :
   sig
-    type ('constr, 'types) pt =
-      | LocalAssum of Id.t binder_annot list * 'types
-      | LocalDef of Id.t binder_annot list * 'constr * 'types
+    type ('constr, 'types, 'r) pt =
+      | LocalAssum of (Id.t,'r) pbinder_annot list * 'types
+      | LocalDef of (Id.t,'r) pbinder_annot list * 'constr * 'types
 
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
-    val of_named_decl : ('c, 't) Named.Declaration.pt -> ('c, 't) pt
-    val to_named_context : ('c, 't) pt -> ('c, 't) Named.pt
+    val map_constr : ('c -> 'c) -> ('c, 'c, 'r) pt -> ('c, 'c, 'r) pt
+    val of_named_decl : ('c, 't, 'r) Named.Declaration.pt -> ('c, 't, 'r) pt
+    val to_named_context : ('c, 't, 'r) pt -> ('c, 't, 'r) Named.pt
   end
 
-  type ('constr, 'types) pt = ('constr, 'types) Declaration.pt list
+  type ('constr, 'types, 'r) pt = ('constr, 'types, 'r) Declaration.pt list
 
-  val fold : (('c, 't) Declaration.pt -> 'a -> 'a) -> ('c, 't) pt -> init:'a -> 'a
+  val fold : (('c, 't, 'r) Declaration.pt -> 'a -> 'a) -> ('c, 't, 'r) pt -> init:'a -> 'a
 end

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -385,7 +385,7 @@ let val_of_named_context ctxt =
 
 
 let eq_named_context_val c1 c2 =
-   c1 == c2 || Context.Named.equal Constr.equal (named_context_of_val c1) (named_context_of_val c2)
+   c1 == c2 || Context.Named.equal Sorts.relevance_equal Constr.equal (named_context_of_val c1) (named_context_of_val c2)
 
 (* A local const is evaluable if it is defined  *)
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -297,19 +297,19 @@ val template_polymorphic_pind : pinductive -> env -> bool
     array is only used to set the names of the context variables, we use the
     less general type to make it easy to use this function on Case nodes. *)
 val expand_arity : Declarations.mind_specif -> pinductive -> constr array ->
-  Name.t Context.binder_annot array -> rel_context
+  Name.t binder_annot array -> rel_context
 
 (** Given an inductive type and its parameters, builds the context of the return
     clause, including the inductive being eliminated. The additional binder
     array is only used to set the names of the context variables, we use the
     less general type to make it easy to use this function on Case nodes. *)
 val expand_branch_contexts : Declarations.mind_specif -> UVars.Instance.t -> constr array ->
-  (Name.t Context.binder_annot array * 'a) array -> rel_context array
+  (Name.t binder_annot array * 'a) array -> rel_context array
 
 (** [instantiate_context u subst nas ctx] applies both [u] and [subst]
   to [ctx] while replacing names using [nas] (order reversed). In particular,
   assumes that [ctx] and [nas] have the same length. *)
-val instantiate_context : UVars.Instance.t -> Vars.substl -> Name.t Context.binder_annot array ->
+val instantiate_context : UVars.Instance.t -> Vars.substl -> Name.t binder_annot array ->
   rel_context -> rel_context
 
 

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -25,8 +25,8 @@ type 'v lambda =
 | Lvar          of Id.t
 | Levar         of Evar.t * 'v lambda array (* arguments *)
 | Lprod         of 'v lambda * 'v lambda
-| Llam          of Name.t Context.binder_annot array * 'v lambda
-| Llet          of Name.t Context.binder_annot * 'v lambda * 'v lambda
+| Llam          of Name.t binder_annot array * 'v lambda
+| Llet          of Name.t binder_annot * 'v lambda * 'v lambda
 | Lapp          of 'v lambda * 'v lambda array
 | Lconst        of pconstant
 | Lproj         of Projection.Repr.t * 'v lambda
@@ -47,9 +47,9 @@ type 'v lambda =
 
 and 'v lam_branches =
   { constant_branches : 'v lambda array;
-    nonconstant_branches : (Name.t Context.binder_annot array * 'v lambda) array }
+    nonconstant_branches : (Name.t binder_annot array * 'v lambda) array }
 
-and 'v fix_decl = Name.t Context.binder_annot array * 'v lambda array * 'v lambda array
+and 'v fix_decl = Name.t binder_annot array * 'v lambda array * 'v lambda array
 
 type evars =
   { evars_val : CClosure.evar_handler }

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -22,8 +22,8 @@ type 'v lambda =
 | Lvar          of Id.t
 | Levar         of Evar.t * 'v lambda array (* arguments *)
 | Lprod         of 'v lambda * 'v lambda
-| Llam          of Name.t Context.binder_annot array * 'v lambda
-| Llet          of Name.t Context.binder_annot * 'v lambda * 'v lambda
+| Llam          of Name.t binder_annot array * 'v lambda
+| Llet          of Name.t binder_annot * 'v lambda * 'v lambda
 | Lapp          of 'v lambda * 'v lambda array
 | Lconst        of pconstant
 | Lproj         of Projection.Repr.t * 'v lambda
@@ -44,9 +44,9 @@ type 'v lambda =
 
 and 'v lam_branches =
   { constant_branches : 'v lambda array;
-    nonconstant_branches : (Name.t Context.binder_annot array * 'v lambda) array }
+    nonconstant_branches : (Name.t binder_annot array * 'v lambda) array }
 
-and 'v fix_decl = Name.t Context.binder_annot array * 'v lambda array * 'v lambda array
+and 'v fix_decl = Name.t binder_annot array * 'v lambda array * 'v lambda array
 
 type evars =
   { evars_val : CClosure.evar_handler }
@@ -56,9 +56,9 @@ val empty_evars : Environ.env -> evars
 (** {5 Manipulation functions} *)
 
 val mkLapp : 'v lambda -> 'v lambda array -> 'v lambda
-val mkLlam : Name.t Context.binder_annot array -> 'v lambda -> 'v lambda
-val decompose_Llam : 'v lambda -> Name.t Context.binder_annot array * 'v lambda
-val decompose_Llam_Llet : 'v lambda -> (Name.t Context.binder_annot * 'v lambda option) array * 'v lambda
+val mkLlam : Name.t binder_annot array -> 'v lambda -> 'v lambda
+val decompose_Llam : 'v lambda -> Name.t binder_annot array * 'v lambda
+val decompose_Llam_Llet : 'v lambda -> (Name.t binder_annot * 'v lambda option) array * 'v lambda
 
 val map_lam_with_binders : (int -> 'a -> 'a) -> ('a -> 'v lambda -> 'v lambda) ->
   'a -> 'v lambda -> 'v lambda

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -377,10 +377,10 @@ let expand_arity = Environ.expand_arity
 
 let expand_branch_contexts = Environ.expand_branch_contexts
 
-type ('constr,'types) pexpanded_case =
-  (case_info * ('constr * Sorts.relevance) * 'constr pcase_invert * 'constr * 'constr array)
+type ('constr,'types,'r) pexpanded_case =
+  (case_info * ('constr * 'r) * 'constr pcase_invert * 'constr * 'constr array)
 
-type expanded_case = (constr,types) pexpanded_case
+type expanded_case = (constr,types,Sorts.relevance) pexpanded_case
 
 let expand_case_specif mib (ci, u, params, (p,rp), iv, c, br) =
   (* Γ ⊢ c : I@{u} params args *)

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -103,19 +103,19 @@ val inductive_params : mind_specif -> int
     array is only used to set the names of the context variables, we use the
     less general type to make it easy to use this function on Case nodes. *)
 val expand_arity : mind_specif -> pinductive -> constr array ->
-  Name.t Context.binder_annot array -> rel_context
+  Name.t binder_annot array -> rel_context
 
 (** Given an inductive type and its parameters, builds the context of the return
     clause, including the inductive being eliminated. The additional binder
     array is only used to set the names of the context variables, we use the
     less general type to make it easy to use this function on Case nodes. *)
 val expand_branch_contexts : mind_specif -> UVars.Instance.t -> constr array ->
-  (Name.t Context.binder_annot array * 'a) array -> rel_context array
+  (Name.t binder_annot array * 'a) array -> rel_context array
 
-type ('constr,'types) pexpanded_case =
-  (case_info * ('constr * Sorts.relevance) * 'constr pcase_invert * 'constr * 'constr array)
+type ('constr,'types,'r) pexpanded_case =
+  (case_info * ('constr * 'r) * 'constr pcase_invert * 'constr * 'constr array)
 
-type expanded_case = (constr,types) pexpanded_case
+type expanded_case = (constr,types,Sorts.relevance) pexpanded_case
 
 (** Given a pattern-matching represented compactly, expands it so as to produce
     lambda and let abstractions in front of the return clause and the pattern
@@ -131,7 +131,7 @@ val contract_case : env -> expanded_case -> case
 (** [instantiate_context u subst nas ctx] applies both [u] and [subst]
     to [ctx] while replacing names using [nas] (order reversed). In particular,
     assumes that [ctx] and [nas] have the same length. *)
-val instantiate_context : Instance.t -> Vars.substl -> Name.t Context.binder_annot array ->
+val instantiate_context : Instance.t -> Vars.substl -> Name.t binder_annot array ->
   rel_context -> rel_context
 
 val build_branches_type :

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -23,9 +23,9 @@ val mkArrowR : types -> types -> constr
 (** For an always-relevant domain *)
 
 (** Named version of the functions from [Term]. *)
-val mkNamedLambda : Id.t Context.binder_annot -> types -> constr -> constr
-val mkNamedLetIn : Id.t Context.binder_annot -> constr -> types -> constr -> constr
-val mkNamedProd : Id.t Context.binder_annot -> types -> types -> types
+val mkNamedLambda : Id.t binder_annot -> types -> constr -> constr
+val mkNamedLetIn : Id.t binder_annot -> constr -> types -> constr -> constr
+val mkNamedProd : Id.t binder_annot -> types -> types -> types
 
 (** Constructs either [(x:t)c] or [[x=b:t]c] *)
 val mkProd_or_LetIn : Constr.rel_declaration -> types -> types
@@ -48,24 +48,24 @@ val appvectc : constr -> constr array -> constr
 
 (** [prodn n l b] = [forall (x_1:T_1)...(x_n:T_n), b]
    where [l] is [(x_n,T_n)...(x_1,T_1)...]. *)
-val prodn : int -> (Name.t Context.binder_annot * constr) list -> constr -> constr
+val prodn : int -> (Name.t binder_annot * constr) list -> constr -> constr
 
 (** [compose_prod l b]
    @return [forall (x_1:T_1)...(x_n:T_n), b]
    where [l] is [(x_n,T_n)...(x_1,T_1)].
    Inverse of [decompose_prod]. *)
-val compose_prod : (Name.t Context.binder_annot * constr) list -> constr -> constr
+val compose_prod : (Name.t binder_annot * constr) list -> constr -> constr
 
 (** [lamn n l b]
     @return [fun (x_1:T_1)...(x_n:T_n) => b]
    where [l] is [(x_n,T_n)...(x_1,T_1)...]. *)
-val lamn : int -> (Name.t Context.binder_annot * constr) list -> constr -> constr
+val lamn : int -> (Name.t binder_annot * constr) list -> constr -> constr
 
 (** [compose_lam l b]
    @return [fun (x_1:T_1)...(x_n:T_n) => b]
    where [l] is [(x_n,T_n)...(x_1,T_1)].
    Inverse of [it_destLam] *)
-val compose_lam : (Name.t Context.binder_annot * constr) list -> constr -> constr
+val compose_lam : (Name.t binder_annot * constr) list -> constr -> constr
 
 (** [to_lambda n l]
    @return [fun (x_1:T_1)...(x_n:T_n) => T]
@@ -112,22 +112,22 @@ val prod_applist_decls : int -> types -> constr list -> types
 
 (** Transforms a product term {% $ %}(x_1:T_1)..(x_n:T_n)T{% $ %} into the pair
    {% $ %}([(x_n,T_n);...;(x_1,T_1)],T){% $ %}, where {% $ %}T{% $ %} is not a product. *)
-val decompose_prod : constr -> (Name.t Context.binder_annot * constr) list * constr
+val decompose_prod : constr -> (Name.t binder_annot * constr) list * constr
 
 (** Transforms a lambda term {% $ %}[x_1:T_1]..[x_n:T_n]T{% $ %} into the pair
    {% $ %}([(x_n,T_n);...;(x_1,T_1)],T){% $ %}, where {% $ %}T{% $ %} is not a lambda. *)
-val decompose_lambda : constr -> (Name.t Context.binder_annot * constr) list * constr
+val decompose_lambda : constr -> (Name.t binder_annot * constr) list * constr
 
 (** Given a positive integer n, decompose a product term
    {% $ %}(x_1:T_1)..(x_n:T_n)T{% $ %}
    into the pair {% $ %}([(xn,Tn);...;(x1,T1)],T){% $ %}.
    Raise a user error if not enough products. *)
-val decompose_prod_n : int -> constr -> (Name.t Context.binder_annot * constr) list * constr
+val decompose_prod_n : int -> constr -> (Name.t binder_annot * constr) list * constr
 
 (** Given a positive integer {% $ %}n{% $ %}, decompose a lambda term
    {% $ %}[x_1:T_1]..[x_n:T_n]T{% $ %} into the pair {% $ %}([(x_n,T_n);...;(x_1,T_1)],T){% $ %}.
    Raise a user error if not enough lambdas. *)
-val decompose_lambda_n : int -> constr -> (Name.t Context.binder_annot * constr) list * constr
+val decompose_lambda_n : int -> constr -> (Name.t binder_annot * constr) list * constr
 
 (** Extract the premisses and the conclusion of a term of the form
    "(xi:Ti) ... (xj:=cj:Tj) ..., T" where T is not a product nor a let *)
@@ -216,9 +216,9 @@ val strip_prod_assum : types -> types
 val strip_lam_assum : constr -> constr
 [@@ocaml.deprecated "Use [strip_lambda_decls] instead."]
 
-val decompose_lam : t -> (Name.t Context.binder_annot * t) list * t
+val decompose_lam : t -> (Name.t binder_annot * t) list * t
 [@@ocaml.deprecated "Use [decompose_lambda] instead."]
-val decompose_lam_n : int -> t -> (Name.t Context.binder_annot * t) list * t
+val decompose_lam_n : int -> t -> (Name.t binder_annot * t) list * t
 [@@ocaml.deprecated "Use [decompose_lambda_n] instead."]
 val decompose_lam_n_assum : int -> t -> rel_context * t
 [@@ocaml.deprecated "Use [decompose_lambda_n_assum] instead."]

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -51,7 +51,7 @@ type guard_error = constr pguard_error
 type ('constr, 'types) pcant_apply_bad_type =
   (int * 'constr * 'constr) * ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
 
-type ('constr, 'types) ptype_error =
+type ('constr, 'types, 'r) ptype_error =
   | UnboundRel of int
   | UnboundVar of variable
   | NotAType of ('constr, 'types) punsafe_judgment
@@ -69,21 +69,21 @@ type ('constr, 'types) ptype_error =
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
   | CantApplyBadType of ('constr, 'types) pcant_apply_bad_type
   | CantApplyNonFunctional of ('constr, 'types) punsafe_judgment * ('constr, 'types) punsafe_judgment array
-  | IllFormedRecBody of 'constr pguard_error * Name.t Context.binder_annot array * int * env * ('constr, 'types) punsafe_judgment array
+  | IllFormedRecBody of 'constr pguard_error * (Name.t,'r) Context.pbinder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of
-      int * Name.t Context.binder_annot array * ('constr, 'types) punsafe_judgment array * 'types array
+      int * (Name.t,'r) Context.pbinder_annot array * ('constr, 'types) punsafe_judgment array * 'types array
   | UnsatisfiedQConstraints of Sorts.QConstraints.t
   | UnsatisfiedConstraints of Constraints.t
   | UndeclaredQualities of Sorts.QVar.Set.t
   | UndeclaredUniverse of Level.t
   | DisallowedSProp
-  | BadBinderRelevance of Sorts.relevance * ('constr, 'types) Context.Rel.Declaration.pt
-  | BadCaseRelevance of Sorts.relevance * 'constr
+  | BadBinderRelevance of 'r * ('constr, 'types, 'r) Context.Rel.Declaration.pt
+  | BadCaseRelevance of 'r * 'constr
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
   | UndeclaredUsedVariables of { declared_vars : Id.Set.t; inferred_vars : Id.Set.t }
 
-type type_error = (constr, types) ptype_error
+type type_error = (constr, types, Sorts.relevance) ptype_error
 
 exception TypeError of env * type_error
 
@@ -142,10 +142,10 @@ val error_cant_apply_bad_type :
       unsafe_judgment -> unsafe_judgment array -> 'a
 
 val error_ill_formed_rec_body :
-  env -> guard_error -> Name.t Context.binder_annot array -> int -> env -> unsafe_judgment array -> 'a
+  env -> guard_error -> Name.t binder_annot array -> int -> env -> unsafe_judgment array -> 'a
 
 val error_ill_typed_rec_body  :
-  env -> int -> Name.t Context.binder_annot array -> unsafe_judgment array -> types array -> 'a
+  env -> int -> Name.t binder_annot array -> unsafe_judgment array -> types array -> 'a
 
 val error_unsatisfied_qconstraints : env -> Sorts.QConstraints.t -> 'a
 
@@ -168,4 +168,4 @@ val error_bad_variance : env -> lev:Level.t -> expected:Variance.t -> actual:Var
 val error_undeclared_used_variables : env -> declared_vars:Id.Set.t -> inferred_vars:Id.Set.t -> 'a
 
 val map_pguard_error : ('c -> 'd) -> 'c pguard_error -> 'd pguard_error
-val map_ptype_error : ('c -> 'd) -> ('c, 'c) ptype_error -> ('d, 'd) ptype_error
+val map_ptype_error : ('r1 -> 'r2) -> ('c -> 'd) -> ('c, 'c, 'r1) ptype_error -> ('d, 'd, 'r2) ptype_error

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -61,9 +61,9 @@ let infer_assumption env t ty =
   with TypeError _ ->
     error_assumption env (make_judge t ty)
 
-type ('constr,'types) bad_relevance =
-| BadRelevanceBinder of Sorts.relevance * ('constr,'types) Context.Rel.Declaration.pt
-| BadRelevanceCase of Sorts.relevance * 'constr
+type ('constr,'types,'r) bad_relevance =
+| BadRelevanceBinder of 'r * ('constr,'types,'r) Context.Rel.Declaration.pt
+| BadRelevanceCase of 'r * 'constr
 
 let warn_bad_relevance_name = "bad-relevance"
 

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -72,7 +72,7 @@ val judge_of_apply :
 
 (** {6 Type of a product. } *)
 val sort_of_product : env -> Sorts.t -> Sorts.t -> Sorts.t
-val type_of_product : env -> Name.t Context.binder_annot -> Sorts.t -> Sorts.t -> types
+val type_of_product : env -> Name.t binder_annot -> Sorts.t -> Sorts.t -> types
 (* val judge_of_product : *)
 (*   env -> Name.t -> unsafe_type_judgment -> unsafe_type_judgment *)
 (*     -> unsafe_judgment *)
@@ -128,11 +128,11 @@ val warn_bad_relevance_name : string
 val bad_relevance_warning : CWarnings.warning
 (** Also used by the pretyper to define a message which uses the evar map. *)
 
-type ('constr,'types) bad_relevance =
-| BadRelevanceBinder of Sorts.relevance * ('constr,'types) Context.Rel.Declaration.pt
-| BadRelevanceCase of Sorts.relevance * 'constr
+type ('constr,'types, 'r) bad_relevance =
+| BadRelevanceBinder of 'r * ('constr,'types,'r) Context.Rel.Declaration.pt
+| BadRelevanceCase of 'r * 'constr
 
-val bad_relevance_msg : (env * (constr,types) bad_relevance) CWarnings.msg
+val bad_relevance_msg : (env * (constr,types,Sorts.relevance) bad_relevance) CWarnings.msg
 (** Used by the higher layers to register a nicer printer than the default. *)
 
 val should_invert_case : env -> Sorts.relevance -> case_info -> bool

--- a/kernel/vars.mli
+++ b/kernel/vars.mli
@@ -114,7 +114,7 @@ val subst_of_rel_context_instance_list : Constr.rel_context -> instance_list -> 
 
 (** Take an index in an instance of a context and returns its index wrt to
     the full context (e.g. 2 in [x:A;y:=b;z:C] is 3, i.e. a reference to z) *)
-val adjust_rel_to_rel_context : ('a, 'b) Context.Rel.pt -> int -> int
+val adjust_rel_to_rel_context : ('a, 'b, 'r) Context.Rel.pt -> int -> int
 
 (** [substnl [a₁;...;an] k c] substitutes in parallel [a₁],...,[an]
     for respectively [Rel(k+1)],...,[Rel(k+n)] in [c]; it relocates

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -865,7 +865,7 @@ let __eps__ = Id.of_string "_eps_"
 let new_state_var typ state =
   let ids = Environ.ids_of_named_context_val (Environ.named_context_val state.env) in
   let id = Namegen.next_ident_away __eps__ ids in
-  let r = Sorts.Relevant in (* TODO relevance *)
+  let r = EConstr.ERelevance.relevant in (* TODO relevance *)
   state.env<- EConstr.push_named (Context.Named.Declaration.LocalAssum (make_annot id r,typ)) state.env;
   id
 

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -254,7 +254,7 @@ let build_projection env sigma intype (cstr : pconstructor) special default =
   let ci = (snd (fst cstr)) in
   let body = Combinators.make_selector env sigma ~pos:ci ~special ~default (mkRel 1) intype in
   let id = fresh_id env (Id.of_string "t") in
-  sigma, mkLambda (make_annot (Name id) Sorts.Relevant, intype, body)
+  sigma, mkLambda (make_annot (Name id) ERelevance.relevant, intype, body)
 
 (* generate an adhoc tactic following the proof tree  *)
 
@@ -326,7 +326,7 @@ let rec proof_term env sigma (typ, lhs, rhs) p = match p.p_rule with
   let sigma, funty = type_and_refresh_ env sigma f in
   let sigma, argty = type_and_refresh_ env sigma t in
   let id = fresh_id env (Id.of_string "f") in
-  let appf = mkLambda (make_annot (Name id) Sorts.Relevant, funty, mkApp (mkRel 1, [|t|])) in
+  let appf = mkLambda (make_annot (Name id) ERelevance.relevant, funty, mkApp (mkRel 1, [|t|])) in
   let sigma, p1 = proof_term env sigma (funty, f, g) p1 in
   let sigma, p2 = proof_term env sigma (argty, t, u) p2 in
   (* lemma1 : ⊢ f t = g t : B{t} *)
@@ -390,7 +390,7 @@ let convert_to_goal_tac c t1 t2 p =
     let neweq= app_global _eq [|sort;tt1;tt2|] in
     let e = Tacmach.pf_get_new_id (Id.of_string "e") gl in
     let x = Tacmach.pf_get_new_id (Id.of_string "X") gl in
-    let identity=mkLambda (make_annot (Name x) Sorts.Relevant,sort,mkRel 1) in
+    let identity=mkLambda (make_annot (Name x) ERelevance.relevant,sort,mkRel 1) in
     let endt = app_global _eq_rect [|sort; tt1; identity; mkVar c; tt2; mkVar e|] in
     Tacticals.tclTHENS (neweq (assert_before (Name e)))
                            [proof_tac (sort, tt1, tt2) p; endt refine_exact_check]
@@ -490,7 +490,7 @@ let cc_tactic depth additional_terms b =
       end
   end
 
-let id t = mkLambda (make_annot Anonymous Sorts.Relevant, t, mkRel 1)
+let id t = mkLambda (make_annot Anonymous ERelevance.relevant, t, mkRel 1)
 
 (* convertible to (not False) -> P -> not P *)
 let mk_neg_ty ff t nt =
@@ -498,8 +498,8 @@ let mk_neg_ty ff t nt =
 
 (* proof of ((not False) -> P -> not P) -> not P *)
 let mk_neg_tm ff t nt =
-  mkLambda (make_annot Anonymous Sorts.Relevant, mk_neg_ty ff t nt,
-    mkLambda (make_annot Anonymous Sorts.Relevant, t,
+  mkLambda (make_annot Anonymous ERelevance.relevant, mk_neg_ty ff t nt,
+    mkLambda (make_annot Anonymous ERelevance.relevant, t,
       mkApp (mkRel 2,[|id ff; mkRel 1; mkRel 1|])))
 
 (* for [simple congruence] process conclusion (not P) *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -128,7 +128,7 @@ let check_fix env sg cb i =
     | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> raise Impossible
 
 let prec_declaration_equal sg (na1, ca1, ta1) (na2, ca2, ta2) =
-  Array.equal (Context.eq_annot Name.equal) na1 na2 &&
+  Array.equal (Context.eq_annot Name.equal (EConstr.ERelevance.equal sg)) na1 na2 &&
   Array.equal (EConstr.eq_constr sg) ca1 ca2 &&
   Array.equal (EConstr.eq_constr sg) ta1 ta2
 

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -26,8 +26,7 @@ val extract_with_type :
   env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
 
 val extract_fixpoint :
-  env -> evar_map -> Constant.t array ->
-    (EConstr.t, EConstr.types) Constr.prec_declaration -> ml_decl
+  env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
 
 val extract_inductive : env -> MutInd.t -> ml_ind
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -114,7 +114,7 @@ let mk_open_instance env sigma id idc c =
     if Int.equal n 0 then sigma, decls else
       let nid = fresh_id_in_env avoid var_id env in
       let (sigma, (c, s)) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
-      let decl = LocalAssum (Context.make_annot (Name nid) (ESorts.relevance_of_sort sigma s), c) in
+      let decl = LocalAssum (Context.make_annot (Name nid) (ESorts.relevance_of_sort s), c) in
       aux (n-1) (Id.Set.add nid avoid) (EConstr.push_rel decl env) sigma (decl::decls)
   in
   let sigma, decls = aux m Id.Set.empty env sigma [] in

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -162,9 +162,9 @@ let ll_ind_tac ~flags (ind,u as indu) largs backtrack id continue seq =
 let ll_arrow_tac ~flags a b c backtrack id continue seq=
   let open EConstr in
   let open Vars in
-  let cc=mkProd(Context.make_annot Anonymous Sorts.Relevant,a,(lift 1 b)) in
-  let d idc = mkLambda (Context.make_annot Anonymous Sorts.Relevant,b,
-                  mkApp (idc, [|mkLambda (Context.make_annot Anonymous Sorts.Relevant,(lift 1 a),(mkRel 2))|])) in
+  let cc=mkProd(Context.make_annot Anonymous ERelevance.relevant,a,(lift 1 b)) in
+  let d idc = mkLambda (Context.make_annot Anonymous ERelevance.relevant,b,
+                  mkApp (idc, [|mkLambda (Context.make_annot Anonymous ERelevance.relevant,(lift 1 a),(mkRel 2))|])) in
     tclORELSE
       (tclTHENS (cut c)
          [tclTHENLIST

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -222,7 +222,7 @@ let change_eq env sigma hyp_id (context : rel_context) x t end_of_type =
   let old_context_length = List.length context + 1 in
   let witness_fun =
     mkLetIn
-      ( make_annot Anonymous Sorts.Relevant
+      ( make_annot Anonymous ERelevance.relevant
       , make_refl_eq constructor t1_typ (fst t1)
       , t
       , mkApp
@@ -530,7 +530,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
                          tclTYPEOFTHEN term (fun sigma termtyp ->
                              let fun_body =
                                mkLambda
-                                 ( make_annot Anonymous Sorts.Relevant
+                                 ( make_annot Anonymous ERelevance.relevant
                                  , termtyp
                                  , Termops.replace_term sigma term (mkRel 1)
                                      dyn_infos.info )
@@ -793,7 +793,7 @@ let generalize_non_dep hyp =
         let open Context.Named.Declaration in
         Environ.fold_named_context_reverse
           (fun (clear, keep) decl ->
-            let decl = map_named_decl EConstr.of_constr decl in
+            let decl = EConstr.of_named_decl decl in
             let hyp = get_id decl in
             if
               Id.List.mem hyp hyps

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -65,9 +65,9 @@ let compute_new_princ_type_from_rel env rel_to_fun sorts princ_type =
     let real_args =
       if princ_type_info.indarg_in_concl then List.tl args else args
     in
-    Context.Named.Declaration.LocalAssum
-      ( map_annot Nameops.Name.get_id (Context.Rel.Declaration.get_annot decl)
-      , Term.it_mkProd_or_LetIn (mkSort new_sort) real_args )
+    let na = map_annot Nameops.Name.get_id (Context.Rel.Declaration.get_annot decl) in
+    let na = map_annot_relevance EConstr.Unsafe.to_relevance na in
+    Context.Named.Declaration.LocalAssum (na, Term.it_mkProd_or_LetIn (mkSort new_sort) real_args)
   in
   let new_predicates =
     List.map_i change_predicate_sort 0 princ_type_info.predicates
@@ -261,6 +261,4 @@ let compute_new_princ_type_from_rel env rel_to_fun sorts princ_type =
                 , t
                 , b ))
           new_predicates))
-    (List.map
-       (fun d -> Termops.map_rel_decl EConstr.Unsafe.to_constr d)
-       princ_type_info.params)
+    (EConstr.Unsafe.to_rel_context princ_type_info.params)

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -103,13 +103,13 @@ val decompose_lambda_n :
      Evd.evar_map
   -> int
   -> EConstr.t
-  -> (Names.Name.t Context.binder_annot * EConstr.t) list * EConstr.t
+  -> (Names.Name.t EConstr.binder_annot * EConstr.t) list * EConstr.t
 
 val compose_lam :
-  (Names.Name.t Context.binder_annot * EConstr.t) list -> EConstr.t -> EConstr.t
+  (Names.Name.t EConstr.binder_annot * EConstr.t) list -> EConstr.t -> EConstr.t
 
 val compose_prod :
-  (Names.Name.t Context.binder_annot * EConstr.t) list -> EConstr.t -> EConstr.t
+  (Names.Name.t EConstr.binder_annot * EConstr.t) list -> EConstr.t -> EConstr.t
 
 type tcc_lemma_value = Undefined | Value of Constr.t | Not_needed
 

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -327,7 +327,7 @@ type journey_info =
           -> constr infos
           -> unit Proofview.tactic)
       -> ( case_info
-           * (constr * Sorts.relevance)
+           * (constr * ERelevance.t)
            * case_invert
            * constr
            * constr array
@@ -1304,7 +1304,7 @@ let abstract_type sigma gl =
     with Not_found -> true in
   Environ.fold_named_context_reverse (fun t decl ->
                                         if is_proof_var decl then
-                                          let decl = Termops.map_named_decl EConstr.of_constr decl in
+                                          let decl = EConstr.of_named_decl decl in
                                           mkNamedProd_or_LetIn sigma decl t
                                         else
                                           t
@@ -1628,7 +1628,7 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls
   let evd, function_type =
     interp_type_evars ~program_mode:false env evd type_of_f
   in
-  let function_r = Sorts.Relevant in
+  let function_r = ERelevance.relevant in
   (* TODO relevance *)
   let env =
     EConstr.push_named

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -158,7 +158,7 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
       let revargs,ownsign =
         fold_named_context
           (fun env d (revargs,hyps) ->
-            let d = map_named_decl EConstr.of_constr d in
+            let d = EConstr.of_named_decl d in
              let id = NamedDecl.get_id d in
              if Id.Set.mem id ivars then
                ((mkVar id)::revargs, Context.Named.add d hyps)
@@ -167,11 +167,11 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
           env ~init:([],[])
       in
       let pty = it_mkNamedProd_or_LetIn sigma (mkSort sort) ownsign in
-      let goal = mkArrow i Sorts.Relevant (applist(mkVar p, List.rev revargs)) in
+      let goal = mkArrow i ERelevance.relevant (applist(mkVar p, List.rev revargs)) in
       (pty,goal)
   in
   let npty = nf_all env sigma pty in
-  let extenv = push_named (LocalAssum (make_annot p Sorts.Relevant,npty)) env in
+  let extenv = push_named (LocalAssum (make_annot p ERelevance.relevant,npty)) env in
   extenv, goal
 
 (* [inversion_scheme sign I]
@@ -206,7 +206,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
   let ownSign = ref begin
     fold_named_context
       (fun env d sign ->
-        let d = map_named_decl EConstr.of_constr d in
+        let d = EConstr.of_named_decl d in
          if mem_named_context_val (NamedDecl.get_id d) global_named_context then sign
          else Context.Named.add d sign)
       invEnv ~init:Context.Named.empty
@@ -220,7 +220,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
         let h = next_ident_away (Id.of_string "H") !avoid in
         let ty,inst = Evarutil.generalize_evar_over_rels sigma (e,args) in
         avoid := Id.Set.add h !avoid;
-        ownSign := Context.Named.add (LocalAssum (make_annot h Sorts.Relevant,ty)) !ownSign;
+        ownSign := Context.Named.add (LocalAssum (make_annot h ERelevance.relevant,ty)) !ownSign;
         applist (mkVar h, inst)
     | _ -> EConstr.map sigma fill_holes c
   in

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -132,7 +132,7 @@ let flatten_contravariant_conj _ ist =
           ~onlybinary:flags.binary_mode typ
   with
   | Some (_,args) ->
-    let newtyp = List.fold_right (fun a b -> mkArrow a Sorts.Relevant b) args c in
+    let newtyp = List.fold_right (fun a b -> mkArrow a ERelevance.relevant b) args c in
     let intros = tclMAP (fun _ -> intro) args in
     let by = tclTHENLIST [intros; apply hyp; split; assumption] in
     tclTHENLIST [assert_ ~by newtyp; clear (destVar sigma hyp)]
@@ -164,7 +164,7 @@ let flatten_contravariant_disj _ ist =
           typ with
   | Some (_,args) ->
       let map i arg =
-        let typ = mkArrow arg Sorts.Relevant c in
+        let typ = mkArrow arg ERelevance.relevant c in
         let ci = Tactics.constructor_tac false None (succ i) Tactypes.NoBindings in
         let by = tclTHENLIST [intro; apply hyp; ci; assumption] in
         assert_ ~by typ

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -174,7 +174,7 @@ val val_constructor : constructor Val.tag
 val val_projection : Projection.t Val.tag
 val val_qvar : Sorts.QVar.t Val.tag
 val val_case : Constr.case_info Val.tag
-val val_binder : (Name.t Context.binder_annot * types) Val.tag
+val val_binder : (Name.t EConstr.binder_annot * types) Val.tag
 val val_univ : Univ.Level.t Val.tag
 val val_quality : Sorts.Quality.t Val.tag
 val val_free : Id.Set.t Val.tag

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -27,6 +27,8 @@ open Context
 open Tactypes
 open McPrinter
 
+module ERelevance = EConstr.ERelevance
+
 (**
   * Debug flag
   *)
@@ -1232,7 +1234,7 @@ let prodn n env b =
   let rec prodrec = function
     | 0, env, b -> b
     | n, (v, t) :: l, b ->
-      prodrec (n - 1, l, EConstr.mkProd (make_annot v Sorts.Relevant, t, b))
+      prodrec (n - 1, l, EConstr.mkProd (make_annot v ERelevance.relevant, t, b))
     | _ -> assert false
   in
   prodrec (n, env, b)
@@ -1314,10 +1316,10 @@ let make_goal_of_formula gl dexpr form =
       EConstr.mkApp
         (Lazy.force coq_iff, [|xdump_prop pi xi x; xdump_prop pi xi y|])
     | Mc.IMPL (_, x, _, y) ->
-      EConstr.mkArrow (xdump_prop pi xi x) Sorts.Relevant
+      EConstr.mkArrow (xdump_prop pi xi x) ERelevance.relevant
         (xdump_prop (pi + 1) (xi + 1) y)
     | Mc.NOT (_, x) ->
-      EConstr.mkArrow (xdump_prop pi xi x) Sorts.Relevant (Lazy.force coq_False)
+      EConstr.mkArrow (xdump_prop pi xi x) ERelevance.relevant (Lazy.force coq_False)
     | Mc.EQ (x, y) ->
       EConstr.mkApp
         ( Lazy.force coq_eq
@@ -1380,7 +1382,7 @@ let set sigma l concl =
       let name, expr, typ = e in
       xset
         (EConstr.mkNamedLetIn sigma
-           (make_annot (Names.Id.of_string name) Sorts.Relevant)
+           (make_annot (Names.Id.of_string name) ERelevance.relevant)
            expr typ acc)
         l
   in
@@ -1723,7 +1725,7 @@ let abstract_formula : TagSet.t -> 'a formula -> 'a formula =
       ; mkIMPL =
           (fun k x y ->
             match k with
-            | Mc.IsProp -> EConstr.mkArrow x Sorts.Relevant y
+            | Mc.IsProp -> EConstr.mkArrow x ERelevance.relevant y
             | Mc.IsBool -> EConstr.mkApp (Lazy.force coq_implb, [|x; y|]))
       ; mkIFF =
           (let coq_iff = Lazy.force coq_iff in

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -14,6 +14,8 @@ open Pp
 open Lazy
 module NamedDecl = Context.Named.Declaration
 
+module ERelevance = EConstr.ERelevance
+
 let debug_zify = CDebug.create ~name:"zify" ()
 
 (* The following [constr] are necessary for constructing the proof terms *)
@@ -189,7 +191,7 @@ type classify_op =
  *)
 
 let name x =
-  Context.make_annot (Name.mk_name (Names.Id.of_string x)) Sorts.Relevant
+  Context.make_annot (Name.mk_name (Names.Id.of_string x)) ERelevance.relevant
 
 let mkconvert_unop i1 i2 op top =
   (* fun x => inj (op x) *)
@@ -1011,7 +1013,7 @@ type typed_constr = {constr : EConstr.t; typ : EConstr.t; inj : EInjT.t}
 (* [arrow] is the term (fun (x:Prop) (y : Prop) => x -> y) *)
 let arrow =
   let name x =
-    Context.make_annot (Name.mk_name (Names.Id.of_string x)) Sorts.Relevant
+    Context.make_annot (Name.mk_name (Names.Id.of_string x)) ERelevance.relevant
   in
   EConstr.mkLambda
     ( name "x"
@@ -1020,7 +1022,7 @@ let arrow =
         ( name "y"
         , EConstr.mkProp
         , EConstr.mkProd
-            ( Context.make_annot Names.Anonymous Sorts.Relevant
+            ( Context.make_annot Names.Anonymous ERelevance.relevant
             , EConstr.mkRel 2
             , EConstr.mkRel 2 ) ) )
 

--- a/plugins/rtauto/refl_tauto.mli
+++ b/plugins/rtauto/refl_tauto.mli
@@ -23,6 +23,6 @@ val make_hyps
   -> atom_env
   -> EConstr.types list
   -> EConstr.named_context
-  -> (Names.Id.t Context.binder_annot * Proof_search.form) list
+  -> (Names.Id.t EConstr.binder_annot * Proof_search.form) list
 
 val rtauto_tac : unit Proofview.tactic

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -433,7 +433,7 @@ let abs_evars env sigma0 ?(rigid = []) (sigma, c0) =
     | _ -> EConstr.map_with_binders sigma ((+) 1) get i c in
     let rec loop c i = function
     | (_, (n, t)) :: evl ->
-      loop (mkLambda (make_annot (mk_evar_name n) Sorts.Relevant, get (i - 1) t, c)) (i - 1) evl
+      loop (mkLambda (make_annot (mk_evar_name n) ERelevance.relevant, get (i - 1) t, c)) (i - 1) evl
     | [] -> c in
     loop (get 1 c0) 1 evlist, List.map fst evlist, ucst
 
@@ -526,7 +526,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
   | (_, (n, t, _)) :: evl ->
     let t = get evlist (i - 1) t in
     let n = Name (Id.of_string (ssr_anon_hyp ^ string_of_int n)) in
-    loopP evlist (RelDecl.LocalAssum (make_annot n Sorts.Relevant, t) :: accu) (i - 1) evl
+    loopP evlist (RelDecl.LocalAssum (make_annot n ERelevance.relevant, t) :: accu) (i - 1) evl
   in
   let rec loop c i = function
   | (_, (n, t, _)) :: evl ->
@@ -537,7 +537,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
     let t = get evlist (i - 1) t in
     let extra_args = List.rev_map (fun (k,_) -> mkRel (fst (lookup k i evlist))) t_evplist in
     let c = if extra_args = [] then c else app extra_args 1 c in
-    loop (mkLambda (make_annot (mk_evar_name n) Sorts.Relevant, t, c)) (i - 1) evl
+    loop (mkLambda (make_annot (mk_evar_name n) ERelevance.relevant, t, c)) (i - 1) evl
   | [] -> c in
   let res = loop (get evlist 1 c0) 1 evlist in
   List.length evlist, res

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -26,8 +26,8 @@ val allocc : ssrocc
 
 val hyp_id : ssrhyp -> Id.t
 val hyps_ids : ssrhyps -> Id.t list
-val check_hyp_exists : ('a, 'b) Context.Named.pt -> ssrhyp -> unit
-val test_hyp_exists : ('a, 'b) Context.Named.pt -> ssrhyp -> bool
+val check_hyp_exists : ('a, 'b, 'r) Context.Named.pt -> ssrhyp -> unit
+val test_hyp_exists : ('a, 'b, 'r) Context.Named.pt -> ssrhyp -> bool
 val check_hyps_uniq : Id.t list -> ssrhyps -> unit
 val not_section_id : Id.t -> bool
 val hyp_err : ?loc:Loc.t -> string -> Id.t -> 'a
@@ -108,7 +108,7 @@ val interp_open_constr :
 val splay_open_constr :
            Environ.env ->
            evar_map * EConstr.t ->
-           (Names.Name.t Context.binder_annot * EConstr.t) list * EConstr.t
+           (Names.Name.t EConstr.binder_annot * EConstr.t) list * EConstr.t
 val isAppInd : Environ.env -> Evd.evar_map -> EConstr.types -> bool
 
 val mk_term : ssrtermkind -> constr_expr -> ssrterm

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -369,7 +369,7 @@ let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n
       let sigma, eq = get_eq_type env sigma in
       let sigma, gen_eq_tac, eq_ty =
         let refl = EConstr.mkApp (eq, [|t; c; c|]) in
-        let new_concl = EConstr.mkArrow refl Sorts.Relevant (EConstr.Vars.lift 1 concl0) in
+        let new_concl = EConstr.mkArrow refl EConstr.ERelevance.relevant (EConstr.Vars.lift 1 concl0) in
         let new_concl = fire_subst sigma new_concl in
         let sigma, erefl = mkRefl env sigma t c in
         let erefl = fire_subst sigma erefl in
@@ -397,7 +397,7 @@ let generate_pred env sigma0 ~concl patterns predty eqid is_rec deps elim_args n
       in
       let rel = k + if c_is_head_p then 1 else 0 in
       let sigma, src = mkProt env sigma eq_ty EConstr.(mkApp (eq,[|t; c; mkRel rel|])) in
-      let concl = EConstr.mkArrow src Sorts.Relevant (EConstr.Vars.lift 1 concl) in
+      let concl = EConstr.mkArrow src EConstr.ERelevance.relevant (EConstr.Vars.lift 1 concl) in
       let clr = if deps <> [] then clr else [] in
       sigma, concl, gen_eq_tac, clr
   | _ -> sigma, concl, Tacticals.tclIDTAC, clr in
@@ -530,7 +530,7 @@ let revtoptac n0 =
   let n = nb_prod sigma concl - n0 in
   let dc, cl = EConstr.decompose_prod_n_decls sigma n concl in
   let ty = EConstr.it_mkProd_or_LetIn cl (List.rev dc) in
-  let dc' = dc @ [Context.Rel.Declaration.LocalAssum(make_annot (Name rev_id) Sorts.Relevant, ty)] in
+  let dc' = dc @ [Context.Rel.Declaration.LocalAssum(make_annot (Name rev_id) EConstr.ERelevance.relevant, ty)] in
   Refine.refine ~typecheck:true begin fun sigma ->
     let f = EConstr.it_mkLambda_or_LetIn (mkEtaApp (EConstr.mkRel (n + 1)) (-n) 1) dc' in
     let sigma, ev = Evarutil.new_evar env sigma ty in
@@ -589,7 +589,7 @@ let perform_injection c =
   let cl = Proofview.Goal.concl gl in
   let n = List.length dc in
   let c_eq = mkEtaApp c n 2 in
-  let cl1 = EConstr.mkLambda EConstr.(make_annot Anonymous Sorts.Relevant, mkArrow eqt Sorts.Relevant cl, mkApp (mkRel 1, [|c_eq|])) in
+  let cl1 = EConstr.mkLambda EConstr.(make_annot Anonymous ERelevance.relevant, mkArrow eqt ERelevance.relevant cl, mkApp (mkRel 1, [|c_eq|])) in
   let id = injecteq_id in
   let id_with_ebind = (EConstr.mkVar id, NoBindings) in
   let injtac = Tacticals.tclTHEN (introid id) (injectidl2rtac id id_with_ebind) in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -395,12 +395,12 @@ let tclMK_ABSTRACT_VAR id = Goal.enter begin fun gl ->
       let sigma, m = Evarutil.new_evar env sigma abstract_ty in
       sigma, (m, abstract_ty) in
     let sigma, kont =
-      let rd = Context.Rel.Declaration.LocalAssum (make_annot (Name id) Sorts.Relevant, abstract_ty) in
+      let rd = Context.Rel.Declaration.LocalAssum (make_annot (Name id) EConstr.ERelevance.relevant, abstract_ty) in
       let sigma, ev = Evarutil.new_evar (EConstr.push_rel rd env) sigma concl in
       sigma, ev
     in
     let term =
-      EConstr.(mkApp (mkLambda(make_annot (Name id) Sorts.Relevant,abstract_ty,kont),[|abstract_proof|])) in
+      EConstr.(mkApp (mkLambda(make_annot (Name id) ERelevance.relevant,abstract_ty,kont),[|abstract_proof|])) in
     let sigma, _ = Typing.type_of env sigma term in
     sigma, term
   end in
@@ -694,7 +694,7 @@ let elim_intro_tac ipats ?seed what eqid ssrelim is_rec clr =
            let name = Ssrcommon.mk_anon_id "K" (Tacmach.pf_ids_of_hyps g) in
 
            let new_concl =
-             mkProd (make_annot (Name name) Sorts.Relevant, case_ty, mkArrow refl Sorts.Relevant (Vars.lift 2 concl)) in
+             mkProd (make_annot (Name name) ERelevance.relevant, case_ty, mkArrow refl ERelevance.relevant (Vars.lift 2 concl)) in
            let erefl, sigma = mkCoqRefl case_ty case env sigma in
            Proofview.Unsafe.tclEVARS sigma <*>
            Tactics.apply_type ~typecheck:true new_concl [case;erefl]
@@ -718,7 +718,7 @@ let mkEq dir cl c t n env sigma =
   eqargs.(Ssrequality.dir_org dir) <- mkRel n;
   let eq, sigma = mkCoqEq env sigma in
   let refl, sigma = mkCoqRefl t c env sigma in
-  mkArrow (mkApp (eq, eqargs)) Sorts.Relevant (Vars.lift 1 cl), refl, sigma
+  mkArrow (mkApp (eq, eqargs)) ERelevance.relevant (Vars.lift 1 cl), refl, sigma
 
 (** in [tac/v: last gens..] the first (last to be run) generalization is
     "special" in that is it also the main argument of [tac] and is eventually
@@ -762,7 +762,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
       Unsafe.tclEVARS sigma <*>
       Ssrcommon.tacTYPEOF p >>= fun pty ->
       (* TODO: check bug: cl0 no lift? *)
-      let ccl = EConstr.mkProd (make_annot (Ssrcommon.constr_name sigma c) Sorts.Relevant, pty, cl0) in
+      let ccl = EConstr.mkProd (make_annot (Ssrcommon.constr_name sigma c) EConstr.ERelevance.relevant, pty, cl0) in
       tclUNIT (false, ccl, p, clr)
   else
     Ssrcommon.errorstrm Pp.(str "generalized term didn't match")

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -542,7 +542,7 @@ let match_upats_FO upats env sigma0 ise orig_c =
          if skip || not (EConstr.Vars.closed0 ise c') then () else try
            let () = match u.up_k with
            | KpatFlex ->
-             let kludge v = mkLambda (make_annot Anonymous Sorts.Relevant, mkProp, v) in
+             let kludge v = mkLambda (make_annot Anonymous ERelevance.relevant, mkProp, v) in
              let (metas, p_FO) = u.up_FO in
              unif_FO env ise metas (kludge p_FO) (kludge c')
            | KpatLet ->
@@ -1363,7 +1363,7 @@ let ssrpatterntac _ist arg =
     fill_occ_pattern env sigma0 concl0 pat noindex 1 in
   let sigma = Evd.set_universe_context sigma0 uc in
   let sigma, tty = Typing.type_of env sigma t in
-  let concl = EConstr.mkLetIn (make_annot (Name (Id.of_string "selected")) Sorts.Relevant, t, tty, concl_x) in
+  let concl = EConstr.mkLetIn (make_annot (Name (Id.of_string "selected")) EConstr.ERelevance.relevant, t, tty, concl_x) in
   Proofview.Unsafe.tclEVARS sigma <*>
   convert_concl ~cast:false ~check:true concl DEFAULTcast
   end

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -218,7 +218,7 @@ let get_type env sigma c =
     | _ -> List.rev acc, t in
   let t = Retyping.get_type_of env sigma (EConstr.of_constr c) in
   let l, t = aux env [] t in
-  List.map (fun (na, a) -> na, EConstr.Unsafe.to_constr a) l,
+  List.map (fun (na, a) -> EConstr.Unsafe.to_binder_annot na, EConstr.Unsafe.to_constr a) l,
   EConstr.Unsafe.to_constr t
 
 (* [elaborate_to_post_params env sigma ty_ind params] builds the

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -475,7 +475,7 @@ let push_current_pattern ~program_mode sigma (cur,ty) eqn =
   let hypnaming = if program_mode then ProgramNaming vars else RenameExistingBut vars in
   match eqn.patterns with
     | pat::pats ->
-        let r = Sorts.Relevant in (* TODO relevance *)
+        let r = ERelevance.relevant in (* TODO relevance *)
         let _,rhs_env = push_rel ~hypnaming sigma (LocalDef (make_annot (alias_of_pat pat) r,cur,ty)) eqn.rhs.rhs_env in
         { eqn with
             rhs = { eqn.rhs with rhs_env = rhs_env };
@@ -1963,7 +1963,7 @@ let extract_arity_signature ?(dolift=true) env0 tomatchl tmsign =
       | NotInd (bo,typ) ->
           (match t with
             | None ->
-              let r = Sorts.Relevant in (* TODO relevance *)
+              let r = ERelevance.relevant in (* TODO relevance *)
               let sign = match bo with
                        | None -> [LocalAssum (make_annot na r, lift n typ)]
                        | Some b -> [LocalDef (make_annot na r, lift n b, lift n typ)] in sign
@@ -2239,7 +2239,7 @@ let constr_of_pat env sigma arsign pat avoid =
               let id = next_ident_away wildcard_id avoid in
                 Name id, Id.Set.add id avoid
         in
-        let r = Sorts.Relevant in (* TODO relevance *)
+        let r = ERelevance.relevant in (* TODO relevance *)
           (sigma, (DAst.make ?loc @@ PatVar name), [LocalAssum (make_annot name r, ty)] @ realargs, mkRel 1, ty,
            (List.map (fun x -> mkRel 1) realargs), 1, avoid)
     | PatCstr (((_, i) as cstr),args,alias) ->
@@ -2438,7 +2438,7 @@ let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
            let args = List.rev args in
              substl args (liftn signlen (succ nargs) arity)
          in
-         let r = Sorts.Relevant in (* TODO relevance *)
+         let r = ERelevance.relevant in (* TODO relevance *)
          let rhs_rels', tycon =
            let neqs_rels, arity =
              match ineqs with
@@ -2504,7 +2504,7 @@ let abstract_tomatch env sigma tomatchs tycon =
                let tycon = Option.map
                  (fun t -> subst_term sigma (lift 1 c) (lift 1 t)) tycon in
                let name = next_ident_away (Id.of_string "filtered_var") names in
-               let r = Sorts.Relevant in (* TODO relevance *)
+               let r = ERelevance.relevant in (* TODO relevance *)
                  (mkRel 1, lift_tomatch_type (succ lenctx) t) :: lift_ctx 1 prev,
                LocalDef (make_annot (Name name) r, lift lenctx c, lift lenctx $ type_of_tomatch t) :: ctx,
                Id.Set.add name names, tycon)
@@ -2568,7 +2568,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
                         make_prime avoid name
                     in
                       (sigma, env, succ nargeqs,
-                       (LocalAssum (make_annot (Name (eq_id avoid previd)) Sorts.Relevant, eq)) :: argeqs,
+                       (LocalAssum (make_annot (Name (eq_id avoid previd)) ERelevance.relevant, eq)) :: argeqs,
                        refl_arg :: refl_args,
                        pred slift,
                        RelDecl.set_name (Name id) decl :: argsign'))
@@ -2583,7 +2583,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
              in
              let sigma, refl_eq = mk_JMeq_refl env sigma ty tm in
              let previd, id = make_prime avoid appn in
-               (sigma, (LocalAssum (make_annot (Name (eq_id avoid previd)) Sorts.Relevant, eq) :: argeqs) :: eqs,
+               (sigma, (LocalAssum (make_annot (Name (eq_id avoid previd)) ERelevance.relevant, eq) :: argeqs) :: eqs,
                 succ nargeqs,
                 refl_eq :: refl_args,
                 pred slift,
@@ -2600,7 +2600,7 @@ let build_dependent_signature env sigma avoid tomatchs arsign =
                 (mkRel slift) (lift nar tm)
             in
             let sigma, refl = mk_eq_refl env sigma tomatch_ty tm in
-            let na = make_annot (Name (eq_id avoid previd)) Sorts.Relevant in
+            let na = make_annot (Name (eq_id avoid previd)) ERelevance.relevant in
             (sigma,
             [LocalAssum (na, eq)] :: eqs, succ neqs,
             refl :: refl_args,
@@ -2679,9 +2679,9 @@ let compile_program_cases ?loc style (typing_function, sigma) tycon env
   (* names of aliases will be recovered from patterns (hence Anonymous here) *)
 
   (* TODO relevance *)
-  let out_tmt na = function NotInd (None,t) -> LocalAssum (make_annot na Sorts.Relevant,t)
-                          | NotInd (Some b, t) -> LocalDef (make_annot na Sorts.Relevant,b,t)
-                          | IsInd (typ,_,_) -> LocalAssum (make_annot na Sorts.Relevant,typ) in
+  let out_tmt na = function NotInd (None,t) -> LocalAssum (make_annot na ERelevance.relevant,t)
+                          | NotInd (Some b, t) -> LocalDef (make_annot na ERelevance.relevant,b,t)
+                          | IsInd (typ,_,_) -> LocalAssum (make_annot na ERelevance.relevant,typ) in
   let typs = List.map2 (fun (na,_) (tm,tmt) -> (tm,out_tmt na tmt)) nal tomatchs in
 
   let typs =
@@ -2758,7 +2758,7 @@ let compile_cases ?loc ~program_mode style (typing_fun, sigma) tycon env (predop
     let out_tmt na = function NotInd (None,t) -> LocalAssum (na,t)
                             | NotInd (Some b,t) -> LocalDef (na,b,t)
                             | IsInd (typ,_,_) -> LocalAssum (na,typ) in
-    let typs = List.map2 (fun (na,_) (tm,tmt) -> (tm,out_tmt (make_annot na Sorts.Relevant) tmt)) nal tomatchs in
+    let typs = List.map2 (fun (na,_) (tm,tmt) -> (tm,out_tmt (make_annot na ERelevance.relevant) tmt)) nal tomatchs in
 
     let typs =
       List.map (fun (c,d) -> (c,extract_inductive_data !!env sigma d,d)) typs in

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -45,9 +45,9 @@ open Esubst
 type cbv_value =
   | VAL of int * constr
   | STACK of int * cbv_value * cbv_stack
-  | LAMBDA of int * (Name.t Context.binder_annot * types) list * constr * cbv_value subs
-  | PROD of Name.t Context.binder_annot * types * types * cbv_value subs
-  | LETIN of Name.t Context.binder_annot * cbv_value * types * constr * cbv_value subs
+  | LAMBDA of int * (Name.t Constr.binder_annot * types) list * constr * cbv_value subs
+  | PROD of Name.t Constr.binder_annot * types * types * cbv_value subs
+  | LETIN of Name.t Constr.binder_annot * cbv_value * types * constr * cbv_value subs
   | FIX of fixpoint * cbv_value subs * cbv_value array
   | COFIX of cofixpoint * cbv_value subs * cbv_value array
   | CONSTRUCT of constructor UVars.puniverses * cbv_value array

--- a/pretyping/combinators.ml
+++ b/pretyping/combinators.ml
@@ -278,6 +278,6 @@ let make_selector env sigma ~pos ~special ~default c ctype =
     it_mkLambda_or_LetIn endpt args in
   let brl =
     List.map build_branch(List.interval 1 (Array.length mip.mind_consnames)) in
-  let rci = Sorts.Relevant in (* TODO relevance *)
+  let rci = ERelevance.relevant in (* TODO relevance *)
   let ci = make_case_info env ind RegularStyle in
   Inductiveops.make_case_or_project env sigma indt ci (p, rci) c (Array.of_list brl)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -57,11 +57,11 @@ let debug_ho_unification = CDebug.create ~name:"ho-unification" ()
 
 (* In case the constants id/ID are not defined *)
 let unit_judge_fallback =
-  let na1 = make_annot (Name (Id.of_string "A")) Sorts.Relevant in
-  let na2 = make_annot (Name (Id.of_string "H")) Sorts.Relevant in
+  let na1 = make_annot (Name (Id.of_string "A")) ERelevance.relevant in
+  let na2 = make_annot (Name (Id.of_string "H")) ERelevance.relevant in
   make_judge
     (mkLambda (na1,mkProp,mkLambda(na2,mkRel 1,mkRel 1)))
-    (mkProd (na1,mkProp,mkArrow (mkRel 1) Sorts.Relevant (mkRel 2)))
+    (mkProd (na1,mkProp,mkArrow (mkRel 1) ERelevance.relevant (mkRel 2)))
 
 let coq_unit_judge env sigma =
   match Coqlib.lib_ref_opt "core.IDProp.idProp" with
@@ -1299,7 +1299,7 @@ and eta_constructor flags env evd ((ind, i), u) sk1 (term2,sk2) =
            let l2' =
              let term = Stack.zip evd (term2,sk2) in
              List.map (fun (p,r) ->
-                 let r = UVars.subst_instance_relevance (Unsafe.to_instance u) r in
+                 let r = EConstr.Vars.subst_instance_relevance u (ERelevance.make r) in
                  EConstr.mkProj (Projection.make p false, r, term))
                (Array.to_list projs)
            in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -84,7 +84,7 @@ let define_pure_evar_as_product env evd na evk =
   let evd1,(dom,u1) =
     new_type_evar evenv evd univ_flexible_alg ~src ~filter:(evar_filter evi)
   in
-  let rdom = Sorts.relevance_of_sort (ESorts.kind evd1 u1) in
+  let rdom = ESorts.relevance_of_sort u1 in
   let evd2,rng =
     let newenv = push_named (LocalAssum (make_annot id rdom, dom)) evenv in
     let src = subterm_source evk ~where:Codomain evksrc in

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -55,7 +55,7 @@ val vars_of_env : t -> Id.Set.t
 
 val push_rel : hypnaming:naming_mode -> evar_map -> rel_declaration -> t -> rel_declaration * t
 val push_rel_context : hypnaming:naming_mode -> ?force_names:bool -> evar_map -> rel_context -> t -> rel_context * t
-val push_rec_types : hypnaming:naming_mode -> evar_map -> Name.t Context.binder_annot array * constr array -> t -> Name.t Context.binder_annot array * t
+val push_rec_types : hypnaming:naming_mode -> evar_map -> Name.t EConstr.binder_annot array * constr array -> t -> Name.t EConstr.binder_annot array * t
 
 (** Declare an evar using renaming information *)
 

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -30,7 +30,7 @@ type dep_flag = bool
 
 type case_analysis = private {
   case_params : EConstr.rel_context;
-  case_pred : Name.t Context.binder_annot * EConstr.types;
+  case_pred : Name.t EConstr.binder_annot * EConstr.types;
   case_branches : EConstr.rel_context;
   case_arity : EConstr.rel_context;
   case_body : EConstr.t;

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -43,8 +43,8 @@ val lift_inductive_family  : int -> inductive_family -> inductive_family
 val substnl_ind_family :
   constr list -> int -> inductive_family -> inductive_family
 
-val relevance_of_inductive : env -> inductive puniverses -> Sorts.relevance
-val relevance_of_inductive_family : env -> inductive_family -> Sorts.relevance
+val relevance_of_inductive : env -> inductive puniverses -> ERelevance.t
+val relevance_of_inductive_family : env -> inductive_family -> ERelevance.t
 
 (** An inductive type with its parameters and real arguments *)
 type inductive_type = IndType of inductive_family * EConstr.constr list
@@ -56,7 +56,7 @@ val lift_inductive_type  : int -> inductive_type -> inductive_type
 val substnl_ind_type : EConstr.constr list -> int -> inductive_type -> inductive_type
 val ind_of_ind_type : inductive_type -> inductive
 
-val relevance_of_inductive_type : env -> inductive_type -> Sorts.relevance
+val relevance_of_inductive_type : env -> inductive_type -> ERelevance.t
 
 val mkAppliedInd : inductive_type -> EConstr.constr
 val mis_is_recursive_subset : inductive list -> wf_paths -> bool
@@ -196,16 +196,16 @@ val make_case_info : env -> inductive -> Constr.case_style -> Constr.case_info
     inductive type does not allow dependent elimination. *)
 val make_case_or_project :
   env -> evar_map -> inductive_type -> Constr.case_info ->
-  (* pred *) EConstr.constr * Sorts.relevance -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
+  (* pred *) EConstr.constr * ERelevance.t -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
 
 (** Sometimes [make_case_or_project] is nicer to call with a pre-built
    [case_invert] than [inductive_type]. *)
 val simple_make_case_or_project :
   env -> evar_map -> Constr.case_info ->
-  (* pred *) EConstr.constr * Sorts.relevance -> EConstr.case_invert -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
+  (* pred *) EConstr.constr * ERelevance.t -> EConstr.case_invert -> (* term *) EConstr.constr -> (* branches *) EConstr.constr array -> EConstr.constr
 
-val make_case_invert : env -> inductive_type -> case_relevance:Sorts.relevance -> Constr.case_info
-  -> EConstr.case_invert
+val make_case_invert : env -> evar_map -> inductive_type -> case_relevance:ERelevance.t
+  -> Constr.case_info -> EConstr.case_invert
 
 (*i Compatibility
 val make_default_case_info : env -> case_style -> inductive -> case_info

--- a/pretyping/keys.mli
+++ b/pretyping/keys.mli
@@ -16,7 +16,7 @@ val declare_equiv_keys : key -> key -> unit
 val equiv_keys : key -> key -> bool
 (** Check equivalence of keys. *)
 
-val constr_key : Environ.env -> ('a -> ('a, 't, 'u, 'i) Constr.kind_of_term) -> 'a -> key option
+val constr_key : Environ.env -> ('a -> ('a, 't, 'u, 'i, 'r) Constr.kind_of_term) -> 'a -> key option
 (** Compute the head key of a term. *)
 
 val pr_keys : (Names.GlobRef.t -> Pp.t) -> Pp.t

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -145,7 +145,7 @@ let build_branches_type env sigma mib mip (ind,u) params (pctx, p) =
   let build_one_branch i (ctx, _) =
     let typi = Inductiveops.instantiate_constructor_params ((ind,i+1),u) (mib,mip) paramsl in
     let decl,indapp = Reductionops.whd_decompose_prod env sigma typi in
-    let decl = List.map (on_snd EConstr.Unsafe.to_constr) decl in
+    let decl = List.map EConstr.Unsafe.(fun (na,c) -> to_binder_annot na, to_constr c) decl in
     let ind,cargs = find_rectype_a env sigma indapp in
     let nparams = Array.length params in
     let carity = snd (rtbl.(i)) in
@@ -393,7 +393,7 @@ and nf_predicate env sigma ind mip params v pctx =
   let env = push_rel_context pctx env in
   let body = nf_type env sigma v in
   let rel = Retyping.relevance_of_type env sigma (EConstr.of_constr body) in
-  body, rel
+  body, EConstr.Unsafe.to_relevance rel
 
 and nf_evar env sigma evk args =
   let evi = try Evd.find_undefined sigma evk with Not_found -> assert false in

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -34,7 +34,9 @@ type position_reporting = (position * int) * constr
 
 type subterm_unification_error = bool * position_reporting * position_reporting
 
-type type_error = (constr, types) ptype_error
+type type_error = (constr, types, ERelevance.t) ptype_error
+
+let of_type_error = map_ptype_error ERelevance.make EConstr.of_constr
 
 type pretype_error =
   (* Old Case *)

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -37,7 +37,9 @@ type position_reporting = (position * int) * constr
 
 type subterm_unification_error = bool * position_reporting * position_reporting
 
-type type_error = (constr, types) ptype_error
+type type_error = (constr, types, ERelevance.t) ptype_error
+
+val of_type_error : Type_errors.type_error -> type_error
 
 type pretype_error =
   | CantFindCaseType of constr
@@ -111,7 +113,7 @@ val error_number_branches :
 
 val error_ill_typed_rec_body :
   ?loc:Loc.t -> env -> Evd.evar_map ->
-      int -> Name.t Context.binder_annot array -> unsafe_judgment array -> types array -> 'b
+      int -> Name.t EConstr.binder_annot array -> unsafe_judgment array -> types array -> 'b
 
 val error_elim_arity :
   ?loc:Loc.t -> env -> Evd.evar_map ->

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -37,7 +37,7 @@ val search_guard :
 
 val esearch_guard :
   ?loc:Loc.t -> env -> evar_map -> int list list ->
-  (EConstr.t, EConstr.t) Constr.prec_declaration -> int array
+  EConstr.rec_declaration -> int array
 
 type typing_constraint =
   | IsType (** Necessarily a type *)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -182,14 +182,14 @@ sig
   type app_node
   val pr_app_node : (EConstr.t -> Pp.t) -> app_node -> Pp.t
 
-  type case_stk = case_info * EInstance.t * EConstr.t array * EConstr.t pcase_return * EConstr.t pcase_invert * EConstr.t pcase_branch array
+  type case_stk = case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.t pcase_invert * EConstr.case_branch array
 
-  val mkCaseStk : case_info * EInstance.t * EConstr.t array * EConstr.t pcase_return * EConstr.t pcase_invert * EConstr.t pcase_branch array -> case_stk
+  val mkCaseStk : case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.t pcase_invert * EConstr.case_branch array -> case_stk
 
   type member =
   | App of app_node
   | Case of case_stk
-  | Proj of Projection.t * Sorts.relevance
+  | Proj of Projection.t * ERelevance.t
   | Fix of fixpoint * t
   | Primitive of CPrimitives.t * (Constant.t * EInstance.t) * t * CPrimitives.args_red
 
@@ -216,7 +216,7 @@ sig
   val zip : evar_map -> constr * t -> constr
   val check_native_args : CPrimitives.t -> t -> bool
   val get_next_primitive_args : CPrimitives.args_red -> t -> CPrimitives.args_red * (t * EConstr.t * t) option
-  val expand_case : env -> evar_map -> case_stk -> case_info * EInstance.t * constr array * ((rel_context * constr) * Sorts.relevance) * (rel_context * constr) array
+  val expand_case : env -> evar_map -> case_stk -> case_info * EInstance.t * constr array * ((rel_context * constr) * ERelevance.t) * (rel_context * constr) array
 end =
 struct
   open EConstr
@@ -237,14 +237,14 @@ struct
 
 
   type case_stk =
-    case_info * EInstance.t * EConstr.t array * EConstr.t pcase_return * EConstr.t pcase_invert * EConstr.t pcase_branch array
+    case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.t pcase_invert * EConstr.case_branch array
 
   let mkCaseStk x = x
 
   type member =
   | App of app_node
   | Case of case_stk
-  | Proj of Projection.t * Sorts.relevance
+  | Proj of Projection.t * ERelevance.t
   | Fix of fixpoint * t
   | Primitive of CPrimitives.t * (Constant.t * EInstance.t) * t * CPrimitives.args_red
 

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -57,9 +57,9 @@ val reinterpret_get_type_of : src:Names.Id.t -> env -> evar_map -> constr -> typ
 
 val print_retype_error : retype_error -> Pp.t
 
-val relevance_of_term : env -> evar_map -> constr -> Sorts.relevance
-val relevance_of_type : env -> evar_map -> types -> Sorts.relevance
-val relevance_of_sort : evar_map -> ESorts.t -> Sorts.relevance
-val relevance_of_sort_family : evar_map -> Sorts.family -> Sorts.relevance
+val relevance_of_term : env -> evar_map -> constr -> ERelevance.t
+val relevance_of_type : env -> evar_map -> types -> ERelevance.t
+val relevance_of_sort : ESorts.t -> ERelevance.t
+val relevance_of_sort_family : evar_map -> Sorts.family -> ERelevance.t
 
 val is_term_irrelevant : env -> Evd.evar_map -> Evd.econstr -> bool

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -441,7 +441,7 @@ let find_opt_with_relevance (c,u) =
   find_opt c |>
   Option.map (fun p ->
       let u = EConstr.Unsafe.to_instance u in
-      p, Relevanceops.relevance_of_projection_repr (Global.env()) (p,u))
+      p, EConstr.ERelevance.make @@ Relevanceops.relevance_of_projection_repr (Global.env()) (p,u))
 
 let is_transparent_constant ts c =
   match find_opt c with

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -161,7 +161,7 @@ val mem : Names.Constant.t -> bool
 val find_opt : Names.Constant.t -> Names.Projection.Repr.t option
 
 val find_opt_with_relevance : Names.Constant.t * EConstr.EInstance.t
-  -> (Names.Projection.Repr.t * Sorts.relevance) option
+  -> (Names.Projection.Repr.t * EConstr.ERelevance.t) option
 
 val is_transparent_constant : TransparentState.t -> Names.Constant.t -> bool
 end

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -554,7 +554,7 @@ let contract_rec env sigma f nbodies mk_rec contract body =
         List.fold_left_i (fun q (* j = n+1-q *) c (ij,tij) ->
             let subst = List.map (Vars.lift (-q)) (List.firstn (n-ij) la) in
             let tij' = Vars.substl (List.rev subst) tij in
-            let x = make_annot xname Sorts.Relevant in  (* TODO relevance *)
+            let x = make_annot xname ERelevance.relevant in  (* TODO relevance *)
             mkLambda_with_eta sigma x tij' c)
           1 body (List.rev lv)
     in

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -39,12 +39,12 @@ val solve_evars : env -> evar_map -> constr -> evar_map * constr
 (** Raise an error message if incorrect elimination for this inductive
     (first constr is term to match, second is return predicate) *)
 val check_allowed_sort : env -> evar_map -> inductive puniverses -> constr -> constr ->
-  Sorts.relevance
+  ERelevance.t
 
 (** Raise an error message if bodies have types not unifiable with the
     expected ones *)
 val check_type_fixpoint : ?loc:Loc.t -> env -> evar_map ->
-  Names.Name.t Context.binder_annot array -> types array -> unsafe_judgment array -> evar_map
+  Names.Name.t EConstr.binder_annot array -> types array -> unsafe_judgment array -> evar_map
 
 (** Variant of {!check} that assumes that the argument term is well-typed. *)
 val check_actual_type : env -> evar_map -> unsafe_judgment -> types -> evar_map
@@ -71,4 +71,4 @@ val checked_applist : env -> evar_map -> constr -> constr list -> evar_map * con
 (** hack *)
 val recheck_against : Environ.env -> evar_map -> constr -> constr -> evar_map * types
 
-val bad_relevance_msg : (Environ.env * evar_map * (constr, types) Typeops.bad_relevance) CWarnings.msg
+val bad_relevance_msg : (Environ.env * evar_map * (constr, types, ERelevance.t) Typeops.bad_relevance) CWarnings.msg

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -493,7 +493,7 @@ let unfold_projection_under_eta env ts n c =
 
 type key =
   | IsKey of CClosure.table_key
-  | IsProj of Projection.t * Sorts.relevance * EConstr.constr
+  | IsProj of Projection.t * ERelevance.t * EConstr.constr
 
 let expand_table_key ts env sigma args = function
   | ConstKey (c, _ as cst) ->
@@ -1788,7 +1788,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
   let likefirst = clause_with_generic_occurrences occs in
   let mkvarid () = EConstr.mkVar id in
   let compute_dependency _ d (remvars,sign,depdecls) =
-    let d = map_named_decl EConstr.of_constr d in
+    let d = EConstr.of_named_decl d in
     let hyp = NamedDecl.get_id d in
     if Id.Set.is_empty remvars then
     match occurrences_of_hyp hyp occs with
@@ -1797,7 +1797,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     | (AllOccurrences | AtLeastOneOccurrence), InHyp as occ ->
         let occ = if likefirst then LikeFirst else AtOccs occ in
         let newdecl = replace_term_occ_decl_modulo env sigma occ test mkvarid d in
-        if Context.Named.Declaration.equal (EConstr.eq_constr sigma) d newdecl
+        if Context.Named.Declaration.equal (ERelevance.equal sigma) (EConstr.eq_constr sigma) d newdecl
            && not (indirectly_dependent sigma c d depdecls)
         then
           if check_occs && not (in_every_hyp occs)

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -404,7 +404,7 @@ let pr_named_context env sigma ne_context =
           ne_context ~init:(mt ()))
 
 let pr_rel_context env sigma rel_context =
-  let rel_context = List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) rel_context in
+  let rel_context = EConstr.of_rel_context rel_context in
   pr_binders env sigma (extern_rel_context None env sigma rel_context)
 
 let pr_rel_context_of env sigma =
@@ -672,8 +672,8 @@ let print_evar_constraints gl sigma =
     | Some g ->
        let env, _ = goal_repr sigma g in fun e' ->
        begin
-         if Context.Named.equal Constr.equal (named_context env) (named_context e') then
-           if Context.Rel.equal Constr.equal (rel_context env) (rel_context e') then mt ()
+         if Context.Named.equal Sorts.relevance_equal Constr.equal (named_context env) (named_context e') then
+           if Context.Rel.equal Sorts.relevance_equal Constr.equal (rel_context env) (rel_context e') then mt ()
            else pr_rel_context_of e' sigma ++ str " |-" ++ spc ()
          else pr_context_of e' sigma ++ str " |-" ++ spc ()
        end

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -235,7 +235,7 @@ type goal = { ty: EConstr.t; env : Environ.env; sigma : Evd.evar_map; }
 (* open Proofview *)
 module CDC = Context.Compacted.Declaration
 
-let to_tuple : EConstr.compacted_declaration -> (Names.Id.t Context.binder_annot list * 'pc option * 'pc) =
+let to_tuple : EConstr.compacted_declaration -> (Names.Id.t EConstr.binder_annot list * 'pc option * 'pc) =
   let open CDC in function
     | LocalAssum(idl, tm)   -> (idl, None, tm)
     | LocalDef(idl,tdef,tm) -> (idl, Some tdef, tm)

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -104,15 +104,15 @@ sig
 
   type cst_member =
     | Cst_const of pconstant
-    | Cst_proj of Projection.t * Sorts.relevance
+    | Cst_proj of Projection.t * ERelevance.t
 
   type 'a case_stk =
-    case_info * EInstance.t * 'a array * 'a pcase_return * 'a pcase_invert * 'a pcase_branch array
+    case_info * EInstance.t * 'a array * ('a,ERelevance.t) pcase_return * 'a pcase_invert * ('a,ERelevance.t) pcase_branch array
   type 'a member =
   | App of 'a app_node
   | Case of 'a case_stk * Cst_stack.t
-  | Proj of Projection.t * Sorts.relevance * Cst_stack.t
-  | Fix of ('a, 'a) pfixpoint * 'a t * Cst_stack.t
+  | Proj of Projection.t * ERelevance.t * Cst_stack.t
+  | Fix of ('a, 'a, ERelevance.t) pfixpoint * 'a t * Cst_stack.t
   | Primitive of CPrimitives.t * (Constant.t * EInstance.t) * 'a t * CPrimitives.args_red * Cst_stack.t
   | Cst of { const : cst_member;
              curr : int;
@@ -128,7 +128,7 @@ sig
   val empty : 'a t
   val append_app : 'a array -> 'a t -> 'a t
   val decomp : 'a t -> ('a * 'a t) option
-  val equal : env -> ('a -> 'a -> bool) -> (('a, 'a) pfixpoint -> ('a, 'a) pfixpoint -> bool)
+  val equal : env -> ('a -> 'a -> bool) -> (('a, 'a, ERelevance.t) pfixpoint -> ('a, 'a, ERelevance.t) pfixpoint -> bool)
     -> ('a case_stk -> 'a case_stk -> bool) -> 'a t -> 'a t -> bool
   val strip_app : 'a t -> 'a t * 'a t
   val strip_n_app : int -> 'a t -> ('a t * 'a * 'a t) option
@@ -162,15 +162,15 @@ struct
 
   type cst_member =
     | Cst_const of pconstant
-    | Cst_proj of Projection.t * Sorts.relevance
+    | Cst_proj of Projection.t * ERelevance.t
 
   type 'a case_stk =
-    case_info * EInstance.t * 'a array * 'a pcase_return * 'a pcase_invert * 'a pcase_branch array
+    case_info * EInstance.t * 'a array * ('a,ERelevance.t) pcase_return * 'a pcase_invert * ('a,ERelevance.t) pcase_branch array
   type 'a member =
   | App of 'a app_node
   | Case of 'a case_stk * Cst_stack.t
-  | Proj of Projection.t * Sorts.relevance * Cst_stack.t
-  | Fix of ('a, 'a) pfixpoint * 'a t * Cst_stack.t
+  | Proj of Projection.t * ERelevance.t * Cst_stack.t
+  | Fix of ('a, 'a, ERelevance.t) pfixpoint * 'a t * Cst_stack.t
   | Primitive of CPrimitives.t * (Constant.t * EInstance.t) * 'a t * CPrimitives.args_red * Cst_stack.t
   | Cst of { const : cst_member;
              curr : int;

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -467,7 +467,7 @@ module Search = struct
     let eq c1 c2 = EConstr.eq_constr sigma c1 c2 in
     if DirPath.equal cwd dir &&
          (onlyc == only_classes) &&
-           Context.Named.equal eq sign sign' &&
+           Context.Named.equal (ERelevance.equal sigma) eq sign sign' &&
              cached_modes == modes
     then cached_hints
     else
@@ -731,7 +731,7 @@ module Search = struct
         in
         let eq c1 c2 = EConstr.eq_constr sigma' c1 c2 in
         let hints' =
-          if b && not (Context.Named.equal eq (Goal.hyps gl') (Goal.hyps gl))
+          if b && not (Context.Named.equal (ERelevance.equal sigma) eq (Goal.hyps gl') (Goal.hyps gl))
           then
             let st = Hint_db.transparent_state info.search_hints in
             let modes = Hint_db.modes info.search_hints in

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -34,7 +34,7 @@ let absurd c =
     let j = Retyping.get_judgment_of env sigma c in
     let sigma, j = Coercion.inh_coerce_to_sort env sigma j in
     let t = nf_betaiota env sigma j.Environ.utj_val in
-    let r = ESorts.relevance_of_sort sigma j.Environ.utj_type in
+    let r = ESorts.relevance_of_sort j.Environ.utj_type in
     Proofview.Unsafe.tclEVARS sigma <*>
     Tactics.exfalso <*> mk_absurd_proof env r t
   end

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -138,8 +138,8 @@ let mkGenDecideEqGoal rectype ops g =
   let hypnames = pf_ids_set_of_hyps g in
   let xname    = next_ident_away idx hypnames in
   let yname    = next_ident_away idy (Id.Set.add xname hypnames) in
-  (mkNamedProd sigma (make_annot xname Sorts.Relevant) rectype
-     (mkNamedProd sigma (make_annot yname Sorts.Relevant) rectype
+  (mkNamedProd sigma (make_annot xname ERelevance.relevant) rectype
+     (mkNamedProd sigma (make_annot yname ERelevance.relevant) rectype
         (mkDecideEqGoal true ops
           rectype (mkVar xname) (mkVar yname))))
 

--- a/tactics/generalize.ml
+++ b/tactics/generalize.ml
@@ -338,15 +338,15 @@ let make_abstract_generalize env id typ concl dep ctx body c eqs args refls =
       let homogeneous = Reductionops.is_conv env sigma ty typ in
       let sigma, (eq, refl) =
         mk_term_eq homogeneous (push_rel_context ctx env) sigma ty (mkRel 1) typ (mkVar id) in
-      sigma, mkProd (make_annot Anonymous Sorts.Relevant, eq, lift 1 concl), [| refl |]
+      sigma, mkProd (make_annot Anonymous ERelevance.relevant, eq, lift 1 concl), [| refl |]
     else sigma, concl, [||]
   in
     (* Abstract by equalities *)
   let eqs = lift_togethern 1 eqs in (* lift together and past genarg *)
   let abseqs = it_mkProd_or_LetIn (lift eqslen abshypeq)
-      (List.map (fun x -> LocalAssum (make_annot Anonymous Sorts.Relevant, x)) eqs)
+      (List.map (fun x -> LocalAssum (make_annot Anonymous ERelevance.relevant, x)) eqs)
   in
-  let r = Sorts.Relevant in (* TODO relevance *)
+  let r = ERelevance.relevant in (* TODO relevance *)
   let decl = match body with
     | None -> LocalAssum (make_annot (Name id) r, c)
     | Some body -> LocalDef (make_annot (Name id) r, body, c)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1496,7 +1496,7 @@ let prepare_hint env init (sigma,c) =
       let id = next_ident_away_from default_prepare_hint_ident (fun id -> Id.Set.mem id !vars) in
       vars := Id.Set.add id !vars;
       subst := (evar,mkVar id)::!subst;
-      mkNamedLambda sigma (make_annot id Sorts.Relevant) t (iter (replace_term sigma evar (mkVar id) c)) in
+      mkNamedLambda sigma (make_annot id ERelevance.relevant) t (iter (replace_term sigma evar (mkVar id) c)) in
   let c' = iter c in
     let diff = UnivGen.diff_sort_context (Evd.sort_context_set sigma) (Evd.sort_context_set init) in
     (c', diff)

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -24,7 +24,7 @@ val decompose_app_bound : evar_map -> constr -> GlobRef.t * constr array
 
 type debug = Debug | Info | Off
 
-val secvars_of_hyps : ('c, 't) Context.Named.pt -> Id.Pred.t
+val secvars_of_hyps : ('c, 't,'r) Context.Named.pt -> Id.Pred.t
 
 val empty_hint_info : 'a Typeclasses.hint_info_gen
 

--- a/tactics/hipattern.mli
+++ b/tactics/hipattern.mli
@@ -86,7 +86,7 @@ val is_equality_type       : testing_function
 val match_with_nottype     : (constr * constr) matching_function
 val is_nottype             : testing_function
 
-val match_with_forall_term    : (Name.t Context.binder_annot * constr * constr) matching_function
+val match_with_forall_term    : (Name.t EConstr.binder_annot * constr * constr) matching_function
 val is_forall_term            : testing_function
 
 val match_with_imp_term    : (constr * constr) matching_function

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -218,7 +218,7 @@ let insert_before decls lasthyp env =
   | Some id ->
   Environ.fold_named_context
     (fun _ d env ->
-      let d = map_named_decl EConstr.of_constr d in
+      let d = EConstr.of_named_decl d in
       let env = if Id.equal id (NamedDecl.get_id d) then push_named_context decls env else env in
       push_named d env)
     ~init:(reset_context env) env
@@ -252,10 +252,10 @@ let mkletin_goal env sigma with_eq dep (id,lastlhyp,ccl,c) ty =
       let sigma, eq = Typing.checked_applist env sigma eq [t] in
       let eq = applist (eq,args) in
       let refl = applist (refl, [t;mkVar id]) in
-      let newenv = insert_before [LocalAssum (make_annot heq Sorts.Relevant,eq); decl] lastlhyp env in
+      let newenv = insert_before [LocalAssum (make_annot heq ERelevance.relevant,eq); decl] lastlhyp env in
       let (sigma, x) = new_evar newenv sigma ~principal:true ccl in
       (sigma, mkNamedLetIn sigma (make_annot id r) c t
-         (mkNamedLetIn sigma (make_annot heq Sorts.Relevant) refl eq x))
+         (mkNamedLetIn sigma (make_annot heq ERelevance.relevant) refl eq x))
   | None ->
       let newenv = insert_before [decl] lastlhyp env in
       let (sigma, x) = new_evar newenv sigma ~principal:true ccl in
@@ -590,7 +590,7 @@ let cook_sign hyp0_opt inhyps indvars env sigma =
   let before = ref true in
   let maindep = ref false in
   let seek_deps env decl rhyp =
-    let decl = map_named_decl EConstr.of_constr decl in
+    let decl = EConstr.of_named_decl decl in
     let hyp = NamedDecl.get_id decl in
     if (match hyp0_opt with Some hyp0 -> Id.equal hyp hyp0 | _ -> false)
     then begin

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -339,7 +339,7 @@ end) = struct
   let unfold_impl n sigma t =
     match EConstr.kind sigma t with
     | App (arrow, [| a; b |])(*  when eq_constr arrow (Lazy.force impl) *) ->
-      mkProd (make_annot n Sorts.Relevant, a, lift 1 b)
+      mkProd (make_annot n ERelevance.relevant, a, lift 1 b)
     | _ -> assert false
 
   let unfold_all sigma t =
@@ -365,7 +365,7 @@ end) = struct
         (app_poly env evd arrow [| a; b |]), unfold_impl n
         (* (evd, mkProd (Anonymous, a, b)), (fun x -> x) *)
       else if bp then (* Dummy forall *)
-        (app_poly env evd coq_all [| a; mkLambda (make_annot n Sorts.Relevant, a, lift 1 b) |]), unfold_forall
+        (app_poly env evd coq_all [| a; mkLambda (make_annot n ERelevance.relevant, a, lift 1 b) |]), unfold_forall
       else (* None in Prop, use arrow *)
         (app_poly env evd arrow [| a; b |]), unfold_impl n
 
@@ -404,8 +404,8 @@ end) = struct
       app_poly env evars pointwise_relation [| t; lift (-1) car; lift (-1) rel |]
     else
       app_poly env evars forall_relation
-        [| t; mkLambda (make_annot n Sorts.Relevant, t, car);
-           mkLambda (make_annot n Sorts.Relevant, t, rel) |]
+        [| t; mkLambda (make_annot n ERelevance.relevant, t, car);
+           mkLambda (make_annot n ERelevance.relevant, t, rel) |]
 
   let lift_cstr env evars (args : constr list) c ty cstr =
     let start evars env car =
@@ -827,7 +827,7 @@ let resolve_morphism env m args args' (b,cstr) evars =
     let _, dosub = app_poly_sort b env evars dosub [||] in
     let _, appsub = app_poly_nocheck env evars appsub [||] in
     let dosub_id = Id.of_string "do_subrelation" in
-    let env' = EConstr.push_named (LocalDef (make_annot dosub_id Sorts.Relevant, dosub, appsub)) env in
+    let env' = EConstr.push_named (LocalDef (make_annot dosub_id ERelevance.relevant, dosub, appsub)) env in
     let evars, morph = new_cstr_evar evars env' app in
     (* Replace the free [dosub_id] in the evar by the global reference *)
     let morph = Vars.replace_vars (fst evars) [dosub_id , dosub] morph in
@@ -923,7 +923,7 @@ let make_leibniz_proof env c ty r =
         let prf =
           e_app_poly env evars coq_f_equal
                 [| r.rew_car; ty;
-                   mkLambda (make_annot Anonymous Sorts.Relevant, r.rew_car, c);
+                   mkLambda (make_annot Anonymous ERelevance.relevant, r.rew_car, c);
                    r.rew_from; r.rew_to; prf |]
         in RewPrf (rel, prf)
     | RewCast k -> r.rew_prf
@@ -1517,7 +1517,7 @@ let cl_rewrite_clause_aux ?(abs=None) strat env avoid sigma concl is_hyp : resul
           match abs with
           | None -> p
           | Some (t, ty) ->
-            mkApp (mkLambda (make_annot (Name (Id.of_string "lemma")) Sorts.Relevant, ty, p), [| t |])
+            mkApp (mkLambda (make_annot (Name (Id.of_string "lemma")) ERelevance.relevant, ty, p), [| t |])
         in
         let proof = match is_hyp with
           | None -> term
@@ -1564,7 +1564,7 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
             tclTHENFIRST (assert_replacing id newt tac) (beta_hyp id)
         | Some id, None ->
             Proofview.Unsafe.tclEVARS undef <*>
-            convert_hyp ~check:false ~reorder:false (LocalAssum (make_annot id Sorts.Relevant, newt)) <*>
+            convert_hyp ~check:false ~reorder:false (LocalAssum (make_annot id ERelevance.relevant, newt)) <*>
             beta_hyp id
         | None, Some p ->
             Proofview.Unsafe.tclEVARS undef <*>

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -735,7 +735,7 @@ let build_beq_scheme env handle kn =
     (* do the [| C1 ... =>  match Y with ... end
                ...
                Cn => match Y with ... end |]  part *)
-    let rci = Sorts.Relevant in (* returning a boolean, hence relevant *)
+    let rci = EConstr.ERelevance.relevant in (* returning a boolean, hence relevant *)
     let open Inductiveops in
     let constrs =
       let params = Context.Rel.instance_list EConstr.mkRel 0 params_ctx in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -466,7 +466,7 @@ let do_instance_type_ctx_instance props k env' ctx' sigma ~program_mode subst =
   | (n, _) :: _ ->
     unbound_method env' sigma k.cl_impl (get_id n)
   | _ ->
-    let kcl_props = List.map (Termops.map_rel_decl of_constr) k.cl_props in
+    let kcl_props = of_rel_context k.cl_props in
     let sigma, res =
       type_ctx_instance ~program_mode
         (push_rel_context ctx' env') sigma kcl_props props subst in
@@ -546,7 +546,7 @@ let interp_instance_context ~program_mode env ctx pl tclass =
   let u_s = EInstance.kind sigma u in
   let cl = Typeclasses.typeclass_univ_instance (k, u_s) in
   let args = List.map of_constr args in
-  let cl_context = List.map (Termops.map_rel_decl of_constr) cl.cl_context in
+  let cl_context = of_rel_context cl.cl_context in
   let _, args =
     List.fold_right (fun decl (args, args') ->
         match decl with

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -188,8 +188,9 @@ let interp_context_gen ~program_mode ~kind ~share ~autoimp_enable ~coercions env
   let sigma, (ienv, ((env, ctx), impls)) = interp_named_context_evars ~program_mode ~share ~autoimp_enable env sigma l in
   (* Note, we must use the normalized evar from now on! *)
   let sigma = solve_remaining_evars all_and_fail_flags env sigma in
-  let sigma, ctx = Evarutil.finalize
-      sigma (fun nf -> List.map (NamedDecl.map_constr_het nf) ctx) in
+  let sigma, ctx = Evarutil.finalize sigma @@ fun nf ->
+    List.map (NamedDecl.map_constr_het (fun x -> x) nf) ctx
+  in
   (* reorder, evar-normalize and add implicit status *)
   let ctx = List.rev_map (fun d ->
       let {binder_name=id}, b, t = NamedDecl.to_tuple d in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -165,14 +165,14 @@ let compute_possible_guardness_evidences (ctx,_,recindex) =
          fixpoints ?) *)
       List.interval 0 (Context.Rel.nhyps ctx - 1)
 
-type ('constr, 'types) recursive_preentry =
-  Id.t list * Sorts.relevance list * 'constr option list * 'types list
+type ('constr, 'types, 'r) recursive_preentry =
+  Id.t list * 'r list * 'constr option list * 'types list
 
 (* Wellfounded definition *)
 
 let fix_proto sigma =
   Evd.fresh_global (Global.env ()) sigma (Coqlib.lib_ref "program.tactic.fix_proto")
-let fix_proto_relevance = Sorts.Relevant
+let fix_proto_relevance = EConstr.ERelevance.relevant
 (* Would probably be overkill to use a specific fix_proto in SProp when in SProp?? *)
 
 let interp_recursive env ~program_mode ~cofix (fixl : 'a Vernacexpr.fix_expr_gen list) =
@@ -241,14 +241,14 @@ let check_recursive ~isfix env evd (fixnames,_,fixdefs,_) =
 
 let ground_fixpoint env evd (fixnames,fixrs,fixdefs,fixtypes) =
   Pretyping.check_evars_are_solved ~program_mode:false env evd;
-  let fixrs = List.map (fun r -> Evarutil.nf_relevance evd r) fixrs in
+  let fixrs = List.map (fun r -> EConstr.ERelevance.kind evd r) fixrs in
   let fixdefs = List.map (fun c -> Option.map EConstr.(to_constr evd) c) fixdefs in
   let fixtypes = List.map EConstr.(to_constr evd) fixtypes in
   Evd.evar_universe_context evd, (fixnames,fixrs,fixdefs,fixtypes)
 
 (* XXX: Unify with interp_recursive  *)
 let interp_fixpoint ?(check_recursivity=true) ?typing_flags ~cofix l :
-  ( (Constr.t, Constr.types) recursive_preentry *
+  ( (Constr.t, Constr.types, Sorts.relevance) recursive_preentry *
     UState.universe_decl * UState.t *
     (EConstr.rel_context * Impargs.manual_implicits * int option) list) =
   let env = Global.env () in

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -66,7 +66,7 @@ val adjust_rec_order
   -> lident option
 
 (** names / relevance / defs / types *)
-type ('constr, 'types) recursive_preentry = Id.t list * Sorts.relevance list * 'constr option list * 'types list
+type ('constr, 'types, 'r) recursive_preentry = Id.t list * 'r list * 'constr option list * 'types list
 
 (** Exported for Program *)
 val interp_recursive :
@@ -78,7 +78,7 @@ val interp_recursive :
   (* env / signature / univs / evar_map *)
   (Environ.env * EConstr.named_context * UState.universe_decl * Evd.evar_map) *
   (* names / defs / types *)
-  (EConstr.t, EConstr.types) recursive_preentry *
+  (EConstr.t, EConstr.types, EConstr.ERelevance.t) recursive_preentry *
   (* ctx per mutual def / implicits / struct annotations *)
   (EConstr.rel_context * Impargs.manual_implicits * int option) list
 
@@ -89,10 +89,10 @@ val interp_fixpoint
   -> ?typing_flags:Declarations.typing_flags
   -> cofix:bool
   -> lident option fix_expr_gen list
-  -> (Constr.t, Constr.types) recursive_preentry *
+  -> (Constr.t, Constr.types, Sorts.relevance) recursive_preentry *
      UState.universe_decl * UState.t *
      (EConstr.rel_context * Impargs.manual_implicits * int option) list
 
 (** Very private function, do not use *)
 val compute_possible_guardness_evidences :
-  ('a, 'b) Context.Rel.pt * 'c * int option -> int list
+  ('a, 'b, 'r) Context.Rel.pt * 'c * int option -> int list

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -41,8 +41,8 @@ let project_hint ~poly pri l2r r =
     it_mkLambda_or_LetIn
       (mkApp
          ( p
-         , [| mkArrow a Sorts.Relevant (Vars.lift 1 b)
-            ; mkArrow b Sorts.Relevant (Vars.lift 1 a)
+         , [| mkArrow a ERelevance.relevant (Vars.lift 1 b)
+            ; mkArrow b ERelevance.relevant (Vars.lift 1 a)
             ; c |] ))
       sign
   in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -138,7 +138,7 @@ let pretype_ind_arity env sigma (loc, c, impls, template_syntax) =
   | exception Reduction.NotArity ->
     user_err ?loc (str "Not an arity")
   | s ->
-    sigma, (t, Retyping.relevance_of_sort sigma s, template_syntax, impls)
+    sigma, (t, Retyping.relevance_of_sort s, template_syntax, impls)
 
 (* ind_rel is the Rel for this inductive in the context without params.
    n is how many arguments there are in the constructor. *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -81,7 +81,7 @@ val interp_mutual_inductive_constr
   -> template:bool option
   -> udecl:UState.universe_decl
   -> variances:Entries.variance_entry
-  -> ctx_params:(EConstr.t, EConstr.t) Context.Rel.Declaration.pt list
+  -> ctx_params:EConstr.rel_context
   -> indnames:Names.Id.t list
   -> arities:EConstr.t list
   -> template_syntax:syntax_allows_template_poly list
@@ -100,7 +100,7 @@ val interp_mutual_inductive_constr
 
 val compute_template_inductive
   : user_template:bool option
-  -> ctx_params:(Constr.constr, Constr.constr) Context.Rel.Declaration.pt list
+  -> ctx_params:Constr.rel_context
   -> univ_entry:UState.universes_entry
   -> Entries.one_inductive_entry
   -> syntax_allows_template_poly

--- a/vernac/comRewriteRule.ml
+++ b/vernac/comRewriteRule.ml
@@ -238,7 +238,7 @@ let rec safe_pattern_of_constr_aux ~loc env evd usubst depth state t = Constr.ki
       state, (head, [])
 
 and safe_pattern_of_constr ~loc env evd usubst depth state t =
-  begin match Retyping.relevance_of_term env evd (EConstr.of_constr t) with
+  begin match EConstr.ERelevance.kind evd @@ Retyping.relevance_of_term env evd (EConstr.of_constr t) with
   | Sorts.Irrelevant -> warn_irrelevant_pattern ?loc ()
   | Sorts.RelevanceVar _ -> () (* FIXME *)
   | Sorts.Relevant -> ()

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1263,6 +1263,7 @@ let declare_mutual_definition ~pm l =
     in
     let term = EConstr.to_constr sigma term in
     let typ = EConstr.to_constr sigma typ in
+    let r = EConstr.ERelevance.kind sigma r in
     let def = (x.prg_reduce term, r, x.prg_reduce typ, x.prg_cinfo.CInfo.impargs, x.prg_cinfo.CInfo.using) in
     let oblsubst = List.map (fun (id, (_, c)) -> (id, c)) oblsubst in
     (def, oblsubst)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -328,7 +328,7 @@ let explain_ill_formed_branch env sigma c ci actty expty =
 let explain_generalization env sigma (name,var) j =
   let pe = pr_ne_context_of (str "In environment") env sigma in
   let pv = pr_letype_env env sigma var in
-  let (pc,pt) = pr_ljudge_env (push_rel_assum (make_annot name Sorts.Relevant,var) env) sigma j in
+  let (pc,pt) = pr_ljudge_env (push_rel_assum (make_annot name EConstr.ERelevance.relevant,var) env) sigma j in
   pe ++ str "Cannot generalize" ++ brk(1,1) ++ pv ++ spc () ++
   str "over" ++ brk(1,1) ++ pc ++ str "," ++ spc () ++
   str "it has type" ++ spc () ++ pt ++
@@ -820,7 +820,7 @@ let explain_disallowed_sprop () =
       ++ strbrk " flag is off.")
 
 let pr_relevance sigma r =
-  let r = Evarutil.nf_relevance sigma r in
+  let r = EConstr.ERelevance.kind sigma r in
   match r with
   | Sorts.Relevant -> str "relevant"
   | Sorts.Irrelevant -> str "irrelevant"
@@ -852,8 +852,8 @@ let explain_bad_relevance env sigma = function
   | BadRelevanceBinder (r,d) -> explain_bad_binder_relevance env sigma r d
 
 let ecast_bad_relevance = let open Typeops in function
-  | BadRelevanceCase (r,c) -> BadRelevanceCase (r, EConstr.of_constr c)
-  | BadRelevanceBinder (r,d) -> BadRelevanceBinder (r, RelDecl.map_constr_het EConstr.of_constr d)
+  | BadRelevanceCase (r,c) -> BadRelevanceCase (EConstr.ERelevance.make r, EConstr.of_constr c)
+  | BadRelevanceBinder (r,d) -> BadRelevanceBinder (EConstr.ERelevance.make r, EConstr.of_rel_decl d)
 
 let () =
   CWarnings.register_printer Typeops.bad_relevance_msg
@@ -1541,7 +1541,7 @@ let explain_pattern_matching_error env sigma = function
 
 let explain_reduction_tactic_error = function
   | Tacred.InvalidAbstraction (env,sigma,c,(env',e)) ->
-      let e = map_ptype_error EConstr.of_constr e in
+      let e = of_type_error e in
       str "The abstracted term" ++ spc () ++
       quote (pr_letype_env ~goal_concl_style:true env sigma c) ++
       spc () ++ str "is not well typed." ++ fnl () ++
@@ -1597,7 +1597,7 @@ let rec vernac_interp_error_handler = function
       UnivNames.pr_level_with_global_universes
       i ++ str "."
   | TypeError(env,te) ->
-    let te = map_ptype_error EConstr.of_constr te in
+    let te = of_type_error te in
     explain_type_error env (Evd.from_env env) te
   | PretypeError(ctx,sigma,te) ->
     explain_pretype_error ctx sigma te

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -222,7 +222,7 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
     List.fold_left_map (build_type_telescope newps env0) sigma records in
   let typs, aritysorts = List.split typs in
   let arities = List.map (fun typ -> EConstr.it_mkProd_or_LetIn typ newps) typs in
-  let relevances = List.map (fun s -> EConstr.ESorts.relevance_of_sort sigma s) aritysorts in
+  let relevances = List.map (fun s -> EConstr.ESorts.relevance_of_sort s) aritysorts in
   let fold accu { DataI.name; _ } arity r =
     EConstr.push_rel (LocalAssum (make_annot (Name name) r,arity)) accu in
   let env_ar = EConstr.push_rel_context newps (List.fold_left3 fold env0 records arities relevances) in
@@ -259,8 +259,8 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
       uvars := Univ.Level.Set.union !uvars varsc;
       c
     in
-    let nf_rel r = Evarutil.nf_relevance sigma r in
-    let map_decl = RelDecl.map_constr_het_with_relevance nf_rel nf in
+    let nf_rel r = EConstr.ERelevance.kind sigma r in
+    let map_decl = RelDecl.map_constr_het nf_rel nf in
     let newps = List.map map_decl newps in
     let map (implfs, fields) (default_dep_elim, typ) =
       let fields = List.map map_decl fields in
@@ -327,7 +327,7 @@ let warning_or_error ~info flags indsp err =
           | None ->
             (Id.print fi ++ str " cannot be defined because it is not typable:" ++ spc() ++
              Himsg.explain_type_error env (Evd.from_env env)
-               (Type_errors.map_ptype_error EConstr.of_constr te))
+               (Pretype_errors.of_type_error te))
   in
   if flags.Data.pf_coercion || flags.Data.pf_instance then user_err ~info st;
   warn_cannot_define_projection (hov 0 st)

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -139,11 +139,11 @@ let etype_of_evar evm evs hyps concl =
       | LocalDef (id, c, _) ->
         let c', s'', trans'' = subst_evar_constr evm evs n EConstr.mkVar c in
         let c' = subst_vars acc 0 c' in
-        ( Term.mkNamedProd_or_LetIn (LocalDef (id, c', t'')) rest
+        ( Term.mkNamedProd_or_LetIn (LocalDef (EConstr.Unsafe.to_binder_annot id, c', t'')) rest
         , Int.Set.union s'' s'
         , Id.Set.union trans'' trans' )
       | LocalAssum (id, _) ->
-        (Term.mkNamedProd_or_LetIn (LocalAssum (id, t'')) rest, s', trans') )
+        (Term.mkNamedProd_or_LetIn (LocalAssum (EConstr.Unsafe.to_binder_annot id, t'')) rest, s', trans') )
     | [] ->
       let t', s, trans = subst_evar_constr evm evs n EConstr.mkVar concl in
       (subst_vars acc 0 t', s, trans)


### PR DESCRIPTION
Overlays:
- https://github.com/coq-community/aac-tactics/pull/139
- https://github.com/coq-community/atbr/pull/43
- https://github.com/damien-pous/coinduction/pull/20
- https://github.com/lukaszcz/coqhammer/pull/178
- https://github.com/LPCIC/coq-elpi/pull/621
- https://github.com/mattam82/Coq-Equations/pull/591
- https://gitlab.inria.fr/fbesson/itauto/-/merge_requests/15
- https://github.com/SkySkimmer/coq-lean-import/pull/19
- https://github.com/Mtac2/Mtac2/pull/402
- https://github.com/unicoq/unicoq/pull/92
- https://github.com/coq-community/paramcoq/pull/123
- https://github.com/ejgallego/coq-serapi/pull/405
- https://github.com/smtcoq/smtcoq/pull/142
- https://github.com/coq-community/stalmarck/pull/31
- https://github.com/coq-tactician/coq-tactician/pull/81
- https://github.com/impermeable/coq-waterproof/pull/53
- https://github.com/MetaCoq/metacoq/pull/1080
- https://github.com/damien-pous/relation-algebra/pull/43