### PR TITLE
[unification] Experiment: add a flag to configure conversion on heads found by FO approximation

### DIFF
--- a/dev/ci/user-overlays/18939-SkySkimmer-unification-fo-function-conversion.sh
+++ b/dev/ci/user-overlays/18939-SkySkimmer-unification-fo-function-conversion.sh
@@ -1,0 +1,1 @@
+overlay bignums https://github.com/SkySkimmer/bignums unification-fo-function-conversion 18939

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -580,8 +580,11 @@ type unirec_flags = {
   with_cs : bool;
 }
 
+let subterm_restriction opt flags =
+  not opt.at_top && flags.restrict_conv_on_strict_subterms
+
 let disallow_conversion opt flags =
-  not opt.with_conv || not opt.at_top && flags.restrict_conv_on_strict_subterms
+  not opt.with_conv || subterm_restriction opt flags
 
 let key_of env sigma b flags f =
   if disallow_conversion b flags then None else
@@ -1112,7 +1115,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
 
   and reduce curenvnb pb opt substn cM cN =
     let sigma = substn.subst_sigma in
-    if flags.modulo_betaiota && not (disallow_conversion opt flags) then
+    if flags.modulo_betaiota && not (subterm_restriction opt flags) then
       let cM' = do_reduce flags.modulo_delta curenvnb sigma cM in
         if not (EConstr.eq_constr sigma cM cM') then
           unirec_rec curenvnb pb opt substn cM' cN

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -69,7 +69,7 @@ let { Goptions.get = is_keyed_unification } =
 let { Goptions.get = firstorder_function_conversion } =
   Goptions.declare_bool_option_and_ref
     ~key:["Unification";"Firstorder";"Function";"Conversion"]
-    ~value:true
+    ~value:false
     ()
 
 let debug_tactic_unification = CDebug.create ~name:"tactic-unification" ()

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -23,6 +23,7 @@ type core_unify_flags = {
   use_meta_bound_pattern_unification : bool;
   allowed_evars : Evarsolve.AllowedEvars.t;
   restrict_conv_on_strict_subterms : bool;
+  firstorder_function_conversion : bool;
   modulo_betaiota : bool;
   modulo_eta : bool;
 }
@@ -45,6 +46,8 @@ val elim_flags : unit -> unify_flags
 val elim_no_delta_flags : unit -> unify_flags
 
 val is_keyed_unification : unit -> bool
+
+val firstorder_function_conversion : unit -> bool
 
 (** The "unique" unification function *)
 val w_unify :

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -957,6 +957,7 @@ let fail_quick_core_unif_flags = {
   use_meta_bound_pattern_unification = true; (* ? *)
   allowed_evars = Evarsolve.AllowedEvars.all;
   restrict_conv_on_strict_subterms = false; (* ? *)
+  firstorder_function_conversion = Unification.firstorder_function_conversion ();
   modulo_betaiota = false;
   modulo_eta = true;
 }

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -44,6 +44,7 @@ let auto_core_unif_flags_of st1 st2 = {
   use_meta_bound_pattern_unification = true;
   allowed_evars = Evarsolve.AllowedEvars.all;
   restrict_conv_on_strict_subterms = false; (* Compat *)
+  firstorder_function_conversion = Unification.firstorder_function_conversion ();
   modulo_betaiota = false;
   modulo_eta = true;
 }

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -136,6 +136,7 @@ let auto_core_unif_flags st allowed_evars = {
   use_meta_bound_pattern_unification = true;
   allowed_evars;
   restrict_conv_on_strict_subterms = false; (* ? *)
+  firstorder_function_conversion = Unification.firstorder_function_conversion ();
   modulo_betaiota = true;
   modulo_eta = false;
 }

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -98,6 +98,7 @@ let rewrite_core_unif_flags = {
   use_meta_bound_pattern_unification = true;
   allowed_evars = Evarsolve.AllowedEvars.all;
   restrict_conv_on_strict_subterms = false;
+  firstorder_function_conversion = Unification.firstorder_function_conversion ();
   modulo_betaiota = false;
   modulo_eta = true;
 }
@@ -162,6 +163,7 @@ let rewrite_conv_closed_core_unif_flags = {
   allowed_evars = Evarsolve.AllowedEvars.all;
 
   restrict_conv_on_strict_subterms = false;
+  firstorder_function_conversion = Unification.firstorder_function_conversion ();
   modulo_betaiota = false;
   modulo_eta = true;
 }
@@ -196,6 +198,8 @@ let rewrite_keyed_core_unif_flags = {
   allowed_evars = Evarsolve.AllowedEvars.all;
 
   restrict_conv_on_strict_subterms = false;
+
+  firstorder_function_conversion = Unification.firstorder_function_conversion (); (* Should really be false *)
   modulo_betaiota = true;
 
   modulo_eta = true;

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -555,6 +555,7 @@ let rewrite_core_unif_flags = {
   Unification.use_meta_bound_pattern_unification = true;
   Unification.allowed_evars = Evarsolve.AllowedEvars.all;
   Unification.restrict_conv_on_strict_subterms = false;
+  Unification.firstorder_function_conversion = Unification.firstorder_function_conversion ();
   Unification.modulo_betaiota = false;
   Unification.modulo_eta = true;
 }

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -795,7 +795,7 @@ Lemma div2_bitwise : forall op n a b,
 Proof.
   intros op n a b; unfold bitwise; fold bitwise.
   destruct (op (odd a) (odd b)).
-  - now rewrite div2_succ_double.
+  - now rewrite add_1_l, div2_succ_double.
   - now rewrite add_0_l, div2_double.
 Qed.
 
@@ -1234,7 +1234,7 @@ Proof. exists 0; reflexivity. Qed.
 Lemma OddT_2 n : OddT n -> OddT (S (S n)).
 Proof.
   intros [m H]; exists (S m).
-  rewrite H, ? mul_succ_r, <- ? add_1_r, add_assoc; reflexivity.
+  rewrite H, ? mul_succ_r, <- 3 add_1_r, add_assoc; reflexivity.
 Qed.
 
 Lemma EvenT_S_OddT n : EvenT (S n) -> OddT n.

--- a/theories/Classes/CEquivalence.v
+++ b/theories/Classes/CEquivalence.v
@@ -126,9 +126,17 @@ Section Respecting.
   Solve Obligations with unfold respecting in * ; simpl_crelation ; program_simpl.
 
   Next Obligation.
+  Proof.
+    intros. unfold respecting. simpl_crelation.
+    unfold respectful in *.
+    program_simpl.
+  Qed.
+
+  Next Obligation.
   Proof. 
     intros. intros f g h H H' x y Rxy.
-    unfold respecting in *. program_simpl. transitivity (g y); auto. firstorder.
+    unfold respecting in *. program_simpl. unfold respectful in *.
+    transitivity (g y); firstorder.
   Qed.
 
 End Respecting.

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -1140,7 +1140,7 @@ Lemma bal_in : forall l x e r y,
  In y (bal l x e r) <-> X.eq y x \/ In y l \/ In y r.
 Proof.
  intros l x e r; induction elt, l, x, e, r, (bal l x e r) using bal_ind; subst; intros; clearf;
- rewrite !create_in; intuition_in.
+ unfold assert_false; rewrite !create_in; intuition_in.
 Qed.
 
 Lemma bal_mapsto : forall l x e r y e',
@@ -1796,7 +1796,7 @@ Lemma equal_cont_IfEq : forall m1 cont e2 l,
   (forall e, IfEq (cont e) l (flatten_e e)) ->
   IfEq (equal_cont cmp m1 cont e2) (elements m1 ++ l) (flatten_e e2).
 Proof.
- induction m1 as [|l1 Hl1 x1 d1 r1 Hr1 h1]; intros; auto.
+ induction m1 as [|l1 Hl1 x1 d1 r1 Hr1 h1]; intros; simpl; auto.
  rewrite <- elements_node; simpl.
  apply Hl1; auto.
  clear e2; intros [|x2 d2 r2 e2].
@@ -2407,7 +2407,7 @@ Module IntMake_ord (I:Int)(X: OrderedType)(D : OrderedType) <:
    (forall e, Cmp (cont e) l (P.flatten_e e)) ->
    Cmp (compare_cont s1 cont e2) (R.elements s1 ++ l) (P.flatten_e e2).
   Proof.
-   induction s1 as [|l1 Hl1 x1 d1 r1 Hr1 h1]; intros; auto.
+   induction s1 as [|l1 Hl1 x1 d1 r1 Hr1 h1]; intros; simpl; auto.
    rewrite <- P.elements_node; simpl.
    apply Hl1; auto. clear e2. intros [|x2 d2 r2 e2].
    - simpl; auto.

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -898,7 +898,7 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   Lemma of_list_2 : forall l, NoDupA eqk l ->
     equivlistA eqke l (to_list (of_list l)).
   Proof.
-  intros l Hnodup (k,e).
+  intros l Hnodup (k,e). unfold to_list.
   rewrite <- elements_mapsto_iff, of_list_1; intuition.
   Qed.
 

--- a/theories/FSets/FSetCompat.v
+++ b/theories/FSets/FSetCompat.v
@@ -293,13 +293,13 @@ Module Update_WSets
   Declare Equivalent Keys In M.In.
 
   Lemma add_spec : In y (add x s) <-> E.eq y x \/ In y s.
-  Proof. intros. rewrite MF.add_iff. intuition. Qed.
+  Proof. intros. unfold In,add. rewrite MF.add_iff. intuition. Qed.
 
   Lemma remove_spec : In y (remove x s) <-> In y s /\ ~E.eq y x.
-  Proof. intros. rewrite MF.remove_iff. intuition. Qed.
+  Proof. intros. unfold In,remove; rewrite MF.remove_iff. intuition. Qed.
 
   Lemma singleton_spec : In y (singleton x) <-> E.eq y x.
-  Proof. intros; rewrite MF.singleton_iff. intuition. Qed.
+  Proof. intros; unfold In, singleton; rewrite MF.singleton_iff. intuition. Qed.
 
   Definition union_spec : In x (union s s') <-> In x s \/ In x s'
    := @MF.union_iff s s' x.

--- a/theories/FSets/FSetPositive.v
+++ b/theories/FSets/FSetPositive.v
@@ -1077,7 +1077,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
     - destruct s' as [|l' o' r'].
       + generalize (Node l o r) as s. simpl. intros. apply choose_empty.
-        rewrite <- equal_spec in H. apply eq_sym in H. rewrite equal_spec in H.
+        rewrite <- equal_spec in H. apply eq_sym in H. unfold eq in H; rewrite equal_spec in H.
         assumption.
 
       + simpl. rewrite <- 2andb_lazy_alt, 2andb_true_iff, eqb_true_iff.

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -570,7 +570,7 @@ Lemma bal_spec : forall l x r y,
  InT y (bal l x r) <-> X.eq y x \/ InT y l \/ InT y r.
 Proof.
  intros l x r; induction l, x, r, (bal l x r) using bal_ind; subst; intros; try clear e0;
- rewrite !create_spec; intuition_in.
+ unfold assert_false; rewrite !create_spec; intuition_in.
 Qed.
 
 #[global]
@@ -644,7 +644,8 @@ Qed.
 Instance join_ok : forall l x r `(Ok l, Ok r, lt_tree x l, gt_tree x r),
  Ok (join l x r).
 Proof.
- join_tac; auto with *; inv; apply bal_ok; auto;
+ (* XXX not sure what's going on here *)
+ join_tac; try solve [auto with *; simpl; auto with *]; inv; apply bal_ok; auto;
  clear Hrl Hlr; intro; intros; rewrite join_spec in *.
  - intuition; [ setoid_replace y with x | ]; eauto.
  - intuition; [ setoid_replace y with x | ]; eauto.

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -992,6 +992,7 @@ Proof.
  - intros s (s1 & s2 & B1 & B2 & E1 & E2 & L).
    assert (eqlistA X.eq (elements s1) (elements s2)).
    + apply SortA_equivlistA_eqlistA with (ltA:=X.lt); auto with *.
+     change (equivlistA X.eq) with L.eq.
      rewrite <- eq_Leq. transitivity s; auto. symmetry; auto.
    + rewrite H in L.
      apply (StrictOrder_Irreflexive (elements s2)); auto.
@@ -1000,6 +1001,7 @@ Proof.
    exists s1', s3'; do 4 (split; trivial).
    assert (eqlistA X.eq (elements s2') (elements s2'')).
    + apply SortA_equivlistA_eqlistA with (ltA:=X.lt); auto with *.
+     change (equivlistA X.eq) with L.eq.
      rewrite <- eq_Leq. transitivity s2; auto. symmetry; auto.
    + transitivity (elements s2'); auto.
      rewrite H; auto.
@@ -1070,7 +1072,7 @@ Lemma compare_cont_Cmp : forall s1 cont e2 l,
  (forall e, Cmp (cont e) l (flatten_e e)) ->
  Cmp (compare_cont s1 cont e2) (elements s1 ++ l) (flatten_e e2).
 Proof.
- induction s1 as [|c1 l1 Hl1 x1 r1 Hr1]; intros; auto.
+ induction s1 as [|c1 l1 Hl1 x1 r1 Hr1]; intros; simpl; auto.
  rewrite elements_node, <- app_assoc; simpl.
  apply Hl1; auto. clear e2. intros [|x2 r2 e2].
  - simpl; auto.

--- a/theories/Numbers/DecimalN.v
+++ b/theories/Numbers/DecimalN.v
@@ -67,6 +67,7 @@ Module Signed.
 Lemma of_to (n:N) : N.of_int (N.to_int n) = Some n.
 Proof.
   unfold N.to_int, N.of_int, norm. f_equal.
+  change Pos.of_uint with N.of_uint.
   rewrite Unsigned.of_uint_norm. apply Unsigned.of_to.
 Qed.
 
@@ -74,7 +75,7 @@ Lemma to_of (d:int)(n:N) : N.of_int d = Some n -> N.to_int n = norm d.
 Proof.
   unfold N.of_int.
   destruct (norm d) eqn:Hd; intros [= <-].
-  unfold N.to_int. rewrite Unsigned.to_of. f_equal.
+  unfold N.to_int. change Pos.of_uint with N.of_uint. rewrite Unsigned.to_of. f_equal.
   revert Hd; destruct d; simpl.
   - intros [= <-]. apply unorm_involutive.
   - destruct (nzhead d); now intros [= <-].

--- a/theories/Numbers/DecimalString.v
+++ b/theories/Numbers/DecimalString.v
@@ -197,6 +197,7 @@ Lemma sus s d :
   uint_of_string s = Some d -> string_of_uint d = s.
 Proof.
   destruct s; [intros [=] | intros H].
+  unfold uint_of_string in H.
   apply NilEmpty.sus in H. now destruct d.
 Qed.
 

--- a/theories/Numbers/HexadecimalN.v
+++ b/theories/Numbers/HexadecimalN.v
@@ -67,6 +67,8 @@ Module Signed.
 Lemma of_to (n:N) : N.of_hex_int (N.to_hex_int n) = Some n.
 Proof.
   unfold N.to_hex_int, N.of_hex_int, norm. f_equal.
+  (* XXX why does "fold N.of_hex_uint" not work here? *)
+  change Pos.of_hex_uint with N.of_hex_uint.
   rewrite Unsigned.of_uint_norm. apply Unsigned.of_to.
 Qed.
 
@@ -74,7 +76,7 @@ Lemma to_of (d:int)(n:N) : N.of_hex_int d = Some n -> N.to_hex_int n = norm d.
 Proof.
   unfold N.of_hex_int.
   destruct (norm d) eqn:Hd; intros [= <-].
-  unfold N.to_hex_int. rewrite Unsigned.to_of. f_equal.
+  unfold N.to_hex_int. change Pos.of_hex_uint with N.of_hex_uint. rewrite Unsigned.to_of. f_equal.
   revert Hd; destruct d; simpl.
   - intros [= <-]. apply unorm_involutive.
   - destruct (nzhead d); now intros [= <-].

--- a/theories/Numbers/HexadecimalString.v
+++ b/theories/Numbers/HexadecimalString.v
@@ -218,7 +218,7 @@ Lemma sus s d :
   uint_of_string s = Some d -> string_of_uint d = s.
 Proof.
   destruct s; [intros [=] | intros H].
-  apply NilEmpty.sus in H. now destruct d.
+  unfold uint_of_string in H; apply NilEmpty.sus in H. now destruct d.
 Qed.
 
 Lemma usu d :

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1527,6 +1527,7 @@ Qed.
 Lemma size_le p : 2^(size p) <= p~0.
 Proof.
  induction p as [p IHp|p IHp|]; simpl; try rewrite pow_succ_r; try easy.
+ change (p~1~0) with (2 * p~1).
  apply mul_le_mono_l.
  apply le_lteq; left. rewrite xI_succ_xO. apply lt_succ_r, IHp.
 Qed.
@@ -1712,7 +1713,8 @@ Lemma sqrtrem_spec p : SqrtSpec (sqrtrem p) p.
 Proof.
 revert p. fix sqrtrem_spec 1.
  intro p; destruct p as [p|p|]; try destruct p; try (constructor; easy);
-  apply sqrtrem_step_spec; auto.
+  simpl; apply sqrtrem_step_spec; auto.
+ (* simpl prevents unification from leaving a raw "fix sqrtrem" *)
 Qed.
 
 Lemma sqrt_spec p :

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -1127,14 +1127,16 @@ Hint Resolve Qopp_le_compat Qopp_lt_compat : qarith.
 Lemma Qle_minus_iff : forall p q, p <= q <-> 0 <= q+-p.
 Proof.
   intros (x1,x2) (y1,y2); unfold Qle; simpl.
-  rewrite Z.mul_1_r, Z.mul_opp_l, <- Z.le_sub_le_add_r, Z.opp_involutive.
+  rewrite Z.mul_1_r, Z.mul_opp_l, <- Z.le_sub_le_add_r.
+  unfold Z.sub. (* we have subterm "0 - - _", this simplifies to "0 + (- - _)" *)
+  rewrite Z.opp_involutive.
   reflexivity.
 Qed.
 
 Lemma Qlt_minus_iff : forall p q, p < q <-> 0 < q+-p.
 Proof.
   intros (x1,x2) (y1,y2); unfold Qlt; simpl.
-  rewrite Z.mul_1_r, Z.mul_opp_l, <- Z.lt_sub_lt_add_r, Z.opp_involutive.
+  rewrite Z.mul_1_r, Z.mul_opp_l, <- Z.lt_sub_lt_add_r; unfold Z.sub; rewrite Z.opp_involutive.
   reflexivity.
 Qed.
 

--- a/theories/Reals/ClassicalConstructiveReals.v
+++ b/theories/Reals/ClassicalConstructiveReals.v
@@ -316,7 +316,14 @@ Definition Rrepr_morphism
 Proof.
   apply (Build_ConstructiveRealsMorphism
            DRealConstructive CRealConstructive Rrepr).
-  - intro q. simpl. unfold IQR. rewrite Rquot2. apply CRealEq_refl.
+  - intro q. simpl. unfold IQR. rewrite Rquot2.
+    Set Printing All.
+    unfold CReq.
+    (* goal is "CReq CRealConstructive q q", which unfolds to "CRle _ q q /\ CRle _ q q"
+       CRle unfolds to "CRlt -> False", CRlt applied to CRealConstructive then unfolds to CRealLt
+       the lemma CRealEq_refl is in terms of CRealLe which unfolds to "CRealLt -> False"
+       thus we cannot do "apply CRealEq_refl" *)
+    apply (CRealEq_refl (inject_Q q)).
   - intros. simpl. simpl in H. rewrite Rlt_def in H.
     apply CRealLtEpsilon in H. exact H.
 Defined.
@@ -326,7 +333,7 @@ Definition Rabst_morphism
 Proof.
   apply (Build_ConstructiveRealsMorphism
            CRealConstructive DRealConstructive Rabst).
-  - intro q. apply Req_constr_refl.
+  - intro q. unfold CReq,CRle. simpl. apply Req_constr_refl.
   - intros. simpl. simpl in H. rewrite Rlt_def.
     apply CRealLtForget. rewrite Rquot2, Rquot2. exact H.
 Defined.

--- a/theories/Reals/Ranalysis1.v
+++ b/theories/Reals/Ranalysis1.v
@@ -149,7 +149,7 @@ Proof.
     intros; apply (limit_mul (fun x:R => a) f (D_x no_cond x0) a (f x0) x0).
   - unfold limit1_in; unfold limit_in; intros; exists 1; split.
     + apply Rlt_0_1.
-    + intros; rewrite Rdist_eq; assumption.
+    + simpl. intros; rewrite Rdist_eq; assumption.
   - assumption.
 Qed.
 
@@ -694,7 +694,7 @@ Proof.
   intros f x l H.
   apply derivable_pt_lim_ext with (f := fun x => (mirr_fct f (- x))).
   - intros; unfold mirr_fct; rewrite Ropp_involutive; reflexivity.
-  - apply derivable_pt_lim_mirr_fwd; exact H.
+  - apply derivable_pt_lim_mirr_fwd in H; exact H.
 Qed.
 
 Lemma derivable_pt_lim_plus :

--- a/theories/Reals/Raxioms.v
+++ b/theories/Reals/Raxioms.v
@@ -473,14 +473,14 @@ Proof.
                         Er Erproper sig_forall_dec sig_not_dec Einhab Ebound).
   exists (Rabst x). split.
   - intros y Ey. apply Rrepr_le. rewrite Rquot2.
-    unfold CRealLe. apply a.
+    unfold CRealLe. unfold CRis_upper_bound in a. simpl in a. apply a.
     unfold Er. replace (Rabst (Rrepr y)) with y.
     + exact Ey.
     + apply Rquot1. rewrite Rquot2. reflexivity.
   - intros. destruct a. apply Rrepr_le. rewrite Rquot2.
-    unfold CRealLe. apply H3. intros y Ey.
+    unfold CRealLe. simpl in H3. apply H3. intros y Ey.
     intros. rewrite <- (Rquot2 y) in H4.
-    apply Rrepr_le in H4.
+    simpl in H4. apply Rrepr_le in H4.
     + exact H4.
     + apply H1, Ey.
 Qed.

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -324,7 +324,8 @@ Module Ascii_as_OT <: UsualOrderedType.
   Definition eq_sym := @eq_sym t.
   Definition eq_trans := @eq_trans t.
 
-  Definition cmp : ascii -> ascii -> comparison := Ascii.compare.
+  Section Cmp.
+  Notation cmp := Ascii.compare.
 
   Lemma cmp_eq (a b : ascii):
     cmp a b = Eq  <->  a = b.
@@ -387,6 +388,9 @@ Module Ascii_as_OT <: UsualOrderedType.
     | Gt => fun E => GT (compare_helper_gt E)
     | Eq => fun E => EQ (compare_helper_eq E)
     end Logic.eq_refl.
+
+  End Cmp.
+  Definition cmp : ascii -> ascii -> comparison := Ascii.compare.
 
   Definition eq_dec (x y : ascii): {x = y} + { ~ (x = y)} := ascii_dec x y.
 End Ascii_as_OT.
@@ -462,7 +466,7 @@ Module String_as_OT <: UsualOrderedType.
     cbn.
     remember (Ascii.compare _ _) as c eqn:Heqc. symmetry in Heqc.
     destruct c; split; try discriminate;
-      try rewrite Ascii_as_OT.cmp_eq in Heqc; try subst;
+      try rewrite Ascii_as_OT.cmp_eq in Heqc; subst;
       try rewrite IHa; intro H.
     { now subst. }
     { now inversion H. }
@@ -478,7 +482,7 @@ Module String_as_OT <: UsualOrderedType.
     cbn. rewrite IHa. clear IHa.
     remember (Ascii.compare _ _) as c eqn:Heqc. symmetry in Heqc.
     destruct c; rewrite Ascii_as_OT.cmp_antisym in Heqc;
-      destruct Ascii_as_OT.cmp; cbn in *; easy.
+      destruct Ascii.compare; cbn in *; easy.
   Qed.
 
   Lemma cmp_lt (a b : string):

--- a/theories/Structures/OrdersAlt.v
+++ b/theories/Structures/OrdersAlt.v
@@ -240,7 +240,7 @@ Module OT_to_Alt (Import O:OrderedType) <: OrderedTypeAlt.
    forall c x y z, (x?=y) = c -> (y?=z) = c -> (x?=z) = c.
  Proof.
  intros c x y z.
- destruct c; unfold compare;
+ destruct c;
   rewrite ?compare_Eq, ?compare_Lt, ?compare_Gt;
   transitivity y; auto.
  Qed.

--- a/theories/micromega/Tauto.v
+++ b/theories/micromega/Tauto.v
@@ -1962,7 +1962,7 @@ Section S.
       + (* pol = true *)
         intros. unfold mk_or in H.
         rewrite eval_cnf_and_opt in H.
-        unfold and_cnf.
+        unfold and_cnf in H.
         rewrite eval_cnf_app in H.
         destruct H as [H0 H1].
         simpl.

--- a/theories/micromega/ZCoeff.v
+++ b/theories/micromega/ZCoeff.v
@@ -143,6 +143,7 @@ Qed.
 Lemma clt_morph : forall x y : Z, (x < y)%Z -> [x] < [y].
 Proof.
 intros x y H.
+unfold gen_order_phi_Z.
 do 2 rewrite (same_genZ (SORsetoid sor) ring_ops_wd (SORrt sor));
 destruct x; destruct y; simpl in *; try discriminate.
 - apply phi_pos1_pos.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -371,7 +371,7 @@ Proof.
   rewrite Zeval_formula_compat'.
   unfold xnnormalise.
   destruct f as [lhs o rhs].
-  destruct o eqn:O ; cbn ; rewrite ?eval_pol_sub;
+  destruct o eqn:O ; cbn ; fold eval_pol; rewrite ?eval_pol_sub;
     rewrite <- !eval_pol_norm ; simpl in *;
       unfold eval_expr;
       generalize (   eval_pexpr  Z.add Z.mul Z.sub Z.opp (fun x : Z => x)
@@ -433,8 +433,8 @@ Lemma xnormalise_correct : forall env f,
     (make_conj (fun x => eval_nformula env x -> False) (xnormalise f)) <-> eval_nformula env f.
 Proof.
   intros env f.
-  destruct f as [e o]; destruct o eqn:Op; cbn - [psub];
-    repeat rewrite eval_pol_sub; fold eval_pol; repeat rewrite eval_pol_Pc;
+  destruct f as [e o]; destruct o eqn:Op; cbn - [psub]; fold eval_pol;
+    repeat rewrite eval_pol_sub; repeat rewrite eval_pol_Pc;
       generalize (eval_pol env e) as x; intro.
   - apply eq_cnf.
   - unfold not. tauto.
@@ -522,8 +522,8 @@ Lemma xnegate_correct : forall env f,
     (make_conj (fun x => eval_nformula env x -> False) (xnegate f)) <-> ~ eval_nformula env f.
 Proof.
   intros env f.
-  destruct f as [e o]; destruct o eqn:Op; cbn - [psub];
-    repeat rewrite eval_pol_sub; fold eval_pol; repeat rewrite eval_pol_Pc;
+  destruct f as [e o]; destruct o eqn:Op; cbn - [psub]; fold eval_pol;
+    repeat rewrite eval_pol_sub; repeat rewrite eval_pol_Pc;
       generalize (eval_pol env e) as x; intro x.
   - tauto.
   - rewrite eq_cnf.
@@ -835,8 +835,11 @@ Lemma Zgcd_pol_correct_lt : forall p env g c, Zgcd_pol p = (g,c) -> 0 < g -> eva
 Proof.
   intros.
   rewrite <- Zdiv_pol_correct ; auto.
-  - rewrite (RingMicromega.PsubC_ok Zsor ZSORaddon).
-    unfold eval_pol. ring.
+  - pose proof (RingMicromega.PsubC_ok Zsor ZSORaddon) as H1.
+    fold eval_pol in H1. simpl in H1.
+    unfold psubC in H1.
+    rewrite H1.
+    ring.
     (**)
   - apply Zgcd_pol_div ; auto.
 Qed.
@@ -1202,6 +1205,7 @@ Proof.
   unfold eval_nformula. unfold RingMicromega.eval_nformula.
   unfold eval_op1.
   intros env e e' c H H0.
+  unfold padd.
   rewrite (RingMicromega.eval_pol_add Zsor ZSORaddon).
   simpl.
   (**)
@@ -1288,6 +1292,7 @@ Proof.
     unfold RingMicromega.eval_nformula in *.
     unfold nformula_of_cutting_plane.
     unfold eval_op1 in *.
+    unfold padd.
     rewrite (RingMicromega.eval_pol_add Zsor ZSORaddon).
     simpl. now rewrite Z.add_0_r.
   - (* Strict *)
@@ -1297,6 +1302,7 @@ Proof.
     inv H1.
     apply (makeCuttingPlane_ns_sound env) with (2:= H).
     simpl in *.
+    change (PsubC Z.sub e 1) with (psubC Z.sub e 1).
     rewrite (RingMicromega.PsubC_ok Zsor ZSORaddon).
     now apply Z.lt_le_pred.
   - (* NonStrict *)
@@ -1709,6 +1715,7 @@ Proof.
            unfold  eval_nformula.
            unfold RingMicromega.eval_nformula.
            simpl.
+           change (PsubC ?x ?y) with (psubC x y).
            rewrite (RingMicromega.PsubC_ok Zsor ZSORaddon).
            unfold eval_pol. ring.
         -- discriminate.

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -122,7 +122,7 @@ Add Zify UnOp Op_Z_abs_nat.
 #[global]
 Instance Op_nat_div2 : UnOp Nat.div2 :=
   { TUOp x := x / 2 ;
-    TUOpInj x := ltac:(now rewrite Nat2Z.inj_div2, Z.div2_div) }.
+    TUOpInj x := ltac:(simpl; now rewrite Nat2Z.inj_div2, Z.div2_div) }.
 Add Zify UnOp Op_nat_div2.
 
 #[global]
@@ -237,7 +237,7 @@ Add Zify UnOp Op_pos_of_succ_nat.
 #[global]
 Instance Op_pos_of_nat : UnOp Pos.of_nat :=
   { TUOp x := Z.max 1 x ;
-    TUOpInj x := ltac: (now destruct x;
+    TUOpInj x := ltac: (simpl; now destruct x;
                         [|rewrite <- Pos.of_nat_succ, <- (Nat2Z.inj_max 1)]) }.
 Add Zify UnOp Op_pos_of_nat.
 
@@ -249,7 +249,7 @@ Add Zify BinOp Op_pos_add.
 #[global]
 Instance Op_pos_add_carry : BinOp Pos.add_carry :=
   { TBOp x y := x + y + 1 ;
-    TBOpInj := ltac:(now intros; rewrite Pos.add_carry_spec, Pos2Z.inj_succ) }.
+    TBOpInj := ltac:(simpl; now intros; rewrite Pos.add_carry_spec, Pos2Z.inj_succ) }.
 Add Zify BinOp Op_pos_add_carry.
 
 #[global]
@@ -429,7 +429,7 @@ Add Zify UnOp Op_N_succ_pos.
 #[global]
 Instance Op_N_div2 : UnOp N.div2 :=
   { TUOp x := x / 2 ;
-    TUOpInj x := ltac:(now rewrite N2Z.inj_div2, Z.div2_div) }.
+    TUOpInj x := ltac:(simpl; now rewrite N2Z.inj_div2, Z.div2_div) }.
 Add Zify UnOp Op_N_div2.
 
 #[global]
@@ -440,7 +440,7 @@ Add Zify BinOp Op_N_pow.
 #[global]
 Instance Op_N_square : UnOp N.square :=
   { TUOp x := x * x ;
-    TUOpInj x := ltac:(now rewrite N.square_spec, N2Z.inj_mul) }.
+    TUOpInj x := ltac:(simpl; now rewrite N.square_spec, N2Z.inj_mul) }.
 Add Zify UnOp Op_N_square.
 
 (** Support for Z - injected to itself *)

--- a/theories/setoid_ring/Ncring_initial.v
+++ b/theories/setoid_ring/Ncring_initial.v
@@ -221,7 +221,8 @@ Global Instance gen_phiZ_morph :
 - apply gen_phiZ_add.
 - intros. rewrite ring_sub_def.
   replace (x-y)%Z with (x + (-y))%Z.
-  + now rewrite gen_phiZ_add, gen_phiZ_opp, ring_sub_def.
+  + unfold bracket,addition,add_notation,opp_notation,opposite.
+    now rewrite gen_phiZ_add, gen_phiZ_opp, ring_sub_def.
   + reflexivity.
 - apply gen_phiZ_mul.
 - apply gen_phiZ_opp.


### PR DESCRIPTION
One can then disallow conversion on the heads (not the arguments) for much faster unification.
This is too crude to use directly, hence just a draft at this point.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.
- https://github.com/coq-community/bignums/pull/93