### PR TITLE
Ltac2 auto-like tactics now take references in the using clause.

### DIFF
--- a/doc/changelog/06-Ltac2-language/18940-ltac2-auto-ref-using.rst
+++ b/doc/changelog/06-Ltac2-language/18940-ltac2-auto-ref-using.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  the using clause argument of :tacn:`auto`-like tactics in Ltac2 now
+  take a global `reference` rather than arbitrary `constr`
+  (`#18940 <https://github.com/coq/coq/pull/18940>`_,
+  by Pierre-Marie Pédrot).

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -573,17 +573,17 @@ let () =
 
 let () =
   define "tac_trivial"
-    (debug @-> list (thunk constr) @-> option (list ident) @-> tac unit)
+    (debug @-> list reference @-> option (list ident) @-> tac unit)
     Tac2tactics.trivial
 
 let () =
   define "tac_eauto"
-    (debug @-> option int @-> list (thunk constr) @-> option (list ident) @-> tac unit)
+    (debug @-> option int @-> list reference @-> option (list ident) @-> tac unit)
     Tac2tactics.eauto
 
 let () =
   define "tac_auto"
-    (debug @-> option int @-> list (thunk constr) @-> option (list ident) @-> tac unit)
+    (debug @-> option int @-> list reference @-> option (list ident) @-> tac unit)
     Tac2tactics.auto
 
 let () =

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -386,18 +386,21 @@ let autorewrite ~all by ids cl =
 
 (** Auto *)
 
+let delayed_of_globref gr = (); fun env sigma ->
+  Evd.fresh_global env sigma gr
+
 let trivial debug lems dbs =
-  let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
+  let lems = List.map delayed_of_globref lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
   Auto.gen_trivial ~debug lems dbs
 
 let auto debug n lems dbs =
-  let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
+  let lems = List.map delayed_of_globref lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
   Auto.gen_auto ~debug n lems dbs
 
 let eauto debug n lems dbs =
-  let lems = List.map (fun c -> delayed_of_thunk Tac2ffi.constr c) lems in
+  let lems = List.map delayed_of_globref lems in
   let dbs = Option.map (fun l -> List.map Id.to_string l) dbs in
   Eauto.gen_eauto ~debug ?depth:n lems dbs
 

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -107,13 +107,13 @@ val injection : evars_flag -> intro_pattern list option -> destruction_arg optio
 
 val autorewrite : all:bool -> unit thunk option -> Id.t list -> clause -> unit tactic
 
-val trivial : Hints.debug -> constr thunk list -> Id.t list option ->
+val trivial : Hints.debug -> GlobRef.t list -> Id.t list option ->
   unit Proofview.tactic
 
-val auto : Hints.debug -> int option -> constr thunk list ->
+val auto : Hints.debug -> int option -> GlobRef.t list ->
   Id.t list option -> unit Proofview.tactic
 
-val eauto : Hints.debug -> int option -> constr thunk list ->
+val eauto : Hints.debug -> int option -> GlobRef.t list ->
   Id.t list option -> unit Proofview.tactic
 
 val typeclasses_eauto : Class_tactics.search_strategy option -> int option ->

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -572,7 +572,7 @@ Ltac2 trivial0 use dbs :=
   Std.trivial Std.Off use dbs.
 
 Ltac2 Notation "trivial"
-  use(opt(seq("using", list1(thunk(constr), ","))))
+  use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := trivial0 use dbs.
 
 Ltac2 Notation trivial := trivial.
@@ -583,7 +583,7 @@ Ltac2 auto0 n use dbs :=
   Std.auto Std.Off n use dbs.
 
 Ltac2 Notation "auto" n(opt(tactic(0)))
-  use(opt(seq("using", list1(thunk(constr), ","))))
+  use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := auto0 n use dbs.
 
 Ltac2 Notation auto := auto.
@@ -594,7 +594,7 @@ Ltac2 eauto0 n use dbs :=
   Std.eauto Std.Off n use dbs.
 
 Ltac2 Notation "eauto" n(opt(tactic(0)))
-  use(opt(seq("using", list1(thunk(constr), ","))))
+  use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := eauto0 n use dbs.
 
 Ltac2 Notation eauto := eauto.

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -255,11 +255,11 @@ Ltac2 Type debug := [ Off | Info | Debug ].
 
 Ltac2 Type strategy := [ BFS | DFS ].
 
-Ltac2 @ external trivial : debug -> (unit -> constr) list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_trivial".
+Ltac2 @ external trivial : debug -> reference list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_trivial".
 
-Ltac2 @ external auto : debug -> int option -> (unit -> constr) list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_auto".
+Ltac2 @ external auto : debug -> int option -> reference list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_auto".
 
-Ltac2 @ external eauto : debug -> int option -> (unit -> constr) list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_eauto".
+Ltac2 @ external eauto : debug -> int option -> reference list -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_eauto".
 
 Ltac2 @ external typeclasses_eauto : strategy option -> int option -> ident list option -> unit := "coq-core.plugins.ltac2" "tac_typeclasses_eauto".
 


### PR DESCRIPTION
I do not think that this feature is used a lot in Ltac2 code so far, so it is better to change it to the most robust behaviour as soon as possible.

Backwards compatible overlays:
- https://github.com/QuickChick/QuickChick/pull/365