### PR TITLE
Improve incomplete proof errors

### DIFF
--- a/doc/changelog/04-tactics/18944-prepare-proof-given-up.rst
+++ b/doc/changelog/04-tactics/18944-prepare-proof-given-up.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  :tacn:`abstract` failing in the presence of admitted goals in the surrounding proof
+  (`#18944 <https://github.com/coq/coq/pull/18944>`_,
+  fixes `#18942 <https://github.com/coq/coq/issues/18942>`_,
+  by Gaëtan Gilbert).

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -76,18 +76,6 @@ val compact : t -> t
 (** [update_sigma_univs] lifts [UState.update_sigma_univs] to the proof *)
 val update_sigma_univs : UGraph.t -> t -> t
 
-(* Returns the proofs (with their type) of the initial goals.
-    Raises [UnfinishedProof] is some goals remain to be considered.
-    Raises [HasShelvedGoals] if some goals are left on the shelf.
-    Raises [HasGivenUpGoals] if some goals have been given up. *)
-type open_error_reason =
-  | UnfinishedProof
-  | HasGivenUpGoals
-
-exception OpenProof of Names.Id.t option * open_error_reason
-
-val return : ?pid:Names.Id.t -> t -> Evd.evar_map
-
 (*** Focusing actions ***)
 
 (* ['a focus_kind] is the type used by focusing and unfocusing
@@ -151,6 +139,9 @@ val unfocus : 'a focus_kind -> t -> unit -> t
 
 (* [unfocused p] returns [true] when [p] is fully unfocused. *)
 val unfocused : t -> bool
+
+(** Unfocus everything (fail if no allowed). *)
+val unfocus_all : t -> t
 
 (* [get_at_focus k] gets the information stored at the closest focus point
     of kind [k].

--- a/test-suite/bugs/bug_18942.v
+++ b/test-suite/bugs/bug_18942.v
@@ -1,0 +1,6 @@
+Lemma foo: True /\ True.
+Proof.
+  split. admit.
+  abstract exact I. (* (in proof foo_subproof): Attempt to save a proof with given up goals. *)
+Fail Qed.
+Abort.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1497,7 +1497,6 @@ module Proof_ending = struct
 end
 
 (* Alias *)
-module Proof_ = Proof
 module Proof = struct
 
 module Proof_info = struct
@@ -1740,31 +1739,71 @@ let { Goptions.get = private_poly_univs } =
 
 let warn_remaining_shelved_goals =
   CWarnings.create ~name:"remaining-shelved-goals" ~category:CWarnings.CoreCategories.tactics
-    (fun () -> Pp.str"The proof has remaining shelved goals")
+    (fun () -> Pp.str"The proof has remaining shelved goals.")
+
+let warn_given_up =
+  CWarnings.create ~name:"remaining-given-up" ~category:CWarnings.CoreCategories.tactics
+    (fun () -> Pp.str"The proof has given up (admitted) goals." )
 
 let warn_remaining_unresolved_evars =
   CWarnings.create ~name:"remaining-unresolved-evars" ~category:CWarnings.CoreCategories.tactics
-    (fun () -> Pp.str"The proof has unresolved variables")
+    (fun () -> Pp.str"The proof has unresolved variables.")
+
+type open_proof_kind =
+  | OpenGoals
+  | NonGroundResult of bool (* true = at least some of the evars in the proof term are given up *)
+
+exception OpenProof of Names.Id.t * open_proof_kind
+
+let () = CErrors.register_handler begin function
+  | OpenProof (pid, reason) ->
+    let open Pp in
+    let ppreason = match reason with
+      | OpenGoals -> str "(there are remaining open goals)"
+      | NonGroundResult has_given_up ->
+        str "(the proof term is not complete" ++
+        (if has_given_up then str " because of given up (admitted) goals" else mt()) ++
+        str ")"
+    in
+    let how_to_admit = match reason with
+      | OpenGoals | NonGroundResult false -> mt()
+      | NonGroundResult true ->
+        fnl() ++ str "If this is really what you want to do, use Admitted in place of Qed."
+    in
+    Some (str " (in proof " ++ Names.Id.print pid ++ str "): " ++
+          str "Attempt to save an incomplete proof" ++ spc() ++ ppreason ++ str "." ++
+          how_to_admit)
+  | _ -> None
+  end
 
 (* XXX: This is still separate from close_proof below due to drop_pt in the STM *)
 let prepare_proof ?(warn_incomplete=true) { proof } =
-  let Proof.{name=pid;entry;poly} = Proof.data proof in
+  let Proof.{name=pid;entry;poly;sigma=evd} = Proof.data proof in
   let initial_goals = Proofview.initial_goals entry in
-  let evd = Proof.return ~pid proof in
-  let () = if warn_incomplete then begin
-    if Evd.has_shelved evd
-    then warn_remaining_shelved_goals ()
-    else if Evd.has_undefined evd then warn_remaining_unresolved_evars ()
-  end
+  let () = if not @@ Proof.is_done proof then raise (OpenProof (pid, OpenGoals)) in
+  let _ : Proof.t =
+    (* checks that we closed all brackets ("}") *)
+    Proof.unfocus_all proof
   in
   let eff = Evd.eval_side_effects evd in
   let evd = Evd.minimize_universes evd in
-  let to_constr_body c =
+  let to_constr c =
     match EConstr.to_constr_opt evd c with
     | Some p ->
       Vars.universes_of_constr p, p
     | None ->
-      CErrors.user_err Pp.(str "Some unresolved existential variables remain")
+      let has_given_up =
+        let exception Found in
+        let rec aux c =
+          let () = match EConstr.kind evd c with
+          | Evar (e,_) -> if Evar.Set.mem e (Evd.given_up evd) then raise Found
+          | _ -> ()
+          in
+          EConstr.iter evd aux c
+        in
+        try aux c; false with Found -> true
+      in
+      raise (OpenProof (pid, NonGroundResult has_given_up))
   in
   (* ppedrot: FIXME, this is surely wrong. There is no reason to duplicate
      side-effects... This may explain why one need to uniquize side-effects
@@ -1778,7 +1817,14 @@ let prepare_proof ?(warn_incomplete=true) { proof } =
      equations and so far there is no code in the CI that will
      actually call those and do a side-effect, TTBOMK *)
   (* EJGA: likely the right solution is to attach side effects to the first constant only? *)
-  let proofs = List.map (fun (_, body, typ) -> (to_constr_body body, eff), to_constr_body typ) initial_goals in
+  let proofs = List.map (fun (_, body, typ) -> (to_constr body, eff), to_constr typ) initial_goals in
+  let () =
+    if warn_incomplete then begin
+      if Evd.has_shelved evd then warn_remaining_shelved_goals ()
+      else if Evd.has_given_up evd then warn_given_up ()
+      else if Evd.has_undefined evd then warn_remaining_unresolved_evars ()
+    end
+  in
   proofs, Evd.evar_universe_context evd
 
 let make_univs_deferred ~poly ~initial_euctx ~uctx ~udecl
@@ -2402,7 +2448,7 @@ let solve_by_tac prg obls i tac =
     let loc = fst obl.obl_location in
     CErrors.user_err ?loc (Lazy.force s)
   (* If the proof is open we absorb the error and leave the obligation open *)
-  | Proof_.OpenProof _ ->
+  | Proof.OpenProof _ ->
     None
   | e when CErrors.noncritical e ->
     let err = CErrors.print e in


### PR DESCRIPTION
The only caller of Proof.return is Declare.Proof.prepare_proof so we move all the checking there and delete Proof.return.

We handle given up goals like remaining shelved or otherwise undefined evars, ie warn instead of error if a ground proof term can be obtained and silently ignore them for non toplevel proof closing (abstract).

Fix #18942