### PR TITLE
Do not rely on floating universes in the upper layers

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1133,8 +1133,8 @@ let univ_entry ~poly evd = UState.univ_entry ~poly evd.universes
 
 let check_univ_decl ~poly evd decl = UState.check_univ_decl ~poly evd.universes decl
 
-let restrict_universe_context evd vars =
-  { evd with universes = UState.restrict evd.universes vars }
+let restrict_universe_context ?lbound evd vars =
+  { evd with universes = UState.restrict ?lbound evd.universes vars }
 
 let universe_subst evd =
   UState.subst evd.universes
@@ -1281,10 +1281,10 @@ let collapse_sort_variables evd =
   let universes = UState.collapse_sort_variables evd.universes in
   { evd with universes }
 
-let minimize_universes evd =
+let minimize_universes ?lbound evd =
   let uctx' = UState.collapse_sort_variables evd.universes in
   let uctx' = UState.normalize_variables uctx' in
-  let uctx' = UState.minimize uctx' in
+  let uctx' = UState.minimize ?lbound uctx' in
   {evd with universes = uctx'}
 
 let universe_of_name evd s = UState.universe_of_name evd.universes s

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -628,7 +628,7 @@ val univ_flexible_alg : rigid
 
 type 'a in_evar_universe_context = 'a * UState.t
 
-val restrict_universe_context : evar_map -> Univ.Level.Set.t -> evar_map
+val restrict_universe_context : ?lbound:UGraph.Bound.t -> evar_map -> Univ.Level.Set.t -> evar_map
 
 (** Raises Not_found if not a name for a universe in this map. *)
 val universe_of_name : evar_map -> Id.t -> Univ.Level.t
@@ -704,7 +704,7 @@ val collapse_sort_variables : evar_map -> evar_map
 val fix_undefined_variables : evar_map -> evar_map
 
 (** Universe minimization *)
-val minimize_universes : evar_map -> evar_map
+val minimize_universes : ?lbound:UGraph.Bound.t -> evar_map -> evar_map
 
 (** Lift [UState.update_sigma_univs] *)
 val update_sigma_univs : UGraph.t -> evar_map -> evar_map

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1128,7 +1128,7 @@ let make_with_initial_binders ~lbound univs binders =
     uctx binders
 
 let from_env ?(binders=[]) env =
-  make_with_initial_binders ~lbound:(Environ.universes_lbound env) (Environ.universes env) binders
+  make_with_initial_binders ~lbound:UGraph.Bound.Set (Environ.universes env) binders
 
 let make_nonalgebraic_variable uctx u =
   { uctx with univ_variables = UnivFlex.make_nonalgebraic_variable uctx.univ_variables u }

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -210,7 +210,6 @@ type t =
    sort_variables : QState.t;
    (** Local quality variables. *)
    universes : UGraph.t; (** The current graph extended with the local constraints *)
-   universes_lbound : UGraph.Bound.t; (** The lower bound on universes (e.g. Set or Prop) *)
    initial_universes : UGraph.t; (** The graph at the creation of the evar_map *)
    minim_extra : UnivMinim.extra;
  }
@@ -222,14 +221,12 @@ let empty =
     univ_variables = UnivFlex.empty;
     sort_variables = QState.empty;
     universes = UGraph.initial_universes;
-    universes_lbound = UGraph.Bound.Set;
     initial_universes = UGraph.initial_universes;
     minim_extra = UnivMinim.empty_extra; }
 
 let make ~lbound univs =
   { empty with
     universes = univs;
-    universes_lbound = lbound;
     initial_universes = univs }
 
 let is_empty uctx =
@@ -263,7 +260,7 @@ let union uctx uctx' =
     let newus = Level.Set.diff newus (UnivFlex.domain uctx.univ_variables) in
     let extra = UnivMinim.extra_union uctx.minim_extra uctx'.minim_extra in
     let declarenew g =
-      Level.Set.fold (fun u g -> UGraph.add_universe u ~lbound:uctx.universes_lbound ~strict:false g) newus g
+      Level.Set.fold (fun u g -> UGraph.add_universe u ~lbound:UGraph.Bound.Set ~strict:false g) newus g
     in
     let fail_union s q1 q2 =
       if UGraph.type_in_type uctx.universes then s
@@ -283,7 +280,6 @@ let union uctx uctx' =
            else
              let cstrsr = ContextSet.constraints uctx'.local in
              UGraph.merge_constraints cstrsr (declarenew uctx.universes));
-        universes_lbound = uctx.universes_lbound;
         minim_extra = extra}
 
 let context_set uctx = uctx.local
@@ -910,7 +906,7 @@ let is_bound l lbound = match lbound with
   | UGraph.Bound.Prop -> false
   | UGraph.Bound.Set -> Level.is_set l
 
-let restrict_universe_context ~lbound (univs, csts) keep =
+let restrict_universe_context ?(lbound = UGraph.Bound.Set) (univs, csts) keep =
   let removed = Level.Set.diff univs keep in
   if Level.Set.is_empty removed then univs, csts
   else
@@ -924,17 +920,17 @@ let restrict_universe_context ~lbound (univs, csts) keep =
   let csts = Constraints.filter (fun (l,d,r) -> not (is_bound l lbound && d == Le)) csts in
   (Level.Set.inter univs keep, csts)
 
-let restrict uctx vars =
+let restrict ?lbound uctx vars =
   let vars = Level.Set.union vars uctx.seff_univs in
   let vars = Id.Map.fold (fun na l vars -> Level.Set.add l vars)
       (snd (fst uctx.names)) vars
   in
-  let uctx' = restrict_universe_context ~lbound:uctx.universes_lbound uctx.local vars in
+  let uctx' = restrict_universe_context ?lbound uctx.local vars in
   { uctx with local = uctx' }
 
-let restrict_even_binders uctx vars =
+let restrict_even_binders ?lbound uctx vars =
   let vars = Level.Set.union vars uctx.seff_univs in
-  let uctx' = restrict_universe_context ~lbound:uctx.universes_lbound uctx.local vars in
+  let uctx' = restrict_universe_context ?lbound uctx.local vars in
   { uctx with local = uctx' }
 
 let restrict_constraints uctx csts =
@@ -958,7 +954,7 @@ let merge ?loc ~sideff rigid uctx uctx' =
   let local = ContextSet.append uctx' uctx.local in
   let declare g =
     Level.Set.fold (fun u g ->
-        try UGraph.add_universe ~lbound:uctx.universes_lbound ~strict:false u g
+        try UGraph.add_universe ~lbound:UGraph.Bound.Set ~strict:false u g
         with UGraph.AlreadyDeclared when sideff -> g)
       levels g
   in
@@ -1040,7 +1036,7 @@ let merge_seff uctx uctx' =
   let levels = ContextSet.levels uctx' in
   let declare g =
     Level.Set.fold (fun u g ->
-        try UGraph.add_universe ~lbound:uctx.universes_lbound ~strict:false u g
+        try UGraph.add_universe ~lbound:UGraph.Bound.Set ~strict:false u g
         with UGraph.AlreadyDeclared -> g)
       levels g
   in
@@ -1086,7 +1082,8 @@ let add_loc l loc (names, (qnames_rev,unames_rev) as orig) =
   | None -> orig
   | Some _ -> (names, (qnames_rev, Level.Map.add l { uname = None; uloc = loc } unames_rev))
 
-let add_universe ?loc name strict lbound uctx u =
+let add_universe ?loc name strict uctx u =
+  let lbound = UGraph.Bound.Set in
   let initial_universes = UGraph.add_universe ~lbound ~strict u uctx.initial_universes in
   let universes = UGraph.add_universe ~lbound ~strict u uctx.universes in
   let local = ContextSet.add_universe u uctx.local in
@@ -1118,10 +1115,10 @@ let new_univ_variable ?loc rigid name uctx =
       let univ_variables = UnivFlex.add u ~algebraic uctx.univ_variables in
       { uctx with univ_variables }
   in
-  let uctx = add_universe ?loc name false uctx.universes_lbound uctx u in
+  let uctx = add_universe ?loc name false uctx u in
   uctx, u
 
-let add_global_univ uctx u = add_universe None true UGraph.Bound.Set uctx u
+let add_global_univ uctx u = add_universe None true uctx u
 
 let make_with_initial_binders ~lbound univs binders =
   let uctx = make ~lbound univs in
@@ -1159,9 +1156,8 @@ let fix_undefined_variables uctx =
 let collapse_sort_variables uctx =
   { uctx with sort_variables = QState.collapse uctx.sort_variables }
 
-let minimize uctx =
+let minimize ?(lbound = UGraph.Bound.Set) uctx =
   let open UnivMinim in
-  let lbound = uctx.universes_lbound in
   let (vars', us') =
     normalize_context_set ~lbound uctx.universes uctx.local uctx.univ_variables
       uctx.minim_extra
@@ -1175,7 +1171,6 @@ let minimize uctx =
         univ_variables = vars';
         sort_variables = uctx.sort_variables;
         universes = universes;
-        universes_lbound = lbound;
         initial_universes = uctx.initial_universes;
         minim_extra = UnivMinim.empty_extra; (* weak constraints are consumed *) }
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -150,20 +150,20 @@ val name_level : Univ.Level.t -> Id.t -> t -> t
    the universes in [keep]. The constraints [csts] are adjusted so
    that transitive constraints between remaining universes (those in
    [keep] and those not in [univs]) are preserved. *)
-val restrict_universe_context : lbound:UGraph.Bound.t -> ContextSet.t -> Level.Set.t -> ContextSet.t
+val restrict_universe_context : ?lbound:UGraph.Bound.t -> ContextSet.t -> Level.Set.t -> ContextSet.t
 
 (** [restrict uctx ctx] restricts the local universes of [uctx] to
    [ctx] extended by local named universes and side effect universes
    (from [demote_seff_univs]). Transitive constraints between retained
    universes are preserved. *)
-val restrict : t -> Univ.Level.Set.t -> t
+val restrict : ?lbound:UGraph.Bound.t -> t -> Univ.Level.Set.t -> t
 
 
 (** [restrict_even_binders uctx ctx] restricts the local universes of [uctx] to
    [ctx] extended by side effect universes
    (from [demote_seff_univs]). Transitive constraints between retained
    universes are preserved. *)
-val restrict_even_binders : t -> Univ.Level.Set.t -> t
+val restrict_even_binders : ?lbound:UGraph.Bound.t -> t -> Univ.Level.Set.t -> t
 
 type rigid =
   | UnivRigid
@@ -214,7 +214,7 @@ val fix_undefined_variables : t -> t
 (** cf UnivFlex *)
 
 (** Universe minimization *)
-val minimize : t -> t
+val minimize : ?lbound:UGraph.Bound.t -> t -> t
 
 val collapse_sort_variables : t -> t
 

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -174,14 +174,14 @@ val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map *
     the form [(x y z : t)] is shared *)
 
 val interp_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env -> ?share:bool ->
+  ?program_mode:bool -> ?unconstrained_sorts:bool -> ?impl_env:internalization_env -> ?share:bool ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 
 (** Interpret named contexts *)
 
 val interp_named_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env -> ?share:bool -> ?autoimp_enable:bool ->
+  ?program_mode:bool -> ?unconstrained_sorts:bool -> ?impl_env:internalization_env -> ?share:bool -> ?autoimp_enable:bool ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * named_context) * Impargs.manual_implicits))
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -72,7 +72,6 @@ type env = private {
   env_rel_context   : rel_context_val;
   env_nb_rel        : int;
   env_universes : UGraph.t;
-  env_universes_lbound : UGraph.Bound.t;
   env_qualities : Sorts.QVar.Set.t;
   irr_constants : Sorts.relevance Cmap_env.t
 (** [irr_constants] is a cache of the relevances which are not Relevant.
@@ -98,8 +97,6 @@ val eq_named_context_val : named_context_val -> named_context_val -> bool
 val empty_env : env
 
 val universes     : env -> UGraph.t
-val universes_lbound : env -> UGraph.Bound.t
-val set_universes_lbound : env -> UGraph.Bound.t -> env
 val rel_context   : env -> Constr.rel_context
 val named_context : env -> Constr.named_context
 val named_context_val : env -> named_context_val
@@ -367,6 +364,9 @@ val push_context_set : ?strict:bool -> ContextSet.t -> env -> env
 (** [push_context_set ?(strict=false) ctx env] pushes the universe
     context set to the environment. It does not fail even if one of the
     universes is already declared. *)
+
+val push_floating_context_set : ContextSet.t -> env -> env
+(** Same as above but keep the universes floating for template. Do not use. *)
 
 val push_subgraph : ContextSet.t -> env -> env
 (** [push_subgraph univs env] adds the universes and constraints in

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -360,8 +360,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
     | Template_ind_entry ctx ->
         (* For that particular case, we typecheck the inductive in an environment
            where the universes introduced by the definition are only [>= Prop] *)
-        let env = set_universes_lbound env UGraph.Bound.Prop in
-        push_context_set ~strict:false ctx env
+        Environ.push_floating_context_set ctx env
     | Monomorphic_ind_entry -> env
     | Polymorphic_ind_entry ctx -> push_context ctx env
   in

--- a/library/global.ml
+++ b/library/global.ml
@@ -126,7 +126,6 @@ let add_module_parameter mbid mte inl =
 (** Queries on the global environment *)
 
 let universes () = Environ.universes (env())
-let universes_lbound () = Environ.universes_lbound (env())
 let named_context () = Environ.named_context (env())
 let named_context_val () = Environ.named_context_val (env())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -21,7 +21,6 @@ val safe_env : unit -> Safe_typing.safe_environment
 val env : unit -> Environ.env
 
 val universes : unit -> UGraph.t
-val universes_lbound : unit -> UGraph.Bound.t
 val named_context_val : unit -> Environ.named_context_val
 val named_context : unit -> Constr.named_context
 

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -589,6 +589,7 @@ let resolve_and_replace_implicits exptyp env sigma rt =
       resolve_tc = true;
       undeclared_evars_patvars = false;
       patvars_abstract = false;
+      unconstrained_sorts = false;
     } in
     let vars = Evarutil.VarSet.variables (Global.env ()) in
     let hypnaming = RenameExistingBut vars in

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -59,6 +59,7 @@ let eval_uconstrs ist cs =
     polymorphic = false;
     undeclared_evars_patvars = false;
     patvars_abstract = false;
+    unconstrained_sorts = false;
   } in
   let map c env sigma = c env sigma in
   List.map (fun c -> map (Tacinterp.type_uconstr ~flags ist c)) cs

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -50,6 +50,7 @@ let with_delayed_uconstr ist c tac =
     polymorphic = false;
     undeclared_evars_patvars = false;
     patvars_abstract = false;
+    unconstrained_sorts = false;
  } in
   let c = Tacinterp.type_uconstr ~flags ist c in
   Tacticals.tclDELAYEDWITHHOLES false c tac
@@ -88,6 +89,7 @@ let constr_flags () = Pretyping.{
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 let refine_tac ist ~simple ~with_classes c =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -631,6 +631,7 @@ let constr_flags () = {
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 (* Interprets a constr; expects evars to be solved *)
@@ -652,6 +653,7 @@ let open_constr_use_classes_flags () = {
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 let open_constr_no_classes_flags () = {
@@ -664,6 +666,7 @@ let open_constr_no_classes_flags () = {
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 let pure_open_constr_flags = {
@@ -676,6 +679,7 @@ let pure_open_constr_flags = {
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 (* Interprets an open constr *)

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -33,6 +33,7 @@ let constr_flags =
     polymorphic = false;
     undeclared_evars_patvars = false;
     patvars_abstract = false;
+    unconstrained_sorts = false;
   }
 
 let open_constr_no_classes_flags =
@@ -47,6 +48,7 @@ let open_constr_no_classes_flags =
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
   }
 
 let preterm_flags =
@@ -61,6 +63,7 @@ let preterm_flags =
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
   }
 
 (** Standard values *)

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -29,6 +29,7 @@ let tactic_infer_flags with_evar = Pretyping.{
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 (** FIXME: export a better interface in Tactics *)

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -146,7 +146,7 @@ let ic_unsafe env sigma c = (*FIXME remove *)
 let decl_constant name univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
-  let univs = UState.restrict_universe_context ~lbound:(Global.universes_lbound ()) univs vars in
+  let univs = UState.restrict_universe_context univs vars in
   let () = Global.push_context_set ~strict:true univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
   let univs = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -177,6 +177,7 @@ let interp_refine env sigma ist ~concl rc =
     polymorphic = false;
     undeclared_evars_patvars = false;
     patvars_abstract = false;
+    unconstrained_sorts = false;
   }
   in
   let sigma, c = Pretyping.understand_ltac flags env sigma vars kind rc in

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -81,6 +81,7 @@ type inference_flags = {
   polymorphic : bool;
   undeclared_evars_patvars : bool;
   patvars_abstract : bool;
+  unconstrained_sorts : bool;
 }
 
 val default_inference_flags : bool -> inference_flags
@@ -179,6 +180,7 @@ type pretype_flags = {
   use_coercions : bool;
   undeclared_evars_patvars : bool;
   patvars_abstract : bool;
+  unconstrained_sorts : bool;
 }
 
 type 'a pretype_fun = ?loc:Loc.t -> flags:pretype_flags -> Evardefine.type_constraint -> GlobEnv.t -> evar_map -> evar_map * 'a

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -66,6 +66,7 @@ let w_refine evk rawc env sigma =
       polymorphic = false;
       undeclared_evars_patvars = false;
       patvars_abstract = false;
+      unconstrained_sorts = false;
     } in
     let expected_type = Pretyping.OfType (Evd.evar_concl evi) in
     try Pretyping.understand_uconstr ~flags ~expected_type env sigma rawc

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -139,6 +139,7 @@ let tactic_infer_flags with_evar = Pretyping.{
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 let onOpenInductionArg env sigma tac = function

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1345,6 +1345,7 @@ let tactic_infer_flags with_evar = Pretyping.{
   polymorphic = false;
   undeclared_evars_patvars = false;
   patvars_abstract = false;
+  unconstrained_sorts = false;
 }
 
 type evars_flag = bool     (* true = pose evars       false = fail on evars *)


### PR DESCRIPTION
We remove the lower universe bound from the UState and environment data types, and rely instead on passing a flag to the pretyper to generate sort-polymorphic universes. The kernel still requires pushing floating template universes, but I will defer this cleanup to a later PR.