### PR TITLE
Properly flush -time-file at exit

### DIFF
--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -40,7 +40,15 @@ type time_output =
 
 let make_time_output = function
   | Coqargs.ToFeedback -> ToFeedback
-  | ToFile f -> ToChannel (Format.formatter_of_out_channel (open_out f))
+  | ToFile f ->
+    let ch = open_out f in
+    let fch = Format.formatter_of_out_channel ch in
+    let close () =
+      Format.pp_print_flush fch ();
+      close_out ch
+    in
+    at_exit close;
+    ToChannel fch
 
 module State = struct
 


### PR DESCRIPTION
Without this it's possible that some output will be omitted. For instance ExtensionalFunctionRepresentative (1 command file in stdlib) sometimes has no timing info.

We could try to explicitly call flushing after running coq eg in ccompile, but getting all time-file users seems awkward and not worth the bother.