### PR TITLE
Fixes #18920: anomaly with evars turned into obligations in binders of Program Fixpoint measure/wf

### DIFF
--- a/doc/changelog/02-specification-language/18958-master+fix18920-evars-leak-program-fixpoint.rst
+++ b/doc/changelog/02-specification-language/18958-master+fix18920-evars-leak-program-fixpoint.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  anomaly with obligations in the binders of a `measure`- or
+  `wf`-based `Program Fixpoint`
+  (`#18958 <https://github.com/coq/coq/pull/18958>`_,
+  fixes `#18920 <https://github.com/coq/coq/issues/18920>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_18920.v
+++ b/test-suite/bugs/bug_18920.v
@@ -1,0 +1,8 @@
+(* Check that obligations resulting from evars in the binders are
+   correctly substituted for wf/measure fixpoints *)
+Require Import Program.
+Program Fixpoint f (A : nat * _) (n:nat) {measure n} : nat :=
+    match n with 0 => 0 | S n => f A n end.
+Next Obligation. exact nat. Defined.
+Next Obligation. Admitted.
+(* used to return an Anomaly "in econstr: grounding a non evar-free term" *)


### PR DESCRIPTION
We simply apply the evar->var and var->const maps provided by retrieve_obligations and the declare's hook.

Fixes / closes #18920 

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
