### PR TITLE
Apply the early check of the universe declaration and the monomorphic universe fixing to all interactive declarations

### DIFF
--- a/doc/changelog/02-specification-language/18960-master+early-udecl-check-interactive-proof.rst
+++ b/doc/changelog/02-specification-language/18960-master+early-udecl-check-interactive-proof.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  More systematic early check of `@{univs}`-like universe declarations
+  at the time of declaring the statement of an interactive
+  definition/theorem
+  (`#18960 <https://github.com/coq/coq/pull/18960>`_,
+  by Hugo Herbelin).

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1130,6 +1130,13 @@ let univ_entry ~poly evd = UState.univ_entry ~poly evd.universes
 
 let check_univ_decl ~poly evd decl = UState.check_univ_decl ~poly evd.universes decl
 
+let check_univ_decl_early ~poly sigma udecl terms =
+  let vars = List.fold_left (fun acc b -> Univ.Level.Set.union acc (Vars.universes_of_constr b)) Univ.Level.Set.empty terms in
+  let uctx = evar_universe_context sigma in
+  let uctx = UState.collapse_sort_variables uctx in
+  let uctx = UState.restrict uctx vars in
+  ignore (UState.check_univ_decl ~poly uctx udecl)
+
 let restrict_universe_context ?lbound evd vars =
   { evd with universes = UState.restrict ?lbound evd.universes vars }
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1130,7 +1130,16 @@ let univ_entry ~poly evd = UState.univ_entry ~poly evd.universes
 
 let check_univ_decl ~poly evd decl = UState.check_univ_decl ~poly evd.universes decl
 
-let check_univ_decl_early ~poly sigma udecl terms =
+let check_univ_decl_early ~poly ~with_obls sigma udecl terms =
+  let () =
+    if with_obls && not poly &&
+       (not udecl.UState.univdecl_extensible_instance
+        || not udecl.UState.univdecl_extensible_constraints)
+    then
+      CErrors.user_err
+        Pp.(str "Non extensible universe declaration not supported \
+                 with monomorphic Program definitions.")
+  in
   let vars = List.fold_left (fun acc b -> Univ.Level.Set.union acc (Vars.universes_of_constr b)) Univ.Level.Set.empty terms in
   let uctx = evar_universe_context sigma in
   let uctx = UState.collapse_sort_variables uctx in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -680,6 +680,10 @@ val univ_entry : poly:bool -> evar_map -> UState.named_universes_entry
 
 val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> UState.named_universes_entry
 
+(** An early check of compatibility of the universe declaration before
+    starting to build a declaration interactively *)
+val check_univ_decl_early : poly:bool -> evar_map -> UState.universe_decl -> Constr.t list -> unit
+
 val merge_universe_context : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -682,7 +682,7 @@ val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> UState.na
 
 (** An early check of compatibility of the universe declaration before
     starting to build a declaration interactively *)
-val check_univ_decl_early : poly:bool -> evar_map -> UState.universe_decl -> Constr.t list -> unit
+val check_univ_decl_early : poly:bool -> with_obls:bool -> evar_map -> UState.universe_decl -> Constr.t list -> unit
 
 val merge_universe_context : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -153,11 +153,11 @@ and rebuild_nal aux bk bl' nal typ =
 let rebuild_bl aux bl typ = rebuild_bl aux bl typ
 
 let recompute_binder_list (rec_order, fixpoint_exprl) =
-  let typel, uctx = ComFixpoint.interp_fixpoint_short rec_order fixpoint_exprl in
+  let typel, sigma = ComFixpoint.interp_fixpoint_short rec_order fixpoint_exprl in
   let constr_expr_typel =
     with_full_print
       (List.map (fun c ->
-           Constrextern.extern_constr (Global.env ()) (Evd.from_ctx uctx)
+           Constrextern.extern_constr (Global.env ()) sigma
              (EConstr.of_constr c)))
       typel
   in

--- a/test-suite/bugs/bug_15410.v
+++ b/test-suite/bugs/bug_15410.v
@@ -1,3 +1,4 @@
 Require Program.Tactics.
 
-Fail Program Definition foo@{u} : Type@{u} := _.
+Program Definition foo@{u} : Type@{u} := _.
+Next Obligation. exact nat. Qed.

--- a/test-suite/bugs/bug_15410.v
+++ b/test-suite/bugs/bug_15410.v
@@ -1,4 +1,11 @@
 Require Program.Tactics.
 
-Program Definition foo@{u} : Type@{u} := _.
-Next Obligation. exact nat. Qed.
+(* To anticipate that obligations may declare universes, we require
+   extensibility of the universe declaration for Program defintiions *)
+Fail Program Definition foo@{u} : Type@{u} := _.
+
+(* Similar tests *)
+
+Fail Program Fixpoint foo@{u} (n:nat) : Type@{u} := _.
+
+Fail Program Fixpoint foo@{u} (n:nat) {measure n} : Type@{u} := _.

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -180,6 +180,7 @@ Module binders.
   Abort.
 
   Fail Lemma bar@{u v | } : let x := (fun x => x) : Type@{u} -> Type@{v} in nat.
+  Fail Fixpoint fbar@{u v | } (n:nat) : let x := (fun x => x) : Type@{u} in nat.
 
   Lemma bar@{i j| i < j} : Type@{j}.
   Proof.
@@ -473,3 +474,52 @@ Module ProgramFixpoint.
   Check f@{Set}. (* Check that it depends on only one universe *)
 
 End ProgramFixpoint.
+
+Module EarlyPolyUniverseDeclarationCheck.
+
+  Local Set Universe Polymorphism.
+
+  Fail Definition f@{u} n : match n return Type@{v} with 0 => Type@{u} | _ => Type@{u} end.
+
+  Definition f@{u v} n : match n return Type@{v} with 0 => Type@{u} | _ => Type@{u} end.
+  exact (match n with 0 => nat | _ => nat end).
+  Defined.
+
+  Program Fixpoint f'@{u} (A:Type@{u}) (n:nat) : Type@{u} :=
+    match n with 0 => _ | S n => f' (A->A) n end.
+  Next Obligation. exact nat. Defined.
+
+  Fail Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
+    match n with 0 => _ | S n => f'' (Type->A) n end.
+
+  Local Set Universe Polymorphism.
+  Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
+    match n with 0 => _ | S n => f'' (A->A) n end.
+  Next Obligation. Show. exact nat. Defined.
+  Next Obligation. Show. Admitted.
+
+End EarlyPolyUniverseDeclarationCheck.
+
+Module EarlyMonoUniverseDeclarationCheck.
+
+  Local Unset Universe Polymorphism.
+
+  Fail Definition f@{u} n : match n return Type@{v} with 0 => Type@{u} | _ => Type@{u} end.
+
+  Definition f@{u v} n : match n return Type@{v} with 0 => Type@{u} | _ => Type@{u} end.
+  exact (match n with 0 => nat | _ => nat end).
+  Defined.
+
+  Program Fixpoint f'@{u} (A:Type@{u}) (n:nat) : Type@{u} :=
+    match n with 0 => _ | S n => f' (A->A) n end.
+  Next Obligation. exact nat. Defined.
+
+  Fail Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
+    match n with 0 => _ | S n => f'' (Type->A) n end.
+
+  Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
+    match n with 0 => _ | S n => f'' (A->A) n end.
+  Next Obligation. Show. exact nat. Defined.
+  Next Obligation. Show. Admitted.
+
+End EarlyMonoUniverseDeclarationCheck.

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -510,14 +510,20 @@ Module EarlyMonoUniverseDeclarationCheck.
   exact (match n with 0 => nat | _ => nat end).
   Defined.
 
-  Program Fixpoint f'@{u} (A:Type@{u}) (n:nat) : Type@{u} :=
+  Fail Program Fixpoint f'@{u} (A:Type@{u}) (n:nat) : Type@{u} := (* By convention, we require extensibility for Program *)
+    match n with 0 => _ | S n => f' (A->A) n end.
+
+  Program Fixpoint f'@{u +} (A:Type@{u}) (n:nat) : Type@{u} :=
     match n with 0 => _ | S n => f' (A->A) n end.
   Next Obligation. exact nat. Defined.
 
   Fail Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
     match n with 0 => _ | S n => f'' (Type->A) n end.
 
-  Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
+  Fail Program Fixpoint f''@{u} (A:Type@{u}) (n:nat) {measure n} : Type@{u} := (* By convention, we require extensibility for Program *)
+    match n with 0 => _ | S n => f'' (A->A) n end.
+
+  Program Fixpoint f''@{u +} (A:Type@{u}) (n:nat) {measure n} : Type@{u} :=
     match n with 0 => _ | S n => f'' (A->A) n end.
   Next Obligation. Show. exact nat. Defined.
   Next Obligation. Show. Admitted.

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -128,14 +128,6 @@ let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using
   in ()
 
 let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
-  let () = if not poly then udecl |> Option.iter (fun udecl ->
-      if not udecl.UState.univdecl_extensible_instance
-      || not udecl.UState.univdecl_extensible_constraints
-      then
-        CErrors.user_err
-          Pp.(str "Non extensible universe declaration not supported \
-                   with monomorphic Program Definition."))
-  in
   let env = Global.env() in
   let env = Environ.update_typing_flags ?typing_flags env in
   (* Explicitly bound universes and constraints *)
@@ -144,6 +136,7 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
     interp_definition ~program_mode:true env evd empty_internalization_env bl red_option c ctypopt
   in
   let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
+  Evd.check_univ_decl_early ~poly evd udecl [body; typ];
   let pm, _ =
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -136,7 +136,7 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
     interp_definition ~program_mode:true env evd empty_internalization_env bl red_option c ctypopt
   in
   let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
-  Evd.check_univ_decl_early ~poly evd udecl [body; typ];
+  Evd.check_univ_decl_early ~poly ~with_obls:true evd udecl [body; typ];
   let pm, _ =
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -345,7 +345,7 @@ let do_mutually_recursive ?pm ?scope ?clearbody ~poly ?typing_flags ?user_warns 
   match pm with
   | Some pm ->
     let bodies = List.map Option.get bodies in
-    Evd.check_univ_decl_early ~poly sigma udecl (bodies @ fixtypes);
+    Evd.check_univ_decl_early ~poly ~with_obls:true sigma udecl (bodies @ fixtypes);
     let sigma = if poly then sigma else Evd.fix_undefined_variables sigma in
     let uctx = Evd.evar_universe_context sigma in
     Some (Declare.Obls.add_mutual_definitions ~pm ~cinfo ~info ~opaque:false ~uctx ~bodies ~possible_guard ?using obls), None
@@ -361,7 +361,7 @@ let do_mutually_recursive ?pm ?scope ?clearbody ~poly ?typing_flags ?user_warns 
       None, None
     with Option.IsNone ->
       (* At least one undefined body *)
-      Evd.check_univ_decl_early ~poly sigma udecl (Option.List.flatten bodies @ fixtypes);
+      Evd.check_univ_decl_early ~poly ~with_obls:false sigma udecl (Option.List.flatten bodies @ fixtypes);
       let lemma = Declare.Proof.start_mutual_definitions ~info ~cinfo
           ~bodies ~possible_guard ?using sigma in
       None, Some lemma

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -284,8 +284,7 @@ let interp_fixpoint_short rec_order fixpoint_exprl =
   let (_, _, sigma),(fix, _, _, _) = interp_recursive_evars env ~program_mode:false (false, CFixRecOrder rec_order) fixpoint_exprl in
   let sigma = Pretyping.(solve_remaining_evars all_no_fail_flags env sigma) in
   let typel = (ground_fixpoint env sigma fix).fixtypes in
-  let uctx = Evd.evar_universe_context sigma in
-  typel, uctx
+  typel, sigma
 
 let build_recthms {fixnames;fixtypes;fixctxs;fiximps} =
   List.map4 (fun name typ ctx impargs ->
@@ -337,20 +336,23 @@ let do_mutually_recursive ?pm ?scope ?clearbody ~poly ?typing_flags ?user_warns 
   let (env,rec_sign,sigma),(fix,isfix,possible_guard,udecl) = interp_recursive_evars env ~program_mode:(Option.has_some pm) (true, rec_order) fixl in
   check_recursive ~isfix env sigma fix;
   let kind = Decls.IsDefinition isfix in
-  let sigma, ({fixdefs=bodies;fixrs} as fix), obls =
+  let sigma, ({fixdefs=bodies;fixrs;fixtypes} as fix), obls =
     match pm with
     | Some pm -> finish_program env sigma rec_sign possible_guard fix
     | None -> finish_regular env sigma fix in
-  let uctx = Evd.evar_universe_context sigma in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ?typing_flags ?user_warns ~ntns:fix.fixntns () in
   let cinfo = build_recthms fix in
   match pm with
   | Some pm ->
     let bodies = List.map Option.get bodies in
+    Evd.check_univ_decl_early ~poly sigma udecl (bodies @ fixtypes);
+    let sigma = if poly then sigma else Evd.fix_undefined_variables sigma in
+    let uctx = Evd.evar_universe_context sigma in
     Some (Declare.Obls.add_mutual_definitions ~pm ~cinfo ~info ~opaque:false ~uctx ~bodies ~possible_guard ?using obls), None
   | None ->
     try
       let bodies = List.map Option.get bodies in
+      let uctx = Evd.evar_universe_context sigma in
       (* All bodies are defined *)
       let _ : GlobRef.t list =
         Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx
@@ -359,7 +361,7 @@ let do_mutually_recursive ?pm ?scope ?clearbody ~poly ?typing_flags ?user_warns 
       None, None
     with Option.IsNone ->
       (* At least one undefined body *)
-      let evd = Evd.from_ctx uctx in
+      Evd.check_univ_decl_early ~poly sigma udecl (Option.List.flatten bodies @ fixtypes);
       let lemma = Declare.Proof.start_mutual_definitions ~info ~cinfo
-          ~bodies ~possible_guard ?using evd in
+          ~bodies ~possible_guard ?using sigma in
       None, Some lemma

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -40,4 +40,4 @@ type ('constr, 'types, 'r) recursive_preentry =
 val interp_fixpoint_short
   :  Constrexpr.fixpoint_order_expr option list
   -> recursive_expr_gen list
-  -> Constr.types list * UState.t
+  -> Constr.types list * Evd.evar_map

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -198,6 +198,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
       in hook
   in
   let hook = Declare.Hook.make hook in
+  Evd.check_univ_decl_early ~poly sigma udecl [evars_def;evars_typ];
   let cinfo = Declare.CInfo.make ~name:recname_func ~typ:evars_typ () in
   let kind = Decls.(IsDefinition Fixpoint) in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ~hook ?typing_flags ?user_warns ~ntns () in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -198,7 +198,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
       in hook
   in
   let hook = Declare.Hook.make hook in
-  Evd.check_univ_decl_early ~poly sigma udecl [evars_def;evars_typ];
+  Evd.check_univ_decl_early ~poly ~with_obls:true sigma udecl [evars_def;evars_typ];
   let cinfo = Declare.CInfo.make ~name:recname_func ~typ:evars_typ () in
   let kind = Decls.(IsDefinition Fixpoint) in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ~hook ?typing_flags ?user_warns ~ntns () in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -656,7 +656,7 @@ let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?u
   let mut_analysis = RecLemmas.look_for_possibly_mutual_statements evd thms in
   let evd = Evd.minimize_universes evd in
   let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
-  Evd.check_univ_decl_early ~poly evd udecl typs;
+  Evd.check_univ_decl_early ~poly ~with_obls:false evd udecl typs;
   let evd = if poly then evd else Evd.fix_undefined_variables evd in
   match mut_analysis with
   | RecLemmas.NonMutual thm ->


### PR DESCRIPTION
Formerly, the early check (at `Definition` time) of the universe declaration and the monomorphic universe fixing (for asynchronous evaluation) were done only for `Theorem` and `Definition` without body (in `post_check_evd`). We do it also for interactive [`Co`]`Fixpoint` and for `Program Fixpoint` and `Program Definition`.

To anticipate what is done when proofs are completed, we apply `UState.collapse_sort_variables` and `UState.restrict` in some cases (this is needed for the test-suite to pass). But maybe should these be applied in all four cases, together with `UState.normalize_variables` and `UState.minimize`, as done at the end of proofs in general???

This gives an alternative solution to #15410 which allows to remove the forbidding for extensible universes introduced in #15424.

This remark at #15410 still hold though: "non extensible universe declarations don't make a lot of sense in universe monomorphic definitions", so maybe it can also be a failure.

- [x] Added / updated **test-suite**.
- [x] TODO: use the same check in all four situations (but which one?)
- [x] Added change log
 
Depends on #18915 (merged)

Fix #19289