### PR TITLE
Add a PUSHENVACCMANY opcode.

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -480,6 +480,20 @@ value coq_interprete
         accu = Field(coq_env, 2 + *pc++);
         Next;
       }
+
+      Instruct(PUSHENVACCMANY) {
+        int first = *pc++;
+        int size = *pc++;
+        int i;
+        print_instr("PUSHENVACCMANY");
+        first += 2;
+        sp -= size;
+        for (i = 1; i < size; ++i) sp[i - 1] = Field(coq_env, first + i);
+        sp[size - 1] = accu;
+        accu = Field(coq_env, first);
+        Next;
+      }
+
       /* Function application */
 
       Instruct(PUSH_RETADDR) {

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -48,6 +48,7 @@ let opcodes =
     "PUSHENVACC2", 0;
     "PUSHENVACC3", 0;
     "PUSHENVACC", 1;
+    "PUSHENVACCMANY", 2;
     "PUSH_RETADDR", 1;
     "APPLY", 1;
     "APPLY1", 0;


### PR DESCRIPTION
When closures are nested inside closures, it might happen that several consecutive values from the environment of the outer closure are pushed onto the stack in order to create the inner closure. This opcode replaces a sequence of repeated "PUSH; ENVACC" of decreasing indices.