### PR TITLE
Add a PUSHACCMANY opcode.

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -418,6 +418,18 @@ value coq_interprete
         Next;
       }
 
+      Instruct(PUSHACCMANY) {
+        int first = *pc++;
+        int size = *pc++;
+        int i;
+        print_instr("PUSHACCMANY");
+        sp -= size;
+        for (i = 1; i < size; ++i) sp[i - 1] = sp[first + i];
+        sp[size - 1] = accu;
+        accu = sp[first];
+        Next;
+      }
+
       Instruct(POP){
         print_instr("POP");
         sp += *pc++;

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -37,6 +37,7 @@ let opcodes =
     "PUSHACC6", 0;
     "PUSHACC7", 0;
     "PUSHACC", 1;
+    "PUSHACCMANY", 2;
     "POP", 1;
     "ENVACC0", 0;
     "ENVACC1", 0;


### PR DESCRIPTION
Especially for symbols defined inside sections, callee functions might be invoked with the exact same arguments as caller functions. A similar situation happens with recursive functions that share most of their arguments across calls. This new opcode replaces a sequence of repeated `PUSH; ACC` opcodes with constant indices.
