### PR TITLE
Use callback to substitute universe instances in VM

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -263,8 +263,6 @@ let v_vm_structured_constant = v_sum "vm_structured_constant" 0 [|
     [|v_ind|];
     [|Fail "Const_evar"|];
     [|Int|];
-    [|v_quality|];
-    [|v_level|];
     [|v_instance|];
     [|Any|]; (* contains a Vmvalues.value *)
     [|v_uint63|];

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -272,6 +272,16 @@ extern void caml_process_pending_signals(void);
 extern double coq_next_up(double);
 extern double coq_next_down(double);
 
+value coq_subst_instance(value arg, value tosubst)
+{
+  static const value * closure_f = NULL;
+  if (closure_f == NULL) {
+     /* First time around, look up by name */
+    closure_f = caml_named_value("coq_subst_instance");
+  }
+  return caml_callback2_exn(*closure_f, arg, tosubst);
+}
+
 /* The interpreter itself */
 
 value coq_interprete
@@ -1313,6 +1323,17 @@ value coq_interprete
         coq_env = sp[1];
         coq_extra_args = Long_val(sp[2]);
         sp += 3;
+        Next;
+      }
+
+      Instruct(SUBSTINSTANCE) {
+        print_instr("SUBSTINSTANCE");
+        print_int(*pc);
+
+        Setup_for_caml_call;
+        accu = coq_subst_instance(accu, Field(coq_global_data, *pc++));
+        Restore_after_caml_call;
+        Handle_potential_exception(accu);
         Next;
       }
 

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -99,6 +99,7 @@ let opcodes =
     "ACCUMULATE", 0;
     "MAKESWITCHBLOCK", 4;
     "MAKEACCU", 1;
+    "SUBSTINSTANCE", 1;
     "BRANCH", 1;
     "CHECKADDINT63", 1;
     "CHECKADDCINT63", 1;

--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -56,6 +56,7 @@ type instruction =
   | Kclosurecofix of int * int * Label.t array * Label.t array
                    (* nb fv, init, lbl types, lbl bodies *)
   | Kgetglobal of Constant.t
+  | Ksubstinstance of UVars.Instance.t
   | Kconst of structured_constant
   | Kmakeblock of int * tag
   | Kmakeswitchblock of Label.t * Label.t * annot_switch * int
@@ -132,6 +133,9 @@ let rec pp_instr i =
              str " bodies = " ++
              prlist_with_sep spc pp_lbl (Array.to_list lblb))
   | Kgetglobal idu -> str "getglobal " ++ Constant.print idu
+  | Ksubstinstance u ->
+    str "subst_instance " ++
+    UVars.Instance.pr Sorts.QVar.raw_pr Univ.Level.raw_pr u
   | Kconst sc ->
       str "const " ++ pp_struct_const sc
   | Kmakeblock(n, m) ->

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -52,6 +52,7 @@ type instruction =
   | Kclosurecofix of int * int * Label.t array * Label.t array
                    (** nb fv, init, lbl types, lbl bodies *)
   | Kgetglobal of Constant.t
+  | Ksubstinstance of UVars.Instance.t
   | Kconst of structured_constant
   | Kmakeblock of (* size: *) int * tag (** allocate an ocaml block. Index 0
                                          ** is accu, all others are popped from

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -372,6 +372,8 @@ let emit_instr env = function
       Array.iter (out_label_with_orig env org) lbl_bodies
   | Kgetglobal q ->
       out env opGETGLOBAL; slot_for_getglobal env q
+  | Ksubstinstance u ->
+      out env opSUBSTINSTANCE; slot_for_const env (Const_univ_instance u)
   | Kconst (Const_b0 i) when is_immed i ->
       if i >= 0 && i <= 3
           then out env (opCONST0 + i)

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -476,7 +476,7 @@ type to_patch = emitcodes * fv * Positions.t
 (* Substitution *)
 let subst_strcst s sc =
   match sc with
-  | Const_sort _ | Const_b0 _ | Const_quality _ | Const_univ_level _ | Const_univ_instance _
+  | Const_sort _ | Const_b0 _ | Const_univ_instance _
   | Const_val _ | Const_uint _ | Const_float _ | Const_evar _ -> sc
   | Const_ind ind -> let kn,i = ind in Const_ind (subst_mind s kn, i)
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -52,8 +52,6 @@ type structured_constant =
   | Const_ind of inductive
   | Const_evar of Evar.t
   | Const_b0 of tag
-  | Const_quality of Sorts.Quality.t
-  | Const_univ_level of Univ.Level.t
   | Const_univ_instance of UVars.Instance.t
   | Const_val of structured_values
   | Const_uint of Uint63.t
@@ -105,10 +103,6 @@ let eq_structured_constant c1 c2 = match c1, c2 with
 | Const_evar _, _ -> false
 | Const_b0 t1, Const_b0 t2 -> Int.equal t1 t2
 | Const_b0 _, _ -> false
-| Const_quality q1, Const_quality q2 -> Sorts.Quality.equal q1 q2
-| Const_quality _, _ -> false
-| Const_univ_level l1 , Const_univ_level l2 -> Univ.Level.equal l1 l2
-| Const_univ_level _ , _ -> false
 | Const_univ_instance u1 , Const_univ_instance u2 -> UVars.Instance.equal u1 u2
 | Const_univ_instance _ , _ -> false
 | Const_val v1, Const_val v2 -> eq_structured_values v1 v2
@@ -125,12 +119,10 @@ let hash_structured_constant c =
   | Const_ind i -> combinesmall 2 (Ind.CanOrd.hash i)
   | Const_evar e -> combinesmall 3 (Evar.hash e)
   | Const_b0 t -> combinesmall 4 (Int.hash t)
-  | Const_quality q -> combinesmall 5 (Sorts.Quality.hash q)
-  | Const_univ_level l -> combinesmall 6 (Univ.Level.hash l)
-  | Const_univ_instance u -> combinesmall 7 (UVars.Instance.hash u)
-  | Const_val v -> combinesmall 8 (hash_structured_values v)
-  | Const_uint i -> combinesmall 9 (Uint63.hash i)
-  | Const_float f -> combinesmall 10 (Float64.hash f)
+  | Const_univ_instance u -> combinesmall 5 (UVars.Instance.hash u)
+  | Const_val v -> combinesmall 6 (hash_structured_values v)
+  | Const_uint i -> combinesmall 7 (Uint63.hash i)
+  | Const_float f -> combinesmall 8 (Float64.hash f)
 
 let eq_annot_switch asw1 asw2 =
   let eq_rlc (i1, j1) (i2, j2) = Int.equal i1 i2 && Int.equal j1 j2 in
@@ -159,8 +151,6 @@ let pp_struct_const = function
   | Const_ind (mind, i) -> Pp.(MutInd.print mind ++ str"#" ++ int i)
   | Const_evar e -> Pp.( str "Evar(" ++ int (Evar.repr e) ++ str ")")
   | Const_b0 i -> Pp.int i
-  | Const_quality q -> Sorts.Quality.raw_pr q
-  | Const_univ_level l -> Univ.Level.raw_pr l
   | Const_univ_instance u -> UVars.Instance.pr Sorts.QVar.raw_pr Univ.Level.raw_pr u
   | Const_val _ -> Pp.str "(value)"
   | Const_uint i -> Pp.str (Uint63.to_string i)
@@ -412,8 +402,6 @@ let obj_of_str_const str =
   | Const_ind ind -> obj_of_atom (Aind ind)
   | Const_evar e -> obj_of_atom (Aid (EvarKey e))
   | Const_b0 tag -> Obj.repr tag
-  | Const_quality q -> Obj.repr q
-  | Const_univ_level l -> Obj.repr l
   | Const_univ_instance u -> Obj.repr u
   | Const_val v -> Obj.repr v
   | Const_uint i -> Obj.repr i

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -39,8 +39,6 @@ type structured_constant =
   | Const_ind of inductive
   | Const_evar of Evar.t
   | Const_b0 of tag
-  | Const_quality of Sorts.Quality.t
-  | Const_univ_level of Univ.Level.t
   | Const_univ_instance of UVars.Instance.t
   | Const_val of structured_values
   | Const_uint of Uint63.t


### PR DESCRIPTION

instead of implementing the substitution in bytecode unrolled over the
instance to substitute.

Since the instances are now handled through structured constants even
when variable they get deduplicated, reducing vo size significantly in
universe polymorphic code.

For instance HoTT total theories/ vo size 141MB -> 90MB
HoTT Colimit_Flattening.vo size 8.7MB -> 3.4MB
list with all files: https://gist.github.com/SkySkimmer/5d9eda76b016404b82239bbe352a9c6d

cf discussion around https://github.com/coq/coq/pull/18959#issuecomment-2071608928
