### PR TITLE
Revert "Add attribute [@@immediate64] to Uint63.t"

### DIFF
--- a/kernel/uint63.mli
+++ b/kernel/uint63.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type t [@@immediate64]
+type t
 
 val uint_size : int
 val maxuint31 : t


### PR DESCRIPTION
This reverts commit 8eb1d2662483711df77483b2b65e8f4686301e12.

Fix #18908
