### PR TITLE
Enter `Hint Extern` patterns syntactically into the Bnet

### DIFF
--- a/tactics/btermdn.mli
+++ b/tactics/btermdn.mli
@@ -31,6 +31,7 @@ sig
   type pattern
 
   val pattern : Environ.env -> TransparentState.t option -> constr_pattern -> pattern
+  val pattern_syntactic : Environ.env -> constr_pattern -> pattern
   val constr_pattern : Environ.env -> Evd.evar_map -> TransparentState.t option -> EConstr.t -> pattern
 
   val empty : t


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This is extracted from #18677 and affects only `Hint Extern` which are now entered into the dnet (bnet?) completely syntactically.

The change reduces the amount of output of `Typeclasses Debug` at higher verbosity levels. Theoretically, it should also positively affect performance but the bench runs in #18677 did not show significant changes.
