### PR TITLE
Add Fixpoint and CoFixpoint in Search logical_kind

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/18983-SearchFixpoint.rst
+++ b/doc/changelog/08-vernac-commands-and-options/18983-SearchFixpoint.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :cmd:`Search` now admits the `is:Fixpoint` and `is:CoFixpoint` logical
+  kinds to search for constants defined with the `Fixpoint` and `CoFixpoint`
+  keywords
+  (`#18983 <https://github.com/coq/coq/pull/18983>`_,
+  by Pierre Rousselin).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -188,7 +188,9 @@ described elsewhere
       .. insertprodn logical_kind logical_kind
 
       .. prodn::
-         logical_kind ::= {| @thm_token | @assumption_token }
+         logical_kind ::= Fixpoint
+         | CoFixpoint
+         | {| @thm_token | @assumption_token }
          | {| Definition | Example | Context | Primitive | Symbol }
          | {| Coercion | Instance | Scheme | Canonical | SubClass }
          | {| Field | Method }

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -188,11 +188,9 @@ described elsewhere
       .. insertprodn logical_kind logical_kind
 
       .. prodn::
-         logical_kind ::= Fixpoint
-         | CoFixpoint
-         | {| @thm_token | @assumption_token }
+         logical_kind ::= {| @thm_token | @assumption_token }
          | {| Definition | Example | Context | Primitive | Symbol }
-         | {| Coercion | Instance | Scheme | Canonical | SubClass }
+         | {| Coercion | Instance | Scheme | Canonical | SubClass | Fixpoint | CoFixpoint }
          | {| Field | Method }
 
       Filters objects by the keyword that was used to define them

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -198,8 +198,8 @@ described elsewhere
       Filters objects by the keyword that was used to define them
       (`Theorem`, `Lemma`, `Axiom`, `Variable`, `Context`,
       `Primitive`...) or its status (`Coercion`, `Instance`, `Scheme`,
-      `Canonical`, `SubClass`, Field` for record fields, `Method` for class
-      fields).  Note that `Coercion`\s, `Canonical Structure`\s, Instance`\s and `Scheme`\s can be
+      `Canonical`, `SubClass`, `Field` for record fields, `Method` for class
+      fields).  Note that `Coercion`\s, `Canonical Structure`\s, `Instance`\s and `Scheme`\s can be
       defined without using those keywords.  See :ref:`this example <search-by-keyword>`.
 
    Additional clauses:
@@ -307,6 +307,13 @@ described elsewhere
       .. coqtop:: all
 
          Search is:Instance [ Reflexive | Symmetric ].
+
+      The following search outputs operations on `nat` defined in the
+      prelude either with the `Definition` or `Fixpoint` keyword:
+
+      .. coqtop:: all reset
+
+         Search (nat -> nat -> nat) -bool [ is:Definition | is:Fixpoint ].
 
 .. cmd:: SearchPattern @one_pattern {? {| inside | in | outside } {+ @qualid } }
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -190,8 +190,8 @@ described elsewhere
       .. prodn::
          logical_kind ::= {| @thm_token | @assumption_token }
          | {| Definition | Example | Context | Primitive | Symbol }
-         | {| Coercion | Instance | Scheme | Canonical | SubClass | Fixpoint | CoFixpoint }
-         | {| Field | Method }
+         | {| Coercion | Instance | Scheme | Canonical | SubClass }
+         | {| Fixpoint | CoFixpoint | Field | Method }
 
       Filters objects by the keyword that was used to define them
       (`Theorem`, `Lemma`, `Axiom`, `Variable`, `Context`,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1971,7 +1971,9 @@ logical_kind: [
 | DELETE "Instance"
 | DELETE "Scheme"
 | DELETE "Canonical"
-| [  "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" ]
+| DELETE "Fixpoint"
+| DELETE "CoFixpoint"
+| [  "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" | "Fixpoint" | "CoFixpoint" ]
 | DELETE "Field"
 | DELETE "Method"
 | [ "Field" | "Method" ]

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1971,12 +1971,12 @@ logical_kind: [
 | DELETE "Instance"
 | DELETE "Scheme"
 | DELETE "Canonical"
+| [  "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" ]
 | DELETE "Fixpoint"
 | DELETE "CoFixpoint"
-| [  "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" | "Fixpoint" | "CoFixpoint" ]
 | DELETE "Field"
 | DELETE "Method"
-| [ "Field" | "Method" ]
+| [  "Fixpoint" | "CoFixpoint" | "Field" | "Method" ]
 ]
 
 (* ltac2 *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1516,6 +1516,8 @@ logical_kind: [
 extended_def_token: [
 | def_token
 | "Coercion"
+| "Fixpoint"
+| "CoFixpoint"
 | "Instance"
 | "Scheme"
 | "Canonical"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1053,11 +1053,9 @@ search_item: [
 ]
 
 logical_kind: [
-| "Fixpoint"
-| "CoFixpoint"
 | [ thm_token | assumption_token ]
 | [ "Definition" | "Example" | "Context" | "Primitive" | "Symbol" ]
-| [ "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" ]
+| [ "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" | "Fixpoint" | "CoFixpoint" ]
 | [ "Field" | "Method" ]
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1055,8 +1055,8 @@ search_item: [
 logical_kind: [
 | [ thm_token | assumption_token ]
 | [ "Definition" | "Example" | "Context" | "Primitive" | "Symbol" ]
-| [ "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" | "Fixpoint" | "CoFixpoint" ]
-| [ "Field" | "Method" ]
+| [ "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" ]
+| [ "Fixpoint" | "CoFixpoint" | "Field" | "Method" ]
 ]
 
 univ_name_list: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1053,6 +1053,8 @@ search_item: [
 ]
 
 logical_kind: [
+| "Fixpoint"
+| "CoFixpoint"
 | [ thm_token | assumption_token ]
 | [ "Definition" | "Example" | "Context" | "Primitive" | "Symbol" ]
 | [ "Coercion" | "Instance" | "Scheme" | "Canonical" | "SubClass" ]

--- a/test-suite/output/SearchFixpoint.out
+++ b/test-suite/output/SearchFixpoint.out
@@ -1,0 +1,3 @@
+Foo.bar: nat -> nat
+Foo.from: nat -> Foo.Stream
+Foo.foo: nat

--- a/test-suite/output/SearchFixpoint.v
+++ b/test-suite/output/SearchFixpoint.v
@@ -1,0 +1,21 @@
+(** Test file for #18983 *)
+
+(** We test that [Search] allows the [is:Fixpoint] and [is:CoFixpoint] search
+    items while not changing [is:Definition]. *)
+Module Foo.
+Definition foo := 42.
+
+Fixpoint bar (n : nat) :=
+  match n with
+  | 0 => 0
+  | S n => bar n
+  end.
+
+(* Example shamelessly taken from the reference manual. *)
+CoInductive Stream := Seq : nat -> Stream -> Stream.
+CoFixpoint from (n : nat) := Seq n (from (S n)).
+End Foo.
+
+Search is:Fixpoint inside Foo.
+Search is:CoFixpoint inside Foo.
+Search is:Definition inside Foo.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1248,6 +1248,8 @@ GRAMMAR EXTEND Gram
   extended_def_token:
     [ [ k = def_token -> { snd k }
       | IDENT "Coercion" -> { Coercion }
+      | IDENT "Fixpoint" -> { Fixpoint }
+      | IDENT "CoFixpoint" -> { CoFixpoint }
       | IDENT "Instance" -> { Instance }
       | IDENT "Scheme" -> { Scheme }
       | IDENT "Canonical" -> { CanonicalStructure }


### PR DESCRIPTION
This makes it possible e.g. to
```coq
Search (nat -> nat -> nat) [is:Fixpoint | is:Definition].
```

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  Here is [the updated `Search ` paragraph](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/4333099/artifacts/_build/default/doc/refman-html/proof-engine/vernacular-commands.html?highlight=search#coq:cmd.Search)
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
