### PR TITLE
Warn when automatically lowering an inductive declared with `: Type` to Prop

### DIFF
--- a/dev/ci/user-overlays/18989-SkySkimmer-warn-auto-lower.sh
+++ b/dev/ci/user-overlays/18989-SkySkimmer-warn-auto-lower.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi warn-auto-lower 18989

--- a/doc/changelog/06-Ltac2-language/18989-warn-auto-lower.rst
+++ b/doc/changelog/06-Ltac2-language/18989-warn-auto-lower.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :flag:`Automatic Proposition Inductives`, :flag:`Dependent Proposition Eliminators` and
+  :warn:`warning when automatically lowering an inductive declared with Type to Prop
+  <automatic-prop-lowering>`
+  (`#18989 <https://github.com/coq/coq/pull/18989>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -158,6 +158,15 @@ At times, it's helpful to know exactly what these notations represent.
   | or_intror (_:B).
   Definition iff (P Q:Prop) := (P -> Q) /\ (Q -> P).
 
+We also have the `Type` level negation:
+
+.. index::
+  single: notT (term)
+
+.. coqtop:: in
+
+  Definition notT (A:Type) := A -> False.
+
 Quantifiers
 +++++++++++
 
@@ -318,14 +327,8 @@ Programming
   Inductive bool : Set := true | false.
   Inductive nat : Set := O | S (n:nat).
   Inductive option (A:Set) : Set := Some (_:A) | None.
-  Inductive identity (A:Type) (a:A) : A -> Type :=
-    refl_identity : identity A a a.
 
 Note that zero is the letter ``O``, and *not* the numeral ``0``.
-
-The predicate ``identity`` is logically
-equivalent to equality but it lives in sort ``Type``.
-It is mainly maintained for compatibility.
 
 We then define the disjoint sum of ``A+B`` of two sets ``A`` and
 ``B``, and their product ``A*B``.
@@ -699,33 +702,6 @@ fixpoint equation can be proved.
   Lemma Fix_eq : forall x:A, Fix x = F x (fun (y:A) (p:R y x) => Fix y).
   End FixPoint.
   End Well_founded.
-
-Accessing the Type level
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The standard library includes ``Type`` level definitions of counterparts of some
-logic concepts and basic lemmas about them.
-
-The module ``Datatypes`` defines ``identity``, which is the ``Type`` level counterpart
-of equality:
-
-.. index::
-   single: identity (term)
-
-.. coqtop:: in
-
-   Inductive identity (A:Type) (a:A) : A -> Type :=
-     identity_refl : identity A a a.
-
-Some properties of ``identity`` are proved in the module ``Logic_Type``, which also
-provides the definition of ``Type`` level negation:
-
-.. index::
-  single: notT (term)
-
-.. coqtop:: in
-
-  Definition notT (A:Type) := A -> False.
 
 Tactics
 ~~~~~~~

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -42,10 +42,9 @@ Inductive types
    respectively correspond to
    on :g:`Type`, :g:`Prop`, :g:`Set` and :g:`SProp`.  Their types
    expresses structural induction/recursion principles over objects of
-   type :n:`@ident`.  The :term:`constant` :n:`@ident`\ ``_ind`` is always
-   generated, whereas :n:`@ident`\ ``_rec`` and :n:`@ident`\ ``_rect``
-   may be impossible to derive (for example, when :n:`@ident` is a
-   proposition).
+   type :n:`@ident`.  These :term:`constants <constant>` are generated when
+   possible (for instance :n:`@ident`\ ``_rect`` may be impossible to derive
+   when :n:`@ident` is a proposition).
 
    .. flag:: Dependent Proposition Eliminators
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -163,6 +163,37 @@ by giving the type of its arguments alone.
 
       Inductive nat : Set := O | S (_:nat).
 
+Automatic Prop lowering
++++++++++++++++++++++++
+
+When an inductive is declared with no explicit sort, it is put in the
+smallest sort which does not prevent large elimination (excluding
+`SProp`). For :ref:`empty and singleton <Empty-and-singleton-elimination>`
+types this means they are declared in `Prop`.
+
+.. flag:: Automatic Proposition Inductives
+
+   By default the above behaviour is extended to empty and singleton
+   inductives explicitly declared in `Type` (but not those in explicit
+   universes using `Type@{u}`, or in `Type` through an auxiliary definition
+   such as `Definition typ := Type.`).
+
+   Disabling this flag prevents inductives with an explicit non-`Prop`
+   type from being lowered to `Prop`. This will become the default in
+   a future version. Note :flag:`Dependent Proposition Eliminators` to
+   declare the inductive type in `Prop` while preserving compatibility.
+
+   Depending on universe minimization they may then be declared in
+   `Set` or in a floating universe level,
+   see also :flag:`Universe Minimization ToSet`.
+
+.. warn:: Automatically putting @ident in Prop even though it was declared with Type.
+   :name: automatic-prop-lowering
+
+   This warning is produced when :flag:`Automatic Proposition
+   Inductives` is enabled and resulted in an inductive type being
+   lowered to `Prop`.
+
 Simple indexed inductive types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -165,8 +165,8 @@ by giving the type of its arguments alone.
 Automatic Prop lowering
 +++++++++++++++++++++++
 
-When an inductive is declared with no explicit sort, it is put in the
-smallest sort which does not prevent large elimination (excluding
+When an inductive is declared without an explicit sort, it is put in the
+smallest sort which permits large elimination (excluding
 `SProp`). For :ref:`empty and singleton <Empty-and-singleton-elimination>`
 types this means they are declared in `Prop`.
 
@@ -179,7 +179,7 @@ types this means they are declared in `Prop`.
 
    Disabling this flag prevents inductives with an explicit non-`Prop`
    type from being lowered to `Prop`. This will become the default in
-   a future version. Note :flag:`Dependent Proposition Eliminators` to
+   a future version. Use :flag:`Dependent Proposition Eliminators` to
    declare the inductive type in `Prop` while preserving compatibility.
 
    Depending on universe minimization they may then be declared in

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -47,6 +47,21 @@ Inductive types
    may be impossible to derive (for example, when :n:`@ident` is a
    proposition).
 
+   .. flag:: Dependent Proposition Eliminators
+
+      The inductive principles express dependent elimination when the
+      inductive type allows it (always true when not using
+      :flag:`Primitive Projections`), except by default when the
+      inductive is explicitly declared in `Prop`.
+
+      Explicitly `Prop` inductive types declared when this flag is
+      enabled also automatically declare dependent inductive
+      principles. Name generation may also change when using tactics
+      such as :tacn:`destruct` on such inductives.
+
+      Note that explicit declarations through :cmd:`Scheme` are not
+      affected by this flag.
+
    :n:`{? %| {* @binder } }`
      The :n:`|` separates uniform and non uniform parameters.
      See :flag:`Uniform Inductive Parameters`.

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -53,9 +53,9 @@ be defined using :cmd:`Variant`.
 
    .. coqtop:: in
 
-      Variant bool : Type := true : bool | false : bool.
-      Variant unit : Type := tt : unit.
-      Variant Empty_set : Type :=.
+      Variant bool : Set := true : bool | false : bool.
+      Variant unit : Set := tt : unit.
+      Variant Empty_set : Set :=.
 
   The option and sum types are defined by:
 

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -524,7 +524,7 @@ We need some infrastructure for that.
 
   Module infrastructure.
 
-    Inductive phantom {T : Type} (t : T) : Type := Phantom.
+    Inductive phantom {T : Type} (t : T) := Phantom.
 
     Definition unify {T1 T2} (t1 : T1) (t2 : T2) (s : option string) :=
       phantom t1 -> phantom t2.

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1518,9 +1518,10 @@ let do_build_inductive evd (funconstants : pconstant list)
   try
     with_full_print
       (Flags.silently
-         (ComInductive.do_mutual_inductive ~template:(Some false) None rel_inds
-            ~cumulative:false ~poly:false ~private_ind:false
-            ~uniform:ComInductive.NonUniformParameters))
+         (Flags.without_option ComInductive.Internal.do_auto_prop_lowering
+            (ComInductive.do_mutual_inductive ~template:(Some false) None rel_inds
+               ~cumulative:false ~poly:false ~private_ind:false
+               ~uniform:ComInductive.NonUniformParameters)))
       Declarations.Finite
   with
   | UserError msg as e ->

--- a/test-suite/bugs/HoTT_coq_054.v
+++ b/test-suite/bugs/HoTT_coq_054.v
@@ -1,6 +1,6 @@
 Inductive Empty : Prop := .
 
-Inductive paths {A : Type} (a : A) : A -> Type :=
+Inductive paths {A : Type} (a : A) : A -> Prop :=
   idpath : paths a a.
 
 Notation "x = y :> A" := (@paths A x y) : type_scope.
@@ -46,10 +46,10 @@ Theorem ex2_8 {A B A' B' : Type} (g : A -> A') (h : B -> B') (x y : A + B)
                          | inl y' => ap g
                          | inr y' => idmap
                        end
-           | inr x' => match y as y return match y return Prop with
+           | inr x' => match y as y return match y  with
                                                inr y' => x' = y'
                                              | _ => Empty
-                                           end -> match f y return Prop with
+                                           end -> match f y  with
                                                     | inr y' => h x' = y'
                                                     | _ => Empty end with
                          | inl y' => idmap

--- a/test-suite/bugs/bug_4116.v
+++ b/test-suite/bugs/bug_4116.v
@@ -36,7 +36,7 @@ Notation compose := (fun g f x => g (f x)).
 
 Notation "g 'o' f" := (compose g%function f%function) (at level 40, left associativity) : function_scope.
 
-Inductive paths {A : Type} (a : A) : A -> Type :=
+Inductive paths {A : Type} (a : A) : A -> Prop :=
   idpath : paths a a.
 
 Arguments idpath {A a} , [A] a.

--- a/test-suite/bugs/bug_5501.v
+++ b/test-suite/bugs/bug_5501.v
@@ -5,7 +5,7 @@ Record Pred@{A} :=
   ; P : car -> Prop
   }.
 
-Class All@{A} (A : Pred@{A}) : Type :=
+Class All@{A} (A : Pred@{A}) :=
   { proof : forall (a : A), P A a
   }.
 

--- a/test-suite/output/ArgumentsScope.v
+++ b/test-suite/output/ArgumentsScope.v
@@ -81,8 +81,8 @@ About g''.
 
 Module SectionTest1.
 
-  Inductive A:Type :=.
-  Inductive B:Type :=.
+  Inductive A :=.
+  Inductive B :=.
   Declare Scope X.
   Section S.
     Declare Scope Y.
@@ -99,7 +99,7 @@ End SectionTest1.
 
 Module SectionTest2.
 
-  Inductive A:Type :=.
+  Inductive A :=.
   Module M.
     Declare Scope X.
     Bind Scope X with A.

--- a/test-suite/output/bug_13266.v
+++ b/test-suite/output/bug_13266.v
@@ -1,4 +1,4 @@
-Inductive proc : Type -> Type :=
+Inductive proc : Type -> Prop :=
 | Tick : proc unit
 .
 

--- a/test-suite/output/inference.v
+++ b/test-suite/output/inference.v
@@ -21,6 +21,6 @@ Print P.
 
 (* Note: exact numbers of evars are not important... *)
 
-Inductive T (n:nat) : Type := A : T n.
+Inductive T (n:nat) := A : T n.
 Check fun n (y:=A n:T n) => _ _ : T n.
 Check fun n => _ _ : T n.

--- a/test-suite/success/AutoPropLowering.v
+++ b/test-suite/success/AutoPropLowering.v
@@ -1,0 +1,17 @@
+Set Warnings "+automatic-prop-lowering".
+
+Fail Inductive foo : Type := .
+
+Unset Automatic Proposition Inductives.
+
+Inductive foo : Type := .
+
+Fail Check foo : Prop.
+
+Inductive bar := .
+
+Check bar : Prop.
+
+Inductive baz := Baz (_:True) (_:baz).
+
+Check baz : Prop.

--- a/test-suite/success/DependentPropositionEliminators.v
+++ b/test-suite/success/DependentPropositionEliminators.v
@@ -1,0 +1,6 @@
+
+Set Dependent Proposition Eliminators.
+
+Inductive bar : Prop := XBAR | YBAR.
+
+Check bar_ind : forall P : bar -> Prop, P XBAR -> P YBAR -> forall b : bar, P b.

--- a/theories/micromega/OrderedRing.v
+++ b/theories/micromega/OrderedRing.v
@@ -43,7 +43,7 @@ Notation "x ~= y" := (~ req x y).
 Notation "x <= y" := (rle x y).
 Notation "x < y" := (rlt x y).
 
-Record SOR : Type := mk_SOR_theory {
+Record SOR : Prop := mk_SOR_theory {
   SORsetoid : Setoid_Theory R req;
   SORplus_wd : forall x1 x2, x1 == x2 -> forall y1 y2, y1 == y2 -> x1 + y1 == x2 + y2;
   SORtimes_wd : forall x1 x2, x1 == x2 -> forall y1 y2, y1 == y2 -> x1 * y1 == x2 * y2;

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -204,8 +204,15 @@ let compute_constructor_levels env evd sign =
           (s :: lev, EConstr.push_rel d env))
     sign ([],env))
 
-let { Goptions.get = do_auto_prop_lowering } =
-  Goptions.declare_bool_option_and_ref ~key:["Automatic";"Proposition";"Inductives"] ~value:true ()
+let do_auto_prop_lowering = ref true
+let () =
+  Goptions.declare_bool_option {
+    optstage = Interp;
+    optdepr = None;
+    optkey = ["Automatic";"Proposition";"Inductives"];
+    optread = (fun () -> !do_auto_prop_lowering);
+    optwrite = (fun b -> do_auto_prop_lowering := b);
+  }
 
 let warn_auto_prop_lowering =
   CWarnings.create ~name:"automatic-prop-lowering" ~category:Deprecation.Version.v8_20
@@ -238,7 +245,7 @@ let prop_lowering_candidates evd ~arities_explicit inds =
     && not (Evd.check_leq evd ESorts.set s)
   in
   let candidates = List.filter_map (fun (explicit,(_,(_,s),_,_ as ind)) ->
-      if (do_auto_prop_lowering() || not explicit) && is_prop_candidate_arity ind
+      if (!do_auto_prop_lowering || not explicit) && is_prop_candidate_arity ind
       then Some s else None)
       (List.combine arities_explicit inds)
   in
@@ -871,6 +878,7 @@ module Internal =
 struct
 
 let inductive_levels = inductive_levels
+let do_auto_prop_lowering = do_auto_prop_lowering
 
 let error_differing_params = error_differing_params
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -59,6 +59,7 @@ let push_types env idl rl tl =
 
 type structured_one_inductive_expr = {
   ind_name : Id.t;
+  ind_arity_explicit : bool;
   ind_arity : constr_expr;
   ind_lc : (Id.t * constr_expr) list
 }
@@ -203,6 +204,15 @@ let compute_constructor_levels env evd sign =
           (s :: lev, EConstr.push_rel d env))
     sign ([],env))
 
+let warn_auto_prop_lowering =
+  CWarnings.create ~name:"automatic-prop-lowering" ~category:Deprecation.Version.v8_20
+    Pp.(fun na ->
+        strbrk "Automatically putting " ++ Id.print na ++ strbrk " in Prop" ++ spc() ++
+        strbrk "even though it was declared with Type." ++ fnl() ++
+        strbrk "Set TODO to prevent this (it will become the default in a future version)." ++ fnl() ++
+        strbrk "If you instead put " ++ Id.print na ++ strbrk " explicitly in Prop," ++ spc() ++
+        strbrk "set Dependent Proposition Eliminators around the declaration for full backwards compatibility.")
+
 let is_flexible_sort evd s = match ESorts.kind evd s with
 | Set | Prop | SProp -> false
 | Type u | QSort (_, u) ->
@@ -282,7 +292,7 @@ let include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort =
 
 type default_dep_elim = DeclareInd.default_dep_elim = DefaultElim | PropButDepElim
 
-let inductive_levels env evd ~poly arities ctors =
+let inductive_levels env evd ~poly ~indnames ~arities_explicit arities ctors =
   let inds = List.map2 (fun x ctors ->
       let ctx, s = Reductionops.dest_arity env evd x in
       x, (ctx, s), List.map (compute_constructor_levels env evd) ctors)
@@ -323,12 +333,15 @@ let inductive_levels env evd ~poly arities ctors =
      as "Type" doesn't produce a qvar.
 
      Perhaps someday we can stop lowering these explicit ": Type". *)
-  let inds = List.map (fun (raw_arity,(ctx,s),indices,ctors) ->
+  let inds = List.map3 (fun na explicit (raw_arity,(ctx,s),indices,ctors) ->
       if List.mem_f (ESorts.equal evd) s candidates then
         (* NB: is_prop_candidate requires is_flexible_sort
            so in this branch we know s <> Prop *)
+        let () = if explicit then warn_auto_prop_lowering na in
         ((PropButDepElim, mkArity (ctx, ESorts.prop)),ESorts.prop,indices,ctors)
       else ((DefaultElim, raw_arity), s, indices, ctors))
+      indnames
+      arities_explicit
       inds
   in
 
@@ -493,7 +506,7 @@ let variance_of_entry ~cumulative ~variances uctx =
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 
-let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
+let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
   (* Compute renewed arities *)
   let ctor_args =  List.map (fun (_,tys) ->
       List.map (fun ty ->
@@ -502,7 +515,7 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
         tys)
       constructors
   in
-  let sigma, (default_dep_elim, arities) = inductive_levels env_ar_params sigma ~poly arities ctor_args in
+  let sigma, (default_dep_elim, arities) = inductive_levels env_ar_params sigma ~poly ~indnames ~arities_explicit arities ctor_args in
   let lbound = if poly then UGraph.Bound.Set else UGraph.Bound.Prop in
   let sigma = Evd.minimize_universes ~lbound sigma in
   let arities = List.map EConstr.(to_constr sigma) arities in
@@ -675,7 +688,8 @@ let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) not
             userimpls @ impls) cimpls)
       indimpls cimpls
   in
-  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~template ~sigma ~ctx_params ~udecl ~variances ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
+  let arities_explicit = List.map (fun ar -> ar.ind_arity_explicit) indl in
+  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~template ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
   (default_dep_elim, mie, binders, impls, ctx)
 
 
@@ -733,6 +747,7 @@ let extract_params indl =
 let extract_inductive indl =
   List.map (fun ({CAst.v=indname},_,ar,lc) -> {
     ind_name = indname;
+    ind_arity_explicit = Option.has_some ar;
     ind_arity = Option.default (CAst.make @@ CSort Constrexpr_ops.expr_Type_sort) ar;
     ind_lc = List.map (fun (_,({CAst.v=id},t)) -> (id,t)) lc
   }) indl

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -83,6 +83,7 @@ val interp_mutual_inductive_constr
   -> variances:Entries.variance_entry
   -> ctx_params:EConstr.rel_context
   -> indnames:Names.Id.t list
+  -> arities_explicit:bool list
   -> arities:EConstr.t list
   -> template_syntax:syntax_allows_template_poly list
   -> constructors:(Names.Id.t list * EConstr.constr list) list
@@ -132,6 +133,9 @@ sig
     : Environ.env
     -> Evd.evar_map
     -> poly:bool
+    -> indnames:Names.Id.t list
+    -> arities_explicit:bool list
+    (* whether the arities were explicit from the user (for auto Prop lowering) *)
     -> EConstr.constr list
     (* arities *)
     -> EConstr.rel_context list list

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -148,4 +148,7 @@ sig
     -> (Names.lident * Vernacexpr.inductive_params_expr)
     -> 'a
 
+
+  val do_auto_prop_lowering : bool ref
+
 end

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -247,8 +247,10 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
     if def then def_class_levels ~def env_ar sigma aritysorts data
     else (* each inductive has one constructor *)
       let ctors = List.map (fun (_,newfs) -> [newfs]) data in
+      let indnames = List.map (fun x -> x.DataI.name) records in
+      let arities_explicit = List.map (fun x -> Option.has_some x.DataI.arity) records in
       let sigma, (default_dep_elim, typs) =
-        ComInductive.Internal.inductive_levels env_ar sigma ~poly typs ctors
+        ComInductive.Internal.inductive_levels env_ar sigma ~poly ~indnames ~arities_explicit typs ctors
       in
       sigma, List.combine default_dep_elim typs
   in


### PR DESCRIPTION
+ option to disable the lowering and option to default declare dependent eliminators for inductives with explicit Prop (for compat when fixing the warning by putting explicit Prop)

Inductives with no explicit type (eg `Inductive foo := C.`) can still get silently put in Prop.

Maybe it would make sense to support `_` as "pick Prop or Type as needed" to make it easier to port indexed inductives? eg `Inductive foo : nat -> Type := .` would become `Inductive foo : nat -> _ := .` (currently it fails saying "not an arity"). But it doesn't look that nice so probably not worth doing.

Funind behaviour is slightly changed as we now force its inductives in Type instead of letting them be lowered (forward compatible way to disable the warning).

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/624