### PR TITLE
Remove useless code in coqtop_bin

### DIFF
--- a/topbin/coqtop_bin.ml
+++ b/topbin/coqtop_bin.ml
@@ -8,9 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let drop_setup () = Mltop.remove ()
-
-(* Main coqtop initialization *)
-let () =
-  drop_setup ();
-  Coqtop.(start_coq coqtop_toplevel)
+(* Main coqtop entry point *)
+let () = Coqtop.(start_coq coqtop_toplevel)


### PR DESCRIPTION
Mltop.remove has no effect when we didn't Mltop.set_top (which we only do in coqtop_byte_bin).
