### PR TITLE
load_printer memprof_limits.cma in dev/db

### DIFF
--- a/dev/db
+++ b/dev/db
@@ -5,6 +5,7 @@ load_printer config.cma
 load_printer boot.cma
 load_printer clib.cma
 load_printer coqperf.cma
+load_printer memprof_limits.cma
 load_printer lib.cma
 load_printer gramlib.cma
 load_printer coqrun.cma


### PR DESCRIPTION
When memprof-limits is installed, lib depends on it and all loads after it fail if we don't load memprof-limits explicitly.

When it is not installed, loading memprof_limits fails but the other loads still work.

Therefore I think trying to load it is better.
