### PR TITLE
Remove the tag branch information from case_info.

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -122,11 +122,9 @@ let v_binder_annot x = v_tuple "binder_annot" [|x;v_relevance|]
 
 let v_puniverses v = v_tuple "punivs" [|v;v_instance|]
 
-let v_boollist = List v_bool
-
 let v_caseinfo =
   let v_cstyle = v_enum "case_style" 5 in
-  let v_cprint = v_tuple "case_printing" [|v_boollist;Array v_boollist;v_cstyle|] in
+  let v_cprint = v_tuple "case_printing" [|v_cstyle|] in
   v_tuple "case_info" [|v_ind;Int;Array Int;Array Int;v_cprint|]
 
 let v_cast = v_enum "cast_kind" 3

--- a/dev/ci/user-overlays/18996-ppedrot-case-info-rm-tags.sh
+++ b/dev/ci/user-overlays/18996-ppedrot-case-info-rm-tags.sh
@@ -1,0 +1,3 @@
+overlay paramcoq https://github.com/ppedrot/paramcoq case-info-rm-tags 18996
+
+overlay elpi https://github.com/ppedrot/coq-elpi case-info-rm-tags 18996

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -39,9 +39,7 @@ type cast_kind = VMcast | NATIVEcast | DEFAULTcast
 (* This defines Cases annotations *)
 type case_style = LetStyle | IfStyle | LetPatternStyle | MatchStyle | RegularStyle
 type case_printing =
-  { ind_tags : bool list; (** tell whether letin or lambda in the arity of the inductive type *)
-    cstr_tags : bool list array; (* whether each pattern var of each constructor is a let-in (true) or not (false) *)
-    style     : case_style }
+  { style     : case_style }
 
 (* INVARIANT:
  * - Array.length ci_cstr_ndecls = Array.length ci_cstr_nargs
@@ -1270,8 +1268,6 @@ struct
   type u = inductive -> inductive
   let hashcons hind ci = { ci with ci_ind = hind ci.ci_ind }
   let pp_info_equal info1 info2 =
-    List.equal (==) info1.ind_tags info2.ind_tags &&
-    Array.equal (List.equal (==)) info1.cstr_tags info2.cstr_tags &&
     info1.style == info2.style
   let eq ci ci' =
     ci.ci_ind == ci'.ci_ind &&
@@ -1280,8 +1276,6 @@ struct
     Array.equal Int.equal ci.ci_cstr_nargs ci'.ci_cstr_nargs && (* we use [Array.equal] on purpose *)
     pp_info_equal ci.ci_pp_info ci'.ci_pp_info  (* we use (=) on purpose *)
   open Hashset.Combine
-  let hash_bool b = if b then 0 else 1
-  let hash_bool_list = List.fold_left (fun n b -> combine n (hash_bool b))
   let hash_pp_info info =
     let h1 = match info.style with
     | LetStyle -> 0
@@ -1289,9 +1283,7 @@ struct
     | LetPatternStyle -> 2
     | MatchStyle -> 3
     | RegularStyle -> 4 in
-    let h2 = hash_bool_list 0 info.ind_tags in
-    let h3 = Array.fold_left hash_bool_list 0 info.cstr_tags in
-    combine3 h1 h2 h3
+    h1
   let hash ci =
     let h1 = Ind.CanOrd.hash ci.ci_ind in
     let h2 = Int.hash ci.ci_npar in

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -25,9 +25,7 @@ type metavariable = int
 type case_style = LetStyle | IfStyle | LetPatternStyle | MatchStyle
   | RegularStyle (** infer printing form from number of constructor *)
 type case_printing =
-  { ind_tags : bool list; (** tell whether letin or lambda in the arity of the inductive type *)
-    cstr_tags : bool list array; (** tell whether letin or lambda in the signature of each constructor *)
-    style     : case_style }
+  { style     : case_style }
 
 (* INVARIANT:
  * - Array.length ci_cstr_ndecls = Array.length ci_cstr_nargs

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -282,7 +282,7 @@ let fake_match_projection env p =
     let rctx, _ = decompose_prod_decls (Vars.substl subst cty) in
     List.chop mip.mind_consnrealdecls.(0) rctx
   in
-  let ci_pp_info = { ind_tags = []; cstr_tags = [|Context.Rel.to_tags ctx|]; style = LetStyle } in
+  let ci_pp_info = { style = LetStyle } in
   let ci = {
     ci_ind = ind;
     ci_npar = mib.mind_nparams;

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -329,13 +329,7 @@ let has_dependent_elim (mib,mip) =
 (* Annotation for cases *)
 let make_case_info env ind style =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
-  let ind_tags =
-    Context.Rel.to_tags (List.firstn mip.mind_nrealdecls mip.mind_arity_ctxt) in
-  let cstr_tags =
-    Array.map2 (fun (d, _) n ->
-      Context.Rel.to_tags (List.firstn n d))
-      mip.mind_nf_lc mip.mind_consnrealdecls in
-  let print_info = { Constr.ind_tags; cstr_tags; style } in
+  let print_info = { Constr.style } in
   { Constr.ci_ind     = ind;
     ci_npar    = mib.mind_nparams;
     ci_cstr_ndecls = mip.mind_consnrealdecls;


### PR DESCRIPTION
This cache was only used in detyping, but even there most of the time it was dead code. Since all actual uses are already assuming that the inductive type exists in the environment, we simply fetch this data from there.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/626
- https://github.com/coq-community/paramcoq/pull/124