### PR TITLE
Phrasing and formatting of the unsatisfiable constraints error message

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -337,12 +337,12 @@ let pr_evar_constraints sigma pbs =
          naming/renaming. *)
       Namegen.make_all_name_different env sigma
     in
-    print_env_short env sigma ++ spc () ++ str "|-" ++ spc () ++
+    hov 2 (hov 2 (print_env_short env sigma) ++ spc () ++ str "|-" ++ spc () ++
       Internal.print_kconstr env sigma t1 ++ spc () ++
       str (match pbty with
             | Conversion.CONV -> "=="
             | Conversion.CUMUL -> "<=") ++
-      spc () ++ Internal.print_kconstr env sigma t2
+      spc () ++ Internal.print_kconstr env sigma t2)
   in
   prlist_with_sep fnl pr_evconstr pbs
 

--- a/test-suite/output/ClassMissingInstance.out
+++ b/test-suite/output/ClassMissingInstance.out
@@ -1,8 +1,6 @@
 File "./output/ClassMissingInstance.v", line 7, characters 0-28:
 The command has indeed failed with message:
 Unable to satisfy the following constraints:
+?arg_2 : Foo 1
 
-?arg_2 : "Foo 1"
-
-?arg_20 : "Foo 2"
-
+?arg_20 : Foo 2

--- a/test-suite/output/ClassMissingInstance.out
+++ b/test-suite/output/ClassMissingInstance.out
@@ -1,6 +1,6 @@
 File "./output/ClassMissingInstance.v", line 7, characters 0-28:
 The command has indeed failed with message:
-Unable to satisfy the following constraints:
+Could not find an instance for the following existential variables:
 ?arg_2 : Foo 1
 
 ?arg_20 : Foo 2

--- a/test-suite/output/bug_13942.out
+++ b/test-suite/output/bug_13942.out
@@ -108,7 +108,6 @@ More precisely:
   i : Union (M A)
 File "./output/bug_13942.v", line 140, characters 2-20:
 The command has indeed failed with message:
-Could not find an instance for the following existential variables:
 In environment:
 K : Type
 M : Type -> Type
@@ -119,6 +118,7 @@ ifalse : Choose false -> Union (M B)
 itrue : Choose true -> Union (M B)
 ib : Insert K B (M B)
 i : Choose false -> Union (M A)
+Could not find an instance for the following existential variables:
 ?hi : Insert K ?A (M ?A)
 
 ?hu : Union (M ?A)

--- a/test-suite/output/bug_13942.out
+++ b/test-suite/output/bug_13942.out
@@ -119,14 +119,11 @@ ifalse : Choose false -> Union (M B)
 itrue : Choose true -> Union (M B)
 ib : Insert K B (M B)
 i : Choose false -> Union (M A)
+?hi : Insert K ?A (M ?A)
 
-?hi : "Insert K ?A (M ?A)"
-
-?hu : "Union (M ?A)"
-
+?hu : Union (M ?A)
 File "./output/bug_13942.v", line 145, characters 16-18:
 The command has indeed failed with message:
-
 Could not find an instance for "Union (M B)" in
 environment:
 K : Type
@@ -143,7 +140,6 @@ fi fu : B
      : B
 File "./output/bug_13942.v", line 307, characters 20-31:
 The command has indeed failed with message:
-
 Could not find an instance for "Insert K K (M A)" in
 environment:
 K : Type

--- a/test-suite/output/bug_13942.out
+++ b/test-suite/output/bug_13942.out
@@ -108,7 +108,7 @@ More precisely:
   i : Union (M A)
 File "./output/bug_13942.v", line 140, characters 2-20:
 The command has indeed failed with message:
-Unable to satisfy the following constraints:
+Could not find an instance for the following existential variables:
 In environment:
 K : Type
 M : Type -> Type

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -682,7 +682,7 @@ let explain_typeclass_resolution env sigma evi k =
   match Typeclasses.class_of_constr env sigma (Evd.evar_concl evi) with
   | Some _ ->
     let env = Evd.evar_filtered_env env evi in
-      fnl () ++ str "Could not find an instance for " ++
+      str "Could not find an instance for " ++
       pr_leconstr_env env sigma (Evd.evar_concl evi) ++
       pr_trailing_ne_context_of env sigma
   | _ -> mt()
@@ -975,10 +975,11 @@ let pr_constraints printenv env sigma evars cstrs =
           pr_ne_context_of (str "In environment:") env' sigma
         else mt ()
       in
+      let env = Global.env () in
       let evs =
-        prlist
-        (fun (ev, evi) -> fnl () ++ pr_existential_key (Global.env ()) sigma ev ++
-            str " : " ++ pr_leconstr_env env' sigma (Evd.evar_concl evi) ++ fnl ()) l
+        prlist_with_sep (fun () -> fnl () ++ fnl ())
+        (fun (ev, evi) -> hov 2 (pr_existential_key env sigma ev ++
+            str " :" ++ spc () ++ Printer.pr_leconstr_env env' sigma (Evd.evar_concl evi))) l
       in
       h (pe ++ evs ++ pr_evar_constraints sigma cstrs)
     else

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1000,8 +1000,12 @@ let explain_unsatisfiable_constraints env sigma constr comp =
   in
   match constr with
   | None ->
-    str "Unable to satisfy the following constraints:" ++ fnl () ++
-    pr_constraints true env sigma undef constraints
+    if List.is_empty constraints then
+      str "Could not find an instance for the following existential variables:" ++ fnl () ++
+      pr_constraints true env sigma undef constraints
+    else
+      str "Unable to satisfy the following constraints:" ++ fnl () ++
+      pr_constraints true env sigma undef constraints
   | Some (ev, k) ->
     let cstr =
       let remaining = Evar.Map.remove ev undef in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -963,7 +963,7 @@ let explain_cannot_unify_occurrences env sigma nested ((cl2,pos2),t2) ((cl1,pos1
     pr_leconstr_env env sigma t1 ++ strbrk " at position " ++
     pr_position (cl1,pos1) ++ str "."
 
-let pr_constraints printenv env sigma evars cstrs =
+let pr_constraints printenv msg env sigma evars cstrs =
   let (ev, evi) = Evar.Map.choose evars in
     if Evar.Map.for_all (fun ev' evi' ->
       eq_named_context_val (Evd.evar_hyps evi) (Evd.evar_hyps evi')) evars
@@ -981,7 +981,7 @@ let pr_constraints printenv env sigma evars cstrs =
         (fun (ev, evi) -> hov 2 (pr_existential_key env sigma ev ++
             str " :" ++ spc () ++ Printer.pr_leconstr_env env' sigma (Evd.evar_concl evi))) l
       in
-      h (pe ++ evs ++ pr_evar_constraints sigma cstrs)
+      h (pe ++ str msg ++ fnl () ++ evs ++ pr_evar_constraints sigma cstrs)
     else
       let filter evk _ = Evar.Map.mem evk evars in
       pr_evar_map_filter ~with_univs:false filter env sigma
@@ -1001,17 +1001,17 @@ let explain_unsatisfiable_constraints env sigma constr comp =
   match constr with
   | None ->
     if List.is_empty constraints then
-      str "Could not find an instance for the following existential variables:" ++ fnl () ++
-      pr_constraints true env sigma undef constraints
+      let msg = "Could not find an instance for the following existential variables:" in
+      pr_constraints true msg env sigma undef constraints
     else
-      str "Unable to satisfy the following constraints:" ++ fnl () ++
-      pr_constraints true env sigma undef constraints
+      let msg = "Unable to satisfy the following constraints:" in
+      pr_constraints true msg env sigma undef constraints
   | Some (ev, k) ->
     let cstr =
       let remaining = Evar.Map.remove ev undef in
       if not (Evar.Map.is_empty remaining) then
-        str "With the following constraints:" ++ fnl () ++
-          pr_constraints false env sigma remaining constraints
+        let msg = "With the following constraints:" in
+        pr_constraints false msg env sigma remaining constraints
       else mt ()
     in
     let info = Evar.Map.find ev undef in


### PR DESCRIPTION
This PR is an attempt to get:
- a more consistent printing (same line breaking and non-quote when printing hypotheses and evars)
- a better space management when reporting about unsatisfiable constraints
- a better message when there are actually no constraints at all

For instance, in an example I'm working on, it gives:
```
Unable to satisfy the following constraints:
In environment:
arity : HSet
FrameBlock :
  forall n : nat,
  nat -> forall prefix : Type, FrameBlockPrev n prefix -> Type
n, p : nat
prefix : Type
FramePrev : FrameBlockPrev n prefix
frame : p <= n -> prefix -> HSet
restrFrame :
  forall (q : nat) (Hpq : p.+1 <= q.+1) (Hq : q.+1 <= n),
  arity ->
  forall D : prefix, frame (↓ (Hpq ↕ Hq)) D -> FramePrev.(frame') p D
q, r : nat
Hpr : p.+2 <= r.+2
Hrq : r.+2 <= q.+2
Hq : q.+2 <= n
ε, ω : arity
D : prefix
d : frame (↓ (?Hpq0 ↕ ?Hq0)) D
?Hpq : p.+2 <= q.+2
?Hq : q.+2 <= n
?Hpq0 : p.+1 <= r.+1
?Hq0 : r.+1 <= n
?Hpq1 : p.+2 <= r.+2
?Hq1 : r.+2 <= n
?Hpq2 : p.+1 <= q.+2
?Hq2 : q.+2 <= n
[arity] [FrameBlock n p prefix FramePrev frame restrFrame q r Hpr Hrq Hq ε ω
  D d q0 Hqn] |- ?Hq2 q0 (?Hpq2 q0 Hqn) == (↓ (?Hpq1 ↕ ?Hq1)) q0 Hqn
[arity] [FrameBlock n p prefix FramePrev frame restrFrame q r Hpr Hrq Hq ε ω
  D d q0 Hqn] |- ?Hq0 q0 (?Hpq0 q0 Hqn) == (↓ (?Hpq ↕ ?Hq)) q0 Hqn
```
while it was before:
```
Unable to satisfy the following constraints:
In environment:
arity : HSet
FrameBlock :
  forall n : nat,
  nat -> forall prefix : Type, FrameBlockPrev n prefix -> Type
n, p : nat
prefix : Type
FramePrev : FrameBlockPrev n prefix
frame : p <= n -> prefix -> HSet
restrFrame :
  forall (q : nat) (Hpq : p.+1 <= q.+1) (Hq : q.+1 <= n),
  arity ->
  forall D : prefix, frame (↓ (Hpq ↕ Hq)) D -> FramePrev.(frame') p D
q, r : nat
Hpr : p.+2 <= r.+2
Hrq : r.+2 <= q.+2
Hq : q.+2 <= n
ε, ω : arity
D : prefix
d : frame (↓ (?Hpq0 ↕ ?Hq0)) D

?Hpq : "p.+2 <= q.+2"

?Hq : "q.+2 <= n"

?Hpq0 : "p.+1 <= r.+1"

?Hq0 : "r.+1 <= n"

?Hpq1 : "p.+2 <= r.+2"

?Hq1 : "r.+2 <= n"

?Hpq2 : "p.+1 <= q.+2"

?Hq2 : "q.+2 <= n"
[arity] [FrameBlock n p prefix FramePrev frame restrFrame q r Hpr Hrq Hq ε ω D d q0 Hqn] |- ?Hq2
                                                 q0 (?Hpq2 q0 Hqn) == (↓ 
                                                 (?Hpq1 ↕ ?Hq1)) q0 Hqn
[arity] [FrameBlock n p prefix FramePrev frame restrFrame q r Hpr Hrq Hq ε ω D d q0 Hqn] |- ?Hq0
                                                 q0 (?Hpq0 q0 Hqn) == (↓ 
                                                 (?Hpq ↕ ?Hq)) q0 Hqn
```
Maybe the context and list of evars should be more clearly separated?

Also, in a situation without proper constraints like this one:
```coq
Class T : SProp.
Parameter t : T.
Parameter c : T -> T -> T.
Parameter P : T -> Type.
Parameter f : forall x, P (c (c x x) t).
Parameter g : forall x, P (c t (c x x)).
Definition h : f _ = g _.
```
the message is now:
```
Could not find an instance for the following existential variables:
?x : T
?x0 : T
```
while it was before:
```
Unable to satisfy the following constraints:

?x : "T"

?x0 : "T"
```
This is to be compared to the case of only one remaining existential variable in a class:
```coq
Class T : SProp.
Parameter t : T.
Parameter c : T -> T -> T.
Parameter P : T -> Type.
Parameter f : forall x, P (c (c x x) t).
Definition h : f _ = f _.
(* Could not find an instance for "T". *)
```
Maybe the message for one or more unresolved evars could be merged actually?

- [ ] Added / updated **test-suite**.

