### PR TITLE
Handle Implicit Type for identonly binders in notations

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -788,8 +788,8 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) binderopt av
       (* Do not try to interpret a variable as a constructor *)
       let na = out_patvar pat in
       let env = push_name_env ~dump:true ntnvars [] env na in
-      let ty' = DAst.make @@ GHole (GBinderType na.CAst.v) in
-      (renaming,env), None, na.v, bk, set_type ty (Some ty')
+      let ty' =  Option.default (DAst.make @@ GHole (GBinderType na.CAst.v)) ty in
+      (renaming,env), None, na.v, bk, Some (locate_if_hole na.v ty')
     else
       (* Interpret as a pattern *)
       let env,pat,bk,t = intern_pat test_kind ntnvars env bk pat in

--- a/test-suite/bugs/bug_9764.v
+++ b/test-suite/bugs/bug_9764.v
@@ -1,0 +1,7 @@
+Notation "[ 'fun' x => F ]" := (fun x => F)
+  (at level 0, x ident, only parsing).
+               (* or `x pattern` *)
+
+Implicit Types (n : nat).
+
+Definition nat_id := [fun n => n].


### PR DESCRIPTION
Fix #9764
