### PR TITLE
Cleanup coq_makefile doc about using -j

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -986,12 +986,7 @@ Building a subset of the targets with ``-j``
 ++++++++++++++++++++++++++++++++++++++++++++
 
 To build, say, two targets foo.vo and bar.vo in parallel one can use
-``make only TGTS="foo.vo bar.vo" -j``.
-
-.. note::
-
-  ``make foo.vo bar.vo -j`` has a different meaning for the ``make``
-  utility, in particular it may build a shared prerequisite twice.
+``make only TGTS="foo.vo bar.vo" -j`` or ``make foo.vo bar.vo``.
 
 Precompiling for ``native_compute``
 +++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
The note about `make foo.vo bar.vo` duplicating prerequisite build steps is nonsense.

Close #5609