### PR TITLE
Ltac2: runtime representation of univ instance is the raw instance

### DIFF
--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -129,18 +129,6 @@ let of_binder b =
 let to_binder b =
   Tac2ffi.to_ext Tac2ffi.val_binder b
 
-let of_instance u =
-  let u = UVars.Instance.to_array (EConstr.Unsafe.to_instance u) in
-  let toqs = Tac2ffi.of_array (fun v -> Tac2ffi.of_ext Tac2ffi.val_quality v) in
-  let tous = Tac2ffi.of_array (fun v -> Tac2ffi.of_ext Tac2ffi.val_univ v) in
-  Tac2ffi.of_pair toqs tous u
-
-let to_instance u =
-  let toqs = Tac2ffi.to_array (fun v -> Tac2ffi.to_ext Tac2ffi.val_quality v) in
-  let tous = Tac2ffi.to_array (fun v -> Tac2ffi.to_ext Tac2ffi.val_univ v) in
-  let u = Tac2ffi.to_pair toqs tous u in
-  EConstr.EInstance.make (UVars.Instance.of_array u)
-
 let of_rec_declaration (nas, ts, cs) =
   let binders = Array.map2 (fun na t -> (na, t)) nas ts in
   (Tac2ffi.of_array of_binder binders,
@@ -547,17 +535,17 @@ let () =
   | Const (cst, u) ->
     v_blk 10 [|
       Tac2ffi.of_constant cst;
-      of_instance u;
+      Tac2ffi.of_instance u;
     |]
   | Ind (ind, u) ->
     v_blk 11 [|
       Tac2ffi.of_ext Tac2ffi.val_inductive ind;
-      of_instance u;
+      Tac2ffi.of_instance u;
     |]
   | Construct (cstr, u) ->
     v_blk 12 [|
       Tac2ffi.of_ext Tac2ffi.val_constructor cstr;
-      of_instance u;
+      Tac2ffi.of_instance u;
     |]
   | Case (ci, u, pms, c, iv, t, bl) ->
     (* FIXME: also change representation Ltac2-side? *)

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -47,8 +47,7 @@ let val_projection = Val.create "projection"
 let val_qvar = Val.create "qvar"
 let val_case = Val.create "case"
 let val_binder = Val.create "binder"
-let val_univ = Val.create "universe"
-let val_quality = Val.create "quality"
+let val_instance = Val.create "instance"
 let val_free : Names.Id.Set.t Val.tag = Val.create "free"
 let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
 let val_uint63 = Val.create "uint63"
@@ -320,6 +319,10 @@ let float = {
 let of_constant c = of_ext val_constant c
 let to_constant c = to_ext val_constant c
 let constant = repr_ext val_constant
+
+let of_instance c = of_ext val_instance c
+let to_instance c = to_ext val_instance c
+let instance = repr_ext val_instance
 
 let of_reference = let open Names.GlobRef in function
 | VarRef id -> ValBlk (0, [| of_ident id |])

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -128,6 +128,10 @@ val of_constant : Constant.t -> valexpr
 val to_constant : valexpr -> Constant.t
 val constant : Constant.t repr
 
+val of_instance : EConstr.EInstance.t -> valexpr
+val to_instance : valexpr -> EConstr.EInstance.t
+val instance : EConstr.EInstance.t repr
+
 val of_reference : GlobRef.t -> valexpr
 val to_reference : valexpr -> GlobRef.t
 val reference : GlobRef.t repr
@@ -175,8 +179,6 @@ val val_projection : Projection.t Val.tag
 val val_qvar : Sorts.QVar.t Val.tag
 val val_case : Constr.case_info Val.tag
 val val_binder : (Name.t EConstr.binder_annot * types) Val.tag
-val val_univ : Univ.Level.t Val.tag
-val val_quality : Sorts.Quality.t Val.tag
 val val_free : Id.Set.t Val.tag
 val val_uint63 : Uint63.t Val.tag
 val val_float : Float64.t Val.tag


### PR DESCRIPTION
instead of a pair of ltac2 arrays

(we only expose instance as an abstract type)
