### PR TITLE
Add SSReflect contextual pattern `UNDER`

### DIFF
--- a/doc/changelog/07-ssreflect/19011-add-under-pattern.rst
+++ b/doc/changelog/07-ssreflect/19011-add-under-pattern.rst
@@ -1,0 +1,9 @@
+- **Added:**
+  Contextual pattern ``UNDER``, which restricts the scope
+  of :tacn:`rewrite <rewrite (ssreflect)>` to the current :tacn:`under` context.
+  This pattern is useful to work around the issue that occurs when rewriting an
+  equality directly involving the main bound variable.
+  Now you can write: :g:`rewrite [UNDER]lem.`, or :g:`rewrite [in UNDER]lem.`
+  (`#19011 <https://github.com/coq/coq/pull/19011>`_,
+  workaround for `#11118 <https://github.com/coq/coq/issues/11118>`_,
+  by Erik Martin-Dorel).

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -3828,6 +3828,28 @@ displayed as ``'Under[ … ]``):
    This terminator tactic allows one to close goals of the form
    ``'Under[ … ]``.
 
+   .. exn:: No applicable tactic.
+      :name: No applicable tactic. (over)
+
+      This error can occur when we have rewritten an equality directly involving
+      the main bound variable, which has an extra hidden occurrence in term ``'Under[ … ]``
+      (see issue `#11118 <https://github.com/coq/coq/issues/11118>`_).
+
+      A simple workaround amounts to using :ref:`occurrence_selection_ssr` or
+      :ref:`contextual_patterns_ssr` during these rewrite steps. For example:
+
+      .. coqdoc::
+
+         rewrite [UNDER]lem.
+         (* or *)
+         rewrite [in UNDER]lem.
+
+      This is made possible thanks to the ``UNDER`` shortcut provided in ``ssreflect.v``:
+
+      .. coqdoc::
+
+         Notation UNDER := (X in @Under_rel _ _ X _)%pattern.
+
 .. tacv:: by rewrite over
 
    This is a variant of :tacn:`over` in order to close ``'Under[ … ]``

--- a/test-suite/bugs/bug_11118.v
+++ b/test-suite/bugs/bug_11118.v
@@ -1,0 +1,13 @@
+(* cf. https://github.com/coq/coq/issues/11118 *)
+
+From Coq Require Import ssreflect.
+From Coq Require Import List.
+
+Lemma no_rhs (A: list (nat * nat)) (f: nat -> nat) :
+  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
+Proof.
+under map_ext => a.
+Fail rewrite (surjective_pairing a); over. (* No applicable tactic. *)
+rewrite [in UNDER](surjective_pairing a); over.
+done.
+Qed.

--- a/test-suite/prerequisite/ssr_mini_mathcomp.v
+++ b/test-suite/prerequisite/ssr_mini_mathcomp.v
@@ -594,6 +594,15 @@ Fixpoint map s := if s is x :: s' then f x :: map s' else [::].
 
 End Map.
 
+Section MapComp.
+
+Variable T2 : Type.
+
+Lemma eq_map (f g : T -> T2) : f =1 g -> map f =1 map g.
+Proof. by move=> Ef; elim=> //= x s ->; rewrite Ef. Qed.
+
+End MapComp.
+
 Section SeqFind.
 
 Variable a : pred T.

--- a/test-suite/ssr/under.v
+++ b/test-suite/ssr/under.v
@@ -2,11 +2,6 @@ Require Import ssreflect.
 Require Import ssrbool TestSuite.ssr_mini_mathcomp.
 Global Unset SsrOldRewriteGoalsOrder.
 
-(* under <names>: {occs}[patt]<lemma>.
-   under <names>: {occs}[patt]<lemma> by tac1.
-   under <names>: {occs}[patt]<lemma> by [tac1 | ...].
- *)
-
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
@@ -184,8 +179,27 @@ Lemma test_big_andb (F : nat -> nat) (m n : nat) :
   \sum_(0 <= i < 5 | odd i && (i == 1)) i = 1.
 Proof.
 under eq_bigl => i do [rewrite andb_idl; first by move/eqP->].
-under eq_bigr => i do move/eqP=>{1}->. (* the 2nd occ should not be touched *)
+Fail under eq_bigr => i do move/eqP->. (* the 2nd occ should not be touched *)
+under eq_bigr => i do move/eqP=>{1}->.
 myadmit.
+Qed.
+
+Lemma test_big_andb_patt (F : nat -> nat) (m n : nat) :
+  \sum_(0 <= i < 5 | odd i && (i == 1)) i = 1.
+Proof.
+under eq_bigl => i do [rewrite andb_idl; first by move/eqP->].
+under eq_bigr => i do [move/eqP=> H; rewrite [UNDER]H].
+myadmit.
+Qed.
+
+(* See also bug_11118.v *)
+Lemma test_eq_map_patt (A: list (nat * nat)) (f: nat -> nat) :
+  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
+Proof.
+under eq_map => a.
+  Fail rewrite (surjective_pairing a); over.
+  rewrite [in UNDER](surjective_pairing a); over.
+  myadmit.
 Qed.
 
 Lemma test_foo (f1 f2 : nat -> nat) (f_eq : forall n, f1 n = f2 n)

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -530,6 +530,9 @@ Ltac over :=
     them in another way than with reflexivity. *)
 Definition UnderE := Under_relE.
 
+(** Contextual pattern to avoid rewriting the hidden occurrence of the var. *)
+Notation UNDER := (X in @Under_rel _ _ X _)%pattern.
+
 (*****************************************************************************)
 
 (** An interface for non-Prop types; used to avoid improper instantiation


### PR DESCRIPTION
Close #11118

This PR proposes a simpler workaround than PR https://github.com/coq/coq/pull/11200.

Cc @gares @CohenCyril @proux01 @mrhaandi FYI

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md