### PR TITLE
Track unused constant arguments in Genlambda and erase them.

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -280,7 +280,7 @@ let v_vm_patches = v_tuple "vm_patches" [|Array v_reloc|]
 
 let v_vm_pbody_code index =
   v_sum "pbody_code" 1 [|
-    [|v_pair index v_vm_patches|];
+    [|Array v_bool; index; v_vm_patches|];
     [|v_cst|];
   |]
 

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -60,13 +60,15 @@ val mkLlam : Name.t binder_annot array -> 'v lambda -> 'v lambda
 val decompose_Llam : 'v lambda -> Name.t binder_annot array * 'v lambda
 val decompose_Llam_Llet : 'v lambda -> (Name.t binder_annot * 'v lambda option) array * 'v lambda
 
+val free_rels : 'v lambda -> Int.Set.t
+
 (* {5 Simplification} *)
 
 val optimize : 'v lambda -> 'v lambda
 
 (** {5 Translation functions} *)
 
-val get_alias : Environ.env -> Constant.t -> Constant.t
+val get_alias : Environ.env -> Constant.t -> Constant.t * bool array
 
 module type S =
 sig

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2224,7 +2224,7 @@ let compile_deps env sigma prefix init t =
   match kind t with
   | Ind ((mind,_),_u) -> compile_mind_deps env prefix init mind
   | Const (c, _u) ->
-    let c = get_alias env c in
+    let c, _ = get_alias env c in
     let cb,(nameref,_) = lookup_constant_key c env in
     let (_, (_, const_updates)) = init in
     if is_code_loaded nameref

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -385,9 +385,9 @@ let push_bytecode vmtab code =
   let open Vmemitcodes in
   let vmtab, code = match code with
   | None -> vmtab, None
-  | Some (BCdefined (code, patches)) ->
+  | Some (BCdefined (mask, code, patches)) ->
     let vmtab, index = Vmlibrary.add code vmtab in
-    vmtab, Some (BCdefined (index, patches))
+    vmtab, Some (BCdefined (mask, index, patches))
   | Some BCconstant -> vmtab, Some BCconstant
   | Some (BCalias kn) -> vmtab, Some (BCalias kn)
   in

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -17,7 +17,7 @@ open Environ
 val compile :
   fail_on_error:bool -> ?universes:int*int ->
   env -> Genlambda.evars -> constr ->
-  (to_patch * patches) option
+  (bool array * to_patch * patches) option
 
 val compile_constant_body : fail_on_error:bool ->
   env -> universes -> (Constr.t, 'opaque, 'symb) constant_def ->

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -538,14 +538,14 @@ let subst_patches subst p =
   { reloc_infos = infos }
 
 type 'a pbody_code =
-  | BCdefined of ('a * patches)
+  | BCdefined of bool array * 'a * patches
   | BCalias of Names.Constant.t
   | BCconstant
 
 type body_code = to_patch pbody_code
 
 let subst_body_code s = function
-| BCdefined (x, tp) -> BCdefined (x, subst_patches s tp)
+| BCdefined (m, x, tp) -> BCdefined (m, x, subst_patches s tp)
 | BCalias cu -> BCalias (subst_constant s cu)
 | BCconstant -> BCconstant
 

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -23,7 +23,7 @@ type patches
 val patch : (to_patch * patches) -> (reloc_info -> int) -> Vmvalues.tcode * fv
 
 type 'a pbody_code =
-  | BCdefined of ('a * patches)
+  | BCdefined of bool array * 'a * patches
   | BCalias of Constant.t
   | BCconstant
 

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -263,7 +263,7 @@ let rec slot_for_getglobal env sigma kn envcache table =
       | None -> set_global (val_of_constant kn) table
       | Some code ->
         match code with
-        | BCdefined (index, patches) ->
+        | BCdefined (_, index, patches) ->
            let code = Environ.lookup_vm_code index env in
            let code = (code, patches) in
            let v = eval_to_patch env sigma code envcache table in
@@ -326,7 +326,7 @@ and eval_to_patch env sigma code envcache table =
 
 and val_of_constr env sigma c envcache table =
   match compile ~fail_on_error:true env sigma c with
-  | Some v -> eval_to_patch env sigma v envcache table
+  | Some (_, code, patch) -> eval_to_patch env sigma (code, patch) envcache table
   | None -> assert false
 
 let global_table =


### PR DESCRIPTION
We replace arguments that do not appear in the lambda body of constants by a dummy constant value. The rationale is that most arguments in symbolic code are type annotations that have no computational content, hence there is no point in generating them in the first place.

This patch seems to have wonderful effects on degenerate examples from UniMath.

Depends on #19015.