### PR TITLE
Factor the lambda compilation passes of VM and native

### DIFF
--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -459,6 +459,11 @@ let rec remove_let subst lam =
       if def == def' && body == body' then lam else Llet(id,def',body')
   | _ -> map_lam_with_binders liftn remove_let subst lam
 
+let optimize lam =
+  let lam = simplify lam in
+  let lam = remove_let (subs_id 0) lam in
+  lam
+
 (* Compiling constants *)
 
 let rec get_alias env kn =

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -314,13 +314,20 @@ let lam_subst_args subst args =
   if is_subs_id subst then args
   else Array.Smart.map (lam_exsubst subst) args
 
-(* [simplify can_subst subst lam] simplifies the expression [lam_subst subst lam] by: *)
+(* [simplify subst lam] simplifies the expression [lam_subst subst lam] by: *)
 (* - Reducing [let] is the definition can be substituted *)
 (* - Transforming beta redex into [let] expression *)
 (* - Moving arguments under [let] *)
 (* Invariant: Terms in [subst] are already simplified and can be substituted *)
 
-let simplify can_subst subst lam =
+let can_subst lam = match lam with
+| Lrel _ | Lvar _ | Lconst _ | Luint _
+| Lval _ | Lsort _ | Lind _ -> true
+| Levar _ | Lprod _ | Llam _ | Llet _ | Lapp _ | Lcase _ | Lfix _ | Lcofix _
+| Lparray _ | Lmakeblock _ | Lfloat _ | Lprim _ | Lproj _ -> false
+| Lint _ -> false (* TODO: allow substitution of integers *)
+
+let simplify lam =
   let rec simplify subst lam =
     match lam with
     | Lrel(id,i) -> lam_subst_rel lam id i subst
@@ -381,7 +388,7 @@ let simplify can_subst subst lam =
       Llam(Array.of_list lids, simplify (liftn (List.length lids) substf) body)
     | [], _ -> simplify_app substf body substa (Array.of_list largs)
   in
-  simplify subst lam
+  simplify (subs_id 0) lam
 
 (* [occurrence kind k lam]:
    If [kind] is [true] return [true] if the variable [k] does not appear in

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -448,12 +448,18 @@ let occur_once lam =
 (* used at most once time in the body, and does not appear under      *)
 (* a lambda or a fix or a cofix                                       *)
 
+let is_value lam = match lam with
+| Lrel _ | Lvar _ | Lconst _ | Luint _
+| Lval _ | Lsort _ | Lind _ | Lint _ | Llam _ | Lfix _ | Lcofix _ | Lfloat _ -> true
+| Levar _ | Lprod _ | Llet _ | Lapp _ | Lcase _
+| Lparray _ | Lmakeblock _ | Lprim _ | Lproj _ -> false
+
 let rec remove_let subst lam =
   match lam with
   | Lrel(id,i) -> lam_subst_rel lam id i subst
   | Llet(id,def,body) ->
     let def' = remove_let subst def in
-    if occur_once body then remove_let (cons def' subst) body
+    if occur_once body && is_value body then remove_let (cons def' subst) body
     else
       let body' = remove_let (lift subst) body in
       if def == def' && body == body' then lam else Llet(id,def',body')

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -73,7 +73,7 @@ val lam_subst_args : 'v lambda Esubst.subs -> 'v lambda array -> 'v lambda array
 
 (* {5 Simplification} *)
 
-val simplify : ('v lambda -> bool) -> 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
+val simplify : 'v lambda -> 'v lambda
 
 val remove_let : 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
 

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -73,9 +73,7 @@ val lam_subst_args : 'v lambda Esubst.subs -> 'v lambda array -> 'v lambda array
 
 (* {5 Simplification} *)
 
-val simplify : 'v lambda -> 'v lambda
-
-val remove_let : 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
+val optimize : 'v lambda -> 'v lambda
 
 (** {5 Translation functions} *)
 

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -60,17 +60,6 @@ val mkLlam : Name.t binder_annot array -> 'v lambda -> 'v lambda
 val decompose_Llam : 'v lambda -> Name.t binder_annot array * 'v lambda
 val decompose_Llam_Llet : 'v lambda -> (Name.t binder_annot * 'v lambda option) array * 'v lambda
 
-val map_lam_with_binders : (int -> 'a -> 'a) -> ('a -> 'v lambda -> 'v lambda) ->
-  'a -> 'v lambda -> 'v lambda
-
-(* {5 Lift and substitution} *)
-
-val lam_exlift : Esubst.lift -> 'v lambda -> 'v lambda
-val lam_lift : int -> 'v lambda -> 'v lambda
-val lam_subst_rel : 'v lambda -> Name.t -> int -> 'v lambda Esubst.subs -> 'v lambda
-val lam_exsubst : 'v lambda Esubst.subs -> 'v lambda -> 'v lambda
-val lam_subst_args : 'v lambda Esubst.subs -> 'v lambda array -> 'v lambda array
-
 (* {5 Simplification} *)
 
 val optimize : 'v lambda -> 'v lambda
@@ -78,11 +67,6 @@ val optimize : 'v lambda -> 'v lambda
 (** {5 Translation functions} *)
 
 val get_alias : Environ.env -> Constant.t -> Constant.t
-val make_args : int -> int -> 'v lambda array
-val makeblock : (int -> 'v lambda array -> 'v option) ->
-  inductive -> int -> int -> int -> 'v lambda array -> 'v lambda
-
-val lambda_of_prim : Environ.env -> pconstant -> CPrimitives.t -> 'v lambda array -> 'v lambda
 
 module type S =
 sig

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -54,4 +54,4 @@ module Lambda = Genlambda.Make(Val)
 
 let lambda_of_constr env sigma c =
   let lam = Lambda.lambda_of_constr env sigma c in
-  simplify lam
+  optimize lam

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Util
-open Esubst
 open Genlambda
 
 (** This file defines the lambda code generation phase of the native compiler *)
@@ -19,15 +18,6 @@ type lambda = Nativevalues.t Genlambda.lambda
 (*s Constructors *)
 
 (** Simplification of lambda expression *)
-
-(* TODO: make the VM and native agree *)
-let can_subst lam =
-  match lam with
-  | Lrel _ | Lvar _ | Lconst _ | Lval _ | Lsort _ | Lind _ | Llam _
-  | Levar _ -> true
-  | _ -> false
-
-let simplify subst lam = simplify can_subst subst lam
 
 let is_value lc =
   match lc with
@@ -64,4 +54,4 @@ module Lambda = Genlambda.Make(Val)
 
 let lambda_of_constr env sigma c =
   let lam = Lambda.lambda_of_constr env sigma c in
-  simplify (subs_id 0) lam
+  simplify lam

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -878,7 +878,7 @@ let compile ?universes:(universes=(0,0)) env sigma c =
   let cont = [Kstop] in
     let cenv, init_code, fun_code =
       if UVars.eq_sizes universes (0,0) then
-        let lam = lambda_of_constr ~optimize:true env sigma c in
+        let lam = lambda_of_constr env sigma c in
         let cenv = empty_comp_env () in
         let env = { env; fun_code = []; uinst_len = (0,0) } in
         let cont = compile_lam env cenv lam 0 cont in
@@ -888,7 +888,7 @@ let compile ?universes:(universes=(0,0)) env sigma c =
         (* We are going to generate a lambda, but merge the universe closure
          * with the function closure if it exists.
          *)
-        let lam = lambda_of_constr ~optimize:true env sigma c in
+        let lam = lambda_of_constr env sigma c in
         let params, body = decompose_Llam lam in
         let arity = Array.length params in
         let cenv = empty_comp_env () in

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -1,5 +1,4 @@
 open Util
-open Esubst
 open Declarations
 open Genlambda
 open Vmvalues
@@ -80,13 +79,9 @@ module Lambda = Genlambda.Make(Val)
 (*********************************)
 let dump_lambda = ref false
 
-let optimize_lambda lam =
-  let lam = simplify lam in
-  remove_let (subs_id 0) lam
-
 let lambda_of_constr env sigma c =
   let lam = Lambda.lambda_of_constr env sigma c in
-  let lam = optimize_lambda lam in
+  let lam = optimize lam in
   if !dump_lambda then
     Feedback.msg_debug (pp_lam lam);
   lam

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -84,9 +84,9 @@ let optimize_lambda lam =
   let lam = simplify lam in
   remove_let (subs_id 0) lam
 
-let lambda_of_constr ~optimize env sigma c =
+let lambda_of_constr env sigma c =
   let lam = Lambda.lambda_of_constr env sigma c in
-  let lam = if optimize then optimize_lambda lam else lam in
+  let lam = optimize_lambda lam in
   if !dump_lambda then
     Feedback.msg_debug (pp_lam lam);
   lam

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -11,15 +11,6 @@ let get_lval (_, v) = v
 
 (** Simplification of lambda expression *)
 
-(* TODO: make the VM and native agree *)
-let can_subst lam =
-  match lam with
-  | Lrel _ | Lvar _ | Lconst _ | Luint _
-  | Lval _ | Lsort _ | Lind _ -> true
-  | _ -> false
-
-let simplify subst lam = simplify can_subst subst lam
-
 (*s Translation from [constr] to [lambda] *)
 
 (* Translation of constructor *)
@@ -90,9 +81,8 @@ module Lambda = Genlambda.Make(Val)
 let dump_lambda = ref false
 
 let optimize_lambda lam =
-  let subst_id = subs_id 0 in
-  let lam = simplify subst_id lam in
-  remove_let subst_id lam
+  let lam = simplify lam in
+  remove_let (subs_id 0) lam
 
 let lambda_of_constr ~optimize env sigma c =
   let lam = Lambda.lambda_of_constr env sigma c in

--- a/kernel/vmlambda.mli
+++ b/kernel/vmlambda.mli
@@ -16,7 +16,7 @@ type lambda = lval Genlambda.lambda
 
 val get_lval : lval -> structured_values
 
-val lambda_of_constr : optimize:bool -> env -> Genlambda.evars -> Constr.t -> lambda
+val lambda_of_constr : env -> Genlambda.evars -> Constr.t -> lambda
 
 (** Dump the VM lambda code after compilation (for debugging purposes) *)
 val dump_lambda : bool ref


### PR DESCRIPTION
This is a series of cleanups that make the VM and native generate the same lambda code up to structured values.  Apart for the simple cleanups, the VM pipeline is untouched. This changes the output of native compilation in the following way:

- Let-bound closures and evars are not substituted unconditionally anymore in the simplification phase.
- Instead, arbitrary let-bindings are inlined using the `remove_let` heuristic, i.e. the bound variable must occur linearly outside of a closure.

EDIT: the last commit also modifies the VM compilation by restricting the remove_let heuristic to syntactic values.