### PR TITLE
Compatibility of new fast "make report" with MacOS X

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -241,7 +241,8 @@ $(foreach S,$(VSUBSYSTEMS),$(eval $(call vdeps,$(S))))
 # Summary
 #######################################################################
 
-summary_dir = echo $(1); find $(2) -name '*.log' -print0 | xargs -0 tail -q -n1 | sort
+# using "-L 999" because some versions of tail do not accept more than ~1k arguments
+summary_dir = echo $(1); find $(2) -name '*.log' -print0 | xargs -0 -L 999  tail -q -n1 | sort
 
 .PHONY: summary summary.log
 

--- a/test-suite/report.sh
+++ b/test-suite/report.sh
@@ -12,7 +12,7 @@ rm -rf "$SAVEDIR"
 mkdir "$SAVEDIR"
 
 FAILED=$(mktemp)
-grep -F 'Error!' -r . -lZ --include="*.log" > "$FAILED"
+grep -F 'Error!' -r . -l --null --include="*.log" > "$FAILED"
 
 rsync -a --from0 --files-from="$FAILED" . "$SAVEDIR"
 cp summary.log "$SAVEDIR"/


### PR DESCRIPTION
The new (and radically faster) test-suite's "make report" (#18975) has issues with Darwin:
- Darwin's `grep` does not support option `-lZ`; replacing with `-l --null` seems to work;
- Darwin's `tail` does not accept more than ~1K arguments; ~~that's not very elegant, but we solve it by splitting the list of `bug_*.v` files into two parts of length less than about 1K~~ we add option `-L 999` to `xargs` as suggested by @SkySkimmer.