### PR TITLE
Faster composed module substitution of terms.

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -108,7 +108,7 @@ let indirect_accessor o =
   | Some c -> c
   in
   let (c, prv) = Discharge.cook_opaque_proofterm ci c in
-  let c = Mod_subst.(List.fold_right subst_mps sub c) in
+  let c = Mod_subst.subst_mps_list sub c in
   (c, prv)
 
 let () = Mod_checking.set_indirect_accessor indirect_accessor

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -427,6 +427,13 @@ let subst_mps subst c =
   if is_empty_subst subst then c
   else map_kn (subst_mind subst) (subst_pcon_term subst) c
 
+let subst_mps_list substs c =
+  if List.is_empty substs || List.for_all is_empty_subst substs then c
+  else
+    let subst_const pcon = List.fold_right subst_mps substs (mkConstU pcon) in
+    let subst_mind pind = List.fold_right subst_mind substs pind in
+    map_kn subst_mind subst_const c
+
 let rec replace_mp_in_mp mpfrom mpto mp =
   match mp with
     | _ when ModPath.equal mp mpfrom -> mpto

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -427,11 +427,39 @@ let subst_mps subst c =
   if is_empty_subst subst then c
   else map_kn (subst_mind subst) (subst_pcon_term subst) c
 
+let subst_mps_aux subst = function
+| Inl (con, u) ->
+  begin match subst_con0 subst con with
+  | con', None -> Inl (con', u)
+  | _, Some t -> Inr (Vars.univ_instantiate_constr u t)
+  | exception No_subst -> Inl (con, u)
+  end
+| Inr t -> Inr (subst_mps subst t)
+
 let subst_mps_list substs c =
   if List.is_empty substs || List.for_all is_empty_subst substs then c
   else
-    let subst_const pcon = List.fold_right subst_mps substs (mkConstU pcon) in
-    let subst_mind pind = List.fold_right subst_mind substs pind in
+    let cache_const = ref Cmap_env.empty in
+    let cache_ind = ref Mindmap_env.empty in
+    let subst_const (con, u as pcon) = match Cmap_env.find_opt con !cache_const with
+    | Some ans ->
+      if ans == con then raise No_subst else mkConstU (ans, u)
+    | None ->
+      let ans = List.fold_right subst_mps_aux substs (Inl pcon) in
+      (* Do not cache arbitrary inline terms *)
+      match ans with
+      | Inl (con', _ as ans) ->
+        let () = cache_const := Cmap_env.add con con' !cache_const in
+        if con' == con then raise No_subst else mkConstU ans
+      | Inr ans -> ans
+    in
+    let subst_mind ind = match Mindmap_env.find_opt ind !cache_ind with
+    | Some ans -> ans
+    | None ->
+      let ans = List.fold_right subst_mind substs ind in
+      let () = cache_ind := Mindmap_env.add ind ans !cache_ind in
+      ans
+    in
     map_kn subst_mind subst_const c
 
 let rec replace_mp_in_mp mpfrom mpto mp =

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -150,3 +150,4 @@ val replace_mp_in_kn : ModPath.t -> ModPath.t -> KerName.t -> KerName.t
 (** [subst_mps sub c] performs the substitution [sub] on all kernel
    names appearing in [c] *)
 val subst_mps : substitution -> constr -> constr
+val subst_mps_list : substitution list -> constr -> constr

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -217,7 +217,7 @@ let access_opaque_table o =
   | None -> None
   | Some (c, ctx) ->
     let (c, ctx) = Discharge.cook_opaque_proofterm ci (c, ctx) in
-    let c = Mod_subst.(List.fold_right subst_mps sub c) in
+    let c = Mod_subst.subst_mps_list sub c in
     Some (c, ctx)
 
 let indirect_accessor = {


### PR DESCRIPTION
Rather than folding over the list, which is repeatingly mapping over the whole term, we map once over the term and perform the substitution of constants there. Most of the time the term is orders of magnitudes bigger than the list, as this function is typically used to force the body of opaque proof terms.

We also introduce a cache internal to this function to only compute the expansion once.

This source of slowdown was observed when calling the checker on compcert.
