### PR TITLE
univminim: always use lbound:Set when adding univs to ugraph

### DIFF
--- a/engine/univMinim.ml
+++ b/engine/univMinim.ml
@@ -359,7 +359,7 @@ let normalize_context_set ~lbound g ctx (us:UnivFlex.t) {weak_constraints=weak;a
     in
     let add_soft u g =
       if not (Level.is_set u || Level.Set.mem u ctx)
-      then try UGraph.add_universe ~lbound ~strict:false u g with UGraph.AlreadyDeclared -> g
+      then try UGraph.add_universe ~lbound:Set ~strict:false u g with UGraph.AlreadyDeclared -> g
       else g
     in
     let g = Constraints.fold


### PR DESCRIPTION
AFAICT this doesn't change behaviour (NB we already add univs from the local context with lbound:Set a couple lines above) but IMO makes use of lbound in this function clearer: it is used in exactly one place now, to decide whether explicit "Set <= u" constraints are kept.

