### PR TITLE
Remove the cutrewrite tactic.

### DIFF
--- a/doc/changelog/04-tactics/19027-rm-cutrewrite.rst
+++ b/doc/changelog/04-tactics/19027-rm-cutrewrite.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the `cutrewrite` tactic, which was deprecated since
+  Coq 8.5
+  (`#19027 <https://github.com/coq/coq/pull/19027>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -266,14 +266,6 @@ Rewriting with Leibniz and setoid equality
    .. exn:: Terms do not have convertible types.
       :undocumented:
 
-   .. tacn:: cutrewrite {? {| -> | <- } } @one_type {? in @ident }
-
-      Where :n:`@one_type` is an equality.
-
-      .. deprecated:: 8.5
-
-         Use :tacn:`replace` instead.
-
 .. tacn:: substitute {? {| -> | <- } } @one_term_with_bindings
    :undocumented:
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1107,9 +1107,6 @@ simple_tactic: [
 | DELETE "unify" constr constr
 | REPLACE "unify" constr constr "with" preident
 | WITH "unify" constr constr OPT ( "with" preident )
-| DELETE "cutrewrite" orient constr
-| REPLACE "cutrewrite" orient constr "in" hyp
-| WITH "cutrewrite" orient one_type OPT ( "in" hyp )
 | DELETE "destauto"
 | REPLACE "destauto" "in" hyp
 | WITH "destauto" OPT ( "in" hyp )

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1754,8 +1754,6 @@ simple_tactic: [
 | "simple" "injection" destruction_arg
 | "dependent" "rewrite" orient constr
 | "dependent" "rewrite" orient constr "in" hyp
-| "cutrewrite" orient constr
-| "cutrewrite" orient constr "in" hyp
 | "decompose" "sum" constr
 | "decompose" "record" constr
 | "absurd" constr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1424,7 +1424,6 @@ simple_tactic: [
 | ltac2_match_key OPT "reverse" "goal" "with" goal_match_list "end"
 | "case_eq" one_term
 | "dependent" "rewrite" OPT [ "->" | "<-" ] one_term OPT ( "in" ident )
-| "cutrewrite" OPT [ "->" | "<-" ] one_type OPT ( "in" ident )
 | "decompose" "sum" one_term
 | "decompose" "record" one_term
 | "absurd" one_type

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -137,12 +137,6 @@ TACTIC EXTEND dependent_rewrite
     -> { rewriteInHyp b c id }
 END
 
-TACTIC EXTEND cut_rewrite
-| [ "cutrewrite" orient(b) constr(eqn) ] -> { cutRewriteInConcl b eqn }
-| [ "cutrewrite" orient(b) constr(eqn) "in" hyp(id) ]
-    -> { cutRewriteInHyp b eqn id }
-END
-
 (**********************************************************************)
 (* Decompose                                                          *)
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -37,7 +37,7 @@ let mytclWithHoles tac with_evars c =
 
 (**********************************************************************)
 (* replace, discriminate, injection, simplify_eq                      *)
-(* cutrewrite, dependent rewrite                                      *)
+(* dependent rewrite                                      *)
 
 let with_delayed_uconstr ist c tac =
   let flags = Pretyping.{

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1511,17 +1511,6 @@ let cutSubstClause l2r eqn cls =
     | None ->    cutSubstInConcl l2r eqn
     | Some id -> cutSubstInHyp l2r eqn id
 
-let warn_deprecated_cutrewrite =
-  CWarnings.create ~name:"deprecated-cutrewrite" ~category:Deprecation.Version.v8_5
-    (fun () -> strbrk"\"cutrewrite\" is deprecated. Use \"replace\" instead.")
-
-let cutRewriteClause l2r eqn cls =
-  warn_deprecated_cutrewrite ();
-  try_rewrite (cutSubstClause l2r eqn cls)
-
-let cutRewriteInHyp l2r eqn id = cutRewriteClause l2r eqn (Some id)
-let cutRewriteInConcl l2r eqn = cutRewriteClause l2r eqn None
-
 let substClause l2r c cls =
   Proofview.Goal.enter begin fun gl ->
   let eq = pf_apply get_type_of gl c in
@@ -1533,17 +1522,13 @@ let rewriteClause l2r c cls = try_rewrite (substClause l2r c cls)
 let rewriteInHyp l2r c id = rewriteClause l2r c (Some id)
 let rewriteInConcl l2r c = rewriteClause l2r c None
 
-(* Naming scheme for rewrite and cutrewrite tactics
+(* Naming scheme for rewrite tactics
 
       give equality        give proof of equality
 
     / cutSubstClause       substClause
 raw | cutSubstInHyp        substInHyp
     \ cutSubstInConcl      substInConcl
-
-    / cutRewriteClause     rewriteClause
-user| cutRewriteInHyp      rewriteInHyp
-    \ cutRewriteInConcl    rewriteInConcl
 
 raw = raise typing error or PatternMatchingFailure
 user = raise user error specific to rewrite

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -83,10 +83,6 @@ val simpleInjClause : inj_flags option -> evars_flag ->
 val dEq : keep_proofs:(bool option) -> evars_flag -> constr with_bindings Tactics.destruction_arg option -> unit Proofview.tactic
 val dEqThen : keep_proofs:(bool option) -> evars_flag -> (int -> unit Proofview.tactic) -> constr with_bindings Tactics.destruction_arg option -> unit Proofview.tactic
 
-(* The family cutRewriteIn expect an equality statement *)
-val cutRewriteInHyp : bool -> types -> Id.t -> unit Proofview.tactic
-val cutRewriteInConcl : bool -> constr -> unit Proofview.tactic
-
 (* The family rewriteIn expect the proof of an equality *)
 val rewriteInHyp : bool -> constr -> Id.t -> unit Proofview.tactic
 val rewriteInConcl : bool -> constr -> unit Proofview.tactic


### PR DESCRIPTION
It was deprecated since Coq 8.5.

Depends on:
- #19060