### PR TITLE
Experiment the addition of sealed/defined attributes

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -395,6 +395,22 @@ let map4 f l1 l2 l3 l4 = match l1, l2, l3, l4 with
     cast c
   | _ -> invalid_arg "List.map4"
 
+let rec map5_loop f p l1 l2 l3 l4 l5 = match l1, l2, l3, l4, l5 with
+  | [], [], [], [], [] -> ()
+  | x :: l1, y :: l2, z :: l3, t :: l4, u :: l5 ->
+    let c = { head = f x y z t u; tail = [] } in
+    p.tail <- cast c;
+    map5_loop f c l1 l2 l3 l4 l5
+  | _ -> invalid_arg "List.map5"
+
+let map5 f l1 l2 l3 l4 l5 = match l1, l2, l3, l4, l5 with
+  | [], [], [], [], [] -> []
+  | x :: l1, y :: l2, z :: l3, t :: l4, u :: l5 ->
+    let c = { head = f x y z t u; tail = [] } in
+    map5_loop f c l1 l2 l3 l4 l5;
+    cast c
+  | _ -> invalid_arg "List.map5"
+
 let rec map_until_loop f p = function
   | [] -> []
   | x :: l as l' ->

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -132,6 +132,10 @@ val map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a list -> 'b list -> 'c list ->
   'd list -> 'e list
 (** Like [map] but for 4 lists. *)
 
+val map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> 'a list -> 'b list -> 'c list ->
+  'd list -> 'e list -> 'f list
+(** Like [map] but for 5 lists. *)
+
 val map_until : ('a -> 'b option) -> 'a list -> 'b list * 'a list
 (** [map_until f l] applies f to the elements of l until one returns None,
     then returns the list of elements where f was applied

--- a/doc/changelog/02-specification-language/19029-master+sealed-attribute.rst
+++ b/doc/changelog/02-specification-language/19029-master+sealed-attribute.rst
@@ -1,0 +1,8 @@
+
+- **Added:**
+  New attributes :attr:`sealed` and :attr:`defined` allow to change
+  the default opacity (now called sealing to prevent the confusion
+  with the notion of opacity implemented by the command :cmd:`Opaque`)
+  of a definition or theorem
+  (`#19029 <https://github.com/coq/coq/pull/19029>`_,
+  by Hugo Herbelin).

--- a/doc/plugin_tutorial/tuto1/src/simple_declare.ml
+++ b/doc/plugin_tutorial/tuto1/src/simple_declare.ml
@@ -1,4 +1,4 @@
 let declare_definition ~poly name sigma body =
-  let cinfo = Declare.CInfo.make ~name ~typ:None () in
+  let cinfo = Declare.CInfo.make ~name ~typ:None ~opaque:(Some false) () in
   let info = Declare.Info.make ~poly () in
-  Declare.declare_definition ~info ~cinfo ~opaque:false ~body sigma
+  Declare.declare_definition ~info ~cinfo ~body sigma

--- a/doc/plugin_tutorial/tuto1/src/simple_declare.ml
+++ b/doc/plugin_tutorial/tuto1/src/simple_declare.ml
@@ -1,4 +1,4 @@
 let declare_definition ~poly name sigma body =
-  let cinfo = Declare.CInfo.make ~name ~typ:None ~opaque:(Some false) () in
+  let cinfo = Declare.CInfo.make ~name ~typ:None ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) () in
   let info = Declare.Info.make ~poly () in
   Declare.declare_definition ~info ~cinfo ~body sigma

--- a/doc/sphinx/language/core/coinductive.rst
+++ b/doc/sphinx/language/core/coinductive.rst
@@ -154,7 +154,7 @@ Top-level definitions of corecursive functions
    .. insertprodn cofix_definition cofix_definition
 
    .. prodn::
-      cofix_definition ::= @ident_decl {* @binder } {? : @type } {? := @term } {? @decl_notations }
+      cofix_definition ::= {* #[ {+, @attribute } ] } @ident_decl {* @binder } {? : @type } {? := @term } {? @decl_notations }
 
    This command introduces a method for constructing an infinite object of a
    coinductive type. For example, the stream containing all natural numbers can

--- a/doc/sphinx/language/core/conversion.rst
+++ b/doc/sphinx/language/core/conversion.rst
@@ -142,8 +142,11 @@ or :term:`constants <constant>` defined in the :term:`global environment` with t
    E[Γ] ⊢ c~\triangleright_δ~t
 
 :term:`Delta-reduction <delta-reduction>` only unfolds :term:`constants <constant>` that are
-marked :gdef:`transparent`.  :gdef:`Opaque <opaque>` is the opposite of
-transparent; :term:`delta-reduction` doesn't unfold opaque constants.
+marked :gdef:`transparent`. A constant that is not transparent is
+either :gdef:`sealed`, meaning that it is never unfolded, or
+:gdef:`opaque` meaning that it is transparent for the purpose
+of validating the correctness of proofs and types but non-unfoldable
+for the purpose of tactics and unification.
 
 ι-reduction
 ~~~~~~~~~~~

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -125,7 +125,8 @@ Section :ref:`typing-rules`.
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using` are accepted.
+   :attr:`warn` and :attr:`using`, as well as the exclusive attributes :attr:`sealed` and
+   :attr:`defined` are accepted.
 
    .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
 
@@ -212,11 +213,13 @@ commands to manage the proof mode (see :ref:`proofhandling`).
 
 When the proof is complete, use the :cmd:`Qed` command so the kernel verifies
 the proof and adds it to the global environment. By default, proofs
-that end with :cmd:`Qed` are :term:`opaque`, that is that their content cannot
+that end with :cmd:`Qed` are sealed, that is that their content cannot
 be unfolded (see :ref:`applyingconversionrules`), thus realizing
 *proof irrelevance*, that is that only provability matters,
 and not the exact proof. Proofs can be made unfoldable, as
-definitions are, by ending the proof with :cmd:`Defined` in place of :cmd:`Qed`.
+definitions are, with the :attr:`defined` attribute or by ending
+the proof with :cmd:`Defined` in place of :cmd:`Qed`. We
+recommend using the attribute.
 
 .. note::
 
@@ -234,3 +237,19 @@ definitions are, by ending the proof with :cmd:`Defined` in place of :cmd:`Qed`.
 
    #. One can also use :cmd:`Admitted` in place of :cmd:`Qed` to turn the
       current asserted statement into an axiom and exit proof mode.
+
+Sealing and transparency
+------------------------
+
+By default, definitions are unfoldable while the proofs of theorems are
+not.  You can change this using these attributes:
+
+.. attr:: sealed
+
+   Prevents the unfoldability of the definition, so it behaves like an abstract definition.
+
+.. attr:: defined
+
+   Makes the proof of a theorem unfoldable, as if it were a definition.
+
+   .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -1,5 +1,22 @@
-Definitions
-===========
+Definitions and theorems
+========================
+
+Definitions associate a specified term with a given name. The name can later
+be replaced with its definition through :term:`δ-reduction`.  Definitions can
+be local (defined with :g:`let`) or global
+(e.g. defined with :cmd:`Definition` and related forms such as :cmd:`Fixpoint`
+and :cmd:`CoFixpoint`).
+
+On its side, a theorem is a statement with a proof. One can view
+the name of a theorem as a way to abbreviate the given proof, in the
+same way as the name of a definition abbreviates a term. That is, in
+the case of definitions (and related forms such as :cmd:`Fixpoint` or
+:cmd:`CoFixpoint`), the term is the body of the definition and the
+type is the type of the body. In the case of a theorem, lemma,
+corollary, etc. the term is the proof and the type is the statement.
+
+Moreover, definitions can be local (defined with :g:`let`) or global
+(defined at top-level).
 
 .. index:: let ... := ... (term)
 
@@ -66,10 +83,7 @@ If a scope is :ref:`bound <LocalInterpretationRulesForNotations>` to
 Top-level definitions
 ---------------------
 
-Definitions extend the global environment by associating names to terms.
-A definition can be seen as a way to give a meaning to a name or as a
-way to abbreviate a term. In any case, the name can later be replaced at
-any time by its definition.
+Top-level definitions extend the global environment by associating names with terms.
 
 The operation of unfolding a name into its definition is called
 :term:`delta-reduction`.
@@ -106,8 +120,7 @@ Section :ref:`typing-rules`.
 
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
-   In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
-   for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
+   In this case, the proof should normally be terminated with :cmd:`Defined`. See :ref:`proof-editing-mode`.
 
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
@@ -125,10 +138,10 @@ Section :ref:`typing-rules`.
 
 .. _Assertions:
 
-Assertions and proofs
----------------------
+Theorems and proofs
+-------------------
 
-An assertion states a proposition (or a type) for which the proof (or an
+Assertions, such as :cmd:`Theorem`s, state a proposition (or a type) for which the proof (or an
 inhabitant of the type) is interactively built using :term:`tactics <tactic>`.
 Assertions cause Rocq to enter :term:`proof mode` (see :ref:`proofhandling`).
 Common tactics are described in the :ref:`writing-proofs` chapter.
@@ -198,7 +211,12 @@ tactics (see :ref:`writing-proofs`). The user may also enter
 commands to manage the proof mode (see :ref:`proofhandling`).
 
 When the proof is complete, use the :cmd:`Qed` command so the kernel verifies
-the proof and adds it to the global environment.
+the proof and adds it to the global environment. By default, proofs
+that end with :cmd:`Qed` are :term:`opaque`, that is that their content cannot
+be unfolded (see :ref:`applyingconversionrules`), thus realizing
+*proof irrelevance*, that is that only provability matters,
+and not the exact proof. Proofs can be made unfoldable, as
+definitions are, by ending the proof with :cmd:`Defined` in place of :cmd:`Qed`.
 
 .. note::
 
@@ -210,11 +228,6 @@ the proof and adds it to the global environment.
       command is understood as if it would have been given before the
       statements still to be proved. Nonetheless, this practice is discouraged
       and may stop working in future versions.
-
-   #. Proofs ended by :cmd:`Qed` are declared :term:`opaque`. Their content cannot be
-      unfolded (see :ref:`applyingconversionrules`), thus
-      realizing some form of *proof-irrelevance*.
-      Proofs that end with :cmd:`Defined` can be unfolded.
 
    #. :cmd:`Proof` is recommended but can currently be omitted. On the opposite
       side, :cmd:`Qed` (or :cmd:`Defined`) is mandatory to validate a proof.

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -92,30 +92,27 @@ Section :ref:`typing-rules`.
       | {* @binder } : @type
       reduce ::= Eval @red_expr in
 
-   These commands bind :n:`@term` to the name :n:`@ident` in the global environment,
-   provided that :n:`@term` is well-typed.  They can take the :attr:`local` :term:`attribute`,
-   which makes the defined :n:`@ident` accessible only through their fully
-   qualified names, even if :cmd:`Import` or its variants has been used on the
-   current :cmd:`Module`.
+   This binds :n:`@term` to the name :n:`@ident` in the global environment,
+   provided that :n:`@term` is well-typed.
+
+   If :n:`@type` is specified, the command checks that the type of :n:`@term`
+   is definitionally equal to :n:`@type`.
+
+   If :n:`@binder` is specified, it distributes over :n:`@term` and :n:`@type` as if they had
+   respectively been :n:`fun {* @binder } => @term` and :n:`forall {* @binder }, @type`.
+
    If :n:`@reduce` is present then :n:`@ident` is bound to the result of the specified
    computation on :n:`@term`.
-
-   These commands also support the :attr:`universes(polymorphic)`,
-   :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
-   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using` attributes.
 
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
 
-   The form :n:`Definition @ident : @type := @term` checks that the type of :n:`@term`
-   is definitionally equal to :n:`@type`, and registers :n:`@ident` as being of type
-   :n:`@type`, and bound to value :n:`@term`.
-
-   The form :n:`Definition @ident {* @binder } : @type := @term` is equivalent to
-   :n:`Definition @ident : forall {* @binder }, @type := fun {* @binder } => @term`.
+   The attributes :attr:`local`, :attr:`universes(polymorphic)`,
+   :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` are accepted.
 
    .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
 
@@ -152,20 +149,19 @@ The basic assertion command is:
       | Property
 
    After the statement is asserted, Rocq needs a proof. Once a proof of
-   :n:`@type` under the assumptions represented by :n:`@binder`\s is given and
-   validated, the proof is generalized into a proof of :n:`forall {* @binder }, @type` and
+   :n:`@type` is given,
    the theorem is bound to the name :n:`@ident` in the global environment.
 
-   These commands accept the :attr:`program` attribute.  See :ref:`program_lemma`.
+   If :n:`@binder` is specified, this behaves as if :n:`@type` had been
+   :n:`forall {* @binder }, @type` and the proof starts in the context :n:`{* @binder }`.
 
    Forms using the :n:`with` clause are useful for theorems that are proved by simultaneous induction
-   over a mutually inductive assumption, or that assert mutually dependent
-   statements in some mutual coinductive type. It is equivalent to
+   over a mutually inductive assumption, or that assert mutually dependent coinductive
+   statements. It is equivalent to
    :cmd:`Fixpoint` or :cmd:`CoFixpoint` but using tactics to build the proof of
    the statements (or the :term:`body` of the specification, depending on the point of
    view). The inductive or coinductive types on which the induction or
-   coinduction has to be done is assumed to be unambiguous and is guessed by
-   the system.
+   coinduction has to be done is guessed by the system.
 
    Like in a :cmd:`Fixpoint` or :cmd:`CoFixpoint` definition, the induction hypotheses
    have to be used on *structurally smaller* arguments (for a :cmd:`Fixpoint`) or
@@ -175,8 +171,10 @@ The basic assertion command is:
    correct at some time of the interactive development of a proof, use the
    command :cmd:`Guarded`.
 
-   This command accepts the :attr:`bypass_check(universes)`,
-   :attr:`bypass_check(guard)`, :attr:`deprecated`, :attr:`warn`, and :attr:`using` attributes.
+   The attributes :attr:`local`, :attr:`universes(polymorphic)`,
+   :attr:`program` (see :ref:`program_lemma`),
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` are accepted.
 
    .. exn:: The term @term has type @type which should be Set, Prop or Type.
       :undocumented:

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -125,8 +125,8 @@ Section :ref:`typing-rules`.
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using`, as well as the exclusive attributes :attr:`sealed` and
-   :attr:`defined` are accepted.
+   :attr:`warn` and :attr:`using` as well as the exclusive attributes :attr:`sealed`,
+   :attr:`opaque` and :attr:`transparent`.
 
    .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
 
@@ -217,7 +217,7 @@ that end with :cmd:`Qed` are sealed, that is that their content cannot
 be unfolded (see :ref:`applyingconversionrules`), thus realizing
 *proof irrelevance*, that is that only provability matters,
 and not the exact proof. Proofs can be made unfoldable, as
-definitions are, with the :attr:`defined` attribute or by ending
+definitions are, by using the :attr:`transparent` attribute or by ending
 the proof with :cmd:`Defined` in place of :cmd:`Qed`. We
 recommend using the attribute.
 
@@ -238,18 +238,34 @@ recommend using the attribute.
    #. One can also use :cmd:`Admitted` in place of :cmd:`Qed` to turn the
       current asserted statement into an axiom and exit proof mode.
 
-Sealing and transparency
-------------------------
+Sealing, transparency and opacity
+---------------------------------
 
-By default, definitions are unfoldable while the proofs of theorems are
-not.  You can change this using these attributes:
+Definitions and theorems can be sealed, transparent or opaque. Sealed
+means that the body of the definition or the proof of the theorem are
+abstract and cannot be unfolded. Transparent means that it can be
+freely unfolded. Opaque means that it is unfoldable for type-checking
+but kept abstract for reduction (see
+e.g. :tacn:`unfold`). Transparency and opacity can be changed at any
+time using the commands :cmd:`Transparent` and :cmd:`Opaque`. On the
+other side, a sealed constant cannot be changed later to transparent
+or opaque, nor a transparent or opaque constant be changed to sealed.
+
+By default, definitions not built by tactics are
+transparent. Definitions built interactively and ended with
+:n:`Defined` are transparent. Theorems built interactively and ended
+with :n:`Qed` are sealed. In the other cases, one of the following
+attribute is expected:
 
 .. attr:: sealed
 
-   Prevents the unfoldability of the definition, so it behaves like an abstract definition.
+.. attr:: transparent
 
-.. attr:: defined
+.. attr:: opaque
 
-   Makes the proof of a theorem unfoldable, as if it were a definition.
-
-   .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
+Note that these attributes can be added either before the declaration
+(e.g. :n:`#[sealed] Definition @ident := @term`) or before the name of
+the constant (e.g. :n:`Definition #[sealed] @ident := @term`). When
+several constants are declared at once (using :n:`with`), the
+attribute given before the declaration is used as the default for all
+names not themselves prefixed by an attribute.

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -465,40 +465,42 @@ constructions.
       fix_definition ::= @ident_decl {* @binder } {? @fixannot } {? : @type } {? := @term } {? @decl_notations }
 
    Allows defining functions by pattern matching over inductive
-   objects using a fixed point construction. The meaning of this declaration is
-   to define :n:`@ident` as a recursive function with arguments specified by
-   the :n:`@binder`\s such that :n:`@ident` applied to arguments
-   corresponding to these :n:`@binder`\s has type :n:`@type`, and is
-   equivalent to the expression :n:`@term`. The type of :n:`@ident` is
-   consequently :n:`forall {* @binder }, @type` and its value is equivalent
-   to :n:`fun {* @binder } => @term`.
+   objects using a fixed point construction.
 
-   This command accepts the :attr:`program`,
-   :attr:`bypass_check(universes)`, and :attr:`bypass_check(guard)` attributes.
+   The basic form :n:`Fixpoint @ident {* @binder} { struct @ident } : @type := @term.
+   declares :n:`@ident` to be the recursive function with arguments
+   :n:`{* @binder}` and body :n:`@term` of type :n:`type`.
 
-   To be accepted, a :cmd:`Fixpoint` definition has to satisfy syntactical
-   constraints on a special argument called the decreasing argument. They
-   are needed to ensure that the :cmd:`Fixpoint` definition always terminates.
+   To be accepted, a :cmd:`Fixpoint` definition has to satisfy a syntactical
+   constraint on a special argument called the decreasing argument. This
+   is needed to ensure that the :cmd:`Fixpoint` definition always terminates.
    The point of the :n:`{struct @ident}` annotation (see :n:`@fixannot`) is to
    let the user tell the system which argument decreases along the recursive calls.
 
-   The :n:`{struct @ident}` annotation may be left implicit, in which case the
-   system successively tries arguments from left to right until it finds one
+   The :n:`{struct @ident}` annotation may be left implicit, in which case
+   Rocq successively tries arguments from left to right until it finds one
    that satisfies the decreasing condition.
 
-   :cmd:`Fixpoint` without the :attr:`program` attribute does not support the
-   :n:`wf` or :n:`measure` clauses of :n:`@fixannot`. See :ref:`program_fixpoint`.
+   The :n:`@type` annotation may be left implicit, in which case Rocq
+   attempts to infer it.
+
+   This command accepts the :attr:`local`, :attr:`universes(polymorphic)`, :attr:`program`,
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` attributes. The :attr:`program` attribute is needed
+   so that the :n:`wf` or :n:`measure` clauses of :n:`@fixannot` are
+   supported. See :ref:`program_fixpoint`.
 
    The :n:`with` clause allows simultaneously defining several mutual fixpoints.
    It is especially useful when defining functions over mutually defined
    inductive types.  Example: :ref:`Mutual Fixpoints<example_mutual_fixpoints>`.
 
+   If :n:`@decl_notation` is present, a notation is defined at the same time
+   (see :ref:`simultaneous-definition-and-notation`).
+
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
-
-   This command accepts the :attr:`using` attribute.
 
    .. note::
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -486,8 +486,8 @@ constructions.
 
    This command accepts the :attr:`local`, :attr:`universes(polymorphic)`, :attr:`program`,
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using` attributes, as well as the exclusive attributes :attr:`sealed`
-   and :attr:`defined`. The :attr:`program` attribute is needed
+   :attr:`warn` and :attr:`using` attributes, as well as the exclusive attributes :attr:`sealed`,
+   :attr:`opaque` and :attr:`transparent`. The :attr:`program` attribute is needed
    so that the :n:`wf` or :n:`measure` clauses of :n:`@fixannot` are
    supported. See :ref:`program_fixpoint`.
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -486,7 +486,8 @@ constructions.
 
    This command accepts the :attr:`local`, :attr:`universes(polymorphic)`, :attr:`program`,
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using` attributes. The :attr:`program` attribute is needed
+   :attr:`warn` and :attr:`using` attributes, as well as the exclusive attributes :attr:`sealed`
+   and :attr:`defined`. The :attr:`program` attribute is needed
    so that the :n:`wf` or :n:`measure` clauses of :n:`@fixannot` are
    supported. See :ref:`program_fixpoint`.
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -462,7 +462,7 @@ constructions.
    .. insertprodn fix_definition fix_definition
 
    .. prodn::
-      fix_definition ::= @ident_decl {* @binder } {? @fixannot } {? : @type } {? := @term } {? @decl_notations }
+      fix_definition ::= {* #[ {+, @attribute } ] } @ident_decl {* @binder } {? @fixannot } {? : @type } {? := @term } {? @decl_notations }
 
    Allows defining functions by pattern matching over inductive
    objects using a fixed point construction.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -644,8 +644,7 @@ while noting a few exceptional commands for which :attr:`local` and
       **Exception:** when :attr:`local` is applied to
       :cmd:`Definition`, :cmd:`Theorem` or their variants, its
       semantics are different: it makes the defined objects available
-      only through their fully qualified names rather than their
-      unqualified names after an :cmd:`Import`.
+      only through their fully qualified names, even after an :cmd:`Import`.
 
 .. attr:: export
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -468,6 +468,8 @@ Reserving notations
       the other. See :ref:`factorization <NotationFactorization>` for
       details.
 
+.. _simultaneous-definition-and-notation:
+
 Simultaneous definition of terms and notations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1507,13 +1507,13 @@ legacy_attr: [
 sentence: [ ]  (* productions defined below *)
 
 fix_definition: [
-| REPLACE ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
+| REPLACE quoted_attributes ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
+| WITH quoted_attributes ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
 ]
 
 cofix_definition: [
-| REPLACE ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
+| REPLACE quoted_attributes ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
+| WITH quoted_attributes ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
 ]
 
 type_cstr: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1058,11 +1058,11 @@ opt_coercion: [
 ]
 
 fix_definition: [
-| ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
+| quoted_attributes ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
 ]
 
 cofix_definition: [
-| ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
+| quoted_attributes ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
 ]
 
 rw_pattern: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -462,7 +462,7 @@ pattern0: [
 ]
 
 fix_definition: [
-| ident_decl LIST0 binder OPT fixannot OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
+| LIST0 [ "#[" LIST1 attribute SEP "," "]" ] ident_decl LIST0 binder OPT fixannot OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
 ]
 
 thm_token: [
@@ -571,7 +571,7 @@ filtered_import: [
 ]
 
 cofix_definition: [
-| ident_decl LIST0 binder OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
+| LIST0 [ "#[" LIST1 attribute SEP "," "]" ] ident_decl LIST0 binder OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
 ]
 
 rw_pattern: [

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -40,8 +40,8 @@ let rec fill_assumptions env sigma = function
     and [lemma] as the proof. *)
 let start_deriving ~atts bl suchthat name : Declare.Proof.t =
 
-  let scope, _local, poly, program_mode, user_warns, typing_flags, using, clearbody =
-    atts.scope, atts.locality, atts.polymorphic, atts.program, atts.user_warns, atts.typing_flags, atts.using, atts.clearbody in
+  let scope, _local, poly, program_mode, user_warns, typing_flags, using, clearbody, opaque =
+    atts.scope, atts.locality, atts.polymorphic, atts.program, atts.user_warns, atts.typing_flags, atts.using, atts.clearbody, atts.opacity in
   if program_mode then CErrors.user_err (Pp.str "Program mode not supported.");
 
   let env = Global.env () in
@@ -71,8 +71,8 @@ let start_deriving ~atts bl suchthat name : Declare.Proof.t =
         let name = get_id d in
         let impargs = Constrintern.implicits_of_decl_in_internalization_env name impls_env in
         let impargs = List.map CAst.make (List.map extract_manual impargs) in
-        make ~name ~typ:() ~impargs ()) ctx' @
-    [make ~name ~typ:() ~impargs ()] in
+        make ~name ~typ:() ~impargs ~opaque:(Some false) ()) ctx' @
+    [make ~name ~typ:() ~impargs ~opaque ()] in
   let lemma = Declare.Proof.start_derive ~name ~info ~cinfo goals in
   Declare.Proof.map lemma ~f:(fun p ->
       Util.pi1 @@ Proof.run_tactic env Proofview.(tclFOCUS 1 1 shelve) p)

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -71,7 +71,7 @@ let start_deriving ~atts bl suchthat name : Declare.Proof.t =
         let name = get_id d in
         let impargs = Constrintern.implicits_of_decl_in_internalization_env name impls_env in
         let impargs = List.map CAst.make (List.map extract_manual impargs) in
-        make ~name ~typ:() ~impargs ~opaque:(Some false) ()) ctx' @
+        make ~name ~typ:() ~impargs ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) ()) ctx' @
     [make ~name ~typ:() ~impargs ~opaque ()] in
   let lemma = Declare.Proof.start_derive ~name ~info ~cinfo goals in
   Declare.Proof.map lemma ~f:(fun p ->

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -884,7 +884,7 @@ let generate_equation_lemma env evd fnames f fun_num nb_params nb_args rec_args_
      constructing the lemma Ensures by: obvious i*)
   let info = Declare.Info.make () in
   let cinfo =
-    Declare.CInfo.make ~name:(mk_equation_id f_id) ~typ:lemma_type ()
+    Declare.CInfo.make ~name:(mk_equation_id f_id) ~typ:lemma_type ~opaque:(Some false) ()
   in
   let lemma = Declare.Proof.start ~cinfo ~info evd in
   let lemma, _ = Declare.Proof.by prove_replacement lemma in

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -889,7 +889,7 @@ let generate_equation_lemma env evd fnames f fun_num nb_params nb_args rec_args_
   let lemma = Declare.Proof.start ~cinfo ~info evd in
   let lemma, _ = Declare.Proof.by prove_replacement lemma in
   let (_ : _ list) =
-    Declare.Proof.save_regular ~proof:lemma ~opaque:Vernacexpr.Transparent
+    Declare.Proof.save_regular ~proof:lemma ~opaque:Vernacexpr.Defined
       ~idopt:None
   in
   evd

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -884,7 +884,7 @@ let generate_equation_lemma env evd fnames f fun_num nb_params nb_args rec_args_
      constructing the lemma Ensures by: obvious i*)
   let info = Declare.Info.make () in
   let cinfo =
-    Declare.CInfo.make ~name:(mk_equation_id f_id) ~typ:lemma_type ~opaque:(Some false) ()
+    Declare.CInfo.make ~name:(mk_equation_id f_id) ~typ:lemma_type ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) ()
   in
   let lemma = Declare.Proof.start ~cinfo ~info evd in
   let lemma, _ = Declare.Proof.by prove_replacement lemma in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -386,7 +386,7 @@ let register_struct is_rec (rec_order, fixpoint_exprl) =
         CErrors.user_err
           Pp.(str "Body of Function must be given.")
     in
-    ComDefinition.do_definition ~name:fname.CAst.v ~poly:false
+    ComDefinition.do_definition ~name:fname.CAst.v ~opaque:(Some false) ~poly:false
       ~kind:Decls.Definition univs binders None body (Some rtype);
     let evd, rev_pconstants =
       List.fold_left
@@ -1484,7 +1484,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let lem_id = mk_correct_id f_id in
           let typ, _ = lemmas_types_infos.(i) in
           let info = Declare.Info.make () in
-          let cinfo = Declare.CInfo.make ~name:lem_id ~typ () in
+          let cinfo = Declare.CInfo.make ~name:lem_id ~typ ~opaque:(Some false) () in
           let lemma = Declare.Proof.start ~cinfo ~info !evd in
           let lemma = fst @@ Declare.Proof.by (proving_tac i) lemma in
           let (_ : _ list) =
@@ -1548,9 +1548,9 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
               Ensures by: obvious
             i*)
           let lem_id = mk_complete_id f_id in
-          let info = Declare.Info.make () in
+          let info = Declare.Info.make() in
           let cinfo =
-            Declare.CInfo.make ~name:lem_id ~typ:(fst lemmas_types_infos.(i)) ()
+            Declare.CInfo.make ~name:lem_id ~typ:(fst lemmas_types_infos.(i)) ~opaque:(Some false) ()
           in
           let lemma = Declare.Proof.start ~cinfo sigma ~info in
           let lemma =
@@ -2091,7 +2091,8 @@ let make_graph (f_ref : GlobRef.t) =
               ; binders = nal_tas @ bl
               ; rtype = t
               ; body_def = Some b'
-              ; notations = [] })
+              ; notations = []
+              ; fix_attrs = [] })
             fixexprl
         in
         l
@@ -2102,7 +2103,8 @@ let make_graph (f_ref : GlobRef.t) =
           ; binders = nal_tas
           ; rtype = t
           ; body_def = Some b
-          ; notations = [] } ]
+          ; notations = []
+          ; fix_attrs = [] } ]
     in
     let mp = Constant.modpath c in
     let expr_list = List.split expr_list in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1335,11 +1335,11 @@ let make_scheme evd (fas : (Constr.pconstant * Sorts.family) list) : _ list =
       | Some finfos -> finfos
     in
     match finfos.equation_lemma with
-    | None -> Vernacexpr.Transparent (* non recursive definition *)
+    | None -> Vernacexpr.Defined (* non recursive definition *)
     | Some equation ->
       if Declareops.is_opaque (Global.lookup_constant equation) then
-        Vernacexpr.Opaque
-      else Vernacexpr.Transparent
+        Vernacexpr.Qed
+      else Vernacexpr.Defined
   in
   let body, typ, univs, _hook, sigma0 =
     try
@@ -1489,7 +1489,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let lemma = fst @@ Declare.Proof.by (proving_tac i) lemma in
           let (_ : _ list) =
             Declare.Proof.save_regular ~proof:lemma
-              ~opaque:Vernacexpr.Transparent ~idopt:None
+              ~opaque:Vernacexpr.Defined ~idopt:None
           in
           let finfo =
             match find_Function_infos (fst f_as_constant) with
@@ -1563,7 +1563,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           in
           let (_ : _ list) =
             Declare.Proof.save_regular ~proof:lemma
-              ~opaque:Vernacexpr.Transparent ~idopt:None
+              ~opaque:Vernacexpr.Defined ~idopt:None
           in
           let finfo =
             match find_Function_infos (fst f_as_constant) with
@@ -2166,7 +2166,7 @@ let build_scheme fas =
   List.iter2
     (fun (princ_id, _, _) (body, types, univs, opaque) ->
       let (_ : Constant.t) =
-        let opaque = if opaque = Vernacexpr.Opaque then true else false in
+        let opaque = if opaque = Vernacexpr.Qed then true else false in
         let def_entry = Declare.definition_entry ~univs ~opaque ?types body in
         Declare.declare_constant ~name:princ_id
           ~kind:Decls.(IsProof Theorem)

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -386,7 +386,7 @@ let register_struct is_rec (rec_order, fixpoint_exprl) =
         CErrors.user_err
           Pp.(str "Body of Function must be given.")
     in
-    ComDefinition.do_definition ~name:fname.CAst.v ~opaque:(Some false) ~poly:false
+    ComDefinition.do_definition ~name:fname.CAst.v ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) ~poly:false
       ~kind:Decls.Definition univs binders None body (Some rtype);
     let evd, rev_pconstants =
       List.fold_left
@@ -1484,7 +1484,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let lem_id = mk_correct_id f_id in
           let typ, _ = lemmas_types_infos.(i) in
           let info = Declare.Info.make () in
-          let cinfo = Declare.CInfo.make ~name:lem_id ~typ ~opaque:(Some false) () in
+          let cinfo = Declare.CInfo.make ~name:lem_id ~typ ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) () in
           let lemma = Declare.Proof.start ~cinfo ~info !evd in
           let lemma = fst @@ Declare.Proof.by (proving_tac i) lemma in
           let (_ : _ list) =
@@ -1550,7 +1550,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let lem_id = mk_complete_id f_id in
           let info = Declare.Info.make() in
           let cinfo =
-            Declare.CInfo.make ~name:lem_id ~typ:(fst lemmas_types_infos.(i)) ~opaque:(Some false) ()
+            Declare.CInfo.make ~name:lem_id ~typ:(fst lemmas_types_infos.(i)) ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) ()
           in
           let lemma = Declare.Proof.start ~cinfo sigma ~info in
           let lemma =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1463,7 +1463,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
     ()
   in
   let info = Declare.Info.make ~hook:(Declare.Hook.make hook) () in
-  let cinfo = Declare.CInfo.make ~name:na ~typ:gls_type () in
+  let cinfo = Declare.CInfo.make ~name:na ~typ:gls_type ~opaque:(Some false (* as in "defined" *)) () in
   let lemma = Declare.Proof.start ~cinfo ~info sigma in
   let lemma =
     if Indfun_common.is_strict_tcc () then
@@ -1496,7 +1496,7 @@ let com_terminate interactive_proof tcc_lemma_name tcc_lemma_ref is_mes
     let cinfo =
       Declare.CInfo.make ~name:thm_name
         ~typ:(EConstr.of_constr (compute_terminate_type nb_args fonctional_ref))
-        ()
+        ~opaque:(Some false) ()
     in
     let info = Declare.Info.make ~hook () in
     let lemma = Declare.Proof.start ~cinfo ~info ctx in
@@ -1568,7 +1568,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
   let cinfo =
     Declare.CInfo.make ~name:eq_name
       ~typ:(EConstr.of_constr equation_lemma_type)
-      ()
+      ~opaque:(Some (opacity == Opaque)) ()
   in
   let lemma = Declare.Proof.start ~cinfo evd ~info in
   let lemma =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -54,7 +54,7 @@ let declare_fun name kind ?univs value =
 
 let defined lemma =
   let (_ : _ list) =
-    Declare.Proof.save_regular ~proof:lemma ~opaque:Vernacexpr.Transparent
+    Declare.Proof.save_regular ~proof:lemma ~opaque:Vernacexpr.Defined
       ~idopt:None
   in
   ()
@@ -1382,11 +1382,11 @@ let is_opaque_constant c =
   let cb = Global.lookup_constant c in
   let open Vernacexpr in
   match cb.Declarations.const_body with
-  | Declarations.OpaqueDef _ -> Opaque
-  | Declarations.Undef _ -> Opaque
-  | Declarations.Def _ -> Transparent
-  | Declarations.Primitive _ -> Opaque
-  | Declarations.Symbol _ -> Opaque
+  | Declarations.OpaqueDef _ -> Vernacexpr.Qed
+  | Declarations.Undef _ -> Vernacexpr.Qed
+  | Declarations.Def _ -> Defined
+  | Declarations.Primitive _ -> Vernacexpr.Qed
+  | Declarations.Symbol _ -> Vernacexpr.Qed
 
 let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
     (gls_type, decompose_and_tac, nb_goal) =
@@ -1568,7 +1568,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
   let cinfo =
     Declare.CInfo.make ~name:eq_name
       ~typ:(EConstr.of_constr equation_lemma_type)
-      ~opaque:(Some (opacity == Opaque)) ()
+      ~opaque:(Some (opacity == Qed)) ()
   in
   let lemma = Declare.Proof.start ~cinfo evd ~info in
   let lemma =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1463,7 +1463,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
     ()
   in
   let info = Declare.Info.make ~hook:(Declare.Hook.make hook) () in
-  let cinfo = Declare.CInfo.make ~name:na ~typ:gls_type ~opaque:(Some false (* as in "defined" *)) () in
+  let cinfo = Declare.CInfo.make ~name:na ~typ:gls_type ~opaque:(Some (Attributes.Defined Conv_oracle.transparent) (* as in "defined" *)) () in
   let lemma = Declare.Proof.start ~cinfo ~info sigma in
   let lemma =
     if Indfun_common.is_strict_tcc () then
@@ -1496,7 +1496,7 @@ let com_terminate interactive_proof tcc_lemma_name tcc_lemma_ref is_mes
     let cinfo =
       Declare.CInfo.make ~name:thm_name
         ~typ:(EConstr.of_constr (compute_terminate_type nb_args fonctional_ref))
-        ~opaque:(Some false) ()
+        ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) ()
     in
     let info = Declare.Info.make ~hook () in
     let lemma = Declare.Proof.start ~cinfo ~info ctx in
@@ -1568,7 +1568,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
   let cinfo =
     Declare.CInfo.make ~name:eq_name
       ~typ:(EConstr.of_constr equation_lemma_type)
-      ~opaque:(Some (opacity == Qed)) ()
+      ~opaque:(Some (match opacity with Vernacexpr.Qed -> Attributes.Sealed | Vernacexpr.Defined -> Attributes.Defined Conv_oracle.transparent)) ()
   in
   let lemma = Declare.Proof.start ~cinfo evd ~info in
   let lemma =

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -35,7 +35,7 @@ let init_setoid () =
 type rewrite_attributes = {
   polymorphic : bool;
   locality : Hints.hint_locality;
-  opaque : bool option;
+  opaque : Attributes.opacity option;
 }
 
 let rewrite_attributes =
@@ -173,7 +173,7 @@ let declare_projection name instance_id r =
   let types = Some (it_mkProd_or_LetIn typ ctx) in
   let kind = Decls.(IsDefinition Definition) in
   let impargs, udecl = [], UState.default_univ_decl in
-  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ~opaque:(Some false) () in
+  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ~opaque:(Some (Attributes.Defined Conv_oracle.transparent)) () in
   let info = Declare.Info.make ~kind ~udecl ~poly () in
   let _r : GlobRef.t =
     Declare.declare_definition ~cinfo ~info ~body sigma

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -35,15 +35,16 @@ let init_setoid () =
 type rewrite_attributes = {
   polymorphic : bool;
   locality : Hints.hint_locality;
+  opaque : bool option;
 }
 
 let rewrite_attributes =
   let open Attributes.Notations in
-  Attributes.(polymorphic ++ locality) >>= fun (polymorphic, locality) ->
+  Attributes.(polymorphic ++ locality ++ opacity) >>= fun ((polymorphic, locality), opaque) ->
   let locality =
     if Locality.make_section_locality locality then Hints.Local else SuperGlobal
   in
-  Attributes.Notations.return { polymorphic; locality }
+  Attributes.Notations.return { polymorphic; locality; opaque }
 
 (** Utility functions *)
 
@@ -70,7 +71,7 @@ let declare_an_instance n s args =
 let declare_instance a aeq n s = declare_an_instance n s [a;aeq]
 
 let anew_instance atts binders (name,t) fields =
-  let _id = Classes.new_instance ~poly:atts.polymorphic
+  let _id : Id.t = Classes.new_instance ~poly:atts.polymorphic ~opaque:atts.opaque
       name binders t (true, CAst.make @@ CRecord (fields))
       ~locality:atts.locality Hints.empty_hint_info
   in
@@ -172,10 +173,10 @@ let declare_projection name instance_id r =
   let types = Some (it_mkProd_or_LetIn typ ctx) in
   let kind = Decls.(IsDefinition Definition) in
   let impargs, udecl = [], UState.default_univ_decl in
-  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types () in
+  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ~opaque:(Some false) () in
   let info = Declare.Info.make ~kind ~udecl ~poly () in
   let _r : GlobRef.t =
-    Declare.declare_definition ~cinfo ~info ~opaque:false ~body sigma
+    Declare.declare_definition ~cinfo ~info ~body sigma
   in ()
 
 let add_setoid atts binders a aeq t n =
@@ -195,7 +196,7 @@ let add_morphism_as_parameter atts m n : unit =
   let instance_id = add_suffix n "_Proper" in
   let env = Global.env () in
   let evd = Evd.from_env env in
-  let poly = atts.polymorphic in
+  let poly, opaque = atts.polymorphic, atts.opaque in
   let kind = Decls.(IsAssumption Logical) in
   let impargs, udecl = [], UState.default_univ_decl in
   let evd, types = Rewrite.Internal.build_morphism_signature env evd m in
@@ -212,7 +213,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
   let env = Global.env () in
   let evd = Evd.from_env env in
   let evd, morph = Rewrite.Internal.build_morphism_signature env evd m in
-  let poly = atts.polymorphic in
+  let poly, opaque = atts.polymorphic, atts.opaque in
   let kind = Decls.(IsDefinition Instance) in
   let hook { Declare.Hook.S.dref; _ } = dref |> function
     | GlobRef.ConstRef cst ->
@@ -224,7 +225,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
   let hook = Declare.Hook.make hook in
   Flags.silently
     (fun () ->
-       let cinfo = Declare.CInfo.make ~name:instance_id ~typ:morph () in
+       let cinfo = Declare.CInfo.make ~name:instance_id ~typ:morph ~opaque () in
        let info = Declare.Info.make ~poly ~hook ~kind () in
        let lemma = Declare.Proof.start ~cinfo ~info evd in
        fst (Declare.Proof.by tactic lemma)) ()
@@ -239,7 +240,7 @@ let add_morphism atts ~tactic binders m s n =
        [cHole; s; m])
   in
   let _id, lemma = Classes.new_instance_interactive
-      ~locality:atts.locality ~poly:atts.polymorphic
+      ~locality:atts.locality ~poly:atts.polymorphic ~opaque:atts.opaque
       instance_name binders instance_t
       ~tac:tactic ~hook:(declare_projection n instance_id)
       Hints.empty_hint_info None

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -303,39 +303,39 @@ let seff id = VtSideff ([id], VtLater)
 END*)
 
 VERNAC COMMAND EXTEND DeriveInversionClear
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; opacity ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c s false inv_clear_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c s false inv_clear_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; opacity ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_clear_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c Sorts.InProp false inv_clear_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveInversion
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; opacity ] [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c s false inv_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c s false inv_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; opacity ] [ "Derive" "Inversion" ident(na) "with" constr(c) ] => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c Sorts.InProp false inv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversion
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; opacity ] [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c s true dinv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversionClear
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; opacity ] [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
-      add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_clear_tac }
+      add_inversion_lemma_exn ~poly:polymorphic ~opaque:opacity na c s true dinv_clear_tac }
 END
 
 (**********************************************************************)

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -229,25 +229,26 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
   let invProof = it_mkNamedLambda_or_LetIn sigma c !ownSign in
   invProof, sigma
 
-let add_inversion_lemma ~poly name env sigma t sort dep inv_op =
+let add_inversion_lemma ~poly ~opaque name env sigma t sort dep inv_op =
   let invProof, sigma = inversion_scheme ~name ~poly env sigma t sort dep inv_op in
-  let cinfo = Declare.CInfo.make ~name ~typ:None () in
+  let opaque = Some (Option.default false opaque) in
+  let cinfo = Declare.CInfo.make ~name ~typ:None ~opaque () in
   let info = Declare.Info.make ~poly ~kind:Decls.(IsProof Lemma) () in
   let _ : Names.GlobRef.t =
-    Declare.declare_definition ~cinfo ~info ~opaque:false ~body:invProof sigma
+    Declare.declare_definition ~cinfo ~info ~body:invProof sigma
   in
   ()
 
 (* inv_op = Inv (derives de complete inv. lemma)
  * inv_op = InvNoThining (derives de semi inversion lemma) *)
 
-let add_inversion_lemma_exn ~poly na com comsort bool tac =
+let add_inversion_lemma_exn ~poly ~opaque na com comsort bool tac =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let c, uctx = Constrintern.interp_type env sigma com in
   let sigma = Evd.from_ctx uctx in
   let sigma, sort = Evd.fresh_sort_in_family ~rigid:univ_rigid sigma comsort in
-  add_inversion_lemma ~poly na env sigma c sort bool tac
+  add_inversion_lemma ~poly ~opaque na env sigma c sort bool tac
 
 (* ================================= *)
 (* Applying a given inversion lemma  *)

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -231,7 +231,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
 
 let add_inversion_lemma ~poly ~opaque name env sigma t sort dep inv_op =
   let invProof, sigma = inversion_scheme ~name ~poly env sigma t sort dep inv_op in
-  let opaque = Some (Option.default false opaque) in
+  let opaque = Some (Option.default (Attributes.Defined Conv_oracle.transparent) opaque) in
   let cinfo = Declare.CInfo.make ~name ~typ:None ~opaque () in
   let info = Declare.Info.make ~poly ~kind:Decls.(IsProof Lemma) () in
   let _ : Names.GlobRef.t =

--- a/plugins/ltac/leminv.mli
+++ b/plugins/ltac/leminv.mli
@@ -16,6 +16,6 @@ open Tactypes
 val lemInv_clause :
   quantified_hypothesis -> constr -> Id.t list -> unit Proofview.tactic
 
-val add_inversion_lemma_exn : poly:bool ->
+val add_inversion_lemma_exn : poly:bool -> opaque:bool option ->
   Id.t -> constr_expr -> Sorts.family -> bool -> (Id.t -> unit Proofview.tactic) ->
     unit

--- a/plugins/ltac/leminv.mli
+++ b/plugins/ltac/leminv.mli
@@ -16,6 +16,6 @@ open Tactypes
 val lemInv_clause :
   quantified_hypothesis -> constr -> Id.t list -> unit Proofview.tactic
 
-val add_inversion_lemma_exn : poly:bool -> opaque:bool option ->
+val add_inversion_lemma_exn : poly:bool -> opaque:Attributes.opacity option ->
   Id.t -> constr_expr -> Sorts.family -> bool -> (Id.t -> unit Proofview.tactic) ->
     unit

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1487,7 +1487,7 @@ end = struct (* {{{ *)
             PG_compat.close_future_proof ~feedback_id:stop (Future.from_val proof) in
 
           let st = Vernacstate.freeze_full_state () in
-          let opaque = Opaque in
+          let opaque = Vernacexpr.Qed in
           try
             let _pstate =
               stm_qed_delay_proof ~st ~id:stop
@@ -1774,7 +1774,7 @@ let collect_proof keep cur hd brkind id =
    | id :: _ -> Names.Id.to_string id in
  let loc = (snd cur).expr.CAst.loc in
  let is_defined_expr = function
-   | VernacSynPure (VernacEndProof (Proved (Transparent,_))) -> true
+   | VernacSynPure (VernacEndProof (Proved (Defined,_))) -> true
    | _ -> false in
  let is_defined = function
    | _, { expr = e } -> is_defined_expr e.CAst.v.expr
@@ -2141,7 +2141,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
                       qed.fproof <- Some (None, ref false); None
                   | VtKeep opaque ->
                     let opaque = match opaque with
-                      | VtKeepOpaque -> Opaque | VtKeepDefined -> Transparent
+                      | VtKeepOpaque -> Vernacexpr.Qed | VtKeepDefined -> Defined
                       | VtKeepAxiom -> assert false
                     in
                     let control, pe = extract_pe x in

--- a/test-suite/bugs/bug_19767.v
+++ b/test-suite/bugs/bug_19767.v
@@ -1,0 +1,11 @@
+Module A.
+  Module Type T. Definition c := 0. #[global] Strategy expand [c]. End T.
+  Module F (M:T). End F.
+  Print F.
+End A.
+
+Module B.
+  Module Type T. Definition c := 0. #[global] Transparent c. End T.
+  Module F (M:T). End F.
+  Print F.
+End B.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -47,7 +47,7 @@ plus_n_O : forall n : nat, n = n + 0
 
 plus_n_O is not universe polymorphic
 Arguments plus_n_O n%nat_scope
-plus_n_O is opaque
+plus_n_O is sealed
 Expands to: Constant Stdlib.Init.Peano.plus_n_O
 Inductive le (n : nat) : nat -> Prop :=
     le_n : n <= n | le_S : forall m : nat, n <= m -> n <= S m.

--- a/test-suite/output/SuggestProofUsing.v
+++ b/test-suite/output/SuggestProofUsing.v
@@ -30,6 +30,7 @@ Section Sec.
   Qed.
 
   (* Having a [Proof using] disables the suggestion message. *)
+  #[sealed]
   Definition bar : Type.
   Proof using A.
     exact A.

--- a/test-suite/output/bug_11608.v
+++ b/test-suite/output/bug_11608.v
@@ -4,6 +4,7 @@ Set Default Proof Using "Type".
 
 Section foo.
   Context (A:Type).
+  #[sealed]
   Definition x : option A.
     (* this can get printed with -vos since without "Proof." there's no Proof
     using, even with a default annotation. *)

--- a/test-suite/success/sealed.v
+++ b/test-suite/success/sealed.v
@@ -1,6 +1,6 @@
 (* Opacity per name *)
 Fixpoint #[sealed] f n := match n with 0 => 0 | S n => g n end
-with #[defined] g n := match n with 0 => 0 | S n => f n end.
+with #[transparent] g n := match n with 0 => 0 | S n => f n end.
 
 Fail Check eq_refl : f 0 = 0.
 Check eq_refl : g 0 = 0.
@@ -24,14 +24,14 @@ with g' n := match n with 0 => 0 | S n => f' n end.
 
 Fail Check eq_refl : c = 0.
 
-#[defined] Theorem u : nat. exact 0. Qed. (* ok *)
+#[transparent] Theorem u : nat. exact 0. Qed. (* ok *)
 #[sealed] Definition v : nat. exact 0. Defined. (* ok *)
 
 Check eq_refl : u = 0.
 Fail Check eq_refl : v = 0.
 
 #[sealed] Theorem w : nat. exact 0. Defined.
-#[defined] Definition x : nat. exact 0. Qed.
+#[transparent] Definition x : nat. exact 0. Qed.
 
 Fail Check eq_refl : w = 0.
 Check eq_refl : x = 0.

--- a/test-suite/success/sealed.v
+++ b/test-suite/success/sealed.v
@@ -1,0 +1,37 @@
+(* Opacity per name *)
+Fixpoint #[sealed] f n := match n with 0 => 0 | S n => g n end
+with #[defined] g n := match n with 0 => 0 | S n => f n end.
+
+Fail Check eq_refl : f 0 = 0.
+Check eq_refl : g 0 = 0.
+
+(* Opacity globally *)
+#[sealed]
+Fixpoint f' n := match n with 0 => 0 | S n => g' n end
+with g' n := match n with 0 => 0 | S n => f' n end.
+
+Fail Check eq_refl : f' 0 = 0.
+Fail Check eq_refl : g' 0 = 0.
+
+(* Don't mix the global and local attribute *)
+Fail #[sealed]
+Fixpoint #[sealed] f' n := match n with 0 => 0 | S n => g' n end
+with g' n := match n with 0 => 0 | S n => f' n end.
+
+(* Other tests *)
+
+#[sealed] Definition c := 0.
+
+Fail Check eq_refl : c = 0.
+
+#[defined] Theorem u : nat. exact 0. Qed. (* ok *)
+#[sealed] Definition v : nat. exact 0. Defined. (* ok *)
+
+Check eq_refl : u = 0.
+Fail Check eq_refl : v = 0.
+
+#[sealed] Theorem w : nat. exact 0. Defined.
+#[defined] Definition x : nat. exact 0. Qed.
+
+Fail Check eq_refl : w = 0.
+Check eq_refl : x = 0.

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -82,6 +82,7 @@ Section Defs.
     #[global] StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
+  #[sealed]
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
   Proof. firstorder. Qed.
 
@@ -348,7 +349,8 @@ Section Binary.
     - firstorder.
     - intros x y z X X0 x0 y0. specialize (X x0 y0). specialize (X0 x0 y0). firstorder.
   Qed.
-    
+
+  #[sealed]
   Global Instance relation_implication_preorder : PreOrder (@subrelation A).
   Proof. firstorder. Qed.
 
@@ -364,6 +366,7 @@ Section Binary.
    morphism for equivalence (see Morphisms).  It is also sufficient to
    show that [R] is antisymmetric w.r.t. [eqA] *)
 
+  #[sealed]
   Global Instance partial_order_antisym `(PartialOrder eqA R) : Antisymmetric eqA R.
   Proof with auto.
     reduce_goal.

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -70,6 +70,7 @@ Section Defs.
     #[global] StrictOrder_Transitive :: Transitive R }.
 
   (** By definition, a strict order is also asymmetric *)
+  #[sealed]
   Global Instance StrictOrder_Asymmetric `(StrictOrder R) : Asymmetric R.
   Proof. firstorder. Qed.
 
@@ -481,10 +482,12 @@ Section Binary.
   
   (** Relation equivalence is an equivalence, and subrelation defines a partial order. *)
 
+  #[sealed]
   Global Instance relation_equivalence_equivalence :
     Equivalence relation_equivalence.
   Proof. exact (@predicate_equivalence_equivalence (A::A::Tnil)). Qed.
   
+  #[sealed]
   Global Instance relation_implication_preorder : PreOrder (@subrelation A).
   Proof. exact (@predicate_implication_preorder (A::A::Tnil)). Qed.
 
@@ -500,6 +503,7 @@ Section Binary.
    morphism for equivalence (see Morphisms).  It is also sufficient to
    show that [R] is antisymmetric w.r.t. [eqA] *)
 
+  #[sealed]
   Global Instance partial_order_antisym `(PartialOrder eqA R) : Antisymmetric A eqA R.
   Proof with auto.
     reduce_goal.

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -1278,6 +1278,7 @@ Qed.
 
 Ltac cmp_solve := unfold eq, lt; simpl; try Raw.MX.elim_comp; auto with ordered_type.
 
+#[sealed]
 Definition compare : forall m1 m2, Compare lt eq m1 m2.
 Proof.
  intros (m1,Hm1); induction m1;
@@ -1294,6 +1295,6 @@ Proof.
    { inversion_clear Hm2; auto. }
    destruct (IHm1 Hm11 (Build_slist Hm22));
      [ apply LT | apply EQ | apply GT ]; cmp_solve.
-Qed.
+Defined.
 
 End Make_ord.

--- a/theories/FSets/FSetBridge.v
+++ b/theories/FSets/FSetBridge.v
@@ -23,27 +23,31 @@ Set Firstorder Depth 2.
 Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
   Local Ltac Tauto.intuition_solver ::= auto with bool set.
 
+  #[sealed]
   Definition empty : {s : t | Empty s}.
   Proof.
     exists empty; auto with set.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition is_empty : forall s : t, {Empty s} + {~ Empty s}.
   Proof.
     intros; generalize (is_empty_1 (s:=s)) (is_empty_2 (s:=s)).
     case (is_empty s); intuition.
-  Qed.
+  Defined.
 
 
+  #[sealed]
   Definition mem : forall (x : elt) (s : t), {In x s} + {~ In x s}.
   Proof.
     intros; generalize (mem_1 (s:=s) (x:=x)) (mem_2 (s:=s) (x:=x)).
     case (mem x s); intuition.
-  Qed.
+  Defined.
 
   Definition Add (x : elt) (s s' : t) :=
     forall y : elt, In y s' <-> E.eq x y \/ In y s.
 
+  #[sealed]
   Definition add : forall (x : elt) (s : t), {s' : t | Add x s s'}.
   Proof.
     intros; exists (add x s); auto.
@@ -51,14 +55,16 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
     elim (E.eq_dec x y); auto.
     intros; right.
     eapply add_3; eauto.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition singleton :
     forall x : elt, {s : t | forall y : elt, In y s <-> E.eq x y}.
   Proof.
     intros; exists (singleton x); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition remove :
     forall (x : elt) (s : t),
     {s' : t | forall y : elt, In y s' <-> ~ E.eq x y /\ In y s}.
@@ -70,40 +76,45 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
       + absurd (In x (remove x s)); auto with set ordered_type.
         apply In_1 with y; auto with ordered_type.
       + eauto with set.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition union :
     forall s s' : t, {s'' : t | forall x : elt, In x s'' <-> In x s \/ In x s'}.
   Proof.
     intros; exists (union s s'); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition inter :
     forall s s' : t, {s'' : t | forall x : elt, In x s'' <-> In x s /\ In x s'}.
   Proof.
     intros; exists (inter s s'); intuition; eauto with set.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition diff :
     forall s s' : t, {s'' : t | forall x : elt, In x s'' <-> In x s /\ ~ In x s'}.
   Proof.
     intros; exists (diff s s'); intuition; eauto with set.
     absurd (In x s'); eauto with set.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition equal : forall s s' : t, {Equal s s'} + {~ Equal s s'}.
   Proof.
     intros.
     generalize (equal_1 (s:=s) (s':=s')) (equal_2 (s:=s) (s':=s')).
     case (equal s s'); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition subset : forall s s' : t, {Subset s s'} + {~Subset s s'}.
   Proof.
     intros.
     generalize (subset_1 (s:=s) (s':=s')) (subset_2 (s:=s) (s':=s')).
     case (subset s s'); intuition.
-  Qed.
+  Defined.
 
   Definition elements :
     forall s : t,
@@ -112,20 +123,22 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
      intros; exists (elements s); intuition.
    Defined.
 
+  #[sealed]
   Definition fold :
     forall (A : Type) (f : elt -> A -> A) (s : t) (i : A),
     {r : A |   let (l,_) := elements s in
                   r = fold_left (fun a e => f e a) l i}.
   Proof.
   intros; exists (fold (A:=A) f s i); exact (fold_1 s i f).
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition cardinal :
       forall s : t,
       {r : nat | let (l,_) := elements s in r = length l }.
   Proof.
     intros; exists (cardinal s); exact (cardinal_1 s).
-  Qed.
+  Defined.
 
   Definition fdec (P : elt -> Prop) (Pdec : forall x : elt, {P x} + {~ P x})
     (x : elt) := if Pdec x then true else false.
@@ -141,6 +154,7 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
   #[global]
   Hint Resolve compat_P_aux : core.
 
+  #[sealed]
   Definition filter :
     forall (P : elt -> Prop) (Pdec : forall x : elt, {P x} + {~ P x}) (s : t),
     {s' : t | compat_P E.eq P -> forall x : elt, In x s' <-> In x s /\ P x}.
@@ -157,8 +171,9 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
     - apply filter_3; auto.
       unfold fdec; simpl.
       case (Pdec x); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition for_all :
     forall (P : elt -> Prop) (Pdec : forall x : elt, {P x} + {~ P x}) (s : t),
     {compat_P E.eq P -> For_all P s} + {compat_P E.eq P -> ~ For_all P s}.
@@ -178,8 +193,9 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
       intro.
       unfold fdec.
       case (Pdec x); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition exists_ :
     forall (P : elt -> Prop) (Pdec : forall x : elt, {P x} + {~ P x}) (s : t),
     {compat_P E.eq P -> Exists P s} + {compat_P E.eq P -> ~ Exists P s}.
@@ -201,8 +217,9 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
       exists x; intuition.
       unfold fdec.
       case (Pdec x); intuition.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition partition :
     forall (P : elt -> Prop) (Pdec : forall x : elt, {P x} + {~ P x}) (s : t),
     {partition : t * t |
@@ -245,15 +262,16 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
     - eapply (filter_1 (s:=s) (x:=x) H2); elim (H4 x); intros B _; apply B;
         auto.
     - eapply (filter_1 (s:=s) (x:=x) H3); elim (H x); intros B _; apply B; auto.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition choose_aux: forall s : t,
     { x : elt | M.choose s = Some x } + { M.choose s = None }.
   Proof.
    intros.
    destruct (M.choose s); [left | right]; auto.
    exists e; auto.
-  Qed.
+  Defined.
 
   Definition choose : forall s : t, {x : elt | In x s} + {Empty s}.
   Proof.
@@ -306,6 +324,7 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
    - apply Hx with x'; unfold Equal in H; rewrite H; auto.
   Qed.
 
+  #[sealed]
   Definition min_elt :
     forall s : t,
     {x : elt | In x s /\ For_all (fun y => ~ E.lt y x) s} + {Empty s}.
@@ -314,8 +333,9 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
      generalize (min_elt_1 (s:=s)) (min_elt_2 (s:=s)) (min_elt_3 (s:=s)).
     case (min_elt s); [ left | right ]; auto.
     exists e; unfold For_all; eauto.
-  Qed.
+  Defined.
 
+  #[sealed]
   Definition max_elt :
     forall s : t,
     {x : elt | In x s /\ For_all (fun y => ~ E.lt x y) s} + {Empty s}.
@@ -324,7 +344,7 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
      generalize (max_elt_1 (s:=s)) (max_elt_2 (s:=s)) (max_elt_3 (s:=s)).
     case (max_elt s); [ left | right ]; auto.
     exists e; unfold For_all; eauto.
-  Qed.
+  Defined.
 
   Definition elt := elt.
   Definition t := t.

--- a/theories/Logic/ClassicalFacts.v
+++ b/theories/Logic/ClassicalFacts.v
@@ -826,6 +826,7 @@ Section Example_of_undecidable_predicate_with_the_minimization_property.
 
   Let P n := exists k, n<=k /\ s k = true.
 
+  #[sealed]
   Example undecidable_predicate_with_the_minimization_property : 
     Minimization_Property P.
   Proof.

--- a/theories/QArith/Qcanon.v
+++ b/theories/QArith/Qcanon.v
@@ -510,7 +510,7 @@ Proof.
   intros _ H; inversion H.
 Qed.
 
-Definition Qcrt : ring_theory 0 1 Qcplus Qcmult Qcminus Qcopp (eq(A:=Qc)).
+Lemma Qcrt : ring_theory 0 1 Qcplus Qcmult Qcminus Qcopp (eq(A:=Qc)).
 Proof.
   constructor.
   - exact Qcplus_0_l.
@@ -524,7 +524,7 @@ Proof.
   - exact Qcplus_opp_r.
 Qed.
 
-Definition Qcft :
+Lemma Qcft :
   field_theory 0%Qc 1%Qc Qcplus Qcmult Qcminus Qcopp Qcdiv Qcinv (eq(A:=Qc)).
 Proof.
   constructor.

--- a/theories/QArith/Qcanon.v
+++ b/theories/QArith/Qcanon.v
@@ -538,6 +538,7 @@ Add Field Qcfield : Qcft.
 
 (** A field tactic for rational numbers *)
 
+#[sealed]
 Example test_field : (forall x y : Qc, y<>0 -> (x/y)*y = x)%Qc.
 Proof.
 intros.

--- a/theories/QArith/Qfield.v
+++ b/theories/QArith/Qfield.v
@@ -14,7 +14,7 @@ Require Import NArithRing.
 
 (** * field and ring tactics for rational numbers *)
 
-Definition Qsrt : ring_theory 0 1 Qplus Qmult Qminus Qopp Qeq.
+Lemma Qsrt : ring_theory 0 1 Qplus Qmult Qminus Qopp Qeq.
 Proof.
   constructor.
   - exact Qplus_0_l.
@@ -28,7 +28,7 @@ Proof.
   - exact Qplus_opp_r.
 Qed.
 
-Definition Qsft : field_theory 0 1 Qplus Qmult Qminus Qopp Qdiv Qinv Qeq.
+Lemma Qsft : field_theory 0 1 Qplus Qmult Qminus Qopp Qdiv Qinv Qeq.
 Proof.
   constructor.
   - exact Qsrt.

--- a/theories/Reals/Abstract/ConstructiveLUB.v
+++ b/theories/Reals/Abstract/ConstructiveLUB.v
@@ -204,7 +204,7 @@ Proof.
     + exact H.
 Qed.
 
-Fixpoint DDcut_limit_fix (upcut : DedekindDecCut) (r : Q) (n : nat) :
+Fixpoint #[sealed] DDcut_limit_fix (upcut : DedekindDecCut) (r : Q) (n : nat) :
   Qlt 0 r
   -> (DDupcut upcut (DDlow upcut + (Z.of_nat n#1) * r))
   -> { q : Q | DDupcut upcut q /\ ~DDupcut upcut (q - r) }.

--- a/theories/Reals/Abstract/ConstructiveReals.v
+++ b/theories/Reals/Abstract/ConstructiveReals.v
@@ -1152,13 +1152,15 @@ Proof.
   - exact H.
 Qed.
 
+#[sealed]
 Definition CRup_nat {R : ConstructiveReals} (x : CRcarrier R)
   : { n : nat  &  x < CR_of_Q R (Z.of_nat n #1) }.
 Proof.
   destruct (CR_archimedean R x). exists (Pos.to_nat x0).
   rewrite positive_nat_Z. exact c.
-Qed.
+Defined.
 
+#[sealed]
 Definition CRfloor {R : ConstructiveReals} (a : CRcarrier R)
   : { p : Z  &  prod (CR_of_Q R (p#1) < a)
                      (a < CR_of_Q R (p#1) + CR_of_Q R 2) }.
@@ -1180,7 +1182,7 @@ Proof.
         -- apply CR_of_Q_le.
            rewrite Qinv_plus_distr. apply Qlt_le_weak, Qlt_floor.
         -- apply CR_of_Q_le. discriminate.
-Qed.
+Defined.
 
 Lemma CRplus_appart_reg_l : forall {R : ConstructiveReals} (r r1 r2 : CRcarrier R),
     (r + r1) ≶ (r + r2) -> r1 ≶ r2.

--- a/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
+++ b/theories/Reals/Abstract/ConstructiveRealsMorphisms.v
@@ -984,6 +984,7 @@ Proof.
   - rewrite q. apply Qle_refl.
 Qed.
 
+#[sealed]
 Definition CR_Q_limit {R : ConstructiveReals} (x : CRcarrier R) (n:nat)
   : { q:Q  &  x < CR_of_Q R q < x + CR_of_Q R (1 # Pos.of_nat n) }.
 Proof.
@@ -991,7 +992,7 @@ Proof.
   rewrite <- (CRplus_0_r x). rewrite CRplus_assoc.
   apply CRplus_lt_compat_l. rewrite CRplus_0_l. apply CR_of_Q_pos.
   reflexivity.
-Qed.
+Defined.
 
 Lemma CR_Q_limit_cv : forall {R : ConstructiveReals} (x : CRcarrier R),
     CR_cv R (fun n => CR_of_Q R (let (q,_) := CR_Q_limit x n in q)) x.

--- a/theories/Reals/Abstract/ConstructiveSum.v
+++ b/theories/Reals/Abstract/ConstructiveSum.v
@@ -400,6 +400,7 @@ Proof.
     + apply H1.
 Qed.
 
+#[sealed]
 Definition series_cv_abs {R : ConstructiveReals} (u : nat -> CRcarrier R)
   : CR_cauchy R (CRsum (fun n => CRabs R (u n)))
     -> { l : CRcarrier R & series_cv u l }.
@@ -409,7 +410,7 @@ Proof.
   - intro n. apply CRle_refl.
   - assumption.
   - exists x0. apply p.
-Qed.
+Defined.
 
 Lemma series_cv_unique :
   forall {R : ConstructiveReals} (Un:nat -> CRcarrier R) (l1 l2:CRcarrier R),

--- a/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
@@ -996,6 +996,7 @@ Proof.
     pose proof Qpower_pos 2 n ltac:(lra). rewrite Z.abs_0, Qreduce_zero. lra.
 Qed.
 
+#[sealed]
 Definition CRealQ_dense (a b : CReal)
   : a < b -> { q : Q  &  a < inject_Q q < b }.
 Proof.
@@ -1016,7 +1017,7 @@ Proof.
     destruct b as [bseq]; simpl in pmaj |- *.
     unfold CReal_opp_seq; rewrite CReal_red_seq.
     lra.
-Qed.
+Defined.
 
 Lemma inject_Q_mult : forall q r : Q,
     inject_Q (q * r) == inject_Q q * inject_Q r.
@@ -1030,6 +1031,7 @@ Proof.
     pose proof Qpower_0_lt 2 n; lra.
 Qed.
 
+#[sealed]
 Definition Rup_nat (x : CReal)
   : { n : nat & x < inject_Q (Z.of_nat n #1) }.
 Proof.
@@ -1040,7 +1042,7 @@ Proof.
   - exists O. apply (CReal_lt_trans _ (inject_Q (Z.neg p # 1))).
     + apply maj.
     + apply inject_Q_lt. reflexivity.
-Qed.
+Defined.
 
 Lemma CReal_mult_le_0_compat : forall (a b : CReal),
     0 <= a -> 0 <= b -> 0 <= a * b.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -67,6 +67,7 @@ Qed.
 
 (* Sharpen the archimedean property : constructive versions of
    the usual floor and ceiling functions. *)
+#[sealed]
 Definition Rfloor (a : CReal)
   : { p : Z  &  inject_Q (p#1) < a < inject_Q (p#1) + 2 }.
 Proof.
@@ -81,7 +82,7 @@ Proof.
     + rewrite inject_Q_plus, (opp_inject_Q 2).
       ring_simplify. exact H.
     + rewrite Qinv_plus_distr. reflexivity.
-Qed.
+Defined.
 
 (* ToDo: Move to ConstructiveCauchyAbs.v *)
 Lemma Qabs_Rabs : forall q : Q,

--- a/theories/Reals/ClassicalDedekindReals.v
+++ b/theories/Reals/ClassicalDedekindReals.v
@@ -215,7 +215,7 @@ Definition DReal : Set
 
 (** ** Induction principle *)
 
-Fixpoint DRealQlim_rec (f : Q -> bool) (low : isLowerCut f) (n p : nat) { struct p }
+Fixpoint #[sealed] DRealQlim_rec (f : Q -> bool) (low : isLowerCut f) (n p : nat) { struct p }
   : f (proj1_sig (lowerCutBelow f low) + (Z.of_nat p # Pos.of_nat (S n)))%Q = false
     -> { q : Q | f q = true /\ f (q + (1 # Pos.of_nat (S n)))%Q = false }.
 Proof.
@@ -345,6 +345,7 @@ Defined.
 
 (** *** Conversion from DReal to CReal *)
 
+#[sealed]
 Definition DRealQlim (x : DReal) (n : nat)
   : { q : Q | proj1_sig x q = true /\ proj1_sig x (q + (1# Pos.of_nat (S n)))%Q = false }.
 Proof.
@@ -369,8 +370,9 @@ Proof.
         -- apply f_equal.
            apply Pos.succ_of_nat. discriminate.
   - exact des.
-Qed.
+Defined.
 
+#[sealed]
 Definition DRealQlimExp2 (x : DReal) (n : nat)
   : { q : Q | proj1_sig x q = true /\ proj1_sig x (q + (1#(Pos.of_nat (2^n)%nat)))%Q = false }.
 Proof.
@@ -379,7 +381,7 @@ Proof.
   rewrite Nat.succ_pred_pos in qmaj.
     2: apply Nat.neq_0_lt_0, Nat.pow_nonzero; intros contra; inversion contra.
   exact qmaj.
-Qed.
+Defined.
 
 Definition CReal_of_DReal_seq (x : DReal) (n : Z) :=
     proj1_sig (DRealQlimExp2 x (Z.to_nat (-n))).

--- a/theories/Reals/PSeries_reg.v
+++ b/theories/Reals/PSeries_reg.v
@@ -32,6 +32,7 @@ apply Rabs_def2 in b_y; apply Rabs_def1;
   apply Rlt_le_trans with (x - c);[|apply Rplus_le_compat_r]];tauto.
 Qed.
 
+#[sealed]
 Definition boule_of_interval x y (h : x < y) :
   {c :R & {r : posreal | c - r = x /\ c + r = y}}.
 Proof.
@@ -42,8 +43,9 @@ assert (radius : 0 < (y - x)/2).
   + now apply Rinv_0_lt_compat, Rlt_0_2.
 - exists (mkposreal _ radius).
   simpl; split; unfold Rdiv; field.
-Qed.
+Defined.
 
+#[sealed]
 Definition boule_in_interval x y z (h : x < z < y) :
   {c : R & {r | Boule c r z /\  x < c - r /\ c + r < y}}.
 Proof.
@@ -69,7 +71,7 @@ exists c, r; split.
     apply Rplus_lt_compat_l, Rmult_lt_compat_r;assumption.
   + replace y with (y * / 2 + y * /2) by field; rewrite P2.
     apply Rplus_lt_compat_r, Rmult_lt_compat_r;assumption.
-Qed.
+Defined.
 
 Lemma Ball_in_inter : forall c1 c2 r1 r2 x,
   Boule c1 r1 x -> Boule c2 r2 x ->

--- a/theories/Reals/Ranalysis_reg.v
+++ b/theories/Reals/Ranalysis_reg.v
@@ -29,6 +29,7 @@ Require Export Ranalysis4.
 Require Export Rpower.
 Local Open Scope R_scope.
 
+#[sealed]
 Definition AppVar : R.
 Proof.
 exact R0.

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -451,6 +451,7 @@ Proof.
   lra.
 Qed.
 
+#[sealed]
 Definition frame_tan y : {x | 0 < x < PI/2 /\ Rabs y < tan x}.
 Proof.
 destruct (total_order_T (Rabs y) 1) as [Hs|Hgt].
@@ -519,7 +520,7 @@ apply Rlt_trans with (/2 * / cos(PI / 2 - u)).
   + assert (t := PI2_1); lra.
   + lra.
   + assumption.
-Qed.
+Defined.
 
 Lemma ub_opp : forall x, x < PI/2 -> -PI/2 < -x.
 Proof.
@@ -534,6 +535,7 @@ Proof.
 intros; rewrite tan_neg; assumption.
 Qed.
 
+#[sealed]
 Definition pre_atan (y : R) : {x : R | -PI/2 < x < PI/2 /\ tan x = y}.
 Proof.
 destruct (frame_tan y) as [ub [[ub0 ubpi2] Ptan_ub]].
@@ -543,7 +545,7 @@ destruct (exists_atan_in_frame (-ub) ub y (pos_opp_lt _ ub0) (ub_opp _ ubpi2)
              ubpi2 pr) as [v [[vl vu] vq]].
 exists v; clear pr.
 split;[rewrite Rdiv_opp_l; split; lra | assumption].
-Qed.
+Defined.
 
 Definition atan x := let (v, _) := pre_atan x in v.
 
@@ -910,6 +912,7 @@ rewrite scal_sum; apply sum_eq; intros i _; unfold tg_alt.
 rewrite Ratan_seq_opp; ring.
 Qed.
 
+#[sealed]
 Definition ps_atan_exists_1 (x : R) (Hx : -1 <= x <= 1) :
    {l : R | Un_cv (fun N : nat => sum_f_R0 (tg_alt (Ratan_seq x)) N) l}.
 Proof.
@@ -924,8 +927,9 @@ apply (Un_cv_ext (fun n => (- 1) * sum_f_R0 (tg_alt (Ratan_seq (- x))) n)).
 replace (-v) with (-1 * v) by ring.
 apply CV_mult;[ | assumption].
 solve[intros; exists 0%nat; intros; rewrite Rdist_eq; auto].
-Qed.
+Defined.
 
+#[sealed]
 Definition in_int (x : R) : {-1 <= x <= 1}+{~ -1 <= x <= 1}.
 Proof.
 destruct (Rle_lt_dec x 1).
@@ -933,7 +937,7 @@ destruct (Rle_lt_dec x 1).
 - left;split; auto.
 - right;intros [a1 a2]; lra.
 - right;intros [a1 a2]; lra.
-Qed.
+Defined.
 
 Definition ps_atan (x : R) : R :=
  match in_int x with

--- a/theories/Reals/Rtrigo1.v
+++ b/theories/Reals/Rtrigo1.v
@@ -191,6 +191,7 @@ rewrite <- !mult_IZR.
 apply IZR_lt; reflexivity.
 Qed.
 
+#[sealed]
 Definition PI_2_aux : {z | 7/8 <= z <= 7/4 /\ -cos z = 0}.
 assert (cc : continuity (fun r =>- cos r)). {
   apply continuity_opp, continuity_cos.
@@ -212,7 +213,7 @@ assert (cun : cos (7/4) < 0). {
  - apply Rlt_le; apply Rlt_trans with (1 := cvp); exact sin_gt_cos_7_8.
 }
 apply IVT; auto; lra.
-Qed.
+Defined.
 
 Definition PI2 := proj1_sig PI_2_aux.
 

--- a/theories/Setoids/Setoid.v
+++ b/theories/Setoids/Setoid.v
@@ -63,7 +63,7 @@ Ltac refl_st :=
       apply (Seq_refl _ _ H); auto
   end.
 
-Definition gen_st : forall A : Set, Setoid_Theory _ (@eq A).
+Lemma gen_st : forall A : Set, Setoid_Theory _ (@eq A).
 Proof.
   constructor; congruence.
 Qed.

--- a/theories/Sorting/CPermutation.v
+++ b/theories/Sorting/CPermutation.v
@@ -282,6 +282,7 @@ Qed.
 
 (** As an equivalence relation compatible with some operations,
 [CPermutation] can be used through [rewrite]. *)
+#[sealed]
 Example CPermutation_rewrite_rev A (l1 l2 l3: list A) :
   CPermutation l1 l2 ->
   CPermutation (rev l1) l3 -> CPermutation l3 (rev l2).

--- a/theories/Strings/BinaryString.v
+++ b/theories/Strings/BinaryString.v
@@ -50,7 +50,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
+  Fixpoint #[sealed] to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p

--- a/theories/Strings/HexString.v
+++ b/theories/Strings/HexString.v
@@ -122,7 +122,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
+  Fixpoint #[sealed] to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p

--- a/theories/Strings/OctalString.v
+++ b/theories/Strings/OctalString.v
@@ -80,7 +80,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
+  Fixpoint #[sealed] to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p

--- a/theories/Strings/PString.v
+++ b/theories/Strings/PString.v
@@ -648,6 +648,7 @@ Module OT <: OrderedType.OrderedType with Definition t := string.
   Hint Immediate eq_sym : core.
   Hint Resolve eq_refl eq_trans lt_not_eq lt_trans : core.
 
+  #[sealed]
   Definition eq_dec (s1 s2 : t) : {eq s1 s2} + {~ eq s1 s2}.
   Proof.
     unfold eq.
@@ -655,5 +656,5 @@ Module OT <: OrderedType.OrderedType with Definition t := string.
     - left. reflexivity.
     - right. discriminate.
     - right. discriminate.
-  Qed.
+  Defined.
 End OT.

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -277,6 +277,7 @@ Module PositiveOrderedTypeBits <: UsualOrderedType.
   exact (bits_lt_antirefl x H).
   Qed.
 
+  #[sealed]
   Definition compare : forall x y : t, Compare lt eq x y.
   Proof.
   induction x; destruct y.
@@ -304,7 +305,7 @@ Module PositiveOrderedTypeBits <: UsualOrderedType.
     apply GT; simpl; auto.
   + (* H H *)
     apply EQ; red; auto.
-  Qed.
+  Defined.
 
   Lemma eq_dec (x y: positive): {x = y} + {x <> y}.
   Proof.

--- a/theories/micromega/RMicromega.v
+++ b/theories/micromega/RMicromega.v
@@ -25,7 +25,7 @@ Require Import DeclConstant.
 
 Require Setoid.
 
-Definition Rsrt : ring_theory R0 R1 Rplus Rmult Rminus Ropp (@eq R).
+Lemma Rsrt : ring_theory R0 R1 Rplus Rmult Rminus Ropp (@eq R).
 Proof.
   constructor.
   - exact Rplus_0_l.

--- a/theories/setoid_ring/Ring_theory.v
+++ b/theories/setoid_ring/Ring_theory.v
@@ -302,7 +302,7 @@ Section ALMOST_RING.
 
  Hypothesis morph_req : forall x y, (reqb x y) = true -> x == y.
 
- Definition SRIDmorph : ring_morph 0 1 radd rmul SRsub SRopp req
+ Lemma SRIDmorph : ring_morph 0 1 radd rmul SRsub SRopp req
                             0 1 radd rmul SRsub SRopp reqb (@IDphi R).
  Proof.
   now apply mkmorph.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -265,6 +265,13 @@ let locality =
     ("global", single_key_parser ~name ~key:"global" false);
   ]
 
+let opacity =
+  let name = "Opacity" in
+  attribute_of_list [
+    ("sealed", single_key_parser ~name ~key:"sealed" true);
+    ("defined", single_key_parser ~name ~key:"defined" false);
+  ]
+
 let ukey = "universes"
 
 let universe_polymorphism_option_name = ["Universe"; "Polymorphism"]

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -265,11 +265,16 @@ let locality =
     ("global", single_key_parser ~name ~key:"global" false);
   ]
 
+type opacity =
+  | Sealed
+  | Defined of Conv_oracle.level
+
 let opacity =
   let name = "Opacity" in
   attribute_of_list [
-    ("sealed", single_key_parser ~name ~key:"sealed" true);
-    ("defined", single_key_parser ~name ~key:"defined" false);
+    ("sealed", single_key_parser ~name ~key:"sealed" Sealed);
+    ("opaque", single_key_parser ~name ~key:"opaque" (Defined Conv_oracle.Opaque));
+    ("transparent", single_key_parser ~name ~key:"transparent" (Defined Conv_oracle.transparent));
   ]
 
 let ukey = "universes"

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -57,6 +57,7 @@ val template : bool option attribute
 val unfold_fix : bool attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
+val opacity : bool option attribute
 val reversible : bool option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -49,6 +49,10 @@ end
 
 (** Definitions for some standard attributes. *)
 
+type opacity =
+  | Sealed
+  | Defined of Conv_oracle.level
+
 val raw_attributes : vernac_flags attribute
 
 val polymorphic : bool attribute
@@ -57,7 +61,7 @@ val template : bool option attribute
 val unfold_fix : bool attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
-val opacity : bool option attribute
+val opacity : opacity option attribute
 val reversible : bool option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -26,6 +26,7 @@ val existing_instance : ?loc:Loc.t -> Hints.hint_locality -> GlobRef.t -> Vernac
 
 val new_instance_interactive
   : locality:Hints.hint_locality
+  -> opaque:bool option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -38,6 +39,7 @@ val new_instance_interactive
 
 val new_instance
   : locality:Hints.hint_locality
+  -> opaque:bool option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -50,6 +52,7 @@ val new_instance
 val new_instance_program
   : locality:Hints.hint_locality
   -> pm:Declare.OblState.t
+  -> opaque:bool option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -26,7 +26,7 @@ val existing_instance : ?loc:Loc.t -> Hints.hint_locality -> GlobRef.t -> Vernac
 
 val new_instance_interactive
   : locality:Hints.hint_locality
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -39,7 +39,7 @@ val new_instance_interactive
 
 val new_instance
   : locality:Hints.hint_locality
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list
@@ -52,7 +52,7 @@ val new_instance
 val new_instance_program
   : locality:Hints.hint_locality
   -> pm:Declare.OblState.t
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> poly:bool
   -> name_decl
   -> local_binder_expr list

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -117,7 +117,7 @@ let interp_statement ~program_mode env evd ~flags ~scope name bl typ  =
   let ids = List.map Context.Rel.Declaration.get_name ctx in
   evd, ids, EConstr.it_mkProd_or_LetIn t' ctx, imps @ imps'
 
-let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
+let do_definition ?hook ~name ?scope ~opaque ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
   let program_mode = false in
   let env = Global.env() in
   let env = Environ.update_typing_flags ?typing_flags env in
@@ -127,13 +127,13 @@ let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using
     interp_definition ~program_mode env evd empty_internalization_env bl red_option c ctypopt
   in
   let kind = Decls.IsDefinition kind in
-  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types () in
+  let cinfo = Declare.CInfo.make ~name ~impargs ~typ:types ~opaque () in
   let info = Declare.Info.make ?scope ?clearbody ~kind ?hook ~udecl ~poly ?typing_flags ?user_warns () in
   let _ : Names.GlobRef.t =
-    Declare.declare_definition ~info ~cinfo ~opaque:false ~body ?using evd
+    Declare.declare_definition ~info ~cinfo ~body ?using evd
   in ()
 
-let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
+let do_definition_program ?hook ~pm ~name ~scope ~opaque ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
   let env = Global.env() in
   let env = Environ.update_typing_flags ?typing_flags env in
   (* Explicitly bound universes and constraints *)
@@ -144,12 +144,12 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
   let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
   Evd.check_univ_decl_early ~poly ~with_obls:true evd udecl [body; typ];
   let pm, _ =
-    let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
+    let cinfo = Declare.CInfo.make ~name ~typ ~impargs ~opaque () in
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
-    Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls
+    Declare.Obls.add_definition ~pm ~info ~cinfo ~body ~uctx ?using obls
   in pm
 
-let do_definition_interactive ~program_mode ?hook ~name ~scope ?clearbody ~poly ~typing_flags ~kind ?using ?user_warns udecl bl t =
+let do_definition_interactive ~program_mode ?hook ~name ~scope ~opaque ?clearbody ~poly ~typing_flags ~kind ?using ?user_warns udecl bl t =
   let env = Global.env () in
   let env = Environ.update_typing_flags ?typing_flags env in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
@@ -162,7 +162,7 @@ let do_definition_interactive ~program_mode ?hook ~name ~scope ?clearbody ~poly 
   Pretyping.check_evars_are_solved ~program_mode env evd;
   let typ = EConstr.to_constr evd typ in
   let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
-  let cinfo = Declare.CInfo.make ~name ~typ ~args ~impargs () in
+  let cinfo = Declare.CInfo.make ~name ~typ ~args ~impargs ~opaque () in
   Evd.check_univ_decl_early ~poly ~with_obls:false evd udecl [typ];
   let evd = if poly then evd else Evd.fix_undefined_variables evd in
   Declare.Proof.start_definition ~info ~cinfo ?using evd

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -29,6 +29,7 @@ val do_definition
   :  ?hook:Declare.Hook.t
   -> name:Id.t
   -> ?scope:Locality.definition_scope
+  -> opaque:bool option
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -47,6 +48,7 @@ val do_definition_program
   -> pm:Declare.OblState.t
   -> name:Id.t
   -> scope:Locality.definition_scope
+  -> opaque:bool option
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -65,6 +67,7 @@ val do_definition_interactive
   -> ?hook:Declare.Hook.t
   -> name:Id.t
   -> scope:Locality.definition_scope
+  -> opaque:bool option
   -> ?clearbody:bool
   -> poly:bool
   -> typing_flags:Declarations.typing_flags option

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -29,7 +29,7 @@ val do_definition
   :  ?hook:Declare.Hook.t
   -> name:Id.t
   -> ?scope:Locality.definition_scope
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -48,7 +48,7 @@ val do_definition_program
   -> pm:Declare.OblState.t
   -> name:Id.t
   -> scope:Locality.definition_scope
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -67,7 +67,7 @@ val do_definition_interactive
   -> ?hook:Declare.Hook.t
   -> name:Id.t
   -> scope:Locality.definition_scope
-  -> opaque:bool option
+  -> opaque:Attributes.opacity option
   -> ?clearbody:bool
   -> poly:bool
   -> typing_flags:Declarations.typing_flags option

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -385,7 +385,7 @@ type ('constr, 'relevance) fix_data = {
   fiximps  : (Names.Name.t * bool) option CAst.t list list;
   fixntns  : Metasyntax.notation_interpretation_decl list;
   fixwfs   : (rel_declaration * EConstr.t * EConstr.t * EConstr.t) option list;
-  fixopaques : bool option list;
+  fixopaques : Attributes.opacity option list;
 }
 
 let interp_wf ~program_mode env sigma recname ctx ccl = function

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -385,6 +385,7 @@ type ('constr, 'relevance) fix_data = {
   fiximps  : (Names.Name.t * bool) option CAst.t list list;
   fixntns  : Metasyntax.notation_interpretation_decl list;
   fixwfs   : (rel_declaration * EConstr.t * EConstr.t * EConstr.t) option list;
+  fixopaques : bool option list;
 }
 
 let interp_wf ~program_mode env sigma recname ctx ccl = function
@@ -413,7 +414,7 @@ let interp_wf ~program_mode env sigma recname ctx ccl = function
     in
     sigma, ((after, [extradecl]), Some (extradecl, rel, relargty, measure), [impl])
 
-let interp_mutual_definition env ~program_mode ~function_mode rec_order fixl =
+let interp_mutual_definition env ~program_mode ~function_mode ?opaque rec_order fixl =
   let open Context.Named.Declaration in
   let open EConstr in
   let fixnames = List.map (fun fix -> fix.Vernacexpr.fname.CAst.v) fixl in
@@ -461,9 +462,13 @@ let interp_mutual_definition env ~program_mode ~function_mode rec_order fixl =
   (* Instantiate evars and check all are resolved *)
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
   let sigma = Evd.minimize_universes sigma in
+  let fixopaques = List.map (fun { Vernacexpr.fix_attrs } -> Attributes.(parse opacity fix_attrs)) fixl in
+  if List.exists Option.has_some fixopaques && Option.has_some opaque then
+    CErrors.user_err Pp.(str "Opacity attribute given both globally for the declaration and locally on the names of the declaration.");
+  let fixopaques = List.map (function None -> (* use global opacity *) opaque | Some _ as o -> o) fixopaques in
 
   (* Build the fix declaration block *)
-  let fix = {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs} in
+  let fix = {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs;fixopaques} in
   (env, rec_sign, sigma), (fix, possible_guard, decl)
 
 let check_recursive ~kind env evd {fixnames;fixdefs;fixwfs} =
@@ -473,12 +478,12 @@ let check_recursive ~kind env evd {fixnames;fixdefs;fixwfs} =
     check_true_recursivity env evd ~kind (List.combine fixnames fixdefs)
   end
 
-let ground_fixpoint env evd {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs} =
+let ground_fixpoint env evd {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs;fixopaques} =
   Pretyping.check_evars_are_solved ~program_mode:false env evd;
   let fixrs = List.map (fun r -> EConstr.ERelevance.kind evd r) fixrs in
   let fixdefs = List.map (fun c -> Option.map EConstr.(to_constr evd) c) fixdefs in
   let fixtypes = List.map EConstr.(to_constr evd) fixtypes in
-  {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs}
+  {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs;fixopaques}
 
 (** For Funind *)
 
@@ -489,11 +494,11 @@ let interp_fixpoint_short rec_order fixpoint_exprl =
   let typel = (ground_fixpoint env sigma fix).fixtypes in
   typel, sigma
 
-let build_recthms {fixnames;fixtypes;fixctxs;fiximps} =
-  List.map4 (fun name typ ctx impargs ->
+let build_recthms {fixnames;fixtypes;fixctxs;fiximps;fixopaques} =
+  List.map5 (fun name typ ctx impargs opaque ->
       let args = List.map Context.Rel.Declaration.get_name ctx in
-      Declare.CInfo.make ~name ~typ ~args ~impargs ()
-    ) fixnames fixtypes fixctxs fiximps
+      Declare.CInfo.make ~name ~typ ~args ~impargs ~opaque ()
+    ) fixnames fixtypes fixctxs fiximps fixopaques
 
 let collect_evars_of_term evd c ty =
   Evar.Set.union (Evd.evars_of_term evd c) (Evd.evars_of_term evd ty)
@@ -528,26 +533,26 @@ let build_program_fixpoint env sigma rec_sign possible_guard fixnames fixrs fixd
   List.split3 (List.map3 (collect_evars env sigma rec_sign) fixnames fixdefs fixtypes)
 
 let finish_obligations env sigma rec_sign possible_guard poly udecl = function
-  | {fixnames=[recname];fixrs;fixdefs=[body];fixtypes=[ccl];fixctxs=[ctx];fiximps=[imps];fixntns;fixwfs=[Some wf]} ->
+  | {fixnames=[recname];fixrs;fixdefs=[body];fixtypes=[ccl];fixctxs=[ctx];fiximps=[imps];fixntns;fixwfs=[Some wf];fixopaques} ->
     let sigma = Evarutil.nf_evar_map sigma in (* use nf_evar_map_undefined?? *)
     let sigma, recname, body, ccl, impls, obls, hook = build_wellfounded env sigma poly udecl recname ctx (Option.get body) ccl imps wf in
     let fixrs = List.map (EConstr.ERelevance.kind sigma) fixrs in
-    sigma, {fixnames=[recname];fixrs;fixdefs=[Some body];fixtypes=[ccl];fixctxs=[ctx];fiximps=[impls];fixntns;fixwfs=[Some wf]}, [obls], hook
-  | {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs} ->
+    sigma, {fixnames=[recname];fixrs;fixdefs=[Some body];fixtypes=[ccl];fixctxs=[ctx];fiximps=[impls];fixntns;fixwfs=[Some wf];fixopaques}, [obls], hook
+  | {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs;fixopaques} ->
     let fixdefs, fixtypes, obls = build_program_fixpoint env sigma rec_sign possible_guard fixnames fixrs fixdefs fixtypes fixwfs in
     let fixrs = List.map (EConstr.ERelevance.kind sigma) fixrs in
-    sigma, {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs}, obls, None
+    sigma, {fixnames;fixrs;fixdefs;fixtypes;fixctxs;fiximps;fixntns;fixwfs;fixopaques}, obls, None
 
 let finish_regular env sigma use_inference_hook fix =
   let inference_hook = if use_inference_hook then Some Declare.Obls.program_inference_hook else None in
   let sigma = Pretyping.(solve_remaining_evars ?hook:inference_hook all_no_fail_flags env sigma) in
   sigma, ground_fixpoint env sigma fix, [], None
 
-let do_mutually_recursive ?pm ~program_mode ?(use_inference_hook=false) ?scope ?clearbody ~kind ~poly ?typing_flags ?user_warns ?using (rec_order, fixl)
+let do_mutually_recursive ?pm ~program_mode ?(use_inference_hook=false) ?scope ?opaque ?clearbody ~kind ~poly ?typing_flags ?user_warns ?using (rec_order, fixl)
   : Declare.OblState.t option * Declare.Proof.t option =
   let env = Global.env () in
   let env = Environ.update_typing_flags ?typing_flags env in
-  let (env,rec_sign,sigma),(fix,possible_guard,udecl) = interp_mutual_definition env ~program_mode ~function_mode:false rec_order fixl in
+  let (env,rec_sign,sigma),(fix,possible_guard,udecl) = interp_mutual_definition env ~program_mode ~function_mode:false ?opaque rec_order fixl in
   check_recursive ~kind env sigma fix;
   let sigma, ({fixdefs=bodies;fixrs;fixtypes;fixwfs} as fix), obls, hook =
     match pm with
@@ -565,11 +570,11 @@ let do_mutually_recursive ?pm ~program_mode ?(use_inference_hook=false) ?scope ?
     (match fixwfs, bodies, cinfo, obls with
     | [Some _], [body], [cinfo], [obls] ->
       (* Program Fixpoint wf/measure *)
-      let pm, _ = Declare.Obls.add_definition ~pm ~cinfo ~info ~opaque:false ~body ~uctx ?using obls in
+      let pm, _ = Declare.Obls.add_definition ~pm ~cinfo ~info ~body ~uctx ?using obls in
       Some pm, None
     | _ ->
       let possible_guard = (possible_guard, fixrs) in
-      Some (Declare.Obls.add_mutual_definitions ~pm ~cinfo ~info ~opaque:false ~uctx ~bodies ~possible_guard ?using obls), None)
+      Some (Declare.Obls.add_mutual_definitions ~pm ~cinfo ~info ~uctx ~bodies ~possible_guard ?using obls), None)
   | None ->
     try
       let bodies = List.map Option.get bodies in
@@ -577,7 +582,7 @@ let do_mutually_recursive ?pm ~program_mode ?(use_inference_hook=false) ?scope ?
       (* All bodies are defined *)
       let possible_guard = (possible_guard, fixrs) in
       let _ : GlobRef.t list =
-        Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx ~possible_guard ~bodies ?using ()
+        Declare.declare_mutual_definitions ~cinfo ~info ~uctx ~possible_guard ~bodies ?using ()
       in
       None, None
     with Option.IsNone ->

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -27,7 +27,7 @@ val do_mutually_recursive
      (* Tell to try the obligation tactic to solve evars *)
   -> ?scope:Locality.definition_scope
      (* Local or Global visibility *)
-  -> ?opaque:bool
+  -> ?opaque:Attributes.opacity
      (* Global opacity attribute if any *)
   -> ?clearbody:bool
      (* Hide body if in sections *)

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -27,6 +27,8 @@ val do_mutually_recursive
      (* Tell to try the obligation tactic to solve evars *)
   -> ?scope:Locality.definition_scope
      (* Local or Global visibility *)
+  -> ?opaque:bool
+     (* Global opacity attribute if any *)
   -> ?clearbody:bool
      (* Hide body if in sections *)
   -> kind:Decls.logical_kind

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1394,41 +1394,6 @@ module State = struct
   let all pm = ProgMap.bindings pm |> List.map (fun (_,v) -> CEphemeron.get v)
   let find m t = ProgMap.find_opt t m |> Option.map CEphemeron.get
 
-  module View = struct
-    module Obl = struct
-      type t =
-        { name : Id.t
-        ; loc : Loc.t option
-        ; status : bool * Evar_kinds.obligation_definition_status
-        ; solved : bool
-        }
-
-      let make (o : Obligation.t) =
-        let { obl_name; obl_location; obl_status; obl_body; _ } = o in
-        { name = obl_name
-        ; loc = fst obl_location
-        ; status = obl_status
-        ; solved = Option.has_some obl_body
-        }
-    end
-
-    type t =
-      { opaque : bool
-      ; remaining : int
-      ; obligations : Obl.t array
-      }
-
-    let make { prg_opaque; prg_obligations; _ } =
-      { opaque = prg_opaque
-      ; remaining = prg_obligations.remaining
-      ; obligations = Array.map Obl.make prg_obligations.obls
-      }
-
-    let make eph = CEphemeron.get eph |> make
-  end
-
-  let view s = Id.Map.map View.make s
-
 end
 
 (* In all cases, the use of the map is read-only so we don't expose the ref *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2071,14 +2071,14 @@ let set_proof_opacity ending kind cinfo opaque_ending =
   let idl = List.filter_map (function CInfo.{ name; opaque = None } -> Some name | _ -> None) cinfo in
   let ending = CEphemeron.default ending Proof_ending.Regular in
   match kind, opaque_ending with
-  | Decls.IsDefinition d, Vernacexpr.Opaque ->
+  | Decls.IsDefinition d, Vernacexpr.Qed ->
     (* A definition ended with Qed: warn if there is no attribute *)
     (match d, ending, idl with
      | (Definition | Fixpoint | CoFixpoint), Proof_ending.Regular, id::_ -> warn_use_sealed (id, true)
      | _ -> ()); true
-  | IsDefinition _, Vernacexpr.Transparent -> false
-  | IsProof _, Vernacexpr.Opaque -> true
-  | IsProof _, Vernacexpr.Transparent -> false
+  | IsDefinition _, Vernacexpr.Defined -> false
+  | IsProof _, Vernacexpr.Qed -> true
+  | IsProof _, Vernacexpr.Defined -> false
   | (Decls.IsPrimitive | IsSymbol | IsAssumption _), _ -> false (* Irrelevant *)
 
 let return_proof p = (prepare_proof p : closed_proof_output)
@@ -2115,7 +2115,7 @@ let build_constant_by_tactic ~name ?warn_incomplete ~sigma ~sign ~poly (typ : EC
   let pinfo = Proof_info.make ~cinfo ~info () in
   let pf = start_proof_core ~name ~pinfo sigma [Some sign, typ] in
   let pf, status = by tac pf in
-  let proof = close_proof ?warn_incomplete ~keep_body_ucst_separate:false ~opaque:Vernacexpr.Transparent pf in
+  let proof = close_proof ?warn_incomplete ~keep_body_ucst_separate:false ~opaque:Vernacexpr.Defined pf in
   let entries = process_proof ~info ~cinfo proof.proof_object in
   let { Proof.sigma } = Proof.data pf.proof in
   let sigma = Evd.set_universe_context sigma (ustate_of_proof proof.proof_object) in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -79,6 +79,7 @@ module CInfo : sig
     -> typ:'constr
     -> ?args:Name.t list
     -> ?impargs:Impargs.manual_implicits
+    -> opaque : bool option
     -> unit
     -> 'constr t
 
@@ -125,7 +126,6 @@ end
 val declare_definition
   :  info:Info.t
   -> cinfo:EConstr.t option CInfo.t
-  -> opaque:bool
   -> body:EConstr.t
   -> ?using:Vernacexpr.section_subset_expr
   -> Evd.evar_map
@@ -134,7 +134,6 @@ val declare_definition
 val declare_mutual_definitions
   :  info:Info.t
   -> cinfo: Constr.t CInfo.t list
-  -> opaque:bool
   -> uctx:UState.t
   -> bodies:Constr.t list
   -> possible_guard:Pretyping.possible_guard * Sorts.relevance list
@@ -431,7 +430,6 @@ val declare_constant
 val declare_definition_full
   :  info:Info.t
   -> cinfo:EConstr.t option CInfo.t
-  -> opaque:bool
   -> body:EConstr.t
   -> ?using:Vernacexpr.section_subset_expr
   -> Evd.evar_map
@@ -538,7 +536,6 @@ val add_definition :
      pm:OblState.t
   -> info:Info.t
   -> cinfo:Constr.types CInfo.t
-  -> opaque:bool
   -> uctx:UState.t
   -> ?body:Constr.t
   -> ?tactic:unit Proofview.tactic
@@ -556,7 +553,6 @@ val add_mutual_definitions :
      pm:OblState.t
   -> info:Info.t
   -> cinfo:Constr.types CInfo.t list
-  -> opaque:bool
   -> uctx:UState.t
   -> bodies:Constr.t list
   -> possible_guard:(Pretyping.possible_guard * Sorts.relevance list)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -151,25 +151,6 @@ module OblState : sig
   type t
   val empty : t
 
-  module View : sig
-    module Obl : sig
-      type t = private
-        { name : Id.t
-        ; loc : Loc.t option
-        ; status : bool * Evar_kinds.obligation_definition_status
-        ; solved : bool
-        }
-    end
-
-    type t = private
-      { opaque : bool
-      ; remaining : int
-      ; obligations : Obl.t array
-      }
-  end
-
-  val view : t -> View.t Id.Map.t
-
 end
 
 (** [Declare.Proof.t] Construction of constants using interactive proofs. *)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -79,7 +79,7 @@ module CInfo : sig
     -> typ:'constr
     -> ?args:Name.t list
     -> ?impargs:Impargs.manual_implicits
-    -> opaque : bool option
+    -> opaque : Attributes.opacity option
     -> unit
     -> 'constr t
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -206,14 +206,14 @@ module Proof : sig
   val save
     : pm:OblState.t
     -> proof:t
-    -> opaque:Vernacexpr.opacity_flag
+    -> opaque:Vernacexpr.proof_opacity
     -> idopt:Names.lident option
     -> OblState.t * GlobRef.t list
 
   (** For proofs known to have [Regular] ending, no need to touch program state. *)
   val save_regular
     : proof:t
-    -> opaque:Vernacexpr.opacity_flag
+    -> opaque:Vernacexpr.proof_opacity
     -> idopt:Names.lident option
     -> GlobRef.t list
 
@@ -291,7 +291,7 @@ module Proof : sig
       instead *)
   type proof_object
 
-  val close_proof : ?warn_incomplete:bool -> opaque:Vernacexpr.opacity_flag -> keep_body_ucst_separate:bool -> t -> proof_object
+  val close_proof : ?warn_incomplete:bool -> opaque:Vernacexpr.proof_opacity -> keep_body_ucst_separate:bool -> t -> proof_object
   val close_future_proof : feedback_id:Stateid.t -> t -> closed_proof_output Future.computation -> proof_object
 
   (** Special cases for delayed proofs, in this case we must provide the

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -65,12 +65,12 @@ GRAMMAR EXTEND Gram
       | IDENT "Abort" -> { VernacSynPure VernacAbort }
       | IDENT "Abort"; IDENT "All" -> { VernacSynPure VernacAbortAll }
       | IDENT "Admitted" -> { VernacSynPure (VernacEndProof Admitted) }
-      | IDENT "Qed" -> { VernacSynPure (VernacEndProof (Proved (Opaque,None))) }
+      | IDENT "Qed" -> { VernacSynPure (VernacEndProof (Proved (Qed,None))) }
       | IDENT "Save"; id = identref ->
-          { VernacSynPure (VernacEndProof (Proved (Opaque, Some id))) }
-      | IDENT "Defined" -> { VernacSynPure (VernacEndProof (Proved (Transparent,None))) }
+          { VernacSynPure (VernacEndProof (Proved (Qed, Some id))) }
+      | IDENT "Defined" -> { VernacSynPure (VernacEndProof (Proved (Defined,None))) }
       |	IDENT "Defined"; id=identref ->
-          { VernacSynPure (VernacEndProof (Proved (Transparent,Some id))) }
+          { VernacSynPure (VernacEndProof (Proved (Defined,Some id))) }
       | IDENT "Restart" -> { VernacSynPure VernacRestart }
       | IDENT "Undo" -> { VernacSynPure (VernacUndo 1) }
       | IDENT "Undo"; n = natural -> { VernacSynPure (VernacUndo n) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -500,18 +500,18 @@ GRAMMAR EXTEND Gram
   ;
   (* (co)-fixpoints *)
   fix_definition:
-    [ [ id_decl = ident_decl;
+    [ [ fix_attrs = quoted_attributes; id_decl = ident_decl;
         bl = binders_fixannot;
         rtype = type_cstr;
         body_def = OPT [":="; def = lconstr -> { def } ]; notations = decl_notations ->
           { let binders, rec_order = bl in
-            ((rec_order : Constrexpr.fixpoint_order_expr option), {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations})
+            ((rec_order : Constrexpr.fixpoint_order_expr option), {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations; fix_attrs})
           } ] ]
   ;
   cofix_definition:
-    [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr;
+    [ [ fix_attrs = quoted_attributes; id_decl = ident_decl; binders = binders; rtype = type_cstr;
         body_def = OPT [":="; def = lconstr -> { def }]; notations = decl_notations ->
-        { {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations}
+        { {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations; fix_attrs}
         } ]]
   ;
   (* Rewrite Rules *)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -876,9 +876,9 @@ let pr_synpure_vernac_expr v =
   | VernacEndProof (Proved (opac,o)) -> return (
       match o with
       | None -> (match opac with
-          | Transparent -> keyword "Defined"
-          | Opaque      -> keyword "Qed")
-      | Some id -> (if opac <> Transparent then keyword "Save" else keyword "Defined") ++ spc() ++ pr_lident id
+          | Defined -> keyword "Defined"
+          | Qed     -> keyword "Qed")
+      | Some id -> (if opac <> Defined then keyword "Save" else keyword "Defined") ++ spc() ++ pr_lident id
     )
   | VernacExactProof c ->
     return (hov 2 (keyword "Proof" ++ pr_lconstrarg c))

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -29,3 +29,5 @@ val pr_using : Vernacexpr.section_subset_expr -> Pp.t
 
 (** Prints a vernac expression and closes it with a dot. *)
 val pr_vernac : Vernacexpr.vernac_control -> Pp.t
+
+val string_of_theorem_kind : Decls.theorem_kind -> string

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -172,7 +172,7 @@ let print_opacity env ref =
     | Some s ->
        [pr_global ref ++ str " is " ++
         match s with
-          | FullyOpaque -> str "opaque"
+          | FullyOpaque -> str "sealed"
           | TransparentMaybeOpacified Conv_oracle.Opaque ->
               str "basically transparent but considered opaque for reduction"
           | TransparentMaybeOpacified lev when Conv_oracle.is_transparent lev ->

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -32,8 +32,8 @@ let string_of_vernac_classification = function
   | VtProofMode _ -> "Proof Mode"
 
 let vtkeep_of_opaque = function
-  | Opaque -> VtKeepOpaque
-  | Transparent -> VtKeepDefined
+  | Qed -> VtKeepOpaque
+  | Defined -> VtKeepDefined
 
 let idents_of_name : Names.Name.t -> Names.Id.t list =
   function

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -60,7 +60,7 @@ module DefAttributes = struct
     using : Vernacexpr.section_subset_expr option;
     reversible : bool;
     clearbody: bool option;
-    opacity: bool option;
+    opacity: Attributes.opacity option;
   }
   (* [locality] is used for [vernac_definition_hook],
      the raw Local/Global attribute is also used to generate [scope].

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -841,8 +841,9 @@ let vernac_definition_interactive ~atts (discharge, kind) (lid, udecl) bl t =
   let canonical_instance, reversible = atts.canonical_instance, atts.reversible in
   let hook = vernac_definition_hook ~canonical_instance ~local ~poly ~reversible kind in
   let name = vernac_definition_name lid scope in
+  let kind = Decls.(match lid.v with Anonymous -> (* Goal *) IsProof Theorem | _ -> IsDefinition kind) in
   ComDefinition.do_definition_interactive ~typing_flags ~program_mode ~name ~poly ~scope ~opaque ?clearbody:atts.clearbody
-    ~kind:(Decls.IsDefinition kind) ?user_warns ?using:atts.using ?hook udecl bl t
+    ~kind ?user_warns ?using:atts.using ?hook udecl bl t
 
 let vernac_definition ~atts ~pm (discharge, kind) (lid, udecl) bl red_option c typ_opt =
   let open DefAttributes in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -907,7 +907,7 @@ let vernac_exact_proof ~lemma ~pm c =
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the beginning of a proof. *)
   let lemma, status = Declare.Proof.by (Tactics.exact_proof c) lemma in
-  let pm, _ = Declare.Proof.save ~pm ~proof:lemma ~opaque:Opaque ~idopt:None in
+  let pm, _ = Declare.Proof.save ~pm ~proof:lemma ~opaque:Qed ~idopt:None in
   if not status then Feedback.feedback Feedback.AddedAxiom;
   pm
 

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -85,6 +85,7 @@ type t = {
   using : Vernacexpr.section_subset_expr option;
   reversible : bool;
   clearbody: bool option;
+  opacity: bool option;
 }
 
 val def_attributes : t Attributes.attribute

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -85,7 +85,7 @@ type t = {
   using : Vernacexpr.section_subset_expr option;
   reversible : bool;
   clearbody: bool option;
-  opacity: bool option;
+  opacity: Attributes.opacity option;
 }
 
 val def_attributes : t Attributes.attribute

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -245,15 +245,15 @@ type one_inductive_expr =
 type typeclass_constraint = name_decl * Glob_term.binding_kind * constr_expr
 and typeclass_context = typeclass_constraint list
 
+type proof_opacity = Qed | Defined
+
 type proof_expr =
   ident_decl * (local_binder_expr list * constr_expr)
-
-type opacity_flag = Opaque | Transparent
 
 type proof_end =
   | Admitted
   (*                         name in `Save ident` when closing goal *)
-  | Proved of opacity_flag * lident option
+  | Proved of proof_opacity * lident option
 
 type scheme_type =
   | SchemeInduction

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -192,6 +192,7 @@ type recursive_expr_gen =
   ; rtype : constr_expr
   ; body_def : constr_expr option
   ; notations : notation_declaration list
+  ; fix_attrs : Attributes.vernac_flags
   }
 
 type fixpoint_expr = fixpoint_order_expr option * recursive_expr_gen

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -119,7 +119,7 @@ module Declare : sig
     -> Declare.Proof.proof_object
 
   val close_proof
-    : opaque:Vernacexpr.opacity_flag
+    : opaque:Vernacexpr.proof_opacity
     -> keep_body_ucst_separate:bool
     -> Declare.Proof.proof_object
 


### PR DESCRIPTION
The PR experiments the implementation of a proposal related to coq/ceps#42. It adds attributes `sealed` and `defined` that allow to indicate the opacity of a definition defined non-interactively.

When used in an interactive proof, `sealed` and `defined` take precedence over `Qed`and `Defined`. Consequently, using an attribute in interactive mode allows to match `Definition` with `Defined` and `Theorem` with `Qed` without impacting the opacity (since it is the attribute which takes precedence).

In non-interactive mode, a `Definition` is declared defined in the absence of an atttribute while `Theorem` mandatorily requires an attribute (however, the syntax `Theorem :=`itself is eventually provided only in #19301).

The main technical change is that the "opaque" value is now part of the `Declare.CInfo.t` while it was before passed as a standalone argument or stored in the program obligation state.


Here are some examples:
```coq
#[sealed] Definition c := 0.
#[defined] Theorem t : nat. exact 0. Defined.
Fixpoint #[sealed] f n := match n with 0 => 0 | S n => g n end
with #[defined] g n := match n with 0 => 0 | S n => f n end.
```

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

Pending questions:
- [x] sealed/defined attributes only in front of names (as in `Fixpoint #[sealed] foo ...`) or also in front of commands (as in `#[sealed] Fixpoint foo ...`) [but easier to done once #19301 is merged]: now added also in front

Depends on:
- #19766 
- #19768