### PR TITLE
A common execution path for universe restriction + universe declaration check

### DIFF
--- a/test-suite/success/ProgramWfPoly.v
+++ b/test-suite/success/ProgramWfPoly.v
@@ -1,0 +1,178 @@
+(* An example extracted by the minimizer from category-theory *)
+
+Require Coq.FSets.FMaps.
+Require Coq.Program.Program.
+
+Axiom proof_admitted : False.
+Tactic Notation "admit" := abstract case proof_admitted.
+
+Declare Scope category_theory_scope.
+Open Scope category_theory_scope.
+
+Module Export Category_DOT_Lib_WRAPPED.
+Module Export Lib.
+#[export] Set Universe Polymorphism.
+#[export] Set Uniform Inductive Parameters.
+#[export] Unset Universe Minimization ToSet.
+
+End Lib.
+
+End Category_DOT_Lib_WRAPPED.
+Module Export Category_DOT_Lib_DOT_FMapExt_WRAPPED.
+Module Export FMapExt.
+Import Coq.FSets.FMapFacts.
+
+Module FMapExt (E : DecidableType) (M : WSfun E).
+
+Module P := WProperties_fun E M.
+Module F := P.F.
+
+#[export] Hint Extern 5 =>
+  match goal with
+    [ H : M.MapsTo _ _ (M.empty _) |- _ ] =>
+      apply F.empty_mapsto_iff in H; contradiction
+  end : core.
+
+End FMapExt.
+
+End FMapExt.
+
+End Category_DOT_Lib_DOT_FMapExt_WRAPPED.
+Module Export Lib.
+Module Export FMapExt.
+Include Category_DOT_Lib_DOT_FMapExt_WRAPPED.FMapExt.
+End FMapExt.
+
+End Lib.
+Import Coq.NArith.NArith.
+Import Coq.FSets.FMaps.
+
+Module PO := PairOrderedType N_as_OT N_as_OT.
+Module M  := FMapList.Make(PO).
+Module Import FMapExt := FMapExt PO M.
+
+Inductive partial (P : Prop) : Set :=
+| Proved : P -> partial
+| Uncertain : partial.
+
+Notation "[ P ]" := (partial P) : type_scope.
+
+Notation "'Yes'" := (Proved _ _) : partial_scope.
+Notation "'No'" := (Uncertain _) : partial_scope.
+
+#[local] Open Scope partial_scope.
+
+Notation "'Reduce' v" := (if v then Yes else No) (at level 100) : partial_scope.
+Notation "x && y" := (if x then Reduce y else No) : partial_scope.
+
+Record environment : Set := {
+  vars : positive -> N
+}.
+
+Inductive term : Set :=
+  | Var   : positive -> term
+  | Value : N -> term.
+
+Program Definition term_eq_dec (x y : term) : {x = y} + {x <> y} :=
+  match x, y with
+  | Var x,   Var y   => if Pos.eq_dec x y then left _ else right _
+  | Value x, Value y => if N.eq_dec   x y then left _ else right _
+  | _, _ => right _
+  end.
+Definition subst_all {A} (f : A -> term -> term -> A) :
+  A -> list (term * term) -> A.
+exact (fold_right (fun '(v, v') rest => f rest v v')).
+Defined.
+
+Definition term_denote env (x : term) : N :=
+  match x with
+  | Var n => vars env n
+  | Value n => n
+  end.
+
+Inductive map_expr : Set :=
+  | Empty : map_expr
+  | Add   : term -> term -> term -> map_expr -> map_expr.
+
+Fixpoint map_expr_denote env (m : map_expr) : M.t N :=
+  match m with
+  | Empty => M.empty N
+  | Add x y f m' => M.add (term_denote env x, term_denote env y)
+                          (term_denote env  f) (map_expr_denote env m')
+  end.
+
+Inductive formula : Set :=
+  | Top    : formula
+  | Bottom : formula
+  | Maps   : term -> term -> term -> map_expr -> formula
+  | Impl   : formula -> formula -> formula.
+Fixpoint subst_formula (t : formula) (v v' : term) : formula.
+Admitted.
+
+Fixpoint formula_denote env (t : formula) : Prop :=
+  match t with
+  | Top => True
+  | Bottom => False
+  | Maps x y f m =>
+    M.MapsTo (term_denote env x, term_denote env y)
+             (term_denote env f) (map_expr_denote env m)
+  | Impl p q => formula_denote env p -> formula_denote env q
+  end.
+Fixpoint formula_size (t : formula) : nat.
+Admitted.
+Fixpoint substitutions (xs : list (term * term)) : list (term * term).
+Admitted.
+Fixpoint remove_conflicts (x y f : term) (m : map_expr) : map_expr.
+Admitted.
+
+Import ListNotations.
+
+Program Definition formula_forward (t : formula) env (hyp : formula)
+        (cont : forall env' defs,
+            [formula_denote env' (subst_all subst_formula t defs)]) :
+  [formula_denote env hyp -> formula_denote env t] :=
+  match hyp with
+  | Top => Reduce (cont env [])
+  | Bottom => Yes
+  | Maps x y f m =>
+    let fix go n : [formula_denote env (Maps x y f n)
+                    -> formula_denote env t] :=
+        match n with
+        | Empty => Yes
+        | Add x' y' f' m' =>
+          cont env (substitutions [(x, x'); (y, y'); (f, f')]) && go m'
+        end in Reduce (go (remove_conflicts x y f m))
+  | Impl _ _ => Reduce (cont env [])
+  end.
+Next Obligation.
+Admitted.
+Next Obligation.
+admit.
+Defined.
+Admit Obligations.
+
+Fixpoint map_contains env (x y : N) (m : map_expr) : option term :=
+  match m with
+  | Empty => None
+  | Add x' y' f' m' =>
+    if (N.eqb x (term_denote env x') &&
+        N.eqb y (term_denote env y'))%bool
+    then Some f'
+    else map_contains env x y m'
+  end.
+
+Program Fixpoint formula_backward (t : formula) env {measure (formula_size t)} :
+  [formula_denote env t] :=
+  match t with
+  | Top => Yes
+  | Bottom => No
+  | Maps x y f m =>
+    match map_contains env (term_denote env x) (term_denote env y) m with
+    | Some f' => Reduce (term_eq_dec f' f)
+    | None => No
+    end
+  | Impl p q =>
+    formula_forward q env p
+      (fun env' defs' => formula_backward (subst_all subst_formula q defs') env')
+  end.
+Admit Obligations. (* used to raise a universe instance length mismatch *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -214,7 +214,7 @@ let make_univs_immediate_private_mono ~initial_euctx ~uctx ~udecl ~eff body typ 
        the body.  So we keep the two sets distinct. *)
     let uctx_body = UState.restrict uctx used_univs in
     UState.check_mono_univ_decl uctx_body udecl in
-  utyp, Default { body = (body, eff); opaque = Opaque ubody }
+  initial_euctx, utyp, Default { body = (body, eff); opaque = Opaque ubody }
 
 let make_univs_immediate_private_poly ~uctx ~udecl ~eff body typ =
   let used_univs_typ, used_univs = universes_of_body_type body typ in
@@ -226,7 +226,7 @@ let make_univs_immediate_private_poly ~uctx ~udecl ~eff body typ =
       (UState.context_set uctx)
       (UState.context_set uctx')
   in
-  utyp, Default { body = (body, eff); opaque = Opaque ubody }
+  uctx', utyp, Default { body = (body, eff); opaque = Opaque ubody }
 
 let make_univs_immediate_default ~poly ~opaque ~uctx ~udecl ~eff body typ =
   let _, used_univs = universes_of_body_type body typ in
@@ -249,7 +249,7 @@ let make_univs_immediate_default ~poly ~opaque ~uctx ~udecl ~eff body typ =
          when monomorphic it shouldn't really matter. *)
       Monomorphic_entry (Univ.ContextSet.union uctx (Safe_typing.universes_of_private eff.Evd.seff_private)), snd utyp
   in
-  utyp, Default { body = (body, eff); opaque = if opaque then Opaque Univ.ContextSet.empty else Transparent }
+  uctx, utyp, Default { body = (body, eff); opaque = if opaque then Opaque Univ.ContextSet.empty else Transparent }
 
 let make_univs_immediate ~poly ?keep_body_ucst_separate ~opaque ~uctx ~udecl ~eff body typ =
   (* allow_deferred case *)
@@ -2004,7 +2004,7 @@ let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate ps =
 
   let make_entry ((body, eff), typ) =
     let keep_body_ucst_separate = if keep_body_ucst_separate then Some initial_euctx else None in
-    let univs, body =
+    let _, univs, body =
       make_univs_immediate ~poly ?keep_body_ucst_separate ~opaque ~uctx ~udecl ~eff body (Some typ) in
     definition_entry_core ?using ~univs ~types:typ body
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -183,6 +183,84 @@ let make_ubinders uctx (univs, ubinders as u) = match univs with
   | UState.Monomorphic_entry _ -> (UState.Monomorphic_entry uctx, ubinders)
   | UState.Polymorphic_entry _ -> u
 
+let { Goptions.get = private_poly_univs } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Private";"Polymorphic";"Universes"]
+    ~value:true
+    ()
+
+let universes_of_body_type body typ =
+  let used_univs_body = Vars.universes_of_constr body in
+  let used_univs_typ = Option.cata Vars.universes_of_constr Univ.Level.Set.empty typ in
+  let used_univs = Univ.Level.Set.union used_univs_body used_univs_typ in
+  used_univs_typ, used_univs
+
+let make_univs_deferred_private_mono ~initial_euctx ?feedback_id ~uctx ~udecl body typ =
+  let _, used_univs = universes_of_body_type body typ in
+  let uctx = UState.constrain_variables (fst (UState.context_set initial_euctx)) uctx in
+  (* For vi2vo compilation proofs are computed now but we need to
+     complement the univ constraints of the typ with the ones of
+     the body.  So we keep the two sets distinct. *)
+  let uctx_body = UState.restrict uctx used_univs in
+  UState.check_mono_univ_decl uctx_body udecl
+
+let make_univs_immediate_private_mono ~initial_euctx ~uctx ~udecl ~eff body typ =
+  let utyp = UState.univ_entry ~poly:false initial_euctx in
+  let ubody =
+    let _, used_univs = universes_of_body_type body typ in
+    let uctx = UState.constrain_variables (fst (UState.context_set initial_euctx)) uctx in
+    (* For vi2vo compilation proofs are computed now but we need to
+       complement the univ constraints of the typ with the ones of
+       the body.  So we keep the two sets distinct. *)
+    let uctx_body = UState.restrict uctx used_univs in
+    UState.check_mono_univ_decl uctx_body udecl in
+  utyp, Default { body = (body, eff); opaque = Opaque ubody }
+
+let make_univs_immediate_private_poly ~uctx ~udecl ~eff body typ =
+  let used_univs_typ, used_univs = universes_of_body_type body typ in
+  let uctx' = UState.restrict uctx used_univs_typ in
+  let utyp = UState.check_univ_decl ~poly:true uctx' udecl in
+  let ubody =
+    let uctx = UState.restrict uctx used_univs in
+    Univ.ContextSet.diff
+      (UState.context_set uctx)
+      (UState.context_set uctx')
+  in
+  utyp, Default { body = (body, eff); opaque = Opaque ubody }
+
+let make_univs_immediate_default ~poly ~opaque ~uctx ~udecl ~eff body typ =
+  let _, used_univs = universes_of_body_type body typ in
+  (* Since the proof is computed now, we can simply have 1 set of
+     constraints in which we merge the ones for the body and the ones
+     for the typ. We recheck the declaration after restricting with
+     the actually used universes.
+     TODO: check if restrict is really necessary now. *)
+  let uctx = UState.restrict uctx used_univs in
+  let utyp = UState.check_univ_decl ~poly uctx udecl in
+  let utyp = match fst utyp with
+    | Polymorphic_entry _ -> utyp
+    | Monomorphic_entry uctx ->
+      (* the constraints from the body may depend on universes from
+         the side effects, so merge it all together.
+         Example failure if we don't is "l1" in test-suite/success/rewrite.v.
+
+         Not sure if it makes more sense to merge them in the ustate
+         before restrict/check_univ_decl or here. Since we only do it
+         when monomorphic it shouldn't really matter. *)
+      Monomorphic_entry (Univ.ContextSet.union uctx (Safe_typing.universes_of_private eff.Evd.seff_private)), snd utyp
+  in
+  utyp, Default { body = (body, eff); opaque = if opaque then Opaque Univ.ContextSet.empty else Transparent }
+
+let make_univs_immediate ~poly ?keep_body_ucst_separate ~opaque ~uctx ~udecl ~eff body typ =
+  (* allow_deferred case *)
+  match keep_body_ucst_separate with
+  | Some initial_euctx when not poly -> make_univs_immediate_private_mono ~initial_euctx ~uctx ~udecl ~eff body typ
+  | _ ->
+  (* private_poly_univs case *)
+  if poly && opaque && private_poly_univs ()
+  then make_univs_immediate_private_poly ~uctx ~udecl ~eff body typ
+  else make_univs_immediate_default ~poly ~opaque ~uctx ~udecl ~eff body typ
+
 (** [univsbody] are universe-constraints attached to the body-only,
    used in vio-delayed opaque constants and private poly universes *)
 let definition_entry_core ?using ?(inline=false) ?types
@@ -1769,12 +1847,6 @@ type proof_object =
   ; pinfo : Proof_info.t
   }
 
-let { Goptions.get = private_poly_univs } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Private";"Polymorphic";"Universes"]
-    ~value:true
-    ()
-
 let warn_remaining_shelved_goals =
   CWarnings.create ~name:"remaining-shelved-goals" ~category:CWarnings.CoreCategories.tactics
     (fun () -> Pp.str"The proof has remaining shelved goals.")
@@ -1863,8 +1935,7 @@ let prepare_proof ?(warn_incomplete=true) { proof; pinfo } =
       let rec_declaration = prepare_recursive_declaration pinfo.cinfo fixtypes fixrelevances fixbodies in
       let typing_flags = pinfo.info.typing_flags in
       fst (make_recursive_bodies env ~typing_flags ~possible_guard ~rec_declaration) in
-  let add_univ c = (Vars.universes_of_constr c, c) in
-  let proofs = List.map (fun (body, typ) -> ((add_univ body, eff), add_univ typ)) proofs in
+  let proofs = List.map (fun (body, typ) -> ((body, eff), typ)) proofs in
   let () =
     if warn_incomplete then begin
       if Evd.has_shelved evd then warn_remaining_shelved_goals ()
@@ -1921,52 +1992,6 @@ let control_only_guard { proof; pinfo } =
       raise (NotGuarded (env, sigma, cofix_error, fix_errors, rec_declaration))
     with Exit -> ()
 
-let make_univs_deferred ~poly ~initial_euctx ~uctx ~udecl
-    (used_univs_typ, typ) (used_univs_body, body) eff =
-  let used_univs = Univ.Level.Set.union used_univs_body used_univs_typ in
-  let utyp = UState.univ_entry ~poly initial_euctx in
-  let uctx = UState.constrain_variables (fst (UState.context_set initial_euctx)) uctx in
-  (* For vi2vo compilation proofs are computed now but we need to
-     complement the univ constraints of the typ with the ones of
-     the body.  So we keep the two sets distinct. *)
-  let uctx_body = UState.restrict uctx used_univs in
-  let ubody = UState.check_mono_univ_decl uctx_body udecl in
-  utyp, Default { body = (body, eff); opaque = Opaque ubody }
-
-let make_univs_private_poly ~poly ~uctx ~udecl (used_univs_typ, typ) (used_univs_body, body) eff =
-  let used_univs = Univ.Level.Set.union used_univs_body used_univs_typ in
-  let uctx = UState.restrict uctx used_univs in
-  let uctx' = UState.restrict uctx used_univs_typ in
-  let utyp = UState.check_univ_decl ~poly uctx' udecl in
-  let ubody = Univ.ContextSet.diff
-      (UState.context_set uctx)
-      (UState.context_set uctx')
-  in
-  utyp, Default { body = (body, eff); opaque = Opaque ubody }
-
-let make_univs ~poly ~uctx ~udecl ~opaque (used_univs_typ, typ) (used_univs_body, body) eff =
-  let used_univs = Univ.Level.Set.union used_univs_body used_univs_typ in
-  (* Since the proof is computed now, we can simply have 1 set of
-     constraints in which we merge the ones for the body and the ones
-     for the typ. We recheck the declaration after restricting with
-     the actually used universes.
-     TODO: check if restrict is really necessary now. *)
-  let uctx = UState.restrict uctx used_univs in
-  let utyp = UState.check_univ_decl ~poly uctx udecl in
-  let utyp = match fst utyp with
-    | Polymorphic_entry _ -> utyp
-    | Monomorphic_entry uctx ->
-      (* the constraints from the body may depend on universes from
-         the side effects, so merge it all together.
-         Example failure if we don't is "l1" in test-suite/success/rewrite.v.
-
-         Not sure if it makes more sense to merge them in the ustate
-         before restrict/check_univ_decl or here. Since we only do it
-         when monomorphic it shouldn't really matter. *)
-      Monomorphic_entry (Univ.ContextSet.union uctx (Safe_typing.universes_of_private eff.Evd.seff_private)), snd utyp
-  in
-  utyp, Default { body = (body, eff); opaque = if opaque then Opaque Univ.ContextSet.empty else Transparent }
-
 let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate ps =
 
   let { using; proof; initial_euctx; pinfo } = ps in
@@ -1977,17 +2002,11 @@ let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate ps =
     | Vernacexpr.Opaque -> true
     | Vernacexpr.Transparent -> false in
 
-  let make_entry ((((_ub, body) as b), eff), ((_ut, typ) as t)) =
-    let utyp, body =
-      (* allow_deferred case *)
-      if not poly && keep_body_ucst_separate
-      then make_univs_deferred ~initial_euctx ~poly ~uctx ~udecl t b eff
-      (* private_poly_univs case *)
-      else if poly && opaque && private_poly_univs ()
-      then make_univs_private_poly ~poly ~uctx ~udecl t b eff
-      else make_univs ~poly ~uctx ~udecl ~opaque t b eff
-    in
-    definition_entry_core ?using ~univs:utyp ~types:typ body
+  let make_entry ((body, eff), typ) =
+    let keep_body_ucst_separate = if keep_body_ucst_separate then Some initial_euctx else None in
+    let univs, body =
+      make_univs_immediate ~poly ?keep_body_ucst_separate ~opaque ~uctx ~udecl ~eff body (Some typ) in
+    definition_entry_core ?using ~univs ~types:typ body
   in
   let entries = CList.map make_entry elist in
   { entries; uctx; pinfo }
@@ -2013,24 +2032,19 @@ let close_proof_delayed ~feedback_id ps (fpl : closed_proof_output Future.comput
   let make_entry i (_, _, types) =
     (* Already checked the univ_decl for the type universes when starting the proof. *)
     let univs = UState.univ_entry ~poly:false initial_euctx in
-    let types = nf (EConstr.Unsafe.to_constr types) in
+    let typ = nf (EConstr.Unsafe.to_constr types) in
 
     (* NB: for Admitted proofs [fpl] is not valid (raises anomaly when forced) *)
     Future.chain fpl (fun (pf, uctx) ->
-        let (pt, eff) = List.nth pf i in
+        let (body, eff) = List.nth pf i in
         (* Deferred proof, we already checked the universe declaration with
              the initial universes, ensure that the final universes respect
              the declaration as well. If the declaration is non-extensible,
              this will prevent the body from adding universes and constraints. *)
-        let uctx = UState.constrain_variables (fst (UState.context_set initial_euctx)) uctx in
-        let used_univs = Univ.Level.Set.union
-            (Vars.universes_of_constr types)
-            (Vars.universes_of_constr pt)
-        in
-        let uctx = UState.restrict uctx used_univs in
-        let uctx = UState.check_mono_univ_decl uctx udecl in
-        ((pt,uctx),eff))
-    |> delayed_definition_entry ?using ~univs ~types ~feedback_id in
+        let uctx = make_univs_deferred_private_mono ~initial_euctx ~uctx ~udecl body (Some typ) in
+        ((body, uctx), eff))
+    |> delayed_definition_entry ?using ~univs ~types:typ ~feedback_id
+  in
   let entries = CList.map_i make_entry 0 (Proofview.initial_goals entry) in
   { entries; uctx = initial_euctx; pinfo }
 
@@ -2038,7 +2052,7 @@ let close_future_proof = close_proof_delayed
 
 let return_proof ps =
   let p, uctx = prepare_proof ps in
-  List.map (fun (((_ub, body),eff),_) -> (body,eff)) p, uctx
+  List.map (fun ((body,eff),_) -> (body,eff)) p, uctx
 
 let update_sigma_univs ugraph p =
   map ~f:(Proof.update_sigma_univs ugraph) p


### PR DESCRIPTION
The PR redirects the calls to `UState.restrict` on definitions/theorems/fixpoints in `declare.ml` towards a reusable encapsulation `make_univs` of the three functions used to build monomorphic deferred, polymorphic private or regular universe restrictions (still to be done for obligations, Derive, Equations though).

In addtion to the centralization, it ensures that `Set Private Universes` is used when defining an opaque polymorphic non-interactive definition or fixpoint (so assuming that a `sealed` attribute is available).

Depends on:
- #18743
- #18795 
- #19090
- #19091