### PR TITLE
added ltac2 bindings for congruence and simple congruence

### DIFF
--- a/doc/changelog/06-Ltac2-language/19032-ltac2-congruence.rst
+++ b/doc/changelog/06-Ltac2-language/19032-ltac2-congruence.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Added Ltac2 bindings for congruence and simpl congruence, it fixes #14289 not entirely but provides Ltac2 bindings for one of the tactics listed there
+  (`#19032 <https://github.com/coq/coq/pull/19032>`_,
+  fixes `#14289 <https://github.com/coq/coq/issues/14289>`_,
+  by Benny Smit, review of Jason Gross, review of Pierre-Marie Pédrot, review of Gaëtan Gilbert).

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -520,12 +520,14 @@ let negative_concl_introf =
   end
 
 let congruence_tac depth l =
+  let depth = Option.default 1000 depth in
   Tacticals.tclTHEN
     (Tacticals.tclREPEAT (Tacticals.tclFIRST [intro; Tacticals.tclTHEN whd_in_concl intro]))
     (cc_tactic depth l false)
 
 
 let simple_congruence_tac depth l =
+  let depth = Option.default 1000 depth in
   Tacticals.tclTHENLIST [
     Tacticals.tclREPEAT intro;
     negative_concl_introf;
@@ -569,7 +571,7 @@ let f_equal =
           begin match EConstr.kind sigma t, EConstr.kind sigma t' with
           | App (f,v), App (f',v') when Int.equal (Array.length v) (Array.length v') ->
               let rec cuts i =
-                if i < 0 then Tacticals.tclTRY (congruence_tac 1000 [])
+                if i < 0 then Tacticals.tclTRY (congruence_tac None [])
                 else Tacticals.tclTHENFIRST (cut_eq v.(i) v'.(i)) (cuts (i-1))
               in cuts (Array.length v - 1)
           | _ -> Proofview.tclUNIT ()

--- a/plugins/cc/cctac.mli
+++ b/plugins/cc/cctac.mli
@@ -10,8 +10,8 @@
 
 open EConstr
 
-val congruence_tac : int -> constr list -> unit Proofview.tactic
+val congruence_tac : int option -> constr list -> unit Proofview.tactic
 
-val simple_congruence_tac : int -> constr list -> unit Proofview.tactic
+val simple_congruence_tac : int option -> constr list -> unit Proofview.tactic
 
 val f_equal : unit Proofview.tactic

--- a/plugins/cc/g_congruence.mlg
+++ b/plugins/cc/g_congruence.mlg
@@ -22,13 +22,13 @@ DECLARE PLUGIN "coq-core.plugins.cc"
 
 TACTIC EXTEND cc
 | [ "congruence" natural_opt(n) ] ->
-   { congruence_tac (Option.default 1000 n) [] }
+   { congruence_tac n [] }
 | [ "congruence" natural_opt(n) "with" ne_constr_list(l) ] ->
-   { congruence_tac (Option.default 1000 n) l }
+   { congruence_tac n l }
 | [ "simple" "congruence" natural_opt(n) ] ->
-   { simple_congruence_tac (Option.default 1000 n) [] }
+   { simple_congruence_tac n [] }
 | [ "simple" "congruence" natural_opt(n) "with" ne_constr_list(l) ] ->
-   { simple_congruence_tac (Option.default 1000 n) l }
+   { simple_congruence_tac n l }
 END
 
 TACTIC EXTEND f_equal

--- a/plugins/ltac2/dune
+++ b/plugins/ltac2/dune
@@ -3,6 +3,6 @@
  (public_name coq-core.plugins.ltac2)
  (synopsis "Ltac2 plugin")
  (modules_without_implementation tac2expr tac2qexpr tac2types)
- (libraries vernac))
+ (libraries vernac coq-core.plugins.cc_core))
 
 (coq.pp (modules g_ltac2))

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -618,3 +618,13 @@ let () =
   define "evarconv_unify"
     (transparent_state @-> constr @-> constr @-> tac unit)
     Tac2tactics.evarconv_unify
+
+let () =
+  define "congruence"
+  (option int @-> option (list constr) @-> tac unit)
+  Tac2tactics.congruence
+
+let () =
+  define "simple_congruence"
+  (option int @-> option (list constr) @-> tac unit)
+  Tac2tactics.simple_congruence

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -457,3 +457,7 @@ let inversion knd arg pat ids =
 let contradiction c =
   let c = Option.map mk_with_bindings c in
   Contradiction.contradiction c
+
+let congruence n l = Cc_core_plugin.Cctac.congruence_tac n (Option.default [] l)
+
+let simple_congruence n l = Cc_core_plugin.Cctac.simple_congruence_tac n (Option.default [] l)

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -132,3 +132,7 @@ val evarconv_unify : TransparentState.t -> constr -> constr -> unit tactic
 (** Internal *)
 
 val mk_intro_pattern : intro_pattern -> Tactypes.intro_pattern
+
+val congruence : int option -> constr list option -> unit Proofview.tactic
+
+val simple_congruence : int option -> constr list option -> unit Proofview.tactic

--- a/test-suite/ltac2/congruence.v
+++ b/test-suite/ltac2/congruence.v
@@ -1,0 +1,56 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 congruence_dev () := congruence.
+Ltac2 simpl_congruence_dev () := simple congruence.
+
+Lemma congruence_test_1 : (forall x:bool, x = true) -> False.
+Proof.
+    intros.
+    Fail congruence.
+    Fail congruence 0 with false.
+    Fail congruence 1 with true.
+    congruence 1 with false.
+Qed.
+
+Lemma congruence_test_2 : (forall x:bool, x = true) -> False.
+Proof.
+    intros.
+    Fail congruence.
+    congruence with false.
+Qed.
+
+Lemma congruence_test_3 {A B} (f: A->B->A) (a:A) (b:B): f a b = a -> f (f a b) b = a.
+Proof.
+congruence.
+Qed.
+
+Lemma congruence_test_4 {A} (f: A->A) (a:A): f (f (f a)) = a -> f (f (f (f (f a)))) = a -> f a = a.
+Proof.
+congruence.
+Qed.
+
+Lemma simple_congruence_test_1 : (forall x:bool, x = true) -> False.
+Proof.
+    intros.
+    Fail simple congruence.
+    Fail simple congruence 0 with false.
+    Fail simple congruence 1 with true.
+    simple congruence 1 with false.
+Qed.
+
+Lemma simple_congruence_test_2 : (forall x:bool, x = true) -> False.
+Proof.
+    intros.
+    Fail simple congruence.
+    simple congruence with false.
+Qed.
+
+Lemma simple_congruence_test_3 {A B} (f: A->B->A) (a:A) (b:B): f a b = a -> f (f a b) b = a.
+Proof.
+simple congruence.
+Qed.
+
+Lemma simple_congruence_test_4 {A} (f: A->A) (a:A): f (f (f a)) = a -> f (f (f (f (f a)))) = a -> f a = a.
+Proof.
+simple congruence.
+Qed.

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -611,6 +611,10 @@ Ltac2 Notation "unify" x(constr) y(constr) := Std.unify x y.
 
 (** Congruence *)
 
+Ltac2 Notation "congruence" n(opt(tactic(0))) l(opt(seq("with", list1(constr)))) := Std.congruence n l.
+
+Ltac2 Notation "simple" "congruence" n(opt(tactic(0))) l(opt(seq("with", list1(constr)))) := Std.simple_congruence n l.
+
 Ltac2 f_equal0 () := ltac1:(f_equal).
 Ltac2 Notation f_equal := f_equal0 ().
 

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -270,3 +270,8 @@ Ltac2 @ external resolve_tc : constr -> unit := "coq-core.plugins.ltac2" "tac_re
     Does not focus. *)
 
 Ltac2 @ external unify : constr -> constr -> unit := "coq-core.plugins.ltac2" "tac_unify".
+
+Ltac2 @ external congruence : int option -> constr list option -> unit :=
+  "coq-core.plugins.ltac2" "congruence".
+Ltac2 @ external simple_congruence : int option -> constr list option -> unit :=
+  "coq-core.plugins.ltac2" "simple_congruence".


### PR DESCRIPTION
Hi,
this is my first PR to Coq so I hope I've done it right otherwise please say when there is something wrong :-)

I wrote ltac2 bindings for the congruence tactic so this is related to issue #14289 
I wasn't sure where to put tests for this and how they should look but I tested it outside the automatic test-suite with the following coq code:

```coq
Require Import Ltac2.Ltac2.

Ltac2 congruence_dev () := congruence.
Ltac2 simpl_congruence_dev () := simple congruence.

Lemma congruence_test_1 : (forall x:bool, x = true) -> False.
Proof.
    intros.
    Fail congruence.
    Fail congruence 0 with false.
    Fail congruence 1 with true.
    congruence 1 with false.
Qed.

Lemma congruence_test_2 : (forall x:bool, x = true) -> False.
Proof.
    intros.
    Fail congruence.
    congruence with false.
Qed.

Lemma congruence_test_3 {A B} (f: A->B->A) (a:A) (b:B): f a b = a -> f (f a b) b = a.
Proof.
congruence.
Qed. 

Lemma congruence_test_4 {A} (f: A->A) (a:A): f (f (f a)) = a -> f (f (f (f (f a)))) = a -> f a = a.
Proof.
congruence.
Qed. 

Lemma simple_congruence_test_1 : (forall x:bool, x = true) -> False.
Proof.
    intros.
    Fail simple congruence.
    Fail simple congruence 0 with false.
    Fail simple congruence 1 with true.
    simple congruence 1 with false.
Qed.

Lemma simple_congruence_test_2 : (forall x:bool, x = true) -> False.
Proof.
    intros.
    Fail simple congruence.
    simple congruence with false.
Qed.

Lemma simple_congruence_test_3 {A B} (f: A->B->A) (a:A) (b:B): f a b = a -> f (f a b) b = a.
Proof.
simple congruence.
Qed. 

Lemma simple_congruence_test_4 {A} (f: A->A) (a:A): f (f (f a)) = a -> f (f (f (f (f a)))) = a -> f a = a.
Proof.
simple congruence.
Qed. 
```

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/612