### PR TITLE
More efficient compilation of PArray blobs in the VM.

### DIFF
--- a/kernel/vmlambda.mli
+++ b/kernel/vmlambda.mli
@@ -15,6 +15,7 @@ type lval
 type lambda = lval Genlambda.lambda
 
 val get_lval : lval -> structured_values
+val as_value : int -> lambda array -> lval option
 
 val lambda_of_constr : env -> Genlambda.evars -> Constr.t -> lambda
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -425,6 +425,8 @@ let val_of_int i = (Obj.magic i : values)
 
 let val_of_uint i = (Obj.magic i : structured_values)
 
+let val_of_float f = (Obj.magic f : structured_values)
+
 let atom_of_proj kn v =
   let r = Obj.new_block proj_tag 2 in
   Obj.set_field r 0 (Obj.repr kn);

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -138,6 +138,7 @@ val val_of_atom : atom -> values
 val val_of_int : int -> structured_values
 val val_of_block : tag -> structured_values array -> structured_values
 val val_of_uint : Uint63.t -> structured_values
+val val_of_float : Float64.t -> structured_values
 
 external val_of_annot_switch : annot_switch -> values = "%identity"
 


### PR DESCRIPTION
We store persistent arrays whose elements are all structured values as a single structured value, and copy the resulting blob at runtime to generate a fresh persistent array.