### PR TITLE
Fix passing line number of errors in xml protocol, causing ill-located or non-located errors, notably in the presence of utf8 characters

### DIFF
--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -151,17 +151,21 @@ state that should become the next tip.
 * Failure:
   - Syntax error. Error offsets are byte offsets (not character offsets) with respect to the start of the sentence, starting at 0.
   ```html
-  <value val="fail"
-      loc_s="${startOffsetOfError}"
-      loc_e="${endOffsetOfError}">
+  <value val="fail">
     <state_id val="${stateId}"/>
+    <option val="none|some">${loc}</option>
     <richpp>${errorMessage}</richpp>
   </value>
   ```
   - Another kind of error, for example, Qed with a pending goal.	
   ```html
-  <value val="fail"><state_id val="${stateId}"/><richpp>${errorMessage}</richpp></value>
+  <value val="fail"><state_id val="${stateId}"/><option val="some">${loc}</option><richpp>${errorMessage}</richpp></value>
   ```
+
+  Note that IDEs may need to convert byte offsets passed in the four position fields of the
+  location to character offsets to correctly handle multi-byte characters. Also, due to
+  asynchronous evaluation, line number fields of locations may need to be adjusted
+  if the sentence has moved since it was sent to Coqtop.
 
 -------------------------------
 
@@ -194,8 +198,9 @@ Moves current tip to `${stateId}`, such that commands may be added to the new st
 ```
 * Failure: If `stateId` is in an error-state and cannot be jumped to, `errorFreeStateId` is the parent state of `stateId` that should be edited instead.
 ```html
-<value val="fail" loc_s="${startOffsetOfError}" loc_e="${endOffsetOfError}">
+<value val="fail">
   <state_id val="${errorFreeStateId}"/>
+  <option val="none|some">${loc}</option>
   ${errorMessage}
 </value>
 ```
@@ -921,7 +926,7 @@ Ex: `status = "Idle"` or `status = "proof: myLemmaName"` or `status = "Dead"`
   </feedback_content>
 </feedback>
 ```
-* <a name="location">Location</a>, a Coq location:
+* <a name="location">Location</a>, a Coq location (`Loc.t`)
 ```xml
    <loc start="${start_offset}" stop="${stop_offset}
         line_nb="${start_line}" bol_pos="${begin_of_start_line_offset}"

--- a/doc/changelog/10-coqide/19040-master+fix-xmlprotocol-loc-line_nb-fail.rst
+++ b/doc/changelog/10-coqide/19040-master+fix-xmlprotocol-loc-line_nb-fail.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Incorrect highlight locations and line numbers for errors and warnings,
+  especially in the presence of unicode characters.  This updates the XML protocol
+  (`#19040 <https://github.com/coq/coq/pull/19040>`_,
+  fixes `#18682 <https://github.com/coq/coq/issues/18682>`_,
+  by Hugo Herbelin).

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -831,7 +831,6 @@ object(self)
                   if Queue.is_empty queue then loop tip []
                   else loop tip (List.rev topstack)
               | Fail (id, loc, msg) ->
-                  let loc = Option.map Loc.make_loc loc in
                   let sentence = Doc.pop document in
                   self#process_interp_error ?loc queue sentence msg tip id in
             Coq.bind coq_query handle_answer
@@ -990,7 +989,7 @@ object(self)
     self#backtrack_until ?move_insert until
 
   method private handle_failure_aux
-    ?(move_insert=false) (safe_id, (loc : (int * int) option), msg)
+    ?(move_insert=false) (safe_id, (loc : Interface.location), msg)
   =
     messages#default_route#push Feedback.Error msg;
     if Stateid.equal safe_id Stateid.dummy then Coq.lift (fun () -> ())

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -161,8 +161,8 @@ open SentenceId
 (* Given a Coq loc, convert it to a pair of iterators start / end in
    the buffer. *)
 let coq_loc_to_gtk_offset ?(line_drift=0) (buffer : GText.buffer) loc =
-  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb - 1 + line_drift) (loc.bp - loc.bol_pos),
-  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb_last - 1 + line_drift) (loc.ep - loc.bol_pos_last)
+  Ideutils.get_iter_at_byte buffer ~line:(loc.Loc.line_nb - 1 + line_drift) (loc.bp - loc.bol_pos),
+  Ideutils.get_iter_at_byte buffer ~line:(loc.Loc.line_nb_last - 1 + line_drift) (loc.ep - loc.bol_pos_last)
 
 (** increase [uni_off] by the number of bytes until [s_uni] This can
     be used to convert a character offset to byte offset if we know a

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -688,8 +688,8 @@ let next_error sn =
     let file,line,start,stop,error_msg = search_next_error () in
     FileAux.load_file file;
     let b = sn.buffer in
-    let starti = b#get_iter_at_byte ~line:(line-1) start in
-    let stopi = b#get_iter_at_byte ~line:(line-1) stop in
+    let starti = Ideutils.get_iter_at_byte b ~line:(line-1) start in
+    let stopi = Ideutils.get_iter_at_byte b ~line:(line-1) stop in
     b#apply_tag Tags.Script.error ~start:starti ~stop:stopi;
     b#place_cursor ~where:starti;
     sn.messages#default_route#set (Pp.str error_msg);

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -458,15 +458,12 @@ let about () = {
 
 let handle_exn (e, info) =
   let dummy = Stateid.dummy in
-  let loc_of e = match Loc.get_loc e with
-    | Some loc -> Some (Loc.unloc loc)
-    | _        -> None in
   let mk_msg () = CErrors.iprint (e,info) in
   match e with
   | e ->
       match Stateid.get info with
-      | Some (valid, _) -> valid, loc_of info, mk_msg ()
-      | None -> dummy, loc_of info, mk_msg ()
+      | Some (valid, _) -> valid, Loc.get_loc info, mk_msg ()
+      | None -> dummy, Loc.get_loc info, mk_msg ()
 
 let init =
   let initialized = ref false in

--- a/ide/coqide/ideutils.ml
+++ b/ide/coqide/ideutils.ml
@@ -174,6 +174,19 @@ let ulen uni_ch =
   else if uni_ch < 0x10000 then 3
   else 4
 
+(* workaround for lablgtk bug up to version 3.1.4 *)
+(* replaces: buffer#get_iter_at_byte ~line index *)
+(* see https://github.com/garrigue/lablgtk/pull/181 *)
+let get_iter_at_byte buffer ~line index =
+  let iter = buffer#get_iter_at_byte ~line 0 in
+  let rec adjust iter cnt =
+    if cnt <= 0 then
+      iter
+    else
+      adjust (iter#forward_char) (cnt - (ulen iter#char))
+  in
+  adjust iter index
+
 (** convert UTF-8 byte offset (used by Coq) to unicode offset (used by GTK buffer) *)
 let byte_off_to_buffer_off buffer byte_off =
   let rec cvt iter cnt =

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -19,6 +19,7 @@ val browse_keyword : (string -> unit) -> string -> unit
 val byte_offset_to_char_offset : string -> int -> int
 val byte_off_to_buffer_off : GText.buffer -> int -> int
 val buffer_off_to_byte_off : GText.buffer -> int -> int
+val get_iter_at_byte : GText.buffer -> line:int -> int -> GText.iter
 
 val ulen : int -> int
 

--- a/ide/coqide/protocol/interface.mli
+++ b/ide/coqide/protocol/interface.mli
@@ -133,7 +133,7 @@ type db_continue_opt =
 
 (** Calls result *)
 
-type location = (int * int) option (* start and end of the error *)
+type location = Loc.t option
 type state_id = Stateid.t
 type route_id = Feedback.route_id
 


### PR DESCRIPTION
Fix was actually very easy and will make life in xml-based UIs much more comfortable.

Fixes #18682, #19139.

- [x] Added **changelog**.
