### PR TITLE
Code factorization around Evarutil.finalize and prepare_obligations

### DIFF
--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -143,7 +143,7 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
   let evd, (body, types), impargs =
     interp_definition ~program_mode:true env evd empty_internalization_env bl red_option c ctypopt
   in
-  let term, typ, uctx, obls = Declare.Obls.prepare_obligation ~name ~body ~types evd in
+  let term, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
   let pm, _ =
     let cinfo = Declare.CInfo.make ~name ~typ ~impargs () in
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -167,10 +167,8 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
       add_suffix recname "_func", it_mkProd_or_LetIn top_arity binders
     else
       recname, it_mkProd_or_LetIn top_arity binders_rel in
-  RetrieveObl.check_evars env sigma;
-  let evars, (_, evmap), evars_def, evars_typ =
-    RetrieveObl.retrieve_obligations env recname_func sigma 0 def typ
-  in
+  let evars_def, evars_typ, uctx, evmap, evars =
+    Declare.Obls.prepare_obligations ~name:recname_func ~body:def ~types:typ env sigma in
   let hook =
     if List.length binders_rel > 1 then
       let hook { Declare.Hook.S.dref; uctx; obls; _ } =
@@ -201,7 +199,6 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) ?scope ?clearbody poly ?typ
       in hook
   in
   let hook = Declare.Hook.make hook in
-  let uctx = Evd.evar_universe_context sigma in
   let cinfo = Declare.CInfo.make ~name:recname_func ~typ:evars_typ () in
   let kind = Decls.(IsDefinition Fixpoint) in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ~hook ?typing_flags ?user_warns ~ntns () in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -853,7 +853,7 @@ let declare_definition_core ~info ~cinfo ~opaque ~obls ~body ?using sigma =
 let declare_definition ~info ~cinfo ~opaque ~body ?using sigma =
   declare_definition_core ~obls:[] ~info ~cinfo ~opaque ~body ?using sigma |> fst
 
-let prepare_obligation ~name ~types ~body sigma =
+let prepare_obligations ~name ?types ~body env sigma =
   let env = Global.env () in
   let types = match types with
     | Some t -> t
@@ -864,9 +864,9 @@ let prepare_obligation ~name ~types ~body sigma =
   in
   RetrieveObl.check_evars env sigma;
   let body, types = EConstr.(of_constr body, of_constr types) in
-  let obls, _, body, cty = RetrieveObl.retrieve_obligations env name sigma 0 body types in
+  let obls, (_, evmap), body, cty = RetrieveObl.retrieve_obligations env name sigma 0 body types in
   let uctx = Evd.evar_universe_context sigma in
-  body, cty, uctx, obls
+  body, cty, uctx, evmap, obls
 
 let prepare_parameter ~poly ~udecl ~types sigma =
   let env = Global.env () in
@@ -2752,7 +2752,7 @@ let check_program_libraries () =
   Coqlib.check_required_library ["Coq";"Init";"Specif"]
 
 (* aliases *)
-let prepare_obligation = prepare_obligation
+let prepare_obligations = prepare_obligations
 let check_solved_obligations =
   let is_empty prg =
     let obls = (Internal.get_obligations (CEphemeron.get prg)).obls in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -828,7 +828,7 @@ let prepare_definition ~info ~opaque ?using ~name ~body ~typ sigma =
   let env = Global.env () in
   Option.iter (check_evars_are_solved env sigma) typ;
   check_evars_are_solved env sigma body;
-  let sigma, (body, types) = Evarutil.finalize ~abort_on_undefined_evars:true
+  let sigma, (body, types) = Evarutil.finalize
       sigma (fun nf -> nf body, Option.map nf typ)
   in
   let univs = Evd.check_univ_decl ~poly sigma udecl in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -521,12 +521,13 @@ type progress =
   | Defined of GlobRef.t  (** Defined as id *)
 
 (** Prepare API, to be removed once we provide the corresponding 1-step API *)
-val prepare_obligation
+val prepare_obligations
   :  name:Id.t
-  -> types:EConstr.t option
+  -> ?types:EConstr.t
   -> body:EConstr.t
+  -> Environ.env
   -> Evd.evar_map
-  -> Constr.constr * Constr.types * UState.t * RetrieveObl.obligation_info
+  -> Constr.constr * Constr.types * UState.t * RetrieveObl.obligation_name_lifter * RetrieveObl.obligation_info
 
 (** Start a [Program Definition c] proof. [uctx] [udecl] [impargs]
    [kind] [scope] [poly] etc... come from the interpretation of the

--- a/vernac/retrieveObl.ml
+++ b/vernac/retrieveObl.ml
@@ -203,6 +203,9 @@ let sort_dependencies evl =
   in
   aux evl Evar.Set.empty []
 
+type obligation_name_lifter =
+  (Names.Id.t -> EConstr.t) -> EConstr.t -> Constr.t
+
 let retrieve_obligations env name evm fs ?deps ?status t ty =
   (* 'Serialize' the evars *)
   let nc = Environ.named_context env in

--- a/vernac/retrieveObl.mli
+++ b/vernac/retrieveObl.mli
@@ -22,6 +22,9 @@ type obligation_info =
    transparent, expand or define), dependencies as indexes into the
    array, tactic to solve it *)
 
+type obligation_name_lifter =
+  (Names.Id.t -> EConstr.t) -> EConstr.t -> Constr.t
+
 val retrieve_obligations :
      Environ.env
   -> Names.Id.t
@@ -32,8 +35,7 @@ val retrieve_obligations :
   -> EConstr.t
   -> EConstr.types
   -> obligation_info
-     * ( (Evar.t * Names.Id.t) list
-       * ((Names.Id.t -> EConstr.t) -> EConstr.t -> Constr.t) )
+     * ( (Evar.t * Names.Id.t) list * obligation_name_lifter )
      * Constr.t
      * Constr.t
 (** [retrieve_obligations env id sigma fs ?status body type] returns


### PR DESCRIPTION
The PR experiments:
1. using `Evarutil.finalize` in.`wf`-based `Program Fixpoint` (what ensures minimization of universes of the main obligation-based constant)
3. changing the flow of control so that `finalize` for definition is called without the `abort` flag to false

I suspect 1.a. to be observable but I don't know well how to build an example (is there a standard example to observe minimization?)

Note also that this is only an intermediate step. See coq/ceps#89 for further possible steps.

- [ ] Added / updated **test-suite**.
