### PR TITLE
Restrict check_conv_problems in pretyping to those problems referring to the term to type

### DIFF
--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -558,6 +558,9 @@ type evar_constraint = conv_pb * env * econstr * econstr
 val add_conv_pb : ?tail:bool -> evar_constraint -> evar_map -> evar_map
 val conv_pbs : evar_map -> evar_constraint list
 
+val extract_conv_pbs : evar_map ->
+      (evar_constraint -> bool) ->
+      evar_map * evar_constraint list
 val extract_changed_conv_pbs : evar_map ->
       (Evar.Set.t -> evar_constraint -> bool) ->
       evar_map * evar_constraint list

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1820,8 +1820,14 @@ let error_cannot_unify env evd pb ?reason t1 t2 =
     ?loc:(loc_of_conv_pb evd pb) env
     evd ?reason (t1, t2)
 
-let check_problems_are_solved env evd =
-  match snd (extract_all_conv_pbs evd) with
+let check_problems_are_solved ?evars env evd =
+  let has_evar (pbty,_,t1,t2) =
+    match evars with
+    | None -> true
+    | Some evars ->
+      (try Evar.Set.mem (head_evar evd t1) evars with NoHeadEvar -> false) ||
+      (try Evar.Set.mem (head_evar evd t2) evars with NoHeadEvar -> false) in
+  match snd (extract_conv_pbs evd has_evar) with
   | (pbty,env,t1,t2) as pb::_ -> error_cannot_unify env evd pb t1 t2
   | _ -> ()
 

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -69,10 +69,10 @@ val unify : ?flags:unify_flags -> ?with_ho:bool ->
 val solve_unif_constraints_with_heuristics :
   env -> ?flags:unify_flags -> ?with_ho:bool -> evar_map -> evar_map
 
-(** Check all pending unification problems are solved and raise a
-    PretypeError otherwise *)
+(** Check all pending unification problems relative to a set of evars
+    are solved and raise a PretypeError otherwise *)
 
-val check_problems_are_solved : env -> evar_map -> unit
+val check_problems_are_solved : ?evars:Evar.Set.t -> env -> evar_map -> unit
 
 (** Check if a canonical structure is applicable *)
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -317,10 +317,11 @@ type frozen_and_pending =
        [None] means empty.*)
     -> frozen_and_pending
 
-let frozen_and_pending_holes (sigma, sigma') =
+let frozen_and_pending_holes (sigma, sigma') term =
   let undefined0 = Option.cata Evd.undefined_map Evar.Map.empty sigma in
+  let included = Option.cata (Evd.evars_of_term sigma') Evar.Set.empty term in
   let pending =
-    if undefined0 == Evd.undefined_map sigma'
+    if undefined0 == Evd.undefined_map sigma' && Evar.Set.is_empty included
     then None
     else
       Some (lazy begin
@@ -341,7 +342,7 @@ let frozen_and_pending_holes (sigma, sigma') =
             (Evd.undefined_map sigma')
             (Evar.Set.empty, Evar.Set.empty)
         in
-        Evar.Set.diff pending aliases;
+        Evar.Set.union included (Evar.Set.diff pending aliases);
       end)
   in
   Frz (Evd.undefined_map sigma', pending)
@@ -433,39 +434,51 @@ let check_evars env ?initial sigma c =
     | _ -> EConstr.iter sigma proc_rec c
   in proc_rec c
 
-let check_evars_are_solved ~program_mode env sigma frozen =
+let check_problems_are_solved env sigma = function
+  | Frz (_, None) -> ()
+  | Frz (_, Some (lazy pending)) -> check_problems_are_solved ~evars:pending env sigma
+
+let check_evars_are_solved_from ~program_mode env sigma frozen frozen_for_pb =
   check_typeclasses_instances_are_solved ~program_mode env sigma frozen;
-  check_problems_are_solved env sigma;
+  check_problems_are_solved env sigma frozen_for_pb;
   check_extra_evars_are_solved env sigma frozen
 
 (* Try typeclasses, hooks, unification heuristics ... *)
 
-let solve_remaining_evars ?hook (flags : inference_flags) env ?initial sigma =
+let solve_remaining_evars_from ?hook (flags : inference_flags) env ?initial sigma term =
   let program_mode = flags.program_mode in
-  let frozen = frozen_and_pending_holes (initial, sigma) in
   let sigma =
     match flags.use_typeclasses with
-    | UseTC -> apply_typeclasses ~program_mode ~fail_evar:false env sigma frozen
+    | UseTC ->
+      let frozen = frozen_and_pending_holes (initial, sigma) None in
+      apply_typeclasses ~program_mode ~fail_evar:false env sigma frozen
     | NoUseTC | UseTCForConv -> sigma
   in
-  let frozen = frozen_and_pending_holes (initial, sigma) in
   let sigma = match hook with
   | None -> sigma
-  | Some hook -> apply_inference_hook hook env sigma frozen
+  | Some hook ->
+    let frozen = frozen_and_pending_holes (initial, sigma) None in
+    apply_inference_hook hook env sigma frozen
   in
   let sigma = if flags.solve_unification_constraints
     then apply_heuristics ~patvars_abstract:flags.patvars_abstract env sigma
     else sigma
   in
-  if flags.fail_evar then check_evars_are_solved ~program_mode env sigma frozen;
+  let () = if flags.fail_evar then
+    let frozen = frozen_and_pending_holes (initial, sigma) None in
+    let frozen_for_pb = frozen_and_pending_holes (initial, sigma) term in
+    check_evars_are_solved_from ~program_mode env sigma frozen frozen_for_pb in
   sigma
 
+let solve_remaining_evars ?hook (flags : inference_flags) env ?initial sigma =
+  solve_remaining_evars_from ?hook (flags : inference_flags) env ?initial sigma None
+
 let check_evars_are_solved ~program_mode env ?initial current_sigma =
-  let frozen = frozen_and_pending_holes (initial, current_sigma) in
-  check_evars_are_solved ~program_mode env current_sigma frozen
+  let frozen = frozen_and_pending_holes (initial, current_sigma) None in
+  check_evars_are_solved_from ~program_mode env current_sigma frozen frozen
 
 let process_inference_flags flags env initial (sigma,c,cty) =
-  let sigma = solve_remaining_evars flags env ~initial sigma in
+  let sigma = solve_remaining_evars_from flags env ~initial sigma (Some cty) in
   let c = if flags.expand_evars then nf_evar sigma c else c in
   sigma,c,cty
 

--- a/test-suite/bugs/bug_19054.v
+++ b/test-suite/bugs/bug_19054.v
@@ -1,0 +1,42 @@
+
+Module PretypingWasRejectingFormerConvPbs.
+
+Notation "x .+1" := (S x) (at level 1, left associativity, format "x .+1").
+
+(** A Yoneda-style encoding of le *)
+Parameter leR : nat -> nat -> SProp.
+Class leY n m := le_intro : forall p, leR p n -> leR p m.
+Infix "<=" := leY: nat_scope.
+
+Definition leY_trans {n m p} (Hnm: n <= m) (Hmp: m <= p): n <= p :=
+  fun q (Hqn: leR q n) => Hmp _ (Hnm _ Hqn).
+Axiom  leY_down : forall {n m} (Hnm: n.+1 <= m), n <= m.
+
+Infix "↕" := leY_trans (at level 45).
+Notation "↓ p" := (leY_down p) (at level 40).
+
+Ltac find _ := assumption || (apply leY_down; eapply leY_trans; eassumption).
+
+(* Below, the presence of open constraints in the goal makes that the typing of 0 fails *)
+Hint Extern 10 (_ <= _) => (find 0) : typeclass_instances.
+
+Parameter p n q r : nat.
+Parameter F : forall (Hp: p <= n), Type.
+Parameter R : forall (Hpq: p <= q) (Hq: q <= n), F (Hpq ↕ Hq).
+
+Section S.
+Context {Hpr: p.+1 <= r} {Hrq: r <= q} {Hq: q <= n}.
+Context (P : F (↓ (Hpr ↕ (Hrq ↕ Hq))) -> Prop).
+Context (C : P (R _ _)).
+End S.
+
+End PretypingWasRejectingFormerConvPbs.
+
+Module PretypingShouldCheckConvPbsAboutExpectedType.
+
+Goal forall x y, x + y = 0 -> exists P, P x y.
+eexists.
+try exact H.
+Abort.
+
+End PretypingShouldCheckConvPbsAboutExpectedType.


### PR DESCRIPTION
I found situations where a tactic needs to type a trivial term and fails because the whole goal includes pending conversion problems about unrelated evars. I then arrived to this PR which restricts the conversion problem checks in `Pretyping.check_evars_are_solved` to only the evars which are relevant for the current typing problem.

One may also wonder whether pretyping should have been called with the fail_evar flag at this point, but at least, it is consistent to skip the frozen evars in conversion problems, as it is done for the other post-`understand` checks of `check_evars_are_solved`.

One may also wonder whether we should check the conversion problems at all when evars are already checked, but maybe can we imagine situations with a pending newly created evar with constraints on it that does not occur in the final term??

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
