### PR TITLE
[8.20] Bump version (8.21+alpha)

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -704,6 +704,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Compat/Coq818.v
     theories/Compat/Coq819.v
     theories/Compat/Coq820.v
+    theories/Compat/Coq821.v
     user-contrib/Ltac2/Compat/Coq818.v
     user-contrib/Ltac2/Compat/Coq819.v
   </dd>

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -231,6 +231,7 @@ let set_option = let open Goptions in function
   | opt, OptionAppend v -> set_string_option_append_value_gen ~locality:OptLocal opt v
 
 let get_compat_file = function
+  | "8.21" -> "Coq.Compat.Coq821"
   | "8.20" -> "Coq.Compat.Coq820"
   | "8.19" -> "Coq.Compat.Coq819"
   | "8.18" -> "Coq.Compat.Coq818"

--- a/test-suite/success/CompatCurrentFlag.v
+++ b/test-suite/success/CompatCurrentFlag.v
@@ -1,3 +1,3 @@
-(* -*- coq-prog-args: ("-compat" "8.20") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.21") -*- *)
 (** Check that the current compatibility flag actually requires the relevant modules. *)
-Import Coq.Compat.Coq820.
+Import Coq.Compat.Coq821.

--- a/test-suite/success/CompatOldFlag.v
+++ b/test-suite/success/CompatOldFlag.v
@@ -1,5 +1,5 @@
-(* -*- coq-prog-args: ("-compat" "8.18") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.19") -*- *)
 (** Check that the current-minus-two compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq821.
 Import Coq.Compat.Coq820.
 Import Coq.Compat.Coq819.
-Import Coq.Compat.Coq818.

--- a/test-suite/success/CompatOldOldFlag.v
+++ b/test-suite/success/CompatOldOldFlag.v
@@ -1,0 +1,6 @@
+(* -*- coq-prog-args: ("-compat" "8.18") -*- *)
+(** Check that the current-minus-three compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq821.
+Import Coq.Compat.Coq820.
+Import Coq.Compat.Coq819.
+Import Coq.Compat.Coq818.

--- a/test-suite/success/CompatPreviousFlag.v
+++ b/test-suite/success/CompatPreviousFlag.v
@@ -1,4 +1,4 @@
-(* -*- coq-prog-args: ("-compat" "8.19") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.20") -*- *)
 (** Check that the current-minus-one compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq821.
 Import Coq.Compat.Coq820.
-Import Coq.Compat.Coq819.

--- a/test-suite/tools/update-compat/run.sh
+++ b/test-suite/tools/update-compat/run.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # we assume that the script lives in test-suite/tools/update-compat/,
 # and that update-compat.py lives in dev/tools/
 cd "${SCRIPT_DIR}/../../.."
-dev/tools/update-compat.py --assert-unchanged --release || exit $?
+dev/tools/update-compat.py --assert-unchanged --master || exit $?

--- a/theories/Compat/Coq821.v
+++ b/theories/Compat/Coq821.v
@@ -8,6 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Compatibility file for making Coq act similar to Coq v8.20 *)
-
-Require Export Coq.Compat.Coq821.
+(** Compatibility file for making Coq act similar to Coq v8.21 *)

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -22,8 +22,8 @@ open CmdArgs.Prefs
 
 let (/) = Filename.concat
 
-let coq_version = "8.20+alpha"
-let vo_magic = 81999
+let coq_version = "8.21+alpha"
+let vo_magic = 82099
 let is_a_released_version = false
 
 (** Default OCaml binaries *)


### PR DESCRIPTION
Prepare a PR on master (not yet to be merged) changing the version name to the next major version and both magic numbers in [tools/configure/configure.ml](https://github.com/coq/tools/configure/configure.ml). For example, for 8.5, the version name will be 8.5+alpha while the magic numbers will end with 80490.
Additionally, in the same commit, update the compatibility infrastructure, which consists of invoking [dev/tools/update-compat.py](https://github.com/coq/coq/tools/update-compat.py) with the --master flag.
Note that the update-compat.py script must be run twice: once in preparation of the release with the --release flag (see earlier in this section) and once on the branching date with the --master flag to mark the start of the next version.
This PR should be opened before the branching date to have time to deal with CI issues, but should not be merged until branching.

C.f. https://github.com/coq/coq/issues/18882

#### Overlays (to be merged before the current PR)

* [x] https://gitlab.mpi-sws.org/iris/stdpp/-/merge_requests/554