### PR TITLE
Allow a direction specifier in replace with.

### DIFF
--- a/doc/changelog/04-tactics/19060-replace-with-diropt.rst
+++ b/doc/changelog/04-tactics/19060-replace-with-diropt.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  the :tacn:`replace` tactic now accepts `->` and `<-`
+  to specify the direction of the replacement
+  when used with a `with` clause
+  (`#19060 <https://github.com/coq/coq/pull/19060>`_,
+  fixes `#13480 <https://github.com/coq/coq/issues/13480>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -238,16 +238,15 @@ Rewriting with Leibniz and setoid equality
    :name: rewrite *; _
    :undocumented:
 
-.. tacn:: replace @one_term__from with @one_term__to {? @occurrences } {? by @ltac_expr3 }
+.. tacn:: replace {? {| -> | <- } } @one_term__from with @one_term__to {? @occurrences } {? by @ltac_expr3 }
           replace {? {| -> | <- } } @one_term__from {? @occurrences }
    :name: replace; _
 
-   The first form replaces all free occurrences of :n:`@one_term__from`
-   in the current goal with :n:`@one_term__to` and generates an equality
-   :n:`@one_term__to = @one_term__from`
-   as a subgoal. (Note the generated equality is reversed with respect
-   to the order of the two terms in the tactic syntax; see
-   issue `#13480 <https://github.com/coq/coq/issues/13480>`_.)
+   The first form, when used with `<-` or no arrow, replaces all free
+   occurrences of :n:`@one_term__from` in the current goal with :n:`@one_term__to`
+   and generates an equality :n:`@one_term__to = @one_term__from` as a subgoal.
+   Note that this equality is reversed with respect to the order of the two terms.
+   When used with `->`, it generates instead an equality :n:`@one_term__from = @one_term__to`.
    When :n:`by @ltac_expr3` is not present, this equality is automatically solved
    if it occurs among the hypotheses, or if its symmetric form occurs.
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1084,6 +1084,10 @@ simple_tactic: [
 | DELETE "replace" "<-" uconstr clause
 | DELETE "replace" uconstr clause
 | "replace" orient uconstr clause
+| REPLACE "replace" uconstr "with" constr clause by_arg_tac
+| WITH "replace" orient constr "with" constr clause OPT ( "by" ltac_expr3 )
+| DELETE "replace" "->" uconstr "with" constr clause by_arg_tac
+| DELETE "replace" "<-" uconstr "with" constr clause by_arg_tac
 | REPLACE "rewrite" "*" orient uconstr "in" hyp "at" occurrences by_arg_tac
 | WITH "rewrite" "*" orient uconstr OPT ( "in" hyp ) OPT ( "at" occurrences ) by_arg_tac
 | DELETE "rewrite" "*" orient uconstr "in" hyp by_arg_tac

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1730,7 +1730,9 @@ simple_tactic: [
 | "assert_succeeds" tactic3
 | "replace" uconstr "with" constr clause by_arg_tac
 | "replace" "->" uconstr clause
+| "replace" "->" uconstr "with" constr clause by_arg_tac
 | "replace" "<-" uconstr clause
+| "replace" "<-" uconstr "with" constr clause by_arg_tac
 | "replace" uconstr clause
 | "simplify_eq"
 | "simplify_eq" destruction_arg

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1383,6 +1383,7 @@ simple_tactic: [
 | "einjection" OPT induction_arg OPT ( "as" LIST0 simple_intropattern )
 | "simple" "injection" OPT induction_arg
 | "replace" OPT [ "->" | "<-" ] one_term OPT occurrences
+| "replace" OPT [ "->" | "<-" ] one_term "with" one_term OPT occurrences OPT ( "by" ltac_expr3 )
 | "typeclasses" "eauto" OPT [ "bfs" | "dfs" | "best_effort" ] OPT nat_or_var OPT ( "with" LIST1 ident )
 | "setoid_replace" one_term "with" one_term OPT ( "using" "relation" one_term ) OPT ( "in" ident ) OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )
 | OPT ( [ natural | "[" ident "]" ] ":" ) "{"
@@ -1545,7 +1546,6 @@ simple_tactic: [
 | "enough" one_type OPT as_ipat OPT ( "by" ltac_expr3 )
 | "eenough" one_type OPT as_ipat OPT ( "by" ltac_expr3 )
 | "generalize" "dependent" one_term
-| "replace" one_term "with" one_term OPT occurrences OPT ( "by" ltac_expr3 )
 | "generalize" LIST1 one_term
 | "generalize" LIST1 [ pattern_occs OPT as_name ] SEP ","
 | "induction" LIST1 induction_clause SEP "," OPT induction_principle

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -36,8 +36,8 @@ TACTIC EXTEND assert_succeeds
 END
 
 TACTIC EXTEND replace
-| ["replace" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
--> { Internals.replace_in_clause_maybe_by ist c1 c2 cl tac }
+| [ "replace" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
+  -> { Internals.replace_in_clause_maybe_by ist None c1 c2 cl tac }
 END
 
 TACTIC EXTEND replace_term_left
@@ -45,9 +45,19 @@ TACTIC EXTEND replace_term_left
   -> { Internals.replace_term ist (Some true) c cl }
 END
 
+TACTIC EXTEND replace_left
+| ["replace" "->" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
+  -> { Internals.replace_in_clause_maybe_by ist (Some true) c1 c2 cl tac }
+END
+
 TACTIC EXTEND replace_term_right
 | [ "replace"  "<-" uconstr(c) clause(cl) ]
   -> { Internals.replace_term ist (Some false) c cl }
+END
+
+TACTIC EXTEND replace_right
+| [ "replace" "<-" uconstr(c1) "with" constr(c2) clause(cl) by_arg_tac(tac) ]
+  -> { Internals.replace_in_clause_maybe_by ist (Some false) c1 c2 cl tac }
 END
 
 TACTIC EXTEND replace_term

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -55,9 +55,9 @@ let with_delayed_uconstr ist c tac =
   let c = Tacinterp.type_uconstr ~flags ist c in
   Tacticals.tclDELAYEDWITHHOLES false c tac
 
-let replace_in_clause_maybe_by ist c1 c2 cl tac =
+let replace_in_clause_maybe_by ist dir_opt c1 c2 cl tac =
   with_delayed_uconstr ist c1
-  (fun c1 -> Equality.replace_in_clause_maybe_by c1 c2 cl (Option.map (Tacinterp.tactic_of_value ist) tac))
+  (fun c1 -> Equality.replace_in_clause_maybe_by dir_opt c1 c2 cl (Option.map (Tacinterp.tactic_of_value ist) tac))
 
 let replace_term ist dir_opt c cl =
   with_delayed_uconstr ist c (fun c -> Equality.replace_term dir_opt c cl)

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -29,7 +29,7 @@ val mytclWithHoles : (Tactics.evars_flag ->
 
 val with_delayed_uconstr : Tacinterp.interp_sign ->
   closed_glob_constr -> (EConstr.constr -> unit tactic) -> unit tactic
-val replace_in_clause_maybe_by : Tacinterp.interp_sign ->
+val replace_in_clause_maybe_by : Tacinterp.interp_sign -> bool option ->
   closed_glob_constr -> EConstr.constr ->
   Locus.clause -> Tacinterp.Value.t option -> unit tactic
 val replace_term : Geninterp.interp_sign -> bool option -> closed_glob_constr ->

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -662,8 +662,12 @@ let replace c1 c2 =
 let replace_by c1 c2 tac =
   replace_using_leibniz onConcl c2 c1 false false (Some tac)
 
-let replace_in_clause_maybe_by c1 c2 cl tac_opt =
-  replace_using_leibniz cl c2 c1 false false tac_opt
+let replace_in_clause_maybe_by dir_opt c1 c2 cl tac_opt =
+  let c1, c2, dir = match dir_opt with
+  | None | Some false -> c1, c2, false
+  | Some true -> c2, c1, true
+  in
+  replace_using_leibniz cl c2 c1 dir false tac_opt
 
 (* End of Eduardo's code. The rest of this file could be improved
    using the functions match_with_equation, etc that I defined

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -53,7 +53,7 @@ val general_multi_rewrite :
   evars_flag -> (bool * multi * clear_flag * delayed_open_constr_with_bindings) list ->
     clause -> (unit Proofview.tactic * conditions) option -> unit Proofview.tactic
 
-val replace_in_clause_maybe_by : constr -> constr -> clause -> unit Proofview.tactic option -> unit Proofview.tactic
+val replace_in_clause_maybe_by : bool option -> constr -> constr -> clause -> unit Proofview.tactic option -> unit Proofview.tactic
 val replace    : constr -> constr -> unit Proofview.tactic
 val replace_by : constr -> constr -> unit Proofview.tactic -> unit Proofview.tactic
 

--- a/test-suite/bugs/bug_13480.v
+++ b/test-suite/bugs/bug_13480.v
@@ -1,0 +1,25 @@
+Axiom dummy : forall x : nat, x = 0.
+
+Goal forall x : nat, x = 0.
+Proof.
+intros x.
+replace -> x with 0.
++ apply (eq_refl 0).
++ apply (dummy x).
+Qed.
+
+Goal forall x : nat, x = 0.
+Proof.
+intros x.
+replace <- x with 0.
++ apply (eq_refl 0).
++ symmetry; apply (dummy x).
+Qed.
+
+Goal forall x : nat, x = 0.
+Proof.
+intros x.
+replace x with 0.
++ apply (eq_refl 0).
++ symmetry; apply (dummy x).
+Qed.


### PR DESCRIPTION
I made the behaviour of the tactic w.r.t. the orientation consistent with the simpler variant of replace, i.e. `->` means that the equation is in the correct direction, `<-` creating it reversed (and being the default).

Fixes #13480: replace tactic subgoal reversed.