### PR TITLE
Force empty case nodes from irrelevant to relevant sorts to be CaseInvert

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -108,6 +108,8 @@ and usubs = fconstr subs UVars.puniverses
 
 and finvert = fconstr array
 
+let get_invert fiv = fiv
+
 let fterm_of v = v.term
 let set_ntrl v = v.mark <- Ntrl
 
@@ -1912,13 +1914,11 @@ and knit : 'a. _ -> _ -> pat_state: 'a depth -> _ -> _ -> _ -> 'a =
   let (ht,s) = knht info e t stk in
   knr info tab ~pat_state ht s
 
-and case_inversion info tab ci u params indices v =
-  let open Declarations in
+and case_inversion info tab ci u params indices v = match v with
+| [||] -> None (* empty type *)
+| [| [||], v |] ->
   (* No binders / lets at all in the unique branch *)
-  let v = match v with
-  | [| [||], v |] -> v
-  | _ -> assert false
-  in
+  let open Declarations in
   if Array.is_empty indices then Some v
   else
     let env = info_env info in
@@ -1938,6 +1938,7 @@ and case_inversion info tab ci u params indices v =
     in
     if Array.for_all_i check_index 0 indices
     then Some v else None
+| _ -> assert false
 
 let knred = {
   red_kni = kni;

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -80,6 +80,8 @@ val check_native_args : CPrimitives.t -> stack -> bool
 val get_native_args1 : CPrimitives.t -> pconstant -> stack ->
   fconstr list * fconstr * fconstr next_native_args * stack
 
+val get_invert : finvert -> fconstr array
+
 val stack_args_size : stack -> int
 
 val inductive_subst : Declarations.mutual_inductive_body

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -698,7 +698,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         if Float64.equal f1 f2 then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else raise NotConvertible
 
-    | FCaseInvert (ci1,u1,pms1,p1,_,_,br1,e1), FCaseInvert (ci2,u2,pms2,p2,_,_,br2,e2) ->
+    | FCaseInvert (ci1,u1,pms1,p1,iv1,_,br1,e1), FCaseInvert (ci2,u2,pms2,p2,iv2,_,br2,e2) ->
       (if not (Ind.CanOrd.equal ci1.ci_ind ci2.ci_ind) then raise NotConvertible);
       let el1 = el_stack lft1 v1 and el2 = el_stack lft2 v2 in
       let fold c1 c2 cuniv = ccnv CONV l2r infos el1 el2 c1 c2 cuniv in
@@ -715,6 +715,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
       let pms1 = mk_clos_vect e1 pms1 in
       let pms2 = mk_clos_vect e2 pms2 in
       let cuniv = Array.fold_right2 fold pms1 pms2 cuniv in
+      let cuniv = Array.fold_right2 fold (get_invert iv1) (get_invert iv2) cuniv in
       let cuniv = convert_return_clause mind mip l2r infos e1 e2 el1 el2 u1 u2 pms1 pms2 p1 p2 cuniv in
       convert_branches mind mip l2r infos e1 e2 el1 el2 u1 u2 pms1 pms2 br1 br2 cuniv
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -503,8 +503,11 @@ let should_invert_case env r ci =
      XXX Someday consider more carefully what happens with letin params and arguments
      (currently they're squashed, see indtyping)
  *)
-  Array.length mip.mind_nf_lc = 1 &&
-  List.length (fst mip.mind_nf_lc.(0)) = List.length mib.mind_params_ctxt
+  match Array.length mip.mind_nf_lc with
+  | 0 -> true
+  | 1 ->
+    List.length (fst mip.mind_nf_lc.(0)) = List.length mib.mind_params_ctxt
+  | _ -> false
 
 let type_case_scrutinee env (mib, _mip) (u', largs) u pms (pctx, p) c =
   let (params, realargs) = List.chop mib.mind_nparams largs in

--- a/test-suite/bugs/bug_19041.v
+++ b/test-suite/bugs/bug_19041.v
@@ -1,0 +1,7 @@
+Inductive T : bool -> SProp := .
+
+Goal forall (x:T true) (y:T false), match x return bool with end = match y return bool with end.
+Proof.
+  intros.
+  Fail reflexivity.
+Abort.


### PR DESCRIPTION
This was surprisingly simple. The kernel code handling CaseInvert doesn't really care about the empty case, and the upper layers ask the kernel to build the case inversion info.

Fixes #19041: Surprising definitional equality between empty matches.