### PR TITLE
coqpp: use location annotations for attributes

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -106,7 +106,7 @@ type classification =
 | ClassifName of string
 
 type vernac_rule = {
-  vernac_atts : (string * string) list option;
+  vernac_atts : (string * code) list option;
   vernac_state : string option;
   vernac_toks : ext_token list;
   vernac_class : code option;

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -376,8 +376,8 @@ let print_atts_right fmt = function
   | Some atts ->
     let rec aux fmt = function
       | [] -> assert false
-      | [_,y] -> fprintf fmt "%s" y
-      | (_,y) :: rem -> fprintf fmt "(%s ++ %a)" y aux rem
+      | [_,y] -> print_code fmt y
+      | (_,y) :: rem -> fprintf fmt "(%a ++ %a)" print_code y aux rem
     in
     let nota = match atts with [_] -> "" | _ -> "Attributes.Notations." in
     fprintf fmt "(Attributes.parse %s%a atts)" nota aux atts

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -59,6 +59,9 @@ let parse_user_entry s sep =
 
 let no_code = { code = ""; loc = None }
 
+let rhs_loc n =
+  { loc_start = Parsing.rhs_start_pos n; loc_end = Parsing.rhs_end_pos n }
+
 %}
 
 %token <Coqpp_ast.code> CODE
@@ -255,8 +258,9 @@ vernac_attributes:
 ;
 
 vernac_attribute:
-| qualid_or_ident EQUAL qualid_or_ident { ($1, $3) }
-| qualid_or_ident { ($1, $1) }
+| qualid_or_ident EQUAL qualid_or_ident {
+  ($1, { code = $3; loc = Some (rhs_loc 3) }) }
+| qualid_or_ident { ($1, { code = $1; loc = Some (rhs_loc 1) }) }
 ;
 
 rule_deprecation:


### PR DESCRIPTION
This puts the "unbound value whatever_attribute" error at the right location when an attribute's ocaml name is changed or typoed.