### PR TITLE
Make CSet extensible on our side, and adding CSet.List.union.

### DIFF
--- a/clib/cSet.ml
+++ b/clib/cSet.ml
@@ -16,7 +16,35 @@ end
 
 module type S = Set.S
 
-module Make(M : OrderedType)= Set.Make(M)
+module type ExtS =
+sig
+  include CSig.SetS
+  module List : sig
+    val union : t list -> t
+  end
+end
+
+module SetExt (M : Set.OrderedType) :
+sig
+  type set = Set.Make(M).t
+  module List : sig
+    val union : set list -> set
+  end
+end =
+struct
+  module S = Set.Make(M)
+  type set = S.t
+
+  module List = struct
+    let union = List.fold_left S.union S.empty
+  end
+end
+
+module Make(M : Set.OrderedType) =
+struct
+  include Set.Make(M)
+  include SetExt(M)
+end
 
 module type HashedType =
 sig

--- a/clib/cSet.mli
+++ b/clib/cSet.mli
@@ -16,7 +16,18 @@ end
 
 module type S = Set.S
 
-module Make(M : OrderedType) : S
+module type ExtS =
+sig
+  include CSig.SetS
+  (** The underlying Set library *)
+
+  module List : sig
+    val union : t list -> t
+    (** Union of sets from a list *)
+  end
+end
+
+module Make(M : Map.OrderedType) : ExtS
   with type elt = M.t
   and type t = Set.Make(M).t
 

--- a/clib/cSig.mli
+++ b/clib/cSig.mli
@@ -39,6 +39,7 @@ sig
     val for_all: (elt -> bool) -> t -> bool
     val exists: (elt -> bool) -> t -> bool
     val filter: (elt -> bool) -> t -> t
+(*    val filter_map: (elt -> elt option) -> t -> t [OCaml 4.11] *)
     val partition: (elt -> bool) -> t -> t * t
     val cardinal: t -> int
     val elements: t -> elt list
@@ -49,11 +50,28 @@ end
     can't be efficiently implemented for HSets are moved to OSetS. *)
 
 module type SetS = sig
-  include USetS
+    include USetS
 
-  val min_elt: t -> elt
-  val max_elt: t -> elt
-  val split: elt -> t -> t * bool * t
+    val disjoint: t -> t -> bool
+    val min_elt: t -> elt
+    val min_elt_opt: t -> elt option
+    val max_elt: t -> elt
+    val max_elt_opt: t -> elt option
+    val choose: t -> elt
+    val choose_opt: t -> elt option
+    val split: elt -> t -> t * bool * t
+    val find: elt -> t -> elt
+    val find_opt: elt -> t -> elt option
+    val find_first: (elt -> bool) -> t -> elt
+    val find_first_opt: (elt -> bool) -> t -> elt option
+    val find_last: (elt -> bool) -> t -> elt
+    val find_last_opt: (elt -> bool) -> t -> elt option
+    val of_list: elt list -> t
+    val to_seq_from : elt -> t -> elt Seq.t
+    val to_seq : t -> elt Seq.t
+    (* val to_rev_seq : t -> elt Seq.t [OCaml 4.12] *)
+    val add_seq : elt Seq.t -> t -> t
+    val of_seq : elt Seq.t -> t
 end
 (** OCaml set operations which require the order structure to be efficient. *)
 

--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -29,7 +29,7 @@ sig
   val is_sub : string -> string -> int -> bool
   val is_prefix : string -> string -> bool
   val is_suffix : string -> string -> bool
-  module Set : Set.S with type elt = t
+  module Set : CSet.ExtS with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
   module Pred : Predicate.S with type elt = t
   module List : CList.MonoS with type elt = t
@@ -167,7 +167,7 @@ struct
   let compare = compare
 end
 
-module Set = Set.Make(Self)
+module Set = CSet.Make(Self)
 module Map = CMap.Make(Self)
 module Pred = Predicate.Make(Self)
 

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -71,7 +71,7 @@ sig
 
   (** {6 Generic operations} **)
 
-  module Set : Set.S with type elt = t
+  module Set : CSet.ExtS with type elt = t
   (** Finite sets on [string] *)
 
   module Map : CMap.ExtS with type key = t and module Set := Set

--- a/dev/ci/user-overlays/19075-herbelin-master+cSet-extensible.sh
+++ b/dev/ci/user-overlays/19075-herbelin-master+cSet-extensible.sh
@@ -1,0 +1,2 @@
+overlay quickchick https://github.com/herbelin/QuickChick master+adapting-coq-pr19075-extended-CSet-interface 19075 master+cSet-extensible
+overlay coq_lsp https://github.com/herbelin/coq-lsp main+adapting-coq-pr19075-extended-CSet-interface 19075 master+cSet-extensible

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -22,9 +22,9 @@ val notation_cat : Libobject.category
 val pr_notation : notation -> Pp.t
 (** Printing *)
 
-module NotationSet : Set.S with type elt = notation
+module NotationSet : CSet.ExtS with type elt = notation
 module NotationMap : CMap.ExtS with type key = notation and module Set := NotationSet
-module SpecificNotationSet : Set.S with type elt = specific_notation
+module SpecificNotationSet : CSet.ExtS with type elt = specific_notation
 module SpecificNotationMap : CMap.ExtS with type key = specific_notation and module Set := SpecificNotationSet
 
 (** {6 Scopes } *)

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -62,7 +62,7 @@ sig
   val print : t -> Pp.t
   (** Pretty-printer. *)
 
-  module Set : Set.S with type elt = t
+  module Set : Set.ExtS with type elt = t
   (** Finite sets of identifiers. *)
 
   module Map : Map.ExtS with type key = t and module Set := Set
@@ -120,7 +120,7 @@ type name = Name.t = Anonymous | Name of Id.t
 type variable = Id.t
 type module_ident = Id.t
 
-module ModIdset : Set.S with type elt = module_ident
+module ModIdset : Set.ExtS with type elt = module_ident
 module ModIdmap : Map.ExtS with type key = module_ident and module Set := ModIdset
 
 (** {6 Directory paths = section names paths } *)
@@ -164,7 +164,7 @@ sig
   val print : t -> Pp.t
 end
 
-module DPset : Set.S with type elt = DirPath.t
+module DPset : Set.ExtS with type elt = DirPath.t
 module DPmap : Map.ExtS with type key = DirPath.t and module Set := DPset
 
 (** {6 Names of structure elements } *)
@@ -198,7 +198,7 @@ sig
   val print : t -> Pp.t
   (** Pretty-printer. *)
 
-  module Set : Set.S with type elt = t
+  module Set : Set.ExtS with type elt = t
   module Map : Map.ExtS with type key = t and module Set := Set
 
   val hcons : t -> t
@@ -240,7 +240,7 @@ sig
 
 end
 
-module MBIset : Set.S with type elt = MBId.t
+module MBIset : Set.ExtS with type elt = MBId.t
 module MBImap : Map.ExtS with type key = MBId.t and module Set := MBIset
 
 (** {6 The module part of the kernel name } *)
@@ -274,7 +274,7 @@ sig
 
 end
 
-module MPset : Set.S with type elt = ModPath.t
+module MPset : Set.ExtS with type elt = ModPath.t
 module MPmap : Map.ExtS with type key = ModPath.t and module Set := MPset
 
 (** {6 The absolute names of objects seen by kernel } *)
@@ -528,10 +528,10 @@ end
 
 type constructor = Construct.t
 
-module Indset : CSet.S with type elt = inductive
-module Constrset : CSet.S with type elt = constructor
-module Indset_env : CSet.S with type elt = inductive
-module Constrset_env : CSet.S with type elt = constructor
+module Indset : CSet.ExtS with type elt = inductive
+module Constrset : CSet.ExtS with type elt = constructor
+module Indset_env : CSet.ExtS with type elt = inductive
+module Constrset_env : CSet.ExtS with type elt = constructor
 module Indmap : CMap.ExtS with type key = inductive and module Set := Indset
 module Constrmap : CMap.ExtS with type key = constructor and module Set := Constrset
 module Indmap_env : CMap.ExtS with type key = inductive and module Set := Indset_env

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -154,7 +154,7 @@ sig
   val repr : t -> (Level.t * int) list
   val unrepr : (Level.t * int) list -> t
 
-  module Set : CSet.S with type elt  = t
+  module Set : CSet.ExtS with type elt  = t
   module Map : CMap.ExtS with type key = t and module Set := Set
 
 end
@@ -174,7 +174,7 @@ type constraint_type = AcyclicGraph.constraint_type = Lt | Le | Eq
 type univ_constraint = Level.t * constraint_type * Level.t
 
 module Constraints : sig
-  include Set.S with type elt = univ_constraint
+  include CSet.ExtS with type elt = univ_constraint
 
   val pr : (Level.t -> Pp.t) -> t -> Pp.t
 end

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -114,6 +114,6 @@ val coercions : unit -> coe_info_typ list
    be hidden, [None] otherwise; it raises [Not_found] if not a coercion *)
 val hide_coercion : coe_typ -> int option
 
-module ClTypSet : Set.S with type elt = cl_typ
+module ClTypSet : CSet.ExtS with type elt = cl_typ
 
 val reachable_from : cl_typ -> ClTypSet.t

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -220,7 +220,7 @@ type context_object =
   | Opaque of Constant.t     (* An opaque constant. *)
   | Transparent of Constant.t
 
-module ContextObjectSet : Set.S with type elt = context_object
+module ContextObjectSet : CSet.ExtS with type elt = context_object
 module ContextObjectMap : CMap.ExtS
   with type key = context_object and module Set := ContextObjectSet
 

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -107,7 +107,7 @@ module PluginSpec : sig
 
   val pp : t -> string
 
-  module Set : CSet.S with type elt = t
+  module Set : CSet.ExtS with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
 
 end = struct

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -104,7 +104,7 @@ type t = Names.Id.Set.t
 
 let definition_using env evd ~fixnames ~using ~terms =
   let l = process_expr env evd fixnames using terms in
-  Names.Id.Set.(List.fold_right add l empty)
+  Names.Id.Set.(CList.fold_right add l empty)
 
 let name_set id expr =
   if Id.equal id all_collection_id then err_redefine_all_collection ();


### PR DESCRIPTION
This PR proposes to make OCaml's `Set` library extensible on our side, like `Map` is already extensible.

As an application, it adds the function `CSet.List.union`, itself useful e.g. to shorten a verbose fold.

Note: The PR seized the opportunity to also update `CSig.SetS` relatively to OCaml 4.09.

Synchronous overlays:
- QuickChick/QuickChick#378
- ejgallego/coq-lsp#767