### PR TITLE
include_constructor_argument don't ignore sort quality when not univ poly

### DIFF
--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -131,6 +131,7 @@ sig
   val inductive_levels
     : Environ.env
     -> Evd.evar_map
+    -> poly:bool
     -> EConstr.constr list
     (* arities *)
     -> EConstr.rel_context list list

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -248,7 +248,7 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
     else (* each inductive has one constructor *)
       let ctors = List.map (fun (_,newfs) -> [newfs]) data in
       let sigma, (default_dep_elim, typs) =
-        ComInductive.Internal.inductive_levels env_ar sigma typs ctors
+        ComInductive.Internal.inductive_levels env_ar sigma ~poly typs ctors
       in
       sigma, List.combine default_dep_elim typs
   in


### PR DESCRIPTION
Without this change, before univ minimization
~~~coq
Inductive prod A B := pair : A -> B -> prod A B.
~~~
produces
~~~coq
Inductive prod (A:Type@{qa|a}) (B:Type@{qb|b}) : Type@{qc|c} := ...
~~~
(with a, b <= c), but we want qa = qb = qc.

This does not matter yet since minimization will collapse qualities but will matter once we want to use them for template poly.