### PR TITLE
Canonically renaming List.safe_index into List.index_opt

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -455,7 +455,7 @@ let rec index_f f x l n = match l with
 
 let index f x l = index_f f x l 1
 
-let safe_index f x l = try Some (index f x l) with Not_found -> None
+let index_opt f x l = try Some (index f x l) with Not_found -> None
 
 let index0 f x l = index_f f x l 0
 

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -159,8 +159,8 @@ val count : ('a -> bool) -> 'a list -> int
 val index : 'a eq -> 'a -> 'a list -> int
 (** [index] returns the 1st index of an element in a list (counting from 1). *)
 
-val safe_index : 'a eq -> 'a -> 'a list -> int option
-(** [safe_index] returns the 1st index of an element in a list (counting from 1)
+val index_opt : 'a eq -> 'a -> 'a list -> int option
+(** [index_opt] returns the 1st index of an element in a list (counting from 1)
     and None otherwise. *)
 
 val index0 : 'a eq -> 'a -> 'a list -> int

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -197,7 +197,7 @@ let focus_id cond inf id pr =
   let (focused_goals, evar_map) = Proofview.proofview pr.proofview in
   begin match try Some (Evd.evar_key id evar_map) with Not_found -> None with
   | Some ev ->
-     begin match CList.safe_index Evar.equal ev focused_goals with
+     begin match CList.index_opt Evar.equal ev focused_goals with
      | Some i ->
         (* goal is already under focus *)
         _focus cond inf i i pr


### PR DESCRIPTION
This follows the usage in OCaml libraries of adding an `_opt` suffix when the possibility of an exceptional result is encapsulated in an `option` type.