### PR TITLE
[Subsumed] Add optional type annotation to Derive

### DIFF
--- a/doc/sphinx/addendum/miscellaneous-extensions.rst
+++ b/doc/sphinx/addendum/miscellaneous-extensions.rst
@@ -7,13 +7,14 @@ of program refinements. To use the Derive extension it must first be
 required with ``Require Coq.derive.Derive``. When the extension is loaded,
 it provides the following command:
 
-.. cmd:: Derive @ident__1 SuchThat @one_term As @ident__2
+.. cmd:: Derive @ident__1 {? : @type__1 } SuchThat @type__2 As @ident__2
 
-   :n:`@ident__1` can appear in :n:`@one_term`. This command opens a new proof
-   presenting the user with a goal for :n:`@one_term` in which the name :n:`@ident__1` is
+   :n:`@ident__1` can appear in :n:`@type__2`. This command opens a new proof
+   presenting the user with a goal for :n:`@type__2` in which the name :n:`@ident__1` is
    bound to an existential variable :g:`?x` (formally, there are other goals
    standing for the existential variables but they are shelved, as
-   described in :tacn:`shelve`).
+   described in :tacn:`shelve`). A specific type :n:`@type__1` can
+   optionally be given to :n:`@ident__1`.
 
    When the proof ends two :term:`constants <constant>` are defined:
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1380,6 +1380,10 @@ command: [
 | REPLACE "Declare" "Scope" IDENT
 | WITH "Declare" "Scope" scope_name
 
+| DELETE "Derive" identref "SuchThat" constr "As" identref      (* derive plugin *)
+| REPLACE "Derive" identref ":" constr "SuchThat" constr "As" identref      (* derive plugin *)
+| WITH "Derive" ident OPT (":" type) "SuchThat" type "As" ident      (* derive plugin *)
+
 (* odd that these are in command while other notation-related ones are in syntax *)
 | REPLACE "Number" "Notation" reference reference reference OPT number_options ":" preident
 | WITH "Number" "Notation" reference reference reference OPT number_options ":" scope_name

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -563,6 +563,7 @@ command: [
 | "Declare" "Reduction" IDENT; ":=" red_expr
 | "Declare" "Custom" "Entry" IDENT
 | "Derive" identref "SuchThat" constr "As" identref      (* derive plugin *)
+| "Derive" identref ":" constr "SuchThat" constr "As" identref      (* derive plugin *)
 | "Extraction" global      (* extraction plugin *)
 | "Recursive" "Extraction" LIST1 global      (* extraction plugin *)
 | "Extraction" string LIST1 global      (* extraction plugin *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -788,7 +788,7 @@ command: [
 | "Debug" [ "On" | "Off" ]
 | "Declare" "Reduction" ident ":=" red_expr
 | "Declare" "Custom" "Entry" ident
-| "Derive" ident "SuchThat" one_term "As" ident      (* derive plugin *)
+| "Derive" ident OPT ( ":" type ) "SuchThat" type "As" ident
 | "Extraction" qualid      (* extraction plugin *)
 | "Recursive" "Extraction" LIST1 qualid      (* extraction plugin *)
 | "Extraction" string LIST1 qualid      (* extraction plugin *)

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -14,7 +14,7 @@ open Context.Named.Declaration
     (which can contain references to [f]) in the context extended by
     [f:=?x]. When the proof ends, [f] is defined as the value of [?x]
     and [lemma] as the proof. *)
-let start_deriving f suchthat name : Declare.Proof.t =
+let start_deriving f typ suchthat name : Declare.Proof.t =
 
   let env = Global.env () in
   let sigma = Evd.from_env env in
@@ -29,13 +29,17 @@ let start_deriving f suchthat name : Declare.Proof.t =
   let goals =
     let open Proofview in
     TCons ( env , sigma , f_type_type , (fun sigma f_type ->
+        let sigma = match typ with
+          | None -> sigma
+          | Some typ ->
+            let sigma, typ = Constrintern.interp_type_evars ~program_mode:false env sigma typ in
+            Evd.define (fst (EConstr.destEvar sigma f_type)) typ sigma in
         TCons ( env , sigma , f_type , (fun sigma ef ->
             let env' = EConstr.push_named (LocalDef (EConstr.annotR f, ef, f_type)) env in
             let sigma, suchthat = Constrintern.interp_type_evars ~program_mode:false env' sigma suchthat in
             TCons ( env' , sigma , suchthat , (fun sigma _ ->
                 TNil sigma))))))
   in
-
   let info = Declare.Info.make ~poly:false ~kind () in
   let lemma = Declare.Proof.start_derive ~name ~f ~info goals in
   Declare.Proof.map lemma ~f:(fun p ->

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Context
 open Context.Named.Declaration
 
 (** [start_deriving f suchthat lemma] starts a proof of [suchthat]
@@ -31,9 +30,7 @@ let start_deriving f suchthat name : Declare.Proof.t =
     let open Proofview in
     TCons ( env , sigma , f_type_type , (fun sigma f_type ->
         TCons ( env , sigma , f_type , (fun sigma ef ->
-            let f_type = EConstr.Unsafe.to_constr f_type in
-            let ef = EConstr.Unsafe.to_constr ef in
-            let env' = Environ.push_named (LocalDef (annotR f, ef, f_type)) env in
+            let env' = EConstr.push_named (LocalDef (EConstr.annotR f, ef, f_type)) env in
             let sigma, suchthat = Constrintern.interp_type_evars ~program_mode:false env' sigma suchthat in
             TCons ( env' , sigma , suchthat , (fun sigma _ ->
                 TNil sigma))))))

--- a/plugins/derive/derive.mli
+++ b/plugins/derive/derive.mli
@@ -14,6 +14,7 @@
     and [lemma] as the proof. *)
 val start_deriving
   :  Names.Id.t
+  -> Constrexpr.constr_expr option
   -> Constrexpr.constr_expr
   -> Names.Id.t
   -> Declare.Proof.t

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -24,5 +24,7 @@ let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpac
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command } STATE open_proof
 | [ "Derive" identref(f) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
-  { Derive.start_deriving f.CAst.v suchthat lemma.CAst.v }
+  { Derive.start_deriving f.CAst.v None suchthat lemma.CAst.v }
+| [ "Derive" identref(f) ":" constr(typ) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
+  { Derive.start_deriving f.CAst.v (Some typ) suchthat lemma.CAst.v }
 END

--- a/test-suite/success/Derive.v
+++ b/test-suite/success/Derive.v
@@ -1,0 +1,8 @@
+Require Import Derive.
+
+Derive foo : nat SuchThat (foo = foo) As bar.
+Proof.
+reflexivity.
+Unshelve.
+exact 0.
+Qed.


### PR DESCRIPTION
The PR adds the following syntax:
```coq
Derive id : typ SuchThat typ' As name.
```
where `typ` is at level 8. Maybe should it be instead the combination of
```coq
Derive id : typ SuchThat typ' As name.
```
with typ at level 0, and
```coq
Derive (id : typ) SuchThat typ' As name.
```
with `typ` at level 200.

The 3rd commit also adds a check that the evars of the statement are resolved. This is a (temporary) regression compared to the current status but the advantage is that it will make easier to integrate `Derive` in the main execution path for theorems. So in this sense the 3rd commit is maybe too early, and support for `Theorem` with unresolved evars should first be provided (the alternative would be to use an unsafe econstr->constr coercion in the meantime).
