### PR TITLE
Fixes #19082: regression with primitive projections with defined fields

### DIFF
--- a/doc/changelog/02-specification-language/19088-master+fix19082-branch-length-mismatch.rst
+++ b/doc/changelog/02-specification-language/19088-master+fix19082-branch-length-mismatch.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Regression from Coq 8.18 in the presence of a defined field in
+  a primitive :n:`Record`
+  (`#19088 <https://github.com/coq/coq/pull/19088>`_,
+  fixes `#19082 <https://github.com/coq/coq/issues/19082>`_,
+  by Hugo Herbelin).

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -472,7 +472,7 @@ let make_project env sigma ind pred c branches ps =
            (i, j + 1, LocalDef (na, Vars.liftn 1 j b, Vars.liftn 1 j ty) :: ctx))
       ctx (0, 1, [])
   in
-  mkLetIn (na, c, ty, it_mkLambda_or_LetIn (Vars.liftn 1 (Array.length ps + 1) br) ctx)
+  mkLetIn (na, c, ty, it_mkLambda_or_LetIn (Vars.liftn 1 (mip.mind_consnrealdecls.(0) + 1) br) ctx)
 
 let simple_make_case_or_project env sigma ci pred invert c branches =
   let ind = ci.Constr.ci_ind in

--- a/test-suite/bugs/bug_19082.v
+++ b/test-suite/bugs/bug_19082.v
@@ -1,0 +1,25 @@
+Inductive boring1 := Boring1.
+Inductive boring2 := Boring2.
+
+Inductive output_wrapper := OutputWrapper {
+    ow_alice : boring1;
+}.
+
+#[projections(primitive)]
+Inductive request := InputWrapper {
+    req_alice : boring1;
+    req_next_bob := Boring2;
+}.
+
+Definition do_the_thing (req : request) : output_wrapper.
+Proof.
+  exact (
+      match req with
+      | {|
+          req_alice := alice;
+       |} =>
+        OutputWrapper alice
+      end
+  ).
+  Validate Proof.
+Qed.


### PR DESCRIPTION
Fixes #19082 (regression introduced in f7de37ebd, #15582).

Commit f7de37ebd was fixing the length of the context of the branch but the adjustment of a lift later on was missing. 

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
