### PR TITLE
Avoid async proofs messing up test output/auto

### DIFF
--- a/test-suite/output/auto.v
+++ b/test-suite/output/auto.v
@@ -5,8 +5,8 @@ Succeed info_auto.
 Succeed debug auto.
 Succeed info_eauto.
 debug eauto.
-Qed.
+Defined.
 
 Goal True.
 info_trivial.
-Qed.
+Defined.


### PR DESCRIPTION
test-suite:base+async has been broken due to this since #19076
