### PR TITLE
Fixes #19099: binders of universe polymorphic primitive constants treated as monomorphic

### DIFF
--- a/doc/changelog/02-specification-language/19100-master+fix19099-poly-prim-constant-with-udecl.rst
+++ b/doc/changelog/02-specification-language/19100-master+fix19099-poly-prim-constant-with-udecl.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Incorrect registration of universe names attached to a primitive
+  polymorphic constant
+  (`#19100 <https://github.com/coq/coq/pull/19100>`_,
+  fixes `#19099 <https://github.com/coq/coq/issues/19099>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_19099.v
+++ b/test-suite/bugs/bug_19099.v
@@ -1,0 +1,4 @@
+Set Universe Polymorphism.
+Primitive array@{u} : Type@{u} -> Type@{u} := #array_type.
+Fail Print Universes Subgraph (Top.array.u).
+(* Was: Anomaly "Uncaught exception Not_found." in coqtop *)


### PR DESCRIPTION
Fixes #19099

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
