### PR TITLE
Merging the code paths for interactive and non-interactive co/fixpoints

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -415,7 +415,8 @@ let register_struct is_rec fixpoint_exprl =
     in
     (None, evd, List.rev rev_pconstants)
   | _ ->
-    ComFixpoint.do_fixpoint ~poly:false fixpoint_exprl;
+    let p = ComFixpoint.do_fixpoint ~poly:false fixpoint_exprl in
+    assert (Option.is_empty p);
     let evd, rev_pconstants =
       List.fold_left
         (fun (evd, l) {Vernacexpr.fname} ->

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -163,7 +163,7 @@ let recompute_binder_list fixpoint_exprl =
       fixpoint_exprl
   in
   let (_, _, _, typel), _, ctx, _ =
-    ComFixpoint.interp_fixpoint ~check_recursivity:false ~cofix:false fixl
+    ComFixpoint.interp_recursive ~check_recursivity:false ~cofix:false fixl
   in
   let constr_expr_typel =
     with_full_print

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -267,25 +267,24 @@ let build_recthms ~indexes fixnames fixtypes fiximps =
   in
   fix_kind, possible_guard, thms
 
-let declare_fixpoint_interactive_generic ?indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
-  let fix_kind, possible_guard, thms = build_recthms ~indexes fixnames fixtypes fiximps in
-  let evd = Evd.from_ctx ctx in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind:(Decls.IsDefinition fix_kind) ~udecl ?typing_flags ?user_warns ~ntns () in
-    Declare.Proof.start_mutual_definitions ~info ~cinfo:thms
-      ~bodies:fixdefs ~possible_guard ?using evd
-
 let declare_fixpoint_generic ?indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
-  (* We shortcut the proof process *)
-  let fix_kind, possible_guard, fixitems = build_recthms ~indexes fixnames fixtypes fiximps in
-  let fixdefs = List.map Option.get fixdefs in
-  let fix_kind = Decls.IsDefinition fix_kind in
-  let info = Declare.Info.make ?scope ?clearbody ~kind:fix_kind ~poly ~udecl ?typing_flags ?user_warns ~ntns () in
-  let cinfo = fixitems in
-  let _ : GlobRef.t list =
-    Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx
-      ~possible_guard ~bodies:(fixdefs,fixrs) ?using ()
-  in
-  ()
+  let fix_kind, possible_guard, cinfo = build_recthms ~indexes fixnames fixtypes fiximps in
+  let kind = Decls.IsDefinition fix_kind in
+  let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ?typing_flags ?user_warns ~ntns () in
+  match Option.List.map (fun x -> x) fixdefs with
+  | Some fixdefs ->
+    (* All bodies are defined *)
+    let _ : GlobRef.t list =
+      Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx
+        ~possible_guard ~bodies:(fixdefs,fixrs) ?using ()
+    in
+    None
+  | None ->
+    (* At least one undefined body *)
+    let evd = Evd.from_ctx uctx in
+    let lemma = Declare.Proof.start_mutual_definitions ~info ~cinfo
+      ~bodies:fixdefs ~possible_guard ?using evd in
+    Some lemma
 
 let extract_decreasing_argument ~structonly { CAst.v = v; _ } =
   let open Constrexpr in
@@ -311,33 +310,17 @@ let adjust_rec_order ~structonly binders rec_order =
   in
   Option.map (extract_decreasing_argument ~structonly) rec_order
 
-let do_fixpoint_common ?typing_flags (fixl : Vernacexpr.fixpoint_expr list) =
+let do_fixpoint ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using (fixl : Vernacexpr.fixpoint_expr list) : Declare.Proof.t option =
   let fixl = List.map (fun fix ->
       Vernacexpr.{ fix
                    with rec_order = adjust_rec_order ~structonly:true fix.binders fix.rec_order }) fixl in
   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
   let (_, _, _, info as fix) = interp_fixpoint ~cofix:false ?typing_flags fixl in
-  fixl, ntns, fix, List.map compute_possible_guardness_evidences info
-
-let do_fixpoint_interactive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l : Declare.Proof.t =
-  let fixl, ntns, fix, possible_indexes = do_fixpoint_common ?typing_flags l in
-  let lemma = declare_fixpoint_interactive_generic ~indexes:possible_indexes ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using fix ntns in
-  lemma
-
-let do_fixpoint ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
-  let fixl, ntns, fix, possible_indexes = do_fixpoint_common ?typing_flags l in
+  let possible_indexes = List.map compute_possible_guardness_evidences info in
   declare_fixpoint_generic ~indexes:possible_indexes ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using fix ntns
 
-let do_cofixpoint_common (fixl : Vernacexpr.cofixpoint_expr list) =
-  let fixl = List.map (fun fix -> {fix with Vernacexpr.rec_order = None}) fixl in
-  let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
-  interp_fixpoint ~cofix:true fixl, ntns
-
-let do_cofixpoint_interactive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
-  let cofix, ntns = do_cofixpoint_common l in
-  let lemma = declare_fixpoint_interactive_generic ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using cofix ntns in
-  lemma
-
-let do_cofixpoint ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l =
-  let cofix, ntns = do_cofixpoint_common l in
-  declare_fixpoint_generic ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using cofix ntns
+let do_cofixpoint ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using fixl =
+   let fixl = List.map (fun fix -> {fix with Vernacexpr.rec_order = None}) fixl in
+   let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
+  let cofix, ntns = interp_fixpoint ~cofix:true fixl, ntns in
+  declare_fixpoint_generic ?scope ?clearbody ~poly ?typing_flags ?user_warns ?using cofix ntns

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -15,45 +15,25 @@ open Vernacexpr
 
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
-val do_fixpoint_interactive
-  : scope:Locality.definition_scope
-  -> ?clearbody:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
-  -> ?user_warns:UserWarn.t
-  -> ?using:Vernacexpr.section_subset_expr
-  -> fixpoint_expr list
-  -> Declare.Proof.t
-
 val do_fixpoint
-   : ?scope:Locality.definition_scope
-   -> ?clearbody:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
-  -> ?user_warns:UserWarn.t
-  -> ?using:Vernacexpr.section_subset_expr
-  -> fixpoint_expr list
-  -> unit
-
-val do_cofixpoint_interactive
-  : scope:Locality.definition_scope
+  : ?scope:Locality.definition_scope
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
-  -> cofixpoint_expr list
-  -> Declare.Proof.t
+  -> fixpoint_expr list
+  -> Declare.Proof.t option
 
 val do_cofixpoint
-  : scope:Locality.definition_scope
+  : ?scope:Locality.definition_scope
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> cofixpoint_expr list
-  -> unit
+  -> Declare.Proof.t option
 
 (************************************************************************)
 (** Internal API  *)

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -51,7 +51,7 @@ val adjust_rec_order
 type ('constr, 'types, 'r) recursive_preentry = Id.t list * 'r list * 'constr option list * 'types list
 
 (** Exported for Program *)
-val interp_recursive :
+val interp_recursive_evars :
   Environ.env ->
   (* Misc arguments *)
   program_mode:bool -> cofix:bool ->
@@ -66,7 +66,7 @@ val interp_recursive :
 
 (** Exported for Funind *)
 
-val interp_fixpoint
+val interp_recursive
   :  ?check_recursivity:bool
   -> ?typing_flags:Declarations.typing_flags
   -> cofix:bool

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -218,7 +218,7 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
   let (env, rec_sign, udecl, evd), fix, info =
     let env = Global.env () in
     let env = Environ.update_typing_flags ?typing_flags env in
-    interp_recursive env ~cofix ~program_mode:true fixl
+    interp_recursive_evars env ~cofix ~program_mode:true fixl
   in
     (* Program-specific code *)
     (* Get the interesting evars, those that were not instantiated *)


### PR DESCRIPTION
This is the first part of #18811. A priori ready to be merged.