### PR TITLE
Merging the code paths for fixpoint and cofixpoints

### DIFF
--- a/dev/ci/user-overlays/19107-herbelin-master+unify-fixpoint-cofixpoint-execution-paths.sh
+++ b/dev/ci/user-overlays/19107-herbelin-master+unify-fixpoint-cofixpoint-execution-paths.sh
@@ -1,0 +1,2 @@
+overlay coq_lsp https://github.com/herbelin/coq-lsp main+adapt-coq-pr19107-merge-fixpoint-cofixpoint 19107 herbelin-master+unify-fixpoint-cofixpoint-execution-paths
+overlay autosubst_ocaml https://github.com/herbelin/autosubst-ocaml master+adapt-coq-pr19107-merge-fixpoint-cofixpoint 19107 herbelin-master+unify-fixpoint-cofixpoint-execution-paths

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -183,17 +183,17 @@ and branch_expr =
 
 and fix_expr =
   lident * relevance_info_expr
-  * recursion_order_expr option *
+  * fixpoint_order_expr option *
   local_binder_expr list * constr_expr * constr_expr
 
 and cofix_expr =
     lident * relevance_info_expr * local_binder_expr list * constr_expr * constr_expr
 
-and recursion_order_expr_r =
+and fixpoint_order_expr_r =
   | CStructRec of lident
   | CWfRec of lident * constr_expr
   | CMeasureRec of lident option * constr_expr * constr_expr option (** argument, measure, relation *)
-and recursion_order_expr = recursion_order_expr_r CAst.t
+and fixpoint_order_expr = fixpoint_order_expr_r CAst.t
 
 (* Anonymous defs allowed ?? *)
 and local_binder_expr =

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -196,7 +196,7 @@ module Constr :
     val open_binders : local_binder_expr list Entry.t
     val one_open_binder : kinded_cases_pattern_expr Entry.t
     val one_closed_binder : kinded_cases_pattern_expr Entry.t
-    val binders_fixannot : (local_binder_expr list * recursion_order_expr option) Entry.t
+    val binders_fixannot : (local_binder_expr list * fixpoint_order_expr option) Entry.t
     val typeclass_constraint : (lname * bool * constr_expr) Entry.t
     val record_declaration : constr_expr Entry.t
     val arg : (constr_expr * explicitation CAst.t option) Entry.t

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -173,14 +173,12 @@ let () =
 
 let is_proof_termination_interactively_checked recsl =
   List.exists (function
-  | _,( Vernacexpr.{ rec_order = Some { CAst.v = CMeasureRec _ } }
-      | Vernacexpr.{ rec_order = Some { CAst.v = CWfRec _} }) -> true
-  | _, Vernacexpr.{ rec_order = Some { CAst.v = CStructRec _ } }
-  | _, Vernacexpr.{ rec_order = None } -> false) recsl
+  | _, ( Some { CAst.v = (CMeasureRec _ | CWfRec _) }, _ ) -> true
+  | _, ( ( Some { CAst.v = CStructRec _ } | None), _) -> false) recsl
 
 let classify_as_Fixpoint recsl =
  Vernac_classifier.classify_vernac
-    (Vernacexpr.(CAst.make @@ { control = []; attrs = []; expr = VernacSynPure (VernacFixpoint(NoDischarge, List.map snd recsl))}))
+    (Vernacexpr.(CAst.make @@ { control = []; attrs = []; expr = VernacSynPure (VernacFixpoint(NoDischarge, List.split (List.map snd recsl)))}))
 
 let classify_funind recsl =
   match classify_as_Fixpoint recsl with
@@ -213,11 +211,11 @@ VERNAC COMMAND EXTEND Function STATE CUSTOM
     if is_interactive recsl then
       Vernactypes.vtopenproof (fun () ->
           CWarnings.with_warn warn
-            Gen_principle.do_generate_principle_interactive (List.map snd recsl))
+            Gen_principle.do_generate_principle_interactive (List.split (List.map snd recsl)))
     else
       Vernactypes.vtdefault (fun () ->
           CWarnings.with_warn warn
-            Gen_principle.do_generate_principle (List.map snd recsl))
+            Gen_principle.do_generate_principle (List.split (List.map snd recsl)))
   }
 END
 

--- a/plugins/funind/gen_principle.mli
+++ b/plugins/funind/gen_principle.mli
@@ -12,9 +12,9 @@ val warn_cannot_define_graph : ?loc:Loc.t -> Pp.t * Pp.t -> unit
 val warn_cannot_define_principle : ?loc:Loc.t -> Pp.t * Pp.t -> unit
 
 val do_generate_principle_interactive :
-  Vernacexpr.fixpoint_expr list -> Declare.Proof.t
+  Vernacexpr.fixpoints_expr -> Declare.Proof.t
 
-val do_generate_principle : Vernacexpr.fixpoint_expr list -> unit
+val do_generate_principle : Vernacexpr.fixpoints_expr -> unit
 val make_graph : Names.GlobRef.t -> unit
 
 (* Can be thrown by build_{,case}_scheme *)

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -36,7 +36,7 @@ val pr_sort_expr : sort_expr -> Pp.t
 val pr_guard_annot
   :  (constr_expr -> Pp.t)
   -> local_binder_expr list
-  -> recursion_order_expr option
+  -> fixpoint_order_expr option
   -> Pp.t
 
 val pr_record : string -> string -> ('a -> Pp.t) -> 'a list -> Pp.t

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -44,7 +44,7 @@ val do_cofixpoint
 val adjust_rec_order
   :  structonly:bool
   -> Constrexpr.local_binder_expr list
-  -> Constrexpr.recursion_order_expr option
+  -> Constrexpr.fixpoint_order_expr option
   -> lident option
 
 (** names / relevance / defs / types *)

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -15,37 +15,19 @@ open Vernacexpr
 
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
-val do_fixpoint
+val do_mutually_recursive
   : ?scope:Locality.definition_scope
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
-  -> fixpoint_expr list
-  -> Declare.Proof.t option
-
-val do_cofixpoint
-  : ?scope:Locality.definition_scope
-  -> ?clearbody:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
-  -> ?user_warns:UserWarn.t
-  -> ?using:Vernacexpr.section_subset_expr
-  -> cofixpoint_expr list
+  -> recursives_expr
   -> Declare.Proof.t option
 
 (************************************************************************)
 (** Internal API  *)
 (************************************************************************)
-
-(** Typing global fixpoints and cofixpoint_expr *)
-
-val adjust_rec_order
-  :  structonly:bool
-  -> Constrexpr.local_binder_expr list
-  -> Constrexpr.fixpoint_order_expr option
-  -> lident option
 
 (** names / relevance / defs / types *)
 type ('constr, 'types, 'r) recursive_preentry = Id.t list * 'r list * 'constr option list * 'types list
@@ -54,27 +36,25 @@ type ('constr, 'types, 'r) recursive_preentry = Id.t list * 'r list * 'constr op
 val interp_recursive_evars :
   Environ.env ->
   (* Misc arguments *)
-  program_mode:bool -> cofix:bool ->
+  program_mode:bool ->
   (* Notations of the fixpoint / should that be folded in the previous argument? *)
-  lident option fix_expr_gen list ->
+  bool * recursion_order_expr ->
+  recursive_expr_gen list ->
   (* env / signature / univs / evar_map *)
   (Environ.env * EConstr.named_context * UState.universe_decl * Evd.evar_map) *
   (* names / defs / types *)
   (EConstr.t, EConstr.types, EConstr.ERelevance.t) recursive_preentry *
   (* ctx per mutual def / implicits / struct annotations *)
-  (EConstr.rel_context * Impargs.manual_implicits * int option) list
+  (EConstr.rel_context * Impargs.manual_implicits) list * Decls.definition_object_kind * Pretyping.possible_guard
 
 (** Exported for Funind *)
 
 val interp_recursive
   :  ?check_recursivity:bool
   -> ?typing_flags:Declarations.typing_flags
-  -> cofix:bool
-  -> lident option fix_expr_gen list
-  -> (Constr.t, Constr.types, Sorts.relevance) recursive_preentry *
-     UState.universe_decl * UState.t *
-     (EConstr.rel_context * Impargs.manual_implicits * int option) list
-
-(** Very private function, do not use *)
-val compute_possible_guardness_evidences :
-  ('a, 'b, 'r) Context.Rel.pt * 'c * int option -> int list
+  -> bool * Vernacexpr.recursion_order_expr
+  -> recursive_expr_gen list
+  -> Decls.definition_object_kind * Pretyping.possible_guard *
+     ((Constr.t, Constr.types, Sorts.relevance) recursive_preentry *
+      UState.universe_decl * UState.t *
+      (EConstr.rel_context * Impargs.manual_implicits) list)

--- a/vernac/comProgramFixpoint.mli
+++ b/vernac/comProgramFixpoint.mli
@@ -19,7 +19,7 @@ val do_fixpoint :
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
-  -> fixpoint_expr list
+  -> fixpoints_expr
   -> Declare.OblState.t
 
 val do_cofixpoint :
@@ -30,5 +30,16 @@ val do_cofixpoint :
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
-  -> cofixpoint_expr list
+  -> cofixpoints_expr
+  -> Declare.OblState.t
+
+val do_mutually_recursive :
+     pm:Declare.OblState.t
+  -> scope:Locality.definition_scope
+  -> ?clearbody:bool
+  -> poly:bool
+  -> ?typing_flags:Declarations.typing_flags
+  -> ?user_warns:UserWarn.t
+  -> ?using:Vernacexpr.section_subset_expr
+  -> recursives_expr
   -> Declare.OblState.t

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -270,9 +270,9 @@ GRAMMAR EXTEND Gram
       | f = inductive_token; indl = LIST1 inductive_or_record_definition SEP "with" ->
           { VernacInductive (f, indl) }
       | "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
-          { VernacFixpoint (NoDischarge, recs) }
+          { VernacFixpoint (NoDischarge, List.split recs) }
       | IDENT "Let"; "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
-          { VernacFixpoint (DoDischarge, recs) }
+          { VernacFixpoint (DoDischarge, List.split recs) }
       | "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
           { VernacCoFixpoint (NoDischarge, corecs) }
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
@@ -503,13 +503,13 @@ GRAMMAR EXTEND Gram
         rtype = type_cstr;
         body_def = OPT [":="; def = lconstr -> { def } ]; notations = decl_notations ->
           { let binders, rec_order = bl in
-            {fname = fst id_decl; univs = snd id_decl; rec_order; binders; rtype; body_def; notations}
+            ((rec_order : Constrexpr.fixpoint_order_expr option), {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations})
           } ] ]
   ;
   cofix_definition:
     [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr;
         body_def = OPT [":="; def = lconstr -> { def }]; notations = decl_notations ->
-        { {fname = fst id_decl; univs = snd id_decl; rec_order = (); binders; rtype; body_def; notations}
+        { {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations}
         } ]]
   ;
   (* Rewrite Rules *)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -524,7 +524,7 @@ let pr_notation_declaration ntn_decl =
 let pr_where_notation decl_ntn =
   fnl () ++ keyword "where " ++ pr_notation_declaration decl_ntn
 
-let pr_rec_definition { fname; univs; rec_order; binders; rtype; body_def; notations } =
+let pr_rec_definition (rec_order, { fname; univs; binders; rtype; body_def; notations }) =
   let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c in
   let annot = pr_guard_annot pr_lconstr_expr binders rec_order in
   pr_ident_decl (fname,univs) ++ pr_binders_arg binders ++ annot
@@ -927,7 +927,7 @@ let pr_synpure_vernac_expr v =
       (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
     )
 
-  | VernacFixpoint (local, recs) ->
+  | VernacFixpoint (local, (rec_order, recs)) ->
     let local = match local with
       | DoDischarge -> "Let "
       | NoDischarge -> ""
@@ -935,7 +935,7 @@ let pr_synpure_vernac_expr v =
     return (
       hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
              prlist_with_sep (fun _ -> fnl () ++ keyword "with"
-                                       ++ spc ()) pr_rec_definition recs)
+                                       ++ spc ()) pr_rec_definition (List.combine rec_order recs))
     )
 
   | VernacCoFixpoint (local, corecs) ->

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -16,7 +16,7 @@ val pr_set_entry_type : ('a -> Pp.t) -> 'a Extend.constr_entry_key_gen -> Pp.t
 val pr_syntax_modifier : Vernacexpr.syntax_modifier CAst.t -> Pp.t
 
 (** Prints a fixpoint body *)
-val pr_rec_definition : Vernacexpr.fixpoint_expr -> Pp.t
+val pr_rec_definition : Constrexpr.fixpoint_order_expr option * Vernacexpr.recursive_expr_gen -> Pp.t
 
 (** Prints a scheme *)
 val pr_onescheme : Names.lident option * Vernacexpr.scheme -> Pp.t

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -118,7 +118,7 @@ let classify_vernac e =
       let ids = List.map (fun (({v=i}, _), _) -> i) l in
       let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
       VtStartProof (guarantee,ids)
-    | VernacFixpoint (discharge,l) ->
+    | VernacFixpoint (discharge,(_,l)) ->
       let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
        let guarantee =
          if discharge = DoDischarge || polymorphic then Doesn'tGuaranteeOpacity

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -172,18 +172,24 @@ type notation_declaration =
   ; ntn_decl_modifiers : syntax_modifier CAst.t list
   }
 
-type 'a fix_expr_gen =
+type recursion_order_expr =
+  | CFixRecOrder of fixpoint_order_expr option list
+  | CCoFixRecOrder
+  | CUnknownRecOrder
+
+type recursive_expr_gen =
   { fname : lident
   ; univs : universe_decl_expr option
-  ; rec_order : 'a
   ; binders : local_binder_expr list
   ; rtype : constr_expr
   ; body_def : constr_expr option
   ; notations : notation_declaration list
   }
 
-type fixpoint_expr = fixpoint_order_expr option fix_expr_gen
-type cofixpoint_expr = unit fix_expr_gen
+type fixpoint_expr = fixpoint_order_expr option * recursive_expr_gen
+type fixpoints_expr = fixpoint_order_expr option list * recursive_expr_gen list
+type cofixpoints_expr = recursive_expr_gen list
+type recursives_expr = recursion_order_expr * recursive_expr_gen list
 
 type local_decl_expr =
   | AssumExpr of lname * local_binder_expr list * constr_expr
@@ -412,8 +418,8 @@ type nonrec synpure_vernac_expr =
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
   | VernacSymbol of (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of inductive_kind * (inductive_expr * notation_declaration list) list
-  | VernacFixpoint of discharge * fixpoint_expr list
-  | VernacCoFixpoint of discharge * cofixpoint_expr list
+  | VernacFixpoint of discharge * fixpoints_expr
+  | VernacCoFixpoint of discharge * cofixpoints_expr
   | VernacScheme of (lident option * scheme) list
   | VernacSchemeEquality of equality_scheme_type * Libnames.qualid Constrexpr.or_by_notation
   | VernacCombinedScheme of lident * lident list

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -182,7 +182,7 @@ type 'a fix_expr_gen =
   ; notations : notation_declaration list
   }
 
-type fixpoint_expr = recursion_order_expr option fix_expr_gen
+type fixpoint_expr = fixpoint_order_expr option fix_expr_gen
 type cofixpoint_expr = unit fix_expr_gen
 
 type local_decl_expr =


### PR DESCRIPTION
This is the second part of #18811.

The merge is obtained by using a data type `recursion_order_expr` that tells if an optional `struct`/`wf`/`measure` (as in `Fixpoint`) or a corecursion (as in `CoFixpoint`) or an unknown cause of recursion (as in `Theorem with`). This is then interpreted as a `possible_guard` (which can be either a recursion or a corecursion, thanks to #18743).

Depends on:
- #19105

Synchronous overlays:
- ejgallego/coq-lsp#792
- uds-psl/autosubst-ocaml#17