### PR TITLE
Constrintern.ml support for setting "force" status of some implicit arguments

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -58,7 +58,7 @@ val empty_internalization_env : internalization_env
 val compute_internalization_data : env -> evar_map -> ?silent:bool -> Id.t -> var_internalization_type ->
   types -> Impargs.manual_implicits -> var_internalization_data
 
-val compute_internalization_env : env -> evar_map -> ?impls:internalization_env -> var_internalization_type ->
+val compute_internalization_env : env -> evar_map -> ?impls:internalization_env -> ?force:Id.Set.t list -> var_internalization_type ->
   Id.t list -> types list -> Impargs.manual_implicits list ->
   internalization_env
 


### PR DESCRIPTION
This is in preparation of the merge of Fixpoint and Program Fixpoint (see #18811): in `comProgramFixpoint.ml`, the force flag is otherwise added in an ad hoc way.