### PR TITLE
Use Coqlib for setoid_rewrite

### DIFF
--- a/doc/changelog/04-tactics/19115-setoid-rewrite-coqlib.rst
+++ b/doc/changelog/04-tactics/19115-setoid-rewrite-coqlib.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Use Coqlib's Register mechanism for the generalized rewriting tactic
+  and make the (C)RelationClasses/(C)Morphisms independent of the `rewrite`
+  tactic to ease maintainance.
+  (`#19115 <https://github.com/coq/coq/pull/19116>`_,
+  by Matthieu Sozeau).

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -738,3 +738,14 @@ Hint Extern 4 (StrictOrder (relation_conjunction _ _)) =>
 #[global]
 Hint Extern 4 (PartialOrder _ (relation_disjunction _ _)) => 
   class_apply StrictOrder_PartialOrder : typeclass_instances.
+
+(* Register bindings for the generalized rewriting tactic *)
+
+Register forall_relation as rewrite.type.forall_relation.
+Register pointwise_relation as rewrite.type.pointwise_relation.
+Register respectful as rewrite.type.respectful.
+Register forall_def as rewrite.type.forall_def.
+Register do_subrelation as rewrite.type.do_subrelation.
+Register apply_subrelation as rewrite.type.apply_subrelation.
+Register Proper as rewrite.type.Proper.
+Register ProperProxy as rewrite.type.ProperProxy.

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -21,6 +21,8 @@ Require Export Coq.Classes.CRelationClasses.
 Generalizable Variables A eqA B C D R RA RB RC m f x y.
 Local Obligation Tactic := try solve [ simpl_crelation ].
 
+Local Arguments transitivity {A R Transitive x} y {z}.
+
 Set Universe Polymorphism.
 
 (** * Morphisms.
@@ -281,8 +283,8 @@ Section GenericInstances.
   Proof with auto.
     intros A R H B R' H0 x y z X X0 x0 y0 X1.
     assert(R x0 x0).
-    - transitivity y0... symmetry...
-    - transitivity (y x0)...
+    - eapply transitivity with y0... now apply symmetry.
+    - eapply transitivity with (y x0)...
   Qed.
 
   Unset Strict Universe Declaration.
@@ -311,8 +313,8 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x y X x0 y0 X0 X1.
-    transitivity x...
-    transitivity x0...
+    apply transitivity with x...
+    apply transitivity with x0...
   Qed.
 
   (** Proper declarations for partial applications. *)
@@ -324,7 +326,7 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x x0 y X X0.
-    transitivity y...
+    apply transitivity with y...
   Qed.
 
   Global Program 
@@ -334,7 +336,7 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x x0 y X X0.
-    transitivity x0...
+    apply transitivity with x0...
   Qed.
 
   Global Program 
@@ -344,7 +346,7 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x x0 y X X0.
-    transitivity y... symmetry...
+    apply transitivity with y... apply symmetry...
   Qed.
 
   Global Program Instance trans_sym_contra_arrow_morphism
@@ -353,7 +355,7 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x x0 y X X0.
-    transitivity x0... symmetry...
+    apply transitivity with x0... apply symmetry...
   Qed.
 
   Global Program Instance per_partial_app_type_morphism
@@ -363,10 +365,10 @@ Section GenericInstances.
   Proof with auto.
     intros A R H x x0 y X.
     split.
-    - intros ; transitivity x0...
+    - intros ; apply transitivity with x0...
     - intros.
-      transitivity y...
-      symmetry...
+      apply transitivity with y...
+      apply symmetry...
   Qed.
 
   (** Every Transitive crelation induces a morphism by "pushing" an [R x y] on the left of an [R x z] proof to get an [R y z] goal. *)
@@ -378,7 +380,7 @@ Section GenericInstances.
   Next Obligation.
   Proof with auto.
     intros A R H x y X y0 y1 e X0; destruct e.
-    transitivity y...
+    apply transitivity with y...
   Qed.
 
   (** Every Symmetric and Transitive crelation gives rise to an equivariant morphism. *)
@@ -390,9 +392,11 @@ Section GenericInstances.
   Proof with auto.
     intros A R H x y X x0 y0 X0.
     split ; intros.
-    - transitivity x0... transitivity x... symmetry...
+    - apply transitivity with x0...
+      apply transitivity with x... apply symmetry...
 
-    - transitivity y... transitivity y0... symmetry...
+    - apply transitivity with y... apply transitivity with y0...
+      apply symmetry...
   Qed.
 
   Lemma symmetric_equiv_flip `(Symmetric A R) : relation_equivalence R (flip R).
@@ -585,7 +589,8 @@ Lemma flip_arrow `(NA : Normalizes A R (flip R'''), NB : Normalizes B R' (flip R
   Normalizes (A -> B) (R ==> R') (flip (R''' ==> R'')%signatureT).
 Proof. 
   unfold Normalizes in *. intros.
-  rewrite NA, NB. firstorder. 
+  eapply transitivity; [|eapply symmetry, flip_respectful].
+  now apply respectful_morphism.
 Qed.
 
 Ltac normalizes :=
@@ -667,11 +672,11 @@ Instance PartialOrder_proper_type `(PartialOrder A eqA R) :
   Proper (eqA==>eqA==>iffT) R.
 Proof.
 intros.
-apply proper_sym_arrow_iffT_2. 1-2: auto with crelations.
+apply proper_sym_arrow_iffT_2. 1-2: typeclasses eauto.
 intros x x' Hx y y' Hy Hr.
-transitivity x.
+apply transitivity with x.
 - generalize (partial_order_equivalence x x'); compute; intuition.
-- transitivity y; auto.
+- apply transitivity with y; auto.
   generalize (partial_order_equivalence y y'); compute; intuition.
 Qed.
 
@@ -689,7 +694,8 @@ split; compute.
   + intro Hxz.
     apply Hxy'.
     apply partial_order_antisym; auto.
-    rewrite Hxz. auto.
+    apply transitivity with z; [assumption|].
+    now apply H.
 Qed.
 
 (** From a [StrictOrder] to the corresponding [PartialOrder]:
@@ -701,12 +707,13 @@ Lemma StrictOrder_PreOrder
  PreOrder (relation_disjunction R eqA).
 Proof.
 split.
-- intros x. right. reflexivity.
+- intros x. right. apply reflexivity.
 - intros x y z [Hxy|Hxy] [Hyz|Hyz].
-  + left. transitivity y; auto.
-  + left. rewrite <- Hyz; auto.
-  + left. rewrite Hxy; auto.
-  + right. transitivity y; auto.
+  + left. apply transitivity with y; auto.
+  + left. eapply H1; try eassumption. apply reflexivity.
+    now apply symmetry.
+  + left. eapply H1; [eassumption|apply reflexivity|eassumption].
+  + right. apply transitivity with y; auto.
 Qed.
 
 #[global]
@@ -717,9 +724,11 @@ Lemma StrictOrder_PartialOrder
   `(Equivalence A eqA, StrictOrder A R, Proper _ (eqA==>eqA==>iffT) R) :
   PartialOrder eqA (relation_disjunction R eqA).
 Proof.
-intros. intros x y. compute. intuition auto with crelations.
-elim (StrictOrder_Irreflexive x).
-transitivity y; auto.
+intros. intros x y. compute. intuition auto.
+- right; now apply symmetry.
+- elim (StrictOrder_Irreflexive x).
+  eapply transitivity with y; eauto.
+- now apply symmetry.
 Qed.
 
 #[global]

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -391,3 +391,17 @@ Hint Extern 3 (PartialOrder (flip _)) => class_apply PartialOrder_inverse : type
 (* Qed. *)
 
 Global Typeclasses Opaque relation_equivalence.
+
+(* Register bindings for the generalized rewriting tactic *)
+
+Register arrow as rewrite.type.arrow.
+Register flip as rewrite.type.flip.
+Register crelation as rewrite.type.relation.
+Register subrelation as rewrite.type.subrelation.
+Register Reflexive as rewrite.type.Reflexive.
+Register reflexivity as rewrite.type.reflexivity.
+Register Symmetric as rewrite.type.Symmetric.
+Register symmetry as rewrite.type.symmetry.
+Register Transitive as rewrite.type.Transitive.
+Register transitivity as rewrite.type.transitivity.
+Register RewriteRelation as rewrite.type.RewriteRelation.

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -493,15 +493,8 @@ Section GenericInstances.
     unfold respectful, relation_equivalence, predicate_equivalence in * ; simpl in *.
     split ; intros H1 x3 y1 H2.
     
-    - rewrite <- H0.
-      apply H1.
-      rewrite H.
-      assumption.
-
-    - rewrite H0.
-      apply H1.
-      rewrite <- H.
-      assumption.
+    - now apply H0, H1, H.
+    - now apply H0, H1, H.
   Qed.
 
   (** [R] is Reflexive, hence we can build the needed proof. *)
@@ -603,10 +596,8 @@ Proof.
   intros x y H y0 y1 e; destruct e.
   reduce in H.
   split ; red ; intros H0.
-  - setoid_rewrite <- H.
-    apply H0.
-  - setoid_rewrite H.
-    apply H0.
+  - apply H, H0.
+  - apply H, H0.
 Qed.
 
 Ltac proper_reflexive :=
@@ -649,8 +640,7 @@ Section Normalize.
 
   Lemma proper_normalizes_proper `(Normalizes R0 R1, Proper A R1 m) : Proper R0 m.
   Proof.
-    rewrite normalizes.
-    assumption.
+    eapply proper_proper; eauto.
   Qed.
 
   Lemma flip_atom R : Normalizes R (flip (flip R)).
@@ -759,7 +749,8 @@ split; compute.
   + intro Hxz.
     apply Hxy'.
     apply partial_order_antisym; auto.
-    rewrite Hxz; auto.
+    eapply PartialOrder_proper; eauto.
+    apply reflexivity.
 Qed.
 
 
@@ -775,8 +766,10 @@ split.
 - intros x. right. reflexivity.
 - intros x y z [Hxy|Hxy] [Hyz|Hyz].
   + left. transitivity y; auto.
-  + left. rewrite <- Hyz; auto.
-  + left. rewrite Hxy; auto.
+  + left. eapply H1; eauto.
+    * apply reflexivity.
+    * now apply symmetry.
+  + left. eapply H1; try eassumption. now apply reflexivity.
   + right. transitivity y; auto.
 Qed.
 

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -793,3 +793,15 @@ Hint Extern 4 (StrictOrder (relation_conjunction _ _)) =>
 #[global]
 Hint Extern 4 (PartialOrder _ (relation_disjunction _ _)) => 
   class_apply StrictOrder_PartialOrder : typeclass_instances.
+
+(* Register bindings for the generalized rewriting tactic *)
+
+Register forall_relation as rewrite.prop.forall_relation.
+Register pointwise_relation as rewrite.prop.pointwise_relation.
+Register respectful as rewrite.prop.respectful.
+Register forall_def as rewrite.prop.forall_def.
+Register do_subrelation as rewrite.prop.do_subrelation.
+Register apply_subrelation as rewrite.prop.apply_subrelation.
+Register RewriteRelation as rewrite.prop.RewriteRelation.
+Register Proper as rewrite.prop.Proper.
+Register ProperProxy as rewrite.prop.ProperProxy.

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -528,3 +528,14 @@ Qed.
 
 Global Typeclasses Opaque arrows predicate_implication predicate_equivalence
             relation_equivalence pointwise_lifting.
+
+(* Register bindings for the generalized rewriting tactic *)
+
+Register relation as rewrite.prop.relation.
+Register subrelation as rewrite.prop.subrelation.
+Register Reflexive as rewrite.prop.Reflexive.
+Register reflexivity as rewrite.prop.reflexivity.
+Register Symmetric as rewrite.prop.Symmetric.
+Register symmetry as rewrite.prop.symmetry.
+Register Transitive as rewrite.prop.Transitive.
+Register transitivity as rewrite.prop.transitivity.

--- a/theories/Classes/SetoidTactics.v
+++ b/theories/Classes/SetoidTactics.v
@@ -34,6 +34,7 @@ Unset Strict Implicit.
    *)
 
 Class DefaultRelation A (R : relation A).
+Register DefaultRelation as rewrite.DefaultRelation.
 
 (** To search for the default relation, just call [default_relation]. *)
 

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -322,6 +322,7 @@ Section ex2_Projections.
 End ex2_Projections.
 
 Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
+Register all as core.all.
 
 (* Rule order is important to give printing priority to fully typed exists *)
 

--- a/theories/Program/Basics.v
+++ b/theories/Program/Basics.v
@@ -39,10 +39,12 @@ Local Open Scope program_scope.
 (** The non-dependent function space between [A] and [B]. *)
 
 Definition arrow (A B : Type) := A -> B.
+Register arrow as core.arrow.
 
 (** Logical implication. *)
 
 Definition impl (A B : Prop) : Prop := A -> B.
+Register impl as core.impl.
 
 (** The constant function [const a] always returns [a]. *)
 
@@ -51,6 +53,7 @@ Definition const {A B} (a : A) := fun _ : B => a.
 (** The [flip] combinator reverses the first two arguments of a function. *)
 
 Definition flip {A B C} (f : A -> B -> C) x y := f y x.
+Register flip as core.flip.
 
 (** Application as a combinator. *)
 


### PR DESCRIPTION
This moves from hardcoded paths of the stdlib to using Register commands in (C)RelationClasses/Morphisms for binding references used by `rewrite.ml`. Should be entirely backwards compatible, with no user-noticeable change.
This also changes the proofs in Morphisms/CMorphisms to avoid having to rely on `rewrite` or the overloaded `reflexivity/symmetry/transitivity` tactics themselves, simplifying maintainance of these files.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
