### PR TITLE
Start a GoodDefaults file collecting recommended option settings.

### DIFF
--- a/doc/changelog/11-corelib/19117-good-defaults-Added.rst
+++ b/doc/changelog/11-corelib/19117-good-defaults-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  A GoodDefaults_2025 module setting various options to their recommended value,
+  see :ref:`the doc <good_defaults>` for more details
+  (`#19117 <https://github.com/rocq-prover/rocq/pull/19117>`_,
+  by Théo Zimmermann and Théo Winterhalter).

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -163,6 +163,7 @@ through the <tt>Require Import</tt> command.</p>
 
   <dt id="Compat"> <a href="#Compat"><b>Compat</b></a>:
     Compatibility wrappers for previous versions of Coq
+     and recommended options at the time of a given Rocq release
   </dt>
   <dd>
     theories/Corelib/Compat/Coq818.v
@@ -170,6 +171,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Corelib/Compat/Coq820.v
     theories/Corelib/Compat/Rocq90.v
     theories/Corelib/Compat/Rocq91.v
+    theories/Corelib/Compat/GoodDefaults_2025.v
     theories/Ltac2/Compat/Coq818.v
     theories/Ltac2/Compat/Coq819.v
   </dd>

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -400,6 +400,20 @@ The :term:`flag`, :term:`option` and :term:`table`
 mechanisms are used to modify the behavior of Rocq more globally in a
 document or project.
 
+.. _good_defaults:
+
+The default value of some settings is not the one that would be recommended
+today for compatibility reasons. We provide a *good default* file in the Corelib
+which can be imported as follows:
+
+.. rocqtop:: in
+
+   From Corelib Require Import GoodDefaults_2025.
+
+This file is versioned to account for the changes in recommendations as the Rocq
+practice evolves. The 2025 edition will remain available without change after
+future versions are released.
+
 .. _attributes:
 
 Attributes

--- a/theories/Corelib/Compat/GoodDefaults_2025.v
+++ b/theories/Corelib/Compat/GoodDefaults_2025.v
@@ -1,0 +1,42 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** * Good defaults 2025
+
+  File exporting recommended option settings at the time of releasing Rocq v9.1
+
+*)
+
+#[ export ] Set Default Goal Selector "!".
+
+#[ export ] Set Asymmetric Patterns.
+
+#[ export ] Set Keyed Unification.
+
+(** The following affect people using [Universe Polymorphism]. *)
+
+#[ export ] Set Polymorphic Inductive Cumulativity.
+
+#[ export ] Set Typeclasses Default Mode "!".
+Hint Constants Opaque : typeclass_instances.
+
+Ltac Tauto.intuition_solver ::= auto with core.
+
+(** Makes the behavior of [injection] consistent with the rest of standard
+  tactics.
+*)
+
+#[ export ] Set Structural Injection.
+
+(** These three affect pepole that set [Implicit Arguments]. *)
+
+#[ export ] Set Strongly Strict Implicit.
+#[ export ] Set Maximal Implicit Insertion.
+#[ export ] Set Contextual Implicit.


### PR DESCRIPTION
Follow-up of Zulip discussion at: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Better.20default.20options

Let's keep the momentum on this good idea. I've started populating this file with an easy one. What else should go in there and is not controversial? For instance, I saw `Set Universe Polymorphism.` being suggested in https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Your.20favorite.20secret.20Coq.20option.3F, but is it already recommended for all users?

- [x] Added **changelog**.
- [x] Added / updated **documentation**.