### PR TITLE
Use algebraic datatypes to signal failure in Conversion API

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -69,8 +69,10 @@ let check_constant_declaration env opac kn cb opacify =
     match body with
     | Some bd ->
       let j = infer env bd in
-      (try conv_leq env j.uj_type ty
-       with NotConvertible -> Type_errors.error_actual_type env j ty)
+      begin match conv_leq env j.uj_type ty with
+      | Result.Ok () -> ()
+      | Result.Error () -> Type_errors.error_actual_type env j ty
+      end
     | None -> ()
   in
   match body with

--- a/dev/ci/user-overlays/19120-ppedrot-conversion-no-inner-exception-api.sh
+++ b/dev/ci/user-overlays/19120-ppedrot-conversion-no-inner-exception-api.sh
@@ -1,0 +1,1 @@
+overlay smtcoq https://github.com/ppedrot/smtcoq conversion-no-inner-exception-api 19120

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -111,8 +111,9 @@ let process_universes env = function
 
 let check_primitive_type env op_t u t =
   let inft = Typeops.type_of_prim_or_type env u op_t in
-  try Conversion.default_conv Conversion.CONV env inft t
-  with Conversion.NotConvertible ->
+  match Conversion.default_conv Conversion.CONV env inft t with
+  | Result.Ok () -> ()
+  | Result.Error () ->
     Type_errors.error_incorrect_primitive env (make_judge op_t inft) t
 
 let adjust_primitive_univ_entry p auctx = function

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -132,6 +132,10 @@ type 'a extended_conversion_function =
 
 exception NotConvertible
 
+type conversion_error =
+| ConvErrDefault
+| ConvErrUniverses of UGraph.univ_inconsistency
+
 (* Convertibility of sorts *)
 
 (* The sort cumulativity is
@@ -146,11 +150,10 @@ type conv_pb =
   | CUMUL
 
 type 'a universe_compare = {
-  (* Might raise NotConvertible *)
-  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> 'a;
-  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> 'a;
+  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, conversion_error) result;
+  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
   compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
-    UVars.Instance.t -> UVars.Instance.t -> 'a -> 'a;
+    UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
 }
 
 type 'a universe_state = 'a * 'a universe_compare
@@ -190,13 +193,18 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     let num_param_arity = inductive_cumulativity_arguments (mind,ind) in
     if not (Int.equal num_param_arity nargs) then
       (* shortcut, not sure if worth doing, could use perf data *)
-      if UVars.Instance.equal u1 u2 then s else raise MustExpand
+      if UVars.Instance.equal u1 u2 then Result.Ok s else raise MustExpand
     else
       cmp_cumul cv_pb variances u1 u2 s
 
+let fail_check (state, check) = match state with
+| Result.Ok state -> (state, check)
+| Result.Error ConvErrDefault -> raise NotConvertible
+| Result.Error (ConvErrUniverses err) -> raise (UGraph.UniverseInconsistency err)
+
 let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
-  convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
-    cv_pb ind nargs u1 u2 s, check
+  fail_check @@ (convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
+    cv_pb ind nargs u1 u2 s, check)
 
 let constructor_cumulativity_arguments (mind, ind, ctor) =
   mind.Declarations.mind_nparams +
@@ -208,7 +216,7 @@ let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u
   | Some _ ->
     let num_cnstr_args = constructor_cumulativity_arguments (mind,ind,cns) in
     if not (Int.equal num_cnstr_args nargs) then
-      if UVars.Instance.equal u1 u2 then s else raise MustExpand
+      if UVars.Instance.equal u1 u2 then Result.Ok s else raise MustExpand
     else
       (** By invariant, both constructors have a common supertype,
           so they are convertible _at that type_. *)
@@ -217,8 +225,8 @@ let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u
       cmp_cumul CONV variance u1 u2 s
 
 let convert_constructors ctor nargs u1 u2 (s, check) =
-  convert_constructors_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
-    ctor nargs u1 u2 s, check
+  fail_check @@ (convert_constructors_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
+    ctor nargs u1 u2 s, check)
 
 let conv_table_key infos ~nargs k1 k2 cuniv =
   if k1 == k2 then cuniv else
@@ -229,7 +237,7 @@ let conv_table_key infos ~nargs k1 k2 cuniv =
     else
       let flex = evaluable_constant cst (info_env infos)
         && RedFlags.red_set (info_flags infos) (RedFlags.fCONST cst)
-      in convert_instances ~flex u u' cuniv
+      in fail_check @@ convert_instances ~flex u u' cuniv
   | VarKey id, VarKey id' when Id.equal id id' -> cuniv
   | RelKey n, RelKey n' when Int.equal n n' -> cuniv
   | _ -> raise NotConvertible
@@ -393,7 +401,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
                if not (is_empty_stack v1 && is_empty_stack v2) then
                  (* May happen because we convert application right to left *)
                  raise NotConvertible;
-              sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
+              fail_check @@ sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
            | (Meta n, Meta m) ->
                if Int.equal n m
                then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
@@ -604,7 +612,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FInd (ind1,u1 as pind1), FInd (ind2,u2 as pind2)) ->
       if Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = convert_instances ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
@@ -621,7 +629,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FConstruct ((ind1,j1),u1 as pctor1), FConstruct ((ind2,j2),u2 as pctor2)) ->
       if Int.equal j1 j2 && Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = convert_instances ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
@@ -722,7 +730,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | FArray (u1,t1,ty1), FArray (u2,t2,ty2) ->
       let len = Parray.length_int t1 in
       if not (Int.equal len (Parray.length_int t2)) then raise NotConvertible;
-      let cuniv = convert_instances_cumul CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
+      let cuniv = fail_check @@ convert_instances_cumul CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
       let el1 = el_stack lft1 v1 in
       let el2 = el_stack lft2 v2 in
       let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
@@ -789,6 +797,7 @@ and convert_stacks l2r infos lft1 lft2 stk1 stk2 cuniv =
                     | None -> convert_instances ~flex:false u1 u2 cu
                     | Some variances -> convert_instances_cumul CONV variances u1 u2 cu
                 in
+                let cu = fail_check cu in
                 let pms1 = mk_clos_vect e1 pms1 in
                 let pms2 = mk_clos_vect e2 pms2 in
                 let fold_params c1 c2 accu = f (l1, c1) (l2, c2) accu in
@@ -889,28 +898,25 @@ let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
     ()
 
 let check_eq univs u u' =
-  if not (UGraph.check_eq_sort univs u u') then raise NotConvertible
+  if UGraph.check_eq_sort univs u u' then Result.Ok univs else Result.Error ConvErrDefault
 
 let check_leq univs u u' =
-  if not (UGraph.check_leq_sort univs u u') then raise NotConvertible
+  if UGraph.check_leq_sort univs u u' then Result.Ok univs else Result.Error ConvErrDefault
 
-let check_sort_cmp_universes pb s0 s1 univs =
+let checked_sort_cmp_universes _env pb s0 s1 univs =
   match pb with
   | CUMUL -> check_leq univs s0 s1
   | CONV -> check_eq univs s0 s1
 
-let checked_sort_cmp_universes _env pb s0 s1 univs =
-  check_sort_cmp_universes pb s0 s1 univs; univs
-
 let check_convert_instances ~flex:_ u u' univs =
-  if UGraph.check_eq_instances univs u u' then univs
-  else raise NotConvertible
+  if UGraph.check_eq_instances univs u u' then Result.Ok univs
+  else Result.Error ConvErrDefault
 
 (* general conversion and inference functions *)
 let check_inductive_instances cv_pb variance u1 u2 univs =
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
-  if Sorts.QConstraints.trivial qcsts && (UGraph.check_constraints ucsts univs) then univs
-  else raise NotConvertible
+  if Sorts.QConstraints.trivial qcsts && (UGraph.check_constraints ucsts univs) then Result.Ok univs
+  else Result.Error ConvErrDefault
 
 let checked_universes =
   { compare_sorts = checked_sort_cmp_universes;

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -130,11 +130,10 @@ type 'a extended_conversion_function =
   ?evars:evar_handler ->
   'a -> 'a -> (unit, unit) result
 
-exception NotConvertible
+type payload = ..
 
-type conversion_error =
-| ConvErrDefault
-| ConvErrUniverses of UGraph.univ_inconsistency
+exception NotConvertible
+exception NotConvertibleTrace of payload
 
 (* Convertibility of sorts *)
 
@@ -149,18 +148,16 @@ type conv_pb =
   | CONV
   | CUMUL
 
-type 'a universe_compare = {
-  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, conversion_error) result;
-  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
+type ('a, 'err) universe_compare = {
+  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
+  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
   compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
-    UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
+    UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
 }
 
-type 'a universe_state = 'a * 'a universe_compare
+type ('a, 'err) universe_state = 'a * ('a, 'err) universe_compare
 
-type 'a generic_conversion_function = 'a universe_state -> constr -> constr -> ('a, conversion_error) result
-
-type 'a infer_conversion_function = env -> 'a -> 'a -> (Univ.Constraints.t, conversion_error) result
+type ('a, 'err) generic_conversion_function = ('a, 'err) universe_state -> constr -> constr -> ('a, 'err option) result
 
 let sort_cmp_universes env pb s0 s1 (u, check) =
   (check.compare_sorts env pb s0 s1 u, check)
@@ -197,13 +194,22 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
-let fail_check (state, check) = match state with
-| Result.Ok state -> (state, check)
-| Result.Error ConvErrDefault -> raise NotConvertible
-| Result.Error (ConvErrUniverses err) -> raise (UGraph.UniverseInconsistency err)
+type 'e conv_tab = {
+  cnv_inf : clos_infos;
+  lft_tab : clos_tab;
+  rgt_tab : clos_tab;
+  err_ret : 'e -> payload;
+}
+(** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
+    location contained both in tl and in tr. *)
 
-let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
-  fail_check @@ (convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
+let fail_check (infos : 'err conv_tab) (state, check) = match state with
+| Result.Ok state -> (state, check)
+| Result.Error None -> raise NotConvertible
+| Result.Error (Some err) -> raise (NotConvertibleTrace (infos.err_ret err))
+
+let convert_inductives infos cv_pb ind nargs u1 u2 (s, check) =
+  fail_check infos @@ (convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
     cv_pb ind nargs u1 u2 s, check)
 
 let constructor_cumulativity_arguments (mind, ind, ctor) =
@@ -224,8 +230,8 @@ let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u
       let variance = Array.make (snd (UVars.Instance.length u1)) UVars.Variance.Irrelevant in
       cmp_cumul CONV variance u1 u2 s
 
-let convert_constructors ctor nargs u1 u2 (s, check) =
-  fail_check @@ (convert_constructors_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
+let convert_constructors infos ctor nargs u1 u2 (s, check) =
+  fail_check infos @@ (convert_constructors_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
     ctor nargs u1 u2 s, check)
 
 let conv_table_key infos ~nargs k1 k2 cuniv =
@@ -233,11 +239,11 @@ let conv_table_key infos ~nargs k1 k2 cuniv =
   match k1, k2 with
   | ConstKey (cst, u), ConstKey (cst', u') when Constant.CanOrd.equal cst cst' ->
     if UVars.Instance.equal u u' then cuniv
-    else if Int.equal nargs 1 && is_array_type (info_env infos) cst then cuniv
+    else if Int.equal nargs 1 && is_array_type (info_env infos.cnv_inf) cst then cuniv
     else
-      let flex = evaluable_constant cst (info_env infos)
-        && RedFlags.red_set (info_flags infos) (RedFlags.fCONST cst)
-      in fail_check @@ convert_instances ~flex u u' cuniv
+      let flex = evaluable_constant cst (info_env infos.cnv_inf)
+        && RedFlags.red_set (info_flags infos.cnv_inf) (RedFlags.fCONST cst)
+      in fail_check infos @@ convert_instances ~flex u u' cuniv
   | VarKey id, VarKey id' when Id.equal id id' -> cuniv
   | RelKey n, RelKey n' when Int.equal n n' -> cuniv
   | _ -> raise NotConvertible
@@ -246,14 +252,6 @@ let same_args_size sk1 sk2 =
   let n = CClosure.stack_args_size sk1 in
   if Int.equal n (CClosure.stack_args_size sk2) then n
   else raise NotConvertible
-
-type conv_tab = {
-  cnv_inf : clos_infos;
-  lft_tab : clos_tab;
-  rgt_tab : clos_tab;
-}
-(** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
-    location contained both in tl and in tr. *)
 
 (** The same heap separation invariant must hold for the fconstr arguments
     passed to each respective side of the conversion function below. *)
@@ -401,7 +399,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
                if not (is_empty_stack v1 && is_empty_stack v2) then
                  (* May happen because we convert application right to left *)
                  raise NotConvertible;
-              fail_check @@ sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
+              fail_check infos @@ sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
            | (Meta n, Meta m) ->
                if Int.equal n m
                then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
@@ -439,10 +437,10 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FFlex fl1, FFlex fl2) ->
       (try
          let nargs = same_args_size v1 v2 in
-         let cuniv = conv_table_key infos.cnv_inf ~nargs fl1 fl2 cuniv in
+         let cuniv = conv_table_key infos ~nargs fl1 fl2 cuniv in
          let () = if irr_flex infos.cnv_inf fl1 then raise NotConvertible (* trigger the fallback *) in
          convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
-       with NotConvertible | UGraph.UniverseInconsistency _ ->
+       with NotConvertible | NotConvertibleTrace _ ->
         let r1 = unfold_ref_with_args infos.cnv_inf infos.lft_tab fl1 v1 in
         let r2 = unfold_ref_with_args infos.cnv_inf infos.rgt_tab fl2 v2 in
         match r1, r2 with
@@ -612,12 +610,12 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FInd (ind1,u1 as pind1), FInd (ind2,u2 as pind2)) ->
       if Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = fail_check @@ convert_instances ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check infos @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
           let nargs = same_args_size v1 v2 in
-          match convert_inductives cv_pb (mind, snd ind1) nargs u1 u2 cuniv with
+          match convert_inductives infos cv_pb (mind, snd ind1) nargs u1 u2 cuniv with
           | cuniv -> convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
           | exception MustExpand ->
             let env = info_env infos.cnv_inf in
@@ -629,12 +627,12 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FConstruct ((ind1,j1),u1 as pctor1), FConstruct ((ind2,j2),u2 as pctor2)) ->
       if Int.equal j1 j2 && Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = fail_check @@ convert_instances ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check infos @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
           let nargs = same_args_size v1 v2 in
-          match convert_constructors (mind, snd ind1, j1) nargs u1 u2 cuniv with
+          match convert_constructors infos (mind, snd ind1, j1) nargs u1 u2 cuniv with
           | cuniv -> convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
           | exception MustExpand ->
             let env = info_env infos.cnv_inf in
@@ -718,7 +716,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let nargs = inductive_cumulativity_arguments ind in
         let u1 = CClosure.usubst_instance e1 u1 in
         let u2 = CClosure.usubst_instance e2 u2 in
-        convert_inductives CONV ind nargs u1 u2 cuniv
+        convert_inductives infos CONV ind nargs u1 u2 cuniv
       in
       let pms1 = mk_clos_vect e1 pms1 in
       let pms2 = mk_clos_vect e2 pms2 in
@@ -730,7 +728,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | FArray (u1,t1,ty1), FArray (u2,t2,ty2) ->
       let len = Parray.length_int t1 in
       if not (Int.equal len (Parray.length_int t2)) then raise NotConvertible;
-      let cuniv = fail_check @@ convert_instances_cumul CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
+      let cuniv = fail_check infos @@ convert_instances_cumul CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
       let el1 = el_stack lft1 v1 in
       let el2 = el_stack lft2 v2 in
       let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
@@ -797,7 +795,7 @@ and convert_stacks l2r infos lft1 lft2 stk1 stk2 cuniv =
                     | None -> convert_instances ~flex:false u1 u2 cu
                     | Some variances -> convert_instances_cumul CONV variances u1 u2 cu
                 in
-                let cu = fail_check cu in
+                let cu = fail_check infos cu in
                 let pms1 = mk_clos_vect e1 pms1 in
                 let pms2 = mk_clos_vect e2 pms2 in
                 let fold_params c1 c2 accu = f (l1, c1) (l2, c2) accu in
@@ -885,23 +883,30 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
   convert_list l2r infos lft1 lft2 v1 v2 cuniv
 | _, _ -> raise NotConvertible
 
-let clos_gen_conv trans cv_pb l2r evars env graph univs t1 t2 =
-  NewProfile.profile "Conversion" (fun () ->
+let clos_gen_conv (type err) trans cv_pb l2r evars env graph univs t1 t2 =
+  NewProfile.profile "Conversion" begin fun () ->
       let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
       let infos = create_conv_infos ~univs:graph ~evars reds env in
+      let module Error = struct type payload += Error of err end in
+      let box e = Error.Error e in
       let infos = {
         cnv_inf = infos;
         lft_tab = create_tab ();
         rgt_tab = create_tab ();
+        err_ret = box;
       } in
-      ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
-    ()
+      try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
+      with
+      | NotConvertible -> Result.Error None
+      | NotConvertibleTrace (Error.Error e) -> Result.Error (Some e)
+      | NotConvertibleTrace _ -> assert false
+  end ()
 
 let check_eq univs u u' =
-  if UGraph.check_eq_sort univs u u' then Result.Ok univs else Result.Error ConvErrDefault
+  if UGraph.check_eq_sort univs u u' then Result.Ok univs else Result.Error None
 
 let check_leq univs u u' =
-  if UGraph.check_leq_sort univs u u' then Result.Ok univs else Result.Error ConvErrDefault
+  if UGraph.check_leq_sort univs u u' then Result.Ok univs else Result.Error None
 
 let checked_sort_cmp_universes _env pb s0 s1 univs =
   match pb with
@@ -910,13 +915,13 @@ let checked_sort_cmp_universes _env pb s0 s1 univs =
 
 let check_convert_instances ~flex:_ u u' univs =
   if UGraph.check_eq_instances univs u u' then Result.Ok univs
-  else Result.Error ConvErrDefault
+  else Result.Error None
 
 (* general conversion and inference functions *)
 let check_inductive_instances cv_pb variance u1 u2 univs =
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
   if Sorts.QConstraints.trivial qcsts && (UGraph.check_constraints ucsts univs) then Result.Ok univs
-  else Result.Error ConvErrDefault
+  else Result.Error None
 
 let checked_universes =
   { compare_sorts = checked_sort_cmp_universes;
@@ -926,8 +931,9 @@ let checked_universes =
 let () =
   let conv infos tab a b =
     try
+      let box = Empty.abort in
       let univs = info_univs infos in
-      let infos = { cnv_inf = infos; lft_tab = tab; rgt_tab = tab; } in
+      let infos = { cnv_inf = infos; lft_tab = tab; rgt_tab = tab; err_ret = box } in
       let univs', _ = ccnv CONV false infos el_id el_id a b
           (univs, checked_universes)
       in
@@ -935,7 +941,7 @@ let () =
       true
     with
     | NotConvertible -> false
-    | UGraph.UniverseInconsistency _ -> assert false
+    | NotConvertibleTrace _ -> assert false
   in
   CClosure.set_conv conv
 
@@ -947,11 +953,9 @@ let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=defaul
   in
     if b then Result.Ok ()
     else match clos_gen_conv reds cv_pb l2r evars env univs (univs, checked_universes) t1 t2 with
-    | (_ : UGraph.t * UGraph.t universe_compare)-> Result.Ok ()
-    | exception NotConvertible -> Result.Error ()
-    | exception UGraph.UniverseInconsistency _ ->
-      (* checked_universes cannot raise this *)
-      assert false
+    | Result.Ok (_ : UGraph.t * (UGraph.t, Empty.t) universe_compare)-> Result.Ok ()
+    | Result.Error None -> Result.Error ()
+    | Result.Error (Some e) -> Empty.abort e
 
 let conv = gen_conv CONV
 let conv_leq = gen_conv CUMUL
@@ -959,9 +963,8 @@ let conv_leq = gen_conv CUMUL
 let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) univs t1 t2 =
   let graph = Environ.universes env in
   match clos_gen_conv reds cv_pb l2r evars env graph univs t1 t2 with
-  | (s, _) -> Result.Ok s
-  | exception NotConvertible -> Result.Error ConvErrDefault
-  | exception (UGraph.UniverseInconsistency err) -> Result.Error (ConvErrUniverses err)
+  | Result.Ok (s, _) -> Result.Ok s
+  | Result.Error e -> Result.Error e
 
 let default_conv cv_pb env t1 t2 =
     gen_conv cv_pb env t1 t2

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -14,8 +14,6 @@ open Environ
 (***********************************************************************
   s conversion functions *)
 
-exception NotConvertible
-
 type conversion_error =
 | ConvErrDefault
 | ConvErrUniverses of UGraph.univ_inconsistency

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -14,10 +14,6 @@ open Environ
 (***********************************************************************
   s conversion functions *)
 
-type conversion_error =
-| ConvErrDefault
-| ConvErrUniverses of UGraph.univ_inconsistency
-
 type 'a kernel_conversion_function = env -> 'a -> 'a -> (unit, unit) result
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
@@ -26,19 +22,16 @@ type 'a extended_conversion_function =
 
 type conv_pb = CONV | CUMUL
 
-type 'a universe_compare = {
-  (* Might raise NotConvertible *)
-  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, conversion_error) result;
-  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
+type ('a, 'err) universe_compare = {
+  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
+  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
   compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
-    UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, conversion_error) result;
+    UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
 }
 
-type 'a universe_state = 'a * 'a universe_compare
+type ('a, 'err) universe_state = 'a * ('a, 'err) universe_compare
 
-type 'a generic_conversion_function = 'a universe_state -> constr -> constr -> ('a, conversion_error) result
-
-type 'a infer_conversion_function = env -> 'a -> 'a -> (Univ.Constraints.t, conversion_error) result
+type ('a, 'err) generic_conversion_function = ('a, 'err) universe_state -> constr -> constr -> ('a, 'err option) result
 
 val get_cumulativity_constraints : conv_pb -> UVars.Variance.t array ->
   UVars.Instance.t -> UVars.Instance.t -> Sorts.QUConstraints.t
@@ -47,27 +40,26 @@ val inductive_cumulativity_arguments : (Declarations.mutual_inductive_body * int
 val constructor_cumulativity_arguments : (Declarations.mutual_inductive_body * int * int) -> int
 
 val sort_cmp_universes : env -> conv_pb -> Sorts.t -> Sorts.t ->
-  'a * 'a universe_compare -> ('a, conversion_error) result * 'a universe_compare
+  'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (* [flex] should be true for constants, false for inductive types and
 constructors. *)
 val convert_instances : flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
-  'a * 'a universe_compare -> ('a, conversion_error) result * 'a universe_compare
+  'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
-(** This function never returns an ConvErrUniverses error. *)
-val checked_universes : UGraph.t universe_compare
+(** This function never returns an non-empty error. *)
+val checked_universes : (UGraph.t, 'err) universe_compare
 
-(** These two functions can only fail with ConvErrDefault *)
+(** These two functions can only fail with unit *)
 val conv : constr extended_conversion_function
 
 val conv_leq : types extended_conversion_function
 
-(** Depending on the universe state functions, this might fail with
-  [ConvErrUniverses] in addition to [ConvErrDefault] (for better error
-  messages). *)
+(** The failure values depend on the universe state functions
+    (for better error messages). *)
 val generic_conv : conv_pb -> l2r:bool
   -> TransparentState.t -> env -> ?evars:CClosure.evar_handler
-  -> 'a generic_conversion_function
+  -> ('a, 'err) generic_conversion_function
 
 val default_conv     : conv_pb -> types kernel_conversion_function
 val default_conv_leq : types kernel_conversion_function

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -98,7 +98,7 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
           in
           begin match cst with
           | Result.Ok cst -> cst
-          | Result.Error Conversion.(ConvErrDefault | ConvErrUniverses _) ->
+          | Result.Error (None | Some _) ->
             error_incorrect_with_constraint lab
           end
         | Polymorphic uctx, Polymorphic ctx ->

--- a/kernel/mod_typing.mli
+++ b/kernel/mod_typing.mli
@@ -26,7 +26,7 @@ type 'a vm_state = 'a * 'a vm_handler
 *)
 
 val translate_module :
-  'a Conversion.universe_state ->
+  ('a, UGraph.univ_inconsistency) Conversion.universe_state ->
   'b vm_state ->
   env -> ModPath.t -> inline -> module_entry -> module_body * 'a * 'b
 
@@ -34,7 +34,7 @@ val translate_module :
     cannot be [None] (and of course [mod_expr] is [Abstract]). *)
 
 val translate_modtype :
-  'a Conversion.universe_state ->
+  ('a, UGraph.univ_inconsistency) Conversion.universe_state ->
   'b vm_state ->
   env -> ModPath.t -> inline -> module_type_entry -> module_type_body * 'a * 'b
 
@@ -42,7 +42,7 @@ val translate_modtype :
     an (optional) signature entry, produces a final [module_body] *)
 
 val finalize_module :
-  'a Conversion.universe_state ->
+  ('a, UGraph.univ_inconsistency) Conversion.universe_state ->
   'b vm_state ->
   env -> ModPath.t -> module_signature * delta_resolver ->
   (module_type_entry * inline) option ->
@@ -52,5 +52,5 @@ val finalize_module :
     module type given to an Include *)
 
 val translate_mse_include :
-  bool -> 'a Conversion.universe_state -> 'b vm_state -> Environ.env -> ModPath.t -> inline ->
+  bool -> ('a, UGraph.univ_inconsistency) Conversion.universe_state -> 'b vm_state -> Environ.env -> ModPath.t -> inline ->
   module_struct_entry -> module_signature * unit * delta_resolver * 'a * 'b

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -18,6 +18,8 @@ open Environ
 
 (** This module implements the conversion test by compiling to OCaml code *)
 
+exception NotConvertible
+
 let fail_check (state, check) = match state with
 | Result.Ok state -> (state, check)
 | Result.Error ConvErrDefault -> raise NotConvertible

--- a/kernel/nativeconv.mli
+++ b/kernel/nativeconv.mli
@@ -16,6 +16,6 @@ val native_conv : conv_pb -> Genlambda.evars -> types kernel_conversion_function
 
 (** A conversion function parametrized by a universe comparator. Used outside of
     the kernel. *)
-val native_conv_gen : conv_pb -> Genlambda.evars -> Environ.env -> 'a generic_conversion_function
+val native_conv_gen : conv_pb -> Genlambda.evars -> Environ.env -> ('a, 'err) generic_conversion_function
 
 val w_native_disabled : CWarnings.warning

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -85,16 +85,13 @@ let make_labmap mp list =
   CList.fold_right add_one list empty_labmap
 
 let check_conv_error error why state poly pb env a1 a2 =
-  try
-    if poly then
-      try
-        let () = Conversion.default_conv pb env a1 a2 in
-        fst state
-      with NotConvertible -> error (IncompatiblePolymorphism (env, a1, a2))
-    else
-      Conversion.generic_conv pb ~l2r:false TransparentState.full env state a1 a2
-  with NotConvertible -> error why
-     | UGraph.UniverseInconsistency e -> error (IncompatibleUniverses e)
+  if poly then match Conversion.default_conv pb env a1 a2 with
+  | Result.Ok () -> fst state
+  | Result.Error () ->  error (IncompatiblePolymorphism (env, a1, a2))
+  else match Conversion.generic_conv pb ~l2r:false TransparentState.full env state a1 a2 with
+  | Result.Ok state -> state
+  | Result.Error Conversion.ConvErrDefault -> error why
+  | Result.Error (Conversion.ConvErrUniverses e) -> error (IncompatibleUniverses e)
 
 let check_universes error env u1 u2 =
   match u1, u2 with

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -90,8 +90,8 @@ let check_conv_error error why state poly pb env a1 a2 =
   | Result.Error () ->  error (IncompatiblePolymorphism (env, a1, a2))
   else match Conversion.generic_conv pb ~l2r:false TransparentState.full env state a1 a2 with
   | Result.Ok state -> state
-  | Result.Error Conversion.ConvErrDefault -> error why
-  | Result.Error (Conversion.ConvErrUniverses e) -> error (IncompatibleUniverses e)
+  | Result.Error None -> error why
+  | Result.Error (Some e) -> error (IncompatibleUniverses e)
 
 let check_universes error env u1 u2 =
   match u1, u2 with

--- a/kernel/subtyping.mli
+++ b/kernel/subtyping.mli
@@ -11,4 +11,4 @@
 open Declarations
 open Environ
 
-val check_subtypes : 'a Conversion.universe_state -> env -> module_type_body -> module_type_body -> 'a
+val check_subtypes : ('a, UGraph.univ_inconsistency) Conversion.universe_state -> env -> module_type_body -> module_type_body -> 'a

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -25,6 +25,7 @@ open Type_errors
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
+exception NotConvertible
 exception NotConvertibleVect of int
 
 let conv_leq env x y = default_conv CUMUL env x y
@@ -745,7 +746,7 @@ let rec execute env cstr =
             let (ct', _) : constr * Sorts.t = execute_is_type env ct' in
             let () = match conv_leq env ct ct' with
             | Result.Ok () -> ()
-            | Result.Error () -> raise NotConvertible (* FIXME *)
+            | Result.Error () -> error_bad_invert env (* TODO: more informative message *)
             in
             let _, args' = decompose_app ct' in
             if args == args' then iv
@@ -919,7 +920,7 @@ let check_context env rels =
         let jty = infer_type env ty in
         let () = match conv_leq env j1.uj_type ty with
         | Result.Ok () -> ()
-        | Result.Error () -> raise NotConvertible (* FIXME *)
+        | Result.Error () -> error_actual_type env j1 ty
         in
         let x = check_let_annot env jty.utj_type x j1.uj_val jty.utj_val in
         push_rel d env, LocalDef (x,j1.uj_val,jty.utj_val) :: rels)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -8,6 +8,8 @@ open Vmsymtable
 
 (* Test la structure des piles *)
 
+exception NotConvertible
+
 let fail_check (state, check) = match state with
 | Result.Ok state -> (state, check)
 | Result.Error ConvErrDefault -> raise NotConvertible

--- a/kernel/vconv.mli
+++ b/kernel/vconv.mli
@@ -17,4 +17,4 @@ val vm_conv : conv_pb -> types kernel_conversion_function
 
 (** A conversion function parametrized by a universe comparator and
    evar normalizer. Used outside of the kernel. *)
-val vm_conv_gen : conv_pb -> Genlambda.evars -> Environ.env -> 'a generic_conversion_function
+val vm_conv_gen : conv_pb -> Genlambda.evars -> Environ.env -> ('a, 'err) generic_conversion_function

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -273,7 +273,7 @@ val native_infer_conv : ?pb:conv_pb -> env -> evar_map -> constr -> constr ->
 (** [infer_conv_gen] behaves like [infer_conv] but is parametrized by a
 conversion function. Used to pretype vm and native casts. *)
 val infer_conv_gen : (conv_pb -> l2r:bool -> evar_map -> TransparentState.t ->
-    Environ.env -> evar_map Conversion.generic_conversion_function) ->
+    Environ.env -> (evar_map, UGraph.univ_inconsistency) Conversion.generic_conversion_function) ->
   ?catch_incon:bool -> ?pb:conv_pb -> ?ts:TransparentState.t -> env ->
   evar_map -> constr -> constr -> evar_map option
 
@@ -306,7 +306,7 @@ val meta_instance : env -> evar_map -> constr freelisted -> constr
 exception AnomalyInConversion of exn
 
 (* inferred_universes just gathers the constraints. *)
-val inferred_universes : (UGraph.t * Univ.Constraints.t) Conversion.universe_compare
+val inferred_universes : (UGraph.t * Univ.Constraints.t, UGraph.univ_inconsistency) Conversion.universe_compare
 
 (** Deprecated *)
 

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -40,7 +40,7 @@ The command has indeed failed with message:
 In environment
 v := pto_punits (Number.UIntDecimal (Decimal.D1 Decimal.Nil)) : punit
 The term "v" has type "punit@{Set}" while it is expected to have type
- "punit@{u}".
+ "punit@{u}" (universe inconsistency: Cannot enforce Set = u).
 S
      : nat -> nat
 S (ack 4 4)


### PR DESCRIPTION
Instead of haphazardly raising exceptions on a unit type and hoping that somebody will eventually catch them, we make the kernel conversion function return a parameterized result type that additionally indicates the ways in which the function may fail.

As a a result, I found at least two bugs in Typeops where a stray NotConvertible exception could have reached toplevel without being caught when given ill-typed terms.

This should also alleviate the hassle of the upper layers where it's never clear which part of the code is supposed to handle the variouse universe failures in universe unification.

Overlays:
- https://github.com/smtcoq/smtcoq/pull/143
