### PR TITLE
[loadpath] Export pure version of `try_locate_absolute_library`

### DIFF
--- a/dev/ci/user-overlays/19124-ejgallego-export_locate_result.sh
+++ b/dev/ci/user-overlays/19124-ejgallego-export_locate_result.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/ejgallego/coq-tactician export_locate_result 19124

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -52,13 +52,14 @@ val locate_file : string -> string
     it does not respect the visibility of paths. *)
 
 (** {6 Locate a library in the load path } *)
-type locate_error = LibUnmappedDir | LibNotFound
-type 'a locate_result = ('a, locate_error) result
+module Error : sig
+  type t = LibUnmappedDir | LibNotFound
+end
 
 val locate_qualified_library
   :  ?root:DirPath.t
   -> Libnames.qualid
-  -> (DirPath.t * CUnix.physical_path) locate_result
+  -> (DirPath.t * CUnix.physical_path, Error.t) Result.t
 
 (** Locates a library by implicit name.
 
@@ -67,7 +68,10 @@ val locate_qualified_library
 
 *)
 
+val locate_absolute_library : DirPath.t -> (CUnix.physical_path, Error.t) Result.t
+
 val try_locate_absolute_library : DirPath.t -> string
+(* To do in another PR: [@@deprecated "use locate_absolute_library instead"] *)
 
 (** {6 Extending the Load Path } *)
 


### PR DESCRIPTION
This is from my coq-lsp share-require branch, and would be nice to have for the 8.20 version.

I'm happy to go ahead with the deprecation, but #17393 should go first. (edit, done, with more improvements, in #19135 )

Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/84