### PR TITLE
Slightly less crazy implementation of atom conversion in Firstorder

### DIFF
--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -37,6 +37,7 @@ type counter = bool -> metavariable
 
 type atom = { atom : constr }
 
+let hole_atom = { atom = mkMeta 1 }
 let repr_atom a = a.atom
 
 exception Is_atom of atom
@@ -212,7 +213,7 @@ type left_pattern=
   | Lor of pinductive
   | Lforall of metavariable*constr*bool
   | Lexists of pinductive
-  | LA of constr*left_arrow_pattern
+  | LA of atom*left_arrow_pattern
 
 type _ identifier =
 | GoalId : [ `Goal ] identifier
@@ -227,7 +228,7 @@ type _ pattern =
 
 type 'a t = {
   id : 'a identifier;
-  constr : constr;
+  constr : atom;
   pat : 'a pattern;
   atoms : atoms;
 }
@@ -274,7 +275,7 @@ let build_formula (type a) ~flags env sigma (side : a side) (nam : a identifier)
                   | Forall (d,_) ->
                       Lforall(m,d,trivial)
                   | Arrow (a,b) ->
-                      let nfa=normalize a in
+                      let nfa = { atom = normalize a } in
                         LA (nfa,
                             match kind_of_formula ~flags env sigma a with
                                 False(i,l)-> LLfalse(i,l)
@@ -287,7 +288,7 @@ let build_formula (type a) ~flags env sigma (side : a side) (nam : a identifier)
                 LeftPattern pat
       in
         Left {id=nam;
-              constr=normalize typ;
+              constr= { atom = normalize typ };
               pat=pattern;
               atoms=atoms}
     with Is_atom a-> Right a (* already in nf *)

--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -35,12 +35,61 @@ type ('a,'b) sum = Left of 'a | Right of 'b
 
 type counter = bool -> metavariable
 
-type atom = { atom : constr }
+module Env :
+sig
+type t
+type uid
+val empty : t
+val add : flags -> Environ.env -> Evd.evar_map -> EConstr.t -> t -> t * uid
+val find : uid -> t -> EConstr.t
+val repr : uid -> int
+val hole : uid
+end =
+struct
 
-let hole_atom = { atom = mkMeta 1 }
-let repr_atom a = a.atom
+module CM = Map.Make(Constr)
 
-exception Is_atom of atom
+type t = {
+  max_uid : int;
+  repr : int CM.t;
+  data : Constr.t Int.Map.t;
+}
+
+type uid = int
+
+let empty = {
+  max_uid = 1; (* uid 0 is reserved for Meta 1 *)
+  repr = CM.singleton (Constr.mkMeta 1) 0;
+  data = Int.Map.singleton 0 (Constr.mkMeta 1);
+}
+
+let hole = 0
+
+(* This is nonsense, but backwards compatibility mandates it *)
+let add flags env sigma c e =
+  let c = Reductionops.clos_norm_flags flags.reds env sigma c in
+  let c = EConstr.to_constr ~abort_on_undefined_evars:false sigma c in
+  match CM.find_opt c e.repr with
+  | Some i -> e, i
+  | None ->
+    let i = e.max_uid in
+    let e = {
+      max_uid = i + 1;
+      repr = CM.add c i e.repr;
+      data = Int.Map.add i c e.data;
+    } in
+    e, i
+
+let find id e = EConstr.of_constr (Int.Map.find id e.data)
+
+let repr id = id
+
+end
+
+type atom = { atom : Env.uid }
+let repr_atom state a = Env.find a.atom state
+let compare_atom a1 a2 =
+  Int.compare (Env.repr a1.atom) (Env.repr a2.atom)
 
 let meta_succ m = m+1
 
@@ -68,9 +117,6 @@ let ind_hyps env sigma nevar ind largs =
       fst (decompose_prod_decls sigma t2) in
     Array.map myhyps types
 
-let special_nf ~flags env sigma t =
-  Reductionops.clos_norm_flags flags.reds env sigma t
-
 let special_whd ~flags env sigma t =
   Reductionops.clos_whd_flags flags.reds env sigma t
 
@@ -81,12 +127,18 @@ type kind_of_formula=
   | Or of pinductive*constr list*bool
   | Exists of pinductive*constr list
   | Forall of constr*constr
-  | Atom of atom
+  | Atom of EConstr.t
 
 let pop t = Vars.lift (-1) t
 
+let fresh_atom ~flags state env sigma atm =
+  let st, uid = Env.add flags env sigma atm !state in
+  let () = state := st in
+  { atom = uid }
+
+let hole_atom = { atom = Env.hole }
+
 let kind_of_formula ~flags env sigma term =
-  let normalize = special_nf ~flags env sigma in
   let cciterm = special_whd ~flags env sigma term in
     match match_with_imp_term env sigma cciterm with
         Some (a,b)-> Arrow (a, pop b)
@@ -110,7 +162,7 @@ let kind_of_formula ~flags env sigma term =
                           if Inductiveops.mis_is_recursive (ind,mib,mip) ||
                             (has_realargs && not is_trivial)
                           then
-                            Atom { atom = cciterm }
+                            Atom cciterm
                           else
                             if Int.equal nconstr 1 then
                               And((ind,u),l,is_trivial)
@@ -122,7 +174,8 @@ let kind_of_formula ~flags env sigma term =
                           let (ind, u) = EConstr.destInd sigma i in
                           let u = EConstr.EInstance.kind sigma u in
                           Exists((ind, u), l)
-                      |_-> Atom { atom = normalize cciterm }
+                      |_->
+                        Atom cciterm
 
 type atoms = {positive:atom list;negative:atom list}
 
@@ -132,11 +185,10 @@ type _ side =
 
 let no_atoms = (false,{positive=[];negative=[]})
 
-let build_atoms (type a) ~flags env sigma metagen (side : a side) cciterm =
+let build_atoms (type a) ~flags state env sigma metagen (side : a side) cciterm =
   let trivial =ref false
   and positive=ref []
   and negative=ref [] in
-  let normalize=special_nf ~flags env sigma in
   let rec build_rec subst polarity cciterm=
     match kind_of_formula ~flags env sigma cciterm with
         False(_,_)->if not polarity then trivial:=true
@@ -146,7 +198,7 @@ let build_atoms (type a) ~flags env sigma metagen (side : a side) cciterm =
       | And(i,l,b) | Or(i,l,b)->
           if b then
             begin
-              let unsigned= { atom = normalize (substnl subst 0 cciterm) } in
+              let unsigned= fresh_atom ~flags state env sigma (substnl subst 0 cciterm) in
                 if polarity then
                   positive:= unsigned :: !positive
                 else
@@ -171,8 +223,8 @@ let build_atoms (type a) ~flags env sigma metagen (side : a side) cciterm =
           let var=mkMeta (metagen true) in
             build_rec (var::subst) polarity b
       | Atom t->
-          let unsigned= { atom = substnl subst 0 t.atom } in
-            if not (isMeta sigma unsigned.atom) then (* discarding wildcard atoms *)
+          let unsigned = fresh_atom ~flags state env sigma (substnl subst 0 t) in
+            if not (isMeta sigma (repr_atom !state unsigned)) then (* discarding wildcard atoms *)
               if polarity then
                 positive:= unsigned :: !positive
               else
@@ -235,13 +287,15 @@ type 'a t = {
 
 type any_formula = AnyFormula : 'a t -> any_formula
 
-let build_formula (type a) ~flags env sigma (side : a side) (nam : a identifier) typ metagen : (a t, atom) sum =
-  let normalize = special_nf ~flags env sigma in
+exception Is_atom of EConstr.t
+
+let build_formula (type a) ~flags state env sigma (side : a side) (nam : a identifier) typ metagen : Env.t * (a t, atom) sum =
     try
+      let state = ref state in
       let m=meta_succ(metagen false) in
       let trivial,atoms=
         if flags.qflag then
-          build_atoms ~flags env sigma metagen side typ
+          build_atoms ~flags state env sigma metagen side typ
         else no_atoms in
       let pattern : a pattern =
         match side with
@@ -264,18 +318,16 @@ let build_formula (type a) ~flags env sigma (side : a side) (nam : a identifier)
                     False(i,_)        ->  Lfalse
                   | Atom a       ->  raise (Is_atom a)
                   | And(i,_,b)         ->
-                      if b then
-                        let nftyp=normalize typ in raise (Is_atom { atom = nftyp })
+                      if b then raise (Is_atom typ)
                       else Land i
                   | Or(i,_,b)          ->
-                      if b then
-                        let nftyp=normalize typ in raise (Is_atom { atom = nftyp })
+                      if b then raise (Is_atom typ)
                       else Lor i
                   | Exists (ind,_) ->  Lexists ind
                   | Forall (d,_) ->
                       Lforall(m,d,trivial)
                   | Arrow (a,b) ->
-                      let nfa = { atom = normalize a } in
+                    let nfa = fresh_atom ~flags state env sigma a in
                         LA (nfa,
                             match kind_of_formula ~flags env sigma a with
                                 False(i,l)-> LLfalse(i,l)
@@ -287,9 +339,10 @@ let build_formula (type a) ~flags env sigma (side : a side) (nam : a identifier)
                               | Forall(_,_)->LLforall a) in
                 LeftPattern pat
       in
-        Left {id=nam;
-              constr= { atom = normalize typ };
-              pat=pattern;
-              atoms=atoms}
-    with Is_atom a-> Right a (* already in nf *)
+      let typ = fresh_atom ~flags state env sigma typ in
+      !state, Left { id = nam; constr = typ; pat = pattern; atoms = atoms}
+    with Is_atom a ->
+      let state = ref state in
+      let a = fresh_atom ~flags state env sigma a in
+      !state, Right a (* already in nf *)
 

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -32,10 +32,17 @@ val construct_nhyps : Environ.env -> pinductive -> int array
 val ind_hyps : Environ.env -> Evd.evar_map -> int -> pinductive ->
   constr list -> EConstr.rel_context array
 
+module Env :
+sig
+  type t
+  val empty : t
+end
+
 type atom
 
 val hole_atom : atom
-val repr_atom : atom -> EConstr.t
+val repr_atom : Env.t -> atom -> EConstr.t
+val compare_atom : atom -> atom -> int
 
 type atoms = { positive:atom list; negative:atom list }
 
@@ -87,5 +94,5 @@ type 'a t = private {
 
 type any_formula = AnyFormula : 'a t -> any_formula
 
-val build_formula : flags:flags -> Environ.env -> Evd.evar_map -> 'a side -> 'a identifier -> types ->
-  counter -> ('a t, atom) sum
+val build_formula : flags:flags -> Env.t -> Environ.env -> Evd.evar_map -> 'a side -> 'a identifier -> types ->
+  counter -> Env.t * ('a t, atom) sum

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -34,6 +34,7 @@ val ind_hyps : Environ.env -> Evd.evar_map -> int -> pinductive ->
 
 type atom
 
+val hole_atom : atom
 val repr_atom : atom -> EConstr.t
 
 type atoms = { positive:atom list; negative:atom list }
@@ -65,7 +66,7 @@ type left_pattern=
   | Lor of pinductive
   | Lforall of metavariable*constr*bool
   | Lexists of pinductive
-  | LA of constr*left_arrow_pattern
+  | LA of atom*left_arrow_pattern
 
 type _ identifier = private
 | GoalId : [ `Goal ] identifier
@@ -80,7 +81,7 @@ type _ pattern =
 
 type 'a t = private {
         id: 'a identifier;
-        constr: constr;
+        constr: atom;
         pat: 'a pattern;
         atoms: atoms}
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -59,7 +59,7 @@ let do_sequent env sigma setref triv id seq i dom atoms=
   let phref=ref triv in
   let do_atoms a1 a2 =
     let do_pair t1 t2 =
-      match unif_atoms env sigma i dom t1 t2 with
+      match unif_atoms (Sequent.state seq) env sigma i dom t1 t2 with
           None->()
         | Some (Phantom _) ->phref:=true
         | Some c ->flag:=false;setref:=IS.add (c,id) !setref in

--- a/plugins/firstorder/rules.mli
+++ b/plugins/firstorder/rules.mli
@@ -26,7 +26,7 @@ val clear_global: GlobRef.t -> tactic
 
 val axiom_tac : Sequent.t -> tactic
 
-val ll_atom_tac : flags:Formula.flags -> constr -> lseqtac with_backtracking
+val ll_atom_tac : flags:Formula.flags -> Formula.atom -> lseqtac with_backtracking
 
 val and_tac : flags:Formula.flags -> seqtac with_backtracking
 

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -34,7 +34,7 @@ val add_formula : flags:flags -> hint:bool -> Environ.env -> Evd.evar_map -> Glo
 
 val re_add_formula_list : Evd.evar_map -> Formula.any_formula list -> t -> t
 
-val find_left : Evd.evar_map -> constr -> t -> GlobRef.t
+val find_left : Evd.evar_map -> atom -> t -> GlobRef.t
 
 val find_goal : Evd.evar_map -> t -> GlobRef.t
 

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -47,3 +47,5 @@ val extend_with_ref_list : flags:flags -> Environ.env -> Evd.evar_map -> GlobRef
 
 val extend_with_auto_hints : flags:flags -> Environ.env -> Evd.evar_map -> Hints.hint_db_name list ->
   t -> t * Evd.evar_map
+
+val state : t -> Env.t

--- a/plugins/firstorder/unify.ml
+++ b/plugins/firstorder/unify.ml
@@ -141,10 +141,10 @@ let mk_rel_inst evd t=
   in
   let nt=renum_rec 0 t in (!new_rel - 1,nt)
 
-let unif_atoms env evd i dom t1 t2 =
+let unif_atoms state env evd i dom t1 t2 =
   try
-    let t1 = Formula.repr_atom t1 in
-    let t=Int.List.assoc i (unif env evd t1 (Formula.repr_atom t2)) in
+    let t1 = Formula.repr_atom state t1 in
+    let t=Int.List.assoc i (unif env evd t1 (Formula.repr_atom state t2)) in
       if isMeta evd t then Some (Phantom dom)
       else Some (Real(mk_rel_inst evd t,value evd i t1))
   with

--- a/plugins/firstorder/unify.mli
+++ b/plugins/firstorder/unify.mli
@@ -25,6 +25,6 @@ type instance=
     Real of Item.t * int (* terme * valeur heuristique *)
   | Phantom of constr        (* domaine de quantification *)
 
-val unif_atoms : Environ.env -> Evd.evar_map -> metavariable -> constr -> Formula.atom -> Formula.atom -> instance option
+val unif_atoms : Formula.Env.t -> Environ.env -> Evd.evar_map -> metavariable -> constr -> Formula.atom -> Formula.atom -> instance option
 
 val more_general : Environ.env -> Evd.evar_map -> Item.t -> Item.t -> bool


### PR DESCRIPTION
The reification code of the firstorder tactic is completely bonkers, as it strongly normalizes (including δ!) all subterms appearing in a goal or hypothesis. We make it a tad less crazy by at least introducing an indirection so that normalized terms are only compared w.r.t. a unique identifier afterwards.

This should help in metacoq.