### PR TITLE
Deprecate the gintuition tactic.

### DIFF
--- a/doc/changelog/04-tactics/19129-deprecate-gintuition.rst
+++ b/doc/changelog/04-tactics/19129-deprecate-gintuition.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  the :tacn:`gintuition` tactic, which used to be undocumented
+  until Coq 8.16
+  (`#19129 <https://github.com/coq/coq/pull/19129>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -148,6 +148,8 @@ Solvers for logic and equality
 
    .. tacn:: gintuition {? @ltac_expr }
 
+      .. deprecated:: 8.20
+
       An extension of :tacn:`intuition` to first-order reasoning
       (similar to how :tacn:`firstorder` extends :tacn:`tauto`).
 

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -129,7 +129,7 @@ TACTIC EXTEND firstorder
       { gen_ground_tac true (Option.map (tactic_of_value ist) t) l l' }
 END
 
-TACTIC EXTEND gintuition
+TACTIC EXTEND gintuition DEPRECATED { Deprecation.make ~since:"8.20" () }
 | [ "gintuition" tactic_opt(t) ] ->
      { gen_ground_tac false (Option.map (tactic_of_value ist) t) [] [] }
 END


### PR DESCRIPTION
It used to be a hidden tactic, that was only documented after #15265 in Coq 8.16. It is neither used in the test-suite nor in the CI, so it is a perfect candidate for quick removal.
