### PR TITLE
Merge PR #18906: [lib] Try to handle critical exceptions from memprof.

### DIFF
--- a/coq-core.opam
+++ b/coq-core.opam
@@ -34,7 +34,7 @@ depends: [
   "conf-linux-libc-dev" {os = "linux"}
   "odoc" {with-doc}
 ]
-depopts: ["coq-native"]
+depopts: ["coq-native" "memprof-limits"]
 dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   (ocamlfind (>= 1.8.1))
   (zarith (>= 1.11))
   (conf-linux-libc-dev (= :os "linux")))
- (depopts coq-native)
+ (depopts coq-native memprof-limits)
  (synopsis "The Coq Proof Assistant -- Core Binaries and Tools")
  (description "Coq is a formal proof management system. It provides
 a formal language to write mathematical definitions, executable

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -155,5 +155,5 @@ let noncritical = function
   | Assert_failure _ | Match_failure _ | Anomaly _
   | Control.Timeout -> false
   | Invalid_argument "equal: functional value" -> false
-  | _ -> true
+  | _ -> not (Interrupted.is_interrupted ())
 [@@@ocaml.warning "+52"]

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -64,11 +64,29 @@ val iprint : Exninfo.iexn -> Pp.t
 val print_no_report : exn -> Pp.t
 val iprint_no_report : Exninfo.iexn -> Pp.t
 
-(** Critical exceptions should not be caught and ignored by mistake
-    by inner functions during a [vernacinterp]. They should be handled
-    only in [Toplevel.do_vernac] (or Ideslave), to be displayed to the user.
-    Typical example: [Sys.Break], [Assert_failure], [Anomaly] ...
-*)
+(** "Critical" exceptions, such as anomalies or interruptions should
+    not be caught and ignored by mistake by inner Coq functions by
+    means of doing a "catch-all". They should be handled instead by
+    the compiler layer which is in charge of coordinating the
+    intepretation of Coq vernaculars.
+
+    Please, avoid exceptions catch-all! If you must do so, then use the form:
+    {[
+    try my_comp ()
+    with exn when noncritical exn ->
+      my_handler
+    ]}
+
+    If you need to re-raise the excepction, you must work to preserve
+    the backtrace and other important information:
+    {[
+    try my_comp ()
+    with exn when noncritical exn ->
+      let iexn = Exninfo.capture exn in
+      ...
+      Exninfo.iraise iexn
+    ]}
+ *)
 val noncritical : exn -> bool
 
 (** Register a printer for errors carrying additional information on

--- a/lib/dune
+++ b/lib/dune
@@ -6,6 +6,9 @@
  (modules_without_implementation xml_datatype)
  (libraries
   coq-core.boot coq-core.clib coq-core.config
+  (select interrupted.ml from
+   (!memprof-limits -> interrupted.std.ml)
+   (memprof-limits -> interrupted.memprof.ml))
   (select instr.ml from
    (!coqperf -> instr.noperf.ml)
    (coqperf -> instr.perf.ml))))

--- a/lib/interrupted.memprof.ml
+++ b/lib/interrupted.memprof.ml
@@ -1,0 +1,1 @@
+let is_interrupted () = Memprof_limits.is_interrupted () [@@inline]

--- a/lib/interrupted.mli
+++ b/lib/interrupted.mli
@@ -1,0 +1,1 @@
+val is_interrupted : unit -> bool

--- a/lib/interrupted.std.ml
+++ b/lib/interrupted.std.ml
@@ -1,0 +1,1 @@
+let is_interrupted _ = false [@@inline]


### PR DESCRIPTION
Backport of #18906 for 8.19.2

This enables users (of coq-lsp, Flèche, `petanque`) to use 8.19 with memprof limits, which is highly desirable.

Should have no effect on regular Coq.
