### PR TITLE
[library] Make error handling explicit when locating libraries

### DIFF
--- a/dev/ci/user-overlays/19135-ejgallego-intern_error_handling.sh
+++ b/dev/ci/user-overlays/19135-ejgallego-intern_error_handling.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/ejgallego/coq-lsp error_intern 19135

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -261,7 +261,7 @@ let vm_seg : seg_vm ObjFile.id = Vmlibrary.vm_segment
 
 module Intern = struct
   module Error = struct
-    type t = string
+    type t = Pp.t
   end
   module Provenance = struct
     type t = string * string
@@ -281,7 +281,13 @@ let intern_from_file file =
   System.check_caml_version ~caml:lsd.md_ocaml ~file;
   register_library_filename lsd.md_name file;
   Library_info.warn_library_info ~transitive:true lsd.md_name lsd.md_info;
-  mk_intern_library lsd lmd digest_lmd del_opaque vmlib
+  mk_intern_library lsd lmd digest_lmd del_opaque vmlib, ("file", file)
+
+let intern_from_file file =
+  match CErrors.to_result ~f:intern_from_file file with
+  | Ok res -> Ok res
+  | Error iexn ->
+    Error (CErrors.iprint iexn)
 
 let check_library_expected_name ~provenance dir library_name =
   if not (DirPath.equal dir library_name) then
@@ -291,7 +297,8 @@ let check_library_expected_name ~provenance dir library_name =
        DirPath.print library_name ++ spc () ++ str "and not library" ++
        spc() ++ DirPath.print dir ++ str ".")
 
-let error_in_intern err = CErrors.user_err Pp.(str "Error when parsing .vo file: " ++ str err)
+let error_in_intern dir err = CErrors.user_err
+    Pp.(str "Error when parsing .vo file for library " ++ Names.DirPath.print dir ++ str ": " ++ err)
 
 (* Returns the digest of a library, checks both caches to see what is loaded *)
 let rec intern_library ~root ~intern (needed, contents as acc) dir =
@@ -310,7 +317,7 @@ let rec intern_library ~root ~intern (needed, contents as acc) dir =
         check_library_expected_name ~provenance dir m.library_name;
         mk_summary m, intern_library_deps ~root ~intern acc dir m
       | Error error ->
-        error_in_intern error
+        error_in_intern dir error
 
 and intern_library_deps ~root ~intern libs dir m =
   let needed, contents =

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -265,11 +265,8 @@ module Intern = struct
     (** A pair of [kind, object], for example ["file",
         "/usr/local/foo.vo"], used for error messages. *)
   end
-  module Error = struct
-    type t = exn
-  end
 
-  type t = DirPath.t -> (library_t, Error.t) Result.t * Provenance.t
+  type t = DirPath.t -> (library_t, exn) Result.t * Provenance.t
 end
 
 let intern_from_file file =

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -30,12 +30,16 @@ val intern_from_file :
   CUnix.physical_path -> library_t
 
 module Intern : sig
+  module Error : sig
+    type t = string
+  end
+
   module Provenance : sig
     type t = string * string
     (** A pair of [kind, object], for example ["file",
         "/usr/local/foo.vo"], used for error messages. *)
   end
-  type t = DirPath.t -> library_t * Provenance.t
+  type t = DirPath.t -> (library_t * Provenance.t, Error.t) Result.t
 end
 
 val require_library_syntax_from_dirpath

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -27,20 +27,21 @@ val require_library_from_dirpath : library_t list -> unit
 
 (** Intern from a .vo file located by libresolver *)
 module Intern : sig
-  module Error : sig
-    type t = Pp.t
-  end
-
   module Provenance : sig
     type t = string * string
     (** A pair of [kind, object], for example ["file",
         "/usr/local/foo.vo"], used for error messages. *)
   end
-  type t = DirPath.t -> (library_t * Provenance.t, Error.t) Result.t
+
+  module Error : sig
+    type t = Pp.t
+  end
+
+  type t = DirPath.t -> (library_t, Error.t) Result.t * Provenance.t
 end
 
 val intern_from_file : CUnix.physical_path ->
-  (library_t * Intern.Provenance.t, Intern.Error.t) Result.t
+  (library_t, Intern.Error.t) Result.t * Intern.Provenance.t
 
 val require_library_syntax_from_dirpath
   :  intern:Intern.t

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -34,7 +34,7 @@ module Intern : sig
   end
 
   module Error : sig
-    type t = Pp.t
+    type t = exn
   end
 
   type t = DirPath.t -> (library_t, Error.t) Result.t * Provenance.t

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -33,15 +33,11 @@ module Intern : sig
         "/usr/local/foo.vo"], used for error messages. *)
   end
 
-  module Error : sig
-    type t = exn
-  end
-
-  type t = DirPath.t -> (library_t, Error.t) Result.t * Provenance.t
+  type t = DirPath.t -> (library_t, exn) Result.t * Provenance.t
 end
 
 val intern_from_file : CUnix.physical_path ->
-  (library_t, Intern.Error.t) Result.t * Intern.Provenance.t
+  (library_t, exn) Result.t * Intern.Provenance.t
 
 val require_library_syntax_from_dirpath
   :  intern:Intern.t

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -26,12 +26,9 @@ type library_t
 val require_library_from_dirpath : library_t list -> unit
 
 (** Intern from a .vo file located by libresolver *)
-val intern_from_file :
-  CUnix.physical_path -> library_t
-
 module Intern : sig
   module Error : sig
-    type t = string
+    type t = Pp.t
   end
 
   module Provenance : sig
@@ -41,6 +38,9 @@ module Intern : sig
   end
   type t = DirPath.t -> (library_t * Provenance.t, Error.t) Result.t
 end
+
+val intern_from_file : CUnix.physical_path ->
+  (library_t * Intern.Provenance.t, Intern.Error.t) Result.t
 
 val require_library_syntax_from_dirpath
   :  intern:Intern.t

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -33,11 +33,11 @@ module Intern : sig
         "/usr/local/foo.vo"], used for error messages. *)
   end
 
-  type t = DirPath.t -> (library_t, exn) Result.t * Provenance.t
+  type t = DirPath.t -> (library_t, Exninfo.iexn) Result.t * Provenance.t
 end
 
 val intern_from_file : CUnix.physical_path ->
-  (library_t, exn) Result.t * Intern.Provenance.t
+  (library_t, Exninfo.iexn) Result.t * Intern.Provenance.t
 
 val require_library_syntax_from_dirpath
   :  intern:Intern.t

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -252,28 +252,6 @@ let locate_qualified_library ?root qid :
       Ok (library, file)
     | Error _ as e -> e
 
-let error_unmapped_dir qid =
-  let prefix, _ = Libnames.repr_qualid qid in
-  CErrors.user_err
-    Pp.(seq [ str "Cannot load "; Libnames.pr_qualid qid; str ":"; spc ()
-            ; str "no physical path bound to"; spc ()
-            ; DP.print prefix; fnl ()
-            ])
-
-let error_lib_not_found qid =
-  let vos = !Flags.load_vos_libraries in
-  let vos_msg = if vos then [Pp.str " (while searching for a .vos file)"] else [] in
-  CErrors.user_err
-    Pp.(seq ([ str "Cannot find library "; Libnames.pr_qualid qid; str" in loadpath"]@vos_msg))
-
-let try_locate_absolute_library dir =
-  match locate_absolute_library dir with
-  | Ok res -> res
-  | Error LibUnmappedDir ->
-    error_unmapped_dir (Libnames.qualid_of_dirpath dir)
-  | Error LibNotFound ->
-    error_lib_not_found (Libnames.qualid_of_dirpath dir)
-
 (** { 5 Extending the load path } *)
 
 type vo_path =

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -178,6 +178,26 @@ let locate_file fname =
 
 module Error = struct
   type t = LibUnmappedDir | LibNotFound
+
+  let unmapped_dir qid =
+    let prefix, _ = Libnames.repr_qualid qid in
+    CErrors.user_err
+      Pp.(seq [ str "Cannot load "; Libnames.pr_qualid qid; str ":"; spc ()
+              ; str "no physical path bound to"; spc ()
+              ; Names.DirPath.print prefix; fnl ()
+              ])
+
+  let lib_not_found dir =
+    let vos = !Flags.load_vos_libraries in
+    let vos_msg = if vos then [Pp.str " (while searching for a .vos file)"] else [] in
+    CErrors.user_err
+      Pp.(seq ([ str "Cannot find library "; Names.DirPath.print dir; str" in loadpath"]@vos_msg))
+
+  let raise dp = function
+    | LibUnmappedDir ->
+      unmapped_dir (Libnames.qualid_of_dirpath dp)
+    | LibNotFound ->
+      lib_not_found dp
 end
 
 (* If [!Flags.load_vos_libraries]

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -63,15 +63,11 @@ val locate_qualified_library
 
 (** Locates a library by implicit name.
 
-  @raise LibUnmappedDir if the library is not in the path
-  @raise LibNotFound if there is no corresponding file in the path
+  @return LibUnmappedDir if the library is not in the path
+  @return LibNotFound if there is no corresponding file in the path
 
 *)
-
 val locate_absolute_library : DirPath.t -> (CUnix.physical_path, Error.t) Result.t
-
-val try_locate_absolute_library : DirPath.t -> string
-(* To do in another PR: [@@deprecated "use locate_absolute_library instead"] *)
 
 (** {6 Extending the Load Path } *)
 

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -54,6 +54,12 @@ val locate_file : string -> string
 (** {6 Locate a library in the load path } *)
 module Error : sig
   type t = LibUnmappedDir | LibNotFound
+
+  (** Raise regular Coq errors with default informative message;
+      usually document managers that have more information about the
+      workspace than coqc will override this with a better
+      mechanism / message. *)
+  val raise : DirPath.t -> t -> 'a
 end
 
 val locate_qualified_library

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -235,9 +235,10 @@ module Intern = struct
     match Loadpath.locate_absolute_library dp with
     | Ok file ->
       Feedback.feedback @@ Feedback.FileDependency (Some file, Names.DirPath.to_string dp);
-      let res = Library.intern_from_file file, ("file", file) in
-      Feedback.feedback @@ Feedback.FileLoaded (Names.DirPath.to_string dp, file);
-      Ok res
+      let res = Library.intern_from_file file in
+      Result.iter (fun _ ->
+          Feedback.feedback @@ Feedback.FileLoaded (Names.DirPath.to_string dp, file)) res;
+      res
     | Error Loadpath.Error.LibNotFound ->
       error_lib_not_found dp
     | Error Loadpath.Error.LibUnmappedDir ->

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -235,10 +235,10 @@ module Intern = struct
     match Loadpath.locate_absolute_library dp with
     | Ok file ->
       Feedback.feedback @@ Feedback.FileDependency (Some file, Names.DirPath.to_string dp);
-      let res = Library.intern_from_file file in
+      let res, provenance = Library.intern_from_file file in
       Result.iter (fun _ ->
           Feedback.feedback @@ Feedback.FileLoaded (Names.DirPath.to_string dp, file)) res;
-      res
+      res, provenance
     | Error Loadpath.Error.LibNotFound ->
       error_lib_not_found dp
     | Error Loadpath.Error.LibUnmappedDir ->


### PR DESCRIPTION
It is still a bit open when to check for errors, for now this is just
a proposal, which allows internalization functions to raise errors.

It would be good to think what other errors we'd like to capture in
the type, certainly at least `Invalid_file` for wrong .vo files would
be great to have in the type.

@SkySkimmer @ppedrot @herbelin , in the next commit is an attempt to improve some error messages that are more now bad.

Overlays:
- coq-lsp: https://github.com/ejgallego/coq-lsp/pull/752