### PR TITLE
Fix mislocated tooltips when UTF-8 characters are present (workaround lablgtk bug)

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -718,6 +718,14 @@ Tactics
   fixes `#18942 <https://github.com/coq/coq/issues/18942>`_,
   by Gaëtan Gilbert).
 
+CoqIDE
+^^^^^^
+
+- **Fixed:**
+  Position error/warning tooltips correctly when multibyte UTF-8 characters are present
+  (`#19137 <https://github.com/coq/coq/pull/19137>`_,
+  fixes `#19136 <https://github.com/coq/coq/issues/19136>`_,
+  by Jim Fehrle).
 
 Version 8.18
 ------------

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -161,8 +161,8 @@ open SentenceId
 (* Given a Coq loc, convert it to a pair of iterators start / end in
    the buffer. *)
 let coq_loc_to_gtk_offset ?(line_drift=0) (buffer : GText.buffer) loc =
-  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb - 1 + line_drift) (loc.bp - loc.bol_pos),
-  buffer#get_iter_at_byte ~line:(loc.Loc.line_nb_last - 1 + line_drift) (loc.ep - loc.bol_pos_last)
+  Ideutils.get_iter_at_byte buffer ~line:(loc.Loc.line_nb - 1 + line_drift) (loc.bp - loc.bol_pos),
+  Ideutils.get_iter_at_byte buffer ~line:(loc.Loc.line_nb_last - 1 + line_drift) (loc.ep - loc.bol_pos_last)
 
 (** increase [uni_off] by the number of bytes until [s_uni] This can
     be used to convert a character offset to byte offset if we know a

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -686,8 +686,8 @@ let next_error sn =
     let file,line,start,stop,error_msg = search_next_error () in
     FileAux.load_file file;
     let b = sn.buffer in
-    let starti = b#get_iter_at_byte ~line:(line-1) start in
-    let stopi = b#get_iter_at_byte ~line:(line-1) stop in
+    let starti = Ideutils.get_iter_at_byte b ~line:(line-1) start in
+    let stopi = Ideutils.get_iter_at_byte b ~line:(line-1) stop in
     b#apply_tag Tags.Script.error ~start:starti ~stop:stopi;
     b#place_cursor ~where:starti;
     sn.messages#default_route#set (Pp.str error_msg);

--- a/ide/coqide/ideutils.ml
+++ b/ide/coqide/ideutils.ml
@@ -174,6 +174,19 @@ let ulen uni_ch =
   else if uni_ch < 0x10000 then 3
   else 4
 
+(* workaround for lablgtk bug up to version 3.1.4 *)
+(* replaces: buffer#get_iter_at_byte ~line index *)
+(* see https://github.com/garrigue/lablgtk/pull/181 *)
+let get_iter_at_byte buffer ~line index =
+  let iter = buffer#get_iter_at_byte ~line 0 in
+  let rec adjust iter cnt =
+    if cnt <= 0 then
+      iter
+    else
+      adjust (iter#forward_char) (cnt - (ulen iter#char))
+  in
+  adjust iter index
+
 (** convert UTF-8 byte offset (used by Coq) to unicode offset (used by GTK buffer) *)
 let byte_off_to_buffer_off buffer byte_off =
   let rec cvt iter cnt =

--- a/ide/coqide/ideutils.mli
+++ b/ide/coqide/ideutils.mli
@@ -19,6 +19,7 @@ val browse_keyword : (string -> unit) -> string -> unit
 val byte_offset_to_char_offset : string -> int -> int
 val byte_off_to_buffer_off : GText.buffer -> int -> int
 val buffer_off_to_byte_off : GText.buffer -> int -> int
+val get_iter_at_byte : GText.buffer -> line:int -> int -> GText.iter
 
 val ulen : int -> int
 


### PR DESCRIPTION
Fixes / closes #19136

This is a partial backport of #19040.

- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
