### PR TITLE
Remove "principal" component of Evd.FutureGoal

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -416,7 +416,7 @@ let next_evar_name sigma naming = match naming with
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
 let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
-    ?principal ?hypnaming env evd typ =
+    ?hypnaming env evd typ =
   let name = next_evar_name evd naming in
   let hypnaming = match hypnaming with
   | Some n -> n
@@ -434,13 +434,13 @@ let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = 
   | None -> ERelevance.relevant (* FIXME: relevant_of_type not defined yet *)
   in
   let (evd, evk) = new_pure_evar sign evd typ' ?src ?filter ~relevance ?abstract_arguments ?candidates ?name
-    ?typeclass_candidate ?principal in
+    ?typeclass_candidate in
   (evd, EConstr.mkEvar (evk, instance))
 
-let new_type_evar ?src ?filter ?naming ?principal ?hypnaming env evd rigid =
+let new_type_evar ?src ?filter ?naming ?hypnaming env evd rigid =
   let (evd', s) = new_sort_variable rigid evd in
   let relevance = EConstr.ESorts.relevance_of_sort s in
-  let (evd', e) = new_evar env evd' ?src ?filter ~relevance ?naming ~typeclass_candidate:false ?principal ?hypnaming (EConstr.mkSort s) in
+  let (evd', e) = new_evar env evd' ?src ?filter ~relevance ?naming ~typeclass_candidate:false ?hypnaming (EConstr.mkSort s) in
   evd', (e, s)
 
 let new_Type ?(rigid=Evd.univ_flexible) evd =

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -45,7 +45,7 @@ val new_evar :
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
-  ?principal:bool -> ?hypnaming:naming_mode ->
+  ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
 (** Alias of {!Evd.new_pure_evar} *)
@@ -55,7 +55,6 @@ val new_pure_evar :
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?name:Id.t ->
   ?typeclass_candidate:bool ->
-  ?principal:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t
 
 (** Create a new Type existential variable, as we keep track of
@@ -63,7 +62,7 @@ val new_pure_evar :
 val new_type_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?naming:intro_pattern_naming_expr ->
-  ?principal:bool -> ?hypnaming:naming_mode ->
+  ?hypnaming:naming_mode ->
   env -> evar_map -> rigid ->
   evar_map * (constr * ESorts.t)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -193,13 +193,11 @@ val new_pure_evar :
   ?abstract_arguments:Abstraction.t -> ?candidates:econstr list ->
   ?name:Id.t ->
   ?typeclass_candidate:bool ->
-  ?principal:bool ->
   named_context_val -> evar_map -> etypes -> evar_map * Evar.t
 (** Low-level interface to create an evar.
   @param src User-facing source for the evar
   @param filter See {!Evd.Filter}, must be the same length as [named_context_val]
   @param name A name for the evar
-  @param principal Whether the evar is the principal goal
   @param named_context_val The context of the evar
   @param types The type of conclusion of the evar
 *)
@@ -344,6 +342,7 @@ val max_undefined_with_candidates : evar_map -> Evar.t option
 
 val set_typeclass_evars : evar_map -> Evar.Set.t -> evar_map
 (** Mark the given set of evars as available for resolution.
+    (The previous marked set is replaced, not added to.)
 
     Precondition: they should indeed refer to undefined typeclass evars.
  *)
@@ -411,21 +410,11 @@ val declare_future_goal : Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals. For
     internal uses only. *)
 
-val declare_principal_goal : Evar.t -> evar_map -> evar_map
-(** Adds an existential variable to the list of future goals and make
-    it principal. Only one existential variable can be made principal, an
-    error is raised otherwise. For internal uses only. *)
-
 module FutureGoals : sig
 
   type t
 
   val comb : t -> Evar.t list
-
-  val principal : t -> Evar.t option
-  (** if [Some e], [e] must be contained in [future_comb]. The evar [e] will
-      inherit properties (now: the name) of the evar which will be instantiated
-      with a term containing [e]. *)
 
   val map_filter : (Evar.t -> Evar.t option) -> t -> t
   (** Applies a function on the future goals *)

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1125,7 +1125,7 @@ let () =
 (** (unit -> constr) -> unit *)
 let () =
   define "refine" (closure @-> tac unit) @@ fun c ->
-  let c = thaw c >>= fun c -> Proofview.tclUNIT ((), Tac2ffi.to_constr c) in
+  let c = thaw c >>= fun c -> Proofview.tclUNIT ((), Tac2ffi.to_constr c, None) in
   Proofview.Goal.enter @@ fun gl ->
   Refine.generic_refine ~typecheck:true c gl
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1898,8 +1898,9 @@ let clear_all_no_check =
         Environ.reset_with_named_context Environ.empty_named_context_val
           (Tacmach.pf_env gl)
       in
-      Refine.refine ~typecheck:false (fun sigma ->
-          Evarutil.new_evar env sigma ~principal:true concl))
+      Refine.refine_with_principal ~typecheck:false (fun sigma ->
+          let sigma, ev = Evarutil.new_evar env sigma concl in
+          sigma, ev, Some (fst (EConstr.destEvar sigma ev))))
 
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Proofview.Goal.enter (fun gl ->

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1165,14 +1165,14 @@ let tacTYPEOF c = Goal.enter_one ~__LOC__ (fun g ->
     does not check anything. *)
 let unsafe_intro env decl b =
   let open Context.Named.Declaration in
-  Refine.refine ~typecheck:false begin fun sigma ->
+  Refine.refine_with_principal ~typecheck:false begin fun sigma ->
     let ctx = Environ.named_context_val env in
     let nctx = EConstr.push_named_context_val decl ctx in
     let inst = EConstr.identity_subst_val (Environ.named_context_val env) in
     let ninst = SList.cons (EConstr.mkRel 1) inst in
     let nb = EConstr.Vars.subst1 (EConstr.mkVar (get_id decl)) b in
-    let sigma, ev = Evarutil.new_pure_evar ~principal:true nctx sigma nb in
-    sigma, EConstr.mkNamedLambda_or_LetIn sigma decl (EConstr.mkEvar (ev, ninst))
+    let sigma, ev = Evarutil.new_pure_evar nctx sigma nb in
+    sigma, EConstr.mkNamedLambda_or_LetIn sigma decl (EConstr.mkEvar (ev, ninst)), Some ev
   end
 
 let set_decl_id id = let open Context in function

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -54,7 +54,7 @@ let generic_refine ~typecheck f gl =
   let sigma = Evd.push_future_goals sigma in
   (* Create the refinement term *)
   Proofview.Unsafe.tclEVARS sigma >>= fun () ->
-  f >>= fun (v, c) ->
+  f >>= fun (v, c, principal) ->
   Proofview.tclEVARMAP >>= fun sigma' ->
   Proofview.wrap_exceptions begin fun () ->
   (* Redo the effects in sigma in the monad's env *)
@@ -74,16 +74,20 @@ let generic_refine ~typecheck f gl =
   (* Restore the [future goals] state. *)
   let future_goals, sigma = Evd.pop_future_goals sigma in
   (* Select the goals *)
+  (* XXX is it useful to advance / filter the [principal] or should we
+     just expect [f] to produce the right thing? *)
   let future_goals = Evd.FutureGoals.map_filter (Proofview.Unsafe.advance sigma) future_goals in
+  let principal = Option.bind principal (Proofview.Unsafe.advance sigma) in
   let shelf = Evd.shelf sigma in
   let future_goals = Evd.FutureGoals.filter (fun ev -> not @@ List.mem ev shelf) future_goals in
+  let principal = Option.filter (fun ev -> not @@ List.mem ev shelf) principal in
   (* Proceed to the refinement *)
   let sigma = match Proofview.Unsafe.advance sigma self with
   | None ->
     (* Nothing to do, the goal has been solved by side-effect *)
     sigma
   | Some self ->
-    match (Evd.FutureGoals.principal future_goals) with
+    match principal with
     | None -> Evd.define self c sigma
     | Some evk ->
         let id = Evd.evar_ident self sigma in
@@ -116,7 +120,13 @@ let make_refine_enter ~typecheck f gl = generic_refine ~typecheck (lift f) gl
 
 let refine ~typecheck f =
   let f evd =
-    let (evd,c) = f evd in (evd,((), c))
+    let (evd,c) = f evd in (evd,((), c, None))
+  in
+  Proofview.Goal.enter (make_refine_enter ~typecheck f)
+
+let refine_with_principal ~typecheck f =
+  let f evd =
+    let (evd,c, principal) = f evd in (evd,((), c, principal))
   in
   Proofview.Goal.enter (make_refine_enter ~typecheck f)
 

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -74,13 +74,9 @@ let generic_refine ~typecheck f gl =
   (* Restore the [future goals] state. *)
   let future_goals, sigma = Evd.pop_future_goals sigma in
   (* Select the goals *)
-  (* XXX is it useful to advance / filter the [principal] or should we
-     just expect [f] to produce the right thing? *)
   let future_goals = Evd.FutureGoals.map_filter (Proofview.Unsafe.advance sigma) future_goals in
-  let principal = Option.bind principal (Proofview.Unsafe.advance sigma) in
   let shelf = Evd.shelf sigma in
   let future_goals = Evd.FutureGoals.filter (fun ev -> not @@ List.mem ev shelf) future_goals in
-  let principal = Option.filter (fun ev -> not @@ List.mem ev shelf) principal in
   (* Proceed to the refinement *)
   let sigma = match Proofview.Unsafe.advance sigma self with
   | None ->

--- a/proofs/refine.mli
+++ b/proofs/refine.mli
@@ -28,7 +28,11 @@ val refine : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * EConstr.t) -> uni
     tactic failures. If [typecheck] is [true] [t] is type-checked beforehand.
     Shelved evars and goals are all marked as unresolvable for typeclasses. *)
 
-val generic_refine : typecheck:bool -> ('a * EConstr.t) tactic ->
+val refine_with_principal : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * EConstr.t * Evar.t option) -> unit tactic
+(** Like [refine], but if the [Evar.t option] is [Some ev] then [ev]
+    inherits properties (the name) of the goal. *)
+
+val generic_refine : typecheck:bool -> ('a * EConstr.t * Evar.t option) tactic ->
   Proofview.Goal.t -> 'a tactic
 (** The general version of refine. *)
 

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -86,12 +86,12 @@ let mk_dectype { eqonleft; op; eq1; eq2; noteq } t x y =
 let generalize_right dty typ c1 c2 =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-  Refine.refine ~typecheck:false begin fun sigma ->
+  Refine.refine_with_principal ~typecheck:false begin fun sigma ->
     let na = Name (next_name_away_with_default "x" Anonymous (Termops.vars_of_env env)) in
     let r = Retyping.relevance_of_type env sigma typ in
     let newconcl = mkProd (make_annot na r, typ, mk_dectype dty typ c1 (mkRel 1)) in
-    let (sigma, x) = Evarutil.new_evar env sigma ~principal:true newconcl in
-    (sigma, mkApp (x, [|c2|]))
+    let (sigma, x) = Evarutil.new_evar env sigma newconcl in
+    (sigma, mkApp (x, [|c2|]), Some (fst @@ destEvar sigma x))
   end
   end
 


### PR DESCRIPTION

It was only used by refine, and all uses look like

~~~ocaml
refine begin fun sigma ->
  let sigma, ev = new_evar ~principal:true sigma ... in
  let c = ... in
  sigma, c
end
~~~

so instead we provide a new API `refine_with_principal` which lets the
closure return the principal evar, transforming the above example into

~~~ocaml
refine_with_principal begin fun sigma ->
  let sigma, ev = new_evar sigma ... in
  let c = ... in
  sigma, c, Some ev
end
~~~

Currently all uses of refine_with_principal statically return `Some`
evar but it shouldn't hurt to support dynamically having a principal
evar.

Notes:

- `new_evar ~principal:false` implied `~typeclass_candidate:false`,
  but this is redundant with refine doing `mark_as_goals` (which removes
  the argument evars from the typeclass candidates).

