### PR TITLE
ci-wrapper: call make-one-time-file directly instead of explicitly using python

### DIFF
--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -47,7 +47,7 @@ fi
 code=$?
 echo 'Aggregating timing log...'
 echo
-python ./tools/make-one-time-file.py --real "$CI_NAME.log"
+tools/make-one-time-file.py --real "$CI_NAME.log"
 if [ "$CI" ] && ! [ $code = 0 ]; then
   set +x
 


### PR DESCRIPTION


As a side effect this means it uses python3 instead of whatever python points to. Since newer systems may only have python3 this is good.
