### PR TITLE
warnings or errors with a known fix

### DIFF
--- a/dev/ci/user-overlays/19147-gares-quickfix.sh
+++ b/dev/ci/user-overlays/19147-gares-quickfix.sh
@@ -1,0 +1,9 @@
+overlay tactician https://github.com/gares/coq-tactician quickfix 19147
+
+overlay coq_lsp https://github.com/gares/coq-lsp quickfix 19147
+
+overlay vscoq https://github.com/gares/vscoq quickfix 19147
+
+overlay autosubst_ocaml https://github.com/gares/autosubst-ocaml quickfix 19147
+
+overlay serapi https://github.com/gares/coq-serapi quickfix 19147

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -643,7 +643,7 @@ object(self)
           self#attach_tooltip ~loc sentence
             (Printf.sprintf "%s %s %s" filepath ident ty)
       | GlobRef (_, _, _, _, _), None -> msg_wo_sent "GlobRef"
-      | Message(Error, loc, msg), Some (id,sentence) ->
+      | Message(Error, loc, _, msg), Some (id,sentence) ->
           log_pp ?id Pp.(str "ErrorMsg " ++ msg);
           remove_flag sentence `PROCESSING;
           let rmsg = Pp.string_of_ppcmds msg in
@@ -651,20 +651,20 @@ object(self)
           self#mark_as_needed sentence;
           self#attach_tooltip ?loc sentence rmsg;
           self#apply_tag_in_sentence ?loc Tags.Script.error sentence
-      | Message(Warning, loc, message), Some (id,sentence) ->
+      | Message(Warning, loc, _, message), Some (id,sentence) ->
           log_pp ?id Pp.(str "WarningMsg " ++ message);
           let rmsg = Pp.string_of_ppcmds message in
           add_flag sentence (`WARNING (loc, rmsg));
           self#attach_tooltip ?loc sentence rmsg;
           self#apply_tag_in_sentence ?loc Tags.Script.warning sentence;
           (messages#route msg.route)#push Warning message
-      | Message(lvl, loc, message), Some (id,sentence) ->
+      | Message(lvl, loc, _, message), Some (id,sentence) ->
           log_pp ?id Pp.(str "Msg " ++ message);
           (messages#route msg.route)#push lvl message
       (* We do nothing here as for BZ#5583 *)
-      | Message(Error, loc, msg), None ->
+      | Message(Error, loc, _, msg), None ->
           log_pp Pp.(str "Error Msg without a sentence" ++ msg)
-      | Message(lvl, loc, message), None ->
+      | Message(lvl, loc, _, message), None ->
           log_pp Pp.(str "Msg without a sentence " ++ message);
           (messages#route msg.route)#push lvl message
       | InProgress n, _ ->

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -76,7 +76,7 @@ let is_known_option cmd = match cmd with
   | _ -> false
 
 let ide_cmd_warns ~id { CAst.loc; v } =
-  let warn msg = Feedback.(feedback ~id (Message (Warning, loc, strbrk msg))) in
+  let warn msg = Feedback.(feedback ~id (Message (Warning, loc, [], strbrk msg))) in
   if is_known_option v.expr then
     warn "Set this option from the IDE menu instead";
   if is_navigation_vernac v.expr || is_undo v.expr then

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -1048,7 +1048,7 @@ let of_message lvl loc msg =
 
 let to_message xml = match xml with
   | Xml_datatype.Element ("message", [], [lvl; xloc; content]) ->
-      Message(to_message_level lvl, to_option to_loc xloc, to_pp content)
+      Message(to_message_level lvl, to_option to_loc xloc, [], to_pp content)
   | x -> raise (Marshal_error("message",x))
 
 let to_feedback_content = do_match "feedback_content" (fun s a -> match s,a with
@@ -1108,7 +1108,7 @@ let of_feedback_content = function
       constructor "feedback_content" "fileloaded" [
         of_string dirpath;
         of_string filename ]
-  | Message (l,loc,m) -> constructor "feedback_content" "message" [ of_message l loc m ]
+  | Message (l,loc,_,m) -> constructor "feedback_content" "message" [ of_message l loc m ]
 
 let of_edit_or_state_id id = ["object","state"], of_stateid id
 

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -128,9 +128,17 @@ let print_gen ~anomaly (e, info) =
     str "<in exception printer>:" ++ spc() ++ print_anomaly anomaly exn ++ print_extra info ++ fnl() ++
     str "<original exception>:" ++ spc() ++ print_anomaly false e ++ extra_msg
 
+let print_quickfix = function
+  | [] -> mt ()
+  | qf -> fnl () ++ Quickfix.print qf
+
 (** The standard exception printer *)
 let iprint (e, info) =
-  print_gen ~anomaly:true (e,info)
+  print_gen ~anomaly:true (e,info) ++
+  if !Flags.test_mode then
+    Result.fold ~ok:print_quickfix ~error:(print_gen ~anomaly:true) (Quickfix.from_exception e)
+  else
+    mt ()
 
 let print e =
   iprint (e, Exninfo.info e)

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -72,7 +72,7 @@ let get_status ~name = match get_warning name with
 
 type _ tag = ..
 
-type w = W : 'a tag * 'a -> w
+type w = W : 'a tag * Quickfix.t list * 'a -> w
 exception WarnError of w
 
 module DMap = PolyMap.Make (struct type nonrec 'a tag = 'a tag = .. end)
@@ -100,7 +100,7 @@ let create_msg warning () =
   let v = { Msg.tag = DMap.make(); warning; } in
   v
 
-let print (W (tag, w)) =
+let print (W (tag,_, w)) =
   let pp = try PrintMap.find tag !printers with Not_found -> assert false in
   pp w
 
@@ -108,12 +108,16 @@ let () = CErrors.register_handler (function
     | WarnError w -> Some (print w)
     | _ -> None)
 
-let warn { Msg.tag; warning } ?loc v =
+let () = Quickfix.register (function
+| WarnError (W(_,qf,_)) -> qf
+| _ -> [])
+
+let warn { Msg.tag; warning } ?loc ?(quickfix=[]) v =
   let tag = DMap.tag_of_onetag tag in
   match warning_status warning with
   | Disabled -> ()
-  | AsError -> Loc.raise ?loc (WarnError (W (tag, v)))
-  | Enabled -> Feedback.msg_warning ?loc (print (W (tag, v)))
+  | AsError -> Loc.raise ?loc (WarnError (W (tag,quickfix,v)))
+  | Enabled -> Feedback.msg_warning ?loc ~quickfix (print (W (tag,quickfix,v)))
 
 (** Flag handling *)
 
@@ -375,12 +379,16 @@ let create_hybrid ?from ?default ~name () =
 let create_in w pp =
   let msg = create_msg w () in
   let () = register_printer msg pp in
-  fun ?loc x -> warn ?loc msg x
+  fun ?loc ?quickfix x -> warn ?loc ?quickfix msg x
 
-let create ~name ?category ?default pp =
+let create_with_quickfix ~name ?category ?default pp =
   let from = Option.map (fun x -> [x]) category in
   let w = create_warning ?from ?default ~name () in
   create_in w pp
+
+let create ~name ?category ?default pp =
+  let f = create_with_quickfix ~name ?category ?default pp in
+  fun ?loc x -> f ?quickfix:None ?loc x
 
 let warn_unknown_warnings = create ~name:"unknown-warning" Pp.(fun flags ->
     str "Could not enable unknown " ++

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -23,7 +23,7 @@ type warning
 type 'a msg
 (** A [msg] belongs to a [warning]. *)
 
-val warn : 'a msg -> ?loc:Loc.t -> 'a -> unit
+val warn : 'a msg -> ?loc:Loc.t -> ?quickfix:Quickfix.t list -> 'a -> unit
 (** Emit a message in some warning. *)
 
 (** Creation functions
@@ -46,7 +46,7 @@ val create_hybrid : ?from:category list -> ?default:status -> name:string -> uni
 val create_msg : warning -> unit -> 'a msg
 (** A message with data ['a] in the given warning. *)
 
-val create_in : warning -> ('a -> Pp.t) -> ?loc:Loc.t -> 'a -> unit
+val create_in : warning -> ('a -> Pp.t) -> ?loc:Loc.t -> ?quickfix:Quickfix.t list -> 'a -> unit
 (** Create a msg with registered printer. *)
 
 val register_printer : 'a msg -> ('a -> Pp.t) -> unit
@@ -55,6 +55,10 @@ val register_printer : 'a msg -> ('a -> Pp.t) -> unit
 val create : name:string -> ?category:category -> ?default:status ->
   ('a -> Pp.t) -> ?loc:Loc.t -> 'a -> unit
 (** Combined creation function. [name] must be a fresh name. *)
+
+val create_with_quickfix : name:string -> ?category:category -> ?default:status ->
+    ('a -> Pp.t) -> ?loc:Loc.t -> ?quickfix:Quickfix.t list -> 'a -> unit
+  (** Combined creation function. [name] must be a fresh name. *)
 
 (** Misc APIs *)
 

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -45,7 +45,7 @@ type feedback_content =
   (* Extra metadata *)
   | Custom of Loc.t option * string * xml
   (* Generic messages *)
-  | Message of level * Loc.t option * Pp.t
+  | Message of level * Loc.t option * Quickfix.t list * Pp.t
 
 type feedback = {
   doc_id   : doc_id;            (* The document being concerned *)
@@ -86,9 +86,9 @@ val msg_info : ?loc:Loc.t -> Pp.t -> unit
 val msg_notice : ?loc:Loc.t -> Pp.t -> unit
 (** Message that should be displayed, such as [Print Foo] or [Show Bar]. *)
 
-val msg_warning : ?loc:Loc.t -> Pp.t -> unit
+val msg_warning : ?loc:Loc.t -> ?quickfix:Quickfix.t list -> Pp.t -> unit
 (** Message indicating that something went wrong, but without serious
-    consequences. *)
+    consequences. A list of quick fixes, in the VSCode sense, can be provided *)
 
 val msg_debug : ?loc:Loc.t -> Pp.t -> unit
 (** For debugging purposes *)

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -85,3 +85,5 @@ let profile_ltac_cutoff = ref 2.0
 (* Default output directory *)
 
 let output_directory = ref None
+
+let test_mode = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -100,3 +100,8 @@ val profile_ltac_cutoff : float ref
 
 (** Default output directory *)
 val output_directory : CUnix.physical_path option ref
+
+
+(** Flag set when the test-suite is called. Its only effect to display
+    verbose information for [Fail] *)
+val test_mode : bool ref

--- a/lib/quickfix.ml
+++ b/lib/quickfix.ml
@@ -1,0 +1,41 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* Quickfix management *)
+
+type t = Loc.t * Pp.t
+let make ~loc txt = loc, txt
+let pp (_,x) = x
+let loc (l,_) = l
+
+let handle_stack = ref []
+
+let register h = handle_stack := h::!handle_stack
+
+let rec accumulate_qf acc stk e =
+  match stk with
+  | [] -> acc
+  | h::stk -> accumulate_qf (h e :: acc) stk e
+
+let from_exception e =
+  try
+    Ok (CList.flatten (accumulate_qf [] !handle_stack e))
+  with exn ->
+    let ei = Exninfo.capture exn in
+    Error ei
+
+let print e =
+  let open Pp in
+  match e with
+  | [] -> mt ()
+  | qf ->
+    let open Pp in
+    let qf = prlist_with_sep cut pp qf in
+    v 0 (prlist_with_sep cut (fun x -> x) [str "Quickfix:"; qf])

--- a/lib/quickfix.mli
+++ b/lib/quickfix.mli
@@ -1,0 +1,37 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type t
+
+val make : loc:Loc.t -> Pp.t -> t
+
+val pp : t -> Pp.t
+
+val loc : t -> Loc.t
+
+(** [register h] registers [h] as a quickfix generator.
+    When an error is generated the toplevel can check if there is
+    quick fix for it.
+
+    Quickfix generators signal that they don't deal with some exception
+    by returning []. Raising any other exception is
+    forbidden.
+
+    Exceptions that are considered anomalies should not be
+    handled by Quickfix generators.
+*)
+
+val register : (exn -> t list) -> unit
+
+(** computes all the quickfixes for a given exception *)
+val from_exception : exn -> (t list, Exninfo.iexn) result
+
+(** Prints all the quickfixes in a vertical box *)
+val print : t list -> Pp.t

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -103,7 +103,7 @@ module type StagedLibS = sig
   val classify_segment : Libobject.t list -> classified_objects
 
   (** Returns the opening node of a given name *)
-  val find_opening_node : Id.t -> summary node
+  val find_opening_node : ?loc:Loc.t -> Id.t -> summary node
 
   val add_entry : summary node -> unit
   val add_leaf_entry : Libobject.t -> unit

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -617,7 +617,7 @@ let rec locate_ref = function
         | None, Some r -> let refs,mps = locate_ref l in r::refs,mps
         | Some mp, None -> let refs,mps = locate_ref l in refs,mp::mps
         | Some mp, Some r ->
-           warning_ambiguous_name (qid,mp,r);
+           warning_ambiguous_name ?loc:qid.CAst.loc (qid,mp,r);
            let refs,mps = locate_ref l in refs,mp::mps
 
 (*s Recursive extraction in the Coq toplevel. The vernacular command is

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -373,7 +373,7 @@ let warning_opaques accessed =
     else warn_extraction_opaque_as_axiom lst
 
 let warning_ambiguous_name =
-  CWarnings.create ~name:"extraction-ambiguous-name" ~category:CWarnings.CoreCategories.extraction
+  CWarnings.create_with_quickfix ~name:"extraction-ambiguous-name" ~category:CWarnings.CoreCategories.extraction
     (fun (q,mp,r) -> strbrk "The name " ++ pr_qualid q ++ strbrk " is ambiguous, " ++
                        strbrk "do you mean module " ++
                        pr_long_mp mp ++
@@ -381,6 +381,10 @@ let warning_ambiguous_name =
                        pr_long_global r ++ str " ?" ++ fnl () ++
                        strbrk "First choice is assumed, for the second one please use " ++
                        strbrk "fully qualified name." ++ fnl ())
+let warning_ambiguous_name ?loc (_,mp,r as x) =
+  match loc with
+  | None -> warning_ambiguous_name x
+  | Some loc -> warning_ambiguous_name ~loc ~quickfix:(List.map (Quickfix.make ~loc) [pr_long_mp mp;pr_long_global r]) x
 
 let error_axiom_scheme ?loc r i =
   err ?loc (str "The type scheme axiom " ++ spc () ++

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -308,8 +308,8 @@ module Make(T : Task) () = struct
   let pp_pid pp = Pp.(str (Spawned.process_id () ^ " ") ++ pp)
 
   let debug_with_pid = Feedback.(function
-    | { contents = Message(Debug, loc, pp) } as fb ->
-       { fb with contents = Message(Debug,loc, pp_pid pp) }
+    | { contents = Message(Debug, loc, qf, pp) } as fb ->
+       { fb with contents = Message(Debug,loc, qf, pp_pid pp) }
     | x -> x)
 
   let main_loop () =

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -88,7 +88,7 @@ let async_proofs_is_master opt =
   !Flags.async_proofs_worker_id = "master"
 
 let execution_error ?loc state_id msg =
-    feedback ~id:state_id (Message (Error, loc, msg))
+    feedback ~id:state_id (Message (Error, loc, [], msg))
 
 module Hooks = struct
 
@@ -1699,9 +1699,10 @@ end = struct (* {{{ *)
       ignore(stm_vernac_interp r_for st { r_what with verbose = true });
       feedback ~id:r_for Processed
     with e when CErrors.noncritical e ->
-      let e = Exninfo.capture e in
-      let msg = iprint e     in
-      feedback ~id:r_for (Message (Error, None, msg))
+      let e,_ as ie = Exninfo.capture e in
+      let msg = iprint ie in
+      let qf = Result.value ~default:[] (Quickfix.from_exception e) in
+      feedback ~id:r_for (Message (Error, None, qf, msg))
 
   let name_of_task { t_what } = string_of_ppcmds (pr_ast t_what)
   let name_of_request { r_what } = string_of_ppcmds (pr_ast r_what)

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -394,7 +394,7 @@ let parse_args ~usage ~init arglist : t * string list =
       { oval with config = {oval.config with native_include_dirs = include_dir :: oval.config.native_include_dirs } }
 
     (* Options with zero arg *)
-    |"-test-mode" -> Synterp.test_mode := true; oval
+    |"-test-mode" -> Flags.test_mode := true; oval
     |"-beautify" -> Flags.beautify := true; Flags.record_comments := true; oval
     |"-config"|"--config" -> set_query oval PrintConfig
 

--- a/test-suite/output/Qf_end.out
+++ b/test-suite/output/Qf_end.out
@@ -1,0 +1,7 @@
+File "./output/Qf_end.v", line 2, characters 4-5:
+Error: Last block to end has name A.
+Quickfix:
+A
+
+
+coqc exited with code 1

--- a/test-suite/output/Qf_end.v
+++ b/test-suite/output/Qf_end.v
@@ -1,0 +1,2 @@
+Module A.
+End B.

--- a/test-suite/output/Qf_extraction.out
+++ b/test-suite/output/Qf_extraction.out
@@ -1,0 +1,13 @@
+File "./output/Qf_extraction.v", line 5, characters 11-14:
+Warning: The name nat is ambiguous, do you mean module Qf_extraction.nat or
+object Coq.Init.Datatypes.nat ?
+First choice is assumed, for the second one please use fully qualified name.
+ [extraction-ambiguous-name,extraction,default]
+Quickfix:
+Qf_extraction.nat
+Coq.Init.Datatypes.nat
+
+module Coq_nat =
+ struct
+ end
+

--- a/test-suite/output/Qf_extraction.v
+++ b/test-suite/output/Qf_extraction.v
@@ -1,0 +1,5 @@
+Require Import Extraction.
+
+Module nat. End nat.
+
+Extraction nat.

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -260,7 +260,7 @@ let init_load_path ~boot ~vo_path =
 let fb_handler = function
   | Feedback.{ contents; _ } ->
     match contents with
-    | Feedback.Message(_lvl,_loc,msg)->
+    | Feedback.Message(_lvl,_loc,_qf, msg)->
       Format.printf "%s@\n%!" Pp.(string_of_ppcmds msg)
     | _ -> ()
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -162,11 +162,11 @@ let error_info_for_buffer ?loc buf =
       | Loc.InFile _ -> Topfmt.pr_phase ~loc ()
 
 (* Actual printing routine *)
-let print_error_for_buffer ?loc lvl msg buf =
+let print_error_for_buffer ?loc ?qf lvl msg buf =
   let pre_hdr = error_info_for_buffer ?loc buf in
   if !print_emacs
   then Topfmt.emacs_logger ?pre_hdr lvl msg
-  else Topfmt.std_logger   ?pre_hdr lvl msg
+  else Topfmt.std_logger   ?pre_hdr ?qf lvl msg
 
 (*
 let print_toplevel_parse_error (e, info) buf =
@@ -312,13 +312,13 @@ let coqloop_feed (fb : Feedback.feedback) = let open Feedback in
   | FileLoaded (_,_) -> ()
   | Custom (_,_,_) -> ()
   (* Re-enable when we switch back to feedback-based error printing *)
-  | Message (Error,loc,msg) -> ()
+  | Message (Error,loc,_,msg) -> ()
   (* TopErr.print_error_for_buffer ?loc lvl msg top_buffer *)
-  | Message (Warning,loc,msg) ->
+  | Message (Warning,loc,qf,msg) ->
     let loc = extract_default_loc loc fb.doc_id fb.span_id in
-    TopErr.print_error_for_buffer ?loc Warning msg top_buffer
-  | Message (lvl,loc,msg) ->
-    TopErr.print_error_for_buffer ?loc lvl msg top_buffer
+    TopErr.print_error_for_buffer ?loc ~qf Warning msg top_buffer
+  | Message (lvl,loc,qf,msg) ->
+    TopErr.print_error_for_buffer ?loc ~qf lvl msg top_buffer
 
 (** Main coq loop : read vernacular expressions until Drop is entered.
     Ctrl-C is handled internally as Sys.Break instead of aborting Coq.

--- a/vernac/future.ml
+++ b/vernac/future.ml
@@ -39,7 +39,8 @@ let eval_fix_exn f (e, info) = match f with
   | None ->
     let loc = Loc.get_loc info in
     let msg = CErrors.iprint (e, info) in
-    let () = Feedback.(feedback ~id (Message (Error, loc, msg))) in
+    let qf = Result.value ~default:[] (Quickfix.from_exception e) in
+    let () = Feedback.(feedback ~id (Message (Error, loc, qf, msg))) in
     (e, Stateid.add info ~valid id)
 
 module UUID = struct

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -243,8 +243,8 @@ let synterp_end_section {CAst.loc; v} =
     (DirPath.to_string (Lib.current_dirpath true)) "<>" "sec";
   Lib.Synterp.close_section ()
 
-let synterp_end_segment ({v=id} as lid) =
-  let ss = Lib.Synterp.find_opening_node id in
+let synterp_end_segment ({v=id;loc} as lid) =
+  let ss = Lib.Synterp.find_opening_node ?loc id in
   match ss with
   | Lib.OpenedModule (false,export,_,_) -> ignore (synterp_end_module export lid)
   | Lib.OpenedModule (true,_,_,_) -> ignore (Declaremods.Synterp.end_modtype ())

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -369,8 +369,6 @@ let with_timeout ~timeout:n (f : 'a -> 'b) (x : 'a) : 'b =
     else ControlTimeout { remaining } :: ctrl, v
   end
 
-let test_mode = ref false
-
 (* Restoring the state is the caller's responsibility *)
 let with_fail f : (Loc.t option * Pp.t, 'a) result =
   try
@@ -397,8 +395,8 @@ let with_fail ~loc f =
   | Error (ctrl, v) ->
     ControlFail { st = transient_st } :: ctrl, v
   | Ok (eloc, msg) ->
-    let loc = if !test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
-    if not !Flags.quiet || !test_mode
+    let loc = if !Flags.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
+    if not !Flags.quiet || !Flags.test_mode
     then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg);
     [], VernacSynterp EVernacNoop
 

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -94,7 +94,3 @@ val add_default_timeout : Vernacexpr.control_flag list -> Vernacexpr.control_fla
 (** Default proof mode set by `start_proof` *)
 val get_default_proof_mode : unit -> Pvernac.proof_mode
 val proof_mode_opt_name : string list
-
-(** Flag set when the test-suite is called. Its only effect to display
-    verbose information for [Fail] *)
-val test_mode : bool ref

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -139,19 +139,23 @@ let info_hdr = mt ()
 let warn_hdr = tag Tag.warning (str "Warning:") ++ spc ()
 let  err_hdr = tag Tag.error   (str "Error:")   ++ spc ()
 
-let make_body quoter info ?pre_hdr s =
-  pr_opt_no_spc (fun x -> x ++ fnl ()) pre_hdr ++ quoter (hov 0 (info ++ s))
+let make_body quoter info ?pre_hdr ?(qf=[]) s =
+  let main = hov 0 (info ++ s) in
+  let main = match qf with
+    | (_ :: _ as qf) when !Flags.test_mode -> v 0 (main ++ cut () ++ Quickfix.print qf)
+    | _ -> main in
+  pr_opt_no_spc (fun x -> x ++ fnl ()) pre_hdr ++ quoter main
 
 (* The empty quoter *)
 let noq x = x
 (* Generic logger *)
-let gen_logger dbg warn ?pre_hdr level msg = let open Feedback in match level with
-  | Debug   -> msgnl_with !std_ft (make_body dbg  dbg_hdr ?pre_hdr msg)
-  | Info    -> msgnl_with !std_ft (make_body dbg info_hdr ?pre_hdr msg)
-  | Notice  -> msgnl_with !std_ft (make_body noq info_hdr ?pre_hdr msg)
+let gen_logger dbg warn ?qf ?pre_hdr level msg = let open Feedback in match level with
+  | Debug   -> msgnl_with !std_ft (make_body dbg  dbg_hdr ?pre_hdr ?qf msg)
+  | Info    -> msgnl_with !std_ft (make_body dbg info_hdr ?pre_hdr ?qf msg)
+  | Notice  -> msgnl_with !std_ft (make_body noq info_hdr ?pre_hdr ?qf msg)
   | Warning -> Flags.if_warn (fun () ->
-               msgnl_with !err_ft (make_body warn warn_hdr ?pre_hdr msg)) ()
-  | Error   -> msgnl_with !err_ft (make_body noq   err_hdr ?pre_hdr msg)
+               msgnl_with !err_ft (make_body warn warn_hdr ?pre_hdr ?qf msg)) ()
+  | Error   -> msgnl_with !err_ft (make_body noq   err_hdr ?pre_hdr ?qf msg)
 
 (** Standard loggers *)
 
@@ -160,8 +164,8 @@ let gen_logger dbg warn ?pre_hdr level msg = let open Feedback in match level wi
 *)
 let std_logger_cleanup = ref (fun () -> ())
 
-let std_logger ?pre_hdr level msg =
-  gen_logger (fun x -> x) (fun x -> x) ?pre_hdr level msg;
+let std_logger ?qf ?pre_hdr level msg =
+  gen_logger (fun x -> x) (fun x -> x) ?qf ?pre_hdr level msg;
   !std_logger_cleanup ()
 
 (** Color logging. Moved from Ppstyle, it may need some more refactoring  *)

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -39,8 +39,8 @@ val set_margin : int option -> unit
 val get_margin : unit -> int option
 
 (** Console display of feedback, we may add some location information *)
-val std_logger   : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
-val emacs_logger : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
+val std_logger   : ?qf:Quickfix.t list -> ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
+val emacs_logger : ?qf:Quickfix.t list -> ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 
 (** Color output *)
 val default_styles : unit -> unit

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1387,8 +1387,8 @@ let msg_of_subsection ss id =
   in
   Pp.str kind ++ spc () ++ Id.print id
 
-let vernac_end_segment ~pm ~proof ({v=id} as lid) =
-  let ss = Lib.Interp.find_opening_node id in
+let vernac_end_segment ~pm ~proof ({v=id; loc} as lid) =
+  let ss = Lib.Interp.find_opening_node ?loc id in
   let what_for = msg_of_subsection ss lid.v in
   if Option.has_some proof then
     CErrors.user_err (Pp.str "Command not supported (Open proofs remain)");

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -47,8 +47,8 @@ let with_fail ~loc ~st f =
   | Error () ->
     CErrors.user_err (Pp.str "The command has not failed!")
   | Ok (eloc, msg) ->
-    let loc = if !Synterp.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
-    if not !Flags.quiet || !Synterp.test_mode
+    let loc = if !Flags.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
+    if not !Flags.quiet || !Flags.test_mode
     then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg)
 
 let with_succeed ~st f =


### PR DESCRIPTION
This PR adds warnings and errors with a quickfix payload, and implements it for some easy cases:
- `intros.`
- `Extraction ambiguous.name.`
- `Axioms only_one : axiom.`
- `Module A. End B.`

Overlay PR:
- https://github.com/coq-community/vscoq/pull/793
- https://github.com/ejgallego/coq-lsp/pull/795
- https://github.com/uds-psl/autosubst-ocaml/pull/18
- https://github.com/coq-tactician/coq-tactician/pull/85
- https://github.com/ejgallego/coq-serapi/pull/421