### PR TITLE
Show tooltips for syntax errors

### DIFF
--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -20,6 +20,7 @@ sig
   val drop_simple_quotes : string -> string
   val quote_coq_string : string -> string
   val unquote_coq_string : string -> string option
+  val html_escape : string -> string
   val string_index_from : string -> int -> string -> int
   val string_contains : where:string -> what:string -> bool
   val plural : int -> string -> string
@@ -90,6 +91,16 @@ let unquote_coq_string s =
       done;
       Some (Buffer.contents b)
     with Exit -> None
+
+let html_escape msg =
+  let buf = Buffer.create (String.length msg) in
+  String.iter (fun c ->
+      if String.contains "\"&'<>" c then
+        Buffer.add_string buf (Printf.sprintf "&#%d;" (Char.code c))
+      else
+        Buffer.add_char buf c)
+    msg;
+  Buffer.contents buf
 
 (* substring searching... *)
 

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -42,6 +42,10 @@ sig
       (i.e. removing surrounding double quotes and undoubling double
       quotes); returns [None] if not a quoted string *)
 
+  val html_escape : string -> string
+  (** replace HTML reserved characters with escape sequences,
+      e.g. `&` -> "&#38;" *)
+
   val string_index_from : string -> int -> string -> int
   (** As [index_from], but takes a string instead of a char as pattern argument *)
 

--- a/doc/changelog/10-coqide/19153-syntax_error_tooltip.rst
+++ b/doc/changelog/10-coqide/19153-syntax_error_tooltip.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Show tooltips for syntax errors
+  (`#19153 <https://github.com/coq/coq/pull/19153>`_,
+  fixes `#19152 <https://github.com/coq/coq/issues/19152>`_,
+  by Jim Fehrle).

--- a/ide/coqide/document.ml
+++ b/ide/coqide/document.ml
@@ -36,6 +36,7 @@ type 'a document = {
   mutable context : ('a sentence list * 'a sentence list) option;
   pushed_sig : ('a * ('a list * 'a list) option) signal;
   popped_sig : ('a * ('a list * 'a list) option) signal;
+  mutable last_errors : string list
 }
 
 let connect d : 'a signals =
@@ -49,6 +50,7 @@ let create () = {
   context = None;
   pushed_sig = new signal ();
   popped_sig = new signal ();
+  last_errors = []
 }
 
 let repr_context s = match s.context with
@@ -78,6 +80,9 @@ let pop = function
   | { stack = [] } -> raise Empty
   | { stack = { data }::xs } as s ->
     s.stack <- xs; s.popped_sig#call (data, repr_context s); data
+
+let set_errors d msgs = d.last_errors <- msgs
+let get_errors d = d.last_errors
 
 let focus d ~cond_top:c_start ~cond_bot:c_stop =
   assert(invariant d.stack);

--- a/ide/coqide/document.mli
+++ b/ide/coqide/document.mli
@@ -52,6 +52,12 @@ val push : 'a document -> 'a -> unit
     @raise Empty *)
 val pop : 'a document -> 'a
 
+(** preserve the last error(s) (tooltip fix) *)
+val set_errors : 'a document -> string list -> unit
+
+(** get the last error(s) (tooltip fix) *)
+val get_errors : 'a document -> string list
+
 (** Assign the state_id of the tip.
     @raise Empty *)
 val assign_tip_id : 'a document -> id -> unit


### PR DESCRIPTION
Sentences with syntax errors were immediately removed from the document, but the tooltip can't be shown in that case.  This PR works around that.
 
This also substitutes HTML escape sequences for reserved characters in the tooltip text such as `"&'<>`.  This prevented tooltip messages containing those characters from displaying (such as the one shown in #19152).

Fixes / closes #19152
<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
