### PR TITLE
Changed critical bug conversion machine classification 11321 from only affecting vm to all 3 kernel conversion machines

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -508,7 +508,7 @@ fix.
 
 #### broken long multiplication primitive integer emulation layer on 32 bits
 
-- component: "virtual machine" (compilation to bytecode ran by a C-interpreter)
+- component: all 3 kernel conversion machines (lazy, VM, native)
 - introduced: [e43b176](https://github.com/coq/coq/commit/e43b1768d0f8399f426b92f4dfe31955daceb1a4)
 - impacted released versions: 8.10.0, 8.10.1, 8.10.2
 - impacted development branches: 8.11


### PR DESCRIPTION
Currently bug 11321 affecting the old 8.10.0, 8.10.1, 8.10.2 versions has only been classified as a vm bug. However I was able to reproduce the bug also for the standard "lazy" machine and the native machine.

This misclassification was also confirmed by silene in the following Coq Discourse thread:
https://coq.discourse.group/t/old-critical-bug-described-as-affecting-virtual-machine-but-also-triggers-on-other-conversion-machines/2316
