### PR TITLE
[vernac] [experiment] Reorganization of parsing state.

### DIFF
--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -285,7 +285,6 @@ val find_custom_entry : ('a, 'b) entry_command -> string -> 'b Entry.t
 val with_grammar_rule_protection : ('a -> 'b) -> 'a -> 'b
 
 type frozen_t
-val parser_summary_tag : frozen_t Summary.Dyn.tag
 
 (** Registering grammars by name *)
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -587,7 +587,7 @@ end = struct (* {{{ *)
   let get_parsing_state id =
     stm_pperr_endline (fun () -> str "retrieve parsing state state " ++ str (Stateid.to_string id) ++ str " }}}");
     match (get_info id).state with
-    | FullState s -> Some s.Vernacstate.synterp.parsing
+    | FullState s -> Some (Vernacstate.System.Synterp.parsing s.synterp)
     | ParsingState s -> Some s
     | ErrorState (s,_) -> s
     | EmptyState -> None
@@ -1980,7 +1980,8 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
 
   (* ugly functions to process nested lemmas, i.e. hard to reproduce
    * side effects *)
-  let inject_non_pstate (s_synterp,l_synterp,s_interp,l_interp) =
+  let inject_non_pstate (s_parsing, s_synterp,l_synterp,s_interp,l_interp) =
+    Pcoq.unfreeze s_parsing;
     Summary.Synterp.unfreeze_summaries ~partial:true s_synterp;
     Lib.Synterp.unfreeze l_synterp;
     Summary.Interp.unfreeze_summaries ~partial:true s_interp;

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -80,8 +80,8 @@ type control_entry =
   | ControlInstructions of { synterp_instructions: System.instruction_count }
   | ControlRedirect of string
   | ControlTimeout of { remaining : float }
-  | ControlFail of { st : Vernacstate.Synterp.t }
-  | ControlSucceed of { st : Vernacstate.Synterp.t }
+  | ControlFail of { st : Vernacstate.System.Synterp.t }
+  | ControlSucceed of { st : Vernacstate.System.Synterp.t }
 
 type synterp_entry =
   | EVernacNoop
@@ -108,7 +108,7 @@ type synterp_entry =
       module_entry list
   | EVernacInclude of Declaremods.module_expr list
   | EVernacSetOption of { export : bool; key : Goptions.option_name; value : Vernacexpr.option_setting }
-  | EVernacLoad of Vernacexpr.verbose_flag * (vernac_control_entry * Vernacstate.Synterp.t) list
+  | EVernacLoad of Vernacexpr.verbose_flag * (vernac_control_entry * Vernacstate.System.Synterp.t) list
   | EVernacExtend of Vernactypes.typed_vernac
 
 and vernac_entry = synterp_entry Vernacexpr.vernac_expr_gen
@@ -389,10 +389,10 @@ let real_error_loc ~cmdloc ~eloc =
   else cmdloc
 
 let with_fail ~loc f =
-  let st = Vernacstate.Synterp.freeze () in
+  let st = Vernacstate.System.Synterp.freeze () in
   let res = with_fail f in
-  let transient_st = Vernacstate.Synterp.freeze () in
-  Vernacstate.Synterp.unfreeze st;
+  let transient_st = Vernacstate.System.Synterp.freeze () in
+  Vernacstate.System.Synterp.unfreeze st;
   match res with
   | Error (ctrl, v) ->
     ControlFail { st = transient_st } :: ctrl, v
@@ -403,10 +403,10 @@ let with_fail ~loc f =
     [], VernacSynterp EVernacNoop
 
 let with_succeed f =
-  let st = Vernacstate.Synterp.freeze () in
+  let st = Vernacstate.System.Synterp.freeze () in
   let (ctrl, v) = f () in
-  let transient_st = Vernacstate.Synterp.freeze () in
-  Vernacstate.Synterp.unfreeze st;
+  let transient_st = Vernacstate.System.Synterp.freeze () in
+  Vernacstate.System.Synterp.unfreeze st;
   ControlSucceed { st = transient_st } :: ctrl, v
 
 (* We restore the state always *)
@@ -534,7 +534,7 @@ and synterp_load ~intern verbosely fname =
     | None -> entries
     | Some cmd ->
       let entry = v_mod (synterp_control ~intern) cmd in
-      let st = Vernacstate.Synterp.freeze () in
+      let st = Vernacstate.System.Synterp.freeze () in
       (load_loop [@ocaml.tailcall]) ((entry,st)::entries)
   in
   let entries = List.rev @@ load_loop [] in

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -32,8 +32,8 @@ type control_entry =
   | ControlInstructions of { synterp_instructions: System.instruction_count }
   | ControlRedirect of string
   | ControlTimeout of { remaining : float }
-  | ControlFail of { st : Vernacstate.Synterp.t }
-  | ControlSucceed of { st : Vernacstate.Synterp.t }
+  | ControlFail of { st : Vernacstate.System.Synterp.t }
+  | ControlSucceed of { st : Vernacstate.System.Synterp.t }
 
 
 type synterp_entry =
@@ -60,7 +60,7 @@ type synterp_entry =
       module_entry list
   | EVernacInclude of Declaremods.module_expr list
   | EVernacSetOption of { export : bool; key : Goptions.option_name; value : Vernacexpr.option_setting }
-  | EVernacLoad of Vernacexpr.verbose_flag * (vernac_control_entry * Vernacstate.Synterp.t) list
+  | EVernacLoad of Vernacexpr.verbose_flag * (vernac_control_entry * Vernacstate.System.Synterp.t) list
   | EVernacExtend of Vernactypes.typed_vernac
 
 and vernac_entry = synterp_entry Vernacexpr.vernac_expr_gen

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -65,10 +65,10 @@ let interp_control_entry ~loc (f : control_entry) ~st
     (fn : st:Vernacstate.t -> Vernacstate.LemmaStack.t option * Declare.OblState.t NeList.t) =
   match f with
   | ControlFail { st = synterp_st } ->
-    with_fail ~loc ~st (fun () -> Vernacstate.Synterp.unfreeze synterp_st; fn ~st);
+    with_fail ~loc ~st (fun () -> Vernacstate.System.Synterp.unfreeze synterp_st; fn ~st);
     st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program
   | ControlSucceed { st = synterp_st } ->
-    with_succeed ~st (fun () -> Vernacstate.Synterp.unfreeze synterp_st; fn ~st);
+    with_succeed ~st (fun () -> Vernacstate.System.Synterp.unfreeze synterp_st; fn ~st);
     st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program
   | ControlTimeout { remaining } ->
     vernac_timeout ~timeout:remaining (fun () -> fn ~st) ()
@@ -130,7 +130,7 @@ and vernac_load ~verbosely entries =
   let st = Vernacstate.freeze_full_state () in
   let v_mod = if verbosely then Flags.verbosely else Flags.silently in
   let interp_entry (stack, pm) (CAst.{ loc; v = cmd }, synterp_st) =
-    Vernacstate.Synterp.unfreeze synterp_st;
+    Vernacstate.System.Synterp.unfreeze synterp_st;
     let st = Vernacstate.{ synterp = synterp_st; interp = { st.interp with Interp.lemmas = stack; program = pm }} in
     v_mod (interp_control ~st) (CAst.make ?loc cmd)
   in
@@ -209,7 +209,7 @@ let interp ~intern ?(verbosely=true) ~st cmd =
   vernac_pperr_endline Pp.(fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr cmd.CAst.v.expr);
   let entry = NewProfile.profile "synterp" (fun () -> Synterp.synterp_control ~intern cmd) () in
   let interp = NewProfile.profile "interp" (fun () -> interp_gen ~verbosely ~st ~interp_fn:interp_control entry) () in
-  Vernacstate.{ synterp = Vernacstate.Synterp.freeze (); interp }
+  Vernacstate.{ synterp = Vernacstate.System.Synterp.freeze (); interp }
 
 let interp_entry ?(verbosely=true) ~st entry =
   Vernacstate.unfreeze_full_state st;

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -25,6 +25,9 @@ module System : sig
 
     type t
 
+    val parsing : t -> Parser.t
+    val freeze : unit -> t
+    val unfreeze : t -> unit
   end
 
   module Interp : sig
@@ -38,22 +41,6 @@ module System : sig
   val protect : ('a -> 'b) -> 'a -> 'b
 
 end
-
-module Synterp : sig
-
-  type t =
-    { parsing : Parser.t
-    (** parsing state [parsing state may not behave 100% functionally yet, beware] *)
-    ; system : System.Synterp.t
-    (** system state needed for the synterp phase *)
-    }
-
-  val init : unit -> t
-  val freeze : unit -> t
-  val unfreeze : t -> unit
-
-end
-
 
 module LemmaStack : sig
 
@@ -92,7 +79,7 @@ val invalidate_cache : unit -> unit
 end
 
 type t =
-  { synterp: Synterp.t
+  { synterp: System.Synterp.t
   ; interp: Interp.t
   }
 
@@ -109,7 +96,7 @@ module Stm : sig
   val set_pstate : t -> pstate -> t
 
   (** Rest of the state, unfortunately this is used in low-level so we need to expose it *)
-  type non_pstate = Summary.Synterp.frozen * Lib.Synterp.frozen * Summary.Interp.frozen * Lib.Interp.frozen
+  type non_pstate = Pcoq.frozen_t * Summary.Synterp.frozen * Lib.Synterp.frozen * Summary.Interp.frozen * Lib.Interp.frozen
   val non_pstate : t -> non_pstate
 
   (** Checks if two states have the same Environ.env (physical eq) *)


### PR DESCRIPTION
As of today, we keep copies of both parsing state in the synterp summary and in the record. This is redundant and in fact makes `Synterp.unfreeze` to perform useless work as it calls `Pcoq.unfreeze` twice.

We try to remove this duplicity and rework a bit the vernacstate organization, so parsing state is a regular entry of synterp state.

This is more flexible (and I prefer that as to be ready for the day `Pcoq.parse st entry pa` could be understood as pure), but we need to be careful, there are some hidden invariants in the unfreze dance.

Let's see what CI finds about this experiment.

