### PR TITLE
Parse `Type@{ Prop/SProp/Set | ... }` rather than failing

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -135,6 +135,9 @@ GRAMMAR EXTEND Gram
       | "SProp" -> { None, UNamed [CSProp, 0] }
       | "Type" -> { None, UAnonymous {rigid=UnivRigid} }
       | "Type"; "@{"; "_"; "}" -> { None, UAnonymous {rigid=UnivFlexible false} }
+      | "Type"; "@{"; "Set" ; "|"; u = universe; "}" -> { None, u }
+      | "Type"; "@{"; "Prop" ; "|"; u = universe; "}" -> { None, UNamed [CProp, 0] }
+      | "Type"; "@{"; "SProp" ; "|"; u = universe; "}" -> { None, UNamed [CSProp, 0] }
       | "Type"; "@{"; test_sort_qvar; q = reference; "|"; u = universe; "}" ->
         { Some (CQVar q), u }
       | "Type"; "@{"; u = universe; "}" -> { None, u } ] ]


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19162


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
