### PR TITLE
Stop repairing bad relevances in the kernel

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -386,7 +386,6 @@ let init_with_argv argv =
   let _fhandle = Feedback.(add_feeder (console_feedback_listener Format.err_formatter)) in
   try
     parse_args argv;
-    CWarnings.set_flags ("+"^Typeops.warn_bad_relevance_name);
     if CDebug.(get_flag misc) then Printexc.record_backtrace true;
     Flags.if_verbose print_header ();
     if not !boot then init_load_path ();

--- a/doc/changelog/01-kernel/19164-good-triumps-when-bad-relevances-are-errors.rst
+++ b/doc/changelog/01-kernel/19164-good-triumps-when-bad-relevances-are-errors.rst
@@ -1,0 +1,6 @@
+- **Removed:**
+  the kernel always produces an error when given terms with bad relevances
+  instead of emitting the default-error `bad-relevance` warning
+  (which is now only used by the higher layers)
+  (`#19164 <https://github.com/coq/coq/pull/19164>`_,
+  by Gaëtan Gilbert).

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -125,19 +125,6 @@ val type_of_prim_type : env -> UVars.Instance.t -> 'a CPrimitives.prim_type -> t
 val type_of_prim : env -> UVars.Instance.t -> CPrimitives.t -> types
 val type_of_prim_or_type : env -> UVars.Instance.t -> CPrimitives.op_or_type -> types
 
-val warn_bad_relevance_name : string
-(** Allow the checker to make this warning into an error. *)
-
-val bad_relevance_warning : CWarnings.warning
-(** Also used by the pretyper to define a message which uses the evar map. *)
-
-type ('constr,'types, 'r) bad_relevance =
-| BadRelevanceBinder of 'r * ('constr,'types,'r) Context.Rel.Declaration.pt
-| BadRelevanceCase of 'r * 'constr
-
-val bad_relevance_msg : (env * (constr,types,Sorts.relevance) bad_relevance) CWarnings.msg
-(** Used by the higher layers to register a nicer printer than the default. *)
-
 val should_invert_case : env -> Sorts.relevance -> case_info -> bool
 (** Matches must be annotated with the indices when going from SProp to non SProp
     (implies 1 or 0 constructors). *)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -406,13 +406,20 @@ let judge_of_array env sigma u tj defj tyj =
   in
   sigma, j
 
-let bad_relevance_msg = CWarnings.create_msg Typeops.bad_relevance_warning ()
+type ('constr,'types,'r) bad_relevance =
+| BadRelevanceBinder of 'r * ('constr,'types,'r) Context.Rel.Declaration.pt
+| BadRelevanceCase of 'r * 'constr
+
+let bad_relevance_warning =
+  CWarnings.create_warning ~name:"bad-relevance" ~default:CWarnings.AsError ()
+
+let bad_relevance_msg = CWarnings.create_msg bad_relevance_warning ()
 (* no need for default printer, pretyping is always linked with himsg in practice *)
 
 let warn_bad_relevance_binder ?loc env sigma rlv bnd =
-  match CWarnings.warning_status Typeops.bad_relevance_warning with
+  match CWarnings.warning_status bad_relevance_warning with
 | CWarnings.Disabled | CWarnings.Enabled ->
-  CWarnings.warn bad_relevance_msg ?loc (env,sigma,Typeops.BadRelevanceBinder (rlv, bnd))
+  CWarnings.warn bad_relevance_msg ?loc (env,sigma,BadRelevanceBinder (rlv, bnd))
 | CWarnings.AsError ->
   Loc.raise ?loc (PretypeError (env, sigma, TypingError (Type_errors.BadBinderRelevance (rlv, bnd))))
 

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -72,4 +72,8 @@ val checked_applist : env -> evar_map -> constr -> constr list -> evar_map * con
 (** hack *)
 val recheck_against : Environ.env -> evar_map -> constr -> constr -> evar_map * types
 
-val bad_relevance_msg : (Environ.env * evar_map * (constr, types, ERelevance.t) Typeops.bad_relevance) CWarnings.msg
+type ('constr,'types,'r) bad_relevance =
+| BadRelevanceBinder of 'r * ('constr,'types,'r) Context.Rel.Declaration.pt
+| BadRelevanceCase of 'r * 'constr
+
+val bad_relevance_msg : (Environ.env * evar_map * (constr, types, ERelevance.t) bad_relevance) CWarnings.msg

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -848,18 +848,8 @@ let explain_bad_case_relevance env sigma rlv case =
     spc () ++ str "(maybe a bugged tactic)."
 
 let explain_bad_relevance env sigma = function
-  | Typeops.BadRelevanceCase (r,c) -> explain_bad_case_relevance env sigma r c
+  | Typing.BadRelevanceCase (r,c) -> explain_bad_case_relevance env sigma r c
   | BadRelevanceBinder (r,d) -> explain_bad_binder_relevance env sigma r d
-
-let ecast_bad_relevance = let open Typeops in function
-  | BadRelevanceCase (r,c) -> BadRelevanceCase (EConstr.ERelevance.make r, EConstr.of_constr c)
-  | BadRelevanceBinder (r,d) -> BadRelevanceBinder (EConstr.ERelevance.make r, EConstr.of_rel_decl d)
-
-let () =
-  CWarnings.register_printer Typeops.bad_relevance_msg
-    (fun (env, b) ->
-       let sigma = Evd.from_env env in
-       explain_bad_relevance env sigma (ecast_bad_relevance b))
 
 let () = CWarnings.register_printer Typing.bad_relevance_msg
     (fun (env, sigma, b) -> explain_bad_relevance env sigma b)


### PR DESCRIPTION
It has been default-error for a while, nobody should be relying on it.
