### PR TITLE
Update browser commands

### DIFF
--- a/ide/coqide/FAQ
+++ b/ide/coqide/FAQ
@@ -1,5 +1,7 @@
 			CoqIDE FAQ
 
+TODO: Put the relevant info in the doc and delete this file.
+
 Q0) What is CoqIDE?
 R0: A powerful graphical interface for Coq. See http://coq.inria.fr. for more informations.
 

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1435,7 +1435,7 @@ let build_ui () =
     item "Latex" ~label:"_LaTeX" ~callback:(File.export "latex");
     item "Dvi" ~label:"_DVI" ~callback:(File.export "dvi");
     item "Pdf" ~label:"_PDF" ~callback:(File.export "pdf");
-    item "Ps" ~label:"_PostScript" ~callback:(File.export "ps");
+    item "Ps" ~label:"P_ostScript" ~callback:(File.export "ps");
   ];
 
   menu edit_menu [

--- a/ide/coqide/dune
+++ b/ide/coqide/dune
@@ -89,11 +89,6 @@
  (deps (:gen ./default_bindings_src.exe))
  (action (run %{gen} %{targets})))
 
-(install
- (section doc)
- (package coqide)
- (files FAQ))
-
 ; FIXME: we should install those in share/coqide. We better do this
 ; once the make-based system has been phased out.
 (install

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -1066,25 +1066,24 @@ let configure ?(apply=(fun () -> ())) parent =
       "External editor"
       ~f:cmd_editor#set
       ~new_allowed: true
-      (predefined@[if List.mem cmd_editor#get predefined then ""
-                   else cmd_editor#get])
+      (predefined@(if List.mem cmd_editor#get predefined then []
+                   else [cmd_editor#get]))
       cmd_editor#get
   in
   let cmd_browse =
     let predefined = [
       Coq_config.browser;
-      "netscape -remote \"openURL(%s)\"";
-      "mozilla -remote \"openURL(%s)\"";
-      "firefox -remote \"openURL(%s,new-windows)\" || firefox %s &";
-      "seamonkey -remote \"openURL(%s)\" || seamonkey %s &"
+      {|firefox "%s"|};
+      {|seamonkey "%s"|};
+      {|chromium "%s"|};
     ] in
     combo
       ~help:"(%s for url)"
       "Browser"
       ~f:cmd_browse#set
       ~new_allowed: true
-      (predefined@[if List.mem cmd_browse#get predefined then ""
-                   else cmd_browse#get])
+      (predefined@(if List.mem cmd_browse#get predefined then []
+                   else [cmd_browse#get]))
       cmd_browse#get
   in
 

--- a/ide/coqide/preferences.mli
+++ b/ide/coqide/preferences.mli
@@ -92,6 +92,8 @@ val opposite_tabs : bool preference
 (* val background_color : string preference *)
 val processing_color : string preference
 val processed_color : string preference
+val incompletely_processed_color : string preference
+val breakpoint_color : string preference
 val db_stopping_point_color : string preference
 val error_color : string preference
 val error_fg_color : string preference

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -65,9 +65,9 @@ let install_precommit_hook prefs =
 let browser prefs arch =
   match prefs.browser with
   | Some b -> b
-  | None when arch_is_win32 arch -> "start %s"
-  | None when arch = "Darwin" -> "open %s"
-  | _ -> "firefox -remote \"OpenURL(%s,new-tab)\" || firefox %s &"
+  | None when arch_is_win32 arch -> {|start "%s"|}
+  | None when arch = "Darwin" -> {|open "%s"|}
+  | _ -> {|xdg-open "%s"|}
 
 (** * OCaml programs *)
 module CamlConf = struct


### PR DESCRIPTION
There is a FAQ file which lies around in the coqide folder, and it seems it’s installed with CoqIDE. I propose updating it and formatting it somewhat.

Also, there are browser commands which are setup as default in CoqIDE, but on my system, they don’t work. I don’t know from where those `-remote "openURL(%s)"` options come, but they are apparently obsolete. Netscape is obsolete too, and maybe Seamonkey too. I am suggesting other commands to solve the problem. Perhaps we should also remove the ampersands in the commands.