### PR TITLE
Revert "Using more often names of universes in universe inconsistency message, if possible."

### DIFF
--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -92,42 +92,42 @@ let enforce_eq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((Prop | SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
   enforce_eq (get_algebraic s1) (get_algebraic s2) cst
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then enforce_eq u1 u2 cst
-  else raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 | (QSort _, (Set | Type _)) | ((Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 
 let enforce_leq_sort s1 s2 cst = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
 | (Prop, (Set | Type _)) -> cst
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (None, (Le, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Le, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
   enforce_leq (get_algebraic s1) (get_algebraic s2) cst
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then enforce_leq u1 u2 cst
-  else raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 | (QSort _, (Set | Type _)) | ((Prop | Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 
 let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> Constraints.empty, g
 | (Prop, (Set | Type _)) -> Constraints.empty, g
 | (((Prop | Set | Type _ | QSort _) as s1), (Prop | SProp as s2))
 | ((SProp as s1), ((Prop | Set | Type _ | QSort _) as s2)) ->
-  raise (UGraph.UniverseInconsistency (None, (Le, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Le, s1, s2, None))
 | (Set | Type _), (Set | Type _) ->
   UGraph.enforce_leq_alg (get_algebraic s1) (get_algebraic s2) g
 | QSort (q1, u1), QSort (q2, u2) ->
   if QVar.equal q1 q2 then UGraph.enforce_leq_alg u1 u2 g
-  else raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  else raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 | (QSort _, (Set | Type _)) | ((Prop | Set | Type _), QSort _) ->
-  raise (UGraph.UniverseInconsistency (None, (Eq, s1, s2, None)))
+  raise (UGraph.UniverseInconsistency (Eq, s1, s2, None))
 
 let enforce_univ_constraint (u,d,v) =
   match d with

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -39,8 +39,7 @@ type explanation =
   | Path of path_explanation
   | Other of Pp.t
 
-type univ_variable_printers = (Sorts.QVar.t -> Pp.t) * (Level.t -> Pp.t)
-type univ_inconsistency = univ_variable_printers option * (constraint_type * Sorts.t * Sorts.t * explanation option)
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
 exception UniverseInconsistency of univ_inconsistency
 
@@ -103,7 +102,7 @@ let enforce_constraint cst g = match enforce_constraint0 cst g with
     let (u, c, v) = cst in
     let e = lazy (G.get_explanation cst g.graph) in
     let mk u = Sorts.sort_of_univ @@ Universe.make u in
-    raise (UniverseInconsistency (None, (c, mk u, mk v, Some (Path e))))
+    raise (UniverseInconsistency (c, mk u, mk v, Some (Path e)))
   else g
 | Some g -> g
 
@@ -153,7 +152,7 @@ let enforce_leq_alg u v g =
   | Inr ((u, c, v), g) ->
     let e = lazy (G.get_explanation (u, c, v) g.graph) in
     let mk u = Sorts.sort_of_univ @@ Universe.make u in
-    let e = UniverseInconsistency (None, (c, mk u, mk v, Some (Path e))) in
+    let e = UniverseInconsistency (c, mk u, mk v, Some (Path e)) in
     raise e
 
 module Bound =
@@ -276,11 +275,7 @@ let pr_universes prl g = pr_pmap Pp.mt (pr_arc prl) g
 
 open Pp
 
-let explain_universe_inconsistency default_prq default_prl (printers, (o,u,v,p) : univ_inconsistency) =
-  let prq, prl = match printers with
-    | Some (prq, prl) -> prq, prl
-    | None -> default_prq, default_prl
-  in
+let explain_universe_inconsistency prq prl (o,u,v,p : univ_inconsistency) =
   let pr_uni u = match u with
   | Sorts.Set -> str "Set"
   | Sorts.Prop -> str "Prop"

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -50,8 +50,7 @@ type explanation =
   | Path of path_explanation
   | Other of Pp.t
 
-type univ_variable_printers = (Sorts.QVar.t -> Pp.t) * (Level.t -> Pp.t)
-type univ_inconsistency = univ_variable_printers option * (constraint_type * Sorts.t * Sorts.t * explanation option)
+type univ_inconsistency = constraint_type * Sorts.t * Sorts.t * explanation option
 
 exception UniverseInconsistency of univ_inconsistency
 

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -251,6 +251,3 @@ Arguments MutualI1' A%type_scope
 Arguments C1' A%type_scope p1
 Arguments MutualI2' A%type_scope
 Arguments C2' A%type_scope p2
-File "./output/UnivBinders.v", line 208, characters 0-33:
-The command has indeed failed with message:
-Universe inconsistency. Cannot enforce a < a because a = a.

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -200,11 +200,3 @@ with MutualI2' (A:Type) := C2' (p2 : MutualI1' A).
 Print MutualI2'.
 
 End MutualTypes.
-
-Module Inconsistency.
-
-Set Universe Polymorphism.
-Definition g@{a b} := Type@{a} : Type@{b}.
-Fail Definition h@{a} := g@{a a}.
-
-End Inconsistency.


### PR DESCRIPTION
It broke coq_lsp (CI for it was temporarily broken during #19114 so I merged by mistake)

This reverts commit 482f8510f388b886a4b9acc81f8b76d16d5385f9.
