### PR TITLE
[lib] Add primitives for async-safe resource masking and thread_maps from memprof-limits

### DIFF
--- a/clib/cThread.ml
+++ b/clib/cThread.ml
@@ -107,21 +107,4 @@ let mask_sigalrm f x =
 let create f x =
   Thread.create (mask_sigalrm f) x
 
-(*
-  Atomic mutex lock taken from https://gitlab.com/gadmm/memprof-limits/-/blob/master/src/thread_map.ml#L23-34
-  Critical sections :
-   - Mutex.lock does not poll on leaving the blocking section
-     since 4.12.
-   - Never inline, to avoid theoretically-possible reorderings with
-     flambda.
-     (workaround to the lack of masking)
-*)
-
-(* We inline the call to Mutex.unlock to avoid polling in bytecode mode *)
-let[@inline always] unlock m = (Mutex.unlock [@inlined]) m
-
-let[@inline never] with_lock m ~scope =
-  let () = Mutex.lock m (* BEGIN ATOMIC *) in
-  match (* END ATOMIC *) scope () with
-  | (* BEGIN ATOMIC *) x -> unlock m ; (* END ATOMIC *) x
-  | (* BEGIN ATOMIC *) exception e -> unlock m ; (* END ATOMIC *) raise e
+let with_lock = Memprof_coq.Mutex_aux.with_lock

--- a/clib/dune
+++ b/clib/dune
@@ -5,7 +5,11 @@
  (wrapped false)
  (modules_without_implementation cSig)
  (modules :standard \ unicodetable_gen)
- (libraries str unix threads))
+ (libraries
+  (select memprof_coq.ml from
+   (!memprof-limits -> memprof_coq.std.ml)
+   (memprof-limits -> memprof_coq.memprof.ml))
+   str unix threads))
 
 (executable
  (name unicodetable_gen)

--- a/clib/memprof_coq.memprof.ml
+++ b/clib/memprof_coq.memprof.ml
@@ -1,0 +1,79 @@
+(* From memprof_limits, see also https://gitlab.com/gadmm/memprof-limits/-/issues/7 *)
+
+let is_interrupted () = Memprof_limits.is_interrupted () [@@inline]
+
+module Resource_bind = Memprof_limits.Resource_bind
+
+(* Not exported by memprof limits :( *)
+(* module Thread_map =  Memprof_limits.Thread_map *)
+(* module Mutex_aux = Memprof_limits.Mutex_aux *)
+
+module Mutex_aux = struct
+  external unlock: Mutex.t -> unit = "caml_mutex_unlock"
+
+  (* Critical sections :
+     - Mutex.lock does not poll on leaving the blocking section
+       since 4.12.
+     - Never inline, to avoid theoretically-possible reorderings with
+       flambda.
+     - Inline the call to Mutex.unlock to avoid polling in bytecode.
+       (workaround to the lack of masking) *)
+  let[@inline never] with_lock m ~scope =
+    let () = Mutex.lock m (* BEGIN ATOMIC *) in
+    match (* END ATOMIC *) scope () with
+    | (* BEGIN ATOMIC *) x -> unlock m ; (* END ATOMIC *) x
+    | (* BEGIN ATOMIC *) exception e -> unlock m ; (* END ATOMIC *) raise e
+
+end
+
+module Thread_map_core = struct
+  open Resource_bind
+
+  module IMap = Map.Make (
+    struct
+      type t = int
+      let compare = Stdlib.compare
+    end)
+
+  type 'a t = { mutex : Mutex.t ; mutable map : 'a IMap.t }
+
+  let create () = { mutex = Mutex.create () ; map = IMap.empty }
+
+  let current_thread () = Thread.id (Thread.self ())
+
+  let get s =
+    (* Concurrent threads do not alter the value for the current
+       thread, so we do not need a lock. *)
+    IMap.find_opt (current_thread ()) s.map
+
+  (* For set and clear we need a lock *)
+
+  let set s v =
+    let& () = Mutex_aux.with_lock s.mutex in
+    let new_map = match v with
+      | None -> IMap.remove (current_thread ()) s.map
+      | Some v -> IMap.add (current_thread ()) v s.map
+    in
+    s.map <- new_map
+
+  let _clear s =
+    let& () = Mutex_aux.with_lock s.mutex in
+    s.map <- IMap.empty
+end
+
+module Masking = Memprof_limits.Masking
+
+module Thread_map = struct
+  include Thread_map_core
+
+  let with_value tls ~value ~scope =
+    let old_value = get tls in
+    (* FIXME: needs proper masking here as there is a race between
+       resources and asynchronous exceptions. For now, it is
+       exception-safe only for exceptions arising from Memprof_callbacks. *)
+    Masking.with_resource
+      ~acquire:(fun () -> set tls (Some value)) ()
+      ~scope
+      ~release:(fun () -> set tls old_value)
+
+end

--- a/clib/memprof_coq.mli
+++ b/clib/memprof_coq.mli
@@ -1,0 +1,53 @@
+(* From memprof-limits *)
+val is_interrupted : unit -> bool
+
+module Masking : sig
+
+  val with_resource :
+    acquire:('a -> 'b) -> 'a -> scope:('b -> 'c) -> release:('b -> unit) -> 'c
+
+  val is_blocked : unit -> bool
+
+  val assert_blocked : unit -> unit
+end
+
+module Thread_map : sig
+
+  (** An async-safe, scoped thread-local store *)
+
+  type 'a t
+
+  val create : unit -> 'a t
+  (** Create an empty map *)
+
+  val with_value : 'a t -> value:'a -> scope:(unit -> 'b) -> 'b
+  (** Associate [~value] to the current thread for the duration of a scope.
+      It can be nested: the previous association is restored on exit. *)
+
+  val get : 'a t -> 'a option
+  (** Get the value currently associated with the current thread. *)
+
+end
+
+module Resource_bind : sig
+  (** Open {!Memprof_limits.Resource_bind} to enable the [let&] binder
+      for resources. *)
+
+  val ( let& ) : (scope:('a -> 'b) -> 'b) -> ('a -> 'b) -> 'b
+(** RAII-style notation for resources cleaned-up at the end of
+    scope. Example:
+    {[open Memprof_limits.Resource_bind
+
+      let with_my_resource x =
+        Memprof_limits.Masking.with_resource ~acquire x ~release
+
+      let f x =
+        let& resource = with_my_resource x in
+        …]} *)
+end
+
+module Mutex_aux : sig
+
+  val with_lock : Mutex.t -> scope:(unit -> 'a) -> 'a
+
+end

--- a/clib/memprof_coq.std.ml
+++ b/clib/memprof_coq.std.ml
@@ -1,0 +1,144 @@
+let is_interrupted _ = false [@@inline]
+
+module Resource_bind = struct
+  let ( let& ) f scope = f ~scope
+end
+
+module Mutex_aux = struct
+  external unlock: Mutex.t -> unit = "caml_mutex_unlock"
+
+  (* Critical sections :
+     - Mutex.lock does not poll on leaving the blocking section
+       since 4.12.
+     - Never inline, to avoid theoretically-possible reorderings with
+       flambda.
+     - Inline the call to Mutex.unlock to avoid polling in bytecode.
+       (workaround to the lack of masking) *)
+  let[@inline never] with_lock m ~scope =
+    let () = Mutex.lock m (* BEGIN ATOMIC *) in
+    match (* END ATOMIC *) scope () with
+    | (* BEGIN ATOMIC *) x -> unlock m ; (* END ATOMIC *) x
+    | (* BEGIN ATOMIC *) exception e -> unlock m ; (* END ATOMIC *) raise e
+
+end
+
+module Thread_map_core = struct
+  open Resource_bind
+
+  module IMap = Map.Make (
+    struct
+      type t = int
+      let compare = Stdlib.compare
+    end)
+
+  type 'a t = { mutex : Mutex.t ; mutable map : 'a IMap.t }
+
+  let create () = { mutex = Mutex.create () ; map = IMap.empty }
+
+  let current_thread () = Thread.id (Thread.self ())
+
+  let get s =
+    (* Concurrent threads do not alter the value for the current
+       thread, so we do not need a lock. *)
+    IMap.find_opt (current_thread ()) s.map
+
+  (* For set and clear we need a lock *)
+
+  let set s v =
+    let& () = Mutex_aux.with_lock s.mutex in
+    let new_map = match v with
+      | None -> IMap.remove (current_thread ()) s.map
+      | Some v -> IMap.add (current_thread ()) v s.map
+    in
+    s.map <- new_map
+
+  let _clear s =
+    let& () = Mutex_aux.with_lock s.mutex in
+    s.map <- IMap.empty
+end
+
+module Masking = struct
+
+  module T = Thread_map_core
+
+  type mask = { mutable on : bool }
+
+  let mask_tls : mask T.t = T.create ()
+  (* whether the current thread is masked *)
+
+  let create_mask () =
+    let r = { on = false } in
+    T.set mask_tls (Some r) ;
+    r
+
+  let delete_mask () = T.set mask_tls None
+
+  let is_blocked () =
+    match T.get mask_tls with
+    | None -> false
+    | Some r -> r.on
+
+  let assert_blocked () = assert (is_blocked ())
+
+  (* The current goal is only to protect from those asynchronous
+     exceptions raised after dutifully checking that [is_blocked ()]
+     evaluates to false, and that expect the asynchronous callback to be
+     called again shortly thereafter (e.g. memprof callbacks). There is
+     currently no mechanism to delay asynchronous callbacks, so this
+     strategy cannot work for other kinds of asynchronous callbacks. *)
+  let with_resource ~acquire arg ~scope ~(release : _ -> unit) =
+    let mask, delete_after = match T.get mask_tls with
+      | None -> create_mask (), true
+      | Some r -> r, false
+    in
+    let old_mask = mask.on in
+    let remove_mask () =
+      (* remove the mask flag from the TLS to avoid it growing
+         uncontrollably when there are lots of threads. *)
+      if delete_after then delete_mask () else mask.on <- old_mask
+    in
+    let release_and_unmask r x =
+      match release r with
+      | () -> remove_mask () ; x
+      | exception e -> remove_mask () ; raise e
+    in
+    mask.on <- true ;
+    let r = try acquire arg with
+      | e -> mask.on <- old_mask ; raise e
+    in
+    match
+      mask.on <- old_mask ;
+      scope r
+    with
+    | (* BEGIN ATOMIC *) y -> (
+        mask.on <- true ;
+        (* END ATOMIC *)
+        release_and_unmask r y
+      )
+    | (* BEGIN ATOMIC *) exception e -> (
+        mask.on <- true ;
+        (* END ATOMIC *)
+        match Printexc.get_raw_backtrace () with
+        | bt -> (
+            let e = release_and_unmask r e in
+            Printexc.raise_with_backtrace e bt
+          )
+        | exception Out_of_memory -> raise (release_and_unmask r e)
+      )
+
+end
+
+module Thread_map = struct
+  include Thread_map_core
+
+  let with_value tls ~value ~scope =
+    let old_value = get tls in
+    (* FIXME: needs proper masking here as there is a race between
+       resources and asynchronous exceptions. For now, it is
+       exception-safe only for exceptions arising from Memprof_callbacks. *)
+    Masking.with_resource
+      ~acquire:(fun () -> set tls (Some value)) ()
+      ~scope
+      ~release:(fun () -> set tls old_value)
+
+end

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -155,7 +155,7 @@ let noncritical = function
   | Assert_failure _ | Match_failure _ | Anomaly _
   | Control.Timeout -> false
   | Invalid_argument "equal: functional value" -> false
-  | _ -> not (Interrupted.is_interrupted ())
+  | _ -> not (Memprof_coq.is_interrupted ())
 [@@@ocaml.warning "+52"]
 
 (* This should be in exninfo, but noncritical is here... *)

--- a/lib/dune
+++ b/lib/dune
@@ -6,9 +6,6 @@
  (modules_without_implementation xml_datatype)
  (libraries
   coq-core.boot coq-core.clib coq-core.config
-  (select interrupted.ml from
-   (!memprof-limits -> interrupted.std.ml)
-   (memprof-limits -> interrupted.memprof.ml))
   (select instr.ml from
    (!coqperf -> instr.noperf.ml)
    (coqperf -> instr.perf.ml))))

--- a/lib/interrupted.memprof.ml
+++ b/lib/interrupted.memprof.ml
@@ -1,1 +1,0 @@
-let is_interrupted () = Memprof_limits.is_interrupted () [@@inline]

--- a/lib/interrupted.mli
+++ b/lib/interrupted.mli
@@ -1,1 +1,0 @@
-val is_interrupted : unit -> bool

--- a/lib/interrupted.std.ml
+++ b/lib/interrupted.std.ml
@@ -1,1 +1,0 @@
-let is_interrupted _ = false [@@inline]


### PR DESCRIPTION
Coq should really depend on `memprof-limits`, but this is still not possible (see also https://gitlab.com/gadmm/memprof-limits/-/issues/7)

This PR imports into Coq 2 critical features present in `memprof-limits`:

- masking: for async safe resource handling, which is critical in order to protect some delicate areas from interruptions (for example summary restore)

- thread_map: local thread maps, which will be very useful in the future (for example to install two different copies of the summary in two different threads), and that can be used already to replace code in exninfo

We also consolidate some code that was already sourced from there (cc #14046)

