### PR TITLE
[core] Improved state protection against memprof-limits interruptions

### DIFF
--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -82,18 +82,11 @@ let is_contextual_implicit_args () = !implicit_args.contextual
 let is_maximal_implicit_args () = !implicit_args.maximal
 
 let with_implicit_protection f x =
-  let oflags = !implicit_args in
-  try
-    let rslt = f x in
-    implicit_args := oflags;
-    rslt
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    let () = implicit_args := oflags in
-    Exninfo.iraise reraise
+  let open Memprof_coq.Resource_bind in
+  let& () = Util.protect_ref implicit_args in
+  f x
 
 type on_trailing_implicit = Error | Info | Silent
-
 
 let msg_trailing_implicit (fail : on_trailing_implicit) na i =
   let pos = match na with

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1818,9 +1818,6 @@ let _ =
       Summary.init_function = init }
 
 let with_notation_protection f x =
-  let fs = freeze () in
-  try let a = with_notation_uninterpretation_protection f x in unfreeze fs; a
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    let () = unfreeze fs in
-    Exninfo.iraise reraise
+  let open Memprof_coq.Resource_bind in
+  let& () = Util.protect_state ~freeze ~unfreeze in
+  with_notation_uninterpretation_protection f x

--- a/interp/notationextern.ml
+++ b/interp/notationextern.ml
@@ -298,12 +298,9 @@ let unfreeze fkm =
   notations_key_table := fkm
 
 let with_notation_uninterpretation_protection f x =
-  let fs = freeze () in
-  try let a = f x in unfreeze fs; a
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    let () = unfreeze fs in
-    Exninfo.iraise reraise
+  let open Memprof_coq.Resource_bind in
+  let& () = Util.protect_state ~freeze ~unfreeze in
+  f x
 
 (** Miscellaneous *)
 type notation_use =

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -47,20 +47,13 @@ let unix_timeout n f x =
       let _ = setitimer ITIMER_REAL { old_timer with it_value = old_timer_value } in
       Sys.set_signal Sys.sigalrm psh
     in
-    try
-      let _ = setitimer ITIMER_REAL {it_interval = 0.; it_value = n} in
-      let res = f x in
-      restore_timeout ();
-      Ok res
-    with
-    | Timeout ->
-      let _, info = Exninfo.capture Timeout in
-      restore_timeout ();
+    let open Memprof_coq.Resource_bind in
+    let& () = Memprof_coq.Masking.with_resource ~acquire:(fun () -> ()) () ~release:restore_timeout in
+    let _ = setitimer ITIMER_REAL {it_interval = 0.; it_value = n} in
+    try Ok (f x)
+    with Timeout as exn ->
+      let _, info = Exninfo.capture exn in
       Error info
-    | e ->
-      let e = Exninfo.capture e in
-      restore_timeout ();
-      Exninfo.iraise e
 
 let windows_timeout n f x =
   let killed = ref false in

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -118,6 +118,12 @@ val delayed_force : 'a delayed -> 'a
    Credit X.Leroy, D.Remy. *)
 val try_finally: ('a -> 'b) -> 'a -> ('c -> unit) -> 'c -> 'b
 
+val protect_ref : scope:(unit -> 'a) -> 'b ref -> 'a
+
+val protect_state : freeze:(unit -> 'st) -> unfreeze:('st ->unit) -> scope:(unit -> 'a) -> 'a
+
+val atomify : ('a -> 'b) -> 'a -> 'b
+
 (** {6 Enriched exceptions} *)
 
 type iexn = Exninfo.iexn

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -518,9 +518,11 @@ let parser_summary_tag =
       Summary.init_function = Summary.nop }
 
 let with_grammar_rule_protection f x =
-  let fs = freeze () in
-  try let a = f x in unfreeze fs; a
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    let () = unfreeze fs in
-    Exninfo.iraise reraise
+  let open Memprof_coq.Resource_bind in
+  let& () = Util.protect_state ~freeze ~unfreeze in
+  f x
+
+(* Usually we don't need to protect unfreeze, as for references doing
+   unfreeze again will restore them to a coherent state, however this
+   is not the case for Procq *)
+let unfreeze = Util.atomify unfreeze

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1713,12 +1713,10 @@ let open_close_scope local ~to_open sc =
 (**********************************************************************)
 
 let with_lib_stk_protection f x =
-  let fs = Lib.Interp.freeze () in
-  try let a = f x in Lib.Interp.unfreeze fs; a
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    let () = Lib.Interp.unfreeze fs in
-    Exninfo.iraise reraise
+  let open Memprof_coq.Resource_bind in
+  let freeze, unfreeze = Lib.Interp.(freeze, unfreeze) in
+  let& () = Util.protect_state ~freeze ~unfreeze in
+  f x
 
 let with_syntax_protection f x =
   with_lib_stk_protection

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -64,20 +64,11 @@ end
 
 module System = struct
 let protect f x =
-  let synterp_st = Synterp.freeze () in
-  let interp_st = Interp_system.freeze () in
-  try
-    let a = f x in
-    Synterp.unfreeze synterp_st;
-    Interp_system.unfreeze interp_st;
-    a
-  with reraise ->
-    let reraise = Exninfo.capture reraise in
-    begin
-      Synterp.unfreeze synterp_st;
-      Interp_system.unfreeze interp_st;
-      Exninfo.iraise reraise
-    end
+  let freeze () = let s = Synterp.freeze () in let i = Interp_system.freeze () in s, i in
+  let unfreeze (s,i) = Synterp.unfreeze s; Interp_system.unfreeze i in
+  let open Memprof_coq.Resource_bind in
+  let& () = Util.protect_state ~freeze ~unfreeze in
+  f x
 end
 
 module LemmaStack = struct


### PR DESCRIPTION
This is a proof-of-concept (based on #19175), but could be merged as
is.

It should fix a few bugs we had when interrupting Coq:

- `Pcoq.unfreeze` caused grammar state to go wrong (in a non
  recoverable way)
- Interrupting module dynlink was also leaving the system in a bad
  state.

It is hard to review the codebase for potential problems like this.