### PR TITLE
Document that wf/measure add an implicit argument

### DIFF
--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -222,6 +222,12 @@ using the syntax:
      | _ => O
      end.
 
+.. note:: The :g:`measure f R` and :g:`wf R x` annotations add an
+   implicit argument to the functions being defined. When the function
+   name is prefixed with :g:`@` (see :ref:`deactivation-of-implicit-arguments`),
+   the position of the extra argument needs to be taken into account,
+   e.g. by providing :g:`_` or an an explicit value.
+
 .. caution:: When defining structurally recursive functions, the generated
    obligations should have the prototype of the currently defined
    functional in their context. In this case, the obligations should be

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -444,6 +444,7 @@ but succeeds in
 
    Check Prop = nat.
 
+.. _deactivation-of-implicit-arguments:
 
 Deactivation of implicit arguments for parsing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes the `@` part of #13697 by documenting that the extra argument introduced by `wf`/`measure` has to be taken into account when using @-explicitation.

This is an alternative to #18878 which was instead making the extra argument invisible even from @.

This PR is the solution that @mattam82 recommended.
