### PR TITLE
Removing indirection from global_declaration to constant_entry

### DIFF
--- a/dev/ci/user-overlays/19185-herbelin-master+flattening-global-declaration.sh
+++ b/dev/ci/user-overlays/19185-herbelin-master+flattening-global-declaration.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/herbelin/coq-lsp main+adapt-coq-pr19185-flattening-global_declaration 19185 master+flattening-global-declaration

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -213,9 +213,9 @@ let infer_parameter ~sec_univs env entry =
   }
 
 let infer_definition ~sec_univs env entry =
-  let env, usubst, _, univs = process_universes env entry.const_entry_universes in
-  let j = Typeops.infer env entry.const_entry_body in
-  let typ = match entry.const_entry_type with
+  let env, usubst, _, univs = process_universes env entry.definition_entry_universes in
+  let j = Typeops.infer env entry.definition_entry_body in
+  let typ = match entry.definition_entry_type with
     | None ->
       Vars.subst_univs_level_constr usubst j.uj_type
     | Some t ->
@@ -225,7 +225,7 @@ let infer_definition ~sec_univs env entry =
   in
   let body = Vars.subst_univs_level_constr usubst j.uj_val in
   let def = Def body in
-  let hyps = used_section_variables env entry.const_entry_secctx (Some body) typ in
+  let hyps = used_section_variables env entry.definition_entry_secctx (Some body) typ in
   {
     const_hyps = hyps;
     const_univ_hyps = make_univ_hyps sec_univs;
@@ -234,15 +234,9 @@ let infer_definition ~sec_univs env entry =
     const_body_code = ();
     const_universes = univs;
     const_relevance = Relevanceops.relevance_of_term env body;
-    const_inline_code = entry.const_entry_inline_code;
+    const_inline_code = entry.definition_entry_inline_code;
     const_typing_flags = Environ.typing_flags env;
   }
-
-let infer_constant ~sec_univs env = function
-  | PrimitiveEntry entry -> infer_primitive env entry
-  | SymbolEntry entry -> infer_symbol env entry
-  | ParameterEntry entry -> infer_parameter ~sec_univs env entry
-  | DefinitionEntry entry -> infer_definition ~sec_univs env entry
 
 (** Definition is opaque (Qed), so we delay the typing of its body. *)
 let infer_opaque ~sec_univs env entry =

--- a/kernel/constant_typing.mli
+++ b/kernel/constant_typing.mli
@@ -29,8 +29,16 @@ val infer_local_def : env -> Id.t -> section_def_entry ->
 
 val infer_local_assum : env -> types -> types * Sorts.relevance
 
-val infer_constant :
-  sec_univs:UVars.Instance.t option -> env -> constant_entry ->
+val infer_primitive : env -> primitive_entry -> ('a, unit) pconstant_body
+
+val infer_symbol : env -> symbol_entry -> ('a, unit) pconstant_body
+
+val infer_parameter :
+  sec_univs:UVars.Instance.t option -> env -> parameter_entry ->
+    ('a, unit) pconstant_body
+
+val infer_definition :
+  sec_univs:UVars.Instance.t option -> env -> definition_entry ->
     ('a, unit) pconstant_body
 
 val infer_opaque :

--- a/kernel/entries.mli
+++ b/kernel/entries.mli
@@ -67,12 +67,12 @@ type mutual_inductive_entry = {
 (** {6 Constants (Definition/Axiom) } *)
 
 type definition_entry = {
-  const_entry_body : constr;
+  definition_entry_body : constr;
   (* List of section variables *)
-  const_entry_secctx : Id.Set.t option;
-  const_entry_type : types option;
-  const_entry_universes : universes_entry;
-  const_entry_inline_code : bool;
+  definition_entry_secctx : Id.Set.t option;
+  definition_entry_type : types option;
+  definition_entry_universes : universes_entry;
+  definition_entry_inline_code : bool;
 }
 
 type section_def_entry = {
@@ -112,6 +112,7 @@ type 'a proof_output = constr Univ.in_universe_context_set * 'a
 
 type constant_entry =
   | DefinitionEntry : definition_entry -> constant_entry
+  | OpaqueEntry : unit opaque_entry -> constant_entry
   | ParameterEntry : parameter_entry -> constant_entry
   | PrimitiveEntry : primitive_entry -> constant_entry
   | SymbolEntry : symbol_entry -> constant_entry

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -57,6 +57,7 @@ val concat_private : private_constants -> private_constants -> private_constants
 
 val inline_private_constants :
   Environ.env -> private_constants Entries.proof_output -> Constr.constr Univ.in_universe_context_set
+(** Abstract the private constants of a proof over the proof output *)
 
 val push_private_constants : Environ.env -> private_constants -> Environ.env
 (** Push the constants in the environment if not already there. *)
@@ -69,10 +70,6 @@ val is_joined_environment : safe_environment -> bool
 (** {6 Enriching a safe environment } *)
 
 (** Insertion of global axioms or definitions *)
-
-type global_declaration =
-| ConstantEntry : Entries.constant_entry -> global_declaration
-| OpaqueEntry : unit Entries.opaque_entry -> global_declaration
 
 type side_effect_declaration =
 | DefinitionEff : Entries.definition_entry -> side_effect_declaration
@@ -90,7 +87,7 @@ val export_private_constants :
 (** returns the main constant *)
 val add_constant :
   ?typing_flags:Declarations.typing_flags ->
-  Label.t -> global_declaration -> Constant.t safe_transformer
+  Label.t -> Entries.constant_entry -> Constant.t safe_transformer
 
 (** Similar to add_constant but also returns a certificate *)
 val add_private_constant :

--- a/library/global.mli
+++ b/library/global.mli
@@ -52,7 +52,7 @@ val export_private_constants :
 
 val add_constant :
   ?typing_flags:typing_flags ->
-  Id.t -> Safe_typing.global_declaration -> Constant.t
+  Id.t -> Entries.constant_entry -> Constant.t
 val fill_opaque : Safe_typing.opaque_certificate -> unit
 val add_private_constant :
   Id.t -> Univ.ContextSet.t -> Safe_typing.side_effect_declaration -> Constant.t * Safe_typing.private_constants

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -311,11 +311,11 @@ let cast_proof_entry e =
         CErrors.anomaly Pp.(str "Local universes in non-opaque polymorphic definition.");
   in
   let univ_entry, ctx = extract_monomorphic univ_entry in
-  { Entries.const_entry_body = body;
-    const_entry_secctx = e.proof_entry_secctx;
-    const_entry_type = e.proof_entry_type;
-    const_entry_universes = univ_entry;
-    const_entry_inline_code = e.proof_entry_inline_code;
+  { Entries.definition_entry_body = body;
+    definition_entry_secctx = e.proof_entry_secctx;
+    definition_entry_type = e.proof_entry_type;
+    definition_entry_universes = univ_entry;
+    definition_entry_inline_code = e.proof_entry_inline_code;
   },
   ctx
 
@@ -400,8 +400,7 @@ let declare_constant_core ~name ~typing_flags cd =
         (* We register the global universes after exporting side-effects, since
            the latter depend on the former. *)
         let () = Global.push_context_set ~strict:true ctx in
-        let cd = Entries.DefinitionEntry e in
-        ConstantEntry cd, false, ubinders, None
+        Entries.DefinitionEntry e, false, ubinders, None
       else
         let map (body, eff) = body, eff.Evd.seff_private in
         let body = Future.chain de.proof_entry_body map in
@@ -410,7 +409,7 @@ let declare_constant_core ~name ~typing_flags cd =
         let cd, ctx = cast_opaque_proof_entry EffectEntry de in
         let ubinders = make_ubinders ctx de.proof_entry_universes in
         let () = Global.push_context_set ~strict:true ctx in
-        OpaqueEntry cd, false, ubinders, Some (body, feedback_id)
+        Entries.OpaqueEntry cd, false, ubinders, Some (body, feedback_id)
     | ParameterEntry e ->
       let univ_entry, ctx = extract_monomorphic (fst e.parameter_entry_universes) in
       let ubinders = make_ubinders ctx e.parameter_entry_universes in
@@ -421,7 +420,7 @@ let declare_constant_core ~name ~typing_flags cd =
         Entries.parameter_entry_universes = univ_entry;
         Entries.parameter_entry_inline_code = e.parameter_entry_inline_code;
       } in
-      ConstantEntry (Entries.ParameterEntry e), not (Lib.is_modtype_strict()), ubinders, None
+      Entries.ParameterEntry e, not (Lib.is_modtype_strict()), ubinders, None
     | PrimitiveEntry e ->
       let typ, univ_entry, ctx = match e.prim_entry_type with
       | None ->
@@ -436,7 +435,7 @@ let declare_constant_core ~name ~typing_flags cd =
         Entries.prim_entry_content = e.prim_entry_content;
       } in
       let ubinders = make_ubinders ctx univ_entry in
-      ConstantEntry (Entries.PrimitiveEntry e), false, ubinders, None
+      Entries.PrimitiveEntry e, false, ubinders, None
     | SymbolEntry { symb_entry_type=typ; symb_entry_unfold_fix=un_fix; symb_entry_universes=entry_univs } ->
       let univ_entry, ctx = extract_monomorphic (fst entry_univs) in
       let () = Global.push_context_set ~strict:true ctx in
@@ -446,7 +445,7 @@ let declare_constant_core ~name ~typing_flags cd =
         Entries.symb_entry_universes = univ_entry;
       } in
       let ubinders = make_ubinders ctx entry_univs in
-      ConstantEntry (Entries.SymbolEntry e), false, ubinders, None
+      Entries.SymbolEntry e, false, ubinders, None
   in
   let kn = Global.add_constant ?typing_flags name decl in
   let () = DeclareUniv.declare_univ_binders (GlobRef.ConstRef kn) ubinders in


### PR DESCRIPTION
This is a cheap PR that allows in particular a better uniformity of naming.

Synchronous overlay:
- ejgallego/coq-lsp#796