### PR TITLE
[vernacstate] Remove duplicate copy of the parsing state.

### DIFF
--- a/dev/ci/user-overlays/19187-ejgallego-vernacstate_remove_pcoq.sh
+++ b/dev/ci/user-overlays/19187-ejgallego-vernacstate_remove_pcoq.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/ejgallego/coq-lsp vernacstate_remove_pcoq 19187
+
+overlay serapi https://github.com/ejgallego/coq-serapi vernacstate_remove_pcoq 19187
+
+overlay vscoq https://github.com/ejgallego/vscoq vernacstate_remove_pcoq 19187

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -87,6 +87,7 @@ module type FrozenStage = sig
   val make_marshallable : frozen -> frozen
   val unfreeze_summaries : ?partial:bool -> frozen -> unit
   val init_summaries : unit -> unit
+  val project_from_summary : frozen -> 'a Dyn.tag -> 'a
 
 end
 
@@ -153,6 +154,10 @@ module Synterp = struct
 
   let init_summaries () =
     init_summaries !sum_map_synterp
+
+  (** Summary projection *)
+  let project_from_summary { summaries; _ } tag =
+    Frozen.find tag summaries
 
 end
 

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -93,6 +93,7 @@ module type FrozenStage = sig
   val make_marshallable : frozen -> frozen
   val unfreeze_summaries : ?partial:bool -> frozen -> unit
   val init_summaries : unit -> unit
+  val project_from_summary : frozen -> 'a Dyn.tag -> 'a
 
 end
 
@@ -104,7 +105,6 @@ module Interp : sig
   (** Typed projection of the summary. Experimental API, use with CARE *)
 
   val modify_summary : frozen -> 'a Dyn.tag -> 'a -> frozen
-  val project_from_summary : frozen -> 'a Dyn.tag -> 'a
   val remove_from_summary : frozen -> 'a Dyn.tag -> frozen
 
 end

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -587,7 +587,7 @@ end = struct (* {{{ *)
   let get_parsing_state id =
     stm_pperr_endline (fun () -> str "retrieve parsing state state " ++ str (Stateid.to_string id) ++ str " }}}");
     match (get_info id).state with
-    | FullState s -> Some s.Vernacstate.synterp.parsing
+    | FullState s -> Some Vernacstate.(Synterp.parsing s.synterp)
     | ParsingState s -> Some s
     | ErrorState (s,_) -> s
     | EmptyState -> None

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -22,82 +22,78 @@ module Parser = struct
 
 end
 
-module System = struct
+module Synterp = struct
 
-  module Synterp = struct
+  type t = Lib.Synterp.frozen * Summary.Synterp.frozen
 
-    type t = Lib.Synterp.frozen * Summary.Synterp.frozen
+  let freeze () =
+    (Lib.Synterp.freeze (), Summary.Synterp.freeze_summaries ())
 
-    let freeze () =
-      (Lib.Synterp.freeze (), Summary.Synterp.freeze_summaries ())
+  let unfreeze (fl,fs) =
+    Lib.Synterp.unfreeze fl;
+    Summary.Synterp.unfreeze_summaries fs
 
-    let unfreeze (fl,fs) =
-      Lib.Synterp.unfreeze fl;
-      Summary.Synterp.unfreeze_summaries fs
+  let init () = freeze ()
 
-    let init () = freeze ()
+  let parsing (_, sum) =
+    Summary.Synterp.project_from_summary sum Pcoq.parser_summary_tag
 
-    let parsing (_, sum) =
-      Summary.Synterp.project_from_summary sum Pcoq.parser_summary_tag
-
-    module Stm = struct
-      let make_shallow (lib, summary) = Lib.Synterp.drop_objects lib, Summary.Synterp.make_marshallable summary
-      let lib = fst
-      let summary = snd
-    end
-
+  module Stm = struct
+    let make_shallow (lib, summary) = Lib.Synterp.drop_objects lib, Summary.Synterp.make_marshallable summary
+    let lib = fst
+    let summary = snd
   end
-
-  module Interp : sig
-    type t
-    val freeze : unit -> t
-    val unfreeze : t -> unit
-    module Stm : sig
-      val make_shallow : t -> t
-      val lib : t -> Lib.Interp.frozen
-      val summary : t -> Summary.Interp.frozen
-      val replace_summary : t -> Summary.Interp.frozen -> t
-    end
-
-  end = struct
-
-    type t = Lib.Interp.frozen * Summary.Interp.frozen
-
-    let freeze () =
-      (Lib.Interp.freeze (), Summary.Interp.freeze_summaries ())
-
-    let unfreeze (fl,fs) =
-      Lib.Interp.unfreeze fl;
-      Summary.Interp.unfreeze_summaries fs
-
-    (* STM-specific state manipulations *)
-    module Stm = struct
-      let make_shallow (lib, summary) = Lib.Interp.drop_objects lib, Summary.Interp.make_marshallable summary
-      let lib = fst
-      let summary = snd
-      let replace_summary (lib,_) summary = (lib,summary)
-    end
-  end
-
-  let protect f x =
-    let synterp_st = Synterp.freeze () in
-    let interp_st = Interp.freeze () in
-    try
-      let a = f x in
-      Synterp.unfreeze synterp_st;
-      Interp.unfreeze interp_st;
-      a
-    with reraise ->
-      let reraise = Exninfo.capture reraise in
-      begin
-        Synterp.unfreeze synterp_st;
-        Interp.unfreeze interp_st;
-        Exninfo.iraise reraise
-      end
 
 end
 
-module Synterp = System.Synterp
+module Interp_system : sig
+  type t
+  val freeze : unit -> t
+  val unfreeze : t -> unit
+  module Stm : sig
+    val make_shallow : t -> t
+    val lib : t -> Lib.Interp.frozen
+    val summary : t -> Summary.Interp.frozen
+    val replace_summary : t -> Summary.Interp.frozen -> t
+  end
+
+end = struct
+
+  type t = Lib.Interp.frozen * Summary.Interp.frozen
+
+  let freeze () =
+    (Lib.Interp.freeze (), Summary.Interp.freeze_summaries ())
+
+  let unfreeze (fl,fs) =
+    Lib.Interp.unfreeze fl;
+    Summary.Interp.unfreeze_summaries fs
+
+  (* STM-specific state manipulations *)
+  module Stm = struct
+    let make_shallow (lib, summary) = Lib.Interp.drop_objects lib, Summary.Interp.make_marshallable summary
+    let lib = fst
+    let summary = snd
+    let replace_summary (lib,_) summary = (lib,summary)
+  end
+end
+
+module System = struct
+let protect f x =
+  let synterp_st = Synterp.freeze () in
+  let interp_st = Interp_system.freeze () in
+  try
+    let a = f x in
+    Synterp.unfreeze synterp_st;
+    Interp_system.unfreeze interp_st;
+    a
+  with reraise ->
+    let reraise = Exninfo.capture reraise in
+    begin
+      Synterp.unfreeze synterp_st;
+      Interp_system.unfreeze interp_st;
+      Exninfo.iraise reraise
+    end
+end
 
 module LemmaStack = struct
 
@@ -131,8 +127,10 @@ let s_program = ref (NeList.singleton Declare.OblState.empty)
 
 module Interp = struct
 
+module System = Interp_system
+
 type t = {
-  system  : System.Interp.t;              (* summary + libstack *)
+  system  : System.t;              (* summary + libstack *)
   lemmas  : LemmaStack.t option;   (* proofs of lemmas currently opened *)
   program : Declare.OblState.t NeList.t;    (* obligations table *)
   opaques : Opaques.Summary.t;     (* opaque proof terms *)
@@ -154,17 +152,17 @@ let do_if_not_cached rf f v =
     ()
 
 let freeze_interp_state () =
-  { system = update_cache s_cache (System.Interp.freeze ());
+  { system = update_cache s_cache (System.freeze ());
     lemmas = !s_lemmas;
     program = !s_program;
     opaques = Opaques.Summary.freeze ();
   }
 
 let make_shallow s =
-  { s with system = System.Interp.Stm.make_shallow s.system }
+  { s with system = System.Stm.make_shallow s.system }
 
 let unfreeze_interp_state { system; lemmas; program; opaques } =
-  do_if_not_cached s_cache System.Interp.unfreeze system;
+  do_if_not_cached s_cache System.unfreeze system;
   s_lemmas := lemmas;
   s_program := program;
   Opaques.Summary.unfreeze opaques
@@ -282,7 +280,7 @@ module Stm = struct
 
   (* Parts of the system state that are morally part of the proof state *)
   let pstate { interp = { lemmas; system }} =
-    let st = System.Interp.Stm.summary system in
+    let st = Interp.System.Stm.summary system in
     lemmas,
     Summary.Interp.project_from_summary st Evarutil.meta_counter_summary_tag,
     Summary.Interp.project_from_summary st Evd.evar_counter_summary_tag
@@ -292,9 +290,9 @@ module Stm = struct
       lemmas =
         Declare_.copy_terminators ~src:s.interp.lemmas ~tgt:pstate
     ; system =
-        System.Interp.Stm.replace_summary s.interp.system
+        Interp.System.Stm.replace_summary s.interp.system
           begin
-            let st = System.Interp.Stm.summary s.interp.system in
+            let st = Interp.System.Stm.summary s.interp.system in
             let st = Summary.Interp.modify_summary st Evarutil.meta_counter_summary_tag c1 in
             let st = Summary.Interp.modify_summary st Evd.evar_counter_summary_tag c2 in
             st
@@ -305,16 +303,16 @@ module Stm = struct
   type non_pstate = Summary.Synterp.frozen * Lib.Synterp.frozen * Summary.Interp.frozen * Lib.Interp.frozen
   let non_pstate { synterp; interp } =
     let system = interp.system in
-    let st = System.Interp.Stm.summary system in
+    let st = Interp.System.Stm.summary system in
     let st = Summary.Interp.remove_from_summary st Evarutil.meta_counter_summary_tag in
     let st = Summary.Interp.remove_from_summary st Evd.evar_counter_summary_tag in
-    System.Synterp.Stm.summary synterp, System.Synterp.Stm.lib synterp,
-      st, System.Interp.Stm.lib system
+    Synterp.Stm.summary synterp, Synterp.Stm.lib synterp,
+      st, Interp.System.Stm.lib system
 
   let same_env { interp = { system = s1 } } { interp = { system = s2 } } =
-    let s1 = System.Interp.Stm.summary s1 in
+    let s1 = Interp.System.Stm.summary s1 in
     let e1 = Summary.Interp.project_from_summary s1 Global.global_env_summary_tag in
-    let s2 = System.Interp.Stm.summary s2 in
+    let s2 = Interp.System.Stm.summary s2 in
     let e2 = Summary.Interp.project_from_summary s2 Global.global_env_summary_tag in
     e1 == e2
 

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -9,6 +9,8 @@
 (************************************************************************)
 
 module Parser : sig
+
+  (** Subset of [Synterp.t] needed to parse *)
   type t
 
   val init : unit -> t
@@ -18,30 +20,11 @@ module Parser : sig
 
 end
 
-(** System State *)
-module System : sig
-
-  module Synterp : sig
-
-    type t
-
-  end
-
-  module Interp : sig
-
-    (** The system state includes the summary and the libobject  *)
-    type t
-
-  end
-
-  (** [protect f x] runs [f x] and discards changes in the system state  *)
-  val protect : ('a -> 'b) -> 'a -> 'b
-
-end
-
+(** Synterp State, includes parser state, etc... ; as of today the
+    parsing state has no functional components. *)
 module Synterp : sig
 
-  type t = System.Synterp.t
+  type t
 
   val init : unit -> t
   val freeze : unit -> t
@@ -50,6 +33,12 @@ module Synterp : sig
 
 end
 
+module System : sig
+  (** [protect f x] runs [f x] and discards changes in the system state
+      (both [Synterp.t] and [Interp.System.t]). It doesn't touch the
+      proof functional state in [Interp.t] *)
+  val protect : ('a -> 'b) -> 'a -> 'b
+end
 
 module LemmaStack : sig
 
@@ -68,22 +57,26 @@ end
 
 module Interp : sig
 
-type t =
-  { system  : System.Interp.t
-  (** summary + libstack *)
-  ; lemmas  : LemmaStack.t option
-  (** proofs of lemmas currently opened *)
-  ; program : Declare.OblState.t NeList.t
-  (** program mode table. One per open module/section including the toplevel module. *)
-  ; opaques : Opaques.Summary.t
-  (** qed-terminated proofs *)
-  }
+  module System : sig
+    type t
+  end
 
-val freeze_interp_state : unit -> t
-val unfreeze_interp_state : t -> unit
+  type t =
+    { system  : System.t
+    (** summary + libstack *)
+    ; lemmas  : LemmaStack.t option
+    (** proofs of lemmas currently opened *)
+    ; program : Declare.OblState.t NeList.t
+    (** program mode table. One per open module/section including the toplevel module. *)
+    ; opaques : Opaques.Summary.t
+    (** qed-terminated proofs *)
+    }
 
-(* WARNING: Do not use, it will go away in future releases *)
-val invalidate_cache : unit -> unit
+  val freeze_interp_state : unit -> t
+  val unfreeze_interp_state : t -> unit
+
+  (* WARNING: Do not use, it will go away in future releases *)
+  val invalidate_cache : unit -> unit
 
 end
 

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -41,16 +41,12 @@ end
 
 module Synterp : sig
 
-  type t =
-    { parsing : Parser.t
-    (** parsing state [parsing state may not behave 100% functionally yet, beware] *)
-    ; system : System.Synterp.t
-    (** system state needed for the synterp phase *)
-    }
+  type t = System.Synterp.t
 
   val init : unit -> t
   val freeze : unit -> t
   val unfreeze : t -> unit
+  val parsing : t -> Parser.t
 
 end
 


### PR DESCRIPTION
As noted in #19159 (of which this PR is an alternative), `Vernacstate` stores a copy of the parsing state, which is also already stored in the summary.

Thus, we do unnecessary job on unfreeze.

We remove this duplication and choose to keep the parsing state in the summary, which seems to work, and seems OK for now as more explicit state management is tricky as noted by Gaëtan Gilbert: sections messing with summaries behind the back of `Vernacstate`, so they would have to restore `Pcoq.frozen_t` too as to support this approach.

There is no real advantage to a separate `Pcoq` state for now.

See second commit for a proposal for an interface rework.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/775
- https://github.com/coq-community/vscoq/pull/783
- https://github.com/ejgallego/coq-serapi/pull/417