### PR TITLE
Include warnings in the Errors panel

### DIFF
--- a/doc/changelog/10-coqide/19188-warnings_in_table.rst
+++ b/doc/changelog/10-coqide/19188-warnings_in_table.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Warnings are now included in the Errors panel
+  (`#19188 <https://github.com/coq/coq/pull/19188>`_,
+  by Jim Fehrle).

--- a/ide/coqide/coqOps.ml
+++ b/ide/coqide/coqOps.ml
@@ -238,7 +238,7 @@ object
   method stop_worker : string -> unit task
 
   method get_n_errors : int
-  method get_errors : (int * string) list
+  method get_errors_warnings : (int * string) list
   method get_slaves_status : int * int * string CString.Map.t
   method backtrack_to_begin : unit -> unit task
   method handle_failure : handle_exn_rty -> unit task
@@ -859,19 +859,24 @@ object(self)
   method get_n_errors =
     Doc.fold_all document 0 (fun n _ _ s -> if has_flag s `ERROR then n+1 else n)
 
-  method get_errors =
-    let extract_error s =
-      match List.find (function `ERROR _ -> true | _ -> false) s.flags with
-      | `ERROR (loc, msg) ->
-         let iter = begin match loc with
-           | None      -> buffer#get_iter_at_mark s.start
-           | Some loc ->
-             fst (coq_loc_to_gtk_offset buffer loc)
-         end in iter#line + 1, msg
-      | _ -> assert false in
+  method get_errors_warnings =
+    let extract s =
+      let l = List.find_all (function `ERROR _ | `WARNING _ -> true | _ -> false) s.flags in
+      List.map (fun item ->
+        match item with
+        | `ERROR (loc, msg)
+        | `WARNING (loc, msg) ->
+           let iter = begin match loc with
+             | None      -> buffer#get_iter_at_mark s.start
+             | Some loc ->
+               fst (coq_loc_to_gtk_offset buffer loc)
+           end in iter#line + 1, msg
+        | _ -> assert false
+      ) l
+    in
     List.rev
       (Doc.fold_all document [] (fun acc _ _ s ->
-        if has_flag s `ERROR then extract_error s :: acc else acc))
+        if has_flag s `ERROR || (has_flag s `WARNING) then extract s @ acc else acc))
 
   method process_next_phrase =
     let until n _ _ = n >= 1 in

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -40,7 +40,7 @@ object
   method stop_worker : string -> unit task
 
   method get_n_errors : int
-  method get_errors : (int * string) list
+  method get_errors_warnings : (int * string) list
   method get_slaves_status : int * int * string CString.Map.t
   method backtrack_to_begin : unit -> unit task
   method handle_failure : handle_exn_rty -> unit task

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1729,7 +1729,7 @@ let build_ui () =
     else
       slaveinfo#set_text (Printf.sprintf "%d / %d" missing n_err);
     slaveinfo#set_use_markup true;
-    sn.errpage#update sn.coqops#get_errors;
+    sn.errpage#update sn.coqops#get_errors_warnings;
     sn.jobpage#update (Util.pi3 sn.coqops#get_slaves_status) in
   let callback () = on_current_term update; true in
   let _ = Glib.Timeout.add ~ms:300 ~callback in

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -327,7 +327,7 @@ let make_table_widget ?sort cd cb =
 let create_errpage (script : Wg_ScriptView.script_view) : errpage =
   let table, access =
     make_table_widget ~sort:(0, `ASCENDING)
-      [`Int,"Line",true; `String,"Error message",true]
+      [`Int,"Line",true; `String,"Error/Warning",true]
       (fun columns store tp vc ->
         let row = store#get_iter tp in
         let lno = store#get ~row ~column:(find_int_col "Line" columns) in
@@ -353,7 +353,7 @@ let create_errpage (script : Wg_ScriptView.script_view) : errpage =
         List.iter (fun (lno, msg) -> access (fun columns store ->
           let line = store#append () in
           store#set ~row:line ~column:(find_int_col "Line" columns) lno;
-          store#set ~row:line ~column:(find_string_col "Error message" columns) msg))
+          store#set ~row:line ~column:(find_string_col "Error/Warning" columns) msg))
           errs
       end
     method on_update ~callback:cb = callback := cb


### PR DESCRIPTION
Currently warnings are printed in the Messages panel and add tooltips in the buffer (underlined blue text).  However, unlike errors, the user needs to scan the file to find them in the buffer, which can be tedious for large files.  Adding them to the error panel makes them easy to find.

- [x] Added **changelog**.

![image](https://github.com/coq/coq/assets/1253341/812955b2-be4b-4f98-9afc-51bbcc0cd0fa)
