### PR TITLE
Slightly tweak the bench diff colours.

### DIFF
--- a/dev/bench/htmloutput.ml
+++ b/dev/bench/htmloutput.ml
@@ -10,7 +10,7 @@
 
 open BenchUtil
 
-let colors = [|"#F08080"; "#EEE8AA"; "#98FB98"|]
+let colors = [|"#FFCECB"; "#D1F8D9"; "#98FB98"|]
 
 let max_data_count = Array.length colors
 


### PR DESCRIPTION
The previous setting was hard to read for the NEW line. The old colour was a light yellow, and was turned into a light green. To reuse a common scheme, the OLD and NEW colours were taken from the GitHub diff UI.