### PR TITLE
Change critical bug conversion machine classification 15070 to also affecting native

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -595,10 +595,10 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 
 #### arbitrary code execution on arrays of floating point numbers
 
-- component: "virtual machine" (compilation to bytecode ran by a C-interpreter)
+- component: "virtual" and "native" conversion machines
 - introduced: 8.13
 - impacted released versions: 8.13.0, 8.13.1, 8.14.0
-- impacted coqchk versions: none (no virtual machine in coqchk)
+- impacted coqchk versions: none (no VM / native computation in coqchk)
 - fixed in: 8.14.1
 - found by: Melquiond
 - GH issue number: coq/coq#15070


### PR DESCRIPTION
Bug 15070 was discussed in the Github issue of the same name: https://github.com/coq/coq/issues/15070
The bug was originally found in the virtual machine. Later proux01 added the native compiler label to the Github issue.
This change is not reflected in [``critical-bugs.md``](https://github.com/coq/coq/blob/master/dev/doc/critical-bugs.md#arbitrary-code-execution-on-arrays-of-floating-point-numbers), this PR updates this.

I've also personally tested that the issue **is** present on the native machine in versions ``8.13.0`` and ``8.14.0`` and **is not** present in version ``8.14.1``.