### PR TITLE
[vernacstate] Remove `Vernacstate.Parser.t`

### DIFF
--- a/dev/ci/user-overlays/19193-ejgallego-vernacstate_remove_parsing.sh
+++ b/dev/ci/user-overlays/19193-ejgallego-vernacstate_remove_parsing.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/ejgallego/coq-lsp vernacstate_remove_parsing 19193
+
+overlay serapi https://github.com/ejgallego/coq-serapi vernacstate_remove_parsing 19193
+
+overlay vscoq https://github.com/ejgallego/vscoq vernacstate_remove_parsing 19193

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -8,20 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Parser = struct
-
-  type t = Pcoq.frozen_t
-
-  let init () = Pcoq.freeze ()
-
-  let cur_state () = Pcoq.freeze ()
-
-  let parse ps entry pa =
-    Pcoq.unfreeze ps;
-    Pcoq.Entry.parse entry pa
-
-end
-
 module Synterp = struct
 
   type t = Lib.Synterp.frozen * Summary.Synterp.frozen
@@ -33,10 +19,10 @@ module Synterp = struct
     Lib.Synterp.unfreeze fl;
     Summary.Synterp.unfreeze_summaries fs
 
-  let init () = freeze ()
+  let parsing (_fl, fs) =
+    Summary.Synterp.project_from_summary fs Pcoq.parser_summary_tag
 
-  let parsing (_, sum) =
-    Summary.Synterp.project_from_summary sum Pcoq.parser_summary_tag
+  let init () = freeze ()
 
   module Stm = struct
     let make_shallow (lib, summary) = Lib.Synterp.drop_objects lib, Summary.Synterp.make_marshallable summary
@@ -68,7 +54,6 @@ end = struct
     Lib.Interp.unfreeze fl;
     Summary.Interp.unfreeze_summaries fs
 
-  (* STM-specific state manipulations *)
   module Stm = struct
     let make_shallow (lib, summary) = Lib.Interp.drop_objects lib, Summary.Interp.make_marshallable summary
     let lib = fst

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -8,18 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Parser : sig
-
-  (** Subset of [Synterp.t] needed to parse *)
-  type t
-
-  val init : unit -> t
-  val cur_state : unit -> t
-
-  val parse : t -> 'a Pcoq.Entry.t -> Pcoq.Parsable.t -> 'a
-
-end
-
 (** Synterp State, includes parser state, etc... ; as of today the
     parsing state has no functional components. *)
 module Synterp : sig
@@ -29,8 +17,7 @@ module Synterp : sig
   val init : unit -> t
   val freeze : unit -> t
   val unfreeze : t -> unit
-  val parsing : t -> Parser.t
-
+  val parsing : t -> Pcoq.frozen_t
 end
 
 module System : sig


### PR DESCRIPTION
We remove `Vernacstate.Parser.t` as it is just a duplicate of
`Vernacstate.Synterp`.

The module was originally introduced to serve the same purpose.

However things still don't work in the stm if we unfreeze the whole
synterp state instead of just the parsing state.

I'd guess this is an stm problem, likely due freezing the synterp
state at the wrong time? (just after parsing, but before synterp has
been run?) It is hard to tell without more research.

I thus wonder how we should proceed here, for now I kept the original
STM semantics.

Follow up to #19187

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/781
- https://github.com/ejgallego/coq-serapi/pull/419
- https://github.com/coq-community/vscoq/pull/787
