### PR TITLE
typing.ml don't produce anomaly when bad relevance warning is AsError

### DIFF
--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -411,7 +411,7 @@ let warn_bad_relevance_binder ?loc env sigma rlv bnd =
 | CWarnings.Disabled | CWarnings.Enabled ->
   CWarnings.warn bad_relevance_msg ?loc (env,sigma,Typeops.BadRelevanceBinder (rlv, bnd))
 | CWarnings.AsError ->
-  CErrors.anomaly (CErrors.print (PretypeError (env, sigma, TypingError (Type_errors.BadBinderRelevance (rlv, bnd)))))
+  Loc.raise ?loc (PretypeError (env, sigma, TypingError (Type_errors.BadBinderRelevance (rlv, bnd))))
 
 type relevance_preunify =
   | Trivial


### PR DESCRIPTION

This was a mistaken squash of test commit f508cfd968935c16bf38aba21b211b3a3cc9169e AFAICT
