### PR TITLE
Ltac2 don't print empty backtrace

### DIFF
--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1019,14 +1019,14 @@ end
 let () = CErrors.register_additional_error_info begin fun info ->
   if !Tac2bt.print_ltac2_backtrace then
     let bt = Exninfo.get info Tac2bt.backtrace in
-    let bt = match bt with
-    | Some bt -> List.rev bt
-    | None -> []
-    in
-    let bt =
-      str "Backtrace:" ++ fnl () ++ prlist_with_sep fnl pr_frame bt ++ fnl ()
-    in
-    Some bt
+    match bt with
+    | None -> None
+    | Some bt ->
+      let bt = List.rev bt in
+      let bt =
+        str "Backtrace:" ++ fnl () ++ prlist_with_sep fnl pr_frame bt ++ fnl ()
+      in
+      Some bt
   else None
 end
 

--- a/test-suite/output/ltac2_bt.out
+++ b/test-suite/output/ltac2_bt.out
@@ -2,9 +2,6 @@ File "./output/ltac2_bt.v", line 8, characters 2-48:
 The command has indeed failed with message:
 Uncaught Ltac2 exception: Invalid_argument None
 Backtrace:
-
-
-Backtrace:
 Prim <coq-core.plugins.ltac2:plus>
 Call {Control.zero e}
 Prim <coq-core.plugins.ltac2:zero>
@@ -20,9 +17,6 @@ Prim <coq-core.plugins.ltac2:throw>
 File "./output/ltac2_bt.v", line 10, characters 2-60:
 The command has indeed failed with message:
 Uncaught Ltac2 exception: Invalid_argument None
-Backtrace:
-
-
 Backtrace:
 Prim <coq-core.plugins.ltac2:plus_bt>
 Call f


### PR DESCRIPTION
This avoids printing an empty "Backtrace:" entry next to the real one when Ltac2 Backtrace is on.

(it gets printed when an exn is wrapped, because the wrapping uses CErrors.print which gives an empty exninfo)

It also avoids printing en empty "Backtrace:" for exception which have nothing to do with ltac2 (eg `Check Prop : Prop.`).
