### PR TITLE
Print extra info after main error message, don't treat backtrace specially

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -66,10 +66,10 @@ let raw_anomaly e = match e with
     str "Uncaught exception " ++ str (Printexc.to_string e) ++ str "."
 
 let print_backtrace e = match Exninfo.get_backtrace e with
-| None -> mt ()
+| None -> None
 | Some bt ->
   let bt = str (Exninfo.backtrace_to_string bt) in
-  fnl () ++ hov 0 bt
+  Some (hov 0 bt)
 
 let print_anomaly askreport e =
   if askreport then
@@ -96,6 +96,8 @@ let additional_error_info_handler = ref []
 let register_additional_error_info (f : Exninfo.info -> Pp.t option) =
   additional_error_info_handler := f :: !additional_error_info_handler
 
+let () = register_additional_error_info print_backtrace
+
 (** [print_gen] is a general exception printer which tries successively
     all the handlers of a list, and finally a [bottom] handler if all
     others have failed *)
@@ -109,24 +111,26 @@ let rec print_gen ~anomaly stk e =
     | Some err_msg -> err_msg
     | None -> print_gen ~anomaly stk' e
 
-let print_gen ~anomaly (e, info) =
-  let extra_msg =
+let print_extra info =
+  let pp =
     CList.map_filter (fun f -> f info) !additional_error_info_handler
-    (* Location info in the handler is ignored *)
-    |> Pp.seq
   in
+  if CList.is_empty pp then mt()
+  else fnl() ++ prlist_with_sep fnl (fun x -> x) pp
+
+let print_gen ~anomaly (e, info) =
+  let extra_msg = print_extra info in
   try
-    extra_msg ++ print_gen ~anomaly !handle_stack e
+    print_gen ~anomaly !handle_stack e ++ extra_msg
   with exn ->
     let exn, info = Exninfo.capture exn in
     (* exception in error printer *)
-    str "<in exception printer>:" ++ spc() ++ print_anomaly anomaly exn ++
-    print_backtrace info ++ fnl() ++
-    str "<original exception>:" ++ spc() ++ extra_msg ++ print_anomaly false e
+    str "<in exception printer>:" ++ spc() ++ print_anomaly anomaly exn ++ print_extra info ++ fnl() ++
+    str "<original exception>:" ++ spc() ++ print_anomaly false e ++ extra_msg
 
 (** The standard exception printer *)
 let iprint (e, info) =
-  print_gen ~anomaly:true (e,info) ++ print_backtrace info
+  print_gen ~anomaly:true (e,info)
 
 let print e =
   iprint (e, Exninfo.info e)
@@ -134,7 +138,7 @@ let print e =
 (** Same as [print], except that the "Please report" part of an anomaly
     isn't printed (used in Ltac debugging). *)
 let iprint_no_report (e, info) =
-  print_gen ~anomaly:false (e,info) ++ print_backtrace info
+  print_gen ~anomaly:false (e,info)
 let print_no_report e = iprint_no_report (e, Exninfo.info e)
 
 (** Predefined handlers **)

--- a/test-suite/output-coqtop/bug_16462.out
+++ b/test-suite/output-coqtop/bug_16462.out
@@ -17,12 +17,13 @@ Toplevel input, characters 2-7:
 >   baz I.
 >   ^^^^^
 Error:
+Tactic failure (level 1).
 In nested Ltac calls to "baz", "f" (bound to fun f x y => idtac v; f x), 
 "f" (bound to
 fun _ => let v' := v in
          constr:((fun _ => ltac:((idtac v'; fail 1))))) and
 "(fun _ => ltac:((idtac v'; fail 1)))" (with x:=I, v':=Unnamed_thm_subproof,
 v:=Unnamed_thm_subproof, H:=H), last term evaluation failed.
-Tactic failure (level 1).
+
 
 Unnamed_thm < 

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -4,14 +4,18 @@ The field t is missing in Errors.M.
 File "./output/Errors.v", line 19, characters 18-19:
 The command has indeed failed with message:
 Unable to unify "nat" with "True".
+
 File "./output/Errors.v", line 20, characters 12-15:
 The command has indeed failed with message:
+Unable to unify "nat" with
+ "True".
 In nested Ltac calls to "f" and "apply x", last call failed.
-Unable to unify "nat" with "True".
+
 File "./output/Errors.v", line 29, characters 21-30:
 The command has indeed failed with message:
-Ltac call to "instantiate ( (ident) := (lglob) )" failed.
 Instance is not well-typed in the environment of ?x.
+Ltac call to "instantiate ( (ident) := (lglob) )" failed.
+
 File "./output/Errors.v", line 34, characters 19-20:
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "?T -> nat" found for the type of f.
@@ -28,6 +32,7 @@ File "./output/Errors.v", line 44, characters 5-23:
 The command has indeed failed with message:
 The first term has type "nat" while the second term has incompatible type
 "bool".
+
 File "./output/Errors.v", line 49, characters 7-24:
 The command has indeed failed with message:
 Replacement would lead to an ill-typed term: Illegal application: 
@@ -38,3 +43,4 @@ cannot be applied to the terms
  "n" : "Type"
 The 2nd term has type "Type" which should be a subtype of 
 "Set". (universe inconsistency: Cannot enforce Errors.27 <= Set)
+

--- a/test-suite/output/bug5778.out
+++ b/test-suite/output/bug5778.out
@@ -1,5 +1,7 @@
 File "./output/bug5778.v", line 7, characters 7-11:
 The command has indeed failed with message:
+The term "I" has type "True"
+which should be Set, Prop or Type.
 In nested Ltac calls to "c", "abs", "abstract b ltac:(())", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.
-The term "I" has type "True" which should be Set, Prop or Type.
+

--- a/test-suite/output/bug6404.out
+++ b/test-suite/output/bug6404.out
@@ -1,5 +1,7 @@
 File "./output/bug6404.v", line 7, characters 7-11:
 The command has indeed failed with message:
+The term "I" has type "True"
+which should be Set, Prop or Type.
 In nested Ltac calls to "c", "abs", "transparent_abstract (tactic3)", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.
-The term "I" has type "True" which should be Set, Prop or Type.
+

--- a/test-suite/output/bug_17155.out
+++ b/test-suite/output/bug_17155.out
@@ -3,10 +3,11 @@ The command has indeed failed with message:
 Uncaught Ltac2 exception: Invalid_argument None
 File "./output/bug_17155.v", line 8, characters 0-23:
 The command has indeed failed with message:
+Uncaught Ltac2 exception: Invalid_argument None
 Backtrace:
 Call M.g
 Call bug_17155.M.f (* local *)
 Prim <coq-core.plugins.ltac2:throw>
-Uncaught Ltac2 exception: Invalid_argument None
+
 Ltac2 M.g : unit -> 'a
       M.g := fun _ => bug_17155.M.f (* local *) ()

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -1,38 +1,45 @@
 File "./output/ltac.v", line 8, characters 13-31:
 The command has indeed failed with message:
 Ltac variable y depends on pattern variable name z which is not bound in current context.
+
 Ltac f x y z :=
   symmetry in x, y; auto with z; auto; intros; clearbody x; generalize
    dependent z
 File "./output/ltac.v", line 38, characters 5-9:
 The command has indeed failed with message:
-In nested Ltac calls to "g1" and "refine (uconstr)", last call failed.
 The term "I" has type "True" while it is expected to have type "False".
+In nested Ltac calls to "g1" and "refine (uconstr)", last call failed.
+
 File "./output/ltac.v", line 39, characters 5-9:
 The command has indeed failed with message:
+The term "I" has type "True" while it is expected to have type "False".
 In nested Ltac calls to "f1 (constr)" and "refine (uconstr)", last call
 failed.
-The term "I" has type "True" while it is expected to have type "False".
+
 File "./output/ltac.v", line 40, characters 5-9:
 The command has indeed failed with message:
+The term "I" has type "True" while it is expected to have type "False".
 In nested Ltac calls to "g2 (constr)", "g1" and "refine (uconstr)", last call
 failed.
-The term "I" has type "True" while it is expected to have type "False".
+
 File "./output/ltac.v", line 41, characters 5-9:
 The command has indeed failed with message:
+The term "I" has type "True" while it is expected to have type "False".
 In nested Ltac calls to "f2", "f1 (constr)" and "refine (uconstr)", last call
 failed.
-The term "I" has type "True" while it is expected to have type "False".
+
 File "./output/ltac.v", line 46, characters 5-8:
 The command has indeed failed with message:
+No primitive equality found.
 In nested Ltac calls to "h" and "injection (destruction_arg)", last call
 failed.
-No primitive equality found.
+
 File "./output/ltac.v", line 48, characters 5-8:
 The command has indeed failed with message:
+No primitive equality found.
 In nested Ltac calls to "h" and "injection (destruction_arg)", last call
 failed.
-No primitive equality found.
+
 Hx
 nat
 nat

--- a/test-suite/output/ltac2_anomaly_backtrace.out
+++ b/test-suite/output/ltac2_anomaly_backtrace.out
@@ -1,10 +1,10 @@
 File "./output/ltac2_anomaly_backtrace.v", line 9, characters 0-18:
-Error:
+Error: Anomaly "Uncaught exception Not_found."
+Please report at http://coq.inria.fr/bugs/.
 Backtrace:
 Call foo
 Prim <coq-core.plugins.ltac2:eval_hnf>
-Anomaly "Uncaught exception Not_found."
-Please report at http://coq.inria.fr/bugs/.
+
 
 
 coqc exited with code 129

--- a/test-suite/output/ltac2_bt.out
+++ b/test-suite/output/ltac2_bt.out
@@ -1,32 +1,38 @@
 File "./output/ltac2_bt.v", line 8, characters 2-48:
 The command has indeed failed with message:
+Uncaught Ltac2 exception: Invalid_argument None
+Backtrace:
+
+
 Backtrace:
 Prim <coq-core.plugins.ltac2:plus>
 Call {Control.zero e}
 Prim <coq-core.plugins.ltac2:zero>
-Backtrace:
 
-Uncaught Ltac2 exception: Invalid_argument None
 File "./output/ltac2_bt.v", line 9, characters 2-49:
 The command has indeed failed with message:
+Uncaught Ltac2 exception: Invalid_argument None
 Backtrace:
 Prim <coq-core.plugins.ltac2:plus>
 Call {Control.throw e}
 Prim <coq-core.plugins.ltac2:throw>
-Uncaught Ltac2 exception: Invalid_argument None
+
 File "./output/ltac2_bt.v", line 10, characters 2-60:
 The command has indeed failed with message:
-Backtrace:
-Prim <coq-core.plugins.ltac2:plus_bt>
-Call f
-Prim <coq-core.plugins.ltac2:zero>
+Uncaught Ltac2 exception: Invalid_argument None
 Backtrace:
 
-Uncaught Ltac2 exception: Invalid_argument None
-File "./output/ltac2_bt.v", line 11, characters 2-61:
-The command has indeed failed with message:
+
 Backtrace:
 Prim <coq-core.plugins.ltac2:plus_bt>
 Call f
 Prim <coq-core.plugins.ltac2:zero>
+
+File "./output/ltac2_bt.v", line 11, characters 2-61:
+The command has indeed failed with message:
 Uncaught Ltac2 exception: Invalid_argument None
+Backtrace:
+Prim <coq-core.plugins.ltac2:plus_bt>
+Call f
+Prim <coq-core.plugins.ltac2:zero>
+

--- a/test-suite/output/ltac_missing_args.out
+++ b/test-suite/output/ltac_missing_args.out
@@ -1,45 +1,52 @@
 File "./output/ltac_missing_args.v", line 11, characters 2-11:
 The command has indeed failed with message:
-Ltac call to "foo" failed.
 The user-defined tactic "foo" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+Ltac call to "foo" failed.
+
 File "./output/ltac_missing_args.v", line 12, characters 2-11:
 The command has indeed failed with message:
-Ltac call to "bar" failed.
 The user-defined tactic "bar" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+Ltac call to "bar" failed.
+
 File "./output/ltac_missing_args.v", line 13, characters 2-16:
 The command has indeed failed with message:
-Ltac call to "bar" failed.
 The user-defined tactic "bar" was not fully applied:
 There is a missing argument for variable y and 1 more,
 1 argument was provided.
+Ltac call to "bar" failed.
+
 File "./output/ltac_missing_args.v", line 14, characters 2-11:
 The command has indeed failed with message:
-In nested Ltac calls to "baz" and "foo", last call failed.
 The user-defined tactic "baz" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+In nested Ltac calls to "baz" and "foo", last call failed.
+
 File "./output/ltac_missing_args.v", line 15, characters 2-11:
 The command has indeed failed with message:
-In nested Ltac calls to "qux" and "bar", last call failed.
 The user-defined tactic "qux" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+In nested Ltac calls to "qux" and "bar", last call failed.
+
 File "./output/ltac_missing_args.v", line 16, characters 2-36:
 The command has indeed failed with message:
-In nested Ltac calls to "mydo" and "tac" (bound to 
-fun _ _ => idtac), last call failed.
 The user-defined tactic "mydo" was not fully applied:
 There is a missing argument for variable _,
 no arguments at all were provided.
+In nested Ltac calls to "mydo" and "tac" (bound to 
+fun _ _ => idtac), last call failed.
+
 File "./output/ltac_missing_args.v", line 17, characters 2-42:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
 There is a missing argument for variable _,
 no arguments at all were provided.
+
 File "./output/ltac_missing_args.v", line 18, characters 2-24:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
@@ -47,11 +54,13 @@ There is a missing argument for variable _,
 no arguments at all were provided.
 File "./output/ltac_missing_args.v", line 19, characters 2-16:
 The command has indeed failed with message:
-In nested Ltac calls to "rec" and "rec", last call failed.
 The user-defined tactic "rec" was not fully applied:
 There is a missing argument for variable x,
 no arguments at all were provided.
+In nested Ltac calls to "rec" and "rec", last call failed.
+
 File "./output/ltac_missing_args.v", line 20, characters 2-40:
 The command has indeed failed with message:
 An unnamed user-defined tactic was not fully applied:
 There is a missing argument for variable x, 1 argument was provided.
+


### PR DESCRIPTION

IMO it's nicer to get "error messsage; ltac2 backtrace" than "error ltac2 backtrace; message"
