### PR TITLE
Adding a modifier "clear simpl" to Arguments to reset "simpl" behavior to its default

### DIFF
--- a/dev/ci/user-overlays/19216-herbelin-clear-simpl.sh
+++ b/dev/ci/user-overlays/19216-herbelin-clear-simpl.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi coq_19216 19216

--- a/doc/changelog/08-vernac-commands-and-options/19216-master+clear-simpl.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19216-master+clear-simpl.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  New :cmd:`Arguments`' modifier `clear simpl` to reset `simpl` reduction flags
+  (`#19216 <https://github.com/coq/coq/pull/19216>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -20,6 +20,7 @@ Setting properties of a function's arguments
       | %{ {+ @name } %}
       args_modifier ::= simpl nomatch
       | simpl never
+      | clear simpl
       | default implicits
       | clear implicits
       | clear scopes
@@ -140,6 +141,9 @@ Setting properties of a function's arguments
          that would expose a match construct in the head position.  See :ref:`Args_effect_on_unfolding`.
       `simpl never`
          prevents performing a simplification step for :n:`@reference`.  See :ref:`Args_effect_on_unfolding`.
+      `clear simpl`
+         resets the modifications made to the simplification steps,
+         i.e., cancels all previous `simpl never`, `simpl nomatch`, `/` and `!`.
 
       `clear bidirectionality hint`
          removes the bidirectionality hint, the `&`

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1307,6 +1307,7 @@ ssexpr0: [
 args_modifier: [
 | "simpl" "nomatch"
 | "simpl" "never"
+| "clear" "simpl"
 | "default" "implicits"
 | "clear" "implicits"
 | "clear" "scopes"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -676,6 +676,7 @@ implicits_alt: [
 args_modifier: [
 | "simpl" "nomatch"
 | "simpl" "never"
+| "clear" "simpl"
 | "default" "implicits"
 | "clear" "implicits"
 | "clear" "scopes"

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -97,8 +97,9 @@ module ReductionBehaviour = struct
 
   let load _ (_,(r, b)) =
     table := (match b with
-                | NeverUnfold -> Cpred.add r (fst !table), Cmap.remove r (snd !table)
-                | _ -> Cpred.remove r (fst !table), Cmap.add r b (snd !table))
+                | None -> Cpred.remove r (fst !table), Cmap.remove r (snd !table)
+                | Some NeverUnfold -> Cpred.add r (fst !table), Cmap.remove r (snd !table)
+                | Some b -> Cpred.remove r (fst !table), Cmap.add r b (snd !table))
 
   let cache o = load 1 o
 
@@ -115,7 +116,7 @@ module ReductionBehaviour = struct
         if Lib.is_in_section gr then
           let vars = Lib.section_instance gr in
           let extra = Array.length vars in
-          more_args extra b
+          Option.map (more_args extra) b
         else b
       in
       Some (false, (gr, b))

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -39,7 +39,7 @@ module ReductionBehaviour : sig
     val all_never_unfold : t -> Cpred.t
   end
 
-  val set : local:bool -> Constant.t -> t -> unit
+  val set : local:bool -> Constant.t -> t option -> unit
   val get_from_db : Db.t -> Constant.t -> t option
   val get : Constant.t -> t option
   val print : Constant.t -> Pp.t

--- a/test-suite/success/simpl_tuning.v
+++ b/test-suite/success/simpl_tuning.v
@@ -147,3 +147,23 @@ End S1.
 
 Arguments f : clear implicits and scopes.
 
+Module TestClearSimpl.
+
+Fail Arguments id _ x / : clear simpl.
+Fail Arguments id _ ! x : clear simpl.
+Fail Arguments id _ : simpl never, clear simpl.
+Fail Arguments id _ : simpl nomatch, clear simpl.
+
+Arguments id _ x /.
+Lemma foo : id 0 = 0.
+simpl.
+match goal with |- 0 = 0 => idtac end.
+Abort.
+
+Arguments id _ x : clear simpl.
+Lemma foo : id 0 = 0.
+simpl.
+match goal with |- id 0 = 0 => idtac end.
+Abort.
+
+End TestClearSimpl.

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -79,8 +79,8 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   let extra_scopes_flag = List.mem `ExtraScopes flags in
   let clear_implicits_flag = List.mem `ClearImplicits flags in
   let default_implicits_flag = List.mem `DefaultImplicits flags in
-  let never_unfold_flag = List.mem `ReductionNeverUnfold flags in
-  let nomatch_flag = List.mem `ReductionDontExposeCase flags in
+  let never_unfold_flag = List.mem `SimplNeverUnfold flags in
+  let nomatch_flag = List.mem `SimplDontExposeCase flags in
   let clear_bidi_hint = List.mem `ClearBidiHint flags in
 
   let err_incompat x y =

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -901,8 +901,8 @@ GRAMMAR EXTEND Gram
              { VernacSynPure (VernacGeneralizable gen) } ] ]
   ;
   args_modifier:
-    [ [ IDENT "simpl"; IDENT "nomatch" -> { [`ReductionDontExposeCase] }
-      | IDENT "simpl"; IDENT "never" -> { [`ReductionNeverUnfold] }
+    [ [ IDENT "simpl"; IDENT "nomatch" -> { [`SimplDontExposeCase] }
+      | IDENT "simpl"; IDENT "never" -> { [`SimplNeverUnfold] }
       | IDENT "default"; IDENT "implicits" -> { [`DefaultImplicits] }
       | IDENT "clear"; IDENT "implicits" -> { [`ClearImplicits] }
       | IDENT "clear"; IDENT "scopes" -> { [`ClearScopes] }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -903,6 +903,7 @@ GRAMMAR EXTEND Gram
   args_modifier:
     [ [ IDENT "simpl"; IDENT "nomatch" -> { [`SimplDontExposeCase] }
       | IDENT "simpl"; IDENT "never" -> { [`SimplNeverUnfold] }
+      | IDENT "clear"; IDENT "simpl" -> { [`ClearReduction] }
       | IDENT "default"; IDENT "implicits" -> { [`DefaultImplicits] }
       | IDENT "clear"; IDENT "implicits" -> { [`ClearImplicits] }
       | IDENT "clear"; IDENT "scopes" -> { [`ClearScopes] }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1128,8 +1128,8 @@ let pr_synpure_vernac_expr v =
         else (mt ()) ++
              (if not (List.is_empty mods) then str" : " else str"") ++
              prlist_with_sep (fun () -> str", " ++ spc()) (function
-                 | `ReductionDontExposeCase -> keyword "simpl nomatch"
-                 | `ReductionNeverUnfold -> keyword "simpl never"
+                 | `SimplDontExposeCase -> keyword "simpl nomatch"
+                 | `SimplNeverUnfold -> keyword "simpl never"
                  | `DefaultImplicits -> keyword "default implicits"
                  | `Rename -> keyword "rename"
                  | `Assert -> keyword "assert"

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1135,6 +1135,7 @@ let pr_synpure_vernac_expr v =
                  | `Assert -> keyword "assert"
                  | `ExtraScopes -> keyword "extra scopes"
                  | `ClearImplicits -> keyword "clear implicits"
+                 | `ClearReduction -> keyword "clear simpl"
                  | `ClearScopes -> keyword "clear scopes"
                  | `ClearBidiHint -> keyword "clear bidirectionality hint")
                mods)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -410,9 +410,9 @@ let print_arguments env ref =
     | ConstRef ref ->
       begin match Reductionops.ReductionBehaviour.get ref with
       | None -> [], [], None
-      | Some NeverUnfold -> [`ReductionNeverUnfold], [], None
+      | Some NeverUnfold -> [`SimplNeverUnfold], [], None
       | Some (UnfoldWhen { nargs; recargs }) -> [], recargs, nargs
-      | Some (UnfoldWhenNoMatch { nargs; recargs }) -> [`ReductionDontExposeCase], recargs, nargs
+      | Some (UnfoldWhenNoMatch { nargs; recargs }) -> [`SimplDontExposeCase], recargs, nargs
       end
     | _ -> [], [], None
   in

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -331,8 +331,8 @@ type arguments_modifier =
   | `ClearScopes
   | `DefaultImplicits
   | `ExtraScopes
-  | `ReductionDontExposeCase
-  | `ReductionNeverUnfold
+  | `SimplDontExposeCase  (* simpl nomatch *)
+  | `SimplNeverUnfold  (* simpl never *)
   | `Rename ]
 
 type extend_name = {

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -328,6 +328,7 @@ type arguments_modifier =
   [  `Assert
   | `ClearBidiHint
   | `ClearImplicits
+  | `ClearReduction
   | `ClearScopes
   | `DefaultImplicits
   | `ExtraScopes


### PR DESCRIPTION
This is proposal for supporting resetting the effect of `simpl never`, `simpl nomatch`, and `/`.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

#### Overlay (to be merged in sync with the current PR)

* https://github.com/LPCIC/coq-elpi/pull/665
