### PR TITLE
Finer API for Clenv.clenv_missing

### DIFF
--- a/dev/ci/user-overlays/19220-ppedrot-clenv-missing-centralize-api.sh
+++ b/dev/ci/user-overlays/19220-ppedrot-clenv-missing-centralize-api.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/ppedrot/coq-elpi clenv-missing-centralize-api 19220

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -301,7 +301,9 @@ let clenv_dependent_gen hyps_only ?(iter=true) env sigma concl =
         Metaset.mem mv deps_in_hyps || Metaset.mem mv deps_in_concl)
     all_undefined
 
-let clenv_missing ce = clenv_dependent_gen true ce.env ce.evd (clenv_type ce)
+let clenv_missing ce =
+  let miss = clenv_dependent_gen true ce.env ce.evd (clenv_type ce) in
+  (miss, List.count (fun arg -> not arg.marg_dep) ce.metas)
 
 (******************************************************************)
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -303,6 +303,7 @@ let clenv_dependent_gen hyps_only ?(iter=true) env sigma concl =
 
 let clenv_missing ce =
   let miss = clenv_dependent_gen true ce.env ce.evd (clenv_type ce) in
+  let miss = List.map (Evd.meta_name ce.evd) miss in
   (miss, List.count (fun arg -> not arg.marg_dep) ce.metas)
 
 (******************************************************************)

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -50,7 +50,7 @@ val clenv_instantiate : ?flags:unify_flags -> ?submetas:(metavariable * clbindin
    clenv (dependent or not). Positions can be negative meaning to
    start from the rightmost argument of the template. *)
 val clenv_independent : clausenv -> metavariable list
-val clenv_missing : clausenv -> metavariable list * int
+val clenv_missing : clausenv -> Names.Name.t list * int
 
 (** start with a clenv to refine with a given term with bindings *)
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -50,7 +50,7 @@ val clenv_instantiate : ?flags:unify_flags -> ?submetas:(metavariable * clbindin
    clenv (dependent or not). Positions can be negative meaning to
    start from the rightmost argument of the template. *)
 val clenv_independent : clausenv -> metavariable list
-val clenv_missing : clausenv -> metavariable list
+val clenv_missing : clausenv -> metavariable list * int
 
 (** start with a clenv to refine with a given term with bindings *)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1396,7 +1396,7 @@ let add_resolves env sigma clist ~locality dbnames =
           strbrk " will only be used by eauto, because applying " ++
           pr_leconstr_env env sigma' c ++
           strbrk " would leave " ++ variables ++ Pp.spc () ++
-          Pp.prlist_with_sep Pp.pr_comma Name.print (List.map (Evd.meta_name (Clenv.clenv_evd ce)) miss) ++
+          Pp.prlist_with_sep Pp.pr_comma Name.print miss ++
           strbrk " as unresolved existential " ++ variables ++ str "."
         )
       | _ -> ()


### PR DESCRIPTION
This makes explicit the data we're actually exposing, and it removes potential bugs when calling this function with lemmas that contain let-bindings. This might also be slightly more efficient.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/638