### PR TITLE
Adding a location to a few Fixpoint-related errors

### DIFF
--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -105,15 +105,15 @@ let check_true_recursivity env evd ~isfix fixl =
     | [x,Inr []] -> warn_non_recursive (x,isfix)
     | _ -> ()
 
-let extract_decreasing_argument ~structonly { CAst.v = v; _ } =
+let extract_decreasing_argument ~structonly { CAst.v = v; loc } =
   let open Constrexpr in
   match v with
   | CStructRec na -> na
   | (CWfRec (na,_) | CMeasureRec (Some na,_,_)) when not structonly -> na
   | CMeasureRec (None,_,_) when not structonly ->
-    CErrors.user_err Pp.(str "Decreasing argument must be specified in measure clause.")
+    CErrors.user_err ?loc Pp.(str "Decreasing argument must be specified in measure clause.")
   | _ ->
-    CErrors.user_err Pp.(str "Well-founded induction requires Program Fixpoint or Function.")
+    CErrors.user_err ?loc Pp.(str "Well-founded induction requires Program Fixpoint or Function.")
 
 (* This is a special case: if there's only one binder, we pick it as
    the recursive argument if none is provided. *)
@@ -130,9 +130,9 @@ let adjust_rec_order ~structonly binders rec_order =
 
 (* Interpret the index of a recursion order annotation *)
 exception Found of int
-let find_rec_annot ~structonly Vernacexpr.{binders} (_, ctx) = function
+let find_rec_annot ~structonly Vernacexpr.{fname={CAst.loc}; binders} (_, ctx) = function
   | None ->
-    if Int.equal (Context.Rel.nhyps ctx) 0 then CErrors.user_err Pp.(str "A fixpoint needs at least one parameter.");
+    if Int.equal (Context.Rel.nhyps ctx) 0 then CErrors.user_err ?loc Pp.(str "A fixpoint needs at least one parameter.");
     List.interval 0 (Context.Rel.nhyps ctx - 1)
   | Some fix_order ->
     let na = adjust_rec_order ~structonly binders fix_order in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -261,7 +261,7 @@ let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (fi
         let recarg = mkIdentC n.CAst.v in
         build_wellfounded pm (id, univs, binders, rtype, out_def body_def) ~scope ?clearbody poly ?typing_flags ?user_warns r recarg notations
 
-    | [Some { CAst.v = CMeasureRec (n, m, r) }],
+    | [Some { CAst.v = CMeasureRec (n, m, r); loc }],
       [Vernacexpr.{fname={CAst.v=id}; univs; binders; rtype; body_def; notations }] ->
       (* We resolve here a clash between the syntax of Program Fixpoint and the one of funind *)
       let r = match n, r with
@@ -269,7 +269,7 @@ let do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (fi
           let loc = id.CAst.loc in
           Some (CAst.make ?loc @@ CRef(qualid_of_ident ?loc id.CAst.v,None))
         | Some _, Some _ ->
-          user_err Pp.(str"Measure takes only two arguments in Program Fixpoint.")
+          user_err ?loc Pp.(str"Measure takes only two arguments in Program Fixpoint.")
         | _, _ -> r
       in
         build_wellfounded pm (id, univs, binders, rtype, out_def body_def) ~scope ?clearbody poly ?typing_flags ?user_warns


### PR DESCRIPTION
This locates more accurately 4 `Fixpoint`-related errors (extracted from #18811).

It depends on
- #19107

to which it adds one commit.
