### PR TITLE
[ci] [bench] CI / Bench for OCaml 5.2.0+trunk

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2024-01-08-011994e15c"
-  EDGE_CACHEKEY: "edge_ubuntu-V2024-06-26-c5d508ba41"
+  EDGE_CACHEKEY: "edge_ubuntu-V2024-06-26-9744d2418e"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 
@@ -305,7 +305,7 @@ build:edge+flambda:
   image: $EDGE_IMAGE
   variables:
     OPAM_VARIANT: "+flambda"
-    COQ_EXTRA_CONF: "-native-compiler yes"
+    COQ_EXTRA_CONF: "-native-compiler no"
   only: *full-ci
 
 build:base:dev:
@@ -527,13 +527,15 @@ test-suite:base:dev:
   script:
     - opam switch create $OCAMLVER --empty
     - eval $(opam env)
-    - opam repo add ocaml-beta https://github.com/ocaml/ocaml-beta-repository.git
     - opam update
     - opam install ocaml-variants=$OCAMLVER
-    - opam install dune zarith
+    - opam install dune zarith ocamlfind ounit2
     - eval $(opam env)
+    - make dunestrap
+    - dune build -p coq-core,coq-stdlib,coqide-server,coq
     - export COQ_UNIT_TEST=noop
     - make test-suite
+  image: $EDGE_IMAGE
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: always

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@ To compile Coq yourself, you need:
 
 - [OCaml](https://ocaml.org/) (version >= 4.09.0)
   (This version of Coq has been tested up to OCaml 4.14.1, for the 4.x series)
+  (This version of Coq has been tested up to OCaml 5.2.0, for the 5.x series)
 
   Support for OCaml 5.x remains experimental.
 

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -64,7 +64,7 @@ check_variable () {
 
 : "${coq_pr_number:=}"
 : "${coq_pr_comment_id:=}"
-: "${new_ocaml_version:=4.14.1}"
+: "${new_ocaml_version:=5.2.0}"
 : "${old_ocaml_version:=4.14.1}"
 : "${new_ocaml_flambda:=0}"
 : "${old_ocaml_flambda:=0}"

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -427,6 +427,9 @@ create_opam "NEW" "$new_ocaml_version" "$new_coq_commit" "$new_coq_version" \
             "$new_coq_opam_archive_dir" "$new_ocaml_flambda"
 new_coq_commit_long="$COQ_HASH_LONG"
 
+# Hack to test Gabriel's patch
+opam pin add -y ocaml-base-compiler https://github.com/ejgallego/ocaml.git#5.2.0_require_streamline
+
 # Create an OPAM-root to which we will install the OLD version of Coq.
 create_opam "OLD" "$old_ocaml_version" "$old_coq_commit" "$old_coq_version" \
             "$old_coq_opam_archive_dir" "$old_ocaml_flambda"

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -415,6 +415,11 @@ create_opam() {
         done
     done
 
+    # Try to install conflicting packages earlier
+    opam update
+    opam install -y -b -j "$this_nproc" coq-elpi.dev
+    opam repo list
+
 }
 
 # Create an OPAM-root to which we will install the NEW version of Coq.

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -36,10 +36,12 @@ ENV NJOBS="2" \
     OPAMYES="true"
 
 # Edge opam is the set of edge packages required by Coq
-ENV COMPILER="4.14.1" \
+# Note: no ppxlib on 5.3.0+trunk , also odoc is broken, thus we need
+# to remove dune-release if we want to test that
+ENV COMPILER="5.2.0+trunk" \
     BASE_OPAM="zarith.1.13 ounit2.2.2.6" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
-    BASE_OPAM_EDGE="dune.3.14.0 dune-build-info.3.14.0 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.3.1" \
+    BASE_OPAM_EDGE="dune.3.14.0 dune-build-info.3.14.0 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.4.2" \
     CI_OPAM_EDGE="elpi.1.19.2 ppx_import.1.10.0 cmdliner.1.1.1 sexplib.v0.15.1 ppx_sexp_conv.v0.15.1 ppx_hash.v0.15.0 ppx_compare.v0.15.0 ppx_deriving_yojson.3.7.0 yojson.2.1.0 uri.4.2.0 ppx_yojson_conv.v0.15.1 ppx_inline_test.v0.15.1 ppx_assert.v0.15.0 ppx_optcomp.v0.15.0 lsp.1.16.2 sel.0.4.0" \
     COQIDE_OPAM_EDGE="lablgtk3-sourceview3.3.1.3"
 
@@ -47,7 +49,6 @@ ENV COMPILER="4.14.1" \
 # `ci-template-flambda` with everything.
 RUN opam init -a --disable-sandboxing --bare && eval $(opam env) && opam update && \
     opam switch create "${COMPILER}+flambda" \
-      --repositories default,ocaml-beta=git+https://github.com/ocaml/ocaml-beta-repository.git \
       --packages="ocaml-variants.${COMPILER}+options,ocaml-option-flambda" && eval $(opam env) && \
     opam install $BASE_OPAM $BASE_OPAM_EDGE $COQIDE_OPAM_EDGE $CI_OPAM $CI_OPAM_EDGE && \
     opam clean -a -c && \


### PR DESCRIPTION
Unfortunately we cannot test against 5.3.0 as math-comp-2 needs ppx, which is not available in that version easily.

We could test math-comp.1 , but that requires some changes in infra.

Moreover there could be another problem in math-comp testing, I'm not sure how much time we spend these days testing MC proper as testing HB setup performance ?

Anyways let's see what the numbers say now, on vanilla Coq GC settings.

cc: @OlivierNicole @gasche 

This replaces #15494 which got too messy, so we start freshly here.