### PR TITLE
Do not create global constraints for applied template polymorphic types

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1096,6 +1096,13 @@ let is_global = EConstr.isRefX
 
 let isGlobalRef = EConstr.isRef
 
+let is_template_polymorphic_ref env sigma f =
+  match EConstr.kind sigma f with
+  | Ind (ind, u) | Construct ((ind, _), u) ->
+    if not (EConstr.EInstance.is_empty u) then false
+    else Environ.template_polymorphic_ind ind env
+  | _ -> false
+
 let is_template_polymorphic_ind env sigma f =
   match EConstr.kind sigma f with
   | Ind (ind, u) ->

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -269,6 +269,7 @@ val is_global : Environ.env -> Evd.evar_map -> GlobRef.t -> constr -> bool
 val isGlobalRef : Evd.evar_map -> constr -> bool
 [@@ocaml.deprecated "(8.12) Use [EConstr.isRef] instead."]
 
+val is_template_polymorphic_ref : env -> Evd.evar_map -> constr -> bool
 val is_template_polymorphic_ind : env -> Evd.evar_map -> constr -> bool
 
 val is_Prop : Evd.evar_map -> constr -> bool

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -52,6 +52,11 @@ type template_univ =
 
 type param_univs = (expected:Univ.Level.t -> template_univ) list
 
+val instantiate_template_constraints
+  : template_univ Univ.Level.Map.t
+  -> Declarations.template_universes
+  -> Univ.Constraints.t
+
 val instantiate_template_universes : mind_specif -> param_univs ->
   Constraints.t * rel_context * template_univ Univ.Level.Map.t
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -160,7 +160,7 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
   (* Refresh the types of evars under template polymorphic references *)
   let rec refresh_term_evars ~onevars ~top t =
     match EConstr.kind !evdref t with
-    | App (f, args) when Termops.is_template_polymorphic_ind env !evdref f ->
+    | App (f, args) when Termops.is_template_polymorphic_ref env !evdref f ->
       let pos = get_polymorphic_positions env !evdref f in
         refresh_polymorphic_positions args pos; t
     | App (f, args) when top && isEvar !evdref f ->

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -173,7 +173,7 @@ let retype ?(polyprop=true) sigma =
          subst1 b (type_of (push_rel (LocalDef (name,b,c1)) env) c2)
     | Fix ((_,i),(_,tys,_)) -> tys.(i)
     | CoFix (i,(_,tys,_)) -> tys.(i)
-    | App(f,args) when Termops.is_template_polymorphic_ind env sigma f ->
+    | App(f,args) when Termops.is_template_polymorphic_ref env sigma f ->
         let t = type_of_global_reference_knowing_parameters env f args in
         strip_outer_cast sigma (subst_type env sigma t (Array.to_list args))
     | App(f,args) ->

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -679,7 +679,7 @@ let rec mk_refgoals env sigma goalacc conclty trm = match trm with
   gl::goalacc, conclty, sigma, ev
 | RfApp (f, l) ->
   let (acc',hdty,sigma,applicand) = match f with
-  | RfGround f when Termops.is_template_polymorphic_ind env sigma f ->
+  | RfGround f when Termops.is_template_polymorphic_ref env sigma f ->
     let ty =
       (* Template polymorphism of definitions and inductive types *)
       let args, _ = List.split_when (fun p -> not (is_ground p)) l in

--- a/test-suite/bugs/bug_19228_1.v
+++ b/test-suite/bugs/bug_19228_1.v
@@ -1,0 +1,8 @@
+Axiom decidable : Prop -> Set.
+
+Class Dec_Eq (A : Type) := { dec_eq : forall (x y : A), decidable (x = y) }.
+
+Lemma Dec_Eq_implies_DecEq {A} {H : Dec_Eq A} (x y : A) : decidable (x = y).
+Proof.
+apply H.
+Qed.

--- a/test-suite/bugs/bug_4816.v
+++ b/test-suite/bugs/bug_4816.v
@@ -21,8 +21,7 @@ End Foo.
 
 Require Coq.Classes.RelationClasses.
 
-Class PreOrder (A : Type) (r : A -> A -> Type) : Type :=
-{ refl : forall x, r x x }.
+Axiom PreOrder : forall (A : Type) (r : A -> A -> Type), Type.
 
 #[universes(polymorphic)]
 Section qux.

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -42,5 +42,5 @@ cannot be applied to the terms
  "n" : "Type"
  "n" : "Type"
 The 2nd term has type "Type" which should be a subtype of 
-"Set". (universe inconsistency: Cannot enforce Errors.27 <= Set)
+"Set". (universe inconsistency: Cannot enforce Errors.31 <= Set)
 

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -42,7 +42,7 @@ let v := 0%test17 in v : myint63
      : myint63
 fun y : nat => # (x, z) |-> y & y
      : forall y : nat,
-       (?T1 * ?T2 -> ?T1 * ?T2 * nat) * (?T * ?T0 -> ?T * ?T0 * nat)
+       (?T * ?T0 -> ?T * ?T0 * nat) * (?T1 * ?T2 -> ?T1 * ?T2 * nat)
 where
 ?T :
   [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0 |- Type] (pat,
@@ -125,7 +125,7 @@ V tt
 fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
-?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
+?T : [x : nat |- Type]
 File "./output/Notations4.v", line 266, characters 0-30:
 Warning: Notation "_ :=: _" was already used.
 [notation-overridden,parsing,default]

--- a/test-suite/output/NotationsSigma.out
+++ b/test-suite/output/NotationsSigma.out
@@ -33,8 +33,8 @@ where
 where
 ?T : [pat : nat * ?T |- Type] (pat cannot be used)
 {'(x, y) : nat * nat & x = 1 & y = 0}
-     : Type
+     : Set
 {'(x, _) : nat * nat & x = 1}
-     : Type
+     : Set
 {'(x, y) : nat * nat & x = 1 & y = 0}
-     : Type
+     : Set

--- a/test-suite/output/prim_array.out
+++ b/test-suite/output/prim_array.out
@@ -4,6 +4,6 @@
      : array nat
 [| | 0 : nat |]@{Set}
      : array@{Set} nat
-[| bool; list nat | nat : Set |]@{prim_array.8}
-     : array@{prim_array.8} Set
-(* {prim_array.8} |= Set < prim_array.8 *)
+[| bool; list nat | nat : Set |]@{prim_array.9}
+     : array@{prim_array.9} Set
+(* {prim_array.9} |= Set < prim_array.9 *)

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -210,3 +210,25 @@ Set Warnings "-no-template-universe".
 Check (foo unit : Prop).
 
 End TemplateParamUnit.
+
+Module TemplateAlg.
+
+  Inductive foo (A:Type) (B :Type) := C (_:A).
+
+  Check foo True nat : Prop.
+
+  Universes u v.
+
+  Axiom U : Type@{u}.
+  Axiom V : Type@{v}.
+
+  Check foo (U * V) True : Type@{max(u,v)}.
+
+End TemplateAlg.
+
+Module TemplateNoExtraCsts.
+
+  Polymorphic Definition opt'@{u|} (A:Type@{u}) := option A.
+  Polymorphic Definition some@{u|} (A:Type@{u}) (x:A) : opt' A := Some x.
+
+End TemplateNoExtraCsts.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -666,8 +666,9 @@ let build_beq_scheme env handle kn =
 
   (* Setting universes *)
   let auctx = Declareops.universes_context mib.mind_universes in
-  let u, uctx = UnivGen.fresh_instance_from auctx None in
-  let uctx = UState.of_context_set uctx in
+  let u, ctx = UnivGen.fresh_instance_from auctx None in
+  let uctx = UState.from_env env in
+  let uctx = UState.merge_sort_context ~sideff:false UState.univ_rigid uctx ctx in
 
   (* number of inductives in the mutual *)
   let nb_ind = Array.length mib.mind_packets in
@@ -851,6 +852,21 @@ let build_beq_scheme env handle kn =
          if not (Sorts.family_leq InSet kelim) then raise (NonSingletonProp (kn,0));
          [|Term.it_mkLambda_or_LetIn (make_one_eq 0) recparams_ctx_with_eqs|]
   in
+
+  let uctx =
+    (* infer univ constraints
+       For instance template poly inductive produces a univ monomorphic scheme
+       which when applied needs to constrain the universe of its argument
+    *)
+    let sigma = Evd.from_ctx uctx in
+    let sigma = Array.fold_left (fun sigma c ->
+        fst @@ Typing.type_of env sigma (EConstr.of_constr c))
+        sigma
+        res
+    in
+    Evd.ustate sigma
+  in
+
   res, uctx
 
 let beq_scheme_kind =


### PR DESCRIPTION
This is a partial step towards coq/ceps#90.

Backwards compatible overlays:
- https://github.com/jwiegley/category-theory/pull/147
- https://github.com/JasonGross/neural-net-coq-interp/pull/62
- https://github.com/mit-plv/fiat-crypto/pull/1933
- https://github.com/PrincetonUniversity/VST/pull/787

Depends on #19501 