### PR TITLE
Stronger invariants in the structure of Declare.proof_entry

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1886,7 +1886,7 @@ let make_univs_deferred ~poly ~initial_euctx ~uctx ~udecl
      the body.  So we keep the two sets distinct. *)
   let uctx_body = UState.restrict uctx used_univs in
   let ubody = UState.check_mono_univ_decl uctx_body udecl in
-  utyp, DeferredOpaque { body = Future.from_val ((body, ubody), eff); feedback_id = None }
+  utyp, Default { body = (body, eff); opaque = Opaque ubody }
 
 let make_univs_private_poly ~poly ~uctx ~udecl (used_univs_typ, typ) (used_univs_body, body) eff =
   let used_univs = Univ.Level.Set.union used_univs_body used_univs_typ in


### PR DESCRIPTION
The PR enforces stronger invariants in the different uses of `proof_entry`. 

Using a sum type `Default`(`Transparent`|`Opaque`)|`DeferredOpaque`, the type `proof_entry` is morally divided into the following variants:
- `constr pproof_entry`: no side effect, no local universes, not deferred
- `'eff default_proof_body pproof_entry`, parameterized by effects: not deferred, possibly transparent, possibly with local universes
- `'eff proof_entry`, parameterized by effects, the most general: possibly deferred, possibly transparent, possibly with local universes

The following excerpt of functions have then refined types:
- `cast_entry_proof`
- `cast_opaque_entry_proof`
- `declare_private_constant`
- `build_constant_by_tactic`
- etc.

Together with a forthcoming PR which will merge `close_proof` and `close_proof_delayed` around a type `Immediate(body,typ,uctx)`|`Delayed(body,type,uctx)`, we should be able to make progresses in the direction of coq/ceps#89, that is to have both `close_proof` and immediate definitions producing an `Immediate`|`Delayed` which is then turned into a `Default`(`Transparent`|`Opaque`)|`DeferredOpaque` proof entry, then processed by `declare_entry` (to distinguish between in or outside a section) and finally by `declare_constant`.

The main commit is the 2nd one. The 3rd commit is mostly about the structuration of the code.