### PR TITLE
Fix a wrong refman line (and a readme update along the way)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -87,16 +87,16 @@ Compilation
 The current documentation targets are:
 
 - `make refman-html`
-  Build the HTML reference manual on `_build/default/doc/refman-html`
+  Build the reference manual in HTML form into `_build/default/doc/refman-html`
 
 - `make refman-pdf`
-  Build the PDF reference manual on `_build/default/doc/refman-pdf`
+  Build the reference manual in PDF form into `_build/default/doc/refman-pdf`
 
 - `make stdlib-html`
-  Build the documentation for Coq's standard library `_build/default/doc/stdlib/html`
+  Build Coq's standard library documentation into `_build/default/doc/stdlib/html`
 
 - `make apidoc`
-  Build the documentation for Coq's standard library `_build/default/_doc/_html`
+  Build the ML API's documentation into `_build/default/_doc/_html`
 
 To build the Sphinx documentation without stopping at the first
 warning, change the value of the `SPHINXWARNOPT` variable (default is

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -64,3 +64,7 @@ This manual is organized in three main parts, plus an appendix:
   :ref:`indexes <indexes>` are very useful to **quickly browse the
   manual and find what you are looking for.** They are often the main
   entry point to the manual.
+
+.. only:: html
+
+   The full table of contents is presented below:

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -64,5 +64,3 @@ This manual is organized in three main parts, plus an appendix:
   :ref:`indexes <indexes>` are very useful to **quickly browse the
   manual and find what you are looking for.** They are often the main
   entry point to the manual.
-
-The full table of contents is presented below:


### PR DESCRIPTION
In the html reference manual the introduction appears before the ToC, but in the PDF it's after and so the sentence doesn't make sense.

Whilst trying to find how to fix this I found some corrections in the `README.md` too.