### PR TITLE
[CI] Make VST compile its own compcert

### DIFF
--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -12,7 +12,8 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 # sometimes (rarely) CompCert master can break VST and it can take
 # weeks or months for VST to catch up, in this case, just uncomment
 # the line below to use the compcert version bundled in VST
-# export COMPCERT=bundled
+export COMPCERT=bundled
+# recomment above line whenever VST compiles again with compcert master
 
 # See ci-compcert.sh
 export COQEXTRAFLAGS='-native-compiler no'


### PR DESCRIPTION
Temporary change since compcert master currently breaks VST. This makes the CI compute two different version of compcert. To be reverted whenever VST supports compcert master again.
