### PR TITLE
Stricter criterion for template universe levels.

### DIFF
--- a/test-suite/bugs/bug_19250.v
+++ b/test-suite/bugs/bug_19250.v
@@ -1,0 +1,6 @@
+#[universes(polymorphic)]
+Inductive t@{u} : Prop := mkt : t.
+
+Inductive runner_sum A := success (a : A).
+(* This inductive should not be template polymorphic as u is not substitutable by an algebraic *)
+Inductive sum_runner@{u} (A : Type@{u}) (f : t@{u}) := sum_eval : runner_sum A -> sum_runner A f.


### PR DESCRIPTION
We restrict template levels so that we can substitute them with arbitrary algebraic levels. The criterion is an overapproximation, and should be removed when algebraic universes are made first-class in the kernel.

The upper layers are actually already implementing this check, so that the kernel could not have received ill-formed template inductive types from user input alone.