### PR TITLE
dev/db: move external dependency loads earlier

### DIFF
--- a/dev/db
+++ b/dev/db
@@ -1,11 +1,13 @@
 load_printer threads.cma
 load_printer str.cma
 load_printer zarith.cma
+load_printer memprof_limits.cma
+load_printer findlib.cma
+load_printer findlib_dynload.cma
 load_printer config.cma
 load_printer boot.cma
 load_printer clib.cma
 load_printer coqperf.cma
-load_printer memprof_limits.cma
 load_printer lib.cma
 load_printer gramlib.cma
 load_printer coqrun.cma
@@ -18,8 +20,6 @@ load_printer proofs.cma
 load_printer parsing.cma
 load_printer printing.cma
 load_printer tactics.cma
-load_printer findlib.cma
-load_printer findlib_dynload.cma
 load_printer vernac.cma
 load_printer sysinit.cma
 load_printer coqworkmgrlib.cma


### PR DESCRIPTION
memprof_limits is now needed for clib.
(since https://github.com/coq/coq/pull/19175 so milestone 8.20)

Moving external dependencies before our own libraries should be more robust.
