### PR TITLE
Stricter conditions for template polymorphic levels

### DIFF
--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -259,8 +259,8 @@ let check_record data =
 let unbounded_from_below u cstrs =
   Univ.Constraints.for_all (fun (l, d, r) ->
       match d with
-      | Eq -> not (Univ.Level.equal l u) && not (Univ.Level.equal r u)
-      | Lt | Le -> not (Univ.Level.equal r u))
+      | Eq | Lt -> not (Univ.Level.equal l u) && not (Univ.Level.equal r u)
+      | Le -> not (Univ.Level.equal r u))
     cstrs
 
 let get_arity c =

--- a/test-suite/bugs/bug_19230.v
+++ b/test-suite/bugs/bug_19230.v
@@ -1,0 +1,3 @@
+(* This inductive cannot be template *)
+Inductive foo@{u} (A:Type@{u}) : Type@{u+1} := .
+Fail Check foo (foo (foo nat)).

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -401,8 +401,8 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt u =
     let open Univ in
     Univ.Constraints.for_all (fun (l, d, r) ->
         match d with
-        | Eq -> not (Univ.Level.equal l u) && not (Univ.Level.equal r u)
-        | Lt | Le -> not (Univ.Level.equal r u))
+        | Eq | Lt -> not (Univ.Level.equal l u) && not (Univ.Level.equal r u)
+        | Le -> not (Univ.Level.equal r u))
       cstrs
   in
   let fold_params accu decl = match decl with

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -415,16 +415,17 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt u =
   | LocalDef _ -> accu
   in
   let paramslevels = List.fold_left fold_params Univ.Level.Set.empty paramsctxt in
-  let check_level l =
+  let check_level (l, n) =
+    Int.equal n 0 &&
     Univ.Level.Set.mem l (Univ.ContextSet.levels uctx) &&
     Univ.Level.Set.mem l paramslevels &&
     (let () = assert (not @@ Univ.Level.is_set l) in true) &&
     unbounded_from_below l (Univ.ContextSet.constraints uctx) &&
     not (Univ.Level.Set.mem l ctor_levels)
   in
-  let univs = Univ.Universe.levels u in
-  let univs = Univ.Level.Set.filter (fun l -> check_level l) univs in
-  univs
+  let univs = Univ.Universe.repr u in
+  let univs = List.filter check_level univs in
+  List.fold_left (fun accu (l, _) -> Univ.Level.Set.add l accu) Univ.Level.Set.empty univs
 
 let template_polymorphism_candidate uctx params entry template_syntax = match template_syntax with
 | SyntaxNoTemplatePoly -> Univ.Level.Set.empty


### PR DESCRIPTION
In order to implement the new template typing rules, one must ensure that all bound template levels only appear in positions where they can be substituted by an algebraic universe. This PR ensures that this is the case and further prohibits the creation of algebraic levels of arbitrary +n increments by restricting the template universes to have no increments in the return sort.

Fixes #19230

Depends on:
- #19250