### PR TITLE
Merging the code paths for Program Co/Fixpoint and Co/Fixpoint

### DIFF
--- a/doc/changelog/02-specification-language/19257-master+merge-fixpoint-program-fixpoint.rst
+++ b/doc/changelog/02-specification-language/19257-master+merge-fixpoint-program-fixpoint.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Mishandling of let binders in `Program Fixpoint`
+  (`#19257 <https://github.com/coq/coq/pull/19257>`_,
+  fixes `#16906 <https://github.com/coq/coq/issues/16906>`_,
+  by Hugo Herbelin).

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -153,7 +153,7 @@ and rebuild_nal aux bk bl' nal typ =
 let rebuild_bl aux bl typ = rebuild_bl aux bl typ
 
 let recompute_binder_list (rec_order, fixpoint_exprl) =
-  let _, _, ((_, _, _, typel), _, uctx, _) =
+  let ((_, _, _, typel, _, _), _, _, _), uctx =
     ComFixpoint.interp_recursive ~check_recursivity:false (false, CFixRecOrder rec_order) fixpoint_exprl
   in
   let constr_expr_typel =

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -153,9 +153,7 @@ and rebuild_nal aux bk bl' nal typ =
 let rebuild_bl aux bl typ = rebuild_bl aux bl typ
 
 let recompute_binder_list (rec_order, fixpoint_exprl) =
-  let ((_, _, _, typel, _, _), _, _, _), uctx =
-    ComFixpoint.interp_recursive ~check_recursivity:false (false, CFixRecOrder rec_order) fixpoint_exprl
-  in
+  let typel, uctx = ComFixpoint.interp_fixpoint_short rec_order fixpoint_exprl in
   let constr_expr_typel =
     with_full_print
       (List.map (fun c ->
@@ -406,8 +404,8 @@ let register_struct is_rec (rec_order, fixpoint_exprl) =
     in
     (None, evd, List.rev rev_pconstants)
   | _ ->
-    let p = ComFixpoint.do_mutually_recursive ~poly:false (CFixRecOrder rec_order, fixpoint_exprl) in
-    assert (Option.is_empty p);
+    let pm, p = ComFixpoint.do_mutually_recursive ~poly:false (CFixRecOrder rec_order, fixpoint_exprl) in
+    assert (Option.is_empty pm && Option.is_empty p);
     let evd, rev_pconstants =
       List.fold_left
         (fun (evd, l) {Vernacexpr.fname} ->

--- a/test-suite/bugs/bug_16906.v
+++ b/test-suite/bugs/bug_16906.v
@@ -1,0 +1,8 @@
+Require Import Coq.Program.Program.
+Require Import Coq.Lists.List.
+Import ListNotations.
+Open Scope list_scope.
+Program Fixpoint foo
+  (_local_inst := tt) (decls : list unit) {struct decls} : list unit
+  := match decls with | [] => [] | _ => [] end.
+(* Was raising a Not_found *)

--- a/test-suite/success/ProgramFixpoint.v
+++ b/test-suite/success/ProgramFixpoint.v
@@ -1,0 +1,22 @@
+Require Import Program.
+
+Module ProgramFixProto.
+
+(* Check the presence of [fix_proto] so that a preliminary work done on
+   obligations can be done automatically *)
+
+Program Fixpoint do_bug m : { k : nat | exists u : nat, k = m }  :=
+  match m with
+  | 0 => 0
+  | S m' => S (do_bug m')
+  end.
+Next Obligation.
+  exists 0.
+  reflexivity.
+Qed.
+Next Obligation.
+  exists 0.
+  reflexivity.
+Defined.
+
+End ProgramFixProto.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -130,7 +130,7 @@ let adjust_rec_order ~structonly binders rec_order =
 
 (* Interpret the index of a recursion order annotation *)
 exception Found of int
-let find_rec_annot ~structonly Vernacexpr.{fname={CAst.loc}; binders} (_, ctx) = function
+let find_rec_annot ~structonly Vernacexpr.{fname={CAst.loc}; binders} ctx = function
   | None ->
     if Int.equal (Context.Rel.nhyps ctx) 0 then CErrors.user_err ?loc Pp.(str "A fixpoint needs at least one parameter.");
     List.interval 0 (Context.Rel.nhyps ctx - 1)
@@ -169,22 +169,22 @@ let interp_rec_annot fixl ctxl (structonly, rec_order) =
 
 let interp_fix_context ~program_mode env sigma {Vernacexpr.binders} =
   let sigma, (impl_env, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma binders in
-  sigma, ((env', ctx), (impl_env, imps))
+  sigma, (env', ctx, (impl_env, imps))
 
-let interp_fix_ccl ~program_mode sigma impls (env,_) fix =
+let interp_fix_ccl ~program_mode sigma impls env fix =
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
   let sigma, (c, impl) = interp_type_evars_impls ~flags ~impls env sigma fix.Vernacexpr.rtype in
   let r = Retyping.relevance_of_type env sigma c in
   sigma, (c, r, impl)
 
-let interp_fix_body ~program_mode env_rec sigma impls (_,ctx) fix ccl =
+let interp_fix_body ~program_mode env_rec sigma impls ctx fix ccl =
   let open EConstr in
   Option.cata (fun body ->
     let env = push_rel_context ctx env_rec in
     let sigma, body = interp_casted_constr_evars ~program_mode env sigma ~impls body ccl in
     sigma, Some (it_mkLambda_or_LetIn body ctx)) (sigma, None) fix.Vernacexpr.body_def
 
-let build_fix_type (_,ctx) ccl = EConstr.it_mkProd_or_LetIn ccl ctx
+let build_fix_type ctx ccl = EConstr.it_mkProd_or_LetIn ccl ctx
 
 (* Jump over let-bindings. *)
 
@@ -213,14 +213,14 @@ let interp_recursive_evars env ~program_mode rec_order fixl =
 
   (* Interp arities allowing for unresolved types *)
   let sigma, decl = interp_mutual_univ_decl_opt env (List.map (fun Vernacexpr.{univs} -> univs) fixl) in
-  let sigma, (fixctxs, fiximppairs) =
-    on_snd List.split @@
+  let sigma, (fixenv, fixctxs, fiximppairs) =
+    on_snd List.split3 @@
       List.fold_left_map (fun sigma -> interp_fix_context ~program_mode env sigma) sigma fixl in
   let fixkind, fixannot = interp_rec_annot fixl fixctxs rec_order in
   let fixctximpenvs, fixctximps = List.split fiximppairs in
   let sigma, (fixccls,fixrs,fixcclimps) =
     on_snd List.split3 @@
-      List.fold_left3_map (interp_fix_ccl ~program_mode) sigma fixctximpenvs fixctxs fixl in
+      List.fold_left3_map (interp_fix_ccl ~program_mode) sigma fixctximpenvs fixenv fixl in
   let fixtypes = List.map2 build_fix_type fixctxs fixccls in
   let fixtypes = List.map (fun c -> Evarutil.nf_evar sigma c) fixtypes in
   let fiximps = List.map2 (fun ctximps cclimps -> ctximps@cclimps) fixctximps fixcclimps in
@@ -249,7 +249,6 @@ let interp_recursive_evars env ~program_mode rec_order fixl =
   (* Instantiate evars and check all are resolved *)
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env_rec sigma in
   let sigma = Evd.minimize_universes sigma in
-  let fixctxs = List.map (fun (_,ctx) -> ctx) fixctxs in
 
   (* Build the fix declaration block *)
   (env,rec_sign,decl,sigma), (fixnames,fixrs,fixdefs,fixtypes), List.combine fixctxs fiximps, fixkind, fixannot

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -223,9 +223,7 @@ let interp_recursive_evars env ~program_mode rec_order fixl =
       List.fold_left3_map (interp_fix_ccl ~program_mode) sigma fixctximpenvs fixctxs fixl in
   let fixtypes = List.map2 build_fix_type fixctxs fixccls in
   let fixtypes = List.map (fun c -> Evarutil.nf_evar sigma c) fixtypes in
-  let fiximps = List.map3
-    (fun ctximps cclimps (_,ctx) -> ctximps@cclimps)
-    fixctximps fixcclimps fixctxs in
+  let fiximps = List.map2 (fun ctximps cclimps -> ctximps@cclimps) fixctximps fixcclimps in
   let sigma, rec_sign =
     List.fold_left3
       (fun (sigma, env') id r t ->

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -16,14 +16,15 @@ open Vernacexpr
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
 val do_mutually_recursive
-  : ?scope:Locality.definition_scope
+  :  ?pm:Declare.OblState.t
+  -> ?scope:Locality.definition_scope
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
   -> ?user_warns:UserWarn.t
   -> ?using:Vernacexpr.section_subset_expr
   -> recursives_expr
-  -> Declare.Proof.t option
+  -> Declare.OblState.t option * Declare.Proof.t option
 
 (************************************************************************)
 (** Internal API  *)
@@ -34,24 +35,9 @@ type ('constr, 'types, 'r) recursive_preentry =
   (Id.t list * 'r list * 'constr option list * 'types list * EConstr.rel_context list * Impargs.manual_implicits list) *
   Decls.definition_object_kind * Pretyping.possible_guard * UState.universe_decl
 
-(** Exported for Program *)
-val interp_recursive_evars :
-  Environ.env ->
-  (* Misc arguments *)
-  program_mode:bool ->
-  (* Notations of the fixpoint / should that be folded in the previous argument? *)
-  bool * recursion_order_expr ->
-  recursive_expr_gen list ->
-  (* env / signature / univs / evar_map *)
-  (Environ.env * EConstr.named_context * Evd.evar_map) *
-  (* names / defs / types *)
-  (EConstr.t, EConstr.types, EConstr.ERelevance.t) recursive_preentry
-
 (** Exported for Funind *)
 
-val interp_recursive
-  :  ?check_recursivity:bool
-  -> ?typing_flags:Declarations.typing_flags
-  -> bool * Vernacexpr.recursion_order_expr
+val interp_fixpoint_short
+  :  Constrexpr.fixpoint_order_expr option list
   -> recursive_expr_gen list
-  -> (Constr.t, Constr.types, Sorts.relevance) recursive_preentry * UState.t
+  -> Constr.types list * UState.t

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -29,8 +29,10 @@ val do_mutually_recursive
 (** Internal API  *)
 (************************************************************************)
 
-(** names / relevance / defs / types *)
-type ('constr, 'types, 'r) recursive_preentry = Id.t list * 'r list * 'constr option list * 'types list
+(** names / relevance / defs / types / contexts / implicit args / struct annotations / universe decl *)
+type ('constr, 'types, 'r) recursive_preentry =
+  (Id.t list * 'r list * 'constr option list * 'types list * EConstr.rel_context list * Impargs.manual_implicits list) *
+  Decls.definition_object_kind * Pretyping.possible_guard * UState.universe_decl
 
 (** Exported for Program *)
 val interp_recursive_evars :
@@ -41,11 +43,9 @@ val interp_recursive_evars :
   bool * recursion_order_expr ->
   recursive_expr_gen list ->
   (* env / signature / univs / evar_map *)
-  (Environ.env * EConstr.named_context * UState.universe_decl * Evd.evar_map) *
+  (Environ.env * EConstr.named_context * Evd.evar_map) *
   (* names / defs / types *)
-  (EConstr.t, EConstr.types, EConstr.ERelevance.t) recursive_preentry *
-  (* ctx per mutual def / implicits / struct annotations *)
-  (EConstr.rel_context * Impargs.manual_implicits) list * Decls.definition_object_kind * Pretyping.possible_guard
+  (EConstr.t, EConstr.types, EConstr.ERelevance.t) recursive_preentry
 
 (** Exported for Funind *)
 
@@ -54,7 +54,4 @@ val interp_recursive
   -> ?typing_flags:Declarations.typing_flags
   -> bool * Vernacexpr.recursion_order_expr
   -> recursive_expr_gen list
-  -> Decls.definition_object_kind * Pretyping.possible_guard *
-     ((Constr.t, Constr.types, Sorts.relevance) recursive_preentry *
-      UState.universe_decl * UState.t *
-      (EConstr.rel_context * Impargs.manual_implicits) list)
+  -> (Constr.t, Constr.types, Sorts.relevance) recursive_preentry * UState.t

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -214,7 +214,7 @@ let collect_evars_of_term evd c ty =
   Evar.Set.union (Evd.evars_of_term evd c) (Evd.evars_of_term evd ty)
 
 let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (rec_order, fixl) =
-  let (env, rec_sign, udecl, evd), fix, info, kind, possible_guard =
+  let (env, rec_sign, evd), fix =
     let env = Global.env () in
     let env = Environ.update_typing_flags ?typing_flags env in
     interp_recursive_evars env ~program_mode:true (false, rec_order) fixl
@@ -224,7 +224,7 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
   let evd = Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals ~fail:true env evd in
     (* Solve remaining evars *)
   let evd = nf_evar_map_undefined evd in
-  let (fixnames,fixrs,fixdefs,fixtypes) = fix in
+  let ((fixnames,fixrs,fixdefs,fixtypes,fixctxs,fiximps),kind,possible_guard,udecl) = fix in
   let collect_evars name def typ impargs =
     (* Generalize by the recursive prototypes  *)
     let def = nf_evar evd def in
@@ -235,7 +235,6 @@ let do_program_recursive ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?
         (List.length rec_sign) ~deps def typ in
     (def, evars, typ)
   in
-  let fiximps = List.map snd info in
   let fixdefs = List.map out_def fixdefs in
   let bodies, obls, typs = List.split3 (List.map4 collect_evars fixnames fixdefs fixtypes fiximps) in
   let cinfo = List.map3 (fun name typ impargs -> Declare.CInfo.make ~name ~typ ~impargs ()) fixnames typs fiximps in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1101,7 +1101,9 @@ let vernac_fixpoint ~atts ~pm (rec_order,fixl as fix) =
       let pm = ComProgramFixpoint.do_fixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using fix in
       Some pm, None
   else
-    let proof = ComFixpoint.do_mutually_recursive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (CFixRecOrder rec_order, fixl) in
+    let pm', proof =
+      ComFixpoint.do_mutually_recursive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (CFixRecOrder rec_order, fixl) in
+    assert (Option.is_empty pm');
     pm, proof
 
 let vernac_cofixpoint_common ~atts l =
@@ -1125,7 +1127,9 @@ let vernac_cofixpoint ~atts ~pm l =
       let pm = ComProgramFixpoint.do_cofixpoint ~pm ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using l in
       Some pm, None
   else
-    let proof = ComFixpoint.do_mutually_recursive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (CCoFixRecOrder, l) in
+    let pm', proof =
+      ComFixpoint.do_mutually_recursive ~scope ?clearbody ~poly ?typing_flags ?user_warns ?using (CCoFixRecOrder, l) in
+    assert (Option.is_empty pm');
     pm, proof
 
 let vernac_scheme l =


### PR DESCRIPTION
This is the sixth part of https://github.com/coq/coq/pull/18811.

This is mostly about moving/factorizing code from `comProgramFixpoint.ml` to `comFixpoint.ml` applying either `finish_regular` or `finish_program` to deal with evars depending on whether `Program` is on or not (main commit is the last one).

Incidentally, a record is introduced to collect all the components of a fixpoint declaration.

Incidentally fixes #16906

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.

Minor dependency on:
- #19223