### PR TITLE
Move code for interactive definitions close to the one for non interactive definitions

### DIFF
--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -111,6 +111,12 @@ let interp_definition ~program_mode env evd impl_env bl red_option c ctypopt =
   let tyopt = Option.map (fun ty -> EConstr.it_mkProd_or_LetIn ty ctx) tyopt in
   evd, (c, tyopt), imps
 
+let interp_statement ~program_mode env evd ~flags ~scope name bl typ  =
+  let evd, (impls, ((env, ctx), imps)) = Constrintern.interp_context_evars ~program_mode env evd bl in
+  let evd, (t', imps') = Constrintern.interp_type_evars_impls ~flags ~impls env evd typ in
+  let ids = List.map Context.Rel.Declaration.get_name ctx in
+  evd, ids, EConstr.it_mkProd_or_LetIn t' ctx, imps @ imps'
+
 let do_definition ?hook ~name ?scope ?clearbody ~poly ?typing_flags ~kind ?using ?user_warns udecl bl red_option c ctypopt =
   let program_mode = false in
   let env = Global.env() in
@@ -142,3 +148,21 @@ let do_definition_program ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_flags 
     let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
     Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls
   in pm
+
+let do_definition_interactive ~program_mode ?hook ~name ~scope ?clearbody ~poly ~typing_flags ~kind ?using ?user_warns udecl bl t =
+  let env = Global.env () in
+  let env = Environ.update_typing_flags ?typing_flags env in
+  let flags = Pretyping.{ all_no_fail_flags with program_mode } in
+  let evd, udecl = Constrintern.interp_univ_decl_opt env udecl in
+  let evd, args, typ,impargs = interp_statement ~program_mode ~flags ~scope env evd name bl t in
+  let evd =
+    let inference_hook = if program_mode then Some Declare.Obls.program_inference_hook else None in
+    Pretyping.solve_remaining_evars ?hook:inference_hook flags env evd in
+  let evd = Evd.minimize_universes evd in
+  Pretyping.check_evars_are_solved ~program_mode env evd;
+  let typ = EConstr.to_constr evd typ in
+  let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
+  let cinfo = Declare.CInfo.make ~name ~typ ~args ~impargs () in
+  Evd.check_univ_decl_early ~poly ~with_obls:false evd udecl [typ];
+  let evd = if poly then evd else Evd.fix_undefined_variables evd in
+  Declare.Proof.start_definition ~info ~cinfo ?using evd

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -59,3 +59,19 @@ val do_definition_program
   -> constr_expr
   -> constr_expr option
   -> Declare.OblState.t
+
+val do_definition_interactive
+  :  program_mode:bool
+  -> ?hook:Declare.Hook.t
+  -> name:Id.t
+  -> scope:Locality.definition_scope
+  -> ?clearbody:bool
+  -> poly:bool
+  -> typing_flags:Declarations.typing_flags option
+  -> kind:Decls.logical_kind
+  -> ?using:Vernacexpr.section_subset_expr
+  -> ?user_warns:UserWarn.t
+  -> universe_decl_expr option
+  -> local_binder_expr list
+  -> constr_expr
+  -> Declare.Proof.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -607,27 +607,6 @@ let check_name_freshness locality {CAst.loc;v=id} : unit =
   then
     user_err ?loc  (Id.print id ++ str " already exists.")
 
-let start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody ~kind ?user_warns ?using ?hook ((id, udecl), (bl, t)) =
-  let env0 = Global.env () in
-  let env0 = Environ.update_typing_flags ?typing_flags env0 in
-  let flags = Pretyping.{ all_no_fail_flags with program_mode } in
-  let evd, udecl = Constrintern.interp_univ_decl_opt env0 udecl in
-  let evd, (impls, ((env, ctx), imps)) = Constrintern.interp_context_evars ~program_mode env0 evd bl in
-  let evd, (t', imps') = Constrintern.interp_type_evars_impls ~flags ~impls env evd t in
-  let ids = List.map Context.Rel.Declaration.get_name ctx in
-  let typ = EConstr.it_mkProd_or_LetIn t' ctx in
-  let evd =
-    let inference_hook = if program_mode then Some Declare.Obls.program_inference_hook else None in
-    Pretyping.solve_remaining_evars ?hook:inference_hook flags env0 evd in
-  let evd = Evd.minimize_universes evd in
-  Pretyping.check_evars_are_solved ~program_mode env0 evd;
-  let info = Declare.Info.make ?hook ~poly ~scope ?clearbody ~kind ~udecl ?typing_flags ?user_warns () in
-  let typ = EConstr.to_constr evd typ in
-  Evd.check_univ_decl_early ~poly ~with_obls:false evd udecl [typ];
-  let evd = if poly then evd else Evd.fix_undefined_variables evd in
-  let thm = Declare.CInfo.make ~name:id.CAst.v ~typ ~args:ids ~impargs:(imps @ imps') () in
-  Declare.Proof.start_definition ~info ~cinfo:thm ?using evd
-
 let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let open Decls in function
 | Coercion ->
   Some (ComCoercion.add_coercion_hook ~reversible)
@@ -659,19 +638,19 @@ let vernac_definition_name lid local =
     | Discharge -> Dumpglob.dump_definition lid true "var"
     | Global _ -> Dumpglob.dump_definition lid false "def"
   in
-  lid
+  lid.v
 
-let vernac_definition_interactive ~atts (discharge, kind) (lid, pl) bl t =
+let vernac_definition_interactive ~atts (discharge, kind) (lid, udecl) bl t =
   let open DefAttributes in
   let scope, local, poly, program_mode, user_warns, typing_flags, using, clearbody =
     atts.scope, atts.locality, atts.polymorphic, atts.program, atts.user_warns, atts.typing_flags, atts.using, atts.clearbody in
   let canonical_instance, reversible = atts.canonical_instance, atts.reversible in
   let hook = vernac_definition_hook ~canonical_instance ~local ~poly ~reversible kind in
   let name = vernac_definition_name lid scope in
-  start_lemma_com ~typing_flags ~program_mode ~poly ~scope ?clearbody
-    ~kind:(Decls.IsDefinition kind) ?user_warns ?using ?hook ((name, pl), (bl, t))
+  ComDefinition.do_definition_interactive ~typing_flags ~program_mode ~name ~poly ~scope ?clearbody:atts.clearbody
+    ~kind:(Decls.IsDefinition kind) ?user_warns ?using:atts.using ?hook udecl bl t
 
-let vernac_definition ~atts ~pm (discharge, kind) (lid, pl) bl red_option c typ_opt =
+let vernac_definition ~atts ~pm (discharge, kind) (lid, udecl) bl red_option c typ_opt =
   let open DefAttributes in
   let scope, local, poly, program_mode, user_warns, typing_flags, using, clearbody =
      atts.scope, atts.locality, atts.polymorphic, atts.program, atts.user_warns, atts.typing_flags, atts.using, atts.clearbody in
@@ -686,14 +665,14 @@ let vernac_definition ~atts ~pm (discharge, kind) (lid, pl) bl red_option c typ_
       Some (snd (Redexpr.interp_redexp_no_ltac env sigma r)) in
   if program_mode then
     let kind = Decls.IsDefinition kind in
-    ComDefinition.do_definition_program ~pm ~name:name.v
+    ComDefinition.do_definition_program ~pm ~name
       ?clearbody ~poly ?typing_flags ~scope ~kind
-      ?user_warns ?using pl bl red_option c typ_opt ?hook
+      ?user_warns ?using udecl bl red_option c typ_opt ?hook
   else
     let () =
-      ComDefinition.do_definition ~name:name.v
+      ComDefinition.do_definition ~name
         ?clearbody ~poly ?typing_flags ~scope ~kind
-        ?user_warns ?using pl bl red_option c typ_opt ?hook in
+        ?user_warns ?using udecl bl red_option c typ_opt ?hook in
     pm
 
 (* NB: pstate argument to use combinators easily *)
@@ -706,8 +685,10 @@ let vernac_start_proof ~atts kind l =
   List.iter (fun ((id, _), _) -> check_name_freshness scope id) l;
   match l with
   | [] -> assert false
-  | [decl] ->
-    start_lemma_com ~typing_flags ~program_mode ~poly   ~scope ~kind:(Decls.IsProof kind) ?user_warns ?using decl
+  | [({v=name},udecl),(bl,typ)] ->
+    ComDefinition.do_definition_interactive
+      ~typing_flags ~program_mode ~name ~poly ?clearbody ~scope
+      ~kind:(Decls.IsProof kind) ?user_warns ?using udecl bl typ
   | _ ->
     let fix = List.map (fun ((fname, univs), (binders, rtype)) ->
         { fname; binders; rtype; body_def = None; univs; notations = []}) l in


### PR DESCRIPTION
This organizes the code in a more structured way.

Interaction with #18960 to be studied.

Possibly to go a step further and merge the common parts of interactive and non interactive definitions to discuss.

Depends on:

- #19259 
 
and thus, indirectly, from:

- #19223 (minor dependency)
- #19257 
- #19258
