### PR TITLE
Laxer kernel typing rule for template inductive types.

### DIFF
--- a/doc/changelog/01-kernel/19262-template-no-sup-constraint-kernel.rst
+++ b/doc/changelog/01-kernel/19262-template-no-sup-constraint-kernel.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  the kernel typing rules for template polymorphic inductive types do not
+  require anymore adding global constraints when applied enough. Rather,
+  template polymorphic inductive types are now a special kind of universe
+  polymorphic inductive types that do not need explicit instances and
+  can handle some amount of algebraic universe levels. The new rules are
+  strictly more general than the previous ones and thus backwards compatible
+  (`#19262 <https://github.com/coq/coq/pull/19262>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/changelog/01-kernel/19262-template-no-sup-constraint-kernel.rst
+++ b/doc/changelog/01-kernel/19262-template-no-sup-constraint-kernel.rst
@@ -1,4 +1,14 @@
 - **Changed:**
+  the criteria for a parameter to be considered template in a template inductive type.
+  For a level to be template, it must now appear only once in the context of parameters,
+  and only as the return sort of the arity of some parameter. Furthermore,
+  it may appear neither in the indices of the inductive type nor in the type of its constructors.
+  Finally, a template level appearing in the return sort of the inductive type must have a zero increment
+  (`#19250 <https://github.com/coq/coq/pull/19250>`_,
+  `#19254 <https://github.com/coq/coq/pull/19254>`_,
+  `#19263 <https://github.com/coq/coq/pull/19263>`_,
+  by Pierre-Marie Pédrot).
+- **Changed:**
   the kernel typing rules for template polymorphic inductive types do not
   require anymore adding global constraints when applied enough. Rather,
   template polymorphic inductive types are now a special kind of universe

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -52,9 +52,10 @@ type template_univ =
 
 type param_univs = (expected:Univ.Level.t -> template_univ) list
 
+val instantiate_template_universes : mind_specif -> param_univs ->
+  Constraints.t * rel_context * template_univ Univ.Level.Map.t
+
 val constrained_type_of_inductive : mind_specif puniverses -> types constrained
-val constrained_type_of_inductive_knowing_parameters :
-  mind_specif puniverses -> param_univs -> types constrained
 
 val relevance_of_ind_body : one_inductive_body -> UVars.Instance.t -> Sorts.relevance
 
@@ -63,7 +64,7 @@ val relevance_of_inductive : env -> pinductive -> Sorts.relevance
 val type_of_inductive : mind_specif puniverses -> types
 
 val type_of_inductive_knowing_parameters :
-  ?polyprop:bool -> mind_specif puniverses -> param_univs -> types
+  ?polyprop:bool -> mind_specif puniverses -> param_univs -> types constrained
 
 val quality_leq : Sorts.Quality.t -> Sorts.Quality.t -> bool
 (** For squashing. *)
@@ -81,6 +82,7 @@ val is_primitive_record : mind_specif -> bool
 
 val constrained_type_of_constructor : pconstructor -> mind_specif -> types constrained
 val type_of_constructor : pconstructor -> mind_specif -> types
+val type_of_constructor_knowing_parameters : pconstructor -> mind_specif -> param_univs -> types constrained
 
 (** Return constructor types in normal form *)
 val arities_of_constructors : pinductive -> mind_specif -> types array

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -217,11 +217,15 @@ let retype ?(polyprop=true) sigma =
       let u = EInstance.kind sigma u in
       let mip = lookup_mind_specif env ind in
       let paramtyps = make_param_univs env sigma (ind,u) args in
-      EConstr.of_constr
-        (Inductive.type_of_inductive_knowing_parameters
-           ~polyprop (mip, u) paramtyps)
+      let (ty, _) = Inductive.type_of_inductive_knowing_parameters ~polyprop (mip, u) paramtyps in
+      EConstr.of_constr ty
     | Construct (cstr, u) ->
-      type_of_constructor env (cstr, u)
+      let u = EInstance.kind sigma u in
+      let (ind, _) = cstr in
+      let mip = lookup_mind_specif env ind in
+      let paramtyps = make_param_univs env sigma (ind, u) args in
+      let (ty, _) = Inductive.type_of_constructor_knowing_parameters (cstr, u) mip paramtyps in
+      EConstr.of_constr ty
     | _ -> assert false
 
   and make_param_univs env sigma indu args =


### PR DESCRIPTION
Under the view that template types are an optimization of sort-polymorphic inductive types, the requirement that the sort of an argument lives below the global template universe of the corresponding parameter is spurious.

This commit is extracted from #19228 and should be mostly backwards compatible, as the new kernel rules are compatible with the old model. Out of easiness I did tweak some pieces of code in Typing / Retyping but in practice I expect it doesn't matter too much.