### PR TITLE
Forbid non-linear template polymorphic universe levels.

### DIFF
--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -292,7 +292,13 @@ let get_template univs ~env_params ~env_ar_par ~params entries data =
     | LocalDef _ -> None
     in
     let template_params = List.map_filter map params in
-    let fold accu u = match u with None -> accu | Some u -> Level.Set.add u accu in
+    let fold accu u = match u with
+    | None -> accu
+    | Some u ->
+      if Level.Set.mem u accu then
+        CErrors.user_err Pp.(str "Non-linear template level " ++ Level.raw_pr u)
+      else Level.Set.add u accu
+    in
     let plevels = List.fold_left fold Level.Set.empty template_params in
     (* We must ensure that template levels can be substituted by an arbitrary
        algebraic universe. A reasonable approximation is to restrict their

--- a/test-suite/bugs/bug_19263.v
+++ b/test-suite/bugs/bug_19263.v
@@ -1,0 +1,7 @@
+Set Warnings "+no-template-universe".
+
+Fail #[universes(template)]
+Inductive sum@{u} (A B : Type@{u}) : Type := inl : A -> sum A B | inr : B -> sum A B.
+
+#[universes(template)]
+Inductive sum (A B : Type) : Type := inl : A -> sum A B | inr : B -> sum A B.


### PR DESCRIPTION
This can break subject reduction in the future poly-like model. In practice, it is not possible to trigger this code path without explicit fidgetting with universe levels in the inductive declaration.