### PR TITLE
Skip existential variable instances in Set Keep Admitted

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2374,10 +2374,7 @@ let save_lemma_admitted_delayed ~pm ~proof =
   let typs = List.map (function { proof_entry_type } -> Option.get proof_entry_type) entries in
   (* Note: an alternative would be to compute sec_vars of the partial
      proof as a Future computation, as in compute_proof_using_for_admitted *)
-  let sec_vars = if get_keep_admitted_vars () then (List.hd entries).proof_entry_secctx else None in
-  (* If the proof is partial, do we want to take the (restriction on
-     visible uvars of) uctx so far or (as done below) the initial ones
-     that refers to only the types *)
+  let sec_vars = (List.hd entries).proof_entry_secctx in
   finish_admitted ~pm ~uctx ~pinfo ~sec_vars typs
 
 let save_lemma_proved_delayed ~pm ~proof ~idopt =


### PR DESCRIPTION
Otherwise, there is reduced interest in the option as all non-cleared section variables would be kept.

Also preserve an explicit `using` clause in deferred mode even when `Set Keep Admitted` is off rather than declaring no section variables at all.

Actually, `Set Keep Admitted` is not documented. So, a first question might be whether we want to keep it or not.

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.
- [ ] Added documentation.