### PR TITLE
[CoqIDE] Display warnings in their own tab.

### DIFF
--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -40,7 +40,8 @@ object
   method stop_worker : string -> unit task
 
   method get_n_errors : int
-  method get_errors_warnings : (int * string) list
+  method get_errors : (int * string) list
+  method get_warnings : (int * string) list
   method get_slaves_status : int * int * string CString.Map.t
   method backtrack_to_begin : unit -> unit task
   method handle_failure : handle_exn_rty -> unit task

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -1729,7 +1729,8 @@ let build_ui () =
     else
       slaveinfo#set_text (Printf.sprintf "%d / %d" missing n_err);
     slaveinfo#set_use_markup true;
-    sn.errpage#update sn.coqops#get_errors_warnings;
+    sn.warnpage#update sn.coqops#get_warnings;
+    sn.errpage#update sn.coqops#get_errors;
     sn.jobpage#update (Util.pi3 sn.coqops#get_slaves_status) in
   let callback () = on_current_term update; true in
   let _ = Glib.Timeout.add ~ms:300 ~callback in

--- a/ide/coqide/session.mli
+++ b/ide/coqide/session.mli
@@ -47,6 +47,7 @@ type session = {
   debugger : Wg_Debugger.debugger_view;
   tab_label : GMisc.label;
   errpage : errpage;
+  warnpage : errpage;
   jobpage : jobpage;
   sid : int;
   basename : string;


### PR DESCRIPTION
Follow-up of #19188. It was annoyingly confusing to get the warnings in the error tab, as it seemed to indicate that the file was not properly compiling.