### PR TITLE
Faster guardedness check when checking non-recursivity.

### DIFF
--- a/lib/rtree.ml
+++ b/lib/rtree.ml
@@ -90,10 +90,11 @@ let dest_node t =
       Node (l,sons) -> (l,sons)
     | _ -> failwith "Rtree.dest_node"
 
-let is_node t =
-  match expand t with
-      Node _ -> true
-    | _ -> false
+let is_node check t =
+  (* no need to expand as the result must be a Node *)
+  match t with
+  | Node (l, _) -> check l
+  | Var _ | Rec _ -> false
 
 let rec map f t = match t with
     Var(i,j) -> Var(i,j)

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -49,7 +49,7 @@ val mk_rec   : 'a t array -> 'a t array
    to avoid captures when a tree appears under [mk_rec] *)
 val lift : int -> 'a t -> 'a t
 
-val is_node : 'a t -> bool
+val is_node : ('a -> bool) -> 'a t -> bool
 
 (** Destructors (recursive calls are expanded) *)
 val dest_node  : 'a t -> 'a * 'a t array array


### PR DESCRIPTION
Instead of performing an expensive unfolding of the rectree to check that an argument is Norec, we simply look directly at the head constructor. Indeed, the only way to get a Node constructor by unfolding is when the argument is itself a Node, i.e. unfolding is useless when we only care about the head.
