### PR TITLE
Fix univ poly Scheme Equality with non stdlib univ mono f_equal

### DIFF
--- a/test-suite/bugs/bug_19264.v
+++ b/test-suite/bugs/bug_19264.v
@@ -1,0 +1,17 @@
+Lemma f_equal@{a b} : forall (A:Type@{a}) (B : Type@{b}) (f : A -> B) (x y : A), x = y -> f x = f y.
+Proof. intros;congruence. Qed.
+
+Register f_equal as core.eq.congr.
+
+Set Universe Polymorphism.
+
+Inductive prod (A B:Type) := pair : A -> B -> prod A B.
+
+Scheme Equality for prod.
+(*
+Error: Unexpected error during scheme creation: Unsatisfied constraints:
+foo.30 <= f_equal.a
+foo.30 <= f_equal.b
+foo.31 <= f_equal.a
+foo.31 <= f_equal.b (maybe a bugged tactic).
+*)

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -1424,7 +1424,14 @@ let compute_dec_tact handle (ind,u) lnamesparrec nparrec =
           let blI = mkConstU (c,u) in
           let c = get_scheme handle lb_scheme_kind ind in
           let lbI = mkConstU (c,u) in
+          (* univ polymorphic schemes may have extra constraints
+             from using univ monomorphic f_equal and the like *)
+          let env, sigma = Proofview.Goal.(env gl, sigma gl) in
+          let sigma, _ = Typing.type_of env sigma (EConstr.of_constr blI) in
+          let sigma, _ = Typing.type_of env sigma (EConstr.of_constr lbI) in
           Tacticals.tclTHENLIST [
+              Proofview.Unsafe.tclEVARS sigma;
+
               (*we do this so we don't have to prove the same goal twice *)
               assert_by (Name freshH) (EConstr.of_constr (
                                            mkApp(sumbool(),[|eqtrue eqbnm; eqfalse eqbnm|])


### PR DESCRIPTION
The stdlib f_equal works because its universe is >= eq_ind_r.u0, and the universes of the scheme are <= eq_ind_r.u0, so the constraints are satisfied; but we shouldn't rely on this.

Fix #19264
