### PR TITLE
Update `flake.lock` to re-enable `nix build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ test-suite/bug_10796.ml
 test-suite/bug_10796.mli
 test-suite/**/*.time
 
+# `nix build` (through flake) symlink
+result
+
 # documentation
 
 doc/common/version.tex

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,12 +20,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684973047,
-        "narHash": "sha256-ZLnSr35L6C49pCZS9fZCCqkIKNAeQzykov2QfosNG9w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "21eb6c6ba74dcbe3ea5926ee46287300fb066630",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-UHGnmQRnbykGt17ycgPddaQxbbs/XZfy9L3vW2RMZ0I=",
+        "path": "/nix/store/y81rakc9v1cv0j0mbqgvnszf6gq5jgwb-source",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",


### PR DESCRIPTION
Currently `nix build` through the flake fails with: `Error: Version 3.6 of the dune language is not supported.`

I just ran `nix flake update` and checked that the `nix build` didn't fail. I also added the result symlink to the `.gitignore` so that running `nix build` doesn't dirty the git repo.

