### PR TITLE
Ensure that andb_true_intro and andb_prop are transparent so that Scheme Equality computes

### DIFF
--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -322,6 +322,6 @@ Inductive bintree :=
 
 Scheme Equality for bintree.
 
-Check eq_refl : (if bintree_eq_dec (Node (Node Leaf Leaf) Leaf) (Node (Node Leaf Leaf) Leaf) then 0 else 1) = 0.
+Check eq_refl : bintree_eq_dec (Node (Node Leaf Leaf) Leaf) (Node (Node Leaf Leaf) Leaf) = left eq_refl.
 
 End ComputableDecidableEquality.

--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -313,3 +313,15 @@ Record machine_state := { machine_reg_state :> reg_state ; machine_flag_state :>
 Fail Scheme Boolean Equality for machine_state.
 
 End M.
+
+Module ComputableDecidableEquality.
+
+Inductive bintree :=
+| Leaf : bintree
+| Node : bintree -> bintree -> bintree.
+
+Scheme Equality for bintree.
+
+Check eq_refl : (if bintree_eq_dec (Node (Node Leaf Leaf) Leaf) (Node (Node Leaf Leaf) Leaf) then 0 else 1) = 0.
+
+End ComputableDecidableEquality.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -83,7 +83,11 @@ Qed.
 #[global]
 Hint Resolve andb_prop: bool.
 
-Register andb_prop as core.bool.andb_prop.
+Lemma andb_prop_inf (a b:bool) : andb a b = true -> a = true /\ b = true.
+Proof.
+  destruct a, b; repeat split; assumption.
+Defined.
+Register andb_prop_inf as core.bool.andb_prop.
 
 Lemma andb_true_intro (b1 b2:bool) :
   b1 = true /\ b2 = true -> andb b1 b2 = true.
@@ -93,7 +97,12 @@ Qed.
 #[global]
 Hint Resolve andb_true_intro: bool.
 
-Register andb_true_intro as core.bool.andb_true_intro.
+Lemma andb_true_intro_inf (b1 b2:bool) :
+  b1 = true /\ b2 = true -> andb b1 b2 = true.
+Proof.
+  destruct b1; destruct b2; simpl; intros [? ?]; assumption.
+Defined.
+Register andb_true_intro_inf as core.bool.andb_true_intro.
 
 (** Interpretation of booleans as propositions *)
 


### PR DESCRIPTION
`Scheme Equality` builds proofs of decidability of equality that do not compute due to `andb_true_intro` and `andb_prop` being opaque.

We add transparent versions of them that `Scheme Equality` can use so that it computes. 

- [x] Added / updated **test-suite**.
- [ ] Added **changelog**.

I forgot to make this PR earlier. That would be nice to have it for 8.20 as it is morally a fix, and otherwise 8.21.

This is a "quick" fix until `Scheme Equality` is able to build a more direct proof of `{x = y} + {x <> y}` (see [Zulip](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Scheme.20Equality.20uses.20opaque.20andb_prop) discussion).