### PR TITLE
Extend Derive with an arbitrary long sequence of dependencies

### DIFF
--- a/doc/changelog/02-specification-language/19295-master+fix18951-anomaly-derive-admitted.rst
+++ b/doc/changelog/02-specification-language/19295-master+fix18951-anomaly-derive-admitted.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  The syntax :n:`Derive x SuchThat type As name` is deprecated and replaced by
+  :n:`Derive x in type as name` which itself is generalized into
+  :n:`Derive open_binders in type as name`, so that several names,
+  and possibly types to these names, can be given
+  (`#19295 <https://github.com/coq/coq/pull/19295>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/addendum/miscellaneous-extensions.rst
+++ b/doc/sphinx/addendum/miscellaneous-extensions.rst
@@ -2,25 +2,29 @@ Program derivation
 ==================
 
 Coq comes with an extension called ``Derive``, which supports program
-derivation. Typically in the style of Bird and Meertens or derivations
+derivation. Typically in the style of Bird and Meertens formalism or derivations
 of program refinements. To use the Derive extension it must first be
 required with ``Require Stdlib.derive.Derive``. When the extension is loaded,
 it provides the following command:
 
-.. cmd:: Derive @ident__1 SuchThat @one_term As @ident__2
+.. cmd:: Derive @open_binders in @type as @ident
+         Derive @open_binders SuchThat @type As @ident
 
-   :n:`@ident__1` can appear in :n:`@one_term`. This command opens a new proof
-   presenting the user with a goal for :n:`@one_term` in which the name :n:`@ident__1` is
-   bound to an existential variable :g:`?x` (formally, there are other goals
-   standing for the existential variables but they are shelved, as
+   where :n:`@open_binders` is a list of the form
+   :n:`@ident__i : @type__i` which can appear in :n:`@type`. This
+   command opens a new proof presenting the user with a goal for
+   :n:`@type` in which each name :n:`@ident__i` is bound to an
+   existential variable of same name :g:`?ident__i` (these
+   existential variables are shelved goals, as
    described in :tacn:`shelve`).
 
-   When the proof ends two :term:`constants <constant>` are defined:
+   When the proof is complete, Coq defines :term:`constants <constant>`
+   for each :n:`@ident__i` and for :n:`@ident`:
 
-   + The first one is named :n:`@ident__1` and is defined as the proof of the
-     shelved goal (which is also the value of :g:`?x`). It is always
+   + The first ones, named :n:`@ident__i`, are defined as the proof of the
+     shelved goals (which are also the value of :n:`?ident__i`). They are always
      transparent.
-   + The second one is named :n:`@ident__2`. It has type :n:`@type`, and its :term:`body` is
+   + The final one is named :n:`@ident`. It has type :n:`@type`, and its :term:`body` is
      the proof of the initially visible goal. It is opaque if the proof
      ends with :cmd:`Qed`, and transparent if the proof ends with :cmd:`Defined`.
 
@@ -35,19 +39,24 @@ it provides the following command:
 
      Variables (n m k:nat).
 
-     Derive p SuchThat ((k*n)+(k*m) = p) As h.
+     Derive j p in ((k*n)+(k*m) = j*p) as h.
      Proof.
      rewrite <- Nat.mul_add_distr_l.
-     subst p.
+     subst j p.
      reflexivity.
      Qed.
 
      End P.
 
+     Print j.
      Print p.
      Check h.
 
-Any property can be used as `term`, not only an equation. In particular,
+Any property can be used as `type`, not only an equation. In particular,
 it could be an order relation specifying some form of program
 refinement or a non-executable property from which deriving a program
 is convenient.
+
+.. note::
+   The syntax :n:`Derive @open_binders SuchThat @type As @ident` is obsolete
+   and to be avoided.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1377,6 +1377,12 @@ command: [
 | REPLACE "Declare" "Scope" IDENT
 | WITH "Declare" "Scope" scope_name
 
+| REPLACE "Derive" open_binders "SuchThat" constr "As" identref      (* derive plugin *)
+| WITH "Derive" open_binders "SuchThat" type "As" ident      (* derive plugin *)
+
+| REPLACE "Derive" open_binders "in" constr "as" identref      (* derive plugin *)
+| WITH "Derive" open_binders "in" type "as" ident      (* derive plugin *)
+
 (* odd that these are in command while other notation-related ones are in syntax *)
 | REPLACE "Number" "Notation" reference reference reference OPT number_options ":" preident
 | WITH "Number" "Notation" reference reference reference OPT number_options ":" scope_name

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -562,7 +562,8 @@ command: [
 | "Debug" "Off"
 | "Declare" "Reduction" IDENT; ":=" red_expr
 | "Declare" "Custom" "Entry" IDENT
-| "Derive" identref "SuchThat" constr "As" identref      (* derive plugin *)
+| "Derive" open_binders "SuchThat" constr "As" identref      (* derive plugin *)
+| "Derive" open_binders "in" constr "as" identref      (* derive plugin *)
 | "Extraction" global      (* extraction plugin *)
 | "Recursive" "Extraction" LIST1 global      (* extraction plugin *)
 | "Extraction" string LIST1 global      (* extraction plugin *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -789,7 +789,8 @@ command: [
 | "Debug" [ "On" | "Off" ]
 | "Declare" "Reduction" ident ":=" red_expr
 | "Declare" "Custom" "Entry" ident
-| "Derive" ident "SuchThat" one_term "As" ident      (* derive plugin *)
+| "Derive" open_binders "SuchThat" type "As" ident
+| "Derive" open_binders "in" type "as" ident
 | "Extraction" qualid      (* extraction plugin *)
 | "Recursive" "Extraction" LIST1 qualid      (* extraction plugin *)
 | "Extraction" string LIST1 qualid      (* extraction plugin *)

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2873,6 +2873,7 @@ let interp_context_evars_gen ?(program_mode=false) ?(unconstrained_sorts = false
       (fun (int_env, acc) b ->
         let int_env, bl = intern_local_binder_aux ~dump (my_intern_constr env lvar) Id.Map.empty (int_env,[]) b in
         let int_env, acc = List.fold_right (fun b' (int_env, (env,sigma,params,impls)) ->
+          let loc = b'.CAst.loc in
           let (na, _, bk, b', t) = glob_local_binder_of_extended b' in
           let sigma, t =
               let t' = if Option.is_empty b' then locate_if_hole ?loc:(loc_of_glob_constr t) na t else t in (* useful? *)
@@ -2883,13 +2884,13 @@ let interp_context_evars_gen ?(program_mode=false) ?(unconstrained_sorts = false
           match b' with
           | None ->
             let int_env = if autoimp_enable then Name.fold_left (push_auto_implicit env sigma t) int_env na else int_env in
-            let d = make_decl (LocalAssum (make_annot na r,t)) in
+            let d = make_decl ?loc (LocalAssum (make_annot na r,t)) in
             let impls = impl_of_binder_kind na bk :: impls in
             (int_env, (push_decl d env, sigma, d::params, impls))
           | Some b ->
             assert (bk = Explicit);
             let sigma, c, _ = Pretyping.ise_pretype_gen flags env sigma empty_lvar (OfType t) b in
-            let d = make_decl (LocalDef (make_annot na r, c, t)) in
+            let d = make_decl ?loc (LocalDef (make_annot na r, c, t)) in
             (int_env, (push_decl d env, sigma, d::params, impls)))
           bl (int_env,acc) in
         int_env, acc)
@@ -2898,12 +2899,12 @@ let interp_context_evars_gen ?(program_mode=false) ?(unconstrained_sorts = false
   sigma, (int_env.impls, ((env, bl), List.rev impls))
 
 let interp_named_context_evars ?program_mode ?unconstrained_sorts ?impl_env ?autoimp_enable env sigma bl =
-  let extract_name = function Name id -> id | Anonymous -> user_err Pp.(str "Unexpected anonymous variable.") in
-  let make_decl = Context.Named.Declaration.of_rel_decl extract_name in
+  let extract_name ?loc = function Name id -> id | Anonymous -> user_err ?loc Pp.(str "Unexpected anonymous variable.") in
+  let make_decl ?loc = Context.Named.Declaration.of_rel_decl (extract_name ?loc) in
   interp_context_evars_gen ?program_mode ?unconstrained_sorts  ?impl_env ?autoimp_enable ~dump:false env sigma make_decl EConstr.push_named bl
 
 let interp_context_evars ?program_mode ?unconstrained_sorts ?impl_env env sigma bl =
-  interp_context_evars_gen ?program_mode ?unconstrained_sorts ?impl_env ~autoimp_enable:false ~dump:true env sigma (fun d -> d) EConstr.push_rel bl
+  interp_context_evars_gen ?program_mode ?unconstrained_sorts ?impl_env ~autoimp_enable:false ~dump:true env sigma (fun ?loc d -> d) EConstr.push_rel bl
 
 (** Local universe and constraint declarations. *)
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -595,7 +595,7 @@ let glob_local_binder_of_extended = DAst.with_loc_val (fun ?loc -> function
       let t = DAst.make ?loc @@ GHole (GBinderType na) in
       (na,None,Explicit,Some c,t)
   | GLocalPattern (_,_,_,_) ->
-      Loc.raise ?loc (Gramlib.Grammar.Error "Pattern with quote not allowed here.")
+      Loc.raise ?loc (Gramlib.Grammar.Error "Pattern with quote not allowed here")
   )
 
 let intern_cases_pattern_fwd = ref (fun _ -> failwith "intern_cases_pattern_fwd")

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -67,6 +67,9 @@ let wit_open_constr = make0 ~dyn:(val_tag (topwit wit_constr)) "open_constr"
 let wit_clause_dft_concl  =
   make0 "clause_dft_concl"
 
+let wit_open_binders =
+  make0 "open_binders"
+
 (** Aliases for compatibility *)
 
 let wit_integer = wit_int

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -61,6 +61,8 @@ val wit_open_constr :
 
 val wit_clause_dft_concl :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) genarg_type
 
+val wit_open_binders : local_binder_expr list uniform_genarg_type
+
 (** Aliases for compatibility *)
 
 val wit_natural : int uniform_genarg_type

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -562,4 +562,5 @@ let () =
   Grammar.register0 wit_smart_global (Prim.smart_global);
   Grammar.register0 wit_sort_family (Constr.sort_family);
   Grammar.register0 wit_constr (Constr.constr);
+  Grammar.register0 wit_open_binders (Constr.open_binders);
   ()

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -10,12 +10,35 @@
 
 open Context.Named.Declaration
 open Vernacentries.DefAttributes
+open Constrexpr
+
+let check_allowed_implicit ?loc = function
+  | Generalized _ | Default (MaxImplicit | NonMaxImplicit) ->
+    CErrors.user_err ?loc (Pp.str "Unexpected implicit argument annotation.")
+  | Default Explicit -> ()
+
+let check_allowed_binders = function
+  | CLocalAssum (n::_, _, impl, _) -> check_allowed_implicit ?loc:n.CAst.loc impl
+  | CLocalPattern _ -> () (* a priori acceptable, but interp_named_context_evars_as_arguments does not support it *)
+  | CLocalDef (n, _, _, _) -> ()
+  | CLocalAssum ([], _, _, _) -> assert false
+
+let rec fill_assumptions env sigma = function
+  | [] -> sigma, env, []
+  | LocalAssum (na,t) :: ctx ->
+    let sigma, ev = Evarutil.new_evar env sigma ~src:(Loc.tag @@ Evar_kinds.GoalEvar) ~typeclass_candidate:false t in
+    let decl = LocalDef (na,ev,t) in
+    let sigma, env, ctx = fill_assumptions (EConstr.push_named decl env) sigma ctx in
+    sigma, env, decl :: ctx
+  | LocalDef _ as decl :: ctx ->
+    let sigma, env, ctx = fill_assumptions (EConstr.push_named decl env) sigma ctx in
+    sigma, env, decl :: ctx
 
 (** [start_deriving f suchthat lemma] starts a proof of [suchthat]
     (which can contain references to [f]) in the context extended by
     [f:=?x]. When the proof ends, [f] is defined as the value of [?x]
     and [lemma] as the proof. *)
-let start_deriving ~atts CAst.{v=f;loc} suchthat name : Declare.Proof.t =
+let start_deriving ~atts bl suchthat name : Declare.Proof.t =
 
   let scope, _local, poly, program_mode, user_warns, typing_flags, using, clearbody =
     atts.scope, atts.locality, atts.polymorphic, atts.program, atts.user_warns, atts.typing_flags, atts.using, atts.clearbody in
@@ -23,31 +46,33 @@ let start_deriving ~atts CAst.{v=f;loc} suchthat name : Declare.Proof.t =
 
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let kind = Decls.(IsDefinition Definition) in
-
-  (* create a sort variable for the type of [f] *)
-  (* spiwack: I don't know what the rigidity flag does, picked the one
-     that looked the most general. *)
-  let sigma, (f_type, f_impargs) =
-    let (sigma,f_type_sort) = Evd.new_sort_variable Evd.univ_flexible_alg sigma in
-    let f_type_type = EConstr.mkSort f_type_sort in
-    let sigma, f_type = Evarutil.new_evar env sigma ~src:(Loc.tag @@ Evar_kinds.GoalEvar) ~typeclass_candidate:false f_type_type in
-    let sigma = Evd.shelve sigma [fst (EConstr.destEvar sigma f_type)] in
-    sigma, (f_type, [])
-  in
-  let (sigma, ef) = Evarutil.new_evar env sigma ~src:(Loc.tag @@ Evar_kinds.GoalEvar) ~typeclass_candidate:false f_type in
-  let env' = EConstr.push_named (LocalDef (EConstr.annotR f, ef, f_type)) env in
-  let impls = Names.Id.Map.add f (Constrintern.compute_internalization_data env sigma f Constrintern.Variable f_type f_impargs) Constrintern.empty_internalization_env in
-  let sigma = Evd.shelve sigma [fst (EConstr.destEvar sigma ef)] in
-  let sigma, (suchthat, impargs) = Constrintern.interp_type_evars_impls env' sigma ~impls suchthat in
+  let () = List.iter check_allowed_binders bl in
+  let sigma, (impls_env, ((env', ctx'), _)) = Constrintern.interp_named_context_evars env sigma bl in
+  let sigma, env', ctx' = fill_assumptions env sigma ctx' in
+  let sigma = Evd.shelve sigma (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma))) in
+  let sigma, (suchthat, impargs) = Constrintern.interp_type_evars_impls env' sigma ~impls:impls_env suchthat in
   (* create the initial goals for the proof: |- Type ; |- ?1 ; f:=?2 |- suchthat *)
   let goals =
     let open Proofview in
-        TCons ( env , sigma , f_type , (fun sigma ef' ->
-            let sigma = Evd.define (fst (EConstr.destEvar sigma ef')) ef sigma in
-            TCons ( env' , sigma , suchthat , (fun sigma _ -> TNil sigma)))) in
-  let info = Declare.Info.make ~poly ~scope ?clearbody ~kind ?typing_flags ?user_warns () in  (* TODO: udecl *)
-  let cinfo = Declare.CInfo.[make ~name:f ~typ:() ~impargs:f_impargs (); make ~name ~typ:() ~impargs ()] in
-  let lemma = Declare.Proof.start_derive ~name ~f ~info ~cinfo goals in
+    let rec aux env sigma = function
+      | [] -> TCons ( env , sigma , suchthat , (fun sigma _ -> TNil sigma))
+      | LocalAssum (id, t) :: _ -> assert false
+      | LocalDef (id, c, t) as d :: ctx ->
+        TCons ( env , sigma , t , (fun sigma ef' ->
+            let sigma = Evd.define (fst (EConstr.destEvar sigma ef')) c sigma in
+            aux (EConstr.push_named d env) sigma ctx)) in
+    aux env sigma ctx' in
+  let kind = Decls.(IsDefinition Definition) in
+  let info = Declare.Info.make ~poly:(Attributes.is_universe_polymorphism ()) ~kind () in
+  let extract_manual = function Some Impargs.{ impl_pos = (na,_,_); impl_expl = Manual; impl_max } -> Some (na, impl_max) | _ -> None in
+  let cinfo =
+    let open Declare.CInfo in
+    List.map (fun d ->
+        let name = get_id d in
+        let impargs = Constrintern.implicits_of_decl_in_internalization_env name impls_env in
+        let impargs = List.map CAst.make (List.map extract_manual impargs) in
+        make ~name ~typ:() ~impargs ()) ctx' @
+    [make ~name ~typ:() ~impargs ()] in
+  let lemma = Declare.Proof.start_derive ~name ~info ~cinfo goals in
   Declare.Proof.map lemma ~f:(fun p ->
       Util.pi1 @@ Proof.run_tactic env Proofview.(tclFOCUS 1 1 shelve) p)

--- a/plugins/derive/derive.mli
+++ b/plugins/derive/derive.mli
@@ -14,7 +14,7 @@
     and [lemma] as the proof. *)
 val start_deriving
   :  atts:Vernacentries.DefAttributes.t
-  -> Names.Id.t CAst.t
+  -> Constrexpr.local_binder_expr list
   -> Constrexpr.constr_expr
   -> Names.Id.t
   -> Declare.Proof.t

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -24,12 +24,17 @@ let () =
    Mltop.add_init_function "coq-core.plugins.derive" (fun () ->
      Pcoq.(set_keyword_state (CLexer.add_keyword_tok (get_keyword_state ()) (Tok.PKEYWORD "SuchThat"))))
 
+let warn_deprecated_derive_suchthat =
+   CWarnings.create ~name:"deprecated-derive-suchthat" ~category:Deprecation.Version.v8_21
+  (fun () -> Pp.strbrk "Use of \"SuchThat\" and \"As\" in \"Derive\" is deprecated; replace them respectively by \"in\" and \"as\".")
+
 }
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command } STATE open_proof
 | #[ atts = Vernacentries.DefAttributes.def_attributes; ]
   [ "Derive" open_binders(bl) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
-  { Derive.start_deriving ~atts bl suchthat lemma.CAst.v }
+  { warn_deprecated_derive_suchthat ();
+    Derive.start_deriving ~atts bl suchthat lemma.CAst.v }
 | #[ atts = Vernacentries.DefAttributes.def_attributes; ]
   [ "Derive" open_binders(bl) "in" constr(suchthat) "as" identref(lemma) ] ->
   { Derive.start_deriving ~atts bl suchthat lemma.CAst.v }

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -20,10 +20,17 @@ DECLARE PLUGIN "coq-core.plugins.derive"
 
 let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpacity,[]))
 
+let () =
+   Mltop.add_init_function "coq-core.plugins.derive" (fun () ->
+     Pcoq.(set_keyword_state (CLexer.add_keyword_tok (get_keyword_state ()) (Tok.PKEYWORD "SuchThat"))))
+
 }
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command } STATE open_proof
 | #[ atts = Vernacentries.DefAttributes.def_attributes; ]
-  [ "Derive" identref(f) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
-  { Derive.start_deriving ~atts f suchthat lemma.CAst.v }
+  [ "Derive" open_binders(bl) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
+  { Derive.start_deriving ~atts bl suchthat lemma.CAst.v }
+| #[ atts = Vernacentries.DefAttributes.def_attributes; ]
+  [ "Derive" open_binders(bl) "in" constr(suchthat) "as" identref(lemma) ] ->
+  { Derive.start_deriving ~atts bl suchthat lemma.CAst.v }
 END

--- a/test-suite/bugs/bug_18951.v
+++ b/test-suite/bugs/bug_18951.v
@@ -1,0 +1,13 @@
+Require Import Derive.
+
+Derive foo : nat in True as bar.
+Proof. Admitted. (* Was an anomaly *)
+Check foo.
+Check bar.
+
+Derive foo' in True as bar'.
+Proof.
+Fail Admitted. (* Has still evars *)
+Unshelve.
+3:exact nat.
+Admitted.

--- a/test-suite/bugs/bug_19234.v
+++ b/test-suite/bugs/bug_19234.v
@@ -1,5 +1,5 @@
 Require Import Derive.
-Derive b SuchThat b As spec.
+Derive b in b as spec.
 Unshelve.
 2:exact Type.
 unfold b.

--- a/test-suite/bugs/bug_6631.v
+++ b/test-suite/bugs/bug_6631.v
@@ -1,6 +1,6 @@
 Require Import Stdlib.derive.Derive.
 
-Derive f SuchThat (f = 1 + 1) As feq.
+Derive f in (f = 1 + 1) as feq.
 Proof.
   transitivity 2; [refine (eq_refl 2)|].
   transitivity 2.

--- a/test-suite/success/Derive.v
+++ b/test-suite/success/Derive.v
@@ -30,12 +30,19 @@ Check id 0.
 
 Set Universe Polymorphism.
 
+(* An example with no polymorphic universe constraints in the witness *)
 Derive id' : (forall {A}, A -> A) in (forall {A} (a:A), id' a = a) as spec'.
 Proof.
-unfold id.
 Unshelve.
 2: exact (fun A a => a).
-reflexivity. (* Polymorphism breaks unification? *)
+reflexivity.
+Qed.
+
+(* An example with polymorphic universe constraints in the witness *)
+Derive id'' : (forall {A}, A -> A) in (forall {A} (a:A), id'' a = a) as spec''.
+Proof.
+unfold id''.
+reflexivity.
 Qed.
 
 Check id'@{Set} 0.

--- a/test-suite/success/Derive.v
+++ b/test-suite/success/Derive.v
@@ -5,10 +5,37 @@ Require Derive.
 End M.
 
 (* Tests when x is refined by typechecking *)
-Derive x SuchThat (eq_refl x = eq_refl 0) As x_ok.
+Derive x in (eq_refl x = eq_refl 0) as x_ok.
 reflexivity.
 Qed.
 
-Derive s SuchThat (forall z, eq_refl (s z) = eq_refl (S z)) As s_ok.
+Derive s in (forall z, eq_refl (s z) = eq_refl (S z)) as s_ok.
 reflexivity.
 Qed.
+
+Derive foo : nat in (foo = foo) as bar.
+Proof.
+reflexivity.
+Unshelve.
+exact 0.
+Qed.
+
+Derive id : (forall {A}, A -> A) in (forall {A} (a:A), id a = a) as spec.
+Proof.
+unfold id.
+reflexivity.
+Qed.
+About id.
+Check id 0.
+
+Set Universe Polymorphism.
+
+Derive id' : (forall {A}, A -> A) in (forall {A} (a:A), id' a = a) as spec'.
+Proof.
+unfold id.
+Unshelve.
+2: exact (fun A a => a).
+reflexivity. (* Polymorphism breaks unification? *)
+Qed.
+
+Check id'@{Set} 0.

--- a/test-suite/success/Derive.v
+++ b/test-suite/success/Derive.v
@@ -1,4 +1,8 @@
-Require Import Derive.
+Module M.
+(* The encapsulation in a module tests that the grammar rules
+   and keywords are correctly registered *)
+Require Derive.
+End M.
 
 (* Tests when x is refined by typechecking *)
 Derive x SuchThat (eq_refl x = eq_refl 0) As x_ok.

--- a/test-suite/success/bug_10890.v
+++ b/test-suite/success/bug_10890.v
@@ -1,6 +1,6 @@
 Require Import Derive.
 
-Derive foo SuchThat (foo = foo :> nat) As bar.
+Derive foo in (foo = foo :> nat) as bar.
 Proof.
   Unshelve.
   2:abstract exact 0.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -173,7 +173,10 @@ let instance_of_univs = function
 
 let add_mono_univ_uctx_for_derived ctx' = function
   | UState.Monomorphic_entry ctx, ubinders -> UState.Monomorphic_entry (Univ.ContextSet.union ctx ctx'), ubinders
-  | UState.Polymorphic_entry ctx, ubinders -> CErrors.anomaly (Pp.str "Derive does not support polymorphism yet.")
+  | UState.Polymorphic_entry ctx, ubinders as x ->
+    if not (Univ.ContextSet.is_empty ctx') then
+      CErrors.anomaly (Pp.str "Transparent component with private polymorphism in Derive.");
+    x
 
 let add_mono_uctx uctx = function
   | UState.Monomorphic_entry ctx, ubinders -> UState.Monomorphic_entry (Univ.ContextSet.union (UState.context_set uctx) ctx), ubinders
@@ -1602,7 +1605,7 @@ module Proof_ending = struct
   type t =
     | Regular
     | End_obligation of Obls_.obligation_qed_info
-    | End_derive of { f : Id.t; name : Id.t }
+    | End_derive
     | End_equations of
         { hook : pm:Obls_.State.t -> Constant.t list -> Evd.evar_map -> Obls_.State.t
         ; i : Id.t
@@ -1729,8 +1732,8 @@ let start_dependent ~info ~cinfo ~name ~proof_ending goals =
   ; pinfo
   }
 
-let start_derive ~f ~name ~info ~cinfo goals =
-  let proof_ending = Proof_ending.End_derive {f; name} in
+let start_derive ~name ~info ~cinfo goals =
+  let proof_ending = Proof_ending.End_derive in
   start_dependent ~info ~cinfo ~name ~proof_ending goals
 
 let start_equations ~name ~info ~hook ~types sigma goals =
@@ -1998,7 +2001,7 @@ let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate ps =
   let elist, uctx = prepare_proof ?warn_incomplete ps in
   let opaques =
     let n = List.length elist in
-    let is_derived = match CEphemeron.default pinfo.Proof_info.proof_ending Regular with End_derive _ -> true | _ -> false in
+    let is_derived = match CEphemeron.default pinfo.Proof_info.proof_ending Regular with End_derive -> true | _ -> false in
     List.init n (fun i ->
         if i < n-1 && is_derived then
           (* Temporary code for setting opacity in Derive, waiting for addition of cinfo-based opacity in #19029 *)
@@ -2278,14 +2281,13 @@ let save_admitted ~pm ~proof =
 (* Saving a lemma-like constant                                         *)
 (************************************************************************)
 
-let finish_derived ~f ~name {entries; pinfo; uctx} =
-  (* [f] and [name] correspond to the proof of [f] and of [suchthat], respectively. *)
-
+let finish_derived {entries; pinfo; uctx} =
+  let n = List.length entries in
   let { Proof_info.info = { Info.hook; scope; clearbody; kind; typing_flags; user_warns; poly; udecl; _ } } = pinfo in
   let _, _, refs, _ =
     List.fold_left2 (fun (i, subst, refs, used_univs) CInfo.{name; impargs} entry ->
       (* The opacity of the specification is adjusted to be [false], as it must.*)
-      let entry = if i = 0 then ProofEntry.set_transparent_for_derived entry else entry in
+      let entry = if i < n-1 then ProofEntry.set_transparent_for_derived entry else entry in
       let f c = UState.nf_universes uctx (Vars.replace_vars subst c) in
       let entry = ProofEntry.map_entry_type entry ~f:(Option.map f) in
       let entry = ProofEntry.map_proof_entry entry ~f:(fun (b,fx) -> (f b, fx)) in
@@ -2338,8 +2340,8 @@ let finish_proof ~pm proof_obj proof_info =
   | End_obligation oinfo ->
     let entry, uctx = check_single_entry proof_obj "Obligation.save" in
     Obls_.obligation_terminator ~pm ~entry ~uctx ~oinfo
-  | End_derive { f ; name } ->
-    pm, finish_derived ~f ~name proof_obj
+  | End_derive ->
+    pm, finish_derived proof_obj
   | End_equations { hook; i; types; sigma } ->
     let kind = proof_info.Proof_info.info.Info.kind in
     finish_proved_equations ~pm ~kind ~hook i proof_obj types sigma

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -193,7 +193,7 @@ module Proof : sig
      both of them. Please, get in touch with the developers if you
      would like to experiment with multi-goal dependent proofs so we
      can use your input on the design of the new API. *)
-  val start_derive : f:Id.t -> name:Id.t -> info:Info.t -> cinfo:unit CInfo.t list -> Proofview.telescope -> t
+  val start_derive : name:Id.t -> info:Info.t -> cinfo:unit CInfo.t list -> Proofview.telescope -> t
 
   val start_equations :
        name:Id.t


### PR DESCRIPTION
This PR replaces coq/coq#19087 and implements the proposition [there](https://github.com/coq/coq/pull/19087#issuecomment-2141333758) of generalizing the syntax of `Derive` into:
```coq
Derive binders in typ as name.
```

The syntax `Derive binders SuchThat typ As name` is also kept for compatibility.

In practice ``Derive `(nat) in t as y`` or `Derive {x} in t as y` or `Derive [x] in t as y` do not really make sense, so we mostly accept  either `ident_list : constr` or a list of `ident | (ident_list : constr)`. On the other side, `Derive '((x,y) as z) in x+y=0 as name` could make sense but `Constrintern.interp_named_context_evars` is too weak to support it.

Regarding the documentation, I kept the generality of `open_binders` even if not all kinds of binders are really meaningful. I hope it is ok.

- [x] Added / updated **test-suite** (the new syntax allows more test of the changes made in #19092)
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

PS: What about moving `Derive` to a proper Gallina command?

Depends on:
- coq/coq#19092