### PR TITLE
Fixes #7913: fixpoint with decreasing argument hidden behind a definition

### DIFF
--- a/doc/changelog/02-specification-language/19296-master+fixes7913-fixpoint-with-hidden-decreasing-arg.rst
+++ b/doc/changelog/02-specification-language/19296-master+fixes7913-fixpoint-with-hidden-decreasing-arg.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Ability to hide the quantification over the decreasing argument of a
+  fixpoint under a definition, with application to declaring fixpoints
+  as instance of a class
+  (`#19296 <https://github.com/coq/coq/pull/19296>`_,
+  fixes `#7913 <https://github.com/coq/coq/issues/7913>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_7913.v
+++ b/test-suite/bugs/bug_7913.v
@@ -1,0 +1,47 @@
+Module Single.
+
+Inductive bexp : Set :=
+  | b_true : bexp
+  | b_false : bexp
+  | b_eq : bexp -> bexp -> bexp.
+
+Class ContainsFalse (A : Set) :=
+  contains_false : A -> bool.
+
+Fixpoint bexp_CF : ContainsFalse bexp := fun b =>
+  match b with
+  | b_true => false
+  | b_false => true
+  | b_eq a1 a2 => orb (contains_false a1) (contains_false a2)
+  end.
+Existing Instance bexp_CF.
+
+End Single.
+
+Module Mutual.
+
+Inductive bexp : Set :=
+  | b_true : bexp
+  | b_false : bexp
+  | b_eq : aexp -> aexp -> bexp
+with aexp : Set :=
+     | a_of_bool : bexp -> aexp.
+
+Class ContainsFalse (A : Set) :=
+  contains_false : A -> bool.
+
+Fixpoint bexp_ContainsFalse : ContainsFalse bexp := fun b =>
+  match b with
+  | b_true => false
+  | b_false => true
+  | b_eq a1 a2 => orb (contains_false a1) (contains_false a2)
+  end with
+aexp_ContainsFalse : ContainsFalse aexp := fun a =>
+  match a with
+  | a_of_bool b => contains_false b
+  end.
+
+Existing Instance bexp_ContainsFalse.
+Existing Instance aexp_ContainsFalse.
+
+End Mutual.


### PR DESCRIPTION
Fixes / closes #7913 (made possible by #19091 and #19259).


- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
