### PR TITLE
Quickfix for deprecated

### DIFF
--- a/dev/ci/user-overlays/19300-gares-quickfix-deprecated.sh
+++ b/dev/ci/user-overlays/19300-gares-quickfix-deprecated.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/gares/coq-elpi quickfix-deprecated 19300
+
+overlay coq_lsp https://github.com/gares/coq-lsp quickfix-deprecated 19300
+
+overlay equations https://github.com/gares/Coq-Equations quickfix-deprecated 19300

--- a/doc/changelog/08-vernac-commands-and-options/19300-quickfix-deprecated.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19300-quickfix-deprecated.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  The ``use`` field of the :attr:`deprecated` attribute lets one specify
+  a replacement for a ``Theorem``, ``Definition`` or ``Notation`` that is
+  printed as part of the deprecation warning message and also used to suggest
+  a quick fix in LSP based user interfaces
+  (`#19300 <https://github.com/coq/coq/pull/19300>`_,
+  by Enrico Tassi).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -416,7 +416,7 @@ assign attributes to a whole document.
    attributes ::= {* #[ {*, @attribute } ] } {* @legacy_attr }
    attribute ::= @ident {? @attr_value }
    attr_value ::= = @string
-   | = @ident
+   | = @qualid
    | ( {+, @attribute } )
    legacy_attr ::= {| Local | Global }
    | {| Polymorphic | Monomorphic }

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -14,7 +14,7 @@ tactic, definition, axiom, theorem or file.  When renaming a definition or theor
 deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 (see :ref:`the example below <compatibility-alias>`).
 
-.. attr:: deprecated ( {? since = @string , } {? note = @string } )
+.. attr:: deprecated ( {? since = @string , } {? note = @string , } {? use = @qualid } )
    :name: deprecated
 
    At least one of :n:`since` or :n:`note` must be present.  If both
@@ -29,16 +29,21 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
    :cmd:`Theorem`, and similar commands. To attach it to a
    compiled library file, use :cmd:`Attributes`.
 
+   The :n:`use` attribute can be used for commands such as :cmd:`Definition`,
+   :cmd:`Theorem`, and ``Notation @ident``. Its value must refer to an
+   existing constant of abbreviation and is printed as part of the warning
+   message as well as used by LSP based user interfaces as a quick fix.
+
    It can trigger the following warnings:
 
-   .. warn:: Library File @qualid is deprecated since @string__since. @string__note
-             Library File (transitively required) @qualid is deprecated since @string__since. @string__note
-             Ltac2 alias @qualid is deprecated since @string__since. @string__note
-             Ltac2 definition @qualid is deprecated since @string__since. @string__note
-             Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note
-             Notation @string is deprecated since @string__since. @string__note
-             Tactic @qualid is deprecated since @string__since. @string__note
-             Tactic Notation @qualid is deprecated since @string__since. @string__note
+   .. warn:: Library File @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Library File (transitively required) @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Ltac2 alias @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Ltac2 definition @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Notation @string is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Tactic @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
+             Tactic Notation @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
 
       :n:`@qualid` or :n:`@string` is the notation,
       :n:`@string__since` is the version number, :n:`@string__note` is

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -841,7 +841,7 @@ attribute: [
 
 attr_value: [
 | "=" string
-| "=" IDENT
+| "=" qualid
 | "(" attribute_list ")"
 |
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -262,7 +262,7 @@ attribute: [
 
 attr_value: [
 | "=" string
-| "=" ident
+| "=" qualid
 | "(" LIST1 attribute SEP "," ")"
 ]
 

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -22,7 +22,7 @@ open Notationextern
 type abbreviation =
   { abbrev_pattern : interpretation;
     abbrev_onlyparsing : bool;
-    abbrev_user_warns : UserWarn.t option;
+    abbrev_user_warns : Globnames.extended_global_reference UserWarn.with_qf option;
     abbrev_activated : bool; (* Not really necessary in practice *)
   }
 

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -15,7 +15,7 @@ open Globnames
 
 (** Abbreviations. *)
 
-val declare_abbreviation : local:bool -> UserWarn.t option -> Id.t ->
+val declare_abbreviation : local:bool -> Globnames.extended_global_reference UserWarn.with_qf option -> Id.t ->
   onlyparsing:bool -> interpretation -> unit
 
 val search_abbreviation : abbreviation -> interpretation

--- a/lib/deprecation.mli
+++ b/lib/deprecation.mli
@@ -9,11 +9,18 @@
 (************************************************************************)
 
 type t = { since : string option ; note : string option }
+type 'a with_qf = { depr : t; use_instead : 'a option }
+
+val drop_qf : 'a with_qf -> t
+val with_empty_qf : t -> 'a with_qf
 
 val make : ?since:string -> ?note:string -> unit -> t
+val make_with_qf : ?since:string -> ?note:string -> ?use_instead:'qf -> unit -> 'qf with_qf
 
 val create_warning : ?default:CWarnings.status -> object_name:string -> warning_name_if_no_since:string ->
   ('b -> Pp.t) -> ?loc:Loc.t -> 'b * t -> unit
+val create_warning_with_qf : ?default:CWarnings.status -> object_name:string -> warning_name_if_no_since:string ->
+  pp_qf:('qf -> Pp.t) -> ('b -> Pp.t) -> ?loc:Loc.t -> 'b * 'qf with_qf -> unit
 
 module Version : sig
   val v8_3 : CWarnings.category

--- a/lib/quickfix.ml
+++ b/lib/quickfix.ml
@@ -13,6 +13,9 @@
 type t = Loc.t * Pp.t
 let make ~loc txt = loc, txt
 let pp (_,x) = x
+let pp_wloc (loc,x) =
+  let open Pp in
+  h (str "Replace " ++ Loc.pr loc ++ str " with " ++ x)
 let loc (l,_) = l
 
 let handle_stack = ref []
@@ -37,5 +40,5 @@ let print e =
   | [] -> mt ()
   | qf ->
     let open Pp in
-    let qf = prlist_with_sep cut pp qf in
+    let qf = prlist_with_sep cut pp_wloc qf in
     v 0 (prlist_with_sep cut (fun x -> x) [str "Quickfix:"; qf])

--- a/lib/userWarn.ml
+++ b/lib/userWarn.ml
@@ -15,7 +15,10 @@ type warn = { note : string; cats : string }
 (** note and comma separated list of categories *)
 
 type t = { depr : Deprecation.t option; warn : warn list }
+type 'a with_qf = { depr_qf : 'a Deprecation.with_qf option; warn_qf : warn list }
 
+let drop_qf { depr_qf; warn_qf } = { depr = Option.map Deprecation.drop_qf depr_qf; warn = warn_qf }
+let with_empty_qf { depr; warn } = { depr_qf = Option.map Deprecation.with_empty_qf depr; warn_qf = warn}
 let empty = { depr = None; warn = [] }
 
 let make_warn ~note ?cats () =

--- a/lib/userWarn.mli
+++ b/lib/userWarn.mli
@@ -15,6 +15,10 @@ type warn = private { note : string; cats : string }
 (** note and comma separated list of categories *)
 
 type t = { depr : Deprecation.t option; warn : warn list }
+type 'a with_qf = { depr_qf : 'a Deprecation.with_qf option; warn_qf : warn list }
+
+val drop_qf : 'a with_qf -> t
+val with_empty_qf : t -> 'a with_qf
 
 val empty : t
 

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -87,6 +87,8 @@ type full_path = {
 let dirpath sp = sp.dirpath
 let basename sp = sp.basename
 
+let full_path_is_ident sp = DirPath.is_empty (dirpath sp)
+
 let make_path pa id = { dirpath = pa; basename = id }
 
 let repr_path { dirpath = pa; basename = id } = (pa,id)
@@ -154,7 +156,7 @@ let qualid_of_dirpath ?loc dir =
 let qualid_of_lident lid = qualid_of_ident ?loc:lid.CAst.loc lid.CAst.v
 
 let qualid_is_ident qid =
-  DirPath.is_empty qid.CAst.v.dirpath
+  full_path_is_ident qid.CAst.v
 
 let qualid_basename qid =
   qid.CAst.v.basename

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -45,6 +45,7 @@ val make_path : DirPath.t -> Id.t -> full_path
 val repr_path : full_path -> DirPath.t * Id.t
 val dirpath : full_path -> DirPath.t
 val basename : full_path -> Id.t
+val full_path_is_ident : full_path -> bool
 
 (** Parsing and printing of section path as ["coq_root.module.id"] *)
 val path_of_string : string -> full_path

--- a/library/library_info.ml
+++ b/library/library_info.ml
@@ -28,7 +28,7 @@ let warn_library_deprecated_transitive =
   Deprecation.create_warning ~object_name:"Library File (transitively required)"
     ~warning_name_if_no_since:"deprecated-transitive-library-file"
     ~default:CWarnings.Disabled
-    (fun dp -> DirPath.print dp)
+   (fun dp -> DirPath.print dp)
 
 let warn_library_warn_transitive =
   UserWarn.create_warning

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -567,14 +567,14 @@ let pr_depr_xref xref =
 let pr_depr_ref ref = pr_depr_xref (TrueGlobal ref)
 
 let warn_deprecated_ref =
-  Deprecation.create_warning ~object_name:"Reference" ~warning_name_if_no_since:"deprecated-reference"
-    pr_depr_ref
+  Deprecation.create_warning_with_qf ~object_name:"Reference" ~warning_name_if_no_since:"deprecated-reference"
+  ~pp_qf:pr_depr_xref pr_depr_ref
 
 let pr_depr_abbrev a = pr_depr_xref (Abbrev a)
 
 let warn_deprecated_abbreviation =
-  Deprecation.create_warning ~object_name:"Notation" ~warning_name_if_no_since:"deprecated-syntactic-definition"
-    pr_depr_abbrev
+  Deprecation.create_warning_with_qf ~object_name:"Notation" ~warning_name_if_no_since:"deprecated-syntactic-definition"
+  ~pp_qf:pr_depr_xref pr_depr_abbrev
 
 let warn_deprecated_xref ?loc depr = function
   | Globnames.TrueGlobal ref -> warn_deprecated_ref ?loc (ref, depr)
@@ -583,12 +583,12 @@ let warn_deprecated_xref ?loc depr = function
 let warn_user_warn =
   UserWarn.create_warning ~warning_name_if_no_cats:"warn-reference" ()
 
-let is_warned_xref xref : UserWarn.t option = Globnames.ExtRefMap.find_opt xref !the_globwarntab
+let is_warned_xref xref : Globnames.extended_global_reference UserWarn.with_qf option = Globnames.ExtRefMap.find_opt xref !the_globwarntab
 
 let warn_user_warn_xref ?loc user_warns xref =
-  user_warns.UserWarn.depr
+  user_warns.UserWarn.depr_qf
     |> Option.iter (fun depr -> warn_deprecated_xref ?loc depr xref);
-  user_warns.UserWarn.warn |> List.iter (warn_user_warn ?loc)
+  user_warns.UserWarn.warn_qf |> List.iter (warn_user_warn ?loc)
 
 let locate_extended_nowarn qid =
   let xref = ExtRefTab.locate qid !the_ccitab in

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -104,19 +104,19 @@ type visibility = Until of int | Exactly of int
 
 val map_visibility : (int -> int) -> visibility -> visibility
 
-val push : ?user_warns:UserWarn.t -> visibility -> full_path -> GlobRef.t -> unit
+val push : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_module : visibility -> DirPath.t -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
-val push_abbreviation : ?user_warns:UserWarn.t -> visibility -> full_path -> Globnames.abbreviation -> unit
+val push_abbreviation : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> Globnames.abbreviation -> unit
 
 val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
 
 (** Deprecation and user warn info *)
 
-val is_warned_xref : Globnames.extended_global_reference -> UserWarn.t option
+val is_warned_xref : Globnames.extended_global_reference -> Globnames.extended_global_reference UserWarn.with_qf option
 
-val warn_user_warn_xref : ?loc:Loc.t -> UserWarn.t -> Globnames.extended_global_reference -> unit
+val warn_user_warn_xref : ?loc:Loc.t -> Globnames.extended_global_reference UserWarn.with_qf -> Globnames.extended_global_reference -> unit
 
 (** {6 The following functions perform globalization of qualified names } *)
 
@@ -218,6 +218,8 @@ val shortest_qualid_of_module : ?loc:Loc.t -> ModPath.t -> qualid
 
 (** In general we have a [UnivNames.universe_binders] around rather than a [Id.Set.t] *)
 val shortest_qualid_of_universe : ?loc:Loc.t -> 'u Id.Map.t -> Univ.UGlobal.t -> qualid
+
+val pr_depr_xref : Globnames.extended_global_reference -> Pp.t
 
 (** {5 Generic name handling} *)
 

--- a/test-suite/output/Qf_deprecated.out
+++ b/test-suite/output/Qf_deprecated.out
@@ -1,13 +1,15 @@
 File "./output/Qf_deprecated.v", line 10, characters 17-18:
-Warning: Reference x is deprecated. [deprecated-reference,deprecated,default]
+Warning: Reference x is deprecated. Use M.y instead.
+[deprecated-reference,deprecated,default]
 Quickfix:
 Replace File "./output/Qf_deprecated.v", line 10, characters 17-18 with M.y
 File "./output/Qf_deprecated.v", line 13, characters 14-15:
-Warning: Reference x is deprecated. [deprecated-reference,deprecated,default]
+Warning: Reference x is deprecated. Use M.y instead.
+[deprecated-reference,deprecated,default]
 Quickfix:
 Replace File "./output/Qf_deprecated.v", line 13, characters 14-15 with M.y
 File "./output/Qf_deprecated.v", line 25, characters 17-18:
-Warning: Notation v is deprecated.
+Warning: Notation v is deprecated. Use M1.w instead.
 [deprecated-syntactic-definition,deprecated,default]
 Quickfix:
 Replace File "./output/Qf_deprecated.v", line 25, characters 17-18 with M1.w

--- a/test-suite/output/Qf_deprecated.out
+++ b/test-suite/output/Qf_deprecated.out
@@ -1,0 +1,16 @@
+File "./output/Qf_deprecated.v", line 10, characters 17-18:
+Warning: Reference x is deprecated. [deprecated-reference,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_deprecated.v", line 10, characters 17-18 with M.y
+File "./output/Qf_deprecated.v", line 13, characters 14-15:
+Warning: Reference x is deprecated. [deprecated-reference,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_deprecated.v", line 13, characters 14-15 with M.y
+File "./output/Qf_deprecated.v", line 25, characters 17-18:
+Warning: Notation v is deprecated.
+[deprecated-syntactic-definition,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_deprecated.v", line 25, characters 17-18 with M1.w
+File "./output/Qf_deprecated.v", line 27, characters 0-69:
+The command has indeed failed with message:
+Attribute use not allowed

--- a/test-suite/output/Qf_deprecated.v
+++ b/test-suite/output/Qf_deprecated.v
@@ -1,0 +1,28 @@
+Module M. Definition y := 4. End M.
+Import M.
+
+#[deprecated(use=y)]
+Definition x := 3.
+
+Module N. Definition y := 5. End N.
+Import N.
+
+Definition d1 := x = 3.
+
+Module M1.
+Notation w := x.
+End M1.
+Import M1.
+
+#[deprecated(use=w)]
+Notation v := 3.
+
+Module M2.
+Notation w := 5.
+End M2.
+Import M2.
+
+Definition d2 := v = 3.
+
+Fail #[deprecated(use=w)]
+Notation "a +++ b" := (a + b) (at level 2).

--- a/test-suite/output/Qf_end.out
+++ b/test-suite/output/Qf_end.out
@@ -1,7 +1,8 @@
 File "./output/Qf_end.v", line 2, characters 4-5:
-Error: Last block to end has name A.
+Error:
+Last block to end has name A.
 Quickfix:
-A
+Replace File "./output/Qf_end.v", line 2, characters 4-5 with A
 
 
 coqc exited with code 1

--- a/test-suite/output/Qf_extraction.out
+++ b/test-suite/output/Qf_extraction.out
@@ -4,8 +4,8 @@ object Coq.Init.Datatypes.nat ?
 First choice is assumed, for the second one please use fully qualified name.
  [extraction-ambiguous-name,extraction,default]
 Quickfix:
-Qf_extraction.nat
-Coq.Init.Datatypes.nat
+Replace File "./output/Qf_extraction.v", line 5, characters 11-14 with Qf_extraction.nat
+Replace File "./output/Qf_extraction.v", line 5, characters 11-14 with Coq.Init.Datatypes.nat
 
 module Coq_nat =
  struct

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -10,7 +10,7 @@
 
 (** The type of parsing attribute data *)
 type vernac_flag_type =
-  | FlagIdent of string
+  | FlagQualid of Libnames.qualid
   | FlagString of string
 
 type vernac_flags = vernac_flag list
@@ -21,8 +21,8 @@ and vernac_flag_value =
   | VernacFlagList of vernac_flags
 
 let pr_vernac_flag_leaf = function
-  | FlagIdent b -> Pp.str b
   | FlagString s -> Pp.(quote (str s))
+  | FlagQualid p -> Libnames.pr_qualid p
 
 let rec pr_vernac_flag_value = let open Pp in function
   | VernacFlagEmpty -> mt ()
@@ -136,7 +136,8 @@ let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option
       CErrors.user_err ?loc Pp.(str "key '" ++ str key ++ str "' has been already set.")
     | None ->
       begin function
-        | VernacFlagLeaf (FlagIdent b) ->
+        | VernacFlagLeaf (FlagQualid q) when Libnames.qualid_is_ident q ->
+          let b = Names.Id.to_string @@ Libnames.qualid_basename q in
           begin match CList.assoc_f String.equal b values with
             | exception Not_found ->
               CErrors.user_err ?loc
@@ -159,12 +160,16 @@ let bool_attribute ~name : bool option attribute =
   key_value_attribute ~key:name ~default:true ~values
 
 (* Variant of the [bool] attribute with only two values (bool has three). *)
+let qualid_is_this_ident fp id =
+  Libnames.qualid_is_ident fp &&
+  Names.Id.to_string @@ Libnames.qualid_basename fp = id
+
 let get_bool_value ?loc ~key ~default =
   function
   | VernacFlagEmpty -> default
-  | VernacFlagLeaf (FlagIdent "yes") ->
+  | VernacFlagLeaf (FlagQualid q) when qualid_is_this_ident q "yes" ->
     true
-  | VernacFlagLeaf (FlagIdent "no") ->
+  | VernacFlagLeaf (FlagQualid q) when qualid_is_this_ident q "no" ->
     false
   | _ ->
     CErrors.user_err ?loc
@@ -283,21 +288,45 @@ let template =
 let unfold_fix =
   enable_attribute ~key:"unfold_fix" ~default:(fun () -> false)
 
-let deprecation_parser : Deprecation.t key_parser = fun ?loc orig args ->
+let rec flags2map m = function
+  | { CAst.v = (n,VernacFlagLeaf l); loc } :: xs ->
+      if CString.Map.mem n m then
+        CErrors.user_err ?loc Pp.(str "Duplicate attribute " ++ str n);
+      flags2map (CString.Map.add n l m) xs
+  | { CAst.v = n,_; loc } :: _ ->
+      CErrors.user_err ?loc Pp.(str "Attribute " ++ str n ++ str " must be a leaf.")
+  | [] -> m
+
+let find_string_opt m s =
+  match CString.Map.find s m with
+  | FlagString s -> Some s
+  | FlagQualid _ -> CErrors.user_err Pp.(str "Attribute " ++ str s ++ str " should be a string")
+  | exception Not_found -> None
+
+let deprecation_parser parse_use : _ key_parser = fun ?loc orig args ->
   assert_once ?loc ~name:"deprecation" orig;
   match args with
-  | VernacFlagList [ {CAst.v="since", VernacFlagLeaf (FlagString since)};
-                     {CAst.v="note", VernacFlagLeaf (FlagString note)} ]
-  | VernacFlagList [ {CAst.v="note", VernacFlagLeaf (FlagString note)};
-                     {CAst.v="since", VernacFlagLeaf (FlagString since)} ] ->
-    Deprecation.make ~since ~note ()
-  | VernacFlagList [ {CAst.v="since", VernacFlagLeaf (FlagString since)} ] ->
-    Deprecation.make ~since ()
-  | VernacFlagList [ {CAst.v="note", VernacFlagLeaf (FlagString note)} ] ->
-    Deprecation.make ~note ()
+  | VernacFlagList l ->
+      let m = flags2map CString.Map.empty l in
+      let note = find_string_opt m "note" in
+      let since = find_string_opt m "since" in
+      CString.Map.find_opt "use" m |> parse_use ?since ?note
   |  _ -> CErrors.user_err ?loc (Pp.str "Ill formed “deprecated” attribute.")
 
-let deprecation = attribute_of_list ["deprecated",deprecation_parser]
+let no_use_allowed ?since ?note = function
+  | None -> Deprecation.make ?since ?note ()
+  | Some _ -> CErrors.user_err Pp.(str "Attribute use not allowed")
+
+let extended_globref_allowed ?since ?note = function
+  | None -> Deprecation.make_with_qf ?since ?note ()
+  | Some (FlagQualid p) ->
+      let use_instead = Nametab.locate_extended p in
+      Deprecation.make_with_qf ?since ?note ~use_instead ()
+  | Some _ -> CErrors.user_err Pp.(str "Attribute \"use\" should be a (qualified) identifier")
+
+
+let deprecation = attribute_of_list ["deprecated",deprecation_parser no_use_allowed]
+let deprecation_with_use_globref_instead = attribute_of_list ["deprecated",deprecation_parser extended_globref_allowed]
 
 let user_warn_parser : UserWarn.warn list key_parser = fun ?loc orig args ->
   let orig = Option.default [] orig in
@@ -321,7 +350,12 @@ let user_warns =
   | None, [] -> return None
   | depr, warn -> return (Some UserWarn.{ depr; warn })
 
-let only_locality atts = parse locality atts
+  let user_warns_with_use_globref_instead =
+    (deprecation_with_use_globref_instead ++ user_warn_warn) >>= function
+    | None, [] -> return None
+    | depr_qf, warn_qf -> return (Some UserWarn.{ depr_qf; warn_qf })
+
+  let only_locality atts = parse locality atts
 
 let only_polymorphism atts = parse polymorphic atts
 
@@ -329,7 +363,7 @@ let only_polymorphism atts = parse polymorphic atts
 let vernac_polymorphic_flag loc =
   CAst.make ?loc (ukey, VernacFlagList [CAst.make ?loc ("polymorphic", VernacFlagEmpty)])
 let vernac_monomorphic_flag loc =
-  CAst.make ?loc (ukey, VernacFlagList [CAst.make ?loc ("polymorphic", VernacFlagLeaf (FlagIdent "no"))])
+  CAst.make ?loc (ukey, VernacFlagList [CAst.make ?loc ("polymorphic", VernacFlagLeaf (FlagQualid (Libnames.qualid_of_string "no")))])
 
 let reversible = bool_attribute ~name:"reversible"
 
@@ -370,9 +404,10 @@ let process_typing_att ?loc ~typing_flags att disable =
     CErrors.user_err ?loc Pp.(str "Unknown “typing” attribute: " ++ str att)
 
 let process_typing_disable ?loc ~key = function
-  | VernacFlagEmpty | VernacFlagLeaf (FlagIdent "yes") ->
+  | VernacFlagEmpty -> true
+  | VernacFlagLeaf (FlagQualid q) when qualid_is_this_ident q "yes" ->
     true
-  | VernacFlagLeaf (FlagIdent "no") ->
+  | VernacFlagLeaf (FlagQualid q) when qualid_is_this_ident q "no" ->
     false
   | _ ->
     CErrors.user_err ?loc Pp.(str "Ill-formed attribute value, must be " ++ str key ++ str "={yes, no}")

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -10,7 +10,7 @@
 
 (** The type of parsing attribute data *)
 type vernac_flag_type =
-  | FlagIdent of string
+  | FlagQualid of Libnames.qualid
   | FlagString of string
 
 type vernac_flags = vernac_flag list
@@ -58,8 +58,10 @@ val unfold_fix : bool attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
 val deprecation : Deprecation.t option attribute
+val deprecation_with_use_globref_instead : Globnames.extended_global_reference Deprecation.with_qf option attribute
 val user_warn_warn : UserWarn.warn list attribute
 val user_warns : UserWarn.t option attribute
+val user_warns_with_use_globref_instead : Globnames.extended_global_reference UserWarn.with_qf option attribute
 val reversible : bool option attribute
 val canonical_field : bool attribute
 val canonical_instance : bool attribute

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -43,7 +43,7 @@ val declare_axiom
   :  coe:coercion_flag
   -> local:Locality.import_status
   -> kind:Decls.assumption_object_kind
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> univs:UState.named_universes_entry
   -> impargs:Impargs.manual_implicits
   -> inline:Declaremods.inline
@@ -57,7 +57,7 @@ val declare_global
   -> try_assum_as_instance:bool (* true = declare a parameter of type a class as an instance *)
   -> local:Locality.import_status
   -> kind:Decls.logical_kind
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> univs:UState.named_universes_entry
   -> impargs:Impargs.manual_implicits
   -> inline:Declaremods.inline
@@ -72,7 +72,7 @@ val do_assumptions
   -> poly:bool
   -> scope:Locality.definition_scope
   -> kind:Decls.assumption_object_kind
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> inline:Declaremods.inline
   -> (ident_decl list * constr_expr) with_coercion list
   -> unit

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -34,7 +34,7 @@ val do_definition
   -> ?typing_flags:Declarations.typing_flags
   -> kind:Decls.definition_object_kind
   -> ?using:Vernacexpr.section_subset_expr
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> universe_decl_expr option
   -> local_binder_expr list
   -> red_expr option
@@ -52,7 +52,7 @@ val do_definition_program
   -> ?typing_flags:Declarations.typing_flags
   -> kind:Decls.logical_kind
   -> ?using:Vernacexpr.section_subset_expr
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> universe_decl_expr option
   -> local_binder_expr list
   -> red_expr option
@@ -70,7 +70,7 @@ val do_definition_interactive
   -> typing_flags:Declarations.typing_flags option
   -> kind:Decls.logical_kind
   -> ?using:Vernacexpr.section_subset_expr
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> universe_decl_expr option
   -> local_binder_expr list
   -> constr_expr

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -32,7 +32,7 @@ val do_mutually_recursive
   -> poly:bool
      (* Use universe polymorphism *)
   -> ?typing_flags:Declarations.typing_flags
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
      (* Warnings and deprecations *)
   -> ?using:Vernacexpr.section_subset_expr
      (* Tell which section variables to use *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -83,7 +83,7 @@ module Info = struct
     ; clearbody : bool (* always false for non Discharge scope *)
     ; hook : Hook.t option
     ; typing_flags : Declarations.typing_flags option
-    ; user_warns : UserWarn.t option
+    ; user_warns : Globnames.extended_global_reference UserWarn.with_qf option
     ; ntns : Metasyntax.notation_interpretation_decl list
     }
 
@@ -320,7 +320,7 @@ let is_local_constant c = Cset_env.mem c !local_csts
 type constant_obj = {
   cst_kind : Decls.logical_kind;
   cst_locl : Locality.import_status;
-  cst_warn : UserWarn.t option;
+  cst_warn : Globnames.extended_global_reference UserWarn.with_qf option;
 }
 
 let load_constant i ((sp,kn), obj) =

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -110,7 +110,7 @@ module Info : sig
     -> ?hook : Hook.t
     (** Callback to be executed after saving the constant *)
     -> ?typing_flags:Declarations.typing_flags
-    -> ?user_warns : UserWarn.t
+    -> ?user_warns : Globnames.extended_global_reference UserWarn.with_qf
     -> ?ntns : Metasyntax.notation_interpretation_decl list
     -> unit
     -> t
@@ -375,7 +375,7 @@ val declare_entry
   :  name:Id.t
   -> ?scope:Locality.definition_scope
   -> kind:Decls.logical_kind
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> ?hook:Hook.t
   -> impargs:Impargs.manual_implicits
   -> uctx:UState.t
@@ -433,7 +433,7 @@ val declare_constant
   -> name:Id.t
   -> kind:Decls.logical_kind
   -> ?typing_flags:Declarations.typing_flags
-  -> ?user_warns:UserWarn.t
+  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> constant_entry
   -> Constant.t
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -97,7 +97,7 @@ let warn_chdir_pwd = CWarnings.create ~name:"change-dir-pwd-deprecated" ~categor
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: vernac_control quoted_attributes attribute_list gallina_ext noedit_mode subprf subprf_with_selector;
+  GLOBAL: vernac_control quoted_attributes attribute_list gallina_ext noedit_mode subprf subprf_with_selector qualid;
   vernac_control: FIRST
     [ [ IDENT "Time"; c = vernac_control ->
         { add_control_flag ~loc ~flag:ControlTime c }
@@ -135,7 +135,7 @@ GRAMMAR EXTEND Gram
   ;
   attr_value:
     [ [ "=" ; v = string -> { VernacFlagLeaf (FlagString v) }
-      | "=" ; v = IDENT -> { VernacFlagLeaf (FlagIdent v) }
+      | "=" ; v = qualid -> { VernacFlagLeaf (FlagQualid v) }
       | "(" ; a = attribute_list ; ")" -> { VernacFlagList a }
       | -> { VernacFlagEmpty } ]
     ]
@@ -152,7 +152,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Cumulative" ->
         { CAst.make ~loc ("universes", VernacFlagList [CAst.make ~loc ("cumulative", VernacFlagEmpty)]) }
       | IDENT "NonCumulative" ->
-        { CAst.make ~loc ("universes", VernacFlagList [CAst.make ~loc ("cumulative", VernacFlagLeaf (FlagIdent "no"))]) }
+        { CAst.make ~loc ("universes", VernacFlagList [CAst.make ~loc ("cumulative", VernacFlagLeaf (FlagQualid (Libnames.qualid_of_string "no")))]) }
       | IDENT "Private" ->
         { CAst.make ~loc ("private", VernacFlagList [CAst.make ~loc ("matching", VernacFlagEmpty)]) }
       | IDENT "Program" ->

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1076,7 +1076,7 @@ let check_useless_entry_types recvars mainvars etyps =
 type notation_main_data = {
   onlyparsing  : bool;
   onlyprinting : bool;
-  user_warns   : UserWarn.t option;
+  user_warns   : Globnames.extended_global_reference UserWarn.with_qf option;
   entry        : notation_entry;
   format       : unparsing Loc.located list option;
   itemscopes  : (Id.t * scope_name) list;
@@ -1855,7 +1855,7 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
     notobj_use = use;
     notobj_interp = (vars, ac);
     notobj_coercion = coe;
-    notobj_user_warns = main_data.user_warns;
+    notobj_user_warns = main_data.user_warns |> Option.map UserWarn.drop_qf;
     notobj_notation = df';
     notobj_specific_pp_rules = sy_pp_rules;
   }
@@ -1916,6 +1916,7 @@ let set_notation_for_interpretation env impls (ntn_decl, main_data, notation_sym
 let build_notation_syntax ~local ~infix user_warns ntn_decl =
   let { ntn_decl_string = {CAst.loc;v=df}; ntn_decl_modifiers = modifiers; ntn_decl_interp = c } = ntn_decl in
   (* Extract the modifiers not affecting the parsing rule *)
+  let user_warns = Option.map UserWarn.with_empty_qf user_warns in
   let (main_data,syntax_modifiers) = interp_non_syntax_modifiers ~reserved:false ~infix ~abbrev:false user_warns modifiers in
   (* Extract the modifiers not affecting the parsing rule *)
   let notation_symbols, is_prim_token = analyze_notation_tokens ~onlyprinting:main_data.onlyprinting ~infix main_data.entry df in

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -63,7 +63,7 @@ val add_reserved_notation :
 
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
-val add_abbreviation : local:bool -> UserWarn.t option -> env ->
+val add_abbreviation : local:bool -> Globnames.extended_global_reference UserWarn.with_qf option -> env ->
   Id.t -> Id.t list * constr_expr -> syntax_modifier CAst.t list -> unit
 
 (** Print the Camlp5 state of a grammar *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -54,7 +54,7 @@ module DefAttributes = struct
     locality : bool option;
     polymorphic : bool;
     program : bool;
-    user_warns : UserWarn.t option;
+    user_warns : Globnames.extended_global_reference UserWarn.with_qf option;
     canonical_instance : bool;
     typing_flags : Declarations.typing_flags option;
     using : Vernacexpr.section_subset_expr option;
@@ -110,7 +110,7 @@ module DefAttributes = struct
     let (((((((locality, user_warns), polymorphic), program),
          canonical_instance), typing_flags), using),
          reversible), clearbody =
-      parse (locality ++ user_warns ++ polymorphic ++ program ++
+      parse (locality ++ user_warns_with_use_globref_instead ++ polymorphic ++ program ++
              canonical_instance ++ typing_flags ++ using ++
              reversible ++ clearbody)
         f
@@ -1511,7 +1511,7 @@ let vernac_hints ~atts dbnames h =
   Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
 
 let vernac_abbreviation ~atts lid x only_parsing =
-  let module_local, user_warns = Attributes.(parse Notations.(module_locality ++ user_warns) atts) in
+  let module_local, user_warns = Attributes.(parse Notations.(module_locality ++ user_warns_with_use_globref_instead) atts) in
   Dumpglob.dump_definition lid false "abbrev";
   Metasyntax.add_abbreviation ~local:module_local user_warns (Global.env()) lid.v x only_parsing
 


### PR DESCRIPTION
`Deprecation` and `UserWarn` declare type `t` and  `'a with_qf` the latter being  like `t` but enriched with a quick fix generated by the datum of type `'a`.
`Attributes` provides the parser for simple case and for the `with_qf` variant when `'a` is `Libnames.extended_global_reference` (a syndef of a globref).

Now stuff like `Definition x := t` of `Notation x := t` can carry `#[deprecated(use=this.qualified.name)]` and that qualid is resolved in the context of the declaration and used to print a quickfix using the Nametab, so that the proposed replacement does not incur in a capture.

Overlay:
- https://github.com/mattam82/Coq-Equations/pull/610
- https://github.com/ejgallego/coq-lsp/pull/801
- https://github.com/LPCIC/coq-elpi/pull/649 (depends on https://github.com/coq/coq/pull/19268)

![playground-1720012114147](https://github.com/coq/coq/assets/1013846/45bfae9c-b603-4c81-8e5b-6206be272e8b)


