### PR TITLE
Unifying the syntax of Definition, Theorem, Fixpoint and CoFixpoint (CEP #42)

### DIFF
--- a/dev/ci/user-overlays/19301-herbelin-master+ceps42-unify-definition-theorem.sh
+++ b/dev/ci/user-overlays/19301-herbelin-master+ceps42-unify-definition-theorem.sh
@@ -1,0 +1,4 @@
+overlay autosubst_ocaml https://github.com/herbelin/autosubst-ocaml master+adapt-coq-pr19301-ceps42-unify-definition-theorem 19301 master+ceps42-unify-definition-theorem
+overlay coq_lsp https://github.com/herbelin/coq-lsp main+adapt-coq-pr19301-ceps42-unify-definition-theorem 19301 master+ceps42-unify-definition-theorem
+overlay elpi https://github.com/herbelin/coq-elpi master+adapt-coq-pr19301-ceps42-unify-definition-theorem 19301 master+ceps42-unify-definition-theorem
+overlay vscoq https://github.com/herbelin/vscoq main+adapt-coq-pr19301-ceps42-unify-definition-theorem 19301 master+ceps42-unify-definition-theorem

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -146,11 +146,11 @@ Coercion Classes
 ----------------
 
 .. cmd:: Coercion @reference {? : @coercion_class >-> @coercion_class }
-         Coercion @ident_decl @def_body
+         Coercion @ident_decl {* @binder } @decl_body
 
   The first form declares the construction denoted by :token:`reference` as a coercion between
   the two given classes.  The second form defines :token:`ident_decl`
-  just like :cmd:`Definition` :n:`@ident_decl @def_body`
+  just like :cmd:`Definition` :n:`@ident_decl @decl_body`
   and then declares :token:`ident_decl` as a coercion between it source and its target.
   Both forms support the :attr:`local` attribute, which makes the coercion local to the current section.
 
@@ -255,7 +255,7 @@ type of the assumption to do so.  See :n:`@of_type`.
    .. exn:: @coercion_class must be a transparent constant.
       :undocumented:
 
-   .. cmd:: SubClass @ident_decl @def_body
+   .. cmd:: SubClass @ident_decl @decl_body
 
       If :n:`@type` is a coercion class :n:`@ident'` applied to some arguments then
       :n:`@ident` is defined and an identity coercion of name

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -146,12 +146,12 @@ Coercion Classes
 ----------------
 
 .. cmd:: Coercion @reference {? : @coercion_class >-> @coercion_class }
-         Coercion @ident_decl {* @binder } @decl_body
+         Coercion @decl_ident {* @binder } @decl_body
 
   The first form declares the construction denoted by :token:`reference` as a coercion between
-  the two given classes.  The second form defines :token:`ident_decl`
-  just like :cmd:`Definition` :n:`@ident_decl @decl_body`
-  and then declares :token:`ident_decl` as a coercion between it source and its target.
+  the two given classes.  The second form defines :token:`decl_ident`
+  just like :cmd:`Definition` :n:`@decl_ident @decl_body`
+  and then declares :token:`decl_ident` as a coercion between it source and its target.
   Both forms support the :attr:`local` attribute, which makes the coercion local to the current section.
 
   :n:`{? : @coercion_class >-> @coercion_class }`
@@ -255,7 +255,7 @@ type of the assumption to do so.  See :n:`@of_type`.
    .. exn:: @coercion_class must be a transparent constant.
       :undocumented:
 
-   .. cmd:: SubClass @ident_decl @decl_body
+   .. cmd:: SubClass @decl_ident @decl_body
 
       If :n:`@type` is a coercion class :n:`@ident'` applied to some arguments then
       :n:`@ident` is defined and an identity coercion of name

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -151,7 +151,7 @@ the value term in Russell and generates proof
 obligations. Once solved using the commands shown below, it binds the
 final Rocq term to the name :n:`@ident` in the global environment.
 
-:n:`Program Definition @ident_decl : @type := @term`
+:n:`Program Definition @decl_ident : @type := @term`
 
 Interprets the type :n:`@type`, potentially generating proof
 obligations to be resolved. Once done with them, we have a Rocq

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -289,7 +289,7 @@ Command summary
 ---------------
 
 .. cmd:: Class @record_definition
-         Class @ident_decl {* @binder } {? : @sort } := @constructor
+         Class @decl_ident {* @binder } {? : @sort } := @constructor
 
    The first form declares a record and makes the record a typeclass with parameters
    :n:`{* @binder }` and the listed record fields.
@@ -344,9 +344,9 @@ Command summary
       or :n:`@constructor` with a right-hand-side that
       is not itself a Class has no effect (apart from emitting this warning).
 
-.. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }
+.. cmd:: Instance {? @decl_ident {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }
 
-   Declares a typeclass instance named :token:`ident_decl` of the typeclass
+   Declares a typeclass instance named :token:`decl_ident` of the typeclass
    :n:`@type` with the specified parameters and with
    fields defined by :token:`field_val`, where each field must be a declared field of
    the typeclass.
@@ -380,7 +380,7 @@ Command summary
       to fill them.  It works exactly as if no :term:`body` had been given and
       the :tacn:`refine` tactic has been used first.
 
-   .. cmd:: Declare Instance @ident_decl {* @binder } : @term {? @hint_info }
+   .. cmd:: Declare Instance @decl_ident {* @binder } : @term {? @hint_info }
 
       In a :cmd:`Module Type`, declares that a corresponding concrete
       instance should exist in any implementation of this :cmd:`Module Type`. This

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -539,6 +539,7 @@ Explicit Universes
    | @qualid
    univ_decl ::= @%{ {? {* @ident } %| } {* @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
    cumul_univ_decl ::= @%{ {? {* @ident } %| } {* {? {| + | = | * } } @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
+   decl_ident ::= @ident {? @univ_decl }
    univ_constraint ::= @universe_name {| < | = | <= } @universe_name
 
 The syntax has been extended to allow users to explicitly bind names

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -171,8 +171,7 @@ has type :n:`@type`.
       | {| Parameter | Parameters }
       | {| Hypothesis | Hypotheses }
       | {| Variable | Variables }
-      assumpt ::= {+ @ident_decl } @of_type
-      ident_decl ::= @ident {? @univ_decl }
+      assumpt ::= {+ @decl_ident } @of_type
       of_type ::= {| : | :> } @type
 
    These commands bind one or more :n:`@ident`\(s) to specified :n:`@type`\(s) as their specifications in
@@ -196,7 +195,7 @@ has type :n:`@type`.
    parameterized (i.e., the variables are *discharged*).  See Section :ref:`section-mechanism`.
 
    :n:`:>`
-     If specified, :token:`ident_decl` is automatically
+     If specified, :token:`decl_ident` is automatically
      declared as a coercion to the class of its type.  See :ref:`coercions`.
 
    The :n:`Inline` clause is only relevant inside functors.  See :cmd:`Module`.

--- a/doc/sphinx/language/core/coinductive.rst
+++ b/doc/sphinx/language/core/coinductive.rst
@@ -149,12 +149,7 @@ corecursion. It is the local counterpart of the :cmd:`CoFixpoint` command. When
 Top-level definitions of corecursive functions
 -----------------------------------------------
 
-.. cmd:: CoFixpoint @cofix_definition {* with @cofix_definition }
-
-   .. insertprodn cofix_definition cofix_definition
-
-   .. prodn::
-      cofix_definition ::= @ident_decl {* @binder } {? : @type } {? := @term } {? @decl_notations }
+.. cmd:: CoFixpoint @declaration_body {* with @declaration_body }
 
    This command introduces a method for constructing an infinite object of a
    coinductive type. For example, the stream containing all natural numbers can

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -102,12 +102,12 @@ Section :ref:`typing-rules`.
    .. insertprodn declaration_body reduce
 
    .. prodn::
-      declaration_body ::= @ident_decl {* @binder } {? @fixannot } @decl_body {? @decl_notations }
+      declaration_body ::= @decl_ident {* @binder } {? @fixannot } @decl_body {? @decl_notations }
       decl_body ::= {? : @type } := {? @reduce } @term
       | : @type
       reduce ::= Eval @red_expr in
 
-   This binds each :n:`@term` in :n:`decl_body` to the respective name :n:`@ident_decl`
+   This binds each :n:`@term` in :n:`decl_body` to the respective name :n:`@decl_ident`
    in the global environment, provided that :n:`@term` is well-typed.
 
    If :n:`@type` is specified, the command checks that the type of :n:`@term`

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -1,5 +1,22 @@
-Definitions
-===========
+Definitions and theorems
+========================
+
+Definitions associate a specified term with a given name. The name can later
+be replaced with its definition through :term:`δ-reduction`.  Definitions can
+be local (defined with :g:`let`) or global
+(e.g. defined with :cmd:`Definition` and related forms such as :cmd:`Fixpoint`
+and :cmd:`CoFixpoint`).
+
+On its side, a theorem is a statement with a proof. One can view
+the name of a theorem as a way to abbreviate the given proof, in the
+same way as the name of a definition abbreviates a term. That is, in
+the case of definitions (and related forms such as :cmd:`Fixpoint` or
+:cmd:`CoFixpoint`), the term is the body of the definition and the
+type is the type of the body. In the case of a theorem, lemma,
+corollary, etc. the term is the proof and the type is the statement.
+
+Moreover, definitions can be local (defined with :g:`let`) or global
+(defined at top-level).
 
 .. index:: let ... := ... (term)
 
@@ -66,10 +83,7 @@ If a scope is :ref:`bound <LocalInterpretationRulesForNotations>` to
 Top-level definitions
 ---------------------
 
-Definitions extend the global environment by associating names to terms.
-A definition can be seen as a way to give a meaning to a name or as a
-way to abbreviate a term. In any case, the name can later be replaced at
-any time by its definition.
+Top-level definitions extend the global environment by associating names with terms.
 
 The operation of unfolding a name into its definition is called
 :term:`delta-reduction`.
@@ -106,8 +120,7 @@ Section :ref:`typing-rules`.
 
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
-   In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
-   for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
+   In this case, the proof should normally be terminated with :cmd:`Defined`. See :ref:`proof-editing-mode`.
 
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
@@ -125,10 +138,10 @@ Section :ref:`typing-rules`.
 
 .. _Assertions:
 
-Assertions and proofs
----------------------
+Theorems and proofs
+-------------------
 
-An assertion states a proposition (or a type) for which the proof (or an
+Assertions, such as :cmd:`Theorem`s, state a proposition (or a type) for which the proof (or an
 inhabitant of the type) is interactively built using :term:`tactics <tactic>`.
 Assertions cause Rocq to enter :term:`proof mode` (see :ref:`proofhandling`).
 Common tactics are described in the :ref:`writing-proofs` chapter.
@@ -198,7 +211,12 @@ tactics (see :ref:`writing-proofs`). The user may also enter
 commands to manage the proof mode (see :ref:`proofhandling`).
 
 When the proof is complete, use the :cmd:`Qed` command so the kernel verifies
-the proof and adds it to the global environment.
+the proof and adds it to the global environment. By default, proofs
+that end with :cmd:`Qed` are :term:`opaque`, that is that their content cannot
+be unfolded (see :ref:`applyingconversionrules`), thus realizing
+*proof irrelevance*, that is that only provability matters,
+and not the exact proof. Proofs can be made unfoldable, as
+definitions are, by ending the proof with :cmd:`Defined` in place of :cmd:`Qed`.
 
 .. note::
 
@@ -210,11 +228,6 @@ the proof and adds it to the global environment.
       command is understood as if it would have been given before the
       statements still to be proved. Nonetheless, this practice is discouraged
       and may stop working in future versions.
-
-   #. Proofs ended by :cmd:`Qed` are declared :term:`opaque`. Their content cannot be
-      unfolded (see :ref:`applyingconversionrules`), thus
-      realizing some form of *proof-irrelevance*.
-      Proofs that end with :cmd:`Defined` can be unfolded.
 
    #. :cmd:`Proof` is recommended but can currently be omitted. On the opposite
       side, :cmd:`Qed` (or :cmd:`Defined`) is mandatory to validate a proof.

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -92,30 +92,27 @@ Section :ref:`typing-rules`.
       | {* @binder } : @type
       reduce ::= Eval @red_expr in
 
-   These commands bind :n:`@term` to the name :n:`@ident` in the global environment,
-   provided that :n:`@term` is well-typed.  They can take the :attr:`local` :term:`attribute`,
-   which makes the defined :n:`@ident` accessible only through their fully
-   qualified names, even if :cmd:`Import` or its variants has been used on the
-   current :cmd:`Module`.
+   This binds :n:`@term` to the name :n:`@ident` in the global environment,
+   provided that :n:`@term` is well-typed.
+
+   If :n:`@type` is specified, the command checks that the type of :n:`@term`
+   is definitionally equal to :n:`@type`.
+
+   If :n:`@binder` is specified, it distributes over :n:`@term` and :n:`@type` as if they had
+   respectively been :n:`fun {* @binder } => @term` and :n:`forall {* @binder }, @type`.
+
    If :n:`@reduce` is present then :n:`@ident` is bound to the result of the specified
    computation on :n:`@term`.
-
-   These commands also support the :attr:`universes(polymorphic)`,
-   :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
-   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
-   :attr:`warn` and :attr:`using` attributes.
 
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
 
-   The form :n:`Definition @ident : @type := @term` checks that the type of :n:`@term`
-   is definitionally equal to :n:`@type`, and registers :n:`@ident` as being of type
-   :n:`@type`, and bound to value :n:`@term`.
-
-   The form :n:`Definition @ident {* @binder } : @type := @term` is equivalent to
-   :n:`Definition @ident : forall {* @binder }, @type := fun {* @binder } => @term`.
+   The attributes :attr:`local`, :attr:`universes(polymorphic)`,
+   :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` are accepted.
 
    .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
 
@@ -152,20 +149,19 @@ The basic assertion command is:
       | Property
 
    After the statement is asserted, Rocq needs a proof. Once a proof of
-   :n:`@type` under the assumptions represented by :n:`@binder`\s is given and
-   validated, the proof is generalized into a proof of :n:`forall {* @binder }, @type` and
+   :n:`@type` is given,
    the theorem is bound to the name :n:`@ident` in the global environment.
 
-   These commands accept the :attr:`program` attribute.  See :ref:`program_lemma`.
+   If :n:`@binder` is specified, this behaves as if :n:`@type` had been
+   :n:`forall {* @binder }, @type` and the proof starts in the context :n:`{* @binder }`.
 
    Forms using the :n:`with` clause are useful for theorems that are proved by simultaneous induction
-   over a mutually inductive assumption, or that assert mutually dependent
-   statements in some mutual coinductive type. It is equivalent to
+   over a mutually inductive assumption, or that assert mutually dependent coinductive
+   statements. It is equivalent to
    :cmd:`Fixpoint` or :cmd:`CoFixpoint` but using tactics to build the proof of
    the statements (or the :term:`body` of the specification, depending on the point of
    view). The inductive or coinductive types on which the induction or
-   coinduction has to be done is assumed to be unambiguous and is guessed by
-   the system.
+   coinduction has to be done is guessed by the system.
 
    Like in a :cmd:`Fixpoint` or :cmd:`CoFixpoint` definition, the induction hypotheses
    have to be used on *structurally smaller* arguments (for a :cmd:`Fixpoint`) or
@@ -175,8 +171,10 @@ The basic assertion command is:
    correct at some time of the interactive development of a proof, use the
    command :cmd:`Guarded`.
 
-   This command accepts the :attr:`bypass_check(universes)`,
-   :attr:`bypass_check(guard)`, :attr:`deprecated`, :attr:`warn`, and :attr:`using` attributes.
+   The attributes :attr:`local`, :attr:`universes(polymorphic)`,
+   :attr:`program` (see :ref:`program_lemma`),
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` are accepted.
 
    .. exn:: The term @term has type @type which should be Set, Prop or Type.
       :undocumented:

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -96,18 +96,19 @@ a type, which is the type of its :term:`body`.
 A formal presentation of constants and environments is given in
 Section :ref:`typing-rules`.
 
-.. cmd:: {| Definition | Example } @ident_decl @def_body
+.. cmd:: {| Definition | Example } @declaration_body {* with @declaration_body }
    :name: Definition; Example
 
-   .. insertprodn def_body reduce
+   .. insertprodn declaration_body reduce
 
    .. prodn::
-      def_body ::= {* @binder } {? : @type } := {? @reduce } @term
-      | {* @binder } : @type
+      declaration_body ::= @ident_decl {* @binder } {? @fixannot } @decl_body {? @decl_notations }
+      decl_body ::= {? : @type } := {? @reduce } @term
+      | : @type
       reduce ::= Eval @red_expr in
 
-   This binds :n:`@term` to the name :n:`@ident` in the global environment,
-   provided that :n:`@term` is well-typed.
+   This binds each :n:`@term` in :n:`decl_body` to the respective name :n:`@ident_decl`
+   in the global environment, provided that :n:`@term` is well-typed.
 
    If :n:`@type` is specified, the command checks that the type of :n:`@term`
    is definitionally equal to :n:`@type`.
@@ -118,9 +119,20 @@ Section :ref:`typing-rules`.
    If :n:`@reduce` is present then :n:`@ident` is bound to the result of the specified
    computation on :n:`@term`.
 
+   If :n:`@fixannot` is present, the definition is supposed to be
+   recursive and the command behaves as if a :cmd:`Fixpoint`.
+
+   If :n:`@decl_notation` is present, a notation is defined at the same time
+   (see :ref:`simultaneous-definition-and-notation`).
+
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should normally be terminated with :cmd:`Defined`. See :ref:`proof-editing-mode`.
+
+   When several declaration bodies are given, the command declares a
+   recursive definition as if using :cmd:`Fixpoint` or
+   :cmd:`CoFixpoint`, trying to decide automatically if the recursion
+   is guarded inductively or coinductively.
 
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
    :attr:`program` (see :ref:`program_definition`), :attr:`canonical`,
@@ -147,7 +159,7 @@ Assertions cause Rocq to enter :term:`proof mode` (see :ref:`proofhandling`).
 Common tactics are described in the :ref:`writing-proofs` chapter.
 The basic assertion command is:
 
-.. cmd:: @thm_token @ident_decl {* @binder } : @type {* with @ident_decl {* @binder } : @type }
+.. cmd:: @thm_token @declaration_body {* with @declaration_body }
    :name: Theorem; Lemma; Fact; Remark; Corollary; Proposition; Property
 
    .. insertprodn thm_token thm_token
@@ -185,7 +197,7 @@ The basic assertion command is:
    command :cmd:`Guarded`.
 
    The attributes :attr:`local`, :attr:`universes(polymorphic)`,
-   :attr:`program` (see :ref:`program_lemma`),
+   :attr:`program` (see :ref:`program_lemma`), :attr:`canonical`,
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
    :attr:`warn` and :attr:`using` are accepted.
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -465,40 +465,42 @@ constructions.
       fix_definition ::= @ident_decl {* @binder } {? @fixannot } {? : @type } {? := @term } {? @decl_notations }
 
    Allows defining functions by pattern matching over inductive
-   objects using a fixed point construction. The meaning of this declaration is
-   to define :n:`@ident` as a recursive function with arguments specified by
-   the :n:`@binder`\s such that :n:`@ident` applied to arguments
-   corresponding to these :n:`@binder`\s has type :n:`@type`, and is
-   equivalent to the expression :n:`@term`. The type of :n:`@ident` is
-   consequently :n:`forall {* @binder }, @type` and its value is equivalent
-   to :n:`fun {* @binder } => @term`.
+   objects using a fixed point construction.
 
-   This command accepts the :attr:`program`,
-   :attr:`bypass_check(universes)`, and :attr:`bypass_check(guard)` attributes.
+   The basic form :n:`Fixpoint @ident {* @binder} { struct @ident } : @type := @term.
+   declares :n:`@ident` to be the recursive function with arguments
+   :n:`{* @binder}` and body :n:`@term` of type :n:`type`.
 
-   To be accepted, a :cmd:`Fixpoint` definition has to satisfy syntactical
-   constraints on a special argument called the decreasing argument. They
-   are needed to ensure that the :cmd:`Fixpoint` definition always terminates.
+   To be accepted, a :cmd:`Fixpoint` definition has to satisfy a syntactical
+   constraint on a special argument called the decreasing argument. This
+   is needed to ensure that the :cmd:`Fixpoint` definition always terminates.
    The point of the :n:`{struct @ident}` annotation (see :n:`@fixannot`) is to
    let the user tell the system which argument decreases along the recursive calls.
 
-   The :n:`{struct @ident}` annotation may be left implicit, in which case the
-   system successively tries arguments from left to right until it finds one
+   The :n:`{struct @ident}` annotation may be left implicit, in which case
+   Rocq successively tries arguments from left to right until it finds one
    that satisfies the decreasing condition.
 
-   :cmd:`Fixpoint` without the :attr:`program` attribute does not support the
-   :n:`wf` or :n:`measure` clauses of :n:`@fixannot`. See :ref:`program_fixpoint`.
+   The :n:`@type` annotation may be left implicit, in which case Rocq
+   attempts to infer it.
+
+   This command accepts the :attr:`local`, :attr:`universes(polymorphic)`, :attr:`program`,
+   :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
+   :attr:`warn` and :attr:`using` attributes. The :attr:`program` attribute is needed
+   so that the :n:`wf` or :n:`measure` clauses of :n:`@fixannot` are
+   supported. See :ref:`program_fixpoint`.
 
    The :n:`with` clause allows simultaneously defining several mutual fixpoints.
    It is especially useful when defining functions over mutually defined
    inductive types.  Example: :ref:`Mutual Fixpoints<example_mutual_fixpoints>`.
 
+   If :n:`@decl_notation` is present, a notation is defined at the same time
+   (see :ref:`simultaneous-definition-and-notation`).
+
    If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
-
-   This command accepts the :attr:`using` attribute.
 
    .. note::
 

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -457,12 +457,7 @@ This section describes the primitive form of definition by recursion over
 inductive objects. See the :cmd:`Function` command for more advanced
 constructions.
 
-.. cmd:: Fixpoint @fix_definition {* with @fix_definition }
-
-   .. insertprodn fix_definition fix_definition
-
-   .. prodn::
-      fix_definition ::= @ident_decl {* @binder } {? @fixannot } {? : @type } {? := @term } {? @decl_notations }
+.. cmd:: Fixpoint @declaration_body {* with @declaration_body }
 
    Allows defining functions by pattern matching over inductive
    objects using a fixed point construction.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -644,8 +644,7 @@ while noting a few exceptional commands for which :attr:`local` and
       **Exception:** when :attr:`local` is applied to
       :cmd:`Definition`, :cmd:`Theorem` or their variants, its
       semantics are different: it makes the defined objects available
-      only through their fully qualified names rather than their
-      unqualified names after an :cmd:`Import`.
+      only through their fully qualified names, even after an :cmd:`Import`.
 
 .. attr:: export
 

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -21,7 +21,7 @@ Defining record types
    .. insertprodn record_definition of_type_inst
 
    .. prodn::
-      record_definition ::= {? > } @ident_decl {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident } }
+      record_definition ::= {? > } @decl_ident {* @binder } {? : @sort } {? := {? @ident } %{ {*; @record_field } {? ; } %} {? as @ident } }
       record_field ::= {* #[ {+, @attribute } ] } @name {? @field_spec } {? %| @natural }
       field_spec ::= {* @binder } @of_type_inst
       | {* @binder } := @term
@@ -49,7 +49,7 @@ Defining record types
      a coercion from the class of the last field type to the record name.
      See :ref:`coercions`.
 
-   :n:`@ident_decl`
+   :n:`@decl_ident`
      The :n:`@ident` within is the record name.
 
    :n:`{* @binder }`

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -55,9 +55,9 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    In some cases, this behaviour can be tuned with locality attributes.
    See :ref:`this table<visibility-attributes-sections>`.
 
-.. cmd:: Let @ident_decl @def_body
-         Let Fixpoint @fix_definition {* with @fix_definition }
-         Let CoFixpoint @cofix_definition {* with @cofix_definition }
+.. cmd:: Let @declaration_body {* with @declaration_body }
+         Let Fixpoint @declaration_body {* with @declaration_body }
+         Let CoFixpoint @declaration_body {* with @declaration_body }
    :name: Let; Let Fixpoint; Let CoFixpoint
 
    These are similar to :cmd:`Definition`, :cmd:`Fixpoint` and :cmd:`CoFixpoint`, except that

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -25,9 +25,9 @@ the type becomes recursive, in which case it can be either
 is reserved for non-recursive types. Natural numbers, lists or streams cannot
 be defined using :cmd:`Variant`.
 
-.. cmd:: Variant @ident_decl {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
+.. cmd:: Variant @decl_ident {* @binder } {? %| {* @binder } } {? : @type } := {? %| } {+| @constructor } {? @decl_notations }
 
-   Defines a variant type named :n:`@ident` (in :n:`@ident_decl`)
+   Defines a variant type named :n:`@ident` (in :n:`@decl_ident`)
    with the given list of constructors.
    No induction scheme is generated for
    this variant, unless the :flag:`Nonrecursive Elimination Schemes` flag is on.

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -28,7 +28,7 @@ value. The complete documentation of canonical structures can be found
 in :ref:`canonicalstructures`; here only a simple example is given.
 
 .. cmd:: Canonical {? Structure } @reference
-         Canonical {? Structure } @ident_decl @def_body
+         Canonical {? Structure } @ident_decl {* @binder } @decl_body
    :name: Canonical Structure; _
 
    The first form of this command declares an existing :n:`@reference` as a

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -28,7 +28,7 @@ value. The complete documentation of canonical structures can be found
 in :ref:`canonicalstructures`; here only a simple example is given.
 
 .. cmd:: Canonical {? Structure } @reference
-         Canonical {? Structure } @ident_decl {* @binder } @decl_body
+         Canonical {? Structure } @decl_ident {* @binder } @decl_body
    :name: Canonical Structure; _
 
    The first form of this command declares an existing :n:`@reference` as a

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1225,7 +1225,7 @@ Inlining hints for the fast reduction machines
 Registering primitive operations
 ````````````````````````````````
 
-.. cmd:: Primitive @ident_decl {? : @term } := #@ident
+.. cmd:: Primitive @decl_ident {? : @term } := #@ident
 
    Makes the primitive type or primitive operator :n:`#@ident` defined in OCaml
    accessible in Rocq commands and tactics.

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -468,6 +468,8 @@ Reserving notations
       the other. See :ref:`factorization <NotationFactorization>` for
       details.
 
+.. _simultaneous-definition-and-notation:
+
 Simultaneous definition of terms and notations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -31,12 +31,12 @@ Notations
 Basic notations
 ~~~~~~~~~~~~~~~
 
-.. cmd:: Notation @notation_declaration
+.. cmd:: Notation @decl_notation
 
-   .. insertprodn notation_declaration notation_declaration
+   .. insertprodn decl_notation decl_notation
 
    .. prodn::
-      notation_declaration ::= @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
+      decl_notation ::= @string := @one_term {? ( {+, @syntax_modifier } ) } {? : @scope_name }
 
    Defines a *notation*, an alternate syntax for entering or displaying
    a specific term or term pattern.
@@ -409,7 +409,7 @@ The Infix command
 The :cmd:`Infix` command is a shortcut for declaring notations for infix
 symbols.
 
-.. cmd:: Infix @notation_declaration
+.. cmd:: Infix @decl_notation
 
    The command
 
@@ -483,7 +483,7 @@ changing a parsing rule are accepted.
    .. insertprodn decl_notations decl_notations
 
    .. prodn::
-      decl_notations ::= where @notation_declaration {* and @notation_declaration }
+      decl_notations ::= where @decl_notation {* and @decl_notation }
 
 Here are examples:
 

--- a/doc/sphinx/using/libraries/funind.rst
+++ b/doc/sphinx/using/libraries/funind.rst
@@ -19,7 +19,7 @@ Advanced recursive functions
 
 The following command is available when the ``FunInd`` library has been loaded via ``Require Import FunInd``:
 
-.. cmd:: Function @fix_definition {* with @fix_definition }
+.. cmd:: Function @declaration_body {* with @declaration_body }
 
    This command is a generalization of :cmd:`Fixpoint`. It is a wrapper
    for several ways of defining a function *and* other useful related

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -122,11 +122,11 @@ RENAME: [
 | Pltac.ltac_expr ltac_expr5
 
 (*
-| G_vernac.def_body def_body
+| G_vernac.decl_body decl_body
 | Prim.by_notation by_notation
 | Prim.natural natural
 *)
-| Vernac.fix_definition fix_definition
+| Vernac.declaration_body declaration_body
 ]
 
 (* written in OCaml *)
@@ -559,12 +559,18 @@ variant_definition: [
 ]
 
 gallina: [
-| REPLACE thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
-| WITH thm_token ident_decl binders ":" type LIST0 [ "with" ident_decl binders ":" type ]
 | DELETE assumptions_token inline assum_list
 | DELETE "Symbols" assum_list
 | REPLACE "Symbol" assum_list
 | WITH [ "Symbol" | "Symbols" ] assum_list
+| REPLACE logical_token LIST1 declaration_body SEP "with"
+| WITH thm_token declaration_body LIST0 ( "with" declaration_body )
+|   ["Definition" | "Example" ] declaration_body LIST0 ( "with" declaration_body )
+|   "Let" declaration_body LIST0 ( "with" declaration_body )
+|   "Fixpoint" declaration_body LIST0 ( "with" declaration_body )
+|   "CoFixpoint" declaration_body LIST0 ( "with" declaration_body )
+|   "Let" "Fixpoint" declaration_body LIST0 ( "with" declaration_body )
+|   "Let" "CoFixpoint" declaration_body LIST0 ( "with" declaration_body )
 | REPLACE inductive_token LIST1 inductive_or_record_definition SEP "with"
 | WITH "Inductive" inductive_definition LIST0 ( "with" inductive_definition )
 |   "Inductive" record_definition LIST0 ( "with" record_definition )
@@ -575,14 +581,6 @@ gallina: [
 |   [ "Record" | "Structure" ] record_definition
 |   "Class" record_definition
 |   "Class" singleton_class_definition
-| REPLACE "Fixpoint" LIST1 fix_definition SEP "with"
-| WITH "Fixpoint" fix_definition LIST0 ( "with" fix_definition )
-| REPLACE "Let" "Fixpoint" LIST1 fix_definition SEP "with"
-| WITH "Let" "Fixpoint" fix_definition LIST0 ( "with" fix_definition )
-| REPLACE "CoFixpoint" LIST1 cofix_definition SEP "with"
-| WITH "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
-| REPLACE "Let" "CoFixpoint" LIST1 cofix_definition SEP "with"
-| WITH "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | REPLACE "Scheme" LIST1 scheme SEP "with"
 | WITH "Scheme" scheme LIST0 ( "with" scheme )
 | DELETE "Scheme" "Boolean" "Equality" "for" smart_global
@@ -664,12 +662,15 @@ of_type_inst: [
 | [ ":" | ":>" | "::" | "::>" ] type
 ]
 
-def_body: [
-| DELETE binders ":=" reduce lconstr
-| REPLACE binders ":" lconstr ":=" reduce lconstr
-| WITH LIST0 binder OPT (":" type) ":=" reduce lconstr
-| REPLACE binders ":" lconstr
-| WITH LIST0 binder ":" type
+declaration_body: [
+]
+
+decl_body: [
+| DELETE ":=" reduce lconstr
+| REPLACE ":" lconstr ":=" reduce lconstr
+| WITH OPT (":" type) ":=" reduce lconstr
+| REPLACE ":" lconstr
+| WITH ":" type
 ]
 
 delta_flag: [
@@ -718,12 +719,12 @@ gallina_ext: [
 | WITH "Implicit" [ "Type" | "Types" ] reserv_list
 | DELETE "Implicit" "Types" reserv_list
 
-(* Per @Zimmi48, the global (qualid) must be a simple identifier if def_body is present
+(* Per @Zimmi48, the global (qualid) must be a simple identifier if decl_body is present
    Note that smart_global is "qualid | by_notation" and that
    ident_decl is "ident OPT univ_decl"; move
  *)
-| REPLACE "Canonical" OPT "Structure" global OPT [ OPT univ_decl def_body ]
-| WITH "Canonical" OPT "Structure" ident_decl def_body
+| REPLACE "Canonical" OPT "Structure" global OPT [ OPT univ_decl binders decl_body ]
+| WITH "Canonical" OPT "Structure" ident_decl binders decl_body
 | REPLACE "Canonical" OPT "Structure" by_notation
 | WITH "Canonical" OPT "Structure" smart_global
 
@@ -733,8 +734,8 @@ gallina_ext: [
 
 (* semantically restricted per https://github.com/coq/coq/pull/12936#discussion_r492705820 *)
 (* global OPT univ_decl is just ident_decl, the first OPT is moved to the rule above *)
-| REPLACE "Coercion" global OPT [ OPT univ_decl def_body ]
-| WITH "Coercion" ident_decl def_body
+| REPLACE "Coercion" global OPT [ OPT univ_decl binders decl_body ]
+| WITH "Coercion" ident_decl binders decl_body
 
 | REPLACE "Include" "Type" module_type_inl LIST0 ext_module_type
 | WITH "Include" "Type" LIST1 module_type_inl SEP "<+"
@@ -1243,7 +1244,7 @@ command: [
 | WITH printable
 | REPLACE "Hint" hint opt_hintbases
 | WITH hint
-| "SubClass" ident_decl def_body
+| "SubClass" ident_decl decl_body
 | REPLACE "Ltac" LIST1 ltac_tacdef_body SEP "with"
 | WITH "Ltac" ltac_tacdef_body LIST0 ( "with" ltac_tacdef_body )
 | REPLACE "Function" LIST1 function_fix_definition SEP "with"      (* funind plugin *)
@@ -1505,16 +1506,6 @@ legacy_attr: [
 ]
 
 sentence: [ ]  (* productions defined below *)
-
-fix_definition: [
-| REPLACE ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
-]
-
-cofix_definition: [
-| REPLACE ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
-]
 
 type_cstr: [
 | REPLACE ":" lconstr

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1655,8 +1655,8 @@ ltac2_in_clause: [
 ]
 
 decl_notations: [
-| REPLACE "where" LIST1 notation_declaration SEP decl_sep
-| WITH "where" notation_declaration LIST0 (decl_sep notation_declaration )
+| REPLACE "where" LIST1 decl_notation SEP decl_sep
+| WITH "where" decl_notation LIST0 (decl_sep decl_notation )
 ]
 
 module_expr: [
@@ -1713,7 +1713,7 @@ by_notation: [
 | WITH ne_string OPT [ "%" scope_key ]
 ]
 
-notation_declaration: [
+decl_notation: [
 | REPLACE lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
 | WITH lstring ":=" constr syntax_modifiers OPT [ ":" scope_name ]
 ]

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -539,23 +539,23 @@ eqn: [
 
 (* No constructor syntax, OPT [ "|" binders ] is not supported for Record *)
 record_definition: [
-| opt_coercion ident_decl binders OPT [ ":" sort ] OPT ( ":=" OPT [ identref ] "{" record_fields "}" OPT [ "as" identref ] )
+| opt_coercion decl_ident binders OPT [ ":" sort ] OPT ( ":=" OPT [ identref ] "{" record_fields "}" OPT [ "as" identref ] )
 ]
 
 (* No mixed inductive-record definitions, opt_coercion is meaningless for Inductive *)
 inductive_definition: [
-| cumul_ident_decl binders OPT [ "|" binders ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" decl_notations
+| decl_ident_cumul binders OPT [ "|" binders ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" decl_notations
 ]
 
 (* No mutual recursion, no inductive classes, type must be a sort *)
 (* constructor is optional but "Class record_definition" covers that case *)
 singleton_class_definition: [
-| ident_decl binders OPT [ ":" sort ] ":=" constructor
+| decl_ident binders OPT [ ":" sort ] ":=" constructor
 ]
 
 (* No record syntax, opt_coercion not supported for Variant, := ... required *)
 variant_definition: [
-| ident_decl binders OPT [ "|" binders ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" decl_notations
+| decl_ident binders OPT [ "|" binders ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" decl_notations
 ]
 
 gallina: [
@@ -721,10 +721,10 @@ gallina_ext: [
 
 (* Per @Zimmi48, the global (qualid) must be a simple identifier if decl_body is present
    Note that smart_global is "qualid | by_notation" and that
-   ident_decl is "ident OPT univ_decl"; move
+   decl_ident is "ident OPT univ_decl"; move
  *)
 | REPLACE "Canonical" OPT "Structure" global OPT [ OPT univ_decl binders decl_body ]
-| WITH "Canonical" OPT "Structure" ident_decl binders decl_body
+| WITH "Canonical" OPT "Structure" decl_ident binders decl_body
 | REPLACE "Canonical" OPT "Structure" by_notation
 | WITH "Canonical" OPT "Structure" smart_global
 
@@ -733,9 +733,9 @@ gallina_ext: [
 | WITH "Coercion" smart_global OPT [ ":" coercion_class ">->" coercion_class ]
 
 (* semantically restricted per https://github.com/coq/coq/pull/12936#discussion_r492705820 *)
-(* global OPT univ_decl is just ident_decl, the first OPT is moved to the rule above *)
+(* global OPT univ_decl is just decl_ident, the first OPT is moved to the rule above *)
 | REPLACE "Coercion" global OPT [ OPT univ_decl binders decl_body ]
-| WITH "Coercion" ident_decl binders decl_body
+| WITH "Coercion" decl_ident binders decl_body
 
 | REPLACE "Include" "Type" module_type_inl LIST0 ext_module_type
 | WITH "Include" "Type" LIST1 module_type_inl SEP "<+"
@@ -1244,7 +1244,7 @@ command: [
 | WITH printable
 | REPLACE "Hint" hint opt_hintbases
 | WITH hint
-| "SubClass" ident_decl decl_body
+| "SubClass" decl_ident decl_body
 | REPLACE "Ltac" LIST1 ltac_tacdef_body SEP "with"
 | WITH "Ltac" ltac_tacdef_body LIST0 ( "with" ltac_tacdef_body )
 | REPLACE "Function" LIST1 function_fix_definition SEP "with"      (* funind plugin *)
@@ -1457,8 +1457,8 @@ assum_list: [
 ]
 
 assumpt: [
-| REPLACE LIST1 ident_decl of_type lconstr
-| WITH LIST1 ident_decl of_type
+| REPLACE LIST1 decl_ident of_type lconstr
+| WITH LIST1 decl_ident of_type
 ]
 
 constructor_type: [
@@ -2416,7 +2416,7 @@ SPLICE: [
 | firstorder_rhs
 | firstorder_using
 | ref_or_pattern_occ
-| cumul_ident_decl
+| decl_ident_cumul
 | variance
 | variance_identref
 | rewriter

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -531,7 +531,7 @@ command: [
 | "Hint" hint opt_hintbases
 | "Comments" LIST0 comment
 | "Attributes" attribute_list
-| "Declare" "Instance" ident_decl binders ":" term200 hint_info
+| "Declare" "Instance" decl_ident binders ":" term200 hint_info
 | "Declare" "Scope" IDENT
 | "Pwd"
 | "Cd"
@@ -899,7 +899,7 @@ gallina: [
 | "Register" global "as" qualid
 | "Register" "Scheme" global "as" qualid "for" global
 | "Register" "Inline" global
-| "Primitive" ident_decl OPT [ ":" lconstr ] ":=" register_token
+| "Primitive" decl_ident OPT [ ":" lconstr ] ":=" register_token
 | "Universe" LIST1 identref
 | "Universes" LIST1 identref
 | "Constraint" LIST1 univ_constraint SEP ","
@@ -989,11 +989,11 @@ cumul_univ_decl: [
 | "@{" LIST0 variance_identref [ "+" | ] univ_decl_constraints
 ]
 
-ident_decl: [
+decl_ident: [
 | identref OPT univ_decl
 ]
 
-cumul_ident_decl: [
+decl_ident_cumul: [
 | identref OPT cumul_univ_decl
 ]
 
@@ -1010,7 +1010,7 @@ finite_token: [
 ]
 
 declaration_body: [
-| ident_decl binders_fixannot decl_body decl_notations
+| decl_ident binders_fixannot decl_body decl_notations
 ]
 
 decl_body: [
@@ -1044,7 +1044,7 @@ opt_constructors_or_fields: [
 ]
 
 inductive_or_record_definition: [
-| opt_coercion cumul_ident_decl binders OPT [ "|" binders ] OPT [ ":" lconstr ] opt_constructors_or_fields decl_notations
+| opt_coercion decl_ident_cumul binders OPT [ "|" binders ] OPT [ ":" lconstr ] opt_constructors_or_fields decl_notations
 ]
 
 constructors_or_record: [
@@ -1120,7 +1120,7 @@ assum_coe: [
 ]
 
 assumpt: [
-| LIST1 ident_decl of_type lconstr
+| LIST1 decl_ident of_type lconstr
 ]
 
 constructor_type: [
@@ -1345,7 +1345,7 @@ implicits_alt: [
 ]
 
 instance_name: [
-| ident_decl binders
+| decl_ident binders
 |
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -885,19 +885,13 @@ subprf_with_selector: [
 ]
 
 gallina: [
-| thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
 | assumption_token inline assum_list
 | assumptions_token inline assum_list
-| def_token ident_decl def_body
 | "Symbol" assum_list
 | "Symbols" assum_list
-| "Let" ident_decl def_body
 | finite_token inductive_or_record_definition
 | inductive_token LIST1 inductive_or_record_definition SEP "with"
-| "Fixpoint" LIST1 fix_definition SEP "with"
-| "Let" "Fixpoint" LIST1 fix_definition SEP "with"
-| "CoFixpoint" LIST1 cofix_definition SEP "with"
-| "Let" "CoFixpoint" LIST1 cofix_definition SEP "with"
+| logical_token LIST1 declaration_body SEP "with"
 | "Scheme" LIST1 scheme SEP "with"
 | "Scheme" "Equality" "for" smart_global
 | "Scheme" "Boolean" "Equality" "for" smart_global
@@ -931,6 +925,16 @@ def_token: [
 | "Definition"
 | "Example"
 | "SubClass"
+]
+
+logical_token: [
+| thm_token
+| def_token
+| "Let"
+| "Fixpoint"
+| "CoFixpoint"
+| "Let" "Fixpoint"
+| "Let" "CoFixpoint"
 ]
 
 assumption_token: [
@@ -1005,10 +1009,14 @@ finite_token: [
 | "Class"
 ]
 
-def_body: [
-| binders ":=" reduce lconstr
-| binders ":" lconstr ":=" reduce lconstr
-| binders ":" lconstr
+declaration_body: [
+| ident_decl binders_fixannot decl_body decl_notations
+]
+
+decl_body: [
+| ":=" reduce lconstr
+| ":" lconstr ":=" reduce lconstr
+| ":" lconstr
 ]
 
 reduce: [
@@ -1055,14 +1063,6 @@ default_inhabitant_ident: [
 opt_coercion: [
 | ">"
 |
-]
-
-fix_definition: [
-| ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
-]
-
-cofix_definition: [
-| ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
 ]
 
 rw_pattern: [
@@ -1162,9 +1162,9 @@ gallina_ext: [
 | "Transparent" OPT "!" LIST1 smart_global
 | "Opaque" OPT "!" LIST1 smart_global
 | "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]
-| "Canonical" OPT "Structure" global OPT [ OPT univ_decl def_body ]
+| "Canonical" OPT "Structure" global OPT [ OPT univ_decl binders decl_body ]
 | "Canonical" OPT "Structure" by_notation
-| "Coercion" global OPT [ OPT univ_decl def_body ]
+| "Coercion" global OPT [ OPT univ_decl binders decl_body ]
 | "Identity" "Coercion" identref ":" coercion_class ">->" coercion_class
 | "Coercion" global ":" coercion_class ">->" coercion_class
 | "Coercion" by_notation ":" coercion_class ">->" coercion_class
@@ -2009,7 +2009,7 @@ with_names: [
 ]
 
 function_fix_definition: [
-| Vernac.fix_definition      (* funind plugin *)
+| Vernac.declaration_body      (* funind plugin *)
 ]
 
 fun_scheme_arg: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1016,7 +1016,7 @@ reduce: [
 |
 ]
 
-notation_declaration: [
+decl_notation: [
 | lstring ":=" constr syntax_modifiers OPT [ ":" IDENT ]
 ]
 
@@ -1025,7 +1025,7 @@ decl_sep: [
 ]
 
 decl_notations: [
-| "where" LIST1 notation_declaration SEP decl_sep
+| "where" LIST1 decl_notation SEP decl_sep
 |
 ]
 
@@ -1559,9 +1559,9 @@ syntax: [
 | "Delimit" "Scope" IDENT; "with" IDENT
 | "Undelimit" "Scope" IDENT
 | "Bind" "Scope" IDENT; "with" LIST1 coercion_class
-| "Infix" notation_declaration
+| "Infix" decl_notation
 | "Notation" identref LIST0 ident ":=" constr syntax_modifiers
-| "Notation" notation_declaration
+| "Notation" decl_notation
 | "Reserved" "Infix" ne_lstring syntax_modifiers
 | "Reserved" "Notation" ne_lstring syntax_modifiers
 | enable_enable_disable "Notation" enable_notation_rule enable_notation_interpretation enable_notation_flags opt_scope

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -104,11 +104,7 @@ assumption_token: [
 ]
 
 assumpt: [
-| LIST1 ident_decl of_type
-]
-
-ident_decl: [
-| ident OPT univ_decl
+| LIST1 decl_ident of_type
 ]
 
 of_type: [
@@ -320,6 +316,10 @@ cumul_univ_decl: [
 | "@{" OPT [ LIST0 ident "|" ] LIST0 ( OPT [ "+" | "=" | "*" ] ident ) OPT "+" OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
 ]
 
+decl_ident: [
+| ident OPT univ_decl
+]
+
 univ_constraint: [
 | universe_name [ "<" | "=" | "<=" ] universe_name
 ]
@@ -483,7 +483,7 @@ logical_token: [
 ]
 
 declaration_body: [
-| ident_decl LIST0 binder OPT fixannot decl_body OPT decl_notations
+| decl_ident LIST0 binder OPT fixannot decl_body OPT decl_notations
 ]
 
 decl_body: [
@@ -540,7 +540,7 @@ pattern_occs: [
 ]
 
 record_definition: [
-| OPT ">" ident_decl LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT [ "as" ident ] )
+| OPT ">" decl_ident LIST0 binder OPT [ ":" sort ] OPT ( ":=" OPT ident "{" LIST0 record_field SEP ";" OPT ";" "}" OPT [ "as" ident ] )
 ]
 
 record_field: [
@@ -855,7 +855,7 @@ command: [
 | "Remove" "Hints" LIST1 qualid OPT ( ":" LIST1 ident )
 | "Comments" LIST0 [ one_term | string | natural ]
 | "Attributes" LIST1 attribute SEP ","
-| "Declare" "Instance" ident_decl LIST0 binder ":" term OPT hint_info
+| "Declare" "Instance" decl_ident LIST0 binder ":" term OPT hint_info
 | "Declare" "Scope" scope_name
 | "Obligation" natural OPT ( "of" ident ) OPT ( "with" ltac_expr )
 | "Next" "Obligation" OPT ( "of" ident ) OPT ( "with" ltac_expr )
@@ -915,7 +915,7 @@ command: [
 | "String" "Notation" qualid qualid qualid OPT ( "(" number_string_via ")" ) ":" scope_name
 | assumption_token OPT ( "Inline" OPT ( "(" natural ")" ) ) [ assumpt | LIST1 ( "(" assumpt ")" ) ]
 | [ "Symbol" | "Symbols" ] [ assumpt | LIST1 ( "(" assumpt ")" ) ]
-| "Variant" ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
+| "Variant" decl_ident LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
 | "Inductive" inductive_definition LIST0 ( "with" inductive_definition )
 | thm_token declaration_body LIST0 ( "with" declaration_body )
 | "Inductive" record_definition LIST0 ( "with" record_definition )
@@ -925,7 +925,7 @@ command: [
 | "Register" qualid "as" qualid
 | "Register" "Scheme" qualid "as" qualid "for" qualid
 | "Register" "Inline" qualid
-| "Primitive" ident_decl OPT [ ":" term ] ":=" "#" ident
+| "Primitive" decl_ident OPT [ ":" term ] ":=" "#" ident
 | "Universe" LIST1 ident
 | "Universes" LIST1 ident
 | "Constraint" LIST1 univ_constraint SEP ","
@@ -940,7 +940,7 @@ command: [
 | "CoInductive" record_definition LIST0 ( "with" record_definition )
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
-| "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
+| "Class" decl_ident LIST0 binder OPT [ ":" sort ] ":=" constructor
 | "Module" OPT ( [ "Import" | "Export" ] OPT import_categories ) ident LIST0 module_binder OPT of_module_type OPT ( ":=" LIST1 module_expr_inl SEP "<+" )
 | "Module" "Type" ident LIST0 module_binder LIST0 ( "<:" module_type_inl ) OPT ( ":=" LIST1 module_type_inl SEP "<+" )
 | "Declare" "Module" OPT ( [ "Import" | "Export" ] OPT import_categories ) ident LIST0 module_binder ":" module_type_inl
@@ -956,13 +956,13 @@ command: [
 | "Transparent" OPT "!" LIST1 reference
 | "Opaque" OPT "!" LIST1 reference
 | "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]
-| "Canonical" OPT "Structure" ident_decl LIST0 binder decl_body
+| "Canonical" OPT "Structure" decl_ident LIST0 binder decl_body
 | "Canonical" OPT "Structure" reference
-| "Coercion" ident_decl LIST0 binder decl_body
+| "Coercion" decl_ident LIST0 binder decl_body
 | "Identity" "Coercion" ident ":" coercion_class ">->" coercion_class
 | "Coercion" reference OPT [ ":" coercion_class ">->" coercion_class ]
 | "Context" LIST1 binder
-| "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_val "}" | ":=" term ]
+| "Instance" OPT ( decl_ident LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_val "}" | ":=" term ]
 | "Existing" "Instance" qualid OPT hint_info
 | "Existing" "Instances" LIST1 qualid OPT [ "|" natural ]
 | "Existing" "Class" qualid
@@ -1002,7 +1002,7 @@ command: [
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
 | "Ltac2" "Check" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Globalize" ltac2_expr      (* ltac2 plugin *)
-| "SubClass" ident_decl decl_body
+| "SubClass" decl_ident decl_body
 | "Hint" "Resolve" LIST1 [ qualid | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
 | "Hint" "Resolve" [ "->" | "<-" ] LIST1 qualid OPT natural OPT ( ":" LIST1 ident )
 | "Hint" "Immediate" LIST1 [ qualid | one_term ] OPT ( ":" LIST1 ident )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -461,10 +461,6 @@ pattern0: [
 | string
 ]
 
-fix_definition: [
-| ident_decl LIST0 binder OPT fixannot OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
-]
-
 thm_token: [
 | "Theorem"
 | "Lemma"
@@ -475,9 +471,24 @@ thm_token: [
 | "Property"
 ]
 
-def_body: [
-| LIST0 binder OPT ( ":" type ) ":=" OPT reduce term
-| LIST0 binder ":" type
+logical_token: [
+| thm_token
+| "Definition"
+| "Example"
+| "Let"
+| "Fixpoint"
+| "CoFixpoint"
+| "Let" "Fixpoint"
+| "Let" "CoFixpoint"
+]
+
+declaration_body: [
+| ident_decl LIST0 binder OPT fixannot decl_body OPT decl_notations
+]
+
+decl_body: [
+| OPT ( ":" type ) ":=" OPT reduce term
+| ":" type
 ]
 
 reduce: [
@@ -568,10 +579,6 @@ import_categories: [
 
 filtered_import: [
 | qualid OPT [ "(" LIST1 ( qualid OPT [ "(" ".." ")" ] ) SEP "," ")" ]
-]
-
-cofix_definition: [
-| ident_decl LIST0 binder OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
 ]
 
 rw_pattern: [
@@ -893,7 +900,7 @@ command: [
 | "Ltac" tacdef_body LIST0 ( "with" tacdef_body )
 | "Print" "Ltac" "Signatures"
 | "Print" "Firstorder" "Solver"
-| "Function" fix_definition LIST0 ( "with" fix_definition )
+| "Function" declaration_body LIST0 ( "with" declaration_body )
 | "Functional" "Scheme" func_scheme_def LIST0 ( "with" func_scheme_def )
 | "Functional" "Case" func_scheme_def      (* funind plugin *)
 | "Generate" "graph" "for" qualid      (* funind plugin *)
@@ -906,18 +913,12 @@ command: [
 | "Declare" "Right" "Step" one_term
 | "Number" "Notation" qualid qualid qualid OPT ( "(" LIST1 number_modifier SEP "," ")" ) ":" scope_name
 | "String" "Notation" qualid qualid qualid OPT ( "(" number_string_via ")" ) ":" scope_name
-| "SubClass" ident_decl def_body
-| thm_token ident_decl LIST0 binder ":" type LIST0 [ "with" ident_decl LIST0 binder ":" type ]
 | assumption_token OPT ( "Inline" OPT ( "(" natural ")" ) ) [ assumpt | LIST1 ( "(" assumpt ")" ) ]
-| [ "Definition" | "Example" ] ident_decl def_body
 | [ "Symbol" | "Symbols" ] [ assumpt | LIST1 ( "(" assumpt ")" ) ]
-| "Let" ident_decl def_body
+| "Variant" ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
 | "Inductive" inductive_definition LIST0 ( "with" inductive_definition )
+| thm_token declaration_body LIST0 ( "with" declaration_body )
 | "Inductive" record_definition LIST0 ( "with" record_definition )
-| "Fixpoint" fix_definition LIST0 ( "with" fix_definition )
-| "Let" "Fixpoint" fix_definition LIST0 ( "with" fix_definition )
-| "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
-| "Let" "CoFixpoint" cofix_definition LIST0 ( "with" cofix_definition )
 | "Scheme" OPT ( ident ":=" ) scheme_kind LIST0 ( "with" OPT ( ident ":=" ) scheme_kind )
 | "Scheme" OPT "Boolean" "Equality" "for" reference
 | "Combined" "Scheme" ident "from" LIST1 ident SEP ","
@@ -929,9 +930,14 @@ command: [
 | "Universes" LIST1 ident
 | "Constraint" LIST1 univ_constraint SEP ","
 | "Rewrite" [ "Rule" | "Rules" ] ident ":=" OPT "|" LIST1 rewrite_rule SEP "|"
+| [ "Definition" | "Example" ] declaration_body LIST0 ( "with" declaration_body )
+| "Let" declaration_body LIST0 ( "with" declaration_body )
+| "Fixpoint" declaration_body LIST0 ( "with" declaration_body )
+| "CoFixpoint" declaration_body LIST0 ( "with" declaration_body )
+| "Let" "Fixpoint" declaration_body LIST0 ( "with" declaration_body )
+| "Let" "CoFixpoint" declaration_body LIST0 ( "with" declaration_body )
 | "CoInductive" inductive_definition LIST0 ( "with" inductive_definition )
 | "CoInductive" record_definition LIST0 ( "with" record_definition )
-| "Variant" ident_decl LIST0 binder OPT [ "|" LIST0 binder ] OPT [ ":" type ] ":=" OPT "|" LIST1 constructor SEP "|" OPT decl_notations
 | [ "Record" | "Structure" ] record_definition
 | "Class" record_definition
 | "Class" ident_decl LIST0 binder OPT [ ":" sort ] ":=" constructor
@@ -950,9 +956,9 @@ command: [
 | "Transparent" OPT "!" LIST1 reference
 | "Opaque" OPT "!" LIST1 reference
 | "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]
-| "Canonical" OPT "Structure" ident_decl def_body
+| "Canonical" OPT "Structure" ident_decl LIST0 binder decl_body
 | "Canonical" OPT "Structure" reference
-| "Coercion" ident_decl def_body
+| "Coercion" ident_decl LIST0 binder decl_body
 | "Identity" "Coercion" ident ":" coercion_class ">->" coercion_class
 | "Coercion" reference OPT [ ":" coercion_class ">->" coercion_class ]
 | "Context" LIST1 binder
@@ -996,6 +1002,7 @@ command: [
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
 | "Ltac2" "Check" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Globalize" ltac2_expr      (* ltac2 plugin *)
+| "SubClass" ident_decl decl_body
 | "Hint" "Resolve" LIST1 [ qualid | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
 | "Hint" "Resolve" [ "->" | "<-" ] LIST1 qualid OPT natural OPT ( ":" LIST1 ident )
 | "Hint" "Immediate" LIST1 [ qualid | one_term ] OPT ( ":" LIST1 ident )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -970,9 +970,9 @@ command: [
 | "Delimit" "Scope" scope_name "with" scope_key
 | "Undelimit" "Scope" scope_name
 | "Bind" "Scope" scope_name "with" LIST1 coercion_class
-| "Infix" notation_declaration
+| "Infix" decl_notation
 | "Notation" ident LIST0 ident ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
-| "Notation" notation_declaration
+| "Notation" decl_notation
 | "Reserved" "Infix" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Reserved" "Notation" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | [ "Enable" | "Disable" ] "Notation" OPT [ string | qualid LIST0 ident ] OPT ( ":=" one_term ) OPT ( "(" LIST1 enable_notation_flag SEP "," ")" ) OPT [ ":" scope_name | ":" "no" "scope" ]
@@ -1343,10 +1343,10 @@ level: [
 ]
 
 decl_notations: [
-| "where" notation_declaration LIST0 ( "and" notation_declaration )
+| "where" decl_notation LIST0 ( "and" decl_notation )
 ]
 
-notation_declaration: [
+decl_notation: [
 | string ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" ) OPT [ ":" scope_name ]
 ]
 

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -47,9 +47,15 @@ type universe_decl_expr = (lident list, lident list, univ_constraint_expr list) 
 type cumul_univ_decl_expr =
   (lident list, (lident * UVars.Variance.t option) list, univ_constraint_expr list) UState.gen_universe_decl
 
-type ident_decl = lident * universe_decl_expr option
-type cumul_ident_decl = lident * cumul_univ_decl_expr option
+type decl_ident = lident * universe_decl_expr option
+type decl_ident_cumul = lident * cumul_univ_decl_expr option
 type name_decl = lname * universe_decl_expr option
+
+type ident_decl = decl_ident
+[@@ocaml.deprecated "(9.0) Use [decl_ident]"]
+
+type cumul_ident_decl = decl_ident_cumul
+[@@ocaml.deprecated "(9.0) Use [decl_ident_cumul]"]
 
 type notation_with_optional_scope = LastLonelyNotation | NotationInScope of string
 

--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -59,6 +59,10 @@ type logical_kind =
   | IsDefinition of definition_object_kind
   | IsProof of theorem_kind
 
+type defined_logical_kind =
+  | IsDefinitionKind of definition_object_kind
+  | IsTheoremKind of theorem_kind
+
 (** Data associated to section variables and local definitions *)
 
 type variable_data = {

--- a/interp/decls.mli
+++ b/interp/decls.mli
@@ -56,6 +56,10 @@ type logical_kind =
   | IsDefinition of definition_object_kind
   | IsProof of theorem_kind
 
+type defined_logical_kind =
+  | IsDefinitionKind of definition_object_kind
+  | IsTheoremKind of theorem_kind
+
 (** This module manages non-kernel informations about declarations. It
     is either non-logical informations or logical informations that
     have no place to be (yet) in the kernel *)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -57,7 +57,9 @@ let test_lpar_nat_coloneq =
 let ensure_fixannot =
   let open Procq.Lookahead in
   to_entry "check_fixannot" begin
-    lk_kw "{" >> lk_kws ["wf"; "struct"; "measure"]
+    lk_kw "{" >> lk_kws ["wf"; "struct"; "measure"] >> lk_not_kw [":"; "}"]
+    (* This is only an approximation, for instance "{struct foo bar}"
+       can only be interpreted as binders but is not recognized as such *)
   end
 
 let test_name_colon =

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -82,6 +82,10 @@ struct
   | Tok.KEYWORD kw' | Tok.IDENT kw' -> if String.equal kw kw' then Some (n + 1) else None
   | _ -> None
 
+  let lk_not_kw kws n kwstate strm = match LStream.peek_nth kwstate n strm with
+  | Tok.KEYWORD kw | Tok.IDENT kw -> if List.exists (String.equal kw) kws then None else Some (n + 1)
+  | _ -> Some (n + 1)
+
   let lk_kws kws n kwstate strm = match LStream.peek_nth kwstate n strm with
   | Tok.KEYWORD kw | Tok.IDENT kw -> if List.mem_f String.equal kw kws then Some (n + 1) else None
   | _ -> None

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -318,7 +318,7 @@ module Prim =
     let name = Entry.make "name"
     let identref = Entry.make "identref"
     let univ_decl = Entry.make "univ_decl"
-    let ident_decl = Entry.make "ident_decl"
+    let decl_ident = Entry.make "decl_ident"
     let pattern_ident = Entry.make "pattern_ident"
 
     (* A synonym of ident - maybe ident will be located one day *)

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -33,6 +33,7 @@ module Lookahead : sig
   val lk_list : t -> t
   val check_no_space : t
   val lk_kw : string -> t
+  val lk_not_kw : string list -> t
   val lk_kws : string list -> t
   val lk_nat : t
   val lk_ident : t

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -152,7 +152,7 @@ module Prim :
     val name : lname Entry.t
     val identref : lident Entry.t
     val univ_decl : universe_decl_expr Entry.t
-    val ident_decl : ident_decl Entry.t
+    val decl_ident : decl_ident Entry.t
     val pattern_ident : lident Entry.t
     val base_ident : Id.t Entry.t
     val bignat : string Entry.t

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -134,7 +134,7 @@ GRAMMAR EXTEND Gram
   GLOBAL: function_fix_definition ;
 
   function_fix_definition:
-    [ [ g = Vernac.fix_definition -> { Loc.tag ~loc g } ]]
+    [ [ g = Vernac.declaration_body -> { Loc.tag ~loc g } ]]
     ;
 
 END
@@ -152,7 +152,7 @@ let is_proof_termination_interactively_checked recsl =
 
 let classify_as_Fixpoint recsl =
  Vernac_classifier.classify_vernac
-    (Vernacexpr.(CAst.make @@ { control = []; attrs = []; expr = VernacSynPure (VernacFixpoint(NoDischarge, List.split (List.map snd recsl)))}))
+    (Vernacexpr.(CAst.make @@ { control = []; attrs = []; expr = VernacSynPure (VernacDefinition((NoDischarge, IsDefinitionKind Fixpoint), List.map snd recsl))}))
 
 let classify_funind recsl =
   match classify_as_Fixpoint recsl with

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -386,8 +386,10 @@ let register_struct is_rec (rec_order, fixpoint_exprl) =
         CErrors.user_err
           Pp.(str "Body of Function must be given.")
     in
-    ComDefinition.do_definition ~name:fname.CAst.v ~poly:false
-      ~kind:Decls.Definition univs binders None body (Some rtype);
+    let pm =
+      ComDefinition.do_definition ~program_mode:false ~name:fname.CAst.v ~poly:false
+        ~kind:Decls.(IsDefinition Definition) univs binders None body (Some rtype) in
+    assert (Option.is_empty pm);
     let evd, rev_pconstants =
       List.fold_left
         (fun (evd, l) {Vernacexpr.fname} ->

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -566,8 +566,7 @@ end = struct (* {{{ *)
   let reachable id = reachable !vcs id
   let mk_branch_name { expr = x } = Branch.make
     (match x.CAst.v.Vernacexpr.expr with
-    | VernacSynPure (VernacDefinition (_,({CAst.v=Name i},_),_)) -> Id.to_string i
-    | VernacSynPure (VernacStartTheoremProof (_,[({CAst.v=i},_),_])) -> Id.to_string i
+    | VernacSynPure (VernacDefinition (_,[(_,{fname={CAst.v=i}})])) -> Id.to_string i
     | VernacSynPure (VernacInstance (({CAst.v=Name i},_),_,_,_,_)) -> Id.to_string i
     | _ -> "branch")
   let edit_branch = Branch.make "edit"
@@ -2527,7 +2526,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ()) x c =
               (* We can't replay a Definition since universes may be differently
                * inferred.  This holds in Coq >= 8.5 *)
               let action = match x.expr.CAst.v.expr with
-                | VernacSynPure (VernacDefinition(_, _, DefineBody _)) -> CherryPickEnv
+                | VernacSynPure (VernacDefinition(_, [_,{body_def=DefineBody _}])) -> CherryPickEnv
                 | _ -> ReplayCommand x in
               VCS.propagate_sideff ~action
           in

--- a/test-suite/bugs/bug_19593.v
+++ b/test-suite/bugs/bug_19593.v
@@ -1,0 +1,20 @@
+From Coq Require Import FinFun.
+From Coq Require Import Classes.Equivalence.
+Definition f_id {X: Type} (x0: X) := x0.
+Lemma simpl_prop:
+True /\ f_id (f_id (f_id True)).
+Proof.
+Fixpoint f_apply {X: Type} (x0: X) (f: X -> X) (n: nat) :=
+match n with
+| 0 => x0
+| S n' => f_apply (f x0) f n' end.
+assert (forall n (X: Prop), X -> f_apply X f_id n).
+{ induction n.
+  + simpl. intros. exact H.
+  + intros. simpl. specialize (IHn (f_id X)).
+    apply IHn. unfold f_id. exact H.  }
+split.
++ exact I.
++ specialize (H 3 True). simpl in H.
+  apply H. exact I.
+Qed.

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -63,7 +63,7 @@ val declare_new_instance
   : locality:Hints.hint_locality
   -> program_mode:bool
   -> poly:bool
-  -> ident_decl
+  -> decl_ident
   -> local_binder_expr list
   -> constr_expr
   -> Vernacexpr.hint_info_expr

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -74,7 +74,7 @@ val do_assumptions
   -> kind:Decls.assumption_object_kind
   -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
   -> inline:Declaremods.inline
-  -> (ident_decl list * constr_expr) with_coercion list
+  -> (decl_ident list * constr_expr) with_coercion list
   -> unit
 
 (** Interpret the command Context *)

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -27,26 +27,10 @@ val interp_definition
 
 val do_definition
   :  ?hook:Declare.Hook.t
+  -> ?pm:Declare.OblState.t
+  -> program_mode:bool
   -> name:Id.t
   -> ?scope:Locality.definition_scope
-  -> ?clearbody:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
-  -> kind:Decls.definition_object_kind
-  -> ?using:Vernacexpr.section_subset_expr
-  -> ?user_warns:Globnames.extended_global_reference UserWarn.with_qf
-  -> universe_decl_expr option
-  -> local_binder_expr list
-  -> red_expr option
-  -> constr_expr
-  -> constr_expr option
-  -> unit
-
-val do_definition_program
-  :  ?hook:Declare.Hook.t
-  -> pm:Declare.OblState.t
-  -> name:Id.t
-  -> scope:Locality.definition_scope
   -> ?clearbody:bool
   -> poly:bool
   -> ?typing_flags:Declarations.typing_flags
@@ -58,7 +42,7 @@ val do_definition_program
   -> red_expr option
   -> constr_expr
   -> constr_expr option
-  -> Declare.OblState.t
+  -> Declare.OblState.t option
 
 val do_definition_interactive
   :  program_mode:bool

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -50,5 +50,5 @@ val do_mutually_recursive
 
 val interp_fixpoint_short
   :  Constrexpr.fixpoint_order_expr option list
-  -> recursive_expr_gen list
+  -> definition_expr list
   -> Constr.types list * Evd.evar_map

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -56,7 +56,7 @@ GRAMMAR EXTEND Gram
   ;
   command: TOP
     [ [ IDENT "Goal"; c = lconstr ->
-        { VernacSynPure (VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c))) }
+        { VernacSynPure (VernacGoal c) }
       | IDENT "Proof" -> { VernacSynPure (VernacProof (None,None)) }
       | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr ->
           { VernacSynPure (VernacProof (None,Some l)) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -49,7 +49,8 @@ let coercion_class = Entry.make "coercion_class"
 let thm_token = Entry.make "thm_token"
 let def_token = Entry.make "def_token"
 let assumption_token = Entry.make "assumption_token"
-let def_body = Entry.make "def_body"
+let decl_body = Entry.make "decl_body"
+let def_body = decl_body
 let decl_notation = Entry.make "decl_notation"
 let notation_declaration = decl_notation
 let decl_notations = Entry.make "decl_notations"
@@ -216,12 +217,6 @@ let test_plural_form_rules loc kwd = function
      warn_plural_command ~loc kwd
   | _ -> ()
 
-let lname_of_lident : lident -> lname =
-  CAst.map (fun s -> Name s)
-
-let name_of_ident_decl : ident_decl -> name_decl =
-  on_fst lname_of_lident
-
 let test_variance_ident =
   let open Procq.Lookahead in
   to_entry "test_variance_ident" begin
@@ -242,44 +237,29 @@ let test_cumul_univ_decl =
 
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
-  GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type of_type_inst
-    record_field decl_notation decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
+  GLOBAL: gallina gallina_ext thm_token def_token assumption_token decl_body of_type of_type_inst
+    record_field decl_notation decl_notations declaration_body ident_decl univ_decl inductive_or_record_definition;
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
-    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = lconstr;
-        l = LIST0
-          [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
-          { (id,(bl,c)) } ] ->
-          { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
-      | stre = assumption_token; nl = inline; bl = assum_list ->
+    [ [ stre = assumption_token; nl = inline; bl = assum_list ->
           { VernacAssumption (stre, nl, bl) }
       | tk = assumptions_token; nl = inline; bl = assum_list ->
           { let (kwd,stre) = tk in
             test_plural_form loc kwd bl;
             VernacAssumption (stre, nl, bl) }
-      | d = def_token; id = ident_decl; b = def_body ->
-          { VernacDefinition (d, name_of_ident_decl id, b) }
       | IDENT "Symbol"; bl = assum_list ->
           { VernacSymbol bl }
       | IDENT "Symbols"; bl = assum_list ->
           { test_plural_form loc "Symbols" bl;
             VernacSymbol bl }
-      | IDENT "Let"; id = ident_decl; b = def_body ->
-          { VernacDefinition ((DoDischarge, Let), name_of_ident_decl id, b) }
       (* Gallina inductive declarations *)
       | f = finite_token; ind = inductive_or_record_definition ->
           { VernacInductive (f, [ind]) }
       | f = inductive_token; indl = LIST1 inductive_or_record_definition SEP "with" ->
           { VernacInductive (f, indl) }
-      | "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
-          { VernacFixpoint (NoDischarge, List.split recs) }
-      | IDENT "Let"; "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
-          { VernacFixpoint (DoDischarge, List.split recs) }
-      | "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
-          { VernacCoFixpoint (NoDischarge, corecs) }
-      | IDENT "Let"; "CoFixpoint"; corecs = LIST1 cofix_definition SEP "with" ->
-          { VernacCoFixpoint (DoDischarge, corecs) }
+      | k = logical_token; bodies = LIST1 declaration_body SEP "with" ->
+          { VernacDefinition (k, bodies) }
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> { VernacScheme l }
       | IDENT "Scheme"; IDENT "Equality"; IDENT "for" ; id = smart_global ->
           { VernacSchemeEquality (SchemeEquality,id) }
@@ -321,6 +301,16 @@ GRAMMAR EXTEND Gram
     [ [ "Definition" -> { (NoDischarge,Definition) }
       | IDENT "Example" -> { (NoDischarge,Example) }
       | IDENT "SubClass" -> { (NoDischarge,SubClass) } ] ]
+  ;
+  logical_token:
+    [ [ k = thm_token -> { (NoDischarge, IsTheoremKind k) }
+      | dk = def_token -> { let (d,k) = dk in (d, IsDefinitionKind k) }
+      | IDENT "Let" -> { (DoDischarge, IsDefinitionKind Let) }
+      | "Fixpoint" -> { (NoDischarge, IsDefinitionKind Fixpoint) }
+      | "CoFixpoint" -> { (NoDischarge, IsDefinitionKind CoFixpoint) }
+      | IDENT "Let"; "Fixpoint" -> { (DoDischarge, IsDefinitionKind Fixpoint) }
+      | IDENT "Let"; "CoFixpoint" -> { (DoDischarge, IsDefinitionKind CoFixpoint) }
+ ] ]
   ;
   assumption_token:
     [ [ "Hypothesis" -> { (DoDischarge, Logical) }
@@ -429,16 +419,26 @@ GRAMMAR EXTEND Gram
       | IDENT "Structure" -> { Structure }
       | IDENT "Class" -> { Class true } ] ]
   ;
-  (* Simple definitions *)
-  def_body:
-    [ [ bl = binders; ":="; red = reduce; c = lconstr ->
+  (* Declarations *)
+  declaration_body:
+    [ [ id_decl = ident_decl;
+        bl = binders_fixannot;
+        body_def = decl_body;
+        notations = decl_notations ->
+          { let binders, rec_order = bl in
+            ((rec_order : Constrexpr.fixpoint_order_expr option),
+            {fname = fst id_decl; univs = snd id_decl; binders; body_def; notations})
+          } ] ]
+  ;
+  decl_body:
+    [ [ ":="; red = reduce; c = lconstr ->
         { match c.CAst.v with
-          | CCast(c, Some C.DEFAULTcast, t) -> DefineBody (bl, red, c, Some t)
-          | _ -> DefineBody (bl, red, c, None) }
-    | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
-        { DefineBody (bl, red, c, Some t) }
-    | bl = binders; ":"; t = lconstr ->
-        { ProveBody (bl, t) } ] ]
+          | CCast(c, Some C.DEFAULTcast, t) -> DefineBody (red, c, Some t)
+          | _ -> DefineBody (red, c, None) }
+      | ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
+        { DefineBody (red, c, Some t) }
+      | ":"; t = lconstr ->
+        { ProveBody t } ] ]
   ;
   reduce:
     [ [ IDENT "Eval"; r = red_expr; "in" -> { Some r }
@@ -498,22 +498,6 @@ GRAMMAR EXTEND Gram
   opt_coercion:
     [ [ ">" -> { AddCoercion }
       |  -> { NoCoercion } ] ]
-  ;
-  (* (co)-fixpoints *)
-  fix_definition:
-    [ [ id_decl = ident_decl;
-        bl = binders_fixannot;
-        rtype = type_cstr;
-        body_def = OPT [":="; def = lconstr -> { def } ]; notations = decl_notations ->
-          { let binders, rec_order = bl in
-            ((rec_order : Constrexpr.fixpoint_order_expr option), {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations})
-          } ] ]
-  ;
-  cofix_definition:
-    [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr;
-        body_def = OPT [":="; def = lconstr -> { def }]; notations = decl_notations ->
-        { {fname = fst id_decl; univs = snd id_decl; binders; rtype; body_def; notations}
-        } ]]
   ;
   (* Rewrite Rules *)
   rw_pattern:
@@ -829,20 +813,24 @@ GRAMMAR EXTEND Gram
           LIST1 [ v=strategy_level; "["; q=LIST1 smart_global; "]" -> { (v,q) } ] ->
             { VernacSynPure (VernacSetStrategy l) }
       (* Canonical structure *)
-      | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; qid = global; ud = OPT [ u = OPT univ_decl; d = def_body -> { (u,d) } ] ->
+      | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; qid = global;
+        ud = OPT [ u = OPT univ_decl; bl = binders; d = decl_body -> { (u, bl, d) } ] ->
           { match ud with
            | None ->
              VernacSynPure (VernacCanonical CAst.(make ?loc:qid.CAst.loc @@ AN qid))
-           | Some (u,d) ->
+           | Some (u,bl,d) ->
              let s = coerce_reference_to_id qid in
-             VernacSynPure (VernacDefinition ((NoDischarge,CanonicalStructure),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d)) }
+             VernacSynPure (VernacDefinition ((NoDischarge,IsDefinitionKind CanonicalStructure),
+               [None, {fname = CAst.make ?loc:qid.CAst.loc s; univs = u; binders = bl; body_def = d; notations = []}])) }
       | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; ntn = by_notation ->
           { VernacSynPure (VernacCanonical CAst.(make ~loc @@ ByNotation ntn)) }
 
       (* Coercions *)
-      | IDENT "Coercion"; qid = global; ud = OPT [ u = OPT univ_decl; d = def_body -> { u, d } ] ->
-          { match ud with Some (u, d) -> let s = coerce_reference_to_id qid in
-          VernacSynPure (VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d))
+      | IDENT "Coercion"; qid = global;
+        ud = OPT [ u = OPT univ_decl; bl = binders; d = decl_body -> { u, bl, d } ] ->
+          { match ud with Some (u, bl, d) -> let s = coerce_reference_to_id qid in
+            VernacSynPure (VernacDefinition ((NoDischarge,IsDefinitionKind Coercion),
+            [None, {fname = CAst.make ?loc:qid.CAst.loc s; univs = u; binders = bl; body_def = d; notations = []}]))
           | None -> VernacSynPure (VernacCoercion (CAst.make ~loc @@ AN qid, None)) }
       | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
          s = coercion_class; ">->"; t = coercion_class ->

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -238,7 +238,7 @@ let test_cumul_univ_decl =
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
   GLOBAL: gallina gallina_ext thm_token def_token assumption_token decl_body of_type of_type_inst
-    record_field decl_notation decl_notations declaration_body ident_decl univ_decl inductive_or_record_definition;
+    record_field decl_notation decl_notations declaration_body decl_ident univ_decl inductive_or_record_definition;
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
@@ -273,7 +273,7 @@ GRAMMAR EXTEND Gram
         { VernacRegister(g, RegisterScheme {inductive = g'; scheme_kind = qid}) }
       | IDENT "Register"; IDENT "Inline"; g = global ->
           { VernacRegister(g, RegisterInline) }
-      | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
+      | IDENT "Primitive"; id = decl_ident; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
           { VernacPrimitive(id, r, typopt) }
       | IDENT "Universe"; l = LIST1 identref -> { VernacUniverse l }
       | IDENT "Universes"; l = LIST1 identref -> { VernacUniverse l }
@@ -401,11 +401,11 @@ GRAMMAR EXTEND Gram
            univdecl_extensible_constraints = snd cs } }
     ] ]
   ;
-  ident_decl:
+  decl_ident:
     [ [ i = identref; l = OPT univ_decl -> { (i, l) }
   ] ]
   ;
-  cumul_ident_decl:
+  decl_ident_cumul:
     [ [ i = identref; l = OPT cumul_univ_decl -> { (i, l) }
   ] ]
   ;
@@ -421,7 +421,7 @@ GRAMMAR EXTEND Gram
   ;
   (* Declarations *)
   declaration_body:
-    [ [ id_decl = ident_decl;
+    [ [ id_decl = decl_ident;
         bl = binders_fixannot;
         body_def = decl_body;
         notations = decl_notations ->
@@ -467,7 +467,7 @@ GRAMMAR EXTEND Gram
       | -> { RecordDecl (None, [], None) } ] ]
   ;
   inductive_or_record_definition:
-    [ [ oc = opt_coercion; id = cumul_ident_decl; indpar = binders;
+    [ [ oc = opt_coercion; id = decl_ident_cumul; indpar = binders;
         extrapar = OPT [ "|"; p = binders -> { p } ];
         c = OPT [ ":"; c = lconstr -> { c } ];
         lc=opt_constructors_or_fields; ntn = decl_notations ->
@@ -578,7 +578,7 @@ GRAMMAR EXTEND Gram
     [ [ "("; a = assumpt; ")" -> { a } ] ]
   ;
   assumpt:
-    [ [ idl = LIST1 ident_decl; oc = of_type; c = lconstr ->
+    [ [ idl = LIST1 decl_ident; oc = of_type; c = lconstr ->
         { (oc,(idl,c)) } ] ]
   ;
 
@@ -956,7 +956,7 @@ GRAMMAR EXTEND Gram
     ]
   ];
   instance_name:
-    [ [ name = ident_decl; bl = binders ->
+    [ [ name = decl_ident; bl = binders ->
           { (CAst.map (fun id -> Name id) (fst name), snd name), bl }
       | -> { ((CAst.make ~loc Anonymous), None), []  } ] ]
   ;
@@ -1033,7 +1033,7 @@ GRAMMAR EXTEND Gram
         { VernacSynPure (VernacAttributes attr) }
 
       (* Hack! Should be in grammar_ext, but camlp5 factorizes badly *)
-      | IDENT "Declare"; IDENT "Instance"; id = ident_decl; bl = binders; ":";
+      | IDENT "Declare"; IDENT "Instance"; id = decl_ident; bl = binders; ":";
          t = term LEVEL "200";
          info = hint_info ->
            { VernacSynPure (VernacDeclareInstance (id, bl, t, info)) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -50,7 +50,8 @@ let thm_token = Entry.make "thm_token"
 let def_token = Entry.make "def_token"
 let assumption_token = Entry.make "assumption_token"
 let def_body = Entry.make "def_body"
-let notation_declaration = Entry.make "notation_declaration"
+let decl_notation = Entry.make "decl_notation"
+let notation_declaration = decl_notation
 let decl_notations = Entry.make "decl_notations"
 let record_field = Entry.make "record_field"
 let of_type = Entry.make "of_type"
@@ -242,7 +243,7 @@ let test_cumul_univ_decl =
 (* Gallina declarations *)
 GRAMMAR EXTEND Gram
   GLOBAL: gallina gallina_ext thm_token def_token assumption_token def_body of_type of_type_inst
-    record_field notation_declaration decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
+    record_field decl_notation decl_notations fix_definition ident_decl univ_decl inductive_or_record_definition;
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
@@ -443,7 +444,7 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Eval"; r = red_expr; "in" -> { Some r }
       | -> { None } ] ]
   ;
-  notation_declaration:
+  decl_notation:
     [ [ ntn = lstring; ":="; c = constr;
         modl = syntax_modifiers;
         scopt = OPT [ ":"; sc = IDENT -> { sc } ] ->
@@ -456,7 +457,7 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "and" -> { () } ] ]
   ;
   decl_notations:
-    [ [ "where"; l = LIST1 notation_declaration SEP decl_sep -> { l }
+    [ [ "where"; l = LIST1 decl_notation SEP decl_sep -> { l }
     | -> { [] } ] ]
   ;
   (* Inductives and records *)
@@ -1343,12 +1344,12 @@ GRAMMAR EXTEND Gram
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
        refl = LIST1 coercion_class -> { VernacSynPure (VernacBindScope (sc,refl)) }
 
-     | IDENT "Infix"; ntn_decl = notation_declaration ->
+     | IDENT "Infix"; ntn_decl = decl_notation ->
          { VernacSynterp (VernacNotation (true,ntn_decl)) }
      | IDENT "Notation"; id = identref; idl = LIST0 ident;
          ":="; c = constr; modl = syntax_modifiers ->
            { VernacSynPure (VernacSyntacticDefinition (id,(idl,c), modl)) }
-     | IDENT "Notation"; ntn_decl = notation_declaration ->
+     | IDENT "Notation"; ntn_decl = decl_notation ->
            { VernacSynterp (VernacNotation (false,ntn_decl)) }
 
      | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring; l = syntax_modifiers ->

--- a/vernac/g_vernac.mli
+++ b/vernac/g_vernac.mli
@@ -34,7 +34,10 @@ val assumption_token :
 
 val def_body : Vernacexpr.definition_expr Procq.Entry.t
 
+val decl_notation : Vernacexpr.notation_declaration Procq.Entry.t
+
 val notation_declaration : Vernacexpr.notation_declaration Procq.Entry.t
+[@@ocaml.deprecated "(9.0) Use [decl_notation]"]
 
 val decl_notations : Vernacexpr.notation_declaration list Procq.Entry.t
 

--- a/vernac/g_vernac.mli
+++ b/vernac/g_vernac.mli
@@ -32,7 +32,10 @@ val def_token :
 val assumption_token :
   (Vernacexpr.discharge * Decls.assumption_object_kind) Procq.Entry.t
 
-val def_body : Vernacexpr.definition_expr Procq.Entry.t
+val decl_body : Vernacexpr.body_expr Procq.Entry.t
+
+val def_body : Vernacexpr.body_expr Procq.Entry.t
+[@@ocaml.deprecated "(9.0) Use [decl_body]"]
 
 val decl_notation : Vernacexpr.notation_declaration Procq.Entry.t
 

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -11,12 +11,16 @@
 (** This module implements pretty-printers for vernac_expr syntactic
     objects and their subcomponents. *)
 
+val string_of_defined_logical_kind : Decls.defined_logical_kind -> string
+
+val string_of_theorem_kind : Decls.theorem_kind -> string
+
 val pr_set_entry_type : ('a -> Pp.t) -> 'a Extend.constr_entry_key_gen -> Pp.t
 
 val pr_syntax_modifier : Vernacexpr.syntax_modifier CAst.t -> Pp.t
 
 (** Prints a fixpoint body *)
-val pr_rec_definition : Constrexpr.fixpoint_order_expr option * Vernacexpr.recursive_expr_gen -> Pp.t
+val pr_rec_definition : Constrexpr.fixpoint_order_expr option * Vernacexpr.definition_expr -> Pp.t
 
 (** Prints a scheme *)
 val pr_onescheme : Names.lident option * Vernacexpr.scheme -> Pp.t

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -43,7 +43,7 @@ module Vernac_ =
     let syntax = Entry.make "syntax_command"
     let vernac_control = Entry.make "vernac_control"
     let inductive_or_record_definition = Entry.make "inductive_or_record_definition"
-    let fix_definition = Entry.make "fix_definition"
+    let declaration_body = Entry.make "declaration_body"
     let red_expr = Entry.make "red_expr"
     let hint_info = Entry.make "hint_info"
     (* Main vernac entry *)

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -22,7 +22,7 @@ module Vernac_ :
     val syntax : vernac_expr Entry.t
     val vernac_control : vernac_control Entry.t
     val inductive_or_record_definition : (inductive_expr * notation_declaration list) Entry.t
-    val fix_definition : fixpoint_expr Entry.t
+    val declaration_body : fixpoint_expr Entry.t
     val noedit_mode : vernac_expr Entry.t
     val command_entry : vernac_expr Entry.t
     val main_entry : vernac_control option Entry.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -856,16 +856,17 @@ let vernac_definition ~atts ~pm (discharge, kind) (lid, udecl) bl red_option c t
       let env = Global.env () in
       let sigma = Evd.from_env env in
       Some (snd (Redexpr.interp_redexp_no_ltac env sigma r)) in
+  let kind = Decls.IsDefinition kind in
   if program_mode then
-    let kind = Decls.IsDefinition kind in
-    ComDefinition.do_definition_program ~pm ~name
+    Option.get (ComDefinition.do_definition ~pm ~program_mode ~name
       ?clearbody ~poly ?typing_flags ~scope ~kind
-      ?user_warns ?using udecl bl red_option c typ_opt ?hook
+      ?user_warns ?using udecl bl red_option c typ_opt ?hook)
   else
-    let () =
-      ComDefinition.do_definition ~name
+    let pm' =
+      ComDefinition.do_definition ~program_mode ~name
         ?clearbody ~poly ?typing_flags ~scope ~kind
         ?user_warns ?using udecl bl red_option c typ_opt ?hook in
+    assert (Option.is_empty pm');
     pm
 
 (* NB: pstate argument to use combinators easily *)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -149,10 +149,9 @@ type option_setting =
 
 (** Identifier and optional list of bound universes and constraints. *)
 
-type definition_expr =
-  | ProveBody of local_binder_expr list * constr_expr
-  | DefineBody of local_binder_expr list * Genredexpr.raw_red_expr option * constr_expr
-      * constr_expr option
+type body_expr =
+  | ProveBody of constr_expr
+  | DefineBody of Genredexpr.raw_red_expr option * constr_expr * constr_expr option
 
 type notation_format =
   | TextFormat of lstring
@@ -185,19 +184,18 @@ type recursion_order_expr =
   | CCoFixRecOrder
   | CUnknownRecOrder
 
-type recursive_expr_gen =
+type definition_expr =
   { fname : lident
   ; univs : universe_decl_expr option
   ; binders : local_binder_expr list
-  ; rtype : constr_expr
-  ; body_def : constr_expr option
+  ; body_def : body_expr
   ; notations : notation_declaration list
   }
 
-type fixpoint_expr = fixpoint_order_expr option * recursive_expr_gen
-type fixpoints_expr = fixpoint_order_expr option list * recursive_expr_gen list
-type cofixpoints_expr = recursive_expr_gen list
-type recursives_expr = recursion_order_expr * recursive_expr_gen list
+type fixpoint_expr = fixpoint_order_expr option * definition_expr
+type fixpoints_expr = fixpoint_order_expr option list * definition_expr list
+type cofixpoints_expr = definition_expr list
+type recursives_expr = recursion_order_expr * definition_expr list
 
 type local_decl_expr =
   | AssumExpr of lname * local_binder_expr list * constr_expr
@@ -243,9 +241,6 @@ type one_inductive_expr =
 
 type typeclass_constraint = name_decl * Glob_term.binding_kind * constr_expr
 and typeclass_context = typeclass_constraint list
-
-type proof_expr =
-  ident_decl * (local_binder_expr list * constr_expr)
 
 type opacity_flag = Opaque | Transparent
 
@@ -419,16 +414,14 @@ type nonrec synpure_vernac_expr =
   | VernacEnableNotation of bool * (string, Id.t list * qualid) Util.union option * constr_expr option * notation_enable_modifier list * notation_with_optional_scope option
 
   (* Gallina *)
-  | VernacDefinition of (discharge * Decls.definition_object_kind) * name_decl * definition_expr
-  | VernacStartTheoremProof of Decls.theorem_kind * proof_expr list
+  | VernacGoal of constr_expr
+  | VernacDefinition of (discharge * Decls.defined_logical_kind) * (fixpoint_order_expr option * definition_expr) list
   | VernacEndProof of proof_end
   | VernacExactProof of constr_expr
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
   | VernacSymbol of (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of inductive_kind * (inductive_expr * notation_declaration list) list
-  | VernacFixpoint of discharge * fixpoints_expr
-  | VernacCoFixpoint of discharge * cofixpoints_expr
   | VernacScheme of (lident option * scheme) list
   | VernacSchemeEquality of equality_scheme_type * Libnames.qualid Constrexpr.or_by_notation
   | VernacCombinedScheme of lident * lident list

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -232,7 +232,7 @@ type inductive_params_expr = local_binder_expr list * local_binder_expr list opt
 (** If the option is nonempty the "|" marker was used *)
 
 type inductive_expr =
-  cumul_ident_decl with_coercion
+  decl_ident_cumul with_coercion
   * inductive_params_expr * constr_expr option
   * constructor_list_or_record_decl_expr
 
@@ -419,8 +419,8 @@ type nonrec synpure_vernac_expr =
   | VernacEndProof of proof_end
   | VernacExactProof of constr_expr
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
-      Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
-  | VernacSymbol of (ident_decl list * constr_expr) with_coercion list
+      Declaremods.inline * (decl_ident list * constr_expr) with_coercion list
+  | VernacSymbol of (decl_ident list * constr_expr) with_coercion list
   | VernacInductive of inductive_kind * (inductive_expr * notation_declaration list) list
   | VernacScheme of (lident option * scheme) list
   | VernacSchemeEquality of equality_scheme_type * Libnames.qualid Constrexpr.or_by_notation
@@ -445,7 +445,7 @@ type nonrec synpure_vernac_expr =
       hint_info_expr
 
   | VernacDeclareInstance of
-      ident_decl * (* name *)
+      decl_ident * (* name *)
       local_binder_expr list * (* binders *)
       constr_expr * (* type *)
       hint_info_expr
@@ -487,7 +487,7 @@ type nonrec synpure_vernac_expr =
   | VernacSearch of searchable * Goal_select.t option * qualid list search_restriction
   | VernacLocate of locatable
   | VernacRegister of qualid * register_kind
-  | VernacPrimitive of ident_decl * CPrimitives.op_or_type * constr_expr option
+  | VernacPrimitive of decl_ident * CPrimitives.op_or_type * constr_expr option
   | VernacComments of comment list
   | VernacAttributes of Attributes.vernac_flags
 


### PR DESCRIPTION
This PR is a first attempt at implementing coq/ceps#42. It parses all of `Definition`/`Theorem`/`Fixpoint`/`CoFixpoint` using the same grammar, and, in particular, it supports:
```coq
Theorem foo : True := I.
```
or even:
```coq
Theorem f n {struct n} := match n with 0 => 0 | S n => S (f n) end .
```

The interpretation is still dispatched into a few commands:
- `ComDefinition.do_definition_interactive`
  - calling `Declare.Proof.start_definition`
- `ComDefinition.do_definition` which itself splits into:
  - `Declare.Obls.add_definition` (`Program` mode)
  - `Declare.declare_definition` (regular mode)
- `ComFixpoint.do_mutually_recursive` which itself splits into:
  - `Declare.Proof.start_mutual_definitions` (interactive)
  - `Declare.Obls.add_mutual_definitions` (`Program` mode)
  - `Declare.declare_mutual_definitions` (regular mode)

which could be merged further. For instance, the recursivity might just be a flag to a regular definition (as in `let rec` vs `let` in OCaml).

The `vtmodifyprogram`/`vtopenproof` dispatch is done in a rather heavy way which should be simplified.

The PR is complementary to #19029 which implements attributes `sealed`/`unsealed`.

A choice of default opacity for `Theorem :=` is easy to do, it is in function `ComDefinition.opacity_of_logical_kind`.

- [ ] add tests for the different combinations
- [ ] add support for e.g. `Coercion f n {struct n} := match n with 0 => 0 | S n => S (f n) end.`, or mutual coercions, or `Instance f n {struct n} := match n with 0 => 0 | S n => S (f n) end.`?
- [x] documentation to update
- [x] improve parsing of `{measure ...}`, `{struct ...}` and `{wf ...}` so that they can also be used as variable names

Incidentally fixes #19593.

Depends on:
- #19260
- #19766

Synchronous overlays:
- coq/vscoq#932
- ejgallego/coq-lsp#869
- uds-psl/autosubst-ocaml#21
- LPCIC/coq-elpi#703