### PR TITLE
[gen_rules] option -dep to depend on other theories

### DIFF
--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -123,11 +123,15 @@ module Theory = struct
     (** Coq's logical path *)
     ; implicit : bool
     (** Use -R or -Q *)
+    ; deps : string list;
+    (** Adds as -Q user-contrib/X X *)
     }
 
-  let args { directory; dirname; implicit } =
+  let args { directory; dirname; implicit; deps } =
     let barg = if implicit then "-R" else "-Q" in
     Arg.[ A barg; Path directory; A (String.concat "." dirname) ]
+    @ List.flatten (deps |> List.map (fun dep ->
+        Arg.[A "-Q"; Path (Path.make @@ "user-contrib"^Filename.dir_sep^dep); A dep]))
 
 end
 

--- a/tools/dune_rule_gen/coq_rules.mli
+++ b/tools/dune_rule_gen/coq_rules.mli
@@ -17,6 +17,8 @@ module Theory : sig
     (** Coq's logical path *)
     ; implicit : bool
     (** Use -R or -Q *)
+    ; deps : string list
+    (** Adds as -Q user-contrib/X X *)
     }
 end
 


### PR DESCRIPTION
I need this in order to add to user-contrib/ a new Ltac2ssr library that depends on Ltac2 (and ssr)