### PR TITLE
Above-prop-below-type

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1264,6 +1264,15 @@ let set_leq_sort env evd s1 s2 =
        add_universe_constraints evd (UnivProblem.Set.singleton (UnivProblem.ULe (u1,u2)))
      else evd
 
+let set_eq_relevance evd r1 r2 =
+  let ustate = evd.universes in
+  let r1 = UState.nf_relevance ustate r1 in
+  let r2 = UState.nf_relevance ustate r2 in
+  if not (Sorts.relevance_equal r1 r2) then
+    add_universe_constraints evd
+      (UnivProblem.enforce_eq_relevance r1 r2 UnivProblem.Set.empty)
+  else evd
+
 let check_eq evd s s' =
   let ustate = evd.universes in
   UGraph.check_eq_sort (UState.ugraph ustate) (UState.nf_sort ustate s) (UState.nf_sort ustate s')

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -653,6 +653,7 @@ val set_eq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_leq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_eq_instances : ?flex:bool ->
   evar_map -> UVars.Instance.t -> UVars.Instance.t -> evar_map
+val set_eq_relevance : evar_map -> erelevance -> erelevance -> evar_map
 
 val check_eq : evar_map -> esorts -> esorts -> bool
 val check_leq : evar_map -> esorts -> esorts -> bool

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -637,10 +637,15 @@ let process_universe_constraints uctx cstrs =
           if UGraph.check_leq_sort univs l r then local
           else sort_inconsistency Le l r
         | ULevel l' ->
-          if is_uset r' && is_local l' then
-            (* Unbounded universe constrained from above, we equalize it *)
-            let () = instantiate_variable l' Universe.type0 vars in
-            add_local (l', Eq, Level.set) local
+          if is_uset r' then
+            if Level.is_set l' then
+              local
+            else if is_local l' then
+              (* Unbounded universe constrained from above, we equalize it *)
+              let () = instantiate_variable l' Universe.type0 vars in
+              add_local (l', Eq, Level.set) local
+            else
+              sort_inconsistency Le l r
           else
             sort_inconsistency Le l r
         | UMax (_, levels) ->

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -114,6 +114,11 @@ let unify_quality ~fail c q1 q2 local = match q1, q2 with
   | Some local -> local
   | None -> fail ()
   end
+| QVar q, QConstant QType when c == Conversion.CUMUL ->
+  begin match set_above_prop q local with
+  | Some local -> local
+  | None -> fail ()
+  end
 | QVar qv1, QVar qv2 -> begin match set qv1 q2 local with
     | Some local -> local
     | None -> match set qv2 q1 local with

--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -139,3 +139,16 @@ let compare_cumulative_instances  cv_pb variances u u' cstrs =
        | Invariant ->
          Set.add (UEq (make u, make u')) cstrs)
     cstrs variances us us'
+
+let enforce_eq_relevance r r' cstrs =
+  let open Sorts in
+  match r, r' with
+  | Relevant, Relevant
+  | Irrelevant, Irrelevant -> cstrs
+  | Relevant, Irrelevant
+  | Irrelevant, Relevant -> Set.add (QEq (QConstant QProp, QConstant QSProp)) cstrs
+  | Irrelevant, RelevanceVar q
+  | RelevanceVar q, Irrelevant -> Set.add (QEq (QVar q, QConstant QSProp)) cstrs
+  | Relevant, RelevanceVar q
+  | RelevanceVar q, Relevant -> Set.add (QLeq (QConstant QProp, QVar q)) cstrs
+  | RelevanceVar q, RelevanceVar q' -> Set.add (QEq (QVar q, QVar q')) cstrs

--- a/engine/univProblem.mli
+++ b/engine/univProblem.mli
@@ -49,3 +49,5 @@ val enforce_eq_instances_univs : bool -> Instance.t constraint_function
 val enforce_eq_qualities : Sorts.Quality.t array constraint_function
 
 val compare_cumulative_instances : Conversion.conv_pb -> Variance.t array -> Instance.t constraint_function
+
+val enforce_eq_relevance : Sorts.relevance constraint_function

--- a/test-suite/bugs/bug_10504.v
+++ b/test-suite/bugs/bug_10504.v
@@ -9,6 +9,6 @@ Notation "[]" := (@nil Type).
 Notation "hd :: tl" := (cons hd tl).
 
 Definition xs := true :: 2137 :: false :: 0 :: [].
-Definition ys := xs :: xs.
+Fail Definition ys := 0 :: xs :: xs.
 
 (* Goal ys = ys. produced an anomaly "Unable to handle arbitrary u+k <= v constraints" *)

--- a/test-suite/bugs/bug_10504.v
+++ b/test-suite/bugs/bug_10504.v
@@ -9,6 +9,6 @@ Notation "[]" := (@nil Type).
 Notation "hd :: tl" := (cons hd tl).
 
 Definition xs := true :: 2137 :: false :: 0 :: [].
-Fail Definition ys := xs :: xs.
+Definition ys := xs :: xs.
 
 (* Goal ys = ys. produced an anomaly "Unable to handle arbitrary u+k <= v constraints" *)

--- a/test-suite/bugs/bug_11039.v
+++ b/test-suite/bugs/bug_11039.v
@@ -18,7 +18,7 @@ Fail #[universes(template)]
 Inductive foo (A:Type) := bar X : foo X -> foo A | nonempty.
 Arguments nonempty {_}.
 
-Fail Check foo nat : Type@{foo.u0}.
+Check foo nat : Type@{foo.u0}.
 (* template poly didn't activate *)
 
 Definition U := Type.

--- a/test-suite/bugs/bug_4328.v
+++ b/test-suite/bugs/bug_4328.v
@@ -1,6 +1,6 @@
 Inductive M (A:Type) : Type := M'.
 Axiom pi : forall (P : Prop) (p : P), Prop.
-Definition test1 A (x : _) := pi A x.           (* success     *)
+Definition test1 A (x : _) := pi A x.           (* success *)
 Definition test2 A (x : A) := pi A x.           (* success *)
-Fail Definition test3 A (x : A) (_ : M A) := pi A x. (* failure     *)
+Definition test3 A (x : A) (_ : M A) := pi A x. (* failure *)
 Fail Definition test4 A (_ : M A) (x : A) := pi A x. (* success ??? *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Makes it so that types which compare less than Type aren't immediately unified to Type, but instead only get tagged "above-prop" (which is synonymous with "below-type")


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
