### PR TITLE
Factorizing universe treatment for Definition, Theorem and Fixpoint (part of CEP #89)

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -788,8 +788,10 @@ let cofixpoint_message l =
   | l -> hov 0 (prlist_with_sep pr_comma Id.print l ++
                     spc () ++ str "are corecursively defined"))
 
-let recursive_message isfix indexes l =
-  (if isfix then fixpoint_message indexes else cofixpoint_message) l
+let recursive_message indexes l =
+  match indexes with
+  | None -> cofixpoint_message l
+  | Some indexes -> fixpoint_message (Some indexes) l
 
 let definition_message id =
   Flags.if_verbose Feedback.msg_info (Id.print id ++ str " is defined")
@@ -1017,9 +1019,8 @@ let declare_mutual_definitions ~info ~cinfo ~opaque ~uctx ~bodies ~possible_guar
          declare_entry ~name ~scope ~clearbody ~kind ~impargs ~uctx ~typing_flags ~user_warns entry)
       cinfo bodies_types
   in
-  let isfix = Option.has_some indexes in
   let fixnames = List.map (fun { CInfo.name } -> name) cinfo in
-  recursive_message isfix indexes fixnames;
+  recursive_message indexes fixnames;
   List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
   csts
 


### PR DESCRIPTION
The PR introduces a sharing of universe treatment across Definition, Theorem and Co/Fixpoint.

In particular, this means that when it willl be possible to declare opaque immediate forms of Definition, Fixpoint or CoFixpoint, they will take automatically benefit of the ability to use private universes.

This is part of coq/ceps#89. Integrating Derive in the process is done in #19578. Then, Program and Equations could also be considered.

Depends on:
- #19320