### PR TITLE
add table of locality attributes in refman

### DIFF
--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -175,6 +175,10 @@ has type :n:`@type`.
 
    :cmd:`Axiom`, :cmd:`Conjecture`, :cmd:`Parameter` and their plural forms
    are equivalent.  They can take the :attr:`local` :term:`attribute`,
+   which makes the declared :n:`@ident` accessible only through their fully
+   qualified names, even if :cmd:`Import` or its variants has been used on the
+   current module.
+
    which makes the defined :n:`@ident`\s accessible by :cmd:`Import` and its variants
    only through their fully qualified names.
 

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -632,11 +632,17 @@ The :cmd:`Set` and :cmd:`Unset` commands support the mutually
 exclusive :attr:`local`, :attr:`export` and :attr:`global` locality
 attributes.
 
-If no attribute is specified, the original value of the flag or option
-is restored at the end of the current module but it is *not* restored
-at the end of the current section.
-
-Newly opened modules and sections inherit the current settings.
+* If no attribute is specified, the original value of the flag or option
+  is restored at the end of the current module but it is *not* restored
+  at the end of the current section.
+* The :attr:`local` attribute makes the setting local to the current
+  :cmd:`Section` (if applicable) or :cmd:`Module`.
+* The :attr:`export` attribute makes the setting local to the current
+  :cmd:`Module`, unless :cmd:`Import` (or one of its variants) is used
+  on the :cmd:`Module`.
+* The :attr:`global` attribute makes the setting persist outside the current
+  :cmd:`Module` in the current file, or whenever :cmd:`Require` is used on the
+  current file.
 
 .. note::
 

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -94,8 +94,9 @@ Section :ref:`typing-rules`.
 
    These commands bind :n:`@term` to the name :n:`@ident` in the global environment,
    provided that :n:`@term` is well-typed.  They can take the :attr:`local` :term:`attribute`,
-   which makes the defined :n:`@ident` accessible by :cmd:`Import` and its variants
-   only through their fully qualified names.
+   which makes the defined :n:`@ident` accessible only through their fully
+   qualified names, even if :cmd:`Import` or its variants has been used on the
+   current :cmd:`Module`.
    If :n:`@reduce` is present then :n:`@ident` is bound to the result of the specified
    computation on :n:`@term`.
 

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -1071,7 +1071,7 @@ while noting a few exceptional commands for which :attr:`local` and
 .. _visibility-attributes-modules:
 
 The following table sums up the locality of vernacular commands in modules, when
-outside the module.
+outside the module where they were entered.
 A similar table for :cmd:`Section` can be found
 :ref:`here<visibility-attributes-sections>`.
 
@@ -1079,75 +1079,75 @@ A similar table for :cmd:`Section` can be found
   :header-rows: 1
 
   * - ``Command``
-    - without attribute,
-
-      not imported
-    - without attribute,
-
-      imported
+    - without attribute
     - :attr:`local`
     - :attr:`export`
     - :attr:`global`
 
   * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - available with qualified name
-    - available with short name
+    - same as :attr:`global`
     - available with qualified name
     - attribute not supported
-    - same as without attribute
+    - available with short name if imported, with qualified name if not
 
   * - :cmd:`Notation`
-    - not available outside
-    - available outside
-    - not available outside
+    - same as :attr:`global`
+    - not available
     - attribute not supported
-    - same as without attribute
+    - available when imported
 
   * - :cmd:`Notation (abbreviation)`
-    - available with qualified name
-    - available with short name
-    - not available outside
+    - same as :attr:`global`
+    - not available
     - attribute not supported
-    - same as without attribute
+    - available with short name if imported, with qualified name if not
 
   * - ``Hints`` (and :cmd:`Instance`)
-    - not available outside
-    - available outside
-    - not available outside
-    - available outside if imported
+    - same as :attr:`export`
+    - not available
+    - available when imported
     - always available outside
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - not available outside
-    - not available outside
-    - not available outside
-    - available outside if imported
-    - always available outside
+    - same as :attr:`local`
+    - no effect
+    - in effect when imported
+    - in effect outside
 
   * - :cmd:`Canonical Structure`
-    - not available outside
-    - available outside
-    - same as without attribute
-    - attribute not supported
-    - same as without attribute
+    - same as :attr:`local`
 
-  * - :cmd:`Ltac`
-    - available with qualified name
-    - available with short name
-    - not available outside
+      or :attr:`global`
+    - available when imported
     - attribute not supported
-    - same as without attribute
+    - available when imported
 
   * - :cmd:`Coercion`
-    - not available outside
-    - available outside
-    - not available outside
+    - same as :attr:`global`
+    - not available
     - attribute not supported
-    - same as without attribute
+    - available when imported
+
+  * - :cmd:`Ltac`
+    - same as :attr:`global`
+    - not available
+    - attribute not supported
+    - available with short name if imported, with qualified name if not
+
+  * - :cmd:`Ltac2`
+    - same as :attr:`global`
+    - not available
+    - attribute not supported
+    - available with short name if imported, with qualified name if not
 
   * - :cmd:`Tactic Notation`
-    - not available outside
-    - available outside
-    - not available outside
+    - same as :attr:`global`
+    - not available
     - attribute not supported
-    - same as without attribute
+    - available when imported
+
+  * - :cmd:`Ltac2 Notation`
+    - same as :attr:`global`
+    - not available
+    - attribute not supported
+    - available when imported

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -683,16 +683,18 @@ commands in a module, when outside the module where they were entered. In the
 following table:
 
 * a cross (❌) marks an unsupported attribute (compilation error);
-* “not available” means that the command has no effect outside the module it was entered;
-* “when imported” means that the command has effect outside the module if, and
-  only if, the module (or the command, via selective importation) is imported;
-* “short name when imported” means that the command has effects outside the module;
-  if the module (or command, via selective importation) is not imported, the
-  associated identifiers must be qualified;
-* “qualified name” means that the command has effects outside the module, but
+* “not available” means that the command has no effect outside the :cmd:`Module` it
+  was entered;
+* “when imported” means that the command has effect outside the :cmd:`Module` if, and
+  only if, the :cmd:`Module` (or the command, via :n:`@filtered_import`) is imported
+  (with :cmd:`Import` or :cmd:`Export`).
+* “short name when imported” means that the command has effects outside the
+  :cmd:`Module`; if the :cmd:`Module` (or command, via :n:`@filtered_import`) is not
+  imported, the associated identifiers must be qualified;
+* “qualified name” means that the command has effects outside the :cmd:`Module`, but
   the corresponding identifier may only be referred to with a qualified name;
-* “always” means that the command always has effects outside the module (even if
-  it is not imported).
+* “always” means that the command always has effects outside the :cmd:`Module` (even
+  if it is not imported).
 
 A similar table for :cmd:`Section` can be found
 :ref:`here<visibility-attributes-sections>`.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -679,13 +679,20 @@ Summary of locality attributes in a module
 ------------------------------------------
 
 This table sums up the effect of locality attributes on the scope of vernacular
-commands in a module, when outside the module where they were entered. A cross
-(❌) marks an unsupported attribute, which will provoke a compilation error. In
-this table, "not available", means that the command has no effect outside the
-module it was entered and "short name when imported" means that the command
-always has effects outside the module but if the module (or the command, via
-selective importation, when available) is not imported, the corresponding
-identifier must be qualified in order to be used.
+commands in a module, when outside the module where they were entered. In the
+following table:
+
+* a cross (❌) marks an unsupported attribute (compilation error);
+* "not available" means that the command has no effect outside the module it was entered;
+* "when imported" means that the command has effect outside the module if, and
+  only if, the module (or the command, via selective importation) is imported;
+* "short name when imported" means that the command has effects outside the module;
+  if the module (or command, via selective importation) is not imported, the
+  associated identifiers must be qualified;
+* "qualified name" means that the command has effects outside the module, but
+  the corresponding identifier may only be referred to with a qualified name;
+* "always" means that the command always has effects outside the module (even if
+  it is not imported).
 
 A similar table for :cmd:`Section` can be found
 :ref:`here<visibility-attributes-sections>`.
@@ -709,46 +716,6 @@ A similar table for :cmd:`Section` can be found
 
       when imported
 
-  * - :cmd:`Notation`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported
-
-  * - :cmd:`Notation (abbreviation)`
-    - :attr:`global`
-    - not available
-    - ❌
-    - short name
-
-      when imported
-
-  * - ``Hints`` (and :cmd:`Instance`)
-    - :attr:`export`
-    - not available
-    - when imported
-    - always
-
-  * - :cmd:`Set` or :cmd:`Unset` a flag
-    - :attr:`local`
-    - not available
-    - when imported
-    - always
-
-  * - :cmd:`Canonical Structure`
-    - :attr:`local`
-
-      or :attr:`global`
-    - when imported
-    - ❌
-    - when imported
-
-  * - :cmd:`Coercion`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported
-
   * - :cmd:`Ltac`
     - :attr:`global`
     - not available
@@ -765,6 +732,20 @@ A similar table for :cmd:`Section` can be found
 
       when imported
 
+  * - :cmd:`Notation (abbreviation)`
+    - :attr:`global`
+    - not available
+    - ❌
+    - short name
+
+      when imported
+
+  * - :cmd:`Notation`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
   * - :cmd:`Tactic Notation`
     - :attr:`global`
     - not available
@@ -776,6 +757,31 @@ A similar table for :cmd:`Section` can be found
     - not available
     - ❌
     - when imported
+
+  * - :cmd:`Coercion`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
+  * - :cmd:`Canonical Structure`
+    - :attr:`global`
+
+    - when imported
+    - ❌
+    - when imported
+
+  * - ``Hints`` (and :cmd:`Instance`)
+    - :attr:`export`
+    - not available
+    - when imported
+    - always
+
+  * - :cmd:`Set` or :cmd:`Unset` a flag
+    - :attr:`local`
+    - not available
+    - when imported
+    - always
 
 Typing Modules
 ------------------

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -699,11 +699,15 @@ A similar table for :cmd:`Section` can be found
     - :attr:`export`
     - :attr:`global`
 
-  * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
+  * - :cmd:`Definition`, :cmd:`Lemma`,
+
+      :cmd:`Axiom`, ...
     - :attr:`global`
     - qualified name
     - ❌
-    - short name when imported
+    - short name
+
+      when imported
 
   * - :cmd:`Notation`
     - :attr:`global`
@@ -715,7 +719,9 @@ A similar table for :cmd:`Section` can be found
     - :attr:`global`
     - not available
     - ❌
-    - short name when imported
+    - short name
+
+      when imported
 
   * - ``Hints`` (and :cmd:`Instance`)
     - :attr:`export`
@@ -747,13 +753,17 @@ A similar table for :cmd:`Section` can be found
     - :attr:`global`
     - not available
     - ❌
-    - short name when imported
+    - short name
+
+      when imported
 
   * - :cmd:`Ltac2`
     - :attr:`global`
     - not available
     - ❌
-    - short name when imported
+    - short name
+
+      when imported
 
   * - :cmd:`Tactic Notation`
     - :attr:`global`

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -683,15 +683,15 @@ commands in a module, when outside the module where they were entered. In the
 following table:
 
 * a cross (❌) marks an unsupported attribute (compilation error);
-* "not available" means that the command has no effect outside the module it was entered;
-* "when imported" means that the command has effect outside the module if, and
+* “not available” means that the command has no effect outside the module it was entered;
+* “when imported” means that the command has effect outside the module if, and
   only if, the module (or the command, via selective importation) is imported;
-* "short name when imported" means that the command has effects outside the module;
+* “short name when imported” means that the command has effects outside the module;
   if the module (or command, via selective importation) is not imported, the
   associated identifiers must be qualified;
-* "qualified name" means that the command has effects outside the module, but
+* “qualified name” means that the command has effects outside the module, but
   the corresponding identifier may only be referred to with a qualified name;
-* "always" means that the command always has effects outside the module (even if
+* “always” means that the command always has effects outside the module (even if
   it is not imported).
 
 A similar table for :cmd:`Section` can be found

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -1070,8 +1070,18 @@ while noting a few exceptional commands for which :attr:`local` and
 
 .. _visibility-attributes-modules:
 
-The following table sums up the locality of vernacular commands in modules, when
-outside the module where they were entered.
+Summary of locality attributes in a module
+------------------------------------------
+
+This table sums up the effect of locality attributes on the scope of vernacular
+commands in a module, when outside the module where they were entered. A cross
+(❌) marks an unsupported attribute, which will provoke a compilation error. In
+this table, "not available", means that the command has no effect outside the
+module it was entered and "short name when imported" means that the command
+always has effects outside the module but if the module (or the command, via
+selective importation, when available) is not imported, the corresponding
+identifier must be qualified in order to be used.
+
 A similar table for :cmd:`Section` can be found
 :ref:`here<visibility-attributes-sections>`.
 
@@ -1079,75 +1089,75 @@ A similar table for :cmd:`Section` can be found
   :header-rows: 1
 
   * - ``Command``
-    - without attribute
+    - no attribute
     - :attr:`local`
     - :attr:`export`
     - :attr:`global`
 
   * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - same as :attr:`global`
-    - available with qualified name
-    - attribute not supported
-    - available with short name if imported, with qualified name if not
+    - :attr:`global`
+    - qualified name
+    - ❌
+    - short name when imported
 
   * - :cmd:`Notation`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available when imported
+    - ❌
+    - when imported
 
   * - :cmd:`Notation (abbreviation)`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available with short name if imported, with qualified name if not
+    - ❌
+    - short name when imported
 
   * - ``Hints`` (and :cmd:`Instance`)
-    - same as :attr:`export`
+    - :attr:`export`
     - not available
-    - available when imported
-    - always available outside
+    - when imported
+    - always
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - same as :attr:`local`
-    - no effect
-    - in effect when imported
-    - in effect outside
+    - :attr:`local`
+    - not available
+    - when imported
+    - always
 
   * - :cmd:`Canonical Structure`
-    - same as :attr:`local`
+    - :attr:`local`
 
       or :attr:`global`
-    - available when imported
-    - attribute not supported
-    - available when imported
+    - when imported
+    - ❌
+    - when imported
 
   * - :cmd:`Coercion`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available when imported
+    - ❌
+    - when imported
 
   * - :cmd:`Ltac`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available with short name if imported, with qualified name if not
+    - ❌
+    - short name when imported
 
   * - :cmd:`Ltac2`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available with short name if imported, with qualified name if not
+    - ❌
+    - short name when imported
 
   * - :cmd:`Tactic Notation`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available when imported
+    - ❌
+    - when imported
 
   * - :cmd:`Ltac2 Notation`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
-    - available when imported
+    - ❌
+    - when imported

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -515,6 +515,258 @@ transparent constraint
 Notice that ``M`` is a correct body for the component ``M2`` since its ``T``
 component is ``nat`` as specified for ``M1.T``.
 
+.. extracted from Gallina extensions chapter
+
+.. _qualified-names:
+
+Qualified names
+---------------
+
+Qualified names (:token:`qualid`\s) are hierarchical names that are used to
+identify items such as definitions, theorems and parameters that may be defined
+inside modules (see :cmd:`Module`).  In addition, they are used to identify
+compiled files.  Syntactically, they have this form:
+
+.. insertprodn qualid qualid
+
+.. prodn::
+   qualid ::= @ident {* .@ident }
+
+*Fully qualified* or *absolute* qualified names uniquely identify files
+(as in the `Require` command) and items within files, such as a single
+:cmd:`Variable` definition.  It's usually possible to use a suffix of the fully
+qualified name (a *short name*) that uniquely identifies an item.
+
+The first part of a fully qualified name identifies a file, which may be followed
+by a second part that identifies a specific item within that file.  Qualified names
+that identify files don't have a second part.
+
+While qualified names always consist of a series of dot-separated :n:`@ident`\s,
+*the following few paragraphs omit the dots for the sake of simplicity.*
+
+**File part.** Files are identified by :gdef:`logical paths <logical path>`,
+which are prefixes in the form :n:`{* @ident__logical } {+ @ident__file }`, such
+as :n:`Coq.Init.Logic`, in which:
+
+- :n:`{* @ident__logical }`, the :gdef:`logical name`, maps to one or more
+  directories (or :gdef:`physical paths <physical path>`) in the user's file system.
+  The logical name
+  is used so that Coq scripts don't depend on where files are installed.
+  For example, the directory associated with :n:`Coq` contains Coq's standard library.
+  The logical name is generally a single :n:`@ident`.
+
+- :n:`{+ @ident__file }` corresponds to the file system path of the file relative
+  to the directory that contains it.  For example, :n:`Init.Logic`
+  corresponds to the file system path :n:`Init/Logic.v` on Linux)
+
+When Coq is processing a script that hasn't been saved in a file, such as a new
+buffer in CoqIDE or anything in coqtop, definitions in the script are associated
+with the logical name :n:`Top` and there is no associated file system path.
+
+**Item part.** Items are further qualified by a suffix in the form
+:n:`{* @ident__module } @ident__base` in which:
+
+- :n:`{* @ident__module }` gives the names of the nested modules, if any,
+  that syntactically contain the definition of the item.  (See :cmd:`Module`.)
+
+- :n:`@ident__base` is the base name used in the command defining
+  the item.  For example, :n:`eq` in the :cmd:`Inductive` command defining it
+  in `Coq.Init.Logic` is the base name for `Coq.Init.Logic.eq`, the standard library
+  definition of :term:`Leibniz equality`.
+
+If :n:`@qualid` is the fully qualified name of an item, Coq
+always interprets :n:`@qualid` as a reference to that item.  If :n:`@qualid` is also a
+partially qualified name for another item, then you must provide a more-qualified
+name to uniquely identify that other item.  For example, if there are two
+fully qualified items named `Foo.Bar` and `Coq.X.Foo.Bar`, then `Foo.Bar` refers
+to the first item and `X.Foo.Bar` is the shortest name for referring to the second item.
+
+Definitions with the :attr:`local` attribute are only accessible with
+their fully qualified name (see :ref:`gallina-definitions`).
+
+.. example::
+
+    .. coqtop:: all
+
+       Check 0.
+
+       Definition nat := bool.
+
+       Check 0.
+
+       Check Datatypes.nat.
+
+       Locate nat.
+
+.. seealso:: Commands :cmd:`Locate`.
+
+:ref:`logical-paths-load-path` describes how :term:`logical paths <logical path>`
+become associated with specific files.
+
+.. _controlling-locality-of-commands:
+
+Controlling the scope of commands with locality attributes
+----------------------------------------------------------
+
+Many commands have effects that apply only within a specific scope,
+typically the section or the module in which the command was
+called. Locality :term:`attributes <attribute>` can alter the scope of
+the effect. Below, we give the semantics of each locality attribute
+while noting a few exceptional commands for which :attr:`local` and
+:attr:`global` attributes are interpreted differently.
+
+.. attr:: local
+
+   This :term:`attribute` limits the effect of the command to the
+   current scope (section or module).
+
+   The ``Local`` prefix is an alternative syntax for the :attr:`local`
+   attribute (see :n:`@legacy_attr`).
+
+   .. note::
+
+      - For some commands, this is the only locality supported within
+        sections (e.g., for :cmd:`Notation`, :cmd:`Ltac` and
+        :ref:`Hint <creating_hints>` commands).
+
+      - For some commands, this is the default locality within
+        sections even though other locality attributes are supported
+        as well (e.g., for the :cmd:`Arguments` command).
+
+   .. warning::
+
+      **Exception:** when :attr:`local` is applied to
+      :cmd:`Definition`, :cmd:`Theorem` or their variants, its
+      semantics are different: it makes the defined objects available
+      only through their fully qualified names rather than their
+      unqualified names after an :cmd:`Import`.
+
+.. attr:: export
+
+   This :term:`attribute` makes the effect of the command
+   persist when the section is closed and applies the effect when the
+   module containing the command is imported.
+
+   Commands supporting this attribute include :cmd:`Set`, :cmd:`Unset`
+   and the :ref:`Hint <creating_hints>` commands, although the latter
+   don't support it within sections.
+
+.. attr:: global
+
+   This :term:`attribute` makes the effect of the command
+   persist even when the current section or module is closed.  Loading
+   the file containing the command (possibly transitively) applies the
+   effect of the command.
+
+   The ``Global`` prefix is an alternative syntax for the
+   :attr:`global` attribute (see :n:`@legacy_attr`).
+
+   .. warning::
+
+      **Exception:** for a few commands (like :cmd:`Notation` and
+      :cmd:`Ltac`), this attribute behaves like :attr:`export`.
+
+   .. warning::
+
+      We strongly discourage using the :attr:`global` locality
+      attribute because the transitive nature of file loading gives
+      the user little control. We recommend using the :attr:`export`
+      locality attribute where it is supported.
+
+.. _visibility-attributes-modules:
+
+Summary of locality attributes in a module
+------------------------------------------
+
+This table sums up the effect of locality attributes on the scope of vernacular
+commands in a module, when outside the module where they were entered. A cross
+(❌) marks an unsupported attribute, which will provoke a compilation error. In
+this table, "not available", means that the command has no effect outside the
+module it was entered and "short name when imported" means that the command
+always has effects outside the module but if the module (or the command, via
+selective importation, when available) is not imported, the corresponding
+identifier must be qualified in order to be used.
+
+A similar table for :cmd:`Section` can be found
+:ref:`here<visibility-attributes-sections>`.
+
+.. list-table::
+  :header-rows: 1
+
+  * - ``Command``
+    - no attribute
+    - :attr:`local`
+    - :attr:`export`
+    - :attr:`global`
+
+  * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
+    - :attr:`global`
+    - qualified name
+    - ❌
+    - short name when imported
+
+  * - :cmd:`Notation`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
+  * - :cmd:`Notation (abbreviation)`
+    - :attr:`global`
+    - not available
+    - ❌
+    - short name when imported
+
+  * - ``Hints`` (and :cmd:`Instance`)
+    - :attr:`export`
+    - not available
+    - when imported
+    - always
+
+  * - :cmd:`Set` or :cmd:`Unset` a flag
+    - :attr:`local`
+    - not available
+    - when imported
+    - always
+
+  * - :cmd:`Canonical Structure`
+    - :attr:`local`
+
+      or :attr:`global`
+    - when imported
+    - ❌
+    - when imported
+
+  * - :cmd:`Coercion`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
+  * - :cmd:`Ltac`
+    - :attr:`global`
+    - not available
+    - ❌
+    - short name when imported
+
+  * - :cmd:`Ltac2`
+    - :attr:`global`
+    - not available
+    - ❌
+    - short name when imported
+
+  * - :cmd:`Tactic Notation`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
+  * - :cmd:`Ltac2 Notation`
+    - :attr:`global`
+    - not available
+    - ❌
+    - when imported
+
 Typing Modules
 ------------------
 
@@ -909,255 +1161,3 @@ and :math:`Γ_C` is :math:`[c_1{:}∀ Γ_P, C_1 ; …; c_n{:}∀ Γ_P, C_n ]`.
    E[] ⊢ p :~\Struct~e_1 ;…;e_i ; \Indp{r}{Γ_I}{Γ_C}{p'} ;… ~\End
    --------------------------
    E[] ⊢ p.c_i \triangleright_δ p'.c_i
-
-.. extracted from Gallina extensions chapter
-
-.. _qualified-names:
-
-Qualified names
----------------
-
-Qualified names (:token:`qualid`\s) are hierarchical names that are used to
-identify items such as definitions, theorems and parameters that may be defined
-inside modules (see :cmd:`Module`).  In addition, they are used to identify
-compiled files.  Syntactically, they have this form:
-
-.. insertprodn qualid qualid
-
-.. prodn::
-   qualid ::= @ident {* .@ident }
-
-*Fully qualified* or *absolute* qualified names uniquely identify files
-(as in the `Require` command) and items within files, such as a single
-:cmd:`Variable` definition.  It's usually possible to use a suffix of the fully
-qualified name (a *short name*) that uniquely identifies an item.
-
-The first part of a fully qualified name identifies a file, which may be followed
-by a second part that identifies a specific item within that file.  Qualified names
-that identify files don't have a second part.
-
-While qualified names always consist of a series of dot-separated :n:`@ident`\s,
-*the following few paragraphs omit the dots for the sake of simplicity.*
-
-**File part.** Files are identified by :gdef:`logical paths <logical path>`,
-which are prefixes in the form :n:`{* @ident__logical } {+ @ident__file }`, such
-as :n:`Coq.Init.Logic`, in which:
-
-- :n:`{* @ident__logical }`, the :gdef:`logical name`, maps to one or more
-  directories (or :gdef:`physical paths <physical path>`) in the user's file system.
-  The logical name
-  is used so that Coq scripts don't depend on where files are installed.
-  For example, the directory associated with :n:`Coq` contains Coq's standard library.
-  The logical name is generally a single :n:`@ident`.
-
-- :n:`{+ @ident__file }` corresponds to the file system path of the file relative
-  to the directory that contains it.  For example, :n:`Init.Logic`
-  corresponds to the file system path :n:`Init/Logic.v` on Linux)
-
-When Coq is processing a script that hasn't been saved in a file, such as a new
-buffer in CoqIDE or anything in coqtop, definitions in the script are associated
-with the logical name :n:`Top` and there is no associated file system path.
-
-**Item part.** Items are further qualified by a suffix in the form
-:n:`{* @ident__module } @ident__base` in which:
-
-- :n:`{* @ident__module }` gives the names of the nested modules, if any,
-  that syntactically contain the definition of the item.  (See :cmd:`Module`.)
-
-- :n:`@ident__base` is the base name used in the command defining
-  the item.  For example, :n:`eq` in the :cmd:`Inductive` command defining it
-  in `Coq.Init.Logic` is the base name for `Coq.Init.Logic.eq`, the standard library
-  definition of :term:`Leibniz equality`.
-
-If :n:`@qualid` is the fully qualified name of an item, Coq
-always interprets :n:`@qualid` as a reference to that item.  If :n:`@qualid` is also a
-partially qualified name for another item, then you must provide a more-qualified
-name to uniquely identify that other item.  For example, if there are two
-fully qualified items named `Foo.Bar` and `Coq.X.Foo.Bar`, then `Foo.Bar` refers
-to the first item and `X.Foo.Bar` is the shortest name for referring to the second item.
-
-Definitions with the :attr:`local` attribute are only accessible with
-their fully qualified name (see :ref:`gallina-definitions`).
-
-.. example::
-
-    .. coqtop:: all
-
-       Check 0.
-
-       Definition nat := bool.
-
-       Check 0.
-
-       Check Datatypes.nat.
-
-       Locate nat.
-
-.. seealso:: Commands :cmd:`Locate`.
-
-:ref:`logical-paths-load-path` describes how :term:`logical paths <logical path>`
-become associated with specific files.
-
-.. _controlling-locality-of-commands:
-
-Controlling the scope of commands with locality attributes
-----------------------------------------------------------
-
-Many commands have effects that apply only within a specific scope,
-typically the section or the module in which the command was
-called. Locality :term:`attributes <attribute>` can alter the scope of
-the effect. Below, we give the semantics of each locality attribute
-while noting a few exceptional commands for which :attr:`local` and
-:attr:`global` attributes are interpreted differently.
-
-.. attr:: local
-
-   This :term:`attribute` limits the effect of the command to the
-   current scope (section or module).
-
-   The ``Local`` prefix is an alternative syntax for the :attr:`local`
-   attribute (see :n:`@legacy_attr`).
-
-   .. note::
-
-      - For some commands, this is the only locality supported within
-        sections (e.g., for :cmd:`Notation`, :cmd:`Ltac` and
-        :ref:`Hint <creating_hints>` commands).
-
-      - For some commands, this is the default locality within
-        sections even though other locality attributes are supported
-        as well (e.g., for the :cmd:`Arguments` command).
-
-   .. warning::
-
-      **Exception:** when :attr:`local` is applied to
-      :cmd:`Definition`, :cmd:`Theorem` or their variants, its
-      semantics are different: it makes the defined objects available
-      only through their fully qualified names rather than their
-      unqualified names after an :cmd:`Import`.
-
-.. attr:: export
-
-   This :term:`attribute` makes the effect of the command
-   persist when the section is closed and applies the effect when the
-   module containing the command is imported.
-
-   Commands supporting this attribute include :cmd:`Set`, :cmd:`Unset`
-   and the :ref:`Hint <creating_hints>` commands, although the latter
-   don't support it within sections.
-
-.. attr:: global
-
-   This :term:`attribute` makes the effect of the command
-   persist even when the current section or module is closed.  Loading
-   the file containing the command (possibly transitively) applies the
-   effect of the command.
-
-   The ``Global`` prefix is an alternative syntax for the
-   :attr:`global` attribute (see :n:`@legacy_attr`).
-
-   .. warning::
-
-      **Exception:** for a few commands (like :cmd:`Notation` and
-      :cmd:`Ltac`), this attribute behaves like :attr:`export`.
-
-   .. warning::
-
-      We strongly discourage using the :attr:`global` locality
-      attribute because the transitive nature of file loading gives
-      the user little control. We recommend using the :attr:`export`
-      locality attribute where it is supported.
-
-.. _visibility-attributes-modules:
-
-Summary of locality attributes in a module
-------------------------------------------
-
-This table sums up the effect of locality attributes on the scope of vernacular
-commands in a module, when outside the module where they were entered. A cross
-(❌) marks an unsupported attribute, which will provoke a compilation error. In
-this table, "not available", means that the command has no effect outside the
-module it was entered and "short name when imported" means that the command
-always has effects outside the module but if the module (or the command, via
-selective importation, when available) is not imported, the corresponding
-identifier must be qualified in order to be used.
-
-A similar table for :cmd:`Section` can be found
-:ref:`here<visibility-attributes-sections>`.
-
-.. list-table::
-  :header-rows: 1
-
-  * - ``Command``
-    - no attribute
-    - :attr:`local`
-    - :attr:`export`
-    - :attr:`global`
-
-  * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - :attr:`global`
-    - qualified name
-    - ❌
-    - short name when imported
-
-  * - :cmd:`Notation`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported
-
-  * - :cmd:`Notation (abbreviation)`
-    - :attr:`global`
-    - not available
-    - ❌
-    - short name when imported
-
-  * - ``Hints`` (and :cmd:`Instance`)
-    - :attr:`export`
-    - not available
-    - when imported
-    - always
-
-  * - :cmd:`Set` or :cmd:`Unset` a flag
-    - :attr:`local`
-    - not available
-    - when imported
-    - always
-
-  * - :cmd:`Canonical Structure`
-    - :attr:`local`
-
-      or :attr:`global`
-    - when imported
-    - ❌
-    - when imported
-
-  * - :cmd:`Coercion`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported
-
-  * - :cmd:`Ltac`
-    - :attr:`global`
-    - not available
-    - ❌
-    - short name when imported
-
-  * - :cmd:`Ltac2`
-    - :attr:`global`
-    - not available
-    - ❌
-    - short name when imported
-
-  * - :cmd:`Tactic Notation`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported
-
-  * - :cmd:`Ltac2 Notation`
-    - :attr:`global`
-    - not available
-    - ❌
-    - when imported

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -1067,3 +1067,81 @@ while noting a few exceptional commands for which :attr:`local` and
       attribute because the transitive nature of file loading gives
       the user little control. We recommend using the :attr:`export`
       locality attribute where it is supported.
+
+The following table sums up the locality of vernacular commands in modules, when
+outside the module.
+
+.. list-table::
+  :header-rows: 1
+
+  * - ``Command``
+    - without attribute,
+      not imported
+    - without attribute,
+      imported
+    - :attr:`local`
+    - :attr:`export`
+    - :attr:`global`
+
+  * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
+    - available with qualified name
+    - available with short name
+    - available with qualified name
+    - attribute not supported
+    - same as without attribute
+
+  * - :cmd:`Notation`
+    - not available outside
+    - available outside
+    - not available outside
+    - attribute not supported
+    - same as without attribute
+
+  * - :cmd:`Notation (abbreviation)`
+    - available with qualified name
+    - available with short name
+    - not available outside
+    - attribute not supported
+    - same as without attribute
+
+  * - ``Hints`` (and :cmd:`Instance`)
+    - not available outside
+    - available outside
+    - not available outside
+    - available outside if imported
+    - always available outside
+
+  * - :cmd:`Set` or :cmd:`Unset` a flag
+    - not available outside
+    - not available outside
+    - not available outside
+    - available outside if imported
+    - always available outside
+
+  * - :cmd:`Canonical Structure`
+    - not available outside
+    - available outside
+    - same as without attribute
+    - attribute not supported
+    - same as without attribute
+
+  * - :cmd:`Ltac`
+    - available with qualified name
+    - available with short name
+    - not available outside
+    - attribute not supported
+    - same as without attribute
+
+  * - :cmd:`Coercion`
+    - not available outside
+    - available outside
+    - not available outside
+    - attribute not supported
+    - same as without attribute
+
+  * - :cmd:`Tactic Notation`
+    - not available outside
+    - available outside
+    - not available outside
+    - attribute not supported
+    - same as without attribute

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -1068,16 +1068,22 @@ while noting a few exceptional commands for which :attr:`local` and
       the user little control. We recommend using the :attr:`export`
       locality attribute where it is supported.
 
+.. _visibility-attributes-modules:
+
 The following table sums up the locality of vernacular commands in modules, when
 outside the module.
+A similar table for :cmd:`Section` can be found
+:ref:`here<visibility-attributes-sections>`.
 
 .. list-table::
   :header-rows: 1
 
   * - ``Command``
     - without attribute,
+
       not imported
     - without attribute,
+
       imported
     - :attr:`local`
     - :attr:`export`

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -136,8 +136,13 @@ usable outside the section as shown in this :ref:`example <section_local_declara
 Summary of locality attributes in a section
 -------------------------------------------
 
-The following table sums up the locality of vernacular commands in sections, when
-outside the section it was entered.
+This table sums up the effect of locality attributes on the scope of vernacular
+commands in a section, when outside the section where they were entered. A cross
+(❌) marks an unsupported attribute, which will provoke a compilation error. In
+this table, "not available", means that the command has no effect outside the
+section it was entered, while "available" means that the effects of the command
+persists outside the section.
+
 A similar table for :cmd:`Module` can be found
 :ref:`here <visibility-attributes-modules>`.
 
@@ -145,76 +150,76 @@ A similar table for :cmd:`Module` can be found
   :header-rows: 1
 
   * - ``Command``
-    - without attribute
+    - no attribute
     - :attr:`local`
     - :attr:`export`
     - :attr:`global`
 
   * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - same as :attr:`local`
+    - :attr:`local`
     - available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
   * - :cmd:`Notation`
-    - same as :`local`
+    - :attr:`local`
     - not available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
   * - :cmd:`Notation (abbreviation)`
-    - same as :attr:`local`
+    - :attr:`local`
     - not available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
   * - ``Hints`` (and :cmd:`Instance`)
-    - same as :attr:`local`
+    - :attr:`local`
     - not available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - same as :attr:`local`
-    - no effect
-    - in effect
-    - in effect
+    - :attr:`local`
+    - not available
+    - available
+    - available
 
   * - :cmd:`Canonical Structure`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
+    - ❌
     - available
 
   * - :cmd:`Coercion`
-    - same as :attr:`global`
+    - :attr:`global`
     - not available
-    - attribute not supported
+    - ❌
     - available
 
   * - :cmd:`Ltac`
-    - same as :attr:`local`
-    - not available outside
-    - attribute not supported
-    - attribute not supported
+    - :attr:`local`
+    - not available
+    - ❌
+    - ❌
 
   * - :cmd:`Ltac2`
-    - same as :attr:`local`
-    - not available outside
-    - attribute not supported
-    - attribute not supported
+    - :attr:`local`
+    - not available
+    - ❌
+    - ❌
 
   * - :cmd:`Tactic Notation`
-    - same as :attr:`local`
+    - :attr:`local`
     - not available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
   * - :cmd:`Ltac2 Notation`
-    - same as :attr:`local`
+    - :attr:`local`
     - not available
-    - attribute not supported
-    - attribute not supported
+    - ❌
+    - ❌
 
 .. _Admissible-rules-for-global-environments:
 

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -172,7 +172,7 @@ A similar table for :cmd:`Module` can be found
     - available [#note1]_
     - :attr:`local` in
 
-      current module [#note1]_
+      module [#note1]_
     - ❌
     - ❌
 
@@ -218,7 +218,7 @@ A similar table for :cmd:`Module` can be found
     - ❌
     - :attr:`global` in
 
-      current module [#note2]_
+      module [#note2]_
 
   * - :cmd:`Canonical Structure`
     - :attr:`global`
@@ -226,7 +226,7 @@ A similar table for :cmd:`Module` can be found
     - ❌
     - :attr:`global` in
 
-      current module [#note2]_
+      module [#note2]_
 
   * - ``Hints`` (and :cmd:`Instance`)
     - :attr:`local`
@@ -235,14 +235,14 @@ A similar table for :cmd:`Module` can be found
     - ❌
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - available
+    - available [#note3]_
     - not available
     - :attr:`export` in
 
-      current module [#note3]_
+      module [#note3]_
     - :attr:`global` in
 
-      current module [#note3]_
+      module [#note3]_
 
 .. [#note1] For :cmd:`Definition`, :cmd:`Lemma`, ... the default visibility is
    to be available outside the section and available with a short name when

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -137,11 +137,12 @@ Summary of locality attributes in a section
 -------------------------------------------
 
 This table sums up the effect of locality attributes on the scope of vernacular
-commands in a section, when outside the section where they were entered. A cross
-(❌) marks an unsupported attribute, which will provoke a compilation error. In
-this table, "not available", means that the command has no effect outside the
-section it was entered, while "available" means that the effects of the command
-persists outside the section.
+commands in a section, when outside the section where they were entered. In the
+following table:
+
+* a cross (❌) marks an unsupported attribute (compilation error);
+* "not available" means that the command has no effect outside the section it was entered;
+* "available" means that the effect of the command persists outside the section.
 
 A similar table for :cmd:`Module` can be found
 :ref:`here <visibility-attributes-modules>`.
@@ -161,7 +162,13 @@ A similar table for :cmd:`Module` can be found
     - ❌
     - ❌
 
-  * - :cmd:`Notation`
+  * - :cmd:`Ltac`
+    - :attr:`local`
+    - not available
+    - ❌
+    - ❌
+
+  * - :cmd:`Ltac2`
     - :attr:`local`
     - not available
     - ❌
@@ -173,37 +180,7 @@ A similar table for :cmd:`Module` can be found
     - ❌
     - ❌
 
-  * - ``Hints`` (and :cmd:`Instance`)
-    - :attr:`local`
-    - not available
-    - ❌
-    - ❌
-
-  * - :cmd:`Set` or :cmd:`Unset` a flag
-    - :attr:`local`
-    - not available
-    - available
-    - available
-
-  * - :cmd:`Canonical Structure`
-    - :attr:`global`
-    - not available
-    - ❌
-    - available
-
-  * - :cmd:`Coercion`
-    - :attr:`global`
-    - not available
-    - ❌
-    - available
-
-  * - :cmd:`Ltac`
-    - :attr:`local`
-    - not available
-    - ❌
-    - ❌
-
-  * - :cmd:`Ltac2`
+  * - :cmd:`Notation`
     - :attr:`local`
     - not available
     - ❌
@@ -220,6 +197,30 @@ A similar table for :cmd:`Module` can be found
     - not available
     - ❌
     - ❌
+
+  * - :cmd:`Coercion`
+    - :attr:`global`
+    - not available
+    - ❌
+    - available
+
+  * - :cmd:`Canonical Structure`
+    - :attr:`global`
+    - not available
+    - ❌
+    - available
+
+  * - ``Hints`` (and :cmd:`Instance`)
+    - :attr:`local`
+    - not available
+    - ❌
+    - ❌
+
+  * - :cmd:`Set` or :cmd:`Unset` a flag
+    - :attr:`local`
+    - not available
+    - available
+    - available
 
 .. _Admissible-rules-for-global-environments:
 

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -143,13 +143,13 @@ Summary of locality attributes in a section
 -------------------------------------------
 
 This table sums up the effect of locality attributes on the scope of vernacular
-commands in a section, when outside the section where they were entered. In the
+commands in a :cmd:`Section`, when outside the :cmd:`Section` where they were entered. In the
 following table:
 
 * a cross (❌) marks an unsupported attribute (compilation error);
-* “not available” means that the command has no effect outside the section it
+* “not available” means that the command has no effect outside the :cmd:`Section` it
   was entered;
-* “available” means that the effects of the command persists outside the section.
+* “available” means that the effects of the command persists outside the :cmd:`Section`.
 * For :cmd:`Definition` (and :cmd:`Lemma`, ...), :cmd:`Canonical Structure`,
   :cmd:`Coercion` and :cmd:`Set` (and :cmd:`Unset`), some locality attributes
   will be passed on to the :cmd:`Module` containing the current :cmd:`Section`,
@@ -245,22 +245,27 @@ A similar table for :cmd:`Module` can be found
       module [#note3]_
 
 .. [#note1] For :cmd:`Definition`, :cmd:`Lemma`, ... the default visibility is
-   to be available outside the section and available with a short name when
-   imported outside the current module. The :attr:`local` attribute make the
-   corresponding identifiers available in the current module but only with a
-   fully qualified name outside the current module.
+   to be available outside the section and available with a short name when the
+   current :cmd:`Module` is imported (with :cmd:`Import` or cmd:`Export`)
+   outside the current :cmd:`Module`.
+   The :attr:`local` attribute make the corresponding identifiers available in
+   the current :cmd:`Module` but only with a fully qualified name outside the
+   current :cmd:`Module`.
 
-.. [#note2] For :cmd:`Coercion` and :cmd:`Canonical Structure`, the :attr:`global`
-   visibility, which is the default, makes them available outside the section,
-   in the current module, and outside the current module when it is imported.
+.. [#note2] For :cmd:`Coercion` and :cmd:`Canonical Structure`, the
+   :attr:`global` visibility, which is the default, makes them available outside
+   the section, in the current :cmd:`Module`, and outside the current
+   :cmd:`Module` when it is imported (with :cmd:`Import` or cmd:`Export`).
 
 .. [#note3] For :cmd:`Set` and :cmd:`Unset`, the :attr:`export` and
    :attr:`global` attributes both make the command's effects persist outside the
-   current section, in the current module. It will also persist outside the
-   current module with the :attr:`global` attribute, or with the :attr:`export`
-   attribute, when the module is imported.
+   current section, in the current :cmd:`Module`.
+   It will also persist outside the current :cmd:`Module` with the
+   :attr:`global` attribute, or with the :attr:`export` attribute, when the
+   :cmd:`Module` is imported (with :cmd:`Import` or cmd:`Export`).
    The default behaviour (no attribute) is to make the setting persist outside
-   the section in the current module, but not outside the current module.
+   the section in the current :cmd:`Module`, but not outside the current
+   :cmd:`Module`.
 
 .. _Admissible-rules-for-global-environments:
 

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -136,8 +136,8 @@ usable outside the section as shown in this :ref:`example <section_local_declara
 Summary of locality attributes in a section
 -------------------------------------------
 
-The following table sums up the locality of vernacular commands in modules, when
-outside the module.
+The following table sums up the locality of vernacular commands in sections, when
+outside the section it was entered.
 A similar table for :cmd:`Module` can be found
 :ref:`here <visibility-attributes-modules>`.
 
@@ -151,56 +151,68 @@ A similar table for :cmd:`Module` can be found
     - :attr:`global`
 
   * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - available
+    - same as :attr:`local`
     - available
     - attribute not supported
     - attribute not supported
 
   * - :cmd:`Notation`
-    - not available outside
-    - not available outside
+    - same as :`local`
+    - not available
     - attribute not supported
     - attribute not supported
 
   * - :cmd:`Notation (abbreviation)`
-    - not available outside
-    - not available outside
+    - same as :attr:`local`
+    - not available
     - attribute not supported
     - attribute not supported
 
   * - ``Hints`` (and :cmd:`Instance`)
-    - not available outside
-    - not available outside
+    - same as :attr:`local`
+    - not available
     - attribute not supported
     - attribute not supported
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - not available outside
-    - not available outside
-    - available outside
-    - available outside
+    - same as :attr:`local`
+    - no effect
+    - in effect
+    - in effect
 
   * - :cmd:`Canonical Structure`
-    - available outside
-    - not available outside
+    - same as :attr:`global`
+    - not available
     - attribute not supported
-    - available outside
-
-  * - :cmd:`Ltac`
-    - not available outside
-    - not available outside
-    - attribute not supported
-    - attribute not supported
+    - available
 
   * - :cmd:`Coercion`
-    - available outside
+    - same as :attr:`global`
+    - not available
+    - attribute not supported
+    - available
+
+  * - :cmd:`Ltac`
+    - same as :attr:`local`
     - not available outside
     - attribute not supported
-    - available outside
+    - attribute not supported
+
+  * - :cmd:`Ltac2`
+    - same as :attr:`local`
+    - not available outside
+    - attribute not supported
+    - attribute not supported
 
   * - :cmd:`Tactic Notation`
-    - not available outside
-    - not available outside
+    - same as :attr:`local`
+    - not available
+    - attribute not supported
+    - attribute not supported
+
+  * - :cmd:`Ltac2 Notation`
+    - same as :attr:`local`
+    - not available
     - attribute not supported
     - attribute not supported
 

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -4,15 +4,19 @@ Sections
 ====================================
 
 Sections are naming scopes that permit creating section-local declarations that can
-be used by other declarations in the section.  Declarations made
-with :cmd:`Variable`, :cmd:`Hypothesis`, :cmd:`Context`,
-:cmd:`Let`, :cmd:`Let Fixpoint` and
-:cmd:`Let CoFixpoint` (or the plural variants of the first two) within sections
-are local to the section.
+be used by other declarations in the section. Declarations made with
+:cmd:`Variable`, :cmd:`Hypothesis`, :cmd:`Context`
+(or the plural variants of the first two)
+and definitions made with
+:cmd:`Let`, :cmd:`Let Fixpoint` and :cmd:`Let CoFixpoint`
+within sections are local to the section.
 
 In proofs done within the section, section-local declarations
 are included in the :term:`local context` of the initial goal of the proof.
 They are also accessible in definitions made with the :cmd:`Definition` command.
+
+Using sections
+--------------
 
 Sections are opened by the :cmd:`Section` command, and closed by :cmd:`End`.
 Sections can be nested.
@@ -48,6 +52,8 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    Most commands, such as the :ref:`Hint <creating_hints>` commands,
    :cmd:`Notation` and option management commands that
    appear inside a section are canceled when the section is closed.
+   In some cases, this behaviour can be tuned with locality attributes.
+   See :ref:`this table<visibility-attributes-sections>`.
 
 .. cmd:: Let @ident_decl @def_body
          Let Fixpoint @fix_definition {* with @fix_definition }
@@ -141,8 +147,14 @@ commands in a section, when outside the section where they were entered. In the
 following table:
 
 * a cross (❌) marks an unsupported attribute (compilation error);
-* "not available" means that the command has no effect outside the section it was entered;
-* "available" means that the effect of the command persists outside the section.
+* “not available” means that the command has no effect outside the section it
+  was entered;
+* “available” means that the effects of the command persists outside the section.
+* For :cmd:`Definition` (and :cmd:`Lemma`, ...), :cmd:`Canonical Structure`,
+  :cmd:`Coercion` and :cmd:`Set` (and :cmd:`Unset`), some locality attributes
+  will be passed on to the :cmd:`Module` containing the current :cmd:`Section`,
+  see the associated footnotes.
+
 
 A similar table for :cmd:`Module` can be found
 :ref:`here <visibility-attributes-modules>`.
@@ -157,8 +169,10 @@ A similar table for :cmd:`Module` can be found
     - :attr:`global`
 
   * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
-    - :attr:`local`
-    - available
+    - available [#note1]_
+    - :attr:`local` in
+
+      current module [#note1]_
     - ❌
     - ❌
 
@@ -202,13 +216,17 @@ A similar table for :cmd:`Module` can be found
     - :attr:`global`
     - not available
     - ❌
-    - available
+    - :attr:`global` in
+
+      current module [#note2]_
 
   * - :cmd:`Canonical Structure`
     - :attr:`global`
     - not available
     - ❌
-    - available
+    - :attr:`global` in
+
+      current module [#note2]_
 
   * - ``Hints`` (and :cmd:`Instance`)
     - :attr:`local`
@@ -217,10 +235,32 @@ A similar table for :cmd:`Module` can be found
     - ❌
 
   * - :cmd:`Set` or :cmd:`Unset` a flag
-    - :attr:`local`
+    - available
     - not available
-    - available
-    - available
+    - :attr:`export` in
+
+      current module [#note3]_
+    - :attr:`global` in
+
+      current module [#note3]_
+
+.. [#note1] For :cmd:`Definition`, :cmd:`Lemma`, ... the default visibility is
+   to be available outside the section and available with a short name when
+   imported outside the current module. The :attr:`local` attribute make the
+   corresponding identifiers available in the current module but only with a
+   fully qualified name outside the current module.
+
+.. [#note2] For :cmd:`Coercion` and :cmd:`Canonical Structure`, the :attr:`global`
+   visibility, which is the default, makes them available outside the section,
+   in the current module, and outside the current module when it is imported.
+
+.. [#note3] For :cmd:`Set` and :cmd:`Unset`, the :attr:`export` and
+   :attr:`global` attributes both make the command's effects persist outside the
+   current section, in the current module. It will also persist outside the
+   current module with the :attr:`global` attribute, or with the :attr:`export`
+   attribute, when the module is imported.
+   The default behaviour (no attribute) is to make the setting persist outside
+   the section in the current module, but not outside the current module.
 
 .. _Admissible-rules-for-global-environments:
 

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -131,6 +131,78 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    Notice the difference between the value of :g:`x'` and :g:`x''` inside section
    :g:`s1` and outside.
 
+.. _visibility-attributes-sections:
+
+Summary of locality attributes in a section
+-------------------------------------------
+
+The following table sums up the locality of vernacular commands in modules, when
+outside the module.
+A similar table for :cmd:`Module` can be found
+:ref:`here <visibility-attributes-modules>`.
+
+.. list-table::
+  :header-rows: 1
+
+  * - ``Command``
+    - without attribute
+    - :attr:`local`
+    - :attr:`export`
+    - :attr:`global`
+
+  * - :cmd:`Definition`, :cmd:`Lemma`, :cmd:`Axiom`, ...
+    - available
+    - available
+    - attribute not supported
+    - attribute not supported
+
+  * - :cmd:`Notation`
+    - not available outside
+    - not available outside
+    - attribute not supported
+    - attribute not supported
+
+  * - :cmd:`Notation (abbreviation)`
+    - not available outside
+    - not available outside
+    - attribute not supported
+    - attribute not supported
+
+  * - ``Hints`` (and :cmd:`Instance`)
+    - not available outside
+    - not available outside
+    - attribute not supported
+    - attribute not supported
+
+  * - :cmd:`Set` or :cmd:`Unset` a flag
+    - not available outside
+    - not available outside
+    - available outside
+    - available outside
+
+  * - :cmd:`Canonical Structure`
+    - available outside
+    - not available outside
+    - attribute not supported
+    - available outside
+
+  * - :cmd:`Ltac`
+    - not available outside
+    - not available outside
+    - attribute not supported
+    - attribute not supported
+
+  * - :cmd:`Coercion`
+    - available outside
+    - not available outside
+    - attribute not supported
+    - available outside
+
+  * - :cmd:`Tactic Notation`
+    - not available outside
+    - not available outside
+    - attribute not supported
+    - attribute not supported
 
 .. _Admissible-rules-for-global-environments:
 

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -41,6 +41,10 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    This command supports the :attr:`local` attribute.  When used, the
    structure is canonical only within the :cmd:`Section` containing it.
 
+   Outside a :cmd:`Section`, the structure is canonical as soon as
+   :cmd:`Import` (or one of its variants) has been used on the :cmd:`Module`
+   in which it is defined, regardless of its locality attribute, if any.
+
    :token:`qualid` (in :token:`reference`) denotes an object :n:`(Build_struct c__1 … c__n)` in the
    structure :g:`struct` for which the fields are :n:`x__1, …, x__n`.
    Then, each time an equation of the form :n:`(x__i _)` |eq_beta_delta_iota_zeta| :n:`c__i` has to be

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1892,6 +1892,11 @@ Abbreviations
    This command supports the :attr:`local` attribute, which limits the notation to the
    current module.
 
+   Unlike a :cmd:`Notation`, an abbreviation defined with the default locality
+   is available (with a fully qualified name) outside the current module even
+   when :cmd:`Import` (or one of its variants) has not been used on the current
+   :cmd:`Module`.
+
    An *abbreviation* is a name, possibly applied to arguments, that
    denotes a (presumably) more complex expression. Here are examples:
 

--- a/test-suite/success/locality_attributes_modules.v
+++ b/test-suite/success/locality_attributes_modules.v
@@ -1,0 +1,386 @@
+(** This file tests how locality attributes affect usual vernacular commands.
+    PLEASE, when this file fails to compute following a voluntary change in
+    Coq's behaviour, modify accordingly the tables in [sections.rst] and
+    [modules.rst] in [doc/sphinx/language/core] *)
+
+(** This structure is used to test availability or not of a
+    [Canonical Structure]. *)
+Structure PointedType : Type := { Carrier :> Set; point : Carrier }.
+
+(** This HintDb is used to test availability or not of a [Hint] command. *)
+Create HintDb plop.
+
+(** ** Tests for modules and visibility attributes *)
+
+(** *** Without attribute (default) *)
+
+Module InModuleDefault.
+
+Module Bar.
+  (* A parameter: *)
+  Parameter (secret : nat).
+  (* An axiom: *)
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  Lemma secret_42 : secret = 42.
+  Proof. find_secret. rfl. Qed.
+  (* A Canonical Structure: *)
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion: *)
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting: *)
+  Set Universe Polymorphism.
+  (* A Hint: *)
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the parameter *)
+Check Bar.secret.
+Fail Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Fail Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Fail Check (point nat).
+(* Availability of the coercion *)
+Fail Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Fail Check foo_ni@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_ni : Bar.secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of the parameter *)
+Check Bar.secret.
+Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Check secret_is_42.
+(* Availability of the tactic *)
+Print find_secret.
+Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Check add_42.
+Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. rfl. Qed.
+(* Availability of the notation *)
+Check (2 +p 3).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Fail Check foo_i@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_i : Bar.secret = 42.
+Proof.
+  solve [auto with plop].
+Qed.
+
+End InModuleDefault.
+
+Module InModuleLocal.
+Module Bar.
+  (* A parameter: *)
+  #[local]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  #[local]
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  #[local]
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  #[local]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  #[local]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  #[local]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  #[local]
+  Lemma secret_42 : secret = 42.
+  Proof. find_secret. rfl. Qed.
+  (* A Canonical Structure *)
+  #[local]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  #[local]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[local]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  #[local]
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the parameter *)
+Check Bar.secret.
+Fail Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Fail Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+Fail Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+Fail Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Fail Check (point nat).
+(* Availability of the coercion *)
+Fail Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Fail Check foo_ni@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_ni : Bar.secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of the parameter *)
+Check Bar.secret.
+Fail Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Fail Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+Fail Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+Fail Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of the coercion *)
+Fail Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Fail Check foo_i@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_i : Bar.secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+
+End InModuleLocal.
+
+Module InModuleExport.
+Module Bar.
+  (* A parameter: *)
+  Fail #[export]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  Fail #[export]
+  Axiom plop : 0 = 0.
+  (* A custom tactic: *)
+  Fail #[export]
+  Ltac find_secret := reflexivity.
+  (* An abbreviation: *)
+  Fail #[export]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  Fail #[export]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  Fail #[export]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  Fail #[export]
+  Lemma secret_42 : secret = 42.
+  (* A Canonical Structure *)
+  Fail #[export]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  Fail#[export]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[export]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  Parameter (secret : nat).
+  Axiom secret_42 : secret = 42.
+  #[export]
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Fail Check foo_ni@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_ni : Bar.secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Check foo_i@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_i : Bar.secret = 42.
+Proof.
+  solve [auto with plop].
+Qed.
+
+End InModuleExport.
+
+Module InModuleGlobal.
+Module Bar.
+  (* A parameter: *)
+  #[global]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  #[global]
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  #[global]
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  #[global]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  #[global]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  #[global]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  #[global]
+  Lemma secret_42 : secret = 42.
+  Proof. find_secret. rfl. Qed.
+  (* A Canonical Structure *)
+  #[global]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  #[global]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[global]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  #[global]
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the parameter *)
+Check Bar.secret.
+Fail Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Fail Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Fail Check (point nat).
+(* Availability of the coercion *)
+Fail Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Check foo_ni@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_ni : Bar.secret = 42.
+Proof.
+  solve [auto with plop].
+Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of the parameter *)
+Check Bar.secret.
+Check secret.
+(* Availability of the axiom *)
+Check Bar.secret_is_42.
+Check secret_is_42.
+(* Availability of the tactic *)
+Print find_secret.
+Print Bar.find_secret.
+(* Availability of the abbreviation *)
+Check add_42.
+Check Bar.add_42.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. rfl. Qed.
+(* Availability of the notation *)
+Check (2 +p 3).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Check foo_i@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_i : Bar.secret = 42.
+Proof.
+  solve [auto with plop].
+Qed.
+
+End InModuleGlobal.
+(** Since I have some global Hints and Settings, the corresponding tests
+   for Sections are in the file locality_attributes_sections.v *)

--- a/test-suite/success/locality_attributes_modules.v
+++ b/test-suite/success/locality_attributes_modules.v
@@ -1,7 +1,23 @@
 (** This file tests how locality attributes affect usual vernacular commands.
     PLEASE, when this file fails to compute following a voluntary change in
     Coq's behaviour, modify accordingly the tables in [sections.rst] and
-    [modules.rst] in [doc/sphinx/language/core] *)
+    [modules.rst] in [doc/sphinx/language/core].
+
+    Also look at the corresponding discussions about locality attributes in the
+    refman (directory doc/sphinx)
+    - For Definition, Lemma, ..., look at language/core/definitions.rst
+    - For Axiom, Conjecture, ..., look at language/core/assumptions.rst
+    - For abbreviations, look at user-extensions/syntax-extensions.rst
+    - For Notations, look at user-extensions/syntax-extensions.rst
+    - For Tactic Notations, look at user-extensions/syntax-extensions.rst
+    - For Ltac, look at proof-engine/ltac.rst
+    - For Canonical Structures, look at language/extensions/canonical.rst
+    - For Hints, look at proofs/automatic-tactics/auto.rst
+    - For Coercions, look at addendum/implicit-coercions.rst
+    - For Ltac2, look at proof-engine/ltac2.rst
+    - For Ltac2 Notations, look at proof-engine/ltac2.rst
+    - For Set, look at language/core/basic.rst
+*)
 
 (** This structure is used to test availability or not of a
     [Canonical Structure]. *)

--- a/test-suite/success/locality_attributes_modules_ltac2.v
+++ b/test-suite/success/locality_attributes_modules_ltac2.v
@@ -113,3 +113,4 @@ Print Bar.find_secret.
 (* Availability of the tactic notation *)
 Lemma plop_i : 2 + 2 = 4.
 Proof. rfl. Qed.
+End InModuleGlobal.

--- a/test-suite/success/locality_attributes_modules_ltac2.v
+++ b/test-suite/success/locality_attributes_modules_ltac2.v
@@ -1,7 +1,23 @@
 (** This file tests how locality attributes affect usual vernacular commands.
     PLEASE, when this file fails to compute following a voluntary change in
     Coq's behaviour, modify accordingly the tables in [sections.rst] and
-    [modules.rst] in [doc/sphinx/language/core] *)
+    [modules.rst] in [doc/sphinx/language/core]
+
+    Also look at the corresponding discussions about locality attributes in the
+    refman (directory doc/sphinx)
+    - For Definition, Lemma, ..., look at language/core/definitions.rst
+    - For Axiom, Conjecture, ..., look at language/core/assumptions.rst
+    - For abbreviations, look at user-extensions/syntax-extensions.rst
+    - For Notations, look at user-extensions/syntax-extensions.rst
+    - For Tactic Notations, look at user-extensions/syntax-extensions.rst
+    - For Ltac, look at proof-engine/ltac.rst
+    - For Canonical Structures, look at language/extensions/canonical.rst
+    - For Hints, look at proofs/automatic-tactics/auto.rst
+    - For Coercions, look at addendum/implicit-coercions.rst
+    - For Ltac2, look at proof-engine/ltac2.rst
+    - For Ltac2 Notations, look at proof-engine/ltac2.rst
+    - For Set, look at language/core/basic.rst
+*)
 
 From Ltac2 Require Import Ltac2.
 

--- a/test-suite/success/locality_attributes_modules_ltac2.v
+++ b/test-suite/success/locality_attributes_modules_ltac2.v
@@ -1,0 +1,115 @@
+(** This file tests how locality attributes affect usual vernacular commands.
+    PLEASE, when this file fails to compute following a voluntary change in
+    Coq's behaviour, modify accordingly the tables in [sections.rst] and
+    [modules.rst] in [doc/sphinx/language/core] *)
+
+From Ltac2 Require Import Ltac2.
+
+(** ** Tests for modules and visibility attributes with Ltac2 *)
+
+(* A parameter: *)
+Parameter (secret : nat).
+(* An axiom: *)
+Axiom secret_is_42 : secret = 42.
+
+(** *** Without attribute (default) *)
+
+Module InModuleDefault.
+
+Module Bar.
+  (* A custom tactic: *)
+  Ltac2 find_secret () := rewrite secret_is_42.
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of the tactic *)
+Print find_secret.
+Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. rfl. Qed.
+
+End InModuleDefault.
+
+Module InModuleLocal.
+Module Bar.
+  #[local]
+  Ltac2 find_secret () := rewrite secret_is_42.
+  #[local]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+Fail Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+(* Availability of the tactic *)
+Fail Print find_secret.
+Fail Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+
+End InModuleLocal.
+
+Module InModuleExport.
+Module Bar.
+  (* A custom tactic: *)
+  Fail #[export]
+  Ltac2 find_secret := reflexivity.
+  (* A tactic notation: *)
+  Fail #[export]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(** Nothing to check, Ltac2 and Ltac2 Notation do not support the [export]
+   attribute. *)
+
+End InModuleExport.
+
+Module InModuleGlobal.
+Module Bar.
+  #[global]
+  Ltac2 find_secret () := rewrite secret_is_42.
+  (* A tactic notation: *)
+  #[global]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+
+(** **** After importing: *)
+
+Import Bar.
+Print find_secret.
+Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. rfl. Qed.

--- a/test-suite/success/locality_attributes_sections.v
+++ b/test-suite/success/locality_attributes_sections.v
@@ -1,0 +1,235 @@
+(** This file tests how locality attributes affect usual vernacular commands.
+    PLEASE, when this file fails to compute following a voluntary change in
+    Coq's behaviour, modify accordingly the tables in [sections.rst] and
+    [modules.rst] in [doc/sphinx/language/core] *)
+
+(** This structure is used to test availability or not of a
+    [Canonical Structure]. *)
+Structure PointedType : Type := { Carrier :> Set; point : Carrier }.
+
+(** This HintDb is used to test availability or not of a [Hint] command. *)
+Create HintDb plop.
+
+(** ** Tests for sections and visibility attributes *)
+
+(** *** Without attribute (default) *)
+
+Module InSectionDefault.
+
+Section Bar.
+  (* A parameter: *)
+  Parameter (secret : nat).
+  (* An axiom: *)
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  Lemma secret_42 : secret = 42.
+  Proof. find_secret. rfl. Qed.
+  (* A Canonical Structure: *)
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion: *)
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting: *)
+  Set Universe Polymorphism.
+  (* A Hint: *)
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(* Availability of the parameter *)
+Check secret.
+(* Availability of the axiom *)
+Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+(* Availability of the tactic notation *)
+Lemma plop_i : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Check foo_i@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_i : secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+
+End InSectionDefault.
+
+Module InSectionLocal.
+
+Section Bar.
+  (* A parameter: *)
+  #[local]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  #[local]
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  #[local]
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  #[local]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  #[local]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  #[local]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  #[local]
+  Lemma secret_42 : secret = 42.
+  Proof. find_secret. rfl. Qed.
+  (* A Canonical Structure *)
+  #[local]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  #[local]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[local]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  #[local]
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the parameter *)
+Check secret.
+(* Availability of the axiom *)
+Check secret_is_42.
+(* Availability of the tactic *)
+Fail Print find_secret.
+(* Availability of the abbreviation *)
+Fail Check add_42.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+(* Availability of the notation *)
+Fail Check (2 +p 3).
+(* Availability of the canonical structure *)
+Fail Check (point nat).
+(* Availability of the coercion *)
+Fail Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Fail Check foo_ni@{_}.
+(* Availability of the [Hint] *)
+Lemma hop_ni : secret = 42.
+Proof.
+  Fail solve [auto with plop].
+Admitted.
+End InSectionLocal.
+
+Module InSectionExport.
+
+Section Bar.
+  (* A parameter: *)
+  Fail #[export]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  Fail #[export]
+  Axiom plop : 0 = 0.
+  (* A custom tactic: *)
+  Fail #[export]
+  Ltac find_secret := reflexivity.
+  (* An abbreviation: *)
+  Fail #[export]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  Fail #[export]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  Fail #[export]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A lemma: *)
+  Fail #[export]
+  Lemma secret_42 : secret = 42.
+  (* A Canonical Structure *)
+  Fail #[export]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  Fail#[export]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[export]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  Parameter (secret : nat).
+  Axiom secret_42 : secret = 42.
+  Fail #[export]
+  Hint Resolve secret_42 : plop.
+End Bar.
+
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Check foo_ni@{_}.
+
+End InSectionExport.
+
+Module InSectionGlobal.
+Section Bar.
+  (* A parameter: *)
+  #[global]
+  Parameter (secret : nat).
+  (* An axiom: *)
+  #[global]
+  Axiom secret_is_42 : secret = 42.
+  (* A custom tactic: *)
+  Fail #[global]
+  Ltac find_secret := rewrite secret_is_42.
+  (* An abbreviation: *)
+  Fail #[global]
+  Notation add_42 := (Nat.add 42).
+  (* A tactic notation: *)
+  Fail #[global]
+  Tactic Notation "rfl" := reflexivity.
+  (* A notation: *)
+  Fail #[global]
+  Infix "+p" := Nat.add (only parsing, at level 30, right associativity) : nat_scope.
+  (* A Canonical Structure *)
+  #[global]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Coercion *)
+  #[global]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Setting *)
+  #[global]
+  Set Universe Polymorphism.
+  (* A Hint *)
+  Fail #[global]
+  Hint Resolve secret_is_42 : plop.
+End Bar.
+
+(** **** Without importing: *)
+
+(* Availability of the parameter *)
+Check secret.
+(* Availability of the axiom *)
+Check secret_is_42.
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Check foo_ni@{_}.
+
+End InSectionGlobal.

--- a/test-suite/success/locality_attributes_sections.v
+++ b/test-suite/success/locality_attributes_sections.v
@@ -1,7 +1,24 @@
 (** This file tests how locality attributes affect usual vernacular commands.
     PLEASE, when this file fails to compute following a voluntary change in
     Coq's behaviour, modify accordingly the tables in [sections.rst] and
-    [modules.rst] in [doc/sphinx/language/core] *)
+    [modules.rst] in [doc/sphinx/language/core].
+
+    Also look at the corresponding discussions about locality attributes in the
+    refman (directory doc/sphinx)
+    - For Definition, Lemma, ..., look at language/core/definitions.rst
+    - For Axiom, Conjecture, ..., look at language/core/assumptions.rst
+    - For abbreviations, look at user-extensions/syntax-extensions.rst
+    - For Notations, look at user-extensions/syntax-extensions.rst
+    - For Tactic Notations, look at user-extensions/syntax-extensions.rst
+    - For Ltac, look at proof-engine/ltac.rst
+    - For Canonical Structures, look at language/extensions/canonical.rst
+    - For Hints, look at proofs/automatic-tactics/auto.rst
+    - For Coercions, look at addendum/implicit-coercions.rst
+    - For Ltac2, look at proof-engine/ltac2.rst
+    - For Ltac2 Notations, look at proof-engine/ltac2.rst
+    - For Set, look at language/core/basic.rst
+*)
+
 
 (** This structure is used to test availability or not of a
     [Canonical Structure]. *)

--- a/test-suite/success/locality_attributes_sections_in_modules.v
+++ b/test-suite/success/locality_attributes_sections_in_modules.v
@@ -1,7 +1,24 @@
 (** This file tests how locality attributes affect usual vernacular commands.
     PLEASE, when this file fails to compute following a voluntary change in
     Coq's behaviour, modify accordingly the tables in [sections.rst] and
-    [modules.rst] in [doc/sphinx/language/core] *)
+    [modules.rst] in [doc/sphinx/language/core].
+
+    Also look at the corresponding discussions about locality attributes in the
+    refman (directory doc/sphinx)
+    - For Definition, Lemma, ..., look at language/core/definitions.rst
+    - For Axiom, Conjecture, ..., look at language/core/assumptions.rst
+    - For abbreviations, look at user-extensions/syntax-extensions.rst
+    - For Notations, look at user-extensions/syntax-extensions.rst
+    - For Tactic Notations, look at user-extensions/syntax-extensions.rst
+    - For Ltac, look at proof-engine/ltac.rst
+    - For Canonical Structures, look at language/extensions/canonical.rst
+    - For Hints, look at proofs/automatic-tactics/auto.rst
+    - For Coercions, look at addendum/implicit-coercions.rst
+    - For Ltac2, look at proof-engine/ltac2.rst
+    - For Ltac2 Notations, look at proof-engine/ltac2.rst
+    - For Set, look at language/core/basic.rst
+*)
+
 
 (** This structure is used to test availability or not of a
     [Canonical Structure]. *)

--- a/test-suite/success/locality_attributes_sections_in_modules.v
+++ b/test-suite/success/locality_attributes_sections_in_modules.v
@@ -1,0 +1,164 @@
+(** This file tests how locality attributes affect usual vernacular commands.
+    PLEASE, when this file fails to compute following a voluntary change in
+    Coq's behaviour, modify accordingly the tables in [sections.rst] and
+    [modules.rst] in [doc/sphinx/language/core] *)
+
+(** This structure is used to test availability or not of a
+    [Canonical Structure]. *)
+Structure PointedType : Type := { Carrier :> Set; point : Carrier }.
+
+(** ** Tests of visibility attributes in a section inside a module *)
+
+(** We only test [Definition], [Coercion], [Canonical] and [Set], the other
+    commands only support the [local] attribute in sections, which is also
+    the default visibility, making them unavailable outside the section. *)
+
+(** *** Without attribute (default) *)
+
+Module InSectionDefault.
+
+Module M.
+Section Bar.
+  (* A definition: *)
+  Definition foo := 42.
+  (* A Coercion: *)
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Canonical Structure: *)
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Setting: *)
+  Set Universe Polymorphism.
+End Bar.
+End M.
+
+Module M_not_imported.
+(** First, we do not import M. *)
+(* Availability of the definition *)
+Fail Check foo. (* not imported *)
+(* Availability of the coercion *)
+Fail Check (true + 2). (* not imported *)
+(* Availability of the canonical structure *)
+Fail Check (point nat). (* not imported *)
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Fail Check foo_i@{_}.
+End M_not_imported.
+
+Module M_imported.
+(** Now we import M. *)
+Import M.
+(* Availability of the definition *)
+Check foo.
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Fail Check foo_i@{_}.
+End M_imported.
+
+End InSectionDefault.
+
+(** *** With the [local] attribute *)
+(** We only need to test a definition, we know the other commands have no effect
+    outside the section (hence outside the module containing the section). *)
+Module InSectionLocal.
+
+Module M.
+Section Bar.
+  (* A definition: *)
+  #[local]
+  Definition foo := 42.
+End Bar.
+End M.
+
+Module M_not_imported.
+(** First, we do not import M. *)
+(* Availability of the definition *)
+Fail Check foo. (* not imported *)
+Check M.foo.
+End M_not_imported.
+
+Module M_imported.
+(** Now we import M. *)
+Import M.
+(* Availability of the definition *)
+Fail Check foo.
+(* /!\ notice the local attribute has been passed to the module! *)
+Check M.foo.
+End M_imported.
+
+End InSectionLocal.
+
+(** *** With the [export] attribute *)
+(** We only need to test a setting, it is the only command for which [export]
+    is supported inside a [Section]. *)
+Module InSectionExport.
+
+Module M.
+Section Bar.
+  (* A Setting *)
+  #[export]
+  Set Universe Polymorphism.
+End Bar.
+End M.
+
+Module M_not_imported.
+(** **** Without importing: *)
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Fail Check foo_ni@{_}.
+End M_not_imported.
+
+Module M_imported.
+Import M.
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_ni@{u} := nat.
+Check foo_ni@{_}.
+End M_imported.
+End InSectionExport.
+
+(** *** With the [export] attribute *)
+(** We only need to test [Coercion], [Canonical] and [Set]. *)
+
+Module InSectionGlobal.
+
+Module M.
+Section Bar.
+  (* A Coercion: *)
+  #[global]
+  Coercion to_nat (b : bool) := if b then 1 else 0.
+  (* A Canonical Structure: *)
+  #[global]
+  Canonical natPointed : PointedType := {| Carrier := nat; point := 42 |}.
+  (* A Setting: *)
+  #[global]
+  Set Universe Polymorphism.
+End Bar.
+End M.
+
+Module M_not_imported.
+(** First, we do not import M. *)
+(* Availability of the coercion *)
+Fail Check (true + 2). (* not imported *)
+(* Availability of the canonical structure *)
+Fail Check (point nat). (* not imported *)
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Check foo_i@{_}. (* available *)
+(* /!\ global for [Set] in a section is passed to the module! *)
+End M_not_imported.
+
+Module M_imported.
+(** Now we import M. *)
+Import M.
+(* Availability of the coercion *)
+Check (true + 2).
+(* Availability of the canonical structure *)
+Check (point nat).
+(* Availability of [Set Universe Polymorphism] *)
+Definition foo_i@{u} := nat.
+Check foo_i@{_}.
+End M_imported.
+
+End InSectionGlobal.

--- a/test-suite/success/locality_attributes_sections_ltac2.v
+++ b/test-suite/success/locality_attributes_sections_ltac2.v
@@ -1,0 +1,78 @@
+(** This file tests how locality attributes affect usual vernacular commands.
+    PLEASE, when this file fails to compute following a voluntary change in
+    Coq's behaviour, modify accordingly the tables in [sections.rst] and
+    [modules.rst] in [doc/sphinx/language/core] *)
+
+From Ltac2 Require Import Ltac2.
+
+(** ** Tests for sections and visibility attributes with Ltac2 *)
+
+(* A parameter: *)
+Parameter (secret : nat).
+(* An axiom: *)
+Axiom secret_is_42 : secret = 42.
+
+(** *** Without attribute (default) *)
+
+Module InSectionDefault.
+
+Section Bar.
+  (* A custom tactic: *)
+  Ltac2 find_secret () := rewrite secret_is_42.
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+
+End InSectionDefault.
+
+Module InSectionLocal.
+Section Bar.
+  #[local]
+  Ltac2 find_secret () := rewrite secret_is_42.
+  #[local]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+Fail Print Bar.find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.
+End InSectionLocal.
+
+Module InSectionExport.
+Section Bar.
+  (* A custom tactic: *)
+  Fail #[export]
+  Ltac2 find_secret := reflexivity.
+  (* A tactic notation: *)
+  Fail #[export]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(** Nothing to check, Ltac2 and Ltac2 Notation do not support the [export]
+   attribute. *)
+
+End InSectionExport.
+
+Module InSectionGlobal.
+Section Bar.
+  (* A custom tactic: *)
+  #[global]
+  Ltac2 find_secret () := rewrite secret_is_42.
+  (* A tactic notation: *)
+  #[global]
+  Ltac2 Notation "rfl" := reflexivity.
+End Bar.
+
+(* Availability of the tactic *)
+Fail Print find_secret.
+(* Availability of the tactic notation *)
+Lemma plop_ni : 2 + 2 = 4.
+Proof. Fail rfl. Admitted.

--- a/test-suite/success/locality_attributes_sections_ltac2.v
+++ b/test-suite/success/locality_attributes_sections_ltac2.v
@@ -76,3 +76,4 @@ Fail Print find_secret.
 (* Availability of the tactic notation *)
 Lemma plop_ni : 2 + 2 = 4.
 Proof. Fail rfl. Admitted.
+End InSectionGlobal.

--- a/test-suite/success/locality_attributes_sections_ltac2.v
+++ b/test-suite/success/locality_attributes_sections_ltac2.v
@@ -1,7 +1,24 @@
 (** This file tests how locality attributes affect usual vernacular commands.
     PLEASE, when this file fails to compute following a voluntary change in
     Coq's behaviour, modify accordingly the tables in [sections.rst] and
-    [modules.rst] in [doc/sphinx/language/core] *)
+    [modules.rst] in [doc/sphinx/language/core].
+
+    Also look at the corresponding discussions about locality attributes in the
+    refman (directory doc/sphinx)
+    - For Definition, Lemma, ..., look at language/core/definitions.rst
+    - For Axiom, Conjecture, ..., look at language/core/assumptions.rst
+    - For abbreviations, look at user-extensions/syntax-extensions.rst
+    - For Notations, look at user-extensions/syntax-extensions.rst
+    - For Tactic Notations, look at user-extensions/syntax-extensions.rst
+    - For Ltac, look at proof-engine/ltac.rst
+    - For Canonical Structures, look at language/extensions/canonical.rst
+    - For Hints, look at proofs/automatic-tactics/auto.rst
+    - For Coercions, look at addendum/implicit-coercions.rst
+    - For Ltac2, look at proof-engine/ltac2.rst
+    - For Ltac2 Notations, look at proof-engine/ltac2.rst
+    - For Set, look at language/core/basic.rst
+*)
+
 
 From Ltac2 Require Import Ltac2.
 


### PR DESCRIPTION
Table of locality attributes behaviour in `modules.rst`.
TODO:
- [x] Check if refman looks good enough
- [x] Double-check that tables are right, possibly adding a test file

- table for modules: [here](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/4641455/artifacts/_build/default/doc/refman-html/language/core/modules.html#summary-of-locality-attributes-in-a-module)
- table for sections: [here](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/4641455/artifacts/_build/default/doc/refman-html/language/core/sections.html#summary-of-locality-attributes-in-a-section)