### PR TITLE
Fix double substitution of relevance annotations in cclosure

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1391,9 +1391,9 @@ and knht info e t stk =
       { mark = Cstr; term = FCoFix (cfx,e) }, stk
     | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
     | Prod (n, t, c) ->
-      { mark = Ntrl; term = FProd (usubst_binder e n, mk_clos e t, c, e) }, stk
+      { mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
     | LetIn (n,b,t,c) ->
-      { mark = Red; term = FLetIn (usubst_binder e n, mk_clos e b, mk_clos e t, c, e) }, stk
+      { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk

--- a/test-suite/bugs/bug_19325.v
+++ b/test-suite/bugs/bug_19325.v
@@ -1,0 +1,8 @@
+Set Universe Polymorphism.
+
+Definition relation@{s|u|} (A : Type@{s|u}) := A -> Set.
+Axiom fail@{a s|a u+|+} : forall {A : Type@{s|u}}, relation@{s|u} (A -> A).
+
+Arguments fail {A}%_type _.
+
+About fail.


### PR DESCRIPTION
Fix #19325

Binders are already documented to be non substituted in cclosure.mli,
this fixes the code to match the documentation.

AFAICT the bug can't be exploited in the kernel in coqc without a plugin, because the toplevel instance will not contain Var so substitution by it is idempotent.

It can probably be exploited by a plugin (which can declare constants pre-univpoly-abstracted) and in coqchk.
