### PR TITLE
API for fast demote

### DIFF
--- a/dev/ci/user-overlays/19336-gares-demote-demote.sh
+++ b/dev/ci/user-overlays/19336-gares-demote-demote.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/LPCIC/coq-elpi master-of-the-universes 19336

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -179,9 +179,9 @@ val merge_sort_context : ?loc:Loc.t -> sideff:bool -> rigid -> t -> UnivGen.sort
 
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 
-val demote_global_univs : Environ.env -> t -> t
+val demote_global_univs : Univ.ContextSet.t -> t -> t
 (** Removes from the uctx_local part of the UState the universes and constraints
-    that are present in the universe graph in the input env (supposedly the
+    that are present in the input constraint set (supposedly the
     global ones) *)
 
 val demote_seff_univs : Univ.Level.Set.t -> t -> t

--- a/engine/univFlex.ml
+++ b/engine/univFlex.ml
@@ -55,6 +55,8 @@ let add l ~algebraic {subst; algs} =
   let algs = if algebraic then Level.Set.add l algs else algs in
   { subst; algs }
 
+let remove l { subst; algs } = { subst = Level.Map.remove l subst; algs = Level.Set.remove l algs }
+
 let add_levels levels ~algebraic subst =
   Level.Set.fold (fun l subst -> add l ~algebraic subst) levels subst
 

--- a/engine/univFlex.mli
+++ b/engine/univFlex.mli
@@ -46,8 +46,10 @@ val fix_undefined_variables : t -> t
 (** Make all undefined flexible levels into rigid levels, ie remove them. *)
 
 val add : Level.t -> algebraic:bool -> t -> t
-(** MAkes a level flexible with no definition.
+(** Makes a level flexible with no definition.
     It must not already be flexible. *)
+
+val remove :  Level.t -> t -> t
 
 val add_levels : Level.Set.t -> algebraic:bool -> t -> t
 (** Make the levels flexible with no definitions.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -910,6 +910,10 @@ let declare_definition_core ~info ~cinfo ~opaque ~obls ~body ?using sigma =
 let declare_definition ~info ~cinfo ~opaque ~body ?using sigma =
   declare_definition_core ~obls:[] ~info ~cinfo ~opaque ~body ?using sigma |> fst
 
+let declare_definition_full ~info ~cinfo ~opaque ~body ?using sigma =
+  let c, uctx = declare_definition_core ~obls:[] ~info ~cinfo ~opaque ~body ?using sigma in
+  c, if info.poly then Univ.ContextSet.empty else UState.context_set uctx
+
 let prepare_obligations ~name ?types ~body env sigma =
   let env = Global.env () in
   let types = match types with

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -437,6 +437,17 @@ val declare_constant
   -> constant_entry
   -> Constant.t
 
+(** Like [declare_definition] but also returns the universes and universe constraints added to the
+    global environment *)
+val declare_definition_full
+  :  info:Info.t
+  -> cinfo:EConstr.t option CInfo.t
+  -> opaque:bool
+  -> body:EConstr.t
+  -> ?using:Vernacexpr.section_subset_expr
+  -> Evd.evar_map
+  -> GlobRef.t * Univ.ContextSet.t
+
 (** Declaration messages, for internal use *)
 
 (** XXX: Scheduled for removal from public API, do not use *)


### PR DESCRIPTION
This PR updates the API so that clients of declare.ml can efficiently demote from the evar map the universes and constraints that were made global by the declaration. The perf gain is visible in HB intensive code.

```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────┬────────────────────────────────────────┬─────────────────────────┐
│                        │      user time [s]      │             CPU cycles              │            CPU instructions            │  max resident mem [KB]  │
│                        │                         │                                     │                                        │                         │
│      package_name      │   NEW      OLD    PDIFF │      NEW            OLD       PDIFF │      NEW             OLD        PDIFF  │   NEW      OLD    PDIFF │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┤
│   coq-mathcomp-algebra │  186.70   204.63  -8.76 │  844756057020   924235863039  -8.60 │  1301083874266   1454289307432  -10.53 │ 1261436  1261104   0.03 │
│ coq-mathcomp-ssreflect │  140.96   154.37  -8.69 │  635160227863   693781911850  -8.45 │   924663537038   1032186906461  -10.42 │ 1679820  1660888   1.14 │
│     coq-mathcomp-field │  113.01   119.74  -5.62 │  510863738242   540275198787  -5.44 │   809243396917    860041835545   -5.91 │ 1278492  1253632   1.98 │
│  coq-mathcomp-analysis │  632.02   663.14  -4.69 │ 2865096199842  3000334722778  -4.51 │  4657174112015   4898901455142   -4.93 │ 1784432  1902072  -6.18 │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────┴────────────────────────────────────────┴─────────────────────────┘
```


overlay PR:
- https://github.com/LPCIC/coq-elpi/pull/651