### PR TITLE
[flags] Deprecate methods for working imperatively with "options"

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -94,9 +94,9 @@ let print_projections = ref false
 
 let print_meta_as_hole = ref false
 
-let with_universes f = Flags.with_option print_universes f
-let with_meta_as_hole f = Flags.with_option print_meta_as_hole f
-let without_symbols f = Flags.with_option print_no_symbol f
+let with_universes f = Flags.with_option print_universes f [@ocaml.warning "-3"]
+let with_meta_as_hole f = Flags.with_option print_meta_as_hole f [@ocaml.warning "-3"]
+let without_symbols f = Flags.with_option print_no_symbol f [@ocaml.warning "-3"]
 
 (**********************************************************************)
 (* Control printing of records *)

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -8,27 +8,19 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* If [restore] is false, whenever [f] modifies the ref, we will
-   preserve the modification. *)
-let with_modified_ref ?(restore=true) r nf f x =
+let with_modified_ref r nf f x =
   let old_ref = !r in r := nf !r;
   try
-    let pre = !r in
     let res = f x in
-    (* If r was modified don't restore its old value *)
-    if restore || pre == !r then r := old_ref;
+    r := old_ref;
     res
   with reraise ->
     let reraise = Exninfo.capture reraise in
     r := old_ref;
     Exninfo.iraise reraise
 
-let with_option o f x = with_modified_ref ~restore:false o (fun _ -> true) f x
-let without_option o f x = with_modified_ref ~restore:false o (fun _ -> false) f x
-let with_extra_values o l f x = with_modified_ref o (fun ol -> ol@l) f x
-
-(* hide the [restore] option as internal *)
-let with_modified_ref r nf f x = with_modified_ref r nf f x
+let with_option o f x = with_modified_ref o (fun _ -> true) f x
+let without_option o f x = with_modified_ref o (fun _ -> false) f x
 
 let with_options ol f x =
   let vl = List.map (!) ol in

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -79,15 +79,24 @@ val with_modified_ref : 'c ref -> ('c -> 'c) -> ('a -> 'b) -> 'a -> 'b
 (** Temporarily activate an option (to activate option [o] on [f x y z],
    use [with_option o (f x y) z]) *)
 val with_option : bool ref -> ('a -> 'b) -> 'a -> 'b
+[@@ocaml.deprecated "using scoped global state to control command \
+                     options is deprecated and will stop to be \
+                     supported in the future; please favor a \
+                     functional parameter passing style instead"]
 
 (** As [with_option], but on several flags. *)
 val with_options : bool ref list -> ('a -> 'b) -> 'a -> 'b
+[@@ocaml.deprecated "using scoped global state to control command \
+                     options is deprecated and will stop to be \
+                     supported in the future; please favor a \
+                     functional parameter passing style instead"]
 
 (** Temporarily deactivate an option *)
 val without_option : bool ref -> ('a -> 'b) -> 'a -> 'b
-
-(** Temporarily extends the reference to a list *)
-val with_extra_values : 'c list ref -> 'c list -> ('a -> 'b) -> 'a -> 'b
+[@@ocaml.deprecated "using scoped global state to control command \
+                     options is deprecated and will stop to be \
+                     supported in the future; please favor a \
+                     functional parameter passing style instead"]
 
 (** Level of inlining during a functor application *)
 val set_inline_level : int -> unit
@@ -96,7 +105,6 @@ val default_inline_level : int
 
 (** Default output directory *)
 val output_directory : CUnix.physical_path option ref
-
 
 (** Flag set when the test-suite is called. Its only effect to display
     verbose information for [Fail] *)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -112,6 +112,7 @@ let compile_file opts stm_opts copts injections (f_in, echo) =
   if !Flags.beautify then
     Flags.with_option Flags.beautify_file
       (fun f_in -> compile opts stm_opts copts injections ~echo ~f_in ~f_out) f_in
+    [@ocaml.warning "-3"]
   else
     compile opts stm_opts copts injections ~echo ~f_in ~f_out
 

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -45,6 +45,7 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
     let access = Library.indirect_accessor[@@warning "-3"] in
     Feedback.msg_notice Pp.(Flags.(with_option raw_print (fun () ->
         Prettyp.print_full_pure_context access env sigma) ()) ++ fnl ())
+    [@ocaml.warning "-3"]
   end;
   ()
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -445,6 +445,7 @@ let init_ocaml_path () =
 let init_and_run_ml_toploop () =
   init_ocaml_path ();
   Flags.with_option Flags.in_ml_toplevel (Mltop.ocaml_toploop ~init_file:"ml_toplevel/include") ()
+  [@ocaml.warning "-3"]
 
 (* We return whether the execution should continue and a new state *)
 let process_toplevel_command ~state stm =
@@ -549,6 +550,7 @@ let loop ~state =
         new_state in
     aux state
   ) ()
+ [@ocaml.warning "-3"]
 
 let run ~opts ~state =
   let open Coqargs in

--- a/toplevel/load.ml
+++ b/toplevel/load.ml
@@ -31,7 +31,7 @@ let load_vernacular opts ~state =
       (* Should make the beautify logic clearer *)
       let load_vernac f = Vernac.load_vernac ~echo ~check:true ~state f in
       if !Flags.beautify
-      then Flags.with_option Flags.beautify_file load_vernac f_in
+      then Flags.with_option Flags.beautify_file load_vernac f_in [@ocaml.warning "-3"]
       else load_vernac s
     ) state opts.pre.load_vernacular_list
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -133,8 +133,8 @@ let display_eq ~flags env sigma t1 t2 =
   (* terms are canonized, then their externalisation is compared syntactically *)
   let t1 = canonize_constr sigma t1 in
   let t2 = canonize_constr sigma t2 in
-  let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () in
-  let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () in
+  let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () [@ocaml.warning "-3"] in
+  let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () [@ocaml.warning "-3"] in
   match ct1, ct2 with
   | None, None -> false
   | Some _, None | None, Some _ -> false
@@ -152,8 +152,8 @@ let rec pr_explicit_aux env sigma t1 t2 = function
     (* The two terms are the same from the user point of view *)
     pr_explicit_aux env sigma t1 t2 rem
   else
-    let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () in
-    let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () in
+    let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () [@ocaml.warning "-3"] in
+    let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () [@ocaml.warning "-3"] in
     let pr = function
     | None -> str "??"
     | Some c -> Ppconstr.pr_lconstr_expr env sigma c
@@ -230,7 +230,7 @@ let explain_elim_arity env sigma ind c okinds =
     | None | Some AlwaysSquashed -> pp ()
     | Some (SometimesSquashed _) ->
       (* universe instance matters, so print it regardless of Printing Universes *)
-      Flags.with_option Constrextern.print_universes pp ()
+      Flags.with_option Constrextern.print_universes pp () [@ocaml.warning "-3"]
   in
   let pc = Option.map (pr_leconstr_env env sigma) c in
   let msg = match okinds with
@@ -238,7 +238,7 @@ let explain_elim_arity env sigma ind c okinds =
     | Some sp ->
       let ppt ?(ppunivs=false) () =
         let pp () = pr_leconstr_env env sigma (mkSort (ESorts.make sp)) in
-        if ppunivs then Flags.with_option Constrextern.print_universes pp ()
+        if ppunivs then Flags.with_option Constrextern.print_universes pp () [@ocaml.warning "-3"]
         else pp ()
       in
       let squash = Option.get (Inductive.is_squashed (specif, snd ind)) in
@@ -549,7 +549,8 @@ let explain_ill_formed_fix_body env sigma names i = function
           | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
      str "Recursive call to " ++ called ++ str " has not enough arguments"
   | FixpointOnNonEliminable (s, s') ->
-  let pr_sort u = quote @@ Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = quote @@
+    Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u [@ocaml.warning "-3"] in
     fmt "Cannot define a fixpoint@ with principal argument living in sort %t@ \
          to produce a value in sort %t@ because %t does not eliminate to %t"
       (fun () -> pr_sort s)
@@ -1489,7 +1490,7 @@ let error_large_non_prop_inductive_not_in_type () =
 
 let error_inductive_missing_constraints env (us,ind_univ) =
   let sigma = Evd.from_env env in
-  let pr_sort u = Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u [@ocaml.warning "-3"] in
   str "Missing universe constraint declared for inductive type:" ++ spc()
   ++ v 0 (prlist_with_sep spc (fun u ->
       hov 0 (pr_sort u ++ str " <= " ++ pr_sort ind_univ))

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -521,12 +521,13 @@ let pr_notation_declaration ntn_decl =
   ++ Flags.without_option Flags.beautify pr_constr c
   ++ pr_syntax_modifiers modifiers
   ++ pr_opt (fun sc -> spc () ++ str ":" ++ spc () ++ str sc) scopt
+ [@ocaml.warning "-3"]
 
 let pr_where_notation decl_ntn =
   fnl () ++ keyword "where " ++ pr_notation_declaration decl_ntn
 
 let pr_rec_definition (rec_order, { fname; univs; binders; rtype; body_def; notations }) =
-  let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c in
+  let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c [@ocaml.warning "-3"] in
   let annot = pr_guard_annot pr_lconstr_expr binders rec_order in
   pr_ident_decl (fname,univs) ++ pr_binders_arg binders ++ annot
   ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) rtype
@@ -544,7 +545,7 @@ let pr_rew_rule (ubinders, lhs, rhs) =
   | _ ->
     pr_universe_decl ubinders ++ spc() ++ str"|-"
   in
-  let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c in
+  let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c [@ocaml.warning "-3"] in
   binders ++ pr_pure_lconstr lhs ++ str"==>" ++ pr_pure_lconstr rhs
 
 (**************************************)
@@ -903,7 +904,7 @@ let pr_synpure_vernac_expr v =
   | VernacInductive (f,l) ->
     let pr_constructor ((attr,coe,ins),(id,c)) =
       hov 2 (pr_vernac_attributes attr ++ pr_lident id ++ pr_oc coe ins ++
-             Flags.without_option Flags.beautify pr_spc_lconstr c)
+             Flags.without_option Flags.beautify pr_spc_lconstr c [@ocaml.warning "-3"])
     in
     let pr_constructor_list l = match l with
       | Constructors [] -> mt()

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -502,4 +502,4 @@ and synterp_control ~intern CAst.{ loc; v = cmd } =
   CAst.make ?loc { expr; control; attrs = cmd.attrs }
 
 let synterp_control ~intern cmd =
-  Flags.with_modified_ref Flags.in_synterp_phase (fun _ -> Some true) (synterp_control ~intern) cmd
+  Flags.with_modified_ref Flags.in_synterp_phase (fun _ -> Some true) (synterp_control ~intern) cmd [@ocaml.warning "-3"]

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1869,7 +1869,7 @@ let vernac_reserve bl =
     let t,ctx = Constrintern.interp_type env sigma c in
     let t = Flags.without_option Detyping.print_universes (fun () ->
         Detyping.detype Detyping.Now env (Evd.from_ctx ctx) t)
-        ()
+        () [@ocaml.warning "-3"]
     in
     let t,_ = Notation_ops.notation_constr_of_glob_constr (default_env ()) t in
     Reserve.declare_reserved_type idl t)


### PR DESCRIPTION
See discussion in #19177 , indeed, there are some parts of Coq code that set some global imperative flags in a scoped way; this is tricky to get right and maintain, and given the current uses, we should not favor this style but instead make it deprecated.

As of today we have 3 kinds of these flags:

- printing: IMO it is a priority to make the printer fully functional, which will remove the uses here
- outlier: `do_auto_prop_lowering` , I am not expert on this but IMO current use doesn't look too good
- debug flags: they should be disabled in production

