### PR TITLE
Automatic Proposition Inductives handled more functionally

### DIFF
--- a/dev/ci/user-overlays/19346-SkySkimmer-func-auto-prop-lower.sh
+++ b/dev/ci/user-overlays/19346-SkySkimmer-func-auto-prop-lower.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi func-auto-prop-lower 19346

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1518,13 +1518,22 @@ let do_build_inductive evd (funconstants : pconstant list)
   (*     ) *)
   (*   in *)
   try
+    let flags = {
+      ComInductive.poly = false;
+      cumulative = false;
+      template = Some false;
+      auto_prop_lowering = false;
+      finite = Finite;
+    }
+    in
     with_full_print
       (Flags.silently
-         (ComInductive.do_mutual_inductive ~do_auto_prop_lowering:false
-            ~template:(Some false) None rel_inds
-            ~cumulative:false ~poly:false ~private_ind:false
-            ~uniform:ComInductive.NonUniformParameters))
-      Declarations.Finite
+         (fun () ->
+            ComInductive.do_mutual_inductive ~flags
+              None rel_inds
+              ~private_ind:false
+              ~uniform:ComInductive.NonUniformParameters))
+      ()
   with
   | UserError msg as e ->
     let repacked_rel_inds =

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1520,10 +1520,10 @@ let do_build_inductive evd (funconstants : pconstant list)
   try
     with_full_print
       (Flags.silently
-         (Flags.without_option ComInductive.Internal.do_auto_prop_lowering
-            (ComInductive.do_mutual_inductive ~template:(Some false) None rel_inds
-               ~cumulative:false ~poly:false ~private_ind:false
-               ~uniform:ComInductive.NonUniformParameters)))
+         (ComInductive.do_mutual_inductive ~do_auto_prop_lowering:false
+            ~template:(Some false) None rel_inds
+            ~cumulative:false ~poly:false ~private_ind:false
+            ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite
   with
   | UserError msg as e ->

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -204,16 +204,6 @@ let compute_constructor_levels env evd sign =
           (s :: lev, EConstr.push_rel d env))
     sign ([],env))
 
-let do_auto_prop_lowering = ref true
-let () =
-  Goptions.declare_bool_option {
-    optstage = Interp;
-    optdepr = None;
-    optkey = ["Automatic";"Proposition";"Inductives"];
-    optread = (fun () -> !do_auto_prop_lowering);
-    optwrite = (fun b -> do_auto_prop_lowering := b);
-  }
-
 let warn_auto_prop_lowering =
   CWarnings.create ~name:"automatic-prop-lowering" ~category:Deprecation.Version.v8_20
     Pp.(fun na ->
@@ -231,7 +221,7 @@ let is_flexible_sort evd s = match ESorts.kind evd s with
   | Some l -> Evd.is_flexible_level evd l
   | None -> false
 
-let prop_lowering_candidates evd ~arities_explicit inds =
+let prop_lowering_candidates ~do_auto_prop_lowering evd ~arities_explicit inds =
   let less_than_2 = function [] | [_] -> true | _ :: _ :: _ -> false in
 
   (* handle automatic lowering to Prop
@@ -245,7 +235,7 @@ let prop_lowering_candidates evd ~arities_explicit inds =
     && not (Evd.check_leq evd ESorts.set s)
   in
   let candidates = List.filter_map (fun (explicit,(_,(_,s),_,_ as ind)) ->
-      if (!do_auto_prop_lowering || not explicit) && is_prop_candidate_arity ind
+      if (do_auto_prop_lowering || not explicit) && is_prop_candidate_arity ind
       then Some s else None)
       (List.combine arities_explicit inds)
   in
@@ -304,7 +294,7 @@ let include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort =
 
 type default_dep_elim = DeclareInd.default_dep_elim = DefaultElim | PropButDepElim
 
-let inductive_levels env evd ~poly ~indnames ~arities_explicit arities ctors =
+let inductive_levels ~do_auto_prop_lowering env evd ~poly ~indnames ~arities_explicit arities ctors =
   let inds = List.map2 (fun x ctors ->
       let ctx, s = Reductionops.dest_arity env evd x in
       x, (ctx, s), List.map (compute_constructor_levels env evd) ctors)
@@ -333,7 +323,7 @@ let inductive_levels env evd ~poly ~indnames ~arities_explicit arities ctors =
       inds
   in
 
-  let candidates = prop_lowering_candidates evd ~arities_explicit inds in
+  let candidates = prop_lowering_candidates ~do_auto_prop_lowering evd ~arities_explicit inds in
   (* Do the lowering. We forget about the generated universe for the
      lowered inductive and rely on universe restriction to get rid of
      it.
@@ -532,7 +522,7 @@ let variance_of_entry ~cumulative ~variances uctx =
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 
-let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
+let interp_mutual_inductive_constr ~do_auto_prop_lowering ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
   (* Compute renewed arities *)
   let ctor_args =  List.map (fun (_,tys) ->
       List.map (fun ty ->
@@ -541,7 +531,7 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~variances ~ctx_param
         tys)
       constructors
   in
-  let sigma, (default_dep_elim, arities) = inductive_levels env_ar_params sigma ~poly ~indnames ~arities_explicit arities ctor_args in
+  let sigma, (default_dep_elim, arities) = inductive_levels ~do_auto_prop_lowering env_ar_params sigma ~poly ~indnames ~arities_explicit arities ctor_args in
   let lbound = if poly then UGraph.Bound.Set else UGraph.Bound.Prop in
   let sigma = Evd.minimize_universes ~lbound sigma in
   let arities = List.map EConstr.(to_constr sigma) arities in
@@ -624,7 +614,7 @@ let maybe_unify_params_in env_ar_par sigma ~ninds ~nparams ~binders:k c =
   in
   aux (env_ar_par,k) sigma c
 
-let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) notations ~cumulative ~poly ~private_ind finite =
+let interp_mutual_inductive_gen env0 ~do_auto_prop_lowering ~template udecl (uparamsl,paramsl,indl) notations ~cumulative ~poly ~private_ind finite =
   check_all_names_different indl;
   List.iter check_param paramsl;
   if not (List.is_empty uparamsl) && not (List.is_empty notations)
@@ -715,7 +705,7 @@ let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) not
       indimpls cimpls
   in
   let arities_explicit = List.map (fun ar -> ar.ind_arity_explicit) indl in
-  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~template ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
+  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~do_auto_prop_lowering ~template ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
   (default_dep_elim, mie, binders, impls, ctx)
 
 
@@ -812,7 +802,7 @@ let rec count_binder_expr = function
   | CLocalPattern {CAst.loc} :: _ ->
     Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
 
-let interp_mutual_inductive ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
+let interp_mutual_inductive ~env ~do_auto_prop_lowering ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let indlocs = List.map (fun ((n,_,_,_),_) -> n.CAst.loc) indl in
   let (params,indl),coercions,ntns = extract_mutual_inductive_declaration_components indl in
   let where_notations = List.map Metasyntax.prepare_where_notation ntns in
@@ -824,15 +814,15 @@ let interp_mutual_inductive ~env ~template udecl indl ~cumulative ~poly ?typing_
       | NonUniformParameters -> ([], params, indl), None
   in
   let env = Environ.update_typing_flags ?typing_flags env in
-  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen env ~template udecl indl where_notations ~cumulative ~poly ~private_ind finite in
+  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen ~do_auto_prop_lowering env ~template udecl indl where_notations ~cumulative ~poly ~private_ind finite in
   let open Mind_decl in
   { mie; default_dep_elim; nuparams; univ_binders; implicits; uctx; where_notations; coercions; indlocs }
 
-let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
+let do_mutual_inductive ~do_auto_prop_lowering ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let open Mind_decl in
   let env = Global.env () in
   let { mie; default_dep_elim; univ_binders; implicits; uctx; where_notations; coercions; indlocs} =
-    interp_mutual_inductive ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite in
+    interp_mutual_inductive ~do_auto_prop_lowering ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite in
   (* Slightly hackish global universe declaration due to template types. *)
   let binders = match mie.mind_entry_universes with
   | Monomorphic_ind_entry -> (UState.Monomorphic_entry uctx, univ_binders)
@@ -892,7 +882,6 @@ module Internal =
 struct
 
 let inductive_levels = inductive_levels
-let do_auto_prop_lowering = do_auto_prop_lowering
 
 let error_differing_params = error_differing_params
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -29,6 +29,14 @@ open EConstr
 
 module RelDecl = Context.Rel.Declaration
 
+type flags = {
+  poly : bool;
+  cumulative : bool;
+  template : bool option;
+  auto_prop_lowering : bool;
+  finite : Declarations.recursivity_kind;
+}
+
 (* 3b| Mutual inductive definitions *)
 
 let warn_auto_template =
@@ -221,7 +229,7 @@ let is_flexible_sort evd s = match ESorts.kind evd s with
   | Some l -> Evd.is_flexible_level evd l
   | None -> false
 
-let prop_lowering_candidates ~do_auto_prop_lowering evd ~arities_explicit inds =
+let prop_lowering_candidates ~auto_prop_lowering evd ~arities_explicit inds =
   let less_than_2 = function [] | [_] -> true | _ :: _ :: _ -> false in
 
   (* handle automatic lowering to Prop
@@ -235,7 +243,7 @@ let prop_lowering_candidates ~do_auto_prop_lowering evd ~arities_explicit inds =
     && not (Evd.check_leq evd ESorts.set s)
   in
   let candidates = List.filter_map (fun (explicit,(_,(_,s),_,_ as ind)) ->
-      if (do_auto_prop_lowering || not explicit) && is_prop_candidate_arity ind
+      if (auto_prop_lowering || not explicit) && is_prop_candidate_arity ind
       then Some s else None)
       (List.combine arities_explicit inds)
   in
@@ -294,7 +302,7 @@ let include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort =
 
 type default_dep_elim = DeclareInd.default_dep_elim = DefaultElim | PropButDepElim
 
-let inductive_levels ~do_auto_prop_lowering env evd ~poly ~indnames ~arities_explicit arities ctors =
+let inductive_levels ~auto_prop_lowering env evd ~poly ~indnames ~arities_explicit arities ctors =
   let inds = List.map2 (fun x ctors ->
       let ctx, s = Reductionops.dest_arity env evd x in
       x, (ctx, s), List.map (compute_constructor_levels env evd) ctors)
@@ -323,7 +331,7 @@ let inductive_levels ~do_auto_prop_lowering env evd ~poly ~indnames ~arities_exp
       inds
   in
 
-  let candidates = prop_lowering_candidates ~do_auto_prop_lowering evd ~arities_explicit inds in
+  let candidates = prop_lowering_candidates ~auto_prop_lowering evd ~arities_explicit inds in
   (* Do the lowering. We forget about the generated universe for the
      lowered inductive and rely on universe restriction to get rid of
      it.
@@ -522,7 +530,14 @@ let variance_of_entry ~cumulative ~variances uctx =
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 
-let interp_mutual_inductive_constr ~do_auto_prop_lowering ~sigma ~template ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~cumulative ~poly ~private_ind ~finite =
+let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~private_ind =
+  let {
+    poly;
+    cumulative;
+    template;
+    auto_prop_lowering;
+    finite;
+  } = flags in
   (* Compute renewed arities *)
   let ctor_args =  List.map (fun (_,tys) ->
       List.map (fun ty ->
@@ -531,7 +546,7 @@ let interp_mutual_inductive_constr ~do_auto_prop_lowering ~sigma ~template ~udec
         tys)
       constructors
   in
-  let sigma, (default_dep_elim, arities) = inductive_levels ~do_auto_prop_lowering env_ar_params sigma ~poly ~indnames ~arities_explicit arities ctor_args in
+  let sigma, (default_dep_elim, arities) = inductive_levels ~auto_prop_lowering env_ar_params sigma ~poly ~indnames ~arities_explicit arities ctor_args in
   let lbound = if poly then UGraph.Bound.Set else UGraph.Bound.Prop in
   let sigma = Evd.minimize_universes ~lbound sigma in
   let arities = List.map EConstr.(to_constr sigma) arities in
@@ -614,7 +629,7 @@ let maybe_unify_params_in env_ar_par sigma ~ninds ~nparams ~binders:k c =
   in
   aux (env_ar_par,k) sigma c
 
-let interp_mutual_inductive_gen env0 ~do_auto_prop_lowering ~template udecl (uparamsl,paramsl,indl) notations ~cumulative ~poly ~private_ind finite =
+let interp_mutual_inductive_gen env0 ~flags udecl (uparamsl,paramsl,indl) notations ~private_ind =
   check_all_names_different indl;
   List.iter check_param paramsl;
   if not (List.is_empty uparamsl) && not (List.is_empty notations)
@@ -624,7 +639,7 @@ let interp_mutual_inductive_gen env0 ~do_auto_prop_lowering ~template udecl (upa
   let ninds = List.length indl in
 
   (* In case of template polymorphism, we need to compute more constraints *)
-  let unconstrained_sorts = not poly in
+  let unconstrained_sorts = not flags.poly in
 
   let sigma, env_params, (ctx_params, env_uparams, ctx_uparams, userimpls, useruimpls, impls, udecl, variances) =
     interp_params ~unconstrained_sorts env0 udecl uparamsl paramsl
@@ -705,7 +720,7 @@ let interp_mutual_inductive_gen env0 ~do_auto_prop_lowering ~template udecl (upa
       indimpls cimpls
   in
   let arities_explicit = List.map (fun ar -> ar.ind_arity_explicit) indl in
-  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~do_auto_prop_lowering ~template ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~poly ~finite ~cumulative ~private_ind ~indnames in
+  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~flags ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar_params ~private_ind ~indnames in
   (default_dep_elim, mie, binders, impls, ctx)
 
 
@@ -802,7 +817,7 @@ let rec count_binder_expr = function
   | CLocalPattern {CAst.loc} :: _ ->
     Loc.raise ?loc (Gramlib.Grammar.Error "pattern with quote not allowed here")
 
-let interp_mutual_inductive ~env ~do_auto_prop_lowering ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
+let interp_mutual_inductive ~env ~flags ?typing_flags udecl indl ~private_ind ~uniform =
   let indlocs = List.map (fun ((n,_,_,_),_) -> n.CAst.loc) indl in
   let (params,indl),coercions,ntns = extract_mutual_inductive_declaration_components indl in
   let where_notations = List.map Metasyntax.prepare_where_notation ntns in
@@ -814,15 +829,15 @@ let interp_mutual_inductive ~env ~do_auto_prop_lowering ~template udecl indl ~cu
       | NonUniformParameters -> ([], params, indl), None
   in
   let env = Environ.update_typing_flags ?typing_flags env in
-  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen ~do_auto_prop_lowering env ~template udecl indl where_notations ~cumulative ~poly ~private_ind finite in
+  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen ~flags env udecl indl where_notations ~private_ind in
   let open Mind_decl in
   { mie; default_dep_elim; nuparams; univ_binders; implicits; uctx; where_notations; coercions; indlocs }
 
-let do_mutual_inductive ~do_auto_prop_lowering ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
+let do_mutual_inductive ~flags ?typing_flags udecl indl ~private_ind ~uniform =
   let open Mind_decl in
   let env = Global.env () in
   let { mie; default_dep_elim; univ_binders; implicits; uctx; where_notations; coercions; indlocs} =
-    interp_mutual_inductive ~do_auto_prop_lowering ~env ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite in
+    interp_mutual_inductive ~flags ~env udecl indl ?typing_flags ~private_ind ~uniform in
   (* Slightly hackish global universe declaration due to template types. *)
   let binders = match mie.mind_entry_universes with
   | Monomorphic_ind_entry -> (UState.Monomorphic_entry uctx, univ_binders)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -20,7 +20,8 @@ type uniform_inductive_flag =
   | NonUniformParameters
 
 val do_mutual_inductive
-  :  template:bool option
+  : do_auto_prop_lowering:bool
+  -> template:bool option
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
   -> cumulative:bool
@@ -61,6 +62,7 @@ end
 (** elaborates an inductive declaration (the first half of do_mutual_inductive) *)
 val interp_mutual_inductive
   :  env:Environ.env
+  -> do_auto_prop_lowering:bool
   -> template:bool option
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
@@ -77,7 +79,8 @@ type syntax_allows_template_poly = SyntaxAllowsTemplatePoly | SyntaxNoTemplatePo
 (** the post-elaboration part of interp_mutual_inductive, mainly dealing with
     universe levels *)
 val interp_mutual_inductive_constr
-  : sigma:Evd.evar_map
+  : do_auto_prop_lowering:bool
+  -> sigma:Evd.evar_map
   -> template:bool option
   -> udecl:UState.universe_decl
   -> variances:Entries.variance_entry
@@ -130,7 +133,8 @@ sig
   (** Returns the modified arities (the result sort may be replaced by Prop).
       Should be called with minimized universes. *)
   val inductive_levels
-    : Environ.env
+    : do_auto_prop_lowering:bool
+    -> Environ.env
     -> Evd.evar_map
     -> poly:bool
     -> indnames:Names.Id.t list
@@ -147,8 +151,5 @@ sig
     -> (Names.lident * Vernacexpr.inductive_params_expr)
     -> (Names.lident * Vernacexpr.inductive_params_expr)
     -> 'a
-
-
-  val do_auto_prop_lowering : bool ref
 
 end

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -13,6 +13,14 @@ open Constrexpr
 
 (** {6 Inductive and coinductive types} *)
 
+type flags = {
+  poly : bool;
+  cumulative : bool;
+  template : bool option;
+  auto_prop_lowering : bool;
+  finite : Declarations.recursivity_kind;
+}
+
 (** Entry points for the vernacular commands Inductive and CoInductive *)
 
 type uniform_inductive_flag =
@@ -20,16 +28,12 @@ type uniform_inductive_flag =
   | NonUniformParameters
 
 val do_mutual_inductive
-  : do_auto_prop_lowering:bool
-  -> template:bool option
+  : flags:flags
+  -> ?typing_flags:Declarations.typing_flags
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
-  -> cumulative:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
   -> private_ind:bool
   -> uniform:uniform_inductive_flag
-  -> Declarations.recursivity_kind
   -> unit
 
 (** User-interface API *)
@@ -62,16 +66,12 @@ end
 (** elaborates an inductive declaration (the first half of do_mutual_inductive) *)
 val interp_mutual_inductive
   :  env:Environ.env
-  -> do_auto_prop_lowering:bool
-  -> template:bool option
+  -> flags:flags
+  -> ?typing_flags:Declarations.typing_flags
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
-  -> cumulative:bool
-  -> poly:bool
-  -> ?typing_flags:Declarations.typing_flags
   -> private_ind:bool
   -> uniform:uniform_inductive_flag
-  -> Declarations.recursivity_kind
   -> Mind_decl.t
 
 type syntax_allows_template_poly = SyntaxAllowsTemplatePoly | SyntaxNoTemplatePoly
@@ -79,9 +79,8 @@ type syntax_allows_template_poly = SyntaxAllowsTemplatePoly | SyntaxNoTemplatePo
 (** the post-elaboration part of interp_mutual_inductive, mainly dealing with
     universe levels *)
 val interp_mutual_inductive_constr
-  : do_auto_prop_lowering:bool
-  -> sigma:Evd.evar_map
-  -> template:bool option
+  :  sigma:Evd.evar_map
+  -> flags:flags
   -> udecl:UState.universe_decl
   -> variances:Entries.variance_entry
   -> ctx_params:EConstr.rel_context
@@ -92,10 +91,7 @@ val interp_mutual_inductive_constr
   -> constructors:(Names.Id.t list * EConstr.constr list) list
   -> env_ar_params:Environ.env
   (** Environment with the inductives and parameters in the rel_context *)
-  -> cumulative:bool
-  -> poly:bool
   -> private_ind:bool
-  -> finite:Declarations.recursivity_kind
   -> DeclareInd.default_dep_elim list * Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
 
 (************************************************************************)
@@ -133,7 +129,7 @@ sig
   (** Returns the modified arities (the result sort may be replaced by Prop).
       Should be called with minimized universes. *)
   val inductive_levels
-    : do_auto_prop_lowering:bool
+    : auto_prop_lowering:bool
     -> Environ.env
     -> Evd.evar_map
     -> poly:bool

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -210,7 +210,7 @@ let def_class_levels ~def env_ar sigma aritysorts ctors =
     sigma, [DefaultElim, EConstr.mkSort s]
 
 (* ps = parameter list *)
-let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_result =
+let typecheck_params_and_fields ~do_auto_prop_lowering def poly udecl ps (records : DataI.t list) : tc_result =
   let env0 = Global.env () in
   (* Special case elaboration for template-polymorphic inductives,
      lower bound on introduced universes is Prop so that we do not miss
@@ -250,7 +250,7 @@ let typecheck_params_and_fields def poly udecl ps (records : DataI.t list) : tc_
       let indnames = List.map (fun x -> x.DataI.name) records in
       let arities_explicit = List.map (fun x -> Option.has_some x.DataI.arity) records in
       let sigma, (default_dep_elim, typs) =
-        ComInductive.Internal.inductive_levels env_ar sigma ~poly ~indnames ~arities_explicit typs ctors
+        ComInductive.Internal.inductive_levels ~do_auto_prop_lowering env_ar sigma ~poly ~indnames ~arities_explicit typs ctors
       in
       sigma, List.combine default_dep_elim typs
   in
@@ -734,7 +734,7 @@ let check_proj_flags kind rf =
 (* remove the definitional argument at the end of the deprecation phase
    (started in 8.17)
    (c.f., https://github.com/coq/coq/pull/16230 ) *)
-let pre_process_structure ?(definitional=false) udecl kind ~poly (records : Ast.t list) =
+let pre_process_structure ?(definitional=false) ~do_auto_prop_lowering udecl kind ~poly (records : Ast.t list) =
   let indlocs = check_unique_names records in
   let () = check_priorities kind records in
   let ps, data = extract_record_data records in
@@ -745,7 +745,7 @@ let pre_process_structure ?(definitional=false) udecl kind ~poly (records : Ast.
        is messing state beyond that.
     *)
     Vernacstate.System.protect (fun () ->
-        typecheck_params_and_fields (kind = Class true) poly udecl ps data) ()
+        typecheck_params_and_fields ~do_auto_prop_lowering (kind = Class true) poly udecl ps data) ()
   in
   let adjust_impls impls = match kind_class kind with
     | NotClass -> impargs @ [CAst.make None] @ impls
@@ -837,10 +837,10 @@ let interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj i
   }
 
 
-let interp_structure udecl kind ~template ~cumulative ~poly ~primitive_proj finite records =
+let interp_structure ~do_auto_prop_lowering udecl kind ~template ~cumulative ~poly ~primitive_proj finite records =
   assert (kind <> Vernacexpr.Class true);
   let impargs, params, univs, variances, projections_kind, data, indlocs =
-    pre_process_structure udecl kind ~poly records in
+    pre_process_structure ~do_auto_prop_lowering udecl kind ~poly records in
   interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj impargs params template ~projections_kind ~indlocs data
 
 let declare_structure { Record_decl.mie; default_dep_elim; primitive_proj; impls; globnames; global_univ_decls; projunivs; ubinders; projections_kind; poly; records; indlocs } =
@@ -1038,11 +1038,11 @@ let declare_existing_class g =
     list telling if the corresponding fields must me declared as coercions
     or subinstances. *)
 
-let definition_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
+let definition_structure ~do_auto_prop_lowering udecl kind ~template ~cumulative ~poly ~primitive_proj
     finite (records : Ast.t list) : GlobRef.t list =
   let impargs, params, univs, variances, projections_kind, data, indlocs =
     let definitional = kind_class kind = DefClass in
-    pre_process_structure ~definitional udecl kind ~poly records
+    pre_process_structure ~do_auto_prop_lowering ~definitional udecl kind ~poly records
   in
   let inds, def = match kind_class kind with
     | DefClass -> declare_class_constant ~univs impargs params data

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -26,14 +26,10 @@ module Ast : sig
 end
 
 val definition_structure
-  : do_auto_prop_lowering:bool
+  : flags:ComInductive.flags
   -> cumul_univ_decl_expr option
   -> inductive_kind
-  -> template:bool option
-  -> cumulative:bool
-  -> poly:bool
   -> primitive_proj:bool
-  -> Declarations.recursivity_kind
   -> Ast.t list
   -> GlobRef.t list
 
@@ -78,14 +74,10 @@ end
 
 (** Ast.t list at the constr level *)
 val interp_structure
-  : do_auto_prop_lowering:bool
+  : flags:ComInductive.flags
   -> cumul_univ_decl_expr option
   -> inductive_kind
-  -> template:bool option
-  -> cumulative:bool
-  -> poly:bool
   -> primitive_proj:bool
-  -> Declarations.recursivity_kind
   -> Ast.t list
   -> Record_decl.t
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -26,7 +26,8 @@ module Ast : sig
 end
 
 val definition_structure
-  :  cumul_univ_decl_expr option
+  : do_auto_prop_lowering:bool
+  -> cumul_univ_decl_expr option
   -> inductive_kind
   -> template:bool option
   -> cumulative:bool
@@ -77,7 +78,8 @@ end
 
 (** Ast.t list at the constr level *)
 val interp_structure
-  :  cumul_univ_decl_expr option
+  : do_auto_prop_lowering:bool
+  -> cumul_univ_decl_expr option
   -> inductive_kind
   -> template:bool option
   -> cumulative:bool

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1006,17 +1006,22 @@ let dump_inductive indl_for_glob decl =
     | Inductive _ -> ()
   end
 
+
+let { Goptions.get = do_auto_prop_lowering } =
+  Goptions.declare_bool_option_and_ref ~key:["Automatic";"Proposition";"Inductives"] ~value:true ()
+
 let vernac_inductive ~atts kind indl =
   let open Preprocessed_Mind_decl in
   let indl_for_glob, decl = preprocess_inductive_decl ~atts kind indl in
   dump_inductive indl_for_glob decl;
+  let do_auto_prop_lowering = do_auto_prop_lowering () in
   match decl with
   | Record { flags = { template; udecl; cumulative; poly; finite; }; kind; primitive_proj; records } ->
     let _ : _ list =
-      Record.definition_structure ~template udecl kind ~cumulative ~poly ~primitive_proj finite records in
+      Record.definition_structure ~do_auto_prop_lowering ~template udecl kind ~cumulative ~poly ~primitive_proj finite records in
     ()
   | Inductive { flags = { template; udecl; cumulative; poly; finite; }; typing_flags; private_ind; uniform; inductives } ->
-    ComInductive.do_mutual_inductive ~template udecl inductives ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite
+    ComInductive.do_mutual_inductive ~do_auto_prop_lowering ~template udecl inductives ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite
 
 let preprocess_inductive_decl ~atts kind indl =
   snd @@ preprocess_inductive_decl ~atts kind indl

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -45,21 +45,17 @@ val allow_sprop_opt_name : string list
 
 (** pre-processing and validation of VernacInductive *)
 module Preprocessed_Mind_decl : sig
-  type flags = {
-    template : bool option;
-    udecl : Constrexpr.cumul_univ_decl_expr option;
-    cumulative : bool;
-    poly : bool;
-    finite : Declarations.recursivity_kind;
-  }
+  type flags = ComInductive.flags
   type record = {
     flags : flags;
+    udecl : Constrexpr.cumul_univ_decl_expr option;
     primitive_proj : bool;
     kind : Vernacexpr.inductive_kind;
     records : Record.Ast.t list;
   }
   type inductive = {
     flags : flags;
+    udecl : Constrexpr.cumul_univ_decl_expr option;
     typing_flags : Declarations.typing_flags option;
     private_ind : bool;
     uniform : ComInductive.uniform_inductive_flag;


### PR DESCRIPTION
+ flag-passing refactoring using a record type to cleanup the code

This lets us avoid without_option in funind.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/657 

