### PR TITLE
Cleanup libobjects `rebuild_function`s

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2021,11 +2021,12 @@ let discharge_arguments_scope (req,r,scs,_cls,available_scopes) =
 let classify_arguments_scope (req,_,_,_,_) =
   if req == ArgsScopeNoDischarge then Dispose else Substitute
 
-let rebuild_arguments_scope sigma (req,r,scs,n_as_cls,available_scopes) =
+let rebuild_arguments_scope (req,r,scs,n_as_cls,available_scopes) =
   match req with
     | ArgsScopeNoDischarge -> assert false
     | ArgsScopeAuto ->
-      let env = Global.env () in (*FIXME?*)
+      let env = Global.env () in
+      let sigma = Evd.from_env env in
       let typ = EConstr.of_constr @@ fst (Typeops.type_of_global_in_context env r) in
       let scs,cls = compute_arguments_scope_full env sigma available_scopes typ in
       (* Note: cls is fixed, but scs can be recomputed in find_arguments_scope *)
@@ -2034,7 +2035,8 @@ let rebuild_arguments_scope sigma (req,r,scs,n_as_cls,available_scopes) =
       (* Add to the manually given scopes the one found automatically
          for the extra parameters of the section. Discard the classes
          of the manually given scopes to avoid further re-computations. *)
-      let env = Global.env () in (*FIXME?*)
+      let env = Global.env () in
+      let sigma = Evd.from_env env in
       let n = List.length n_as_cls in
       let typ = EConstr.of_constr @@ fst (Typeops.type_of_global_in_context env r) in
       let scs',cls = compute_arguments_scope_full env sigma available_scopes typ in
@@ -2056,8 +2058,7 @@ let inArgumentsScope : arguments_scope_obj -> obj =
       subst_function = subst_arguments_scope;
       classify_function = classify_arguments_scope;
       discharge_function = discharge_arguments_scope;
-      (* XXX: Should we pass the sigma here or not, see @herbelin's comment in 6511 *)
-      rebuild_function = rebuild_arguments_scope Evd.empty }
+      rebuild_function = rebuild_arguments_scope }
 
 let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -50,15 +50,12 @@ let discharge_rename_args = function
      with Not_found -> Some req)
   | _ -> None
 
-let rebuild_rename_args x = x
-
 let inRenameArgs = declare_object { (default_object "RENAME-ARGUMENTS" ) with
   load_function = load_rename_args;
   cache_function = cache_rename_args;
   classify_function = classify_rename_args;
   subst_function = subst_rename_args;
   discharge_function = discharge_rename_args;
-  rebuild_function = rebuild_rename_args;
 }
 
 let rename_arguments local r names =

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -23,7 +23,6 @@ open Term
 open Constr
 open Context
 open Environ
-module CVars = Vars
 open EConstr
 open Vars
 open Reductionops
@@ -406,8 +405,8 @@ let rec reapply_coercions sigma trace c = match trace with
 
 let instance_of_global_constr sigma c =
   match kind sigma c with
-  | Const (_,u) | Ind (_,u) | Construct (_,u) -> EInstance.kind sigma u
-  | _ -> UVars.Instance.empty
+  | Const (_,u) | Ind (_,u) | Construct (_,u) -> u
+  | _ -> EInstance.empty
 
 (* Apply coercion path from p to h of type hty; raise NoCoercion if not applicable *)
 let apply_coercion env sigma p h hty =
@@ -419,10 +418,10 @@ let apply_coercion env sigma p h hty =
          let sigma, c = Evd.fresh_global env sigma i.coe_value in
          let u = instance_of_global_constr sigma c in
          let isproj = Option.map (fun p ->
-             p, ERelevance.make @@ Relevanceops.relevance_of_projection_repr env (p,u))
+             p, Retyping.relevance_of_projection_repr env (p,u))
              isproj
          in
-         let typ = EConstr.of_constr (CVars.subst_instance_constr u i.coe_typ) in
+         let typ = Coercionops.coercion_type env sigma (i,u) in
          let sigma, j', args, jty =
            apply_coercion_args env sigma isproj c typ j jty i.coe_param in
          let trace =

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -64,7 +64,6 @@ module CoeTypMap = GlobRef.Map_env
 
 type coe_info_typ = {
   coe_value : GlobRef.t;
-  coe_typ : Constr.t;
   coe_local : bool;
   coe_reversible : bool;
   coe_is_identity : bool;
@@ -151,6 +150,9 @@ let class_nparams cl = (class_info cl).cl_param
 let class_exists cl = ClTypMap.mem cl !class_tab
 
 let coercion_info coe = CoeTypMap.find coe !coercion_tab
+
+let coercion_type env sigma (coe,u) =
+  Retyping.get_type_of env sigma (EConstr.mkRef (coe.coe_value,u))
 
 let coercion_exists coe = CoeTypMap.mem coe !coercion_tab
 
@@ -415,14 +417,13 @@ let add_coercion_in_graph env sigma ?(update=false) ic =
 let subst_coercion subst c =
   let env = Global.env () in
   let coe = subst_coe_typ subst c.coe_value in
-  let typ = subst_mps subst c.coe_typ in
   let cls = subst_cl_typ env subst c.coe_source in
   let clt = subst_cl_typ env subst c.coe_target in
   let clp = Option.Smart.map (subst_proj_repr subst) c.coe_is_projection in
   if c.coe_value == coe && c.coe_source == cls && c.coe_target == clt &&
      c.coe_is_projection == clp
   then c
-  else { c with coe_value = coe; coe_typ = typ; coe_source = cls; coe_target = clt;
+  else { c with coe_value = coe; coe_source = cls; coe_target = clt;
                 coe_is_projection = clp; }
 
 (* Computation of the class arity *)

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -37,7 +37,6 @@ type coe_typ = GlobRef.t
 (** This is the type of infos for declared coercions *)
 type coe_info_typ = {
   coe_value : GlobRef.t;
-  coe_typ : Constr.t;
   coe_local : bool;
   coe_reversible : bool;
   coe_is_identity : bool;
@@ -77,6 +76,8 @@ val declare_coercion : env -> evar_map -> ?update:bool -> coe_info_typ -> unit
 val coercion_exists : coe_typ -> bool
 
 val coercion_info : coe_typ -> coe_info_typ
+
+val coercion_type : Environ.env -> Evd.evar_map -> coe_info_typ EConstr.puniverses -> EConstr.t
 
 (** {6 Lookup functions for coercion paths } *)
 

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -329,6 +329,9 @@ let expand_projection env sigma pr c args =
     mkApp (mkConstU (Projection.constant pr,u),
            Array.of_list (ind_args @ (c :: args)))
 
+let relevance_of_projection_repr env (p, u) =
+  ERelevance.make @@ Relevanceops.relevance_of_projection_repr env (p, EConstr.Unsafe.to_instance u)
+
 let relevance_of_term env sigma c =
   if Environ.sprop_allowed env then
     let rec aux rels c =

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -57,6 +57,8 @@ val reinterpret_get_type_of : src:Names.Id.t -> env -> evar_map -> constr -> typ
 
 val print_retype_error : retype_error -> Pp.t
 
+val relevance_of_projection_repr : env -> Names.Projection.Repr.t EConstr.puniverses -> ERelevance.t
+
 val relevance_of_term : env -> evar_map -> constr -> ERelevance.t
 val relevance_of_type : env -> evar_map -> types -> ERelevance.t
 val relevance_of_sort : ESorts.t -> ERelevance.t

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -237,12 +237,6 @@ let discharge_class cl =
   with Not_found -> (* not defined in the current section *)
     cl
 
-let rebuild_class cl =
-  try
-    let cst = Tacred.evaluable_of_global_reference (Global.env ()) cl.cl_impl in
-      set_typeclass_transparency ~locality:Hints.Local [cst] false; cl
-  with e when CErrors.noncritical e -> cl
-
 let class_input : typeclass -> obj =
   declare_object
     { (default_object "type classes state") with
@@ -250,8 +244,8 @@ let class_input : typeclass -> obj =
       load_function = (fun _ -> cache_class);
       classify_function = (fun x -> Substitute);
       discharge_function = (fun a -> Some (discharge_class a));
-      rebuild_function = rebuild_class;
-      subst_function = subst_class }
+      subst_function = subst_class;
+    }
 
 let add_class cl =
   Lib.add_leaf (class_input cl);

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -248,9 +248,6 @@ let discharge_coercion c =
     } in
     Some nc
 
-let rebuild_coercion c =
-  { c with coe_typ = fst (Typeops.type_of_global_in_context (Global.env ()) c.coe_value) }
-
 let classify_coercion obj =
   if obj.coe_local then Dispose else Substitute
 
@@ -263,9 +260,9 @@ let inCoercion : coe_info_typ -> obj =
     subst_function = (fun (subst,c) -> subst_coercion subst c);
     classify_function = classify_coercion;
     discharge_function = discharge_coercion;
-    rebuild_function = rebuild_coercion }
+  }
 
-let declare_coercion coef typ ?(local = false) ~reversible ~isid ~src:cls ~target:clt ~params:ps () =
+let declare_coercion coef ?(local = false) ~reversible ~isid ~src:cls ~target:clt ~params:ps () =
   let isproj =
     match coef with
     | GlobRef.ConstRef c -> Structures.PrimitiveProjections.find_opt c
@@ -273,7 +270,6 @@ let declare_coercion coef typ ?(local = false) ~reversible ~isid ~src:cls ~targe
   in
   let c = {
     coe_value = coef;
-    coe_typ = typ;
     coe_local = local;
     coe_reversible = reversible;
     coe_is_identity = isid;
@@ -333,7 +329,7 @@ let add_new_coercion_core coef stre ~reversible source target isid : unit =
   | `GLOBAL -> false
   in
   let params = List.length (Context.Rel.instance_list EConstr.mkRel 0 ctx) in
-  declare_coercion coef t ~local ~reversible ~isid ~src:cls ~target:clt ~params ()
+  declare_coercion coef ~local ~reversible ~isid ~src:cls ~target:clt ~params ()
 
 let try_add_new_coercion_core ref ~local c ~reversible d e =
   try add_new_coercion_core ref (loc_of_bool local) c ~reversible d e


### PR DESCRIPTION
- avoid Evd.empty in notation rebuild_arguments_scope

- remove trivial rebuild for argument renaming

- remove coe_typ field of Coercionops.coe_info_typ, this makes the rebuild function trivial so we can remove it. While we're at it cleanup universe instance handling around coercion types.

- remove useless rebuild_function of Class libobject