### PR TITLE
[unification] tolerate Proj applied to "untyped" term

### DIFF
--- a/dev/ci/user-overlays/19358-gares-fix-primproj-notype.sh
+++ b/dev/ci/user-overlays/19358-gares-fix-primproj-notype.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/gares/coq-elpi fix-primproj-notype 19358

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -76,7 +76,7 @@ val check_problems_are_solved : ?evars:Evar.Set.t -> env -> evar_map -> unit
 
 (** Hook for the canonical structure resolution *)
 
-type hook = Environ.env -> Evd.evar_map -> ((Names.Constant.t * EConstr.EInstance.t) * EConstr.t list * EConstr.t) -> (EConstr.t * EConstr.t list) -> (Evd.evar_map * Structures.CanonicalSolution.t) option
+type hook = Environ.env -> Evd.evar_map -> ((Names.Constant.t * EConstr.EInstance.t) * EConstr.t list option * EConstr.t) -> (EConstr.t * EConstr.t list) -> (Evd.evar_map * Structures.CanonicalSolution.t) option
 
 val all_hooks : hook CString.Map.t ref
 
@@ -95,7 +95,7 @@ val apply_hooks : hook
 val check_conv_record : env -> evar_map ->
   state -> state ->
   evar_map * (constr * constr)
-  * constr * constr list * (EConstr.t list * EConstr.t list) *
+  * constr * constr list * (EConstr.t list * EConstr.t list option) *
     (EConstr.t list * EConstr.t list) *
     (Stack.t * Stack.t) * constr *
     (int option * constr)

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1242,7 +1242,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
         with Invalid_argument _ -> assert false (* check_conv_record ensures lengths coincide *)
       in
       let substn = foldl (push_sigma evd substn) us2 us in
-      let substn = foldl substn params1 params in
+      let substn = match params1 with None -> substn | Some params1 -> foldl substn params1 params in
       let substn = Reductionops.Stack.fold2 (fun s u1 u2 -> unirec_rec curenvnb pb opt' s u1 u2) substn ts ts1 in
       let app = mkApp (c, Array.rev_of_list ks) in
       (* let substn = unirec_rec curenvnb pb b false substn t cN in *)

--- a/test-suite/success/primproj_evarconv.v
+++ b/test-suite/success/primproj_evarconv.v
@@ -29,3 +29,42 @@ Module T.
     refine (eq_refl _).
   Qed.
 End T.
+
+(* Here we test that CS inference happens even if the projection is
+   primitive and the projected term has a type that is not an inductive
+   (but rather an evar). We exploit the fact that Coq considers are
+   well typed terms containing evars for which a suspended
+   unif problem exists. *)
+Require Import Ltac2.Ltac2 Ltac2.Unification Ltac2.Constr Ltac2.Printf.
+
+Module U.
+
+  #[projections(primitive=yes)] Record r := R { r_car : Type }.
+  #[projections(primitive=yes)] Record s := S { s_car : Type }.
+
+  (* The type of the CS instance will help unification make a choice
+     for the (_ : _ r) problem below *)
+  Canonical Structure foo (x : s): (fun x=>x) r := R (s_car x).
+
+  Axiom a : s.
+
+  Goal True.
+  Ltac2 Eval
+    let t1 := open_constr:( ( _ : _ r ).(r_car) ) in (* the problem mentioned above *)
+    let t2 := constr:( (a).(s_car) ) in
+    (* safeguard against parser *)
+    match (Constr.Unsafe.kind t1) with
+    | Constr.Unsafe.Proj _ _ _ => ()
+    | _ => fail
+    end;
+    match (Constr.Unsafe.kind t2) with
+    | Constr.Unsafe.Proj _ _ _ => ()
+    | _ => fail
+    end;
+    (* printf "%t = %t" t1 t2; *)
+    unify_with_full_ts t1 t2; (* fails before #19358 *)
+    (* printf "%t = %t" t1 t2. *)
+    ().
+  Abort.
+
+End U.


### PR DESCRIPTION
As the test points out, the projected can be typed, but its type not reduce to an applied inductive.
In vanilla Coq this can happen because of unif constraints.

Overlays:
- LPCIC/coq-elpi#668