### PR TITLE
Fix incorrect error locations with `}` in coqtop

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,7 +56,12 @@ dune* whitespace=blank-at-eol,tab-in-indent
 .gitattributes whitespace=blank-at-eol,tab-in-indent
 _CoqProject whitespace=blank-at-eol,tab-in-indent
 Dockerfile whitespace=blank-at-eol,tab-in-indent
+
+# multiple newlines at the end
 00000-title.rst -whitespace
+
+# tests location correctness with trailing whitespace
+/test-suite/output-coqtop/BracketLoc.v -whitespace
 
 # tabs are allowed in Makefiles.
 Makefile* whitespace=blank-at-eol

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -723,11 +723,7 @@ let rec next_token ~diff_mode ttree loc s =
       Stream.junk () s;
       let ep = Stream.count s in
       let t,new_between_commands =
-        if !between_commands then begin
-          (* peek to force reading a following newline, cf #19355 *)
-          let _ = Stream.peek () s in
-          (KEYWORD (String.make 1 c), set_loc_pos loc bp ep), true
-        end
+        if !between_commands then (KEYWORD (String.make 1 c), set_loc_pos loc bp ep), true
         else process_chars ~diff_mode ttree loc bp [c] s, false
       in
       between_commands := new_between_commands; t

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -723,7 +723,11 @@ let rec next_token ~diff_mode ttree loc s =
       Stream.junk () s;
       let ep = Stream.count s in
       let t,new_between_commands =
-        if !between_commands then (KEYWORD (String.make 1 c), set_loc_pos loc bp ep), true
+        if !between_commands then begin
+          (* peek to force reading a following newline, cf #19355 *)
+          let _ = Stream.peek () s in
+          (KEYWORD (String.make 1 c), set_loc_pos loc bp ep), true
+        end
         else process_chars ~diff_mode ttree loc bp [c] s, false
       in
       between_commands := new_between_commands; t

--- a/test-suite/output-coqtop/BracketLoc.out
+++ b/test-suite/output-coqtop/BracketLoc.out
@@ -4,6 +4,11 @@ Coq < 1 goal
   ============================
   True
 
+Toplevel input, characters 11-12:
+> Goal True. }
+>            ^
+Error: The proof is not focused
+
 Unnamed_thm < Toplevel input, characters 2-3:
 >   }
 >   ^

--- a/test-suite/output-coqtop/BracketLoc.out
+++ b/test-suite/output-coqtop/BracketLoc.out
@@ -1,0 +1,22 @@
+
+Coq < 1 goal
+  
+  ============================
+  True
+
+Unnamed_thm < Toplevel input, characters 2-3:
+>   }
+>   ^
+Error: The proof is not focused
+
+Unnamed_thm < Toplevel input, characters 2-3:
+>   }
+>   ^
+Error: The proof is not focused
+
+Unnamed_thm < Toplevel input, characters 8-9:
+>   exact 0.
+>         ^
+Error: The term "0" has type "nat" while it is expected to have type "True".
+
+Unnamed_thm < 

--- a/test-suite/output-coqtop/BracketLoc.v
+++ b/test-suite/output-coqtop/BracketLoc.v
@@ -1,0 +1,4 @@
+Goal True.
+  }
+  }
+  exact 0.

--- a/test-suite/output-coqtop/BracketLoc.v
+++ b/test-suite/output-coqtop/BracketLoc.v
@@ -1,4 +1,4 @@
-Goal True.
-  }
+Goal True. }
+  }  
   }
   exact 0.

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -54,7 +54,7 @@ let emacs_prompt_endstring   () = if !print_emacs then "</prompt>" else ""
 
 (* Read a char in an input channel, displaying a prompt at every
    beginning of line. *)
-let prompt_char doc ic ibuf count =
+let prompt_char doc ic ibuf () =
   let bol = match ibuf.bols with
     | ll::_ -> Int.equal ibuf.len ll
     | [] -> Int.equal ibuf.len 0
@@ -140,7 +140,7 @@ let print_highlight_location ib loc =
   highlight_lines
 
 let valid_buffer_loc ib loc =
-  let (b,e) = Loc.unloc loc in b-ib.start >= 0 && e-ib.start < ib.len && b<=e
+  let (b,e) = Loc.unloc loc in b-ib.start >= 0 && e-ib.start <= ib.len && b<=e
 
 (* Toplevel error explanation. *)
 let error_info_for_buffer ?loc buf =

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -13,13 +13,7 @@
 (** A buffer for the character read from a channel. We store the command
  * entered to be able to report errors without pretty-printing. *)
 
-type input_buffer = {
-  mutable prompt : Stm.doc -> string;
-  mutable str : Bytes.t; (** buffer of already read characters *)
-  mutable len : int;    (** number of chars in the buffer *)
-  mutable bols : int list; (** offsets in str of beginning of lines *)
-  mutable tokens : Pcoq.Parsable.t; (** stream of tokens *)
-  mutable start : int } (** stream count of the first char of the buffer *)
+type input_buffer
 
 (** The input buffer of stdin. *)
 


### PR DESCRIPTION
Fix #19355
