### PR TITLE
improve done

### DIFF
--- a/dev/ci/user-overlays/19372-gares-done.sh
+++ b/dev/ci/user-overlays/19372-gares-done.sh
@@ -1,1 +1,0 @@
-overlay fcsl_pcm https://github.com/gares/fcsl-pcm done 19372

--- a/dev/ci/user-overlays/19372-gares-done.sh
+++ b/dev/ci/user-overlays/19372-gares-done.sh
@@ -1,0 +1,1 @@
+overlay fcsl_pcm https://github.com/gares/fcsl-pcm done 19372

--- a/doc/changelog/07-ssreflect/19372-changelog-ssr.rst
+++ b/doc/changelog/07-ssreflect/19372-changelog-ssr.rst
@@ -1,0 +1,3 @@
+- **Changed:**
+  The :tacn:`done` tactic now tries to apply `sym_equal` with four arguments
+  instead of trying first with zero to three arguments.

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -399,7 +399,7 @@ Proof. unlock; discriminate. Qed.
 (**  The basic closing tactic "done".  **)
 Ltac done :=
   trivial; hnf; intros; solve
-   [ do ![solve [trivial | apply: sym_equal; trivial]
+   [ do ![solve [trivial | apply: (@sym_equal _ _ _ _); trivial]
          | discriminate | contradiction | split]
    | case not_locked_false_eq_true; assumption
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].


### PR DESCRIPTION

Minor improvement to `done`, where we give the number of holes `sym_equal` is expected to use instead of letting Coq try all possibilities.


- [x] Added **changelog**.
- [x] Opened **overlay** pull requests.
  - https://github.com/imdea-software/fcsl-pcm/pull/42