### PR TITLE
Speedup proof of nzhead_revapp in DecimalFacts and HexadecimalFacts

### DIFF
--- a/theories/Numbers/DecimalFacts.v
+++ b/theories/Numbers/DecimalFacts.v
@@ -466,7 +466,7 @@ Proof.
   revert d'.
   induction d; intros d' H; simpl in *;
   try destruct (nztail d) eqn:E;
-  (now rewrite ?nzhead_revapp_0) || (now rewrite IHd).
+  (rewrite IHd;[reflexivity|discriminate]) || (now rewrite ?nzhead_revapp_0).
 Qed.
 
 Lemma nzhead_rev d : nztail d <> Nil ->

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -486,7 +486,7 @@ Proof.
   revert d'.
   induction d; intros d' H; simpl in *;
   try destruct (nztail d) eqn:E;
-  (now rewrite ?nzhead_revapp_0) || (now rewrite IHd).
+  (rewrite IHd;[reflexivity|discriminate]) || (now rewrite ?nzhead_revapp_0).
 Qed.
 
 Lemma nzhead_rev d : nztail d <> Nil ->


### PR DESCRIPTION
The `now rewrite IHd` case solves 256 goals out of 273 so should be tried first, also replace its `now` by more precise tactics.

In HexadecimalFacts the command goes from 1.2s to 0.1s. It's less impressive in DecimalFacts since 10 < 16.
