### PR TITLE
Clarify --index flag in coqdoc.rst

### DIFF
--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -350,8 +350,8 @@ Command line options
     with large source files, where binder information may dominate the index.
   :--multi-index: Generate one page for each category and each letter in
     the index, together with a top page ``index.html``.
-  :--index string: Make the filename of the index string instead of
-    “index”. Useful since “index.html” is special.
+  :--index string: Make the filename of the index "``string``.html" instead of
+    “index.html”. Useful since “index.html” is special.
 
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->

<!-- If this breaks external libraries or plugins in CI: -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->

This tiny pull request aims to clarify an ambiguity in the `coqdoc` section of the reference manual.

In particular, the `--index` flag of `coqdoc` accepts an argument for the filename of the index file, and appends the string `".html"` to it, which in my opinion is clearer after the edit. Please let me know if this is redundant or could be made better. Thanks!