### PR TITLE
[ssr] Remove no longer used not_locked_false_eq_true

### DIFF
--- a/doc/changelog/07-ssreflect/19382-ssr_rm_not_locked_false_eq_true.rst
+++ b/doc/changelog/07-ssreflect/19382-ssr_rm_not_locked_false_eq_true.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  no longer used lemma ``not_locked_false_eq_true``
+  and its call in the :tacn:`done` tactic
+  (`#19382 <https://github.com/coq/coq/pull/19382>`_,
+  by Pierre Roux).

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -2155,13 +2155,11 @@ with a ``by``, like in:
         trivial; hnf; intros; solve
          [ do ![solve [trivial | apply: sym_equal; trivial]
                | discriminate | contradiction | split]
-         | case not_locked_false_eq_true; assumption
          | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].
 
-   The lemma :g:`not_locked_false_eq_true` is needed to discriminate
-   *locked* boolean predicates (see Section :ref:`locking_ssr`). The iterator
-   tactical ``do`` is presented in Section :ref:`iteration_ssr`. This tactic can be
-   customized by the user, for instance to include an :tacn:`auto` tactic.
+   The iterator tactical ``do`` is presented in Section
+   :ref:`iteration_ssr`. This tactic can be customized by the user,
+   for instance to include an :tacn:`auto` tactic.
 
 A natural and common way of closing a goal is to apply a lemma that
 is the exact one needed for the goal to be solved. The defective form

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -392,16 +392,11 @@ Register locked as plugins.ssreflect.locked.
 
 Lemma lock A x : x = locked x :> A. Proof. unlock; reflexivity. Qed.
 
-(**  Needed for locked predicates, in particular for eqType's.  **)
-Lemma not_locked_false_eq_true : locked false <> true.
-Proof. unlock; discriminate. Qed.
-
 (**  The basic closing tactic "done".  **)
 Ltac done :=
   trivial; hnf; intros; solve
    [ do ![solve [trivial | apply: sym_equal; trivial]
          | discriminate | contradiction | split]
-   | case not_locked_false_eq_true; assumption
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].
 
 (**  Quicker done tactic not including split, syntax: /0/  **)
@@ -409,7 +404,6 @@ Ltac ssrdone0 :=
   trivial; hnf; intros; solve
    [ do ![solve [trivial | apply: sym_equal; trivial]
          | discriminate | contradiction ]
-   | case not_locked_false_eq_true; assumption
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].
 
 (**  To unlock opaque constants.  **)


### PR DESCRIPTION
Successfully tested on math-comp CI: https://github.com/math-comp/math-comp/pull/1246

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- ~[ ] Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - ~[ ] Documented any new / changed **user messages**.~
  - ~[ ] Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
<!-- - [ ] Opened **overlay** pull requests. -->

#### Overlays (to be merged before the current PR)

* https://github.com/math-comp/analysis/pull/1262
* https://github.com/math-comp/bigenough/pull/12
* https://github.com/coq-community/graph-theory/pull/41

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
