### PR TITLE
Cleanup UState universe demoting APIs

### DIFF
--- a/dev/ci/user-overlays/19384-SkySkimmer-more-demote.sh
+++ b/dev/ci/user-overlays/19384-SkySkimmer-more-demote.sh
@@ -1,1 +1,3 @@
 overlay rewriter https://github.com/SkySkimmer/rewriter more-demote 19384
+
+overlay metacoq https://github.com/SkySkimmer/metacoq more-demote 19384

--- a/dev/ci/user-overlays/19384-SkySkimmer-more-demote.sh
+++ b/dev/ci/user-overlays/19384-SkySkimmer-more-demote.sh
@@ -1,0 +1,1 @@
+overlay rewriter https://github.com/SkySkimmer/rewriter more-demote 19384

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1184,8 +1184,8 @@ let new_sort_variable ?loc rigid sigma =
   let uctx, q = UState.new_sort_variable sigma.universes in
   ({ sigma with universes = uctx }, Sorts.qsort q u)
 
-let add_global_univ d u =
-  { d with universes = UState.add_global_univ d.universes u }
+let add_forgotten_univ d u =
+  { d with universes = UState.add_forgotten_univ d.universes u }
 
 let make_nonalgebraic_variable evd u =
   { evd with universes = UState.make_nonalgebraic_variable evd.universes u }

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -640,7 +640,7 @@ val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> e
 val new_quality_variable : ?loc:Loc.t -> ?name:Id.t -> evar_map -> evar_map * Sorts.QVar.t
 val new_sort_variable : ?loc:Loc.t -> rigid -> evar_map -> evar_map * esorts
 
-val add_global_univ : evar_map -> Univ.Level.t -> evar_map
+val add_forgotten_univ : evar_map -> Univ.Level.t -> evar_map
 
 val universe_rigidity : evar_map -> Univ.Level.t -> rigid
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1137,7 +1137,7 @@ let new_univ_variable ?loc rigid name uctx =
   let uctx = add_universe ?loc name false uctx u in
   uctx, u
 
-let add_global_univ uctx u = add_universe None true uctx u
+let add_forgotten_univ uctx u = add_universe None true uctx u
 
 let make_with_initial_binders ~lbound univs binders =
   let uctx = make ~lbound univs in

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1049,6 +1049,10 @@ let demote_global_univs (lvl_set,csts_set) uctx =
   let universes = UGraph.merge_constraints csts_set uctx.universes in
   { uctx with local = (local_univs, local_constraints); univ_variables; universes; initial_universes }
 
+let demote_global_univ_entry entry uctx = match entry with
+  | Monomorphic_entry entry -> demote_global_univs entry uctx
+  | Polymorphic_entry _ -> uctx
+
 let merge_seff uctx uctx' =
   let levels = ContextSet.levels uctx' in
   let declare g =

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -177,9 +177,12 @@ val merge_sort_context : ?loc:Loc.t -> sideff:bool -> rigid -> t -> UnivGen.sort
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 
 val demote_global_univs : Univ.ContextSet.t -> t -> t
-(** Removes from the uctx_local part of the UState the universes and constraints
-    that are present in the input constraint set (supposedly the
-    global ones) *)
+(** After declaring global universes, call this if you want to keep using the UState.
+
+    Removes from the uctx_local part of the UState the universes
+    that are present in the input constraint set (supposedly the global ones),
+    and adds any new universes and constraints to the UGraph part of the UState.
+*)
 
 val demote_global_univ_entry : universes_entry -> t -> t
 (** After declaring a global, call this with its universe entry

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -181,6 +181,17 @@ val demote_global_univs : Univ.ContextSet.t -> t -> t
     that are present in the input constraint set (supposedly the
     global ones) *)
 
+val demote_global_univ_entry : universes_entry -> t -> t
+(** After declaring a global, call this with its universe entry
+    if you want to keep using the ustate instead of restarting it
+    with [from_env (Global.env())] or using the slow
+    [update_sigma_univs _ (Environ.universes (Global/env()))].
+
+    Equivalently:
+    - In the monomorphic case, call [demote_global_univs] on the contextset.
+    - In the polymorphic case, do nothing.
+*)
+
 val demote_seff_univs : Univ.Level.Set.t -> t -> t
 (** Mark the universes as not local any more, because they have been
    globally declared by some side effect. You should be using

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -174,8 +174,6 @@ val merge : ?loc:Loc.t -> sideff:bool -> rigid -> t -> Univ.ContextSet.t -> t
 val merge_sort_variables : ?loc:Loc.t -> sideff:bool -> t -> QVar.Set.t -> t
 val merge_sort_context : ?loc:Loc.t -> sideff:bool -> rigid -> t -> UnivGen.sort_context_set -> t
 
-val emit_side_effects : Safe_typing.private_constants -> t -> t
-
 val demote_global_univs : Univ.ContextSet.t -> t -> t
 (** After declaring global universes, call this if you want to keep using the UState.
 
@@ -195,10 +193,8 @@ val demote_global_univ_entry : universes_entry -> t -> t
     - In the polymorphic case, do nothing.
 *)
 
-val demote_seff_univs : Univ.Level.Set.t -> t -> t
-(** Mark the universes as not local any more, because they have been
-   globally declared by some side effect. You should be using
-   emit_side_effects instead. *)
+val emit_side_effects : Safe_typing.private_constants -> t -> t
+(** Calls [demote_global_univs] for the private constant universes. *)
 
 val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> t -> t * QVar.t
 (** Declare a new local sort. *)

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -205,7 +205,8 @@ val new_univ_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Leve
     univ_flexible_alg for a universe existential variable allowed to
     be instantiated with an algebraic universe *)
 
-val add_global_univ : t -> Univ.Level.t -> t
+val add_forgotten_univ : t -> Univ.Level.t -> t
+(** Don't use this, it only exists for funind *)
 
 val make_nonalgebraic_variable : t -> Univ.Level.t -> t
 (** cf UnivFlex *)

--- a/engine/univFlex.ml
+++ b/engine/univFlex.ml
@@ -55,7 +55,15 @@ let add l ~algebraic {subst; algs} =
   let algs = if algebraic then Level.Set.add l algs else algs in
   { subst; algs }
 
-let remove l { subst; algs } = { subst = Level.Map.remove l subst; algs = Level.Set.remove l algs }
+let remove l { subst; algs } =
+  let subst = match Level.Map.find_opt l subst with
+    | None -> subst
+    | Some None -> Level.Map.remove l subst
+    | Some (Some _) ->
+      (* removing [l := v] is unsound as it loses a constraint *)
+      assert false
+  in
+  { subst = subst; algs = Level.Set.remove l algs }
 
 let add_levels levels ~algebraic subst =
   Level.Set.fold (fun l subst -> add l ~algebraic subst) levels subst

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -181,7 +181,7 @@ let level_name sigma = function
   | GSet -> Some (sigma, Univ.Level.set)
   | GUniv u -> Some (sigma, u)
   | GRawUniv u ->
-    let sigma = try Evd.add_global_univ sigma u with UGraph.AlreadyDeclared -> sigma in
+    let sigma = try Evd.add_forgotten_univ sigma u with UGraph.AlreadyDeclared -> sigma in
     Some (sigma, u)
   | GLocalUniv l ->
     let sigma, u = universe_level_name sigma l in


### PR DESCRIPTION
UState.emit_side_effects uses demote_global_univs letting us get rid of demote_seff_univs and the seff_univs field in the ustate

Add an assert in UnivFlex.remove


There is still update_sigma_univs and reboot with unclear status. 

update_sigma_univs is called
- https://github.com/coq/coq/blob/c80c62854458761abf2131b9532b9bf61398b29d/stm/stm.ml#L1990
- https://github.com/coq/coq/blob/c80c62854458761abf2131b9532b9bf61398b29d/vernac/vernacinterp.ml#L159
- https://github.com/coq/coq/blob/c80c62854458761abf2131b9532b9bf61398b29d/vernac/declare.ml#L2465
- https://github.com/coq/coq/blob/c80c62854458761abf2131b9532b9bf61398b29d/vernac/declare.ml#L2560

reboot is called by https://github.com/coq/coq/blob/c80c62854458761abf2131b9532b9bf61398b29d/vernac/declare.ml#L1143

Overlays:
- https://github.com/mit-plv/rewriter/pull/156
- https://github.com/MetaCoq/metacoq/pull/1096