### PR TITLE
Remove useless UFAIL API in Firstorder.

### DIFF
--- a/plugins/firstorder/unify.mli
+++ b/plugins/firstorder/unify.mli
@@ -11,8 +11,6 @@
 open Constr
 open EConstr
 
-exception UFAIL of constr*constr
-
 module Item :
 sig
   type t


### PR DESCRIPTION
This exception was not used outside of its internal module.