### PR TITLE
Support localities for goptions tables Add/Remove

### DIFF
--- a/dev/ci/user-overlays/19390-SkySkimmer-ref-table-locality.sh
+++ b/dev/ci/user-overlays/19390-SkySkimmer-ref-table-locality.sh
@@ -1,0 +1,1 @@
+overlay coqhammer https://github.com/SkySkimmer/coqhammer ref-table-locality 19390

--- a/doc/changelog/08-vernac-commands-and-options/19390-ref-table-locality.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19390-ref-table-locality.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`Add` and :cmd:`Remove`
+  now support attributes :attr:`local`, :attr:`export` and :attr:`global`
+  (`#19390 <https://github.com/coq/coq/pull/19390>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -579,9 +579,16 @@ they appear after a boldface label.  They are listed in the
 
    Adds the specified values to the table :n:`@setting_name`.
 
+   This command supports the :attr:`local`, :attr:`global` and :attr:`export` attributes.
+   The default is `export` outside sections and `local` inside sections.
+   Depending on the table some values may only allow `local`,
+   typically section variables cannot be added with `export` or `global`.
+
 .. cmd:: Remove @setting_name {+ {| @qualid | @string } }
 
    Removes the specified value from the table :n:`@setting_name`.
+
+   This command supports the same attributes as :cmd:`Add`.
 
 .. cmd:: Test @setting_name {? for {+ {| @qualid | @string } } }
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -86,7 +86,7 @@ module MakeTable =
 
     module MySet = A.Set
 
-    let t = Summary.ref ~stage:Summary.Stage.Synterp MySet.empty ~name:nick
+    let t = Summary.ref ~stage:Interp MySet.empty ~name:nick
 
     let (add_option,remove_option) =
         let cache_options (f,p) = match f with
@@ -100,7 +100,7 @@ module MakeTable =
         in
         let inGo : option_mark * A.t -> Libobject.obj =
           Libobject.declare_object {(Libobject.default_object nick) with
-                Libobject.object_stage = Summary.Stage.Synterp;
+                Libobject.object_stage = Interp;
                 Libobject.load_function = load_options;
                 Libobject.open_function = Libobject.simple_open ~cat:opts_cat load_options;
                 Libobject.cache_function = cache_options;

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -81,22 +81,28 @@ end
    the internal version of the vernacular "Test ...": it tells if a
    given object is in the table.  *)
 
+module type RefConvertArg = sig
+  type t
+  module Set : CSig.USetS with type elt = t
+  val encode : Environ.env -> Libnames.qualid -> t
+  val subst : Mod_subst.substitution -> t -> t
+
+  val check_local : Libobject.locality -> t -> unit
+  val discharge : t -> t
+  (** Elements which cannot be discharged should only be added with Local *)
+
+  val printer : t -> Pp.t
+  val key : option_name
+  val title : string
+  val member_message : t -> bool -> Pp.t
+end
+
 module MakeRefTable :
-  functor
-    (A : sig
-       type t
-       module Set : CSig.USetS with type elt = t
-       val encode : Environ.env -> Libnames.qualid -> t
-       val subst : Mod_subst.substitution -> t -> t
-       val printer : t -> Pp.t
-       val key : option_name
-       val title : string
-       val member_message : t -> bool -> Pp.t
-     end) ->
+  functor (A : RefConvertArg) ->
 sig
   val v : unit -> A.Set.t
   val active : A.t -> bool
-  val set : A.t -> bool -> unit
+  val set : Libobject.locality -> A.t -> bool -> unit
 end
 
 
@@ -159,8 +165,8 @@ val declare_interpreted_string_option_and_ref : (string -> 'a) -> ('a -> string)
 module OptionMap : CSig.MapS with type key = option_name
 
 type 'a table_of_A =  {
-  add : Environ.env -> 'a -> unit;
-  remove : Environ.env -> 'a -> unit;
+  add : Environ.env -> Libobject.locality -> 'a -> unit;
+  remove : Environ.env -> Libobject.locality -> 'a -> unit;
   mem : Environ.env -> 'a -> unit;
   print : unit -> unit;
 }

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -481,6 +481,20 @@ module CoercionPrinting =
     module Set = GlobRef.Set
     let encode _env = coercion_of_reference
     let subst = subst_coe_typ
+
+    let check_local local = let open GlobRef in function
+      | ConstRef _ | ConstructRef _ | IndRef _ -> ()
+      | VarRef x -> match local with
+        | Libobject.Local -> ()
+        | Export | SuperGlobal ->
+          let local = if local = Export then "export" else "global" in
+          CErrors.user_err
+            Pp.(Id.print x ++ str " cannot be added with locality " ++ str local ++ str ".")
+
+    let discharge = let open GlobRef in function
+      | ConstRef _ | ConstructRef _ | IndRef _ as x -> x
+      | VarRef _ as x -> assert (not (Lib.is_in_section x)); x
+
     let printer x = Nametab.pr_global_env Id.Set.empty x
     let key = ["Printing";"Coercion"]
     let title = "Explicitly printed coercions: "

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -270,11 +270,12 @@ module PrintingInductiveMake =
     module Set = Indset
     let encode = Test.encode
     let subst subst obj = subst_ind subst obj
+    let check_local _ _ = ()
+    let discharge (i:t) = i
     let printer ind = Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef ind)
     let key = ["Printing";Test.field]
     let title = Test.title
     let member_message x = Test.member_message (printer x)
-    let synchronous = true
   end
 
 module PrintingCasesIf =

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -76,15 +76,4 @@ module PrintingInductiveMake :
     val member_message : Pp.t -> bool -> Pp.t
     val field : string
     val title : string
-  end) ->
-    sig
-      type t = Names.inductive
-      module Set = Indset
-      val encode : Environ.env -> Libnames.qualid -> Names.inductive
-      val subst : substitution -> t -> t
-      val printer : t -> Pp.t
-      val key : Goptions.option_name
-      val title : string
-      val member_message : t -> bool -> Pp.t
-      val synchronous : bool
-    end
+  end) -> Goptions.RefConvertArg with type t = inductive and module Set = Indset

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -736,6 +736,8 @@ struct
   module Set = Indset_env
   let encode _env r = Nametab.global_inductive r
   let subst subst obj = Mod_subst.subst_ind subst obj
+  let check_local _ _ = ()
+  let discharge (i:t) = i
   let printer ind = Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef ind)
   let key = ["Keep"; "Equalities"]
   let title = "Prop-valued inductive types for which injection keeps equality proofs"

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -87,7 +87,7 @@ val dEqThen : keep_proofs:(bool option) -> evars_flag -> (int -> unit Proofview.
 val rewriteInHyp : bool -> constr -> Id.t -> unit Proofview.tactic
 val rewriteInConcl : bool -> constr -> unit Proofview.tactic
 
-val set_keep_equality : inductive -> bool -> unit
+val set_keep_equality : Libobject.locality -> inductive -> bool -> unit
 
 (* Subst *)
 

--- a/test-suite/output/PrintingCoercion.out
+++ b/test-suite/output/PrintingCoercion.out
@@ -1,0 +1,29 @@
+a : C
+     : C
+File "./output/PrintingCoercion.v", line 25, characters 6-43:
+The command has indeed failed with message:
+h' cannot be added with locality global.
+File "./output/PrintingCoercion.v", line 26, characters 6-46:
+The command has indeed failed with message:
+h' cannot be added with locality export.
+g (f a) : D
+     : D
+File "./output/PrintingCoercion.v", line 30, characters 6-35:
+The command has indeed failed with message:
+h is not a coercion.
+h' (g (f a)) : D
+     : D
+g a : C
+     : C
+h (g (f a)) : D
+     : D
+f a : C
+     : C
+f a : C
+     : C
+a : C
+     : C
+a : D
+     : D
+h (g a) : D
+     : D

--- a/test-suite/output/PrintingCoercion.v
+++ b/test-suite/output/PrintingCoercion.v
@@ -1,0 +1,59 @@
+
+Parameter A B C D : Type.
+
+Parameter f : A -> B.
+Parameter g : B -> C.
+Parameter h : C -> D.
+
+Coercion f : A >-> B.
+Coercion g : B >-> C.
+
+Parameter a : A.
+
+Check a : C.
+
+Module M.
+  Module N.
+    Section S.
+      Add Printing Coercion f. (* implicit local *)
+      #[export] Add Printing Coercion g.
+
+      Variable h' : C -> D.
+
+      Coercion h' : C >-> D.
+
+      Fail Global Add Printing Coercion h'.
+      Fail #[export] Add Printing Coercion h'.
+
+      Check a : D.
+
+      Fail Add Printing Coercion h.
+      Add Printing Coercion h'.
+
+      Check a : D.
+
+    End S.
+
+    Check a : C.
+
+    Global Add Printing Coercion f.
+
+    Coercion h : C >-> D.
+    Add Printing Coercion h. (* implicit export *)
+
+    Check a : D.
+  End N.
+  Check a : C.
+
+  Remove Printing Coercion f. (* implicit export *)
+End M.
+Check a : C.
+
+Import M.
+Check a : C.
+
+Import(coercions) N.
+Check a : D.
+
+Import(options) N.
+Check a : D.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2539,13 +2539,13 @@ let translate_pure_vernac ?loc ~atts v = let open Vernactypes in match v with
 
   | VernacRemoveOption (key,v) ->
     vtdefault(fun () ->
-      unsupported_attributes atts;
-      Vernacoptions.vernac_remove_option key v)
+      let local = Attributes.parse Attributes.hint_locality atts in
+      Vernacoptions.vernac_remove_option local key v)
 
   | VernacAddOption (key,v) ->
     vtdefault(fun () ->
-      unsupported_attributes atts;
-      Vernacoptions.vernac_add_option key v)
+      let local = Attributes.parse Attributes.hint_locality atts in
+      Vernacoptions.vernac_add_option local key v)
 
   | VernacMemOption (key,v) ->
     vtdefault(fun () ->

--- a/vernac/vernacoptions.ml
+++ b/vernac/vernacoptions.ml
@@ -38,9 +38,9 @@ let vernac_set_option ~locality ~stage table v = match v with
 
 let iter_table f k v = Goptions.iter_table (Global.env()) f k v
 
-let vernac_add_option = iter_table { aux = fun table -> table.add }
+let vernac_add_option local = iter_table { aux = fun table env x -> table.add env local x }
 
-let vernac_remove_option = iter_table { aux = fun table -> table.remove }
+let vernac_remove_option local = iter_table { aux = fun table env x -> table.remove env local x }
 
 let vernac_mem_option = iter_table { aux = fun table -> table.mem }
 

--- a/vernac/vernacoptions.mli
+++ b/vernac/vernacoptions.mli
@@ -19,10 +19,10 @@ val vernac_set_option :
   option_name -> Vernacexpr.option_setting -> unit
 
 val vernac_add_option :
-  option_name -> table_value list -> unit
+  Libobject.locality -> option_name -> table_value list -> unit
 
 val vernac_remove_option :
-  option_name -> table_value list -> unit
+  Libobject.locality -> option_name -> table_value list -> unit
 
 val vernac_mem_option : option_name -> table_value list -> unit
 


### PR DESCRIPTION
NB the previous code did
`load_function = fun i o -> if i = 1 then cache o`
but load_function of leaf objects is always called with i > 1
(the parent module is the one that gets i = 1)
so the actual behaviour was always `export` (local in sections).

Depends:
- https://github.com/coq/coq/pull/19362 (merged)

Overlays:
- https://github.com/lukaszcz/coqhammer/pull/182