### PR TITLE
Ignore universe constraints from comparing types in old unification

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1136,8 +1136,10 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
       match subst_defined_metas_evars sigma subst cN with
       | None -> (* some undefined Metas in cN *) None
       | Some n1 ->
-         (* No subterm restriction there, too much incompatibilities *)
-         let uprob =
+        (* No subterm restriction there, too much incompatibilities
+           don't care about universes from comparing the types
+        *)
+         let _ : UnivProblem.Set.t =
            if opt.with_types then
              try (* Ensure we call conversion on terms of the same type *)
                let tyM = get_type_of curenv ~lax:true sigma m1 in
@@ -1148,8 +1150,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
            else UnivProblem.Set.empty
          in
         match infer_conv_ustate ~pb ~ts:convflags curenv sigma m1 n1 with
-        | Some uprob' ->
-          let uprob = UnivProblem.Set.union uprob uprob' in
+        | Some uprob ->
           begin match Evd.add_universe_constraints sigma uprob with
           | sigma -> Some (push_sigma sigma substn)
           | exception (UGraph.UniverseInconsistency _ | UniversesDiffer) -> None

--- a/test-suite/bugs/bug_19221.v
+++ b/test-suite/bugs/bug_19221.v
@@ -1,0 +1,29 @@
+
+Module Left.
+  Definition mayRet {A:Type} (a b:A): Prop := a=b.
+
+  Lemma zarb A (k:  A) : mayRet k k.
+  Proof.
+
+    Succeed Constraint mayRet.u0 < eq.u0.
+
+    apply eq_refl.
+
+    Succeed Constraint mayRet.u0 < eq.u0.
+  Defined.
+End Left.
+
+Module Right.
+  Definition mayRet {A:Type} (a b:A): Prop := a=b.
+
+  Definition mayRet_refl {A} k : @mayRet A k k := eq_refl.
+
+  Lemma zarb A (k:  A) : k = k.
+  Proof.
+    Succeed Constraint mayRet.u0 < eq.u0.
+
+    apply mayRet_refl.
+
+    Succeed Constraint mayRet.u0 < eq.u0.
+  Defined.
+End Right.


### PR DESCRIPTION
They are too strict sometimes, and don't seem to be needed (but let's see what CI says).

Fix #19221
