### PR TITLE
done with simple refine

### DIFF
--- a/doc/changelog/07-ssreflect/19399-done_with_simple_refine.rst
+++ b/doc/changelog/07-ssreflect/19399-done_with_simple_refine.rst
@@ -1,0 +1,2 @@
+- **Changed:**
+  `done` uses `simple refine` instead of `apply` to apply `sym_equal`

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -395,7 +395,7 @@ Lemma lock A x : x = locked x :> A. Proof. unlock; reflexivity. Qed.
 (**  The basic closing tactic "done".  **)
 Ltac done :=
   trivial; hnf; intros; solve
-   [ do ![solve [trivial | apply: (@sym_equal _ _ _ _); trivial]
+   [ do ![solve [trivial | simple refine (@sym_equal _ _ _ _); trivial]
          | discriminate | contradiction | split]
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
As suggested by [at]silene, we test whether using `simple refine` improves over `apply:` to apply `sym_equal`.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
