### PR TITLE
Avoid allocating a new term when already whnf in Reductionops.red_of_state_red

### DIFF
--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1043,7 +1043,13 @@ let whd_nored = red_of_state_red whd_nored_state
 
 let whd_beta_state = local_whd_state_gen RedFlags.beta
 let whd_beta_stack = stack_red_of_state_red whd_beta_state
-let whd_beta = red_of_state_red whd_beta_state
+let whd_beta env sigma c =
+  let is_whnf = match EConstr.kind sigma c with
+    | App (h,_) -> EConstr.isRef sigma h
+    | _ -> EConstr.isRef sigma c
+  in
+  if is_whnf then c
+  else red_of_state_red whd_beta_state env sigma c
 
 let whd_betalet_state = local_whd_state_gen RedFlags.betazeta
 let whd_betalet_stack = stack_red_of_state_red whd_betalet_state

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1066,7 +1066,13 @@ let whd_betadeltazeta = red_of_state_red whd_betadeltazeta_state
 
 let whd_betaiota_state = local_whd_state_gen RedFlags.betaiota
 let whd_betaiota_stack = stack_red_of_state_red whd_betaiota_state
-let whd_betaiota = red_of_state_red whd_betaiota_state
+let whd_betaiota env sigma c =
+  let is_whnf = match EConstr.kind sigma c with
+    | App (h,_) -> EConstr.isRef sigma h
+    | _ -> EConstr.isRef sigma c
+  in
+  if is_whnf then c
+  else red_of_state_red whd_betaiota_state env sigma c
 
 let whd_betaiotazeta_state = local_whd_state_gen RedFlags.betaiotazeta
 let whd_betaiotazeta_stack = stack_red_of_state_red whd_betaiotazeta_state


### PR DESCRIPTION


This is crucially used with `strongrec` in `meta_instance` such that when we unify `S ?M == S (S ...)` without this code the value we get for ?M is not shared with the RHS at all. eg in

~~~coq
Inductive is_nat : nat -> Prop :=
| Is_nat_Z : is_nat 0
| Is_nat_S : forall n, is_nat n -> is_nat (S n).

Lemma is_nat_500 : is_nat 500.
Proof.
  repeat constructor.
  (* proof = Is_nat_S 499 (Is_nat_S 498 ...) *)
Time Qed.
~~~
all the copies of 1, 2, 3, ..., 499 are not shared with each other without this change.

(example from #18520)
