### PR TITLE
Vars.lift_substituend use previous computation to detect closed subterms

### DIFF
--- a/clib/sList.ml
+++ b/clib/sList.ml
@@ -103,6 +103,14 @@ let rec exists f l = match l with
 | Cons (x, l) -> f x || exists f l
 | Default (_, l) -> exists f l
 
+let rec map2 f l1 l2 = match l1, l2 with
+  | Nil, Nil -> Nil
+  | Cons (x,l1), Cons (y,l2) -> let z = f x y in Cons (z, map2 f l1 l2)
+  | Default (n,l1), Default (m,l2) ->
+    if not (Int.equal n m) then invalid_arg "SList.map2"
+    else Default (n, map2 f l1 l2)
+  | (Nil | Cons _ | Default _), _ -> invalid_arg "SList.map2"
+
 end
 
 module Smart =

--- a/clib/sList.mli
+++ b/clib/sList.mli
@@ -64,6 +64,10 @@ val fold : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 val for_all : ('a -> bool) -> 'a t -> bool
 val exists : ('a -> bool) -> 'a t -> bool
 
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** The skip structure of the 2 maps should be identical,
+    otherwise raise [Invalid_argument] after mapping the matching prefixes. *)
+
 end
 (** These iterators ignore the default values in the list. *)
 

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -408,6 +408,8 @@ val destFix : constr -> fixpoint
 
 val destCoFix : constr -> cofixpoint
 
+val destArray : constr -> UVars.Instance.t * constr array * constr * types
+
 val destRef : constr -> GlobRef.t UVars.puniverses
 
 (** {6 Equality} *)


### PR DESCRIPTION
The critical property is that for nonzero `n`, `lift n c = c` iff `c` is closed (and the extension to lift under binders).
