### PR TITLE
Factorize handling of control flags between synterp and interp + use control flags in stm close_proof calls

### DIFF
--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -75,14 +75,6 @@ let with_generic_atts ~check atts f =
 
 type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * Entries.inline
 
-type control_entry =
-  | ControlTime of { synterp_duration: System.duration }
-  | ControlInstructions of { synterp_instructions: System.instruction_count }
-  | ControlRedirect of string
-  | ControlTimeout of { remaining : float }
-  | ControlFail of { st : Vernacstate.Synterp.t }
-  | ControlSucceed of { st : Vernacstate.Synterp.t }
-
 type synterp_entry =
   | EVernacNoop
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
@@ -113,7 +105,9 @@ type synterp_entry =
 
 and vernac_entry = synterp_entry Vernacexpr.vernac_expr_gen
 
-and vernac_control_entry = (control_entry, synterp_entry) Vernacexpr.vernac_control_gen_r CAst.t
+and vernac_control_entry =
+  (Vernacstate.Synterp.t VernacControl.control_entry, synterp_entry)
+    Vernacexpr.vernac_control_gen_r CAst.t
 
 let synterp_reserved_notation ~module_local ~infix l =
   Metasyntax.add_reserved_notation ~local:module_local ~infix l
@@ -349,104 +343,15 @@ let synterp_begin_section ({v=id} as lid) =
   Dumpglob.dump_definition lid true "sec";
   Lib.Synterp.open_section id
 
-(** A global default timeout, controlled by option "Set Default Timeout n".
-    Use "Unset Default Timeout" to deactivate it (or set it to 0). *)
-
-let check_timeout n =
-  if n <= 0 then CErrors.user_err Pp.(str "Timeout must be > 0.")
-
-(* Timeout *)
-let with_timeout ~timeout:n (f : 'a -> 'b) (x : 'a) : 'b =
-  check_timeout n;
-  let n = float_of_int n in
-  let start = Unix.gettimeofday () in
-  begin match Control.timeout n f x with
-  | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
-  | Some (ctrl,v) ->
-    let stop = Unix.gettimeofday () in
-    let remaining = n -. (start -. stop) in
-    if remaining <= 0. then Exninfo.iraise (Exninfo.capture CErrors.Timeout)
-    else ControlTimeout { remaining } :: ctrl, v
-  end
-
-(* Restoring the state is the caller's responsibility *)
-let with_fail f : (Loc.t option * Pp.t, 'a) result =
-  try
-    let x = f () in
-    Error x
-  with
-  (* Fail Timeout is a common pattern so we need to support it. *)
-  | e ->
-    (* The error has to be printed in the failing state *)
-    let _, info as exn = Exninfo.capture e in
-    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
-    Ok (Loc.get_loc info, CErrors.iprint exn)
-
-let real_error_loc ~cmdloc ~eloc =
-  if Loc.finer eloc cmdloc then eloc
-  else cmdloc
-
-let with_fail ~loc f =
-  let st = Vernacstate.Synterp.freeze () in
-  let res = with_fail f in
-  let transient_st = Vernacstate.Synterp.freeze () in
-  Vernacstate.Synterp.unfreeze st;
-  match res with
-  | Error (ctrl, v) ->
-    ControlFail { st = transient_st } :: ctrl, v
-  | Ok (eloc, msg) ->
-    let loc = if !Flags.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
-    if not !Flags.quiet || !Flags.test_mode
-    then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg);
-    [], VernacSynterp EVernacNoop
-
-let with_succeed f =
-  let st = Vernacstate.Synterp.freeze () in
-  let (ctrl, v) = f () in
-  let transient_st = Vernacstate.Synterp.freeze () in
-  Vernacstate.Synterp.unfreeze st;
-  ControlSucceed { st = transient_st } :: ctrl, v
-
-let synpure_control : control_flag -> control_entry =
-  let freeze = Vernacstate.Synterp.freeze in function
-  | ControlTime -> ControlTime { synterp_duration = System.empty_duration }
-  | ControlInstructions -> ControlInstructions { synterp_instructions = Ok 0L }
-  | ControlRedirect s -> ControlRedirect s
-  | ControlTimeout timeout ->
-    check_timeout timeout;
-    ControlTimeout { remaining = float_of_int timeout }
-  | ControlFail -> ControlFail { st = freeze() }
-  | ControlSucceed -> ControlSucceed { st = freeze() }
-
-(* We restore the state always *)
-let rec synterp_control_flag ~loc (f : control_flag list) fn expr =
-  match f with
-  | [] -> [], fn expr
-  | ControlFail :: l ->
-    with_fail ~loc (fun () -> synterp_control_flag ~loc l fn expr)
-  | ControlSucceed :: l ->
-    with_succeed (fun () -> synterp_control_flag ~loc l fn expr)
-  | ControlTimeout timeout :: l ->
-    with_timeout ~timeout (synterp_control_flag ~loc l fn) expr
-  | ControlTime :: l ->
-    begin match System.measure_duration (synterp_control_flag ~loc l fn) expr with
-    | Ok((ctrl,v), synterp_duration) ->
-      ControlTime { synterp_duration } :: ctrl, v
-    | Error(exn, synterp_duration) as e ->
-      Feedback.msg_notice @@ System.fmt_transaction_result e;
-      Exninfo.iraise exn
-    end
-  | ControlInstructions :: l ->
-    begin match System.count_instructions (synterp_control_flag ~loc l fn) expr with
-    | Ok((ctrl,v), synterp_instructions) ->
-      ControlInstructions { synterp_instructions } :: ctrl, v
-    | Error(exn, synterp_instructions) as e ->
-      Feedback.msg_notice @@ System.fmt_instructions_result e;
-      Exninfo.iraise exn
-    end
-  | ControlRedirect s :: l ->
-    let (ctrl, v) = Topfmt.with_output_to_file s (synterp_control_flag ~loc l fn) expr in
-    (ControlRedirect s :: ctrl, v)
+let with_synterp_state =
+  let with_local_state () f =
+    let st = Vernacstate.Synterp.freeze () in
+    let v = f () in
+    let transient_st = Vernacstate.Synterp.freeze () in
+    Vernacstate.Synterp.unfreeze st;
+    transient_st, v
+  in
+  { VernacControl.with_local_state }
 
 let rec synterp ~intern ?loc ~atts v =
   match v with
@@ -553,34 +458,13 @@ and synterp_control ~intern CAst.{ loc; v = cmd } =
     with_generic_atts ~check:true cmd.attrs (fun ~atts ->
         synterp ~intern ?loc ~atts cmd.expr)
   in
-  let control, expr = synterp_control_flag ~loc cmd.control fn cmd.expr in
+  let control, expr =
+    VernacControl.under_control ~loc ~with_local_state:with_synterp_state
+      (VernacControl.from_syntax cmd.control)
+      ~noop:(VernacSynterp EVernacNoop)
+      (fun () -> fn cmd.expr)
+  in
   CAst.make ?loc { expr; control; attrs = cmd.attrs }
-
-let default_timeout = ref None
-
-let () = let open Goptions in
-  declare_int_option
-    { optstage = Summary.Stage.Synterp;
-      optdepr  = None;
-      optkey   = ["Default";"Timeout"];
-      optread  = (fun () -> !default_timeout);
-      optwrite = (fun n -> Option.iter check_timeout n; default_timeout := n) }
-
-let has_timeout ctrl = ctrl |> List.exists (function
-    | Vernacexpr.ControlTimeout _ -> true
-    | _ -> false)
-
-let add_default_timeout control =
-  match !default_timeout with
-  | None -> control
-  | Some n ->
-    if has_timeout control then control
-    else Vernacexpr.ControlTimeout n :: control
-
-let synterp_control ~intern cmd =
-  synterp_control ~intern (CAst.map (fun cmd ->
-      { cmd with control = add_default_timeout cmd.control })
-      cmd)
 
 let synterp_control ~intern cmd =
   Flags.with_option Flags.in_synterp_phase (synterp_control ~intern) cmd

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -27,17 +27,6 @@ val with_generic_atts :
 
 type module_entry = Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * Entries.inline
 
-type control_entry =
-  | ControlTime of { synterp_duration: System.duration }
-  | ControlInstructions of { synterp_instructions: System.instruction_count }
-  | ControlRedirect of string
-  | ControlTimeout of { remaining : float }
-  | ControlFail of { st : Vernacstate.Synterp.t }
-  | ControlSucceed of { st : Vernacstate.Synterp.t }
-
-(** Interprete control flag assuming a synpure command. *)
-val synpure_control : Vernacexpr.control_flag -> control_entry
-
 type synterp_entry =
   | EVernacNoop
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
@@ -69,7 +58,9 @@ and vernac_entry = synterp_entry Vernacexpr.vernac_expr_gen
 
 (** [vernac_control_entry] defines elaborated vernacular expressions, after the
     syntactic interpretation phase and before full interpretation *)
-and vernac_control_entry = (control_entry, synterp_entry) Vernacexpr.vernac_control_gen_r CAst.t
+and vernac_control_entry =
+  (Vernacstate.Synterp.t VernacControl.control_entry, synterp_entry)
+    Vernacexpr.vernac_control_gen_r CAst.t
 
 exception UnmappedLibrary of Names.DirPath.t option * Libnames.qualid
 exception NotFoundLibrary of Names.DirPath.t option * Libnames.qualid
@@ -88,8 +79,6 @@ val synterp_control :
   intern:Library.Intern.t ->
   Vernacexpr.vernac_control ->
   vernac_control_entry
-
-val add_default_timeout : Vernacexpr.control_flag list -> Vernacexpr.control_flag list
 
 (** Default proof mode set by `start_proof` *)
 val get_default_proof_mode : unit -> Pvernac.proof_mode

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -408,11 +408,15 @@ let print_err_exn any =
   let msg = CErrors.iprint (e, info) ++ fnl () in
   std_logger ?pre_hdr Feedback.Error msg
 
-let with_output_to_file fname func input =
+let with_output_to_file ~truncate fname func input =
   let fname = String.concat "." [fname; "out"] in
   let fullfname = System.get_output_path fname in
   System.mkdir (Filename.dirname fullfname);
-  let channel = open_out fullfname in
+  let channel =
+    let flags = [Open_wronly; Open_creat; Open_text] in
+    let flags = if truncate then Open_trunc :: flags else flags in
+    open_out_gen flags 0o666 fullfname
+  in
   let old_fmt = !std_ft, !err_ft, !deep_ft in
   let new_ft = Format.formatter_of_out_channel channel in
   set_gp new_ft (get_gp !std_ft);

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -68,8 +68,9 @@ val in_phase : phase:execution_phase -> ('a -> 'b) -> 'a -> 'b
 val pr_phase : ?loc:Loc.t -> unit -> Pp.t option
 val print_err_exn : exn -> unit
 
-(** [with_output_to_file file f x] executes [f x] with logging
-    redirected to a file [file] *)
-val with_output_to_file : string -> ('a -> 'b) -> 'a -> 'b
+(** [with_output_to_file ~truncate file f x] executes [f x] with
+    logging redirected to a file [file] (starting empty if
+    [truncate:true], otherwise appending if it already exists). *)
+val with_output_to_file : truncate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 
 val pr_cmd_header : Vernacexpr.vernac_control -> Pp.t

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -81,6 +81,8 @@ let with_fail f : (Loc.t option * Pp.t, 'a) result =
 
 type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }
 
+let trivial_state = { with_local_state = fun () f -> (), f () }
+
 let with_fail ~loc ~with_local_state st0 f =
   let transient_st, res = with_local_state.with_local_state st0 (fun () -> with_fail f) in
   match res with

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -1,0 +1,186 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Partially interpreted control flags.
+
+    [ControlTime {duration}] means "Time" where the
+    partial interpretation has already take [duration].
+
+    In [ControlRedirect], [truncate] tells whether we should truncate
+    the file before printing (ie [false] if not the first phase).
+    Alternatively we could do [ControlRedirect of out_channel],
+    but that risks leaking open channels.
+
+    [ControlFail {st}] means "Fail" where the partial interpretation
+    did not fail and produced state [st].
+
+    [ControlSucceed {st}] means "Succeed" where the partial
+    interpretation succeeded and produced state [st].
+*)
+type 'state control_entry =
+  | ControlTime of { duration: System.duration }
+  | ControlInstructions of { instructions: System.instruction_count }
+  | ControlRedirect of { fname : string; truncate : bool}
+  | ControlTimeout of { remaining : float }
+  | ControlFail of { st : 'state }
+  | ControlSucceed of { st : 'state }
+
+type 'state control_entries = 'state control_entry list
+
+let check_timeout_f n =
+  if n <= 0. then CErrors.user_err Pp.(str "Timeout must be > 0.")
+
+let with_measure measure add fmt flag init f =
+  let result = measure f () in
+  let result = match result with
+    | Ok (v,d) -> Ok (v, add init d)
+    | Error (e,d) -> Error (e, add init d)
+  in
+  begin match result with
+  | Ok (v,result) -> Some (flag result, v)
+  | Error (e,_) ->
+    Feedback.msg_notice @@ fmt result;
+    Exninfo.iraise e
+  end
+
+let with_timeout ~timeout:n f =
+  check_timeout_f n;
+  let start = Unix.gettimeofday () in
+  begin match Control.timeout n f () with
+  | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+  | Some v ->
+    let stop = Unix.gettimeofday () in
+    let remaining = n -. (stop -. start) in
+    if remaining <= 0. then Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+    else Some (ControlTimeout { remaining }, v)
+  end
+
+let real_error_loc ~cmdloc ~eloc =
+  if Loc.finer eloc cmdloc then eloc
+  else cmdloc
+
+(* Restoring the state is the caller's responsibility *)
+let with_fail f : (Loc.t option * Pp.t, 'a) result =
+  try
+    let x = f () in
+    Error x
+  with
+  (* Fail Timeout is a common pattern so we need to support it. *)
+  | e ->
+    (* The error has to be printed in the failing state *)
+    let _, info as exn = Exninfo.capture e in
+    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
+    Ok (Loc.get_loc info, CErrors.iprint exn)
+
+type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }
+
+let with_fail ~loc ~with_local_state st0 f =
+  let transient_st, res = with_local_state.with_local_state st0 (fun () -> with_fail f) in
+  match res with
+  | Error v ->
+    Some (ControlFail { st = transient_st }, v)
+  | Ok (eloc, msg) ->
+    let loc = if !Flags.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
+    if not !Flags.quiet || !Flags.test_mode
+    then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg);
+    None
+
+let with_succeed ~with_local_state st0 f =
+  let transient_st, v = with_local_state.with_local_state st0 f in
+  Some (ControlSucceed { st = transient_st }, v)
+
+let under_one_control ~loc ~with_local_state control f =
+  match control with
+  | ControlTime { duration } ->
+    with_measure System.measure_duration System.duration_add System.fmt_transaction_result
+      (fun duration -> ControlTime {duration})
+      duration
+      f
+  | ControlInstructions {instructions} ->
+    with_measure System.count_instructions System.instruction_count_add System.fmt_instructions_result
+      (fun instructions -> ControlInstructions {instructions})
+      instructions
+      f
+  | ControlRedirect { fname; truncate } ->
+    let v = Topfmt.with_output_to_file ~truncate fname f () in
+    Some (ControlRedirect {fname; truncate=false}, v)
+  | ControlTimeout {remaining} -> with_timeout ~timeout:remaining f
+  | ControlFail {st} -> with_fail ~loc ~with_local_state st f
+  | ControlSucceed {st} -> with_succeed ~with_local_state st f
+
+let rec under_control ~loc ~with_local_state controls ~noop f =
+  match controls with
+  | [] -> [], f ()
+  | control :: rest ->
+    let f () = under_control ~loc ~with_local_state rest ~noop f in
+    match under_one_control ~loc ~with_local_state control f with
+    | Some (control, (rest,v)) -> control :: rest, v
+    | None -> [], noop
+
+let ignore_state = { with_local_state = fun _ f -> (), f () }
+
+let rec after_last_phase ~loc = function
+  | [] -> false
+  | control :: rest ->
+    (* don't match on [control] before processing [rest]: correctly handle eg [Fail Fail]. *)
+    let rest () = after_last_phase ~loc rest in
+    match under_one_control ~loc ~with_local_state:ignore_state control rest with
+    | None -> true
+    | Some (control,noop) ->
+      match control with
+      | ControlTime {duration} ->
+        Feedback.msg_notice @@ System.fmt_transaction_result (Ok ((),duration));
+        noop
+      | ControlInstructions {instructions} ->
+        Feedback.msg_notice @@ System.fmt_instructions_result (Ok ((),instructions));
+        noop
+      | ControlRedirect _ -> noop
+      | ControlTimeout _ -> noop
+      | ControlFail _ -> CErrors.user_err Pp.(str "The command has not failed!")
+      | ControlSucceed _ -> true
+
+(** A global default timeout, controlled by option "Set Default Timeout n".
+    Use "Unset Default Timeout" to deactivate it. *)
+
+let default_timeout = ref None
+
+let check_timeout n =
+  if n <= 0 then CErrors.user_err Pp.(str "Timeout must be > 0.")
+
+let () = let open Goptions in
+  declare_int_option
+    { optstage = Summary.Stage.Synterp;
+      optdepr  = None;
+      optkey   = ["Default";"Timeout"];
+      optread  = (fun () -> !default_timeout);
+      optwrite = (fun n -> Option.iter check_timeout n; default_timeout := n) }
+
+let has_timeout ctrl = ctrl |> List.exists (function
+    | Vernacexpr.ControlTimeout _ -> true
+    | _ -> false)
+
+let add_default_timeout control =
+  match !default_timeout with
+  | None -> control
+  | Some n ->
+    if has_timeout control then control
+    else Vernacexpr.ControlTimeout n :: control
+
+let from_syntax_one : Vernacexpr.control_flag -> unit control_entry = function
+  | ControlTime -> ControlTime { duration = System.empty_duration }
+  | ControlInstructions -> ControlInstructions { instructions = Ok 0L }
+  | ControlRedirect s -> ControlRedirect { fname = s; truncate = true }
+  | ControlTimeout timeout ->
+    (* don't check_timeout here as the error won't be caught by surrounding Fail *)
+    ControlTimeout { remaining = float_of_int timeout }
+  | ControlFail -> ControlFail { st = () }
+  | ControlSucceed -> ControlSucceed { st = () }
+
+let from_syntax control = List.map from_syntax_one (add_default_timeout control)

--- a/vernac/vernacControl.mli
+++ b/vernac/vernacControl.mli
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Partially interpreted control flags. *)
+type 'state control_entry
+
+type 'state control_entries = 'state control_entry list
+
+(** Translate from syntax and add default timeout. *)
+val from_syntax : Vernacexpr.control_flag list -> unit control_entries
+
+type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }
+(** [with_local_state state0 f] should run [f] with [state0] installed,
+    capture the state produced by running [f] and revert the global state afterwards.
+*)
+
+(** [under_control ~loc ~with_local_state control ~noop f]
+    runs [f ()] in the context given by the [control].
+
+    If the [control] cause execution to end with no more work to be
+    done and no error (eg [Fail] when [f] raised an exception) then
+    [noop] is returned.
+*)
+val under_control : loc:Loc.t option ->
+  with_local_state:('state0,'state) with_local_state ->
+  'state0 control_entries ->
+  noop:'b ->
+  (unit -> 'b) ->
+  'state control_entries * 'b
+
+(** Print any final messages (eg from [Time]) and raise final
+    exceptions (eg from [Fail] when the command did not fail). The
+    returned boolean tells if we should be noop ([Fail] where the
+    command failed or [Succeed] where it succeeded).
+*)
+val after_last_phase : loc:Loc.t option -> _ control_entries -> bool

--- a/vernac/vernacControl.mli
+++ b/vernac/vernacControl.mli
@@ -21,6 +21,8 @@ type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a)
     capture the state produced by running [f] and revert the global state afterwards.
 *)
 
+val trivial_state : (unit,unit) with_local_state
+
 (** [under_control ~loc ~with_local_state control ~noop f]
     runs [f ()] in the context given by the [control].
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -13,89 +13,49 @@ open Synterp
 
 let vernac_pperr_endline = CDebug.create ~name:"vernacinterp" ()
 
-(* Timeout *)
-let vernac_timeout ~timeout (f : 'a -> 'b) (x : 'a) : 'b =
-  match Control.timeout timeout f x with
-  | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
-  | Some x -> x
-
-(* Fail *)
-
-(* Restoring the state is the caller's responsibility *)
-let with_fail f : (Loc.t option * Pp.t, unit) result =
-  try
-    let _ = f () in
-    Error ()
-  with
-  (* Fail Timeout is a common pattern so we need to support it. *)
-  | e ->
-    (* The error has to be printed in the failing state *)
-    let _, info as exn = Exninfo.capture e in
-    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
-    Ok (Loc.get_loc info, CErrors.iprint exn)
-
 let real_error_loc ~cmdloc ~eloc =
   if Loc.finer eloc cmdloc then eloc
   else cmdloc
 
-(* We restore the state always *)
-let with_fail ~loc ~st f =
-  let res = with_fail f in
-  Vernacstate.Interp.invalidate_cache ();
-  Vernacstate.unfreeze_full_state st;
-  match res with
-  | Error () ->
-    CErrors.user_err (Pp.str "The command has not failed!")
-  | Ok (eloc, msg) ->
-    let loc = if !Flags.test_mode then real_error_loc ~cmdloc:loc ~eloc else None in
-    if not !Flags.quiet || !Flags.test_mode
-    then Feedback.msg_notice ?loc Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg)
-
-let with_succeed ~st f =
-  let () = ignore (f ()) in
-  Vernacstate.Interp.invalidate_cache ();
-  Vernacstate.unfreeze_full_state st;
-  if not !Flags.quiet
-  then Feedback.msg_notice Pp.(str "The command has succeeded and its effects have been reverted.")
-
 let locate_if_not_already ?loc (e, info) =
   (e, Option.cata (Loc.add_loc info) info (real_error_loc ~cmdloc:loc ~eloc:(Loc.get_loc info)))
 
-let interp_control_entry ~loc (f : control_entry) ~st
-    (fn : st:Vernacstate.t -> Vernacstate.LemmaStack.t option * Declare.OblState.t NeList.t) =
-  match f with
-  | ControlFail { st = synterp_st } ->
-    with_fail ~loc ~st (fun () -> Vernacstate.Synterp.unfreeze synterp_st; fn ~st);
-    st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program
-  | ControlSucceed { st = synterp_st } ->
-    with_succeed ~st (fun () -> Vernacstate.Synterp.unfreeze synterp_st; fn ~st);
-    st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program
-  | ControlTimeout { remaining } ->
-    vernac_timeout ~timeout:remaining (fun () -> fn ~st) ()
-  | ControlTime { synterp_duration } ->
-    let result = System.measure_duration (fun () -> fn ~st) () in
-    let result = Result.map (fun (v,d) -> v, System.duration_add d synterp_duration) result in
-    Feedback.msg_notice @@ System.fmt_transaction_result result;
-    begin match result with
-    | Ok (v,_) -> v
-    | Error (exn, _) -> Exninfo.iraise exn
-    end
-  | ControlInstructions { synterp_instructions } ->
-    let result = System.count_instructions (fun () -> fn ~st) () in
-    let result = Result.map (fun (v,d) -> v, System.instruction_count_add d synterp_instructions) result in
-    Feedback.msg_notice @@ System.fmt_instructions_result result;
-    begin match result with
-    | Ok (v,_) -> v
-    | Error (exn, _) -> Exninfo.iraise exn
-    end
-  | ControlRedirect s ->
-    Topfmt.with_output_to_file s (fun () -> fn ~st) ()
+let with_interp_state ~unfreeze_transient st =
+  let with_local_state synterp_st f =
+    unfreeze_transient synterp_st;
+    let v = f () in
+    Vernacstate.Interp.invalidate_cache ();
+    Vernacstate.unfreeze_full_state st;
+    (), v
+  in
+  { VernacControl.with_local_state }
 
-(* "locality" is the prefix "Local" attribute, while the "local" component
- * is the outdated/deprecated "Local" attribute of some vernacular commands
- * still parsed as the obsolete_locality grammar entry for retrocompatibility.
- * loc is the Loc.t of the vernacular command being interpreted. *)
-let rec interp_expr ?loc ~atts ~st c =
+let interp_control_gen ~loc ~st ~unfreeze_transient control f =
+  let noop = st.Vernacstate.interp.lemmas, st.Vernacstate.interp.program in
+  let control, res =
+    VernacControl.under_control ~loc
+      ~with_local_state:(with_interp_state ~unfreeze_transient st)
+      control
+      ~noop
+      f
+  in
+  if VernacControl.after_last_phase ~loc control
+  then noop
+  else res
+
+(* [loc] is the [Loc.t] of the vernacular command being interpreted. *)
+let rec interp_expr ?loc ~st cmd =
+  let before_univs = Global.universes () in
+  let pstack, pm = with_generic_atts ~check:false cmd.attrs (fun ~atts ->
+      interp_expr_core ?loc ~atts ~st cmd.expr)
+  in
+  let after_univs = Global.universes () in
+  if before_univs == after_univs then pstack, pm
+  else
+    let f = Declare.Proof.update_sigma_univs after_univs in
+    Option.map (Vernacstate.LemmaStack.map ~f) pstack, pm
+
+and interp_expr_core ?loc ~atts ~st c =
   match c with
 
   (* The STM should handle that, but LOAD bypasses the STM... *)
@@ -146,19 +106,9 @@ and vernac_load ~verbosely entries =
   stack, pm
 
 and interp_control ~st ({ CAst.v = cmd; loc }) =
-  List.fold_right (fun flag fn -> interp_control_entry ~loc flag fn)
-    cmd.control
-    (fun ~st ->
-       let before_univs = Global.universes () in
-       let pstack, pm = with_generic_atts ~check:false cmd.attrs (fun ~atts ->
-           interp_expr ?loc ~atts ~st cmd.expr)
-       in
-       let after_univs = Global.universes () in
-       if before_univs == after_univs then pstack, pm
-       else
-         let f = Declare.Proof.update_sigma_univs after_univs in
-         Option.map (Vernacstate.LemmaStack.map ~f) pstack, pm)
-    ~st
+  interp_control_gen ~loc ~st cmd.control
+    ~unfreeze_transient:Vernacstate.Synterp.unfreeze
+    (fun () -> interp_expr ?loc ~st cmd)
 
 (* XXX: This won't properly set the proof mode, as of today, it is
    controlled by the STM. Thus, we would need access information from
@@ -183,10 +133,9 @@ let interp_qed_delayed ~proof ~st pe =
   stack, pm
 
 let interp_qed_delayed_control ~proof ~st ~control { CAst.loc; v=pe } =
-  List.fold_right (fun flag fn -> interp_control_entry ~loc flag fn)
-    control
-    (fun ~st -> interp_qed_delayed ~proof ~st pe)
-    ~st
+  interp_control_gen ~loc ~st control
+    ~unfreeze_transient:(fun () -> ())
+    (fun () -> interp_qed_delayed ~proof ~st pe)
 
 (* General interp with management of state *)
 
@@ -233,8 +182,7 @@ let fs_intern = Intern.fs_intern
 
 let interp_qed_delayed_proof ~proof ~st ~control (CAst.{loc; v = pe } as e) : Vernacstate.Interp.t =
   (* Synterp duplication of control handling bites us here... *)
-  let control = Synterp.add_default_timeout control in
-  let control = List.map Synterp.synpure_control control in
+  let control = VernacControl.from_syntax control in
   NewProfile.profile "interp-delayed-qed" (fun () ->
       interp_gen ~verbosely:false ~st
         ~interp_fn:(interp_qed_delayed_control ~proof ~control) e)

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -181,8 +181,6 @@ end
 let fs_intern = Intern.fs_intern
 
 let interp_qed_delayed_proof ~proof ~st ~control (CAst.{loc; v = pe } as e) : Vernacstate.Interp.t =
-  (* Synterp duplication of control handling bites us here... *)
-  let control = VernacControl.from_syntax control in
   NewProfile.profile "interp-delayed-qed" (fun () ->
       interp_gen ~verbosely:false ~st
         ~interp_fn:(interp_qed_delayed_control ~proof ~control) e)

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -30,6 +30,6 @@ val interp_entry
 val interp_qed_delayed_proof
   :  proof:Declare.Proof.proof_object
   -> st:Vernacstate.t
-  -> control:Vernacexpr.control_flag list
+  -> control:unit VernacControl.control_entries
   -> Vernacexpr.proof_end CAst.t
   -> Vernacstate.Interp.t


### PR DESCRIPTION

The main goal is to include the close_proof time in
Time/Instructions/Timeout results.
