### PR TITLE
[CI] Unpin Jasmin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -861,14 +861,14 @@ library:ci-mathcomp_word:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
   stage: build-2
 
 library:ci-jasmin:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
   - library:ci-mathcomp_word
   stage: build-3+
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -141,7 +141,7 @@ ci-oddorder: ci-mathcomp
 ci-fcsl_pcm: ci-mathcomp_1
 ci-mczify: ci-mathcomp
 ci-mathcomp_test: ci-mathcomp
-ci-mathcomp_word: ci-mathcomp_1
+ci-mathcomp_word: ci-mathcomp
 ci-finmap: ci-mathcomp
 ci-bigenough: ci-mathcomp
 ci-analysis: ci-elpi_hb ci-finmap ci-bigenough

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -492,18 +492,14 @@ project itauto "https://gitlab.inria.fr/fbesson/itauto" "master"
 ########################################################################
 # Mathcomp-word
 ########################################################################
-project mathcomp_word "https://github.com/jasmin-lang/coqword" "v2.2"
+project mathcomp_word "https://github.com/jasmin-lang/coqword" "main"
 # Contact @vbgl, @strub on github
-# go back to "main" and change dependency to MC 2 when
-# https://github.com/jasmin-lang/jasmin/pull/560 is merged
 
 ########################################################################
 # Jasmin
 ########################################################################
-project jasmin "https://github.com/jasmin-lang/jasmin" "e8380c779b5c284c6d4c654d4ea86c56521a6d4c"
+project jasmin "https://github.com/jasmin-lang/jasmin" "main"
 # Contact @vbgl, @bgregoir on github
-# go back to "main" and change dependency to MC 2 when
-# https://github.com/jasmin-lang/jasmin/pull/560 is merged
 
 ########################################################################
 # Lean Importer

--- a/dev/ci/user-overlays/19432-proux01-unpin-jasmin.sh
+++ b/dev/ci/user-overlays/19432-proux01-unpin-jasmin.sh
@@ -1,0 +1,1 @@
+overlay jasmin https://github.com/proux01/jasmin coq_master 19432


### PR DESCRIPTION
Now that https://github.com/jasmin-lang/jasmin/pull/560 is merged.

Only fcsl-pcm now actually depends on mathcomp 1.
Quickchick will also require some CI configuration update due to menhir that is also used by coq-elpi.

#### Overlay (to be merged before the current PR):

* https://github.com/jasmin-lang/jasmin/pull/872