### PR TITLE
Reduce the Typeops API.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -2,7 +2,6 @@ open Pp
 open Util
 open Names
 open Conversion
-open Typeops
 open Declarations
 open Environ
 
@@ -49,7 +48,7 @@ let check_constant_declaration env opac kn cb opacify =
       true, env
   in
   let ty = cb.const_type in
-  let jty = infer_type env ty in
+  let jty = Typeops.infer_type env ty in
   if not (Sorts.relevance_equal cb.const_relevance (Sorts.relevance_of_sort jty.utj_type))
   then raise Pp.(BadConstant (kn, str "incorrect const_relevance"));
   let body, env = match cb.const_body with
@@ -68,7 +67,7 @@ let check_constant_declaration env opac kn cb opacify =
   let () =
     match body with
     | Some bd ->
-      let j = infer env bd in
+      let j = Typeops.infer env bd in
       begin match conv_leq env j.uj_type ty with
       | Result.Ok () -> ()
       | Result.Error () -> Type_errors.error_actual_type env j ty

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -226,7 +226,7 @@ let infer_definition ~sec_univs env entry =
       Vars.subst_univs_level_constr usubst j.uj_type
     | Some t ->
       let tj = Typeops.infer_type env t in
-      let _ = Typeops.judge_of_cast env j DEFAULTcast tj in
+      let () = Typeops.check_cast env j DEFAULTcast tj in
       Vars.subst_univs_level_constr usubst tj.utj_val
   in
   let body = Vars.subst_univs_level_constr usubst j.uj_val in
@@ -285,7 +285,7 @@ let check_delayed (type a) (handle : a effect_handler) tyenv (body : a proof_out
   let hbody = HConstr.of_constr env body in
   let j = Typeops.infer_hconstr env hbody in
   let j = unzip ectx j in
-  let _ = Typeops.judge_of_cast env j DEFAULTcast tyj in
+  let () = Typeops.check_cast env j DEFAULTcast tyj in
   let declared =
     if List.is_empty (named_context env) then declared
     else Environ.really_needed env (Id.Set.union declared (global_vars_set env tyj.utj_val))
@@ -310,7 +310,7 @@ let infer_local_def env _id { secdef_body; secdef_type; } =
     | None -> j.uj_type
     | Some typ ->
       let tj = Typeops.infer_type env typ in
-      let _ = Typeops.judge_of_cast env j DEFAULTcast tj in
+      let () = Typeops.check_cast env j DEFAULTcast tj in
       tj.utj_val
   in
   let c = j.uj_val in

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -372,21 +372,6 @@ let check_cast env c ct k expected_type =
   | Result.Error () ->
     error_actual_type env (make_judge c ct) expected_type
 
-let judge_of_int env i =
-  make_judge (Constr.mkInt i) (type_of_int env)
-
-let judge_of_float env f =
-  make_judge (Constr.mkFloat f) (type_of_float env)
-
-let judge_of_string env s =
-  make_judge (Constr.mkString s) (type_of_string env)
-
-let judge_of_array env u tj defj =
-  let def = defj.uj_val in
-  let ty = defj.uj_type in
-  Array.iter (fun j -> check_cast env j.uj_val j.uj_type DEFAULTcast ty) tj;
-  make_judge (mkArray(u, Array.map j_val tj, def, ty)) (mkApp (type_of_array env u, [|ty|]))
-
 (* Inductive types. *)
 
 (* The type is parametric over the uniform parameters whose conclusion
@@ -890,10 +875,6 @@ let infer env c =
 let assumption_of_judgment env {uj_val=c; uj_type=t} =
   infer_assumption env c t
 
-let type_judgment env {uj_val=c; uj_type=t} =
-  let s = check_type env c t in
-  {utj_val = c; utj_type = s }
-
 let infer_type env constr =
   let () = check_wellformed_universes env constr in
   let hconstr = HConstr.of_constr env constr in
@@ -923,49 +904,8 @@ let check_context env rels =
         push_rel d env, LocalDef (x,j1.uj_val,jty.utj_val) :: rels)
     rels ~init:(env,[])
 
-let judge_of_prop = make_judge mkProp type1
-let judge_of_set = make_judge mkSet type1
-let judge_of_type u = make_judge (mkType u) (type_of_type u)
-
-let judge_of_relative env k = make_judge (mkRel k) (type_of_relative env k)
-
-let judge_of_variable env x = make_judge (mkVar x) (type_of_variable env x)
-
-let judge_of_constant env cst = make_judge (mkConstU cst) (type_of_constant env cst)
-
-let judge_of_projection env p cj =
-  let r, ty = type_of_projection env p cj.uj_val cj.uj_type in
-  make_judge (mkProj (p,r,cj.uj_val)) ty
-
-let dest_judgev v =
-  Array.map j_val v, Array.map j_type v
-
-let judge_of_apply env funj argjv =
-  let args, argtys = dest_judgev argjv in
-  make_judge (mkApp (funj.uj_val, args)) (type_of_apply env funj.uj_val funj.uj_type args argtys)
-
-(* let judge_of_abstraction env x varj bodyj = *)
-(*   make_judge (mkLambda (x, varj.utj_val, bodyj.uj_val)) *)
-(*              (type_of_abstraction env x varj.utj_val bodyj.uj_type) *)
-
-(* let judge_of_product env x varj outj = *)
-(*   make_judge (mkProd (x, varj.utj_val, outj.utj_val)) *)
-(*              (mkSort (sort_of_product env varj.utj_type outj.utj_type)) *)
-
-(* let judge_of_letin env name defj typj j = *)
-(*   make_judge (mkLetIn (name, defj.uj_val, typj.utj_val, j.uj_val)) *)
-(*              (subst1 defj.uj_val j.uj_type) *)
-
-let judge_of_cast env cj k tj =
-  let () = check_cast env cj.uj_val cj.uj_type k tj.utj_val in
-  let c = mkCast (cj.uj_val, k, tj.utj_val) in
-  make_judge c tj.utj_val
-
-let judge_of_inductive env indu =
-  make_judge (mkIndU indu) (type_of_inductive env indu)
-
-let judge_of_constructor env cu =
-  make_judge (mkConstructU cu) (type_of_constructor env cu)
+let check_cast env cj k tj =
+  check_cast env cj.uj_val cj.uj_type k tj.utj_val
 
 (* Building type of primitive operators and type *)
 

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -10,8 +10,6 @@
 
 open Names
 open Constr
-open Univ
-open UVars
 open Environ
 
 (** {6 Typing functions (not yet tagged as safe) }
@@ -37,60 +35,29 @@ val check_context :
    returns the type {% $ %}c{% $ %}, checking that {% $ %}t{% $ %} is a sort. *)
 
 val assumption_of_judgment :  env -> unsafe_judgment -> Sorts.relevance
-val type_judgment          :  env -> unsafe_judgment -> unsafe_type_judgment
 
 (** {6 Type of sorts. } *)
 val type1 : types
 val type_of_sort : Sorts.t -> types
-val judge_of_prop : unsafe_judgment
-val judge_of_set  : unsafe_judgment
-val judge_of_type           : Universe.t -> unsafe_judgment
 
 (** {6 Type of a bound variable. } *)
 val type_of_relative : env -> int -> types
-val judge_of_relative : env -> int -> unsafe_judgment
 
 (** {6 Type of variables } *)
 val type_of_variable : env -> variable -> types
-val judge_of_variable : env -> variable -> unsafe_judgment
 
 (** {6 type of a constant } *)
 val type_of_constant_in : env -> pconstant -> types
-val judge_of_constant : env -> pconstant -> unsafe_judgment
 
 (** {6 type of an applied projection } *)
-val judge_of_projection : env -> Projection.t -> unsafe_judgment -> unsafe_judgment
-
-(** {6 Type of application. } *)
-val judge_of_apply :
-  env -> unsafe_judgment -> unsafe_judgment array
-    -> unsafe_judgment
-
-(** {6 Type of an abstraction. } *)
-(* val judge_of_abstraction : *)
-(*   env -> Name.t -> unsafe_type_judgment -> unsafe_judgment *)
-(*     -> unsafe_judgment *)
+val type_of_projection : env -> Projection.t -> constr -> types -> Sorts.relevance * types
 
 (** {6 Type of a product. } *)
 val sort_of_product : env -> Sorts.t -> Sorts.t -> Sorts.t
-val type_of_product : env -> Name.t binder_annot -> Sorts.t -> Sorts.t -> types
-(* val judge_of_product : *)
-(*   env -> Name.t -> unsafe_type_judgment -> unsafe_type_judgment *)
-(*     -> unsafe_judgment *)
-
-(** s Type of a let in. *)
-(* val judge_of_letin : *)
-(*   env -> Name.t -> unsafe_judgment -> unsafe_type_judgment -> unsafe_judgment *)
-(*     -> unsafe_judgment *)
 
 (** {6 Type of a cast. } *)
-val judge_of_cast :
-  env -> unsafe_judgment -> cast_kind -> unsafe_type_judgment ->
-  unsafe_judgment
-
-(** {6 Inductive types. } *)
-val judge_of_inductive : env -> inductive puniverses -> unsafe_judgment
-val judge_of_constructor : env -> constructor puniverses -> unsafe_judgment
+val check_cast :
+  env -> unsafe_judgment -> cast_kind -> unsafe_type_judgment -> unit
 
 (** {6 Type of global references. } *)
 
@@ -111,17 +78,9 @@ val check_hyps_inclusion : env -> ?evars:CClosure.evar_handler ->
 (** Types for primitives *)
 
 val type_of_int : env -> types
-val judge_of_int : env -> Uint63.t -> unsafe_judgment
-
 val type_of_float : env -> types
-val judge_of_float : env -> Float64.t -> unsafe_judgment
-
 val type_of_string : env -> types
-val judge_of_string : env -> Pstring.t -> unsafe_judgment
-
 val type_of_array : env -> UVars.Instance.t -> types
-val judge_of_array : env -> UVars.Instance.t -> unsafe_judgment array -> unsafe_judgment -> unsafe_judgment
-
 val type_of_prim_type : env -> UVars.Instance.t -> 'a CPrimitives.prim_type -> types
 val type_of_prim : env -> UVars.Instance.t -> CPrimitives.t -> types
 val type_of_prim_or_type : env -> UVars.Instance.t -> CPrimitives.op_or_type -> types

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -287,7 +287,7 @@ and nf_prod env sigma (na, dom, codom) =
   let vn = mk_rel_accu (nb_rel env) in
   let env = push_rel (LocalAssum (na, dom)) env in
   let codom, scodom = nf_type_sort env sigma (apply codom vn) in
-  mkProd (na, dom, codom), destSort (Typeops.type_of_product env na sdom scodom)
+  mkProd (na, dom, codom), Typeops.sort_of_product env sdom scodom
 
 and nf_atom env sigma atom =
   match atom with
@@ -378,8 +378,8 @@ and nf_atom_type env sigma atom =
       let c,tc = nf_accu_type env sigma c in
       let cj = make_judge c tc in
       let p, _ = get_proj env p in
-      let uj = Typeops.judge_of_projection env p cj in
-      uj.uj_val, uj.uj_type
+      let r, ty = Typeops.type_of_projection env p cj.uj_val cj.uj_type in
+      mkProj (p, r, cj.uj_val), ty
 
 
 and nf_predicate env sigma ind mip params v pctx =

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -19,7 +19,6 @@ open Sorts
 open Constr
 open Indrec
 open Declarations
-open Typeops
 open Ind_tables
 
 (* Induction/recursion schemes *)
@@ -85,7 +84,7 @@ let optimize_non_type_induction_scheme kind dep sort env _handle ind =
        appropriate type *)
     let sigma, cte = Evd.fresh_constant_instance env sigma cte in
     let c = mkConstU cte in
-    let t = type_of_constant_in env cte in
+    let t = Typeops.type_of_constant_in env cte in
     let (mib,mip) = Inductive.lookup_mind_specif env ind in
     let npars =
       (* if a constructor of [ind] contains a recursive call, the scheme


### PR DESCRIPTION
We remove a bunch of functions that were never really used, which included all the judge_* functions. Indeed, in the current implementation the kernel typechecker is merely a blackbox used by the kernel alone. The typing functions from the upper layers are all reimplemented from scratch to handle the unification state, and as a result the small-step variants of the kernel typing rules are not needed.

Reducing the exposed API also results in less coupling between what the kernel does and what the toplevel users rely on. In particular it makes it easier to tweak the kernel typing rules (e.g. for efficiency) without breaking the user-facing ones.

Hopefully the plugins do not rely on this API.