### PR TITLE
bench.sh: Do not attempt to double unlimited stack limit

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -316,7 +316,9 @@ zulip_autofail() {
 if [[ $zulip_post ]]; then trap zulip_autofail ERR; fi
 
 # see https://github.com/coq/coq/pull/15807
-ulimit -S -s $((2 * $(ulimit -s)))
+if [ "$(ulimit -s)" != "unlimited" ]; then
+  ulimit -S -s $((2 * $(ulimit -s)))
+fi
 
 # Clone the indicated git-repository.
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The resulting value is `0` and `ulimit` accepts it just fine. But afterwards every single command fails with `Arguments list too long`. Unfortunately it took me way too long to see that it wasn't just `git clone` that failed..

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
