### PR TITLE
Remember original constr in some CClosure nodes

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -28,7 +28,7 @@ type evar_repack
 
 type usubs = fconstr subs UVars.puniverses
 
-type table_key = Constant.t UVars.puniverses tableKey
+type table_key = Constr.t tableKey
 
 (** Relevances (eg in binder_annot or case_info) have NOT been substituted
     when there is a usubs field *)
@@ -36,8 +36,8 @@ type fterm =
   | FRel of int
   | FAtom of constr (** Metas and Sorts *)
   | FFlex of table_key
-  | FInd of pinductive
-  | FConstruct of pconstructor
+  | FInd of Constr.t
+  | FConstruct of Constr.t
   | FApp of fconstr * fconstr array
   | FProj of Projection.t * Sorts.relevance * fconstr
   | FFix of fixpoint * usubs
@@ -67,7 +67,7 @@ type stack_member =
   | ZcaseT of case_info * UVars.Instance.t * constr array * case_return * case_branch array * usubs
   | Zproj of Projection.Repr.t * Sorts.relevance
   | Zfix of fconstr * stack
-  | Zprimitive of CPrimitives.t * pconstant * fconstr list * fconstr next_native_args
+  | Zprimitive of CPrimitives.t * Constr.t * fconstr list * fconstr next_native_args
        (* operator, constr def, arguments already seen (in rev order), next arguments *)
   | Zshift of int
   | Zupdate of fconstr
@@ -78,7 +78,7 @@ val empty_stack : stack
 val append_stack : fconstr array -> stack -> stack
 
 val check_native_args : CPrimitives.t -> stack -> bool
-val get_native_args1 : CPrimitives.t -> pconstant -> stack ->
+val get_native_args1 : CPrimitives.t -> Constr.t -> stack ->
   fconstr list * fconstr * fconstr next_native_args * stack
 
 val get_invert : finvert -> fconstr array

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -202,7 +202,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
       try
         let infer_mode = get_infer_mode variances in
         let variances = if Option.has_some def then set_infer_mode false variances else variances in
-        let variances = infer_constant (info_env (fst infos)) variances con in
+        let variances = infer_constant (info_env (fst infos)) variances (destConst con) in
         let variances = infer_stack infos variances stk in
         set_infer_mode infer_mode variances
       with BadVariance _ | NotInferring as e ->
@@ -221,13 +221,15 @@ let rec infer_fterm cv_pb infos variances hd stk =
     let na = usubst_binder e na in
     let variances = infer_fterm CONV infos variances dom [] in
     infer_fterm cv_pb (push_relevance infos na) variances (mk_clos (CClosure.usubs_lift e) codom) []
-  | FInd (ind, u) ->
+  | FInd ind ->
+    let (ind, u) = destInd ind in
     let variances =
       let nargs = stack_args_size stk in
       infer_inductive_instance cv_pb (info_env (fst infos)) variances ind nargs u
     in
     infer_stack infos variances stk
-  | FConstruct (ctor,u) ->
+  | FConstruct ctor ->
+    let (ctor,u) = destConstruct ctor in
     let variances =
       let nargs = stack_args_size stk in
       infer_constructor_instance_eq (info_env (fst infos)) variances ctor nargs u


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This was meant to be a straw man proposal for increasing sharing at the leaves of the term in the hopes that it would spur more discussion (see https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/Memtrace.20observations, and also the ongoing discussion in https://github.com/coq/coq/issues/18520). But I wanted to learn to run the benchmarks locally and I got results I did not expect. The benchmarks are still running so the results below are partial and will probably be updated later. (EDIT: the bench is now complete.)

<details><summary>Benchmark results</summary>

```
┌─────────────────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┐
│                                     │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │
│                                     │                         │                                       │                                       │                         │
│            package_name             │   NEW      OLD    PDIFF │      NEW             OLD        PDIFF │      NEW             OLD        PDIFF │   NEW      OLD    PDIFF │
├─────────────────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┤
│            coq-metacoq-translations │   13.07    13.52  -3.33 │    54734548375     56674564744  -3.42 │    88440221555     88662924508  -0.25 │ 2631684  2635788  -0.16 │
│                 coq-category-theory │  642.62   663.09  -3.09 │  2727136655992   2764427031356  -1.35 │  4458117936070   4472550852942  -0.32 │ 2594188  2621844  -1.05 │
│                           coq-verdi │   45.64    46.73  -2.33 │   186641251566    189961894226  -1.75 │   274931458061    275857976512  -0.34 │ 2332336  2339020  -0.29 │
│               coq-mathcomp-fingroup │   25.57    26.10  -2.03 │   108966175691    110516013501  -1.40 │   158304918658    158123136007   0.11 │ 2392832  2392468   0.02 │
│               coq-engine-bench-lite │  120.56   122.88  -1.89 │   497436999212    507075102199  -1.90 │   865998215192    871238260031  -0.60 │ 2920436  2919956   0.02 │
│                         coq-coqutil │   43.21    43.99  -1.77 │   179350532693    181268598374  -1.06 │   253169559598    253284083389  -0.05 │ 2485228  2485092   0.01 │
│                  coq-mathcomp-field │   88.89    90.49  -1.77 │   380015322713    387359606475  -1.90 │   585277184548    587678841021  -0.41 │ 2896904  2898696  -0.06 │
│                            coq-corn │  652.74   663.81  -1.67 │  2767971306345   2814349778500  -1.65 │  4245560740769   4254426477225  -0.21 │ 2425692  2472464  -1.89 │
│               coq-mathcomp-solvable │   92.83    94.39  -1.65 │   395773209383    402542750234  -1.68 │   602233302844    604885726105  -0.44 │ 2594692  2609088  -0.55 │
│                    coq-math-classes │   80.90    82.21  -1.59 │   340287901532    344313612205  -1.17 │   457464178840    457989057995  -0.11 │ 2345668  2344956   0.03 │
│          coq-performance-tests-lite │  887.28   901.61  -1.59 │  3764784445594   3822969535577  -1.52 │  6824660260568   6857780846595  -0.48 │ 3284440  3284252   0.01 │
│                   coq-metacoq-utils │   22.93    23.27  -1.46 │    95267173500     96082674932  -0.85 │   138598697235    138597091575   0.00 │ 2463768  2463392   0.02 │
│                  coq-metacoq-common │   63.44    64.38  -1.46 │   268248091677    271748411136  -1.29 │   386296351855    388525662920  -0.57 │ 2885764  2955180  -2.35 │
│                          coq-stdlib │  359.67   364.86  -1.42 │  1344403072322   1350360984817  -0.44 │  1100947707940   1101895761740  -0.09 │ 2757584  2757868  -0.01 │
│                coq-mathcomp-algebra │  144.42   146.19  -1.21 │   616654428285    624716925555  -1.29 │   911016398523    911117246783  -0.01 │ 2783728  2789676  -0.21 │
│                       coq-fiat-core │   57.17    57.87  -1.21 │   221860481132    224765216720  -1.29 │   318369960440    318395126499  -0.01 │ 2319164  2319020   0.01 │
│                         coq-unimath │ 1274.44  1289.52  -1.17 │  5378183747621   5436490574809  -1.07 │ 10120841464622  10092612458878   0.28 │ 2829820  2830292  -0.02 │
│              coq-mathcomp-ssreflect │  104.71   105.94  -1.16 │   445911283628    451704651337  -1.28 │   642879094972    642811685800   0.01 │ 3126892  3124724   0.07 │
│                coq-metacoq-template │  143.09   144.69  -1.11 │   590610839011    597808857004  -1.20 │   858310052266    862590341505  -0.50 │ 2885848  2954728  -2.33 │
│                       coq-equations │   11.84    11.97  -1.09 │    45851583773     45979596137  -0.28 │    64220444874     64228597839  -0.01 │ 1795832  1801988  -0.34 │
│              coq-mathcomp-odd-order │  584.92   590.63  -0.97 │  2495391563114   2518466546590  -0.92 │  3862354830268   3863905429797  -0.04 │ 3075024  3101400  -0.85 │
│                        coq-rewriter │  370.85   374.34  -0.93 │  1574186297892   1588917930127  -0.93 │  2588163900237   2593934068591  -0.22 │ 2942072  2944036  -0.07 │
│                    coq-fiat-parsers │  276.81   279.41  -0.93 │  1154361798672   1166932942394  -1.08 │  2014689417330   2017094711801  -0.12 │ 3563392  3640552  -2.12 │
│                      coq-coquelicot │   35.27    35.58  -0.87 │   145969950187    147641778099  -1.13 │   196852536144    197251056250  -0.20 │ 2600032  2604404  -0.17 │
│                            coq-core │  213.85   215.53  -0.78 │   808941415552    802015625757   0.86 │   451679945610    451674007873   0.00 │  972708  1007080  -3.41 │
│                   coq-iris-examples │  383.92   386.77  -0.74 │  1634619763470   1646538964149  -0.72 │  2426696361661   2427792421648  -0.05 │ 2820628  2860960  -1.41 │
│                   coq-metacoq-pcuic │  678.87   683.73  -0.71 │  2900197842534   2918220275375  -0.62 │  4189050746052   4197651831214  -0.20 │ 4656188  4434432   5.00 │
│        coq-fiat-crypto-with-bedrock │ 5502.22  5538.41  -0.65 │ 23428046472920  23565227374490  -0.58 │ 41855173608808  41856116684898  -0.00 │ 4750772  4750932  -0.00 │
│                           coq-color │  231.40   232.89  -0.64 │   972868942536    980743658726  -0.80 │  1350564526534   1352031283741  -0.11 │ 2830412  2836672  -0.22 │
│                        coq-coqprime │   47.33    47.60  -0.57 │   198674380225    200645562459  -0.98 │   300395482678    300558797586  -0.05 │ 2646796  2644348   0.09 │
│                        coq-bedrock2 │  334.05   335.87  -0.54 │  1414332443448   1423003790627  -0.61 │  2666364102337   2655773524589   0.40 │ 2544872  2555012  -0.40 │
│                            coq-hott │  157.13   157.91  -0.49 │   655556712190    658273832394  -0.41 │  1017405869596   1019195919391  -0.18 │ 2297876  2301820  -0.17 │
│                 coq-metacoq-erasure │  509.90   511.98  -0.41 │  2177991722106   2188789213497  -0.49 │  3361244555121   3374316616781  -0.39 │ 3360784  3679940  -8.67 │
│             coq-metacoq-safechecker │  381.96   383.47  -0.39 │  1627892179473   1637831470964  -0.61 │  2711536483031   2716381786140  -0.18 │ 3378720  3375704   0.09 │
│               coq-mathcomp-analysis │  562.43   564.65  -0.39 │  2397329630186   2412557370438  -0.63 │  3873445187763   3870471714850   0.08 │ 2967524  2975428  -0.27 │
│                         coq-bignums │   29.12    29.23  -0.38 │   123430874520    123832723414  -0.32 │   172028432219    172134204256  -0.06 │ 2291620  2291388   0.01 │
│                      coq-verdi-raft │  569.39   571.54  -0.38 │  2348426123402   2360619686152  -0.52 │  3585868043860   3594836875792  -0.25 │ 2605664  2605676  -0.00 │
│                             coq-vst │  893.01   895.01  -0.22 │  3779734651425   3790930972844  -0.30 │  6350681538974   6331485058907   0.30 │ 3582292  3570096   0.34 │
│                       coq-fourcolor │ 1440.17  1439.61   0.04 │  6009673358806   6063871658596  -0.89 │ 11996417978888  11998812103200  -0.02 │ 2586676  2594884  -0.32 │
│ coq-neural-net-interp-computed-lite │  257.00   256.24   0.30 │  1074589245123   1075162851719  -0.05 │  2248016825670   2248182846763  -0.01 │ 2686400  2686236   0.01 │
│              coq-mathcomp-character │   79.97    79.33   0.81 │   334476246978    335582980329  -0.33 │   488841206147    489026828663  -0.04 │ 2733564  2733588  -0.00 │
│         coq-rewriter-perf-SuperFast │  816.01   802.40   1.70 │  3411471585758   3388608996311   0.67 │  5586648697936   5597541924942  -0.19 │ 3064236  3065164  -0.03 │
│                        coq-compcert │  285.84   280.47   1.91 │  1186523201649   1183996103363   0.21 │  1703417992726   1705249167505  -0.11 │ 2902808  2893404   0.33 │
└─────────────────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┘
```
</details

The results are not strictly positive. `coq-unimath` specifically is unhappy about this in terms of cpu instructions. But that's probably very expected given the stupid way this change is implemented (i.e. calling `destConst`, `destInd`, and `destConstruct` all over the place).

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
