### PR TITLE
[CI] Remove one more dependency to MathComp 1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -981,7 +981,7 @@ plugin:ci-quickchick:
   - build:edge+flambda
   - library:ci-ext_lib
   - library:ci-simple_io
-  - library:ci-mathcomp_1
+  - library:ci-mathcomp
   stage: build-3+
 
 plugin:ci-quickchick_test:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -158,7 +158,7 @@ ci-jasmin: ci-mathcomp_word
 ci-iris: ci-autosubst
 
 ci-simple_io: ci-ext_lib
-ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp_1
+ci-quickchick: ci-ext_lib ci-simple_io ci-mathcomp
 ci-quickchick_test: ci-quickchick
 ci-itree: ci-ext_lib ci-paco
 ci-itree_io: ci-itree ci-simple_io

--- a/dev/ci/ci-json.sh
+++ b/dev/ci/ci-json.sh
@@ -10,6 +10,6 @@ git_download json
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/json"
-  make
+  make MENHIRFLAGS="--coq --coq-no-version-check"
   make install
 )

--- a/dev/ci/ci-menhir.sh
+++ b/dev/ci/ci-menhir.sh
@@ -15,8 +15,6 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
     sed -i.bak "s/unreleased/$date/" dune-project
     echo "Definition require_$date := tt." > coq-menhirlib/src/Version.v
   fi
-  dune build @install -p menhirLib,menhirSdk,menhir
-  dune install -p menhirLib,menhirSdk,menhir menhir menhirSdk menhirLib --prefix="$CI_INSTALL_DIR"
 
   make -C coq-menhirlib
   make -C coq-menhirlib install


### PR DESCRIPTION
This was a fake dependency, QuickChick perfectly builds with MC2 but was kept on MC1 for some nasty menhir version kludge in ci-json. This copies in ci-json the menhir config already used by CompCert.
