### PR TITLE
Typeclasses default mode

### DIFF
--- a/dev/ci/user-overlays/19473-mattam82-typeclasses-default-mode.sh
+++ b/dev/ci/user-overlays/19473-mattam82-typeclasses-default-mode.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/mattam82/coq-elpi typeclasses-default-mode 19473

--- a/doc/changelog/08-vernac-commands-and-options/19473-typeclasses-default-mode.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19473-typeclasses-default-mode.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  Default hint mode option for typeclasses, mode attribute on Class
+  declarations overriding the default and class-declaration-default-mode
+  warning to check for uses of the default mode
+  (`#19473 <https://github.com/coq/coq/pull/19473>`_,
+  by Matthieu Sozeau).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -317,12 +317,21 @@ Command summary
    :attr:`universes(polymorphic)`, :attr:`universes(template)`,
    :attr:`universes(cumulative)` and :attr:`private(matching)` attributes.
 
+   It also supports the :attr:`mode` attribute for setting a hint mode
+   declaration for the class.
+
    .. note::
       Don't confuse typeclasses with "coercion classes", described in
       `implicit coercions<classes-implicit-coercions>`.
 
    When record syntax is used, this command also supports the
    :attr:`projections(primitive)` :term:`attribute`.
+
+   .. attr:: mode = @string
+      :name: mode
+
+      Sets the mode of resolution for queries on the class.
+      The syntax to use in the quoted string is explained in :cmd:`Hint Mode`.
 
    .. cmd:: Existing Class @qualid
 
@@ -563,6 +572,25 @@ type, like:
 
 Settings
 ~~~~~~~~
+
+.. _TypeclassesDefaultMode:
+
+.. opt:: Typeclasses Default Mode {| "+" | "-" | "!" }.
+
+   Sets the default mode declaration associated with a :cmd:`Class` or :cmd:`Existing Class`
+   declaration. It is set by default to "-", i.e. doing no mode filtering
+   by default. Each class declaration uses this default mode for *all* its parameters,
+   unless a :attr:`mode` attribute is used to set the mode explicitly.
+
+   .. _class-declaration-default-mode:
+
+   .. warn:: Using inferred default mode: “mode” for “@ident”
+
+      Indicates that the :attr:`mode` for a :cmd:`Class` declaration has been
+      assigned automatically using the default mode.
+      This warning is named ``class-declaration-default-mode``.
+      It is disabled by default.
+      Enable it to find (and fix) any typeclasses that don't have explicit mode declarations.
 
 .. flag:: Typeclasses Dependency Order
 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1524,6 +1524,7 @@ let do_build_inductive evd (funconstants : pconstant list)
       template = Some false;
       auto_prop_lowering = false;
       finite = Finite;
+      mode = None;
     }
     in
     with_full_print

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -263,12 +263,14 @@ let resolve_typeclasses ?(filter=no_goals) ?(unique=get_typeclasses_unique_solut
 let error_unresolvable env evd comp =
   let exception MultipleFound in
   let fold ev accu =
-    let evi = Evd.find_undefined evd ev in
-    let ev_class = class_of_constr env evd (Evd.evar_concl evi) in
-    if Option.is_empty ev_class then accu
-    else (* focus on one instance if only one was searched for *)
-    if Option.has_some accu then raise MultipleFound
-    else (Some ev)
+    match Evd.find_undefined evd ev with
+    | exception Not_found -> None
+    | evi ->
+      let ev_class = class_of_constr env evd (Evd.evar_concl evi) in
+      if Option.is_empty ev_class then accu
+      else (* focus on one instance if only one was searched for *)
+      if Option.has_some accu then raise MultipleFound
+      else (Some ev)
   in
   let ev = try Evar.Set.fold fold comp None with MultipleFound -> None in
   Pretype_errors.unsatisfiable_constraints env evd ev comp

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1007,8 +1007,8 @@ let make_extern pri pat tacast =
 let make_mode ref m =
   let open Term in
   let ty, _ = Typeops.type_of_global_in_context (Global.env ()) ref in
-  let ctx, t = decompose_prod ty in
-  let n = List.length ctx in
+  let ctx, t = decompose_prod_decls ty in
+  let n = Context.Rel.nhyps ctx in
   let m' = Array.of_list m in
     if not (n == Array.length m') then
       user_err
@@ -1691,10 +1691,23 @@ let pr_applicable_hint pf =
   | g::_ ->
     pr_hint_term env sigma (Evd.evar_concl (Evd.find_undefined sigma g))
 
-let pp_hint_mode = function
-  | ModeInput -> str"+"
-  | ModeNoHeadEvar -> str"!"
-  | ModeOutput -> str"-"
+let parse_mode s =
+  match s with
+  | "+" -> ModeInput
+  | "-" -> ModeOutput
+  | "!" -> ModeNoHeadEvar
+  | _ -> CErrors.user_err Pp.(str"Unrecognized hint mode " ++ str s)
+
+let parse_modes s =
+  let modes = String.split_on_char ' ' s in
+  List.map parse_mode modes
+
+let string_of_mode = function
+  | ModeInput -> "+"
+  | ModeOutput -> "-"
+  | ModeNoHeadEvar -> "!"
+
+let pp_hint_mode m = str (string_of_mode m)
 
 (* displays the whole hint database db *)
 let pr_hint_db_env env sigma db =

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -95,6 +95,10 @@ type hints_path = GlobRef.t hints_path_gen
 val path_matches_epsilon : hints_path -> bool
 val path_derivate : hints_path -> GlobRef.t option -> hints_path
 val pp_hints_path_gen : ('a -> Pp.t) -> 'a hints_path_gen -> Pp.t
+
+val parse_mode : string -> hint_mode
+val parse_modes : string -> hint_mode list
+val string_of_mode : hint_mode -> string
 val pp_hint_mode : hint_mode -> Pp.t
 val glob_hints_path : pre_hints_path -> hints_path
 

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -59,3 +59,39 @@ Module BestEffort.
   Admitted.
 
 End BestEffort.
+
+Module Plus.
+  Parameter plus : nat -> nat -> nat -> Prop.
+
+  Axiom plus0l : forall m : nat, plus 0 m m.
+  Axiom plus0r : forall n : nat, plus n 0 n.
+  Axiom plusSl : forall n m r : nat, plus n m r -> plus (S n) m (S r).
+  Axiom plusSr : forall n m r : nat, plus n m r -> plus m (S m) (S r).
+
+  Hint Resolve plus0l plus0r plusSl plusSr : plus.
+  Hint Mode plus ! - - : plus.
+  Hint Mode plus - ! - : plus.
+
+  Require Coq.derive.Derive.
+  Derive r SuchThat (plus 1 4 r) As r_proof.
+  Proof.
+    subst r. typeclasses eauto with plus.
+  Qed.
+
+  Goal exists x y, plus x y 12.
+  Proof.
+    eexists ?[x], ?[y].
+    Set Typeclasses Debug.
+    Fail typeclasses eauto with plus.
+    instantiate (y := 1).
+    typeclasses eauto with plus.
+  Defined.
+End Plus.
+
+Module ModeAttr.
+  Fail #[mode="+"] Inductive foo (A : Type) : Set :=.
+
+  Fail #[mode=""] Class Foo (A : Type) := {}.
+  #[mode="+"] Class Foo (A : Type) := {}.
+  Fail #[mode="+ +"] Class Foo' (A : Type) := {}.
+End ModeAttr.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -26,6 +26,11 @@ open Libobject
 module RelDecl = Context.Rel.Declaration
 (*i*)
 
+let warn_default_mode = CWarnings.create ~name:"class-declaration-default-mode" ~category:CWarnings.CoreCategories.automation
+  ~default:CWarnings.Disabled
+  Pp.(fun (gr, m) -> hov 2 (str "Using an inferred default mode: " ++ prlist_with_sep spc Hints.pp_hint_mode m ++
+    spc () ++ str "for" ++ spc () ++ Printer.pr_global gr))
+
 let set_typeclass_transparency ~locality c b =
   Hints.add_hints ~locality [typeclasses_db]
     (Hints.HintsTransparencyEntry (Hints.HintsReferences c, b))
@@ -38,6 +43,10 @@ let set_typeclass_transparency_com ~locality refs b =
       refs
   in
   set_typeclass_transparency ~locality refs b
+
+let set_typeclass_mode ~locality c b =
+  Hints.add_hints ~locality [typeclasses_db]
+    (Hints.HintsModeEntry (c, b))
 
 let add_instance_hint gr ~locality info =
   let inst = Hints.hint_globref gr in

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -115,6 +115,12 @@ val set_typeclass_transparency_com
   -> bool
   -> unit
 
+val set_typeclass_mode
+  :  locality:Hints.hint_locality
+  -> GlobRef.t
+  -> Hints.hint_mode list
+  -> unit
+
 (** For generation on names based on classes only *)
 
 val id_of_class : typeclass -> Id.t
@@ -126,3 +132,7 @@ module Internal :
 sig
 val add_instance : typeclass -> hint_info -> Hints.hint_locality -> GlobRef.t -> unit
 end
+
+
+(** A configurable warning to output if a default mode is used for a class declaration. *)
+val warn_default_mode : ?loc:Loc.t -> (GlobRef.t * Hints.hint_mode list) -> unit

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -35,6 +35,7 @@ type flags = {
   template : bool option;
   auto_prop_lowering : bool;
   finite : Declarations.recursivity_kind;
+  mode : Hints.hint_mode list option;
 }
 
 (* 3b| Mutual inductive definitions *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -19,6 +19,7 @@ type flags = {
   template : bool option;
   auto_prop_lowering : bool;
   finite : Declarations.recursivity_kind;
+  mode : Hints.hint_mode list option;
 }
 
 (** Entry points for the vernacular commands Inductive and CoInductive *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

- Allow to set globally a default mode for all parameters of a class
- Add an attribute that overrides this on a class by class basis
- Add a settable warning for using the default mode
- The default is still "-", meaning no mode filtering and full compatibility.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.
https://github.com/LPCIC/coq-elpi/pull/683
