### PR TITLE
Tweak formatting of "Print HintDb" output

### DIFF
--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1628,11 +1628,11 @@ let pr_id_hint env sigma (id, v) =
   | Some (ConstrPattern p | SyntacticPattern p) -> str", pattern " ++ pr_lconstr_pattern_env env sigma p
   | Some DefaultPattern -> str", pattern " ++ pr_leconstr_env env sigma (get_default_pattern v.code.obj)
   in
-  (pr_hint env sigma v.code ++ str"(level " ++ int v.pri ++ pr_pat v
-   ++ str", id " ++ int id ++ str ")" ++ spc ())
+  (pr_hint env sigma v.code ++ str" (level " ++ int v.pri ++ pr_pat v
+   ++ str", id " ++ int id ++ str ")")
 
 let pr_hint_list env sigma hintlist =
-  (str "  " ++ hov 0 (prlist (pr_id_hint env sigma) hintlist) ++ fnl ())
+  (str "  " ++ hov 0 (prlist_with_sep fnl (pr_id_hint env sigma) hintlist) ++ fnl ())
 
 let pr_hints_db env sigma (name,db,hintlist) =
   (str "In the database " ++ str name ++ str ":" ++

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -40,7 +40,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -48,7 +48,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -65,7 +65,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -94,7 +94,7 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   simple apply 0 ; trivial(level 1, pattern nat, id 0) 
+For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
 For S (modes !) ->   
 
 File "./output/HintLocality.v", line 92, characters 0-39:


### PR DESCRIPTION
This PR ensures that no more than one hint is shown on each line, unlike the current formatting:

![image](https://github.com/user-attachments/assets/88ee2c08-74a9-40c0-ae41-d403387dee23)
