### PR TITLE
Continuing #18564: further more "standard" namings of lemmas of the form "length (foo l)"

### DIFF
--- a/doc/changelog/11-standard-library/19478-master+extend-18564-further-list-length-renamings.rst
+++ b/doc/changelog/11-standard-library/19478-master+extend-18564-further-list-length-renamings.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Several lemmas from various libraries about :g:`firstn` and
+  :g:`skipn` have been collected in :g:`List.v`
+  (`#19478 <https://github.com/coq/coq/pull/19478>`_,
+  by Hugo Herbelin).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2949,6 +2949,27 @@ Section NatSeq.
     cbn [option_map]; rewrite ?plus_n_Sm; trivial.
   Qed.
 
+  Lemma firstn_seq_min n m start : firstn n (seq start m) = seq start (Nat.min n m).
+  Proof.
+    induction m in n, start |- *; simpl.
+    - now rewrite Nat.min_0_r, firstn_nil.
+    - destruct n; simpl.
+      + reflexivity.
+      + now rewrite IHm.
+  Qed.
+
+  Lemma firstn_seq_le n m start :
+    n <= m -> firstn n (seq start m) = seq start n.
+  Proof.
+    intro. now rewrite firstn_seq_min, Nat.min_l.
+  Qed.
+
+  Lemma firstn_seq_ge n m start :
+    m <= n -> firstn n (seq start m) = seq start m.
+  Proof.
+    intro. now rewrite firstn_seq_min, Nat.min_r.
+  Qed.
+
 End NatSeq.
 
 (***********************)
@@ -3861,6 +3882,28 @@ Section Repeat.
     intro Hnm. rewrite (nth_error_nth' _ a).
     - now rewrite nth_repeat.
     - now rewrite length_repeat.
+  Qed.
+
+  Lemma firstn_repeat_min a m n :
+    firstn n (repeat a m) = repeat a (Nat.min m n).
+  Proof.
+    induction m in n |- *; simpl.
+    - apply firstn_nil.
+    - destruct n; simpl.
+      + reflexivity.
+      + now rewrite IHm.
+  Qed.
+
+  Lemma firstn_repeat_le a m n :
+    n <= m -> firstn n (repeat a m) = repeat a n.
+  Proof.
+    intro. now rewrite firstn_repeat_min, Nat.min_r.
+  Qed.
+
+  Lemma firstn_repeat_ge a m n :
+    m <= n -> firstn n (repeat a m) = repeat a m.
+  Proof.
+    intro. now rewrite firstn_repeat_min, Nat.min_l.
   Qed.
 
 End Repeat.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2172,6 +2172,12 @@ Section Cutting.
     case Nat.ltb; trivial.
   Qed.
 
+  Lemma nth_error_firstn_Some n m l x
+    : nth_error (firstn n l) m = Some x -> nth_error l m = Some x.
+  Proof.
+    induction m in n, l |- *; intros H; destruct n, l; cbn in *; try solve [inversion H]; eauto.
+  Qed.
+
   Lemma nth_firstn (n : nat) (l : list A) (i : nat) (d : A) :
     nth i (firstn n l) d = if i <? n then nth i l d else d.
   Proof.
@@ -2194,6 +2200,9 @@ Section Cutting.
   Lemma firstn_0 l: firstn 0 l = [].
   Proof. now simpl. Qed.
 
+  Lemma firstn_O_eq n l : n = 0 -> firstn n l = [].
+  Proof. now intros ->. Qed.
+
   Lemma length_firstn_min : forall n l, length (firstn n l) = min n (length l).
   Proof.
     intro n; induction n; intro l; destruct l; simpl; auto.
@@ -2213,6 +2222,12 @@ Section Cutting.
     n <= length l -> length (firstn n l) = n.
   Proof.
     intros. rewrite length_firstn_min. now apply Nat.min_l.
+  Qed.
+
+  Lemma length_firstn_le_inv n : forall l:list A,
+    length (firstn n l) = n -> n <= length l.
+  Proof.
+    intros l <-. apply le_length_firstn_length.
   Qed.
 
   Lemma length_firstn_length_le n: forall l:list A,
@@ -2235,7 +2250,7 @@ Section Cutting.
     forall l1 l2,
     firstn (length l1) (l1 ++ l2) = l1.
   Proof.
-    intros. now rewrite firstn_app, Nat.sub_diag, firstn_O, firstn_all, app_nil_r.
+    intros. now rewrite firstn_app, Nat.sub_diag, firstn_0, firstn_all, app_nil_r.
   Qed.
 
   Lemma firstn_app_exact_eq:
@@ -2257,6 +2272,13 @@ Section Cutting.
       * rewrite firstn_app. assert (H0 : (length l1 + S k - length l1) = S k).
         1:now rewrite Nat.add_comm, Nat.add_sub.
         rewrite H0, firstn_all2; [reflexivity | now apply Nat.le_add_r].
+  Qed.
+
+  Lemma firstn_app_2_eq n:
+    forall l1 l2 k,
+    k = length l1 + n -> firstn k (l1 ++ l2) = l1 ++ firstn n l2.
+  Proof.
+    intros * ->; apply firstn_app_2.
   Qed.
 
   Lemma firstn_firstn_min:
@@ -2334,6 +2356,21 @@ Section Cutting.
   skipn m (firstn n l) = firstn (n - m) (skipn m l).
   Proof. now intro m; induction m; intros [] []; simpl; rewrite ?firstn_nil. Qed.
 
+  Lemma firstn_add : forall m n l,
+  firstn (m + n) l = firstn m l ++ firstn n (skipn m l).
+  Proof.
+    induction m. simpl. reflexivity.
+    simpl. destruct l; simpl.
+    now rewrite firstn_nil.
+    rewrite IHm. now rewrite app_comm_cons.
+  Qed.
+
+  Lemma skipn_firstn_succ_skipn_succ n (l : list A) : skipn n (firstn (S n) l) ++ skipn (S n) l = skipn n l.
+  Proof.
+    induction l in n |- *; simpl; auto. now rewrite app_nil_r.
+    destruct n; simpl; auto.
+  Qed.
+
   Lemma skipn_0 : forall l, skipn 0 l = l.
   Proof. reflexivity. Qed.
 
@@ -2401,6 +2438,19 @@ Section Cutting.
   Lemma skipn_app n : forall l1 l2,
     skipn n (l1 ++ l2) = (skipn n l1) ++ (skipn (n - length l1) l2).
   Proof. induction n; auto; intros [|]; simpl; auto. Qed.
+
+  Lemma skipn_app_exact (l1 l2 : list A) : skipn (length l1) (l1 ++ l2) = l2.
+  Proof.
+    intros.
+    induction l1 in l2 |- *.
+    - reflexivity.
+    - simpl. eauto.
+  Qed.
+
+  Lemma skipn_app_exact_eq n (l1 l2 : list A) : n = length l1 -> skipn n (l1 ++ l2) = l2.
+  Proof.
+    intros ->. apply skipn_app_exact.
+  Qed.
 
   Lemma firstn_skipn_rev: forall x l,
       firstn x l = rev (skipn (length l - x) (rev l)).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2231,6 +2231,20 @@ Section Cutting.
       * rewrite <- app_comm_cons. simpl. f_equal. apply iHk.
   Qed.
 
+  Lemma firstn_app_exact:
+    forall l1 l2,
+    firstn (length l1) (l1 ++ l2) = l1.
+  Proof.
+    intros. now rewrite firstn_app, Nat.sub_diag, firstn_O, firstn_all, app_nil_r.
+  Qed.
+
+  Lemma firstn_app_exact_eq:
+    forall n l1 l2,
+    n = length l1 -> firstn n (l1 ++ l2) = l1.
+  Proof.
+    intros * ->. apply firstn_app_exact.
+  Qed.
+
   Lemma firstn_app_2 n:
     forall l1 l2,
     firstn ((length l1) + n) (l1 ++ l2) = l1 ++ firstn n l2.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2194,20 +2194,31 @@ Section Cutting.
   Lemma firstn_0 l: firstn 0 l = [].
   Proof. now simpl. Qed.
 
-  Lemma length_firstn_le n: forall l:list A, length (firstn n l) <= n.
+  Lemma length_firstn_min : forall n l, length (firstn n l) = min n (length l).
   Proof.
-    induction n as [|k iHk]; simpl; [auto | intro l; destruct l as [|x xs]; simpl].
-    - now apply Nat.le_0_l.
-    - now rewrite <- Nat.succ_le_mono.
+    intro n; induction n; intro l; destruct l; simpl; auto.
   Qed.
 
-  Lemma length_firstn_eq: forall l:list A, forall n:nat,
+  Lemma le_length_firstn n: forall l:list A, length (firstn n l) <= n.
+  Proof.
+    intros. rewrite length_firstn_min. apply Nat.le_min_l.
+  Qed.
+
+  Lemma le_length_firstn_length n: forall l:list A, length (firstn n l) <= length l.
+  Proof.
+    intros. rewrite length_firstn_min. apply Nat.le_min_r.
+  Qed.
+
+  Lemma length_firstn_le n: forall l:list A,
     n <= length l -> length (firstn n l) = n.
-  Proof. intro l; induction l as [|x xs Hrec].
-    - simpl. intros n H. apply Nat.le_0_r in H. now subst.
-    - intro n; destruct n as [|n].
-      * now simpl.
-      * simpl. intro H. f_equal. apply Hrec. now apply Nat.succ_le_mono.
+  Proof.
+    intros. rewrite length_firstn_min. now apply Nat.min_l.
+  Qed.
+
+  Lemma length_firstn_length_le n: forall l:list A,
+    length l <= n -> length (firstn n l) = length l.
+  Proof.
+    intros. rewrite length_firstn_min. now apply Nat.min_r.
   Qed.
 
   Lemma firstn_app n:
@@ -2234,8 +2245,8 @@ Section Cutting.
         rewrite H0, firstn_all2; [reflexivity | now apply Nat.le_add_r].
   Qed.
 
-  Lemma firstn_firstn:
-    forall l:list A,
+  Lemma firstn_firstn_min:
+    forall l : list A,
     forall i j : nat,
     firstn i (firstn j l) = firstn (min i j) l.
   Proof. intro l; induction l as [|x xs Hl].
@@ -2243,6 +2254,38 @@ Section Cutting.
     - intros [|i]; [easy|].
       intros [|j]; [easy|].
       cbn. f_equal. apply Hl.
+  Qed.
+
+  Lemma firstn_idemp:
+    forall l : list A,
+    forall i : nat,
+    firstn i (firstn i l) = firstn i l.
+  Proof.
+    now intros; rewrite firstn_firstn_min, Nat.min_id.
+  Qed.
+
+  Lemma firstn_firstn_l:
+    forall l : list A,
+    forall i j : nat,
+    i <= j -> firstn i (firstn j l) = firstn i l.
+  Proof.
+    now intros; rewrite firstn_firstn_min, Nat.min_l.
+  Qed.
+
+  Lemma firstn_firstn_r:
+    forall l : list A,
+    forall i j : nat,
+    j <= i -> firstn i (firstn j l) = firstn j l.
+  Proof.
+    now intros; rewrite firstn_firstn_min, Nat.min_r.
+  Qed.
+
+  Lemma firstn_comm:
+    forall l : list A,
+    forall i j : nat,
+    firstn i (firstn j l) = firstn j (firstn i l).
+  Proof.
+    now intros; rewrite !firstn_firstn_min, Nat.min_comm.
   Qed.
 
   Fixpoint skipn (n:nat)(l:list A) : list A :=
@@ -2331,11 +2374,6 @@ Section Cutting.
     - injection 1. intros ->. reflexivity.
     - discriminate.
     - simpl. intros H. f_equal. apply IH. exact H.
-  Qed.
-
-  Lemma length_firstn : forall n l, length (firstn n l) = min n (length l).
-  Proof.
-    intro n; induction n; intro l; destruct l; simpl; auto.
   Qed.
 
   Lemma length_skipn n :
@@ -4010,8 +4048,8 @@ Notation split_length_r := length_snd_split (only parsing).
 Notation combine_length := length_combine (only parsing).
 #[deprecated(since = "8.20", use = length_prod)]
 Notation prod_length := length_prod (only parsing).
-#[deprecated(since = "8.20", use = length_firstn)]
-Notation firstn_length := length_firstn (only parsing).
+#[deprecated(since = "8.20", use = length_firstn_min)]
+Notation firstn_length := length_firstn_min(only parsing).
 #[deprecated(since = "8.20", use = length_skipn)]
 Notation skipn_length := length_skipn (only parsing).
 #[deprecated(since = "8.20", use = length_seq)]
@@ -4027,11 +4065,14 @@ Notation skipn_O := skipn_0 (only parsing).
 Notation list_power_length := length_list_power (only parsing).
 Notation remove_length_le := length_remove_le (only parsing).
 Notation remove_length_lt := length_remove_lt (only parsing).
+Notation length_firstn := length_firstn_min (only parsing). (* grab the name to prevent further uses *)
 Notation filter_length := length_filter (only parsing).
 Notation filter_length_le := length_filter_le (only parsing).
 Notation filter_length_forallb := forallb_length_filter (only parsing).
-Notation firstn_le_length := length_firstn_le (only parsing).
-Notation firstn_length_le := length_firstn_eq (only parsing).
+Notation firstn_le_length := le_length_firstn (only parsing).
+#[deprecated(since = "8.21", use = length_firstn_le)]
+Definition firstn_length_le A l n := @length_firstn_le A n l.
+Notation firstn_firstn := firstn_firstn_min (only parsing).
 Notation repeat_length := length_repeat (only parsing).
 Notation flat_map_constant_length := length_flat_map_constant (only parsing).
 (* end hide *)

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2162,7 +2162,7 @@ Section Cutting.
   Lemma firstn_nil n: firstn n [] = [].
   Proof. induction n; now simpl. Qed.
 
-  Lemma firstn_cons n a l: firstn (S n) (a::l) = a :: (firstn n l).
+  Lemma firstn_S_cons n a l: firstn (S n) (a::l) = a :: (firstn n l).
   Proof. now simpl. Qed.
 
   Lemma nth_error_firstn n l i
@@ -2516,7 +2516,7 @@ Section Combining.
       - destruct l' as [| x' l'].
         + simpl. repeat (rewrite firstn_nil). rewrite combine_nil. reflexivity.
         + simpl. destruct n as [| n]; [reflexivity|].
-          repeat (rewrite firstn_cons). simpl.
+          repeat (rewrite firstn_S_cons). simpl.
           rewrite IHl. reflexivity.
     Qed.
 
@@ -4126,6 +4126,8 @@ Notation length_firstn := length_firstn_min (only parsing). (* grab the name to 
 Notation filter_length := length_filter (only parsing).
 Notation filter_length_le := length_filter_le (only parsing).
 Notation filter_length_forallb := forallb_length_filter (only parsing).
+#[deprecated(since = "8.21", note = "Use firstn_S_cons instead.")]
+Notation firstn_cons := firstn_S_cons (only parsing).
 Notation firstn_le_length := le_length_firstn (only parsing).
 #[deprecated(since = "8.21", use = length_firstn_le)]
 Definition firstn_length_le A l n := @length_firstn_le A n l.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2165,6 +2165,17 @@ Section Cutting.
   Lemma firstn_S_cons n a l: firstn (S n) (a::l) = a :: (firstn n l).
   Proof. now simpl. Qed.
 
+  Lemma unfold_firstn n l :
+    firstn n l =
+    match n with
+      | 0 => nil
+      | S n0 => match l with
+                  | nil => nil
+                  | a :: l0 => a :: firstn n0 l0
+                end
+    end.
+  Proof. now destruct n. Qed.
+
   Lemma nth_error_firstn n l i
     : nth_error (firstn n l) i = if i <? n then nth_error l i else None.
   Proof.
@@ -2332,6 +2343,17 @@ Section Cutting.
                  | a::l => skipn n l
                end
     end.
+
+  Lemma unfold_skipn n l :
+    skipn n l =
+    match n with
+      | 0 => l
+      | S n => match l with
+                 | nil => nil
+                 | a::l => skipn n l
+               end
+    end.
+  Proof. now destruct n. Qed.
 
   Lemma nth_error_skipn n l i : nth_error (skipn n l) i = nth_error l (n + i).
   Proof.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -4156,7 +4156,7 @@ Notation combine_length := length_combine (only parsing).
 #[deprecated(since = "8.20", use = length_prod)]
 Notation prod_length := length_prod (only parsing).
 #[deprecated(since = "8.20", use = length_firstn_min)]
-Notation firstn_length := length_firstn_min(only parsing).
+Notation firstn_length := length_firstn_min (only parsing).
 #[deprecated(since = "8.20", use = length_skipn)]
 Notation skipn_length := length_skipn (only parsing).
 #[deprecated(since = "8.20", use = length_seq)]
@@ -4176,7 +4176,7 @@ Notation length_firstn := length_firstn_min (only parsing). (* grab the name to 
 Notation filter_length := length_filter (only parsing).
 Notation filter_length_le := length_filter_le (only parsing).
 Notation filter_length_forallb := forallb_length_filter (only parsing).
-#[deprecated(since = "8.21", note = "Use firstn_S_cons instead.")]
+#[deprecated(since = "8.21", use = firstn_S_cons)]
 Notation firstn_cons := firstn_S_cons (only parsing).
 Notation firstn_le_length := le_length_firstn (only parsing).
 #[deprecated(since = "8.21", use = length_firstn_le)]

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2166,7 +2166,7 @@ Section Cutting.
   Proof. now simpl. Qed.
 
   Lemma nth_error_firstn n l i
-    : nth_error (firstn n l) i = if Nat.ltb i n then nth_error l i else None.
+    : nth_error (firstn n l) i = if i <? n then nth_error l i else None.
   Proof.
     revert l i; induction n, l, i; cbn [firstn nth_error]; trivial.
     case Nat.ltb; trivial.
@@ -2182,7 +2182,7 @@ Section Cutting.
   Lemma firstn_all l: firstn (length l) l = l.
   Proof. induction l as [| ? ? H]; simpl; [reflexivity | now rewrite H]. Qed.
 
-  Lemma firstn_all2 n: forall (l:list A), (length l) <= n -> firstn n l = l.
+  Lemma firstn_all2 n: forall (l:list A), length l <= n -> firstn n l = l.
   Proof. induction n as [|k iHk].
     - intro l. inversion 1 as [H1|?].
       rewrite (length_zero_iff_nil l) in H1. subst. now simpl.

--- a/theories/Numbers/DecimalFacts.v
+++ b/theories/Numbers/DecimalFacts.v
@@ -603,7 +603,7 @@ Proof.
   { simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
   intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.length_rev.
   case (_ - _); [now simpl|]; intros n' _.
-  rewrite List.firstn_cons, lnzhead_head_nd0; [now simpl|].
+  rewrite List.firstn_S_cons, lnzhead_head_nd0; [now simpl|].
   intro Hh; revert Hu'; rewrite Hh; apply lnzhead_neq_d0_head.
 Qed.
 

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -623,7 +623,7 @@ Proof.
   { simpl; intro H; exfalso; revert H; apply Nat.le_ngt, Nat.le_0_l. }
   intro Hn'; generalize (Nat.sub_gt _ _ Hn'); rewrite List.length_rev.
   case (_ - _); [now simpl|]; intros n' _.
-  rewrite List.firstn_cons, lnzhead_head_nd0; [now simpl|].
+  rewrite List.firstn_S_cons, lnzhead_head_nd0; [now simpl|].
   intro Hh; revert Hu'; rewrite Hh; apply lnzhead_neq_d0_head.
 Qed.
 

--- a/theories/Strings/PString.v
+++ b/theories/Strings/PString.v
@@ -124,7 +124,7 @@ Lemma sub_length_spec (s : string) (off len : int) :
 Proof.
   intros Hoff Hlen.
   pose proof (length_spec (sub s off len)) as Hs.
-  rewrite sub_spec, List.length_firstn_eq in Hs; [lia|].
+  rewrite sub_spec, List.length_firstn_le in Hs; [lia|].
   rewrite List.length_skipn, <-length_spec. lia.
 Qed.
 

--- a/theories/Strings/PString.v
+++ b/theories/Strings/PString.v
@@ -124,7 +124,7 @@ Lemma sub_length_spec (s : string) (off len : int) :
 Proof.
   intros Hoff Hlen.
   pose proof (length_spec (sub s off len)) as Hs.
-  rewrite sub_spec, List.firstn_length_le in Hs; [lia|].
+  rewrite sub_spec, List.length_firstn_eq in Hs; [lia|].
   rewrite List.length_skipn, <-length_spec. lia.
 Qed.
 


### PR DESCRIPTION
This addresses [this comment](https://github.com/coq/coq/pull/19281#issuecomment-2313315793) (hoping I'm doing it correctly).

- [x] Added **changelog**.
