### PR TITLE
Allow fast fresh name generation in detyping

### DIFF
--- a/dev/ci/user-overlays/19481-ppedrot-fast-namegen-detyping.sh
+++ b/dev/ci/user-overlays/19481-ppedrot-fast-namegen-detyping.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi fast-namegen-detyping 19481
+
+overlay serapi https://github.com/ppedrot/coq-serapi fast-namegen-detyping 19481
+
+overlay tactician https://github.com/ppedrot/coq-tactician fast-namegen-detyping 19481

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -292,6 +292,18 @@ type 'a input = 'a t * 'a
 let fresh = Fresh
 let idset = IdSet
 
+let max_map (type a) (gen : a t) (avoid : a) =
+match gen with
+| Fresh -> Fresh.max_map avoid
+| IdSet ->
+  let fold id accu =
+    let id, ss = get_subscript id in
+    match Id.Map.find_opt id accu with
+    | Some old_ss when Subscript.compare ss old_ss <= 0 -> accu
+    | _ -> Id.Map.add id ss accu
+  in
+  Id.Set.fold fold avoid Id.Map.empty
+
 let is_fresh (type a) (gen : a t) id (avoid : a) = match gen with
 | Fresh -> not (Fresh.mem id avoid)
 | IdSet -> not (Id.Set.mem id avoid)

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -116,6 +116,8 @@ val fresh : Nameops.Fresh.t t
 val idset : Id.Set.t t
 
 val next_name_away : 'a t -> Name.t -> 'a -> Id.t * 'a
+
+val max_map : 'a t -> 'a -> Nameops.Subscript.t Id.Map.t
 end
 
 type renaming_flags =

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -105,20 +105,30 @@ val set_reserved_typed_name : (types -> Name.t) -> unit
 (*********************************************************************
    Making name distinct for displaying *)
 
+val make_all_rel_context_name_different : env -> evar_map -> rel_context -> env * rel_context
+val make_all_name_different : env -> evar_map -> env
+
+module Generator :
+sig
+type 'a t
+type 'a input = 'a t * 'a
+val fresh : Nameops.Fresh.t t
+val idset : Id.Set.t t
+
+val next_name_away : 'a t -> Name.t -> 'a -> Id.t * 'a
+end
+
 type renaming_flags =
   | RenamingForCasesPattern of (Name.t list * constr) (** avoid only global constructors *)
   | RenamingForGoal (** avoid all globals (as in intro) *)
   | RenamingElsewhereFor of (Name.t list * constr)
 
-val make_all_rel_context_name_different : env -> evar_map -> rel_context -> env * rel_context
-val make_all_name_different : env -> evar_map -> env
-
 val compute_displayed_name_in :
-  Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
+  'a Generator.t -> Environ.env -> evar_map -> renaming_flags -> 'a -> Name.t -> constr -> Name.t * 'a
 val compute_displayed_let_name_in :
-  Environ.env -> evar_map -> renaming_flags -> Id.Set.t -> Name.t -> Name.t * Id.Set.t
+  'a Generator.t -> Environ.env -> evar_map -> renaming_flags -> 'a -> Name.t -> Name.t * 'a
 
 (* Generic function expecting a "not occurn" function *)
 val compute_displayed_name_in_gen :
-  (evar_map -> int -> 'a -> bool) ->
-  Environ.env -> evar_map -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
+  'a Generator.t -> (evar_map -> int -> 'constr -> bool) ->
+  Environ.env -> evar_map -> 'a -> Name.t -> 'constr -> Name.t * 'a

--- a/engine/nameops.mli
+++ b/engine/nameops.mli
@@ -65,6 +65,8 @@ sig
   val of_list : Id.t list -> t
   val of_set : Id.Set.t -> t
   val of_named_context_val : Environ.named_context_val -> t
+
+  val max_map : t -> Subscript.t Id.Map.t
 end
 
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1426,9 +1426,11 @@ let any_any_branch =
   (* | _ => _ *)
   CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (GInternalHole))
 
+let genset = Namegen.Generator.idset
+
 let compute_displayed_name_in_pattern sigma avoid na c =
   let open Namegen in
-  compute_displayed_name_in_gen (fun _ -> Patternops.noccurn_pattern) sigma avoid na c
+  compute_displayed_name_in_gen genset (fun _ -> Patternops.noccurn_pattern) sigma avoid na c
 
 let glob_of_pat_under_context glob_of_pat avoid env sigma (nas, pat) =
   let fold (avoid, env, nas, epat) na =
@@ -1481,7 +1483,7 @@ let rec glob_of_pat
       let env' = Termops.add_name na' env in
       GProd (na',None,Explicit,glob_of_pat avoid env sigma t,glob_of_pat avoid' env' sigma c)
   | PLetIn (na,b,t,c) ->
-      let na',avoid' = Namegen.compute_displayed_let_name_in (Global.env ()) sigma Namegen.RenamingForGoal avoid na in
+      let na',avoid' = Namegen.compute_displayed_let_name_in genset (Global.env ()) sigma Namegen.RenamingForGoal avoid na in
       let env' = Termops.add_name na' env in
       GLetIn (na',None,glob_of_pat avoid env sigma b, Option.map (glob_of_pat avoid env sigma) t,
               glob_of_pat avoid' env' sigma c)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1396,11 +1396,10 @@ let extern_constr ?(inctx=false) ?scope env sigma t =
 let extern_constr_in_scope ?inctx scope env sigma t =
   extern_constr ?inctx ~scope env sigma t
 
-type any_input = Any : 'a Namegen.Generator.input -> any_input
-
 let make_avoid goal_concl_style env =
-  if goal_concl_style then Any (Namegen.Generator.idset, vars_of_env env) (* TODO *)
-  else Any (Namegen.Generator.fresh, Nameops.Fresh.empty)
+  if goal_concl_style then (Namegen.Generator.fresh, Fresh.of_set @@ vars_of_env env)
+  (* TODO: this is linear in the size of the environment, maybe we can do better *)
+  else (Namegen.Generator.fresh, Nameops.Fresh.empty)
 
 let extern_type ?(goal_concl_style=false) env sigma ?impargs t =
   (* "goal_concl_style" means do alpha-conversion using the "goal" convention *)
@@ -1410,14 +1409,14 @@ let extern_type ?(goal_concl_style=false) env sigma ?impargs t =
   (* Not "goal_concl_style" means do alpha-conversion avoiding only *)
   (* those goal/section/rel variables that occurs in the subterm under *)
   (* consideration; see namegen.ml for further details *)
-  let Any avoid = make_avoid goal_concl_style env in
+  let avoid = make_avoid goal_concl_style env in
   let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid env sigma t in
   extern_glob_type ?impargs (extern_env env sigma) r
 
 let extern_sort sigma s = extern_glob_sort (Evd.universe_binders sigma) (detype_sort sigma s)
 
 let extern_closed_glob ?(goal_concl_style=false) ?(inctx=false) ?scope env sigma t =
-  let Any avoid = make_avoid goal_concl_style env in
+  let avoid = make_avoid goal_concl_style env in
   let r =
     Detyping.detype_closed_glob ~isgoal:goal_concl_style ~avoid env sigma t
   in

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -783,11 +783,11 @@ let notation_constr_of_glob_constr nenv a =
 (**********************************************************************)
 (* Substitution of kernel names, avoiding a list of bound identifiers *)
 
-let notation_constr_of_constr avoiding t =
+let notation_constr_of_constr avoid t =
   let t = EConstr.of_constr t in
   let env = Global.env () in
   let evd = Evd.from_env env in
-  let t = Detyping.detype Detyping.Now avoiding env evd t in
+  let t = Detyping.detype Detyping.Now ~avoid env evd t in
   let nenv = {
     ninterp_var_type = Id.Map.empty;
     ninterp_rec_vars = Id.Map.empty;
@@ -942,8 +942,8 @@ let rec subst_notation_constr subst bound raw =
           NArray(t',def',ty')
 
 let subst_interpretation subst (metas,pat) =
-  let bound = List.fold_left (fun accu (id, _) -> Id.Set.add id accu) Id.Set.empty metas in
-  (metas,subst_notation_constr subst bound pat)
+  let bound = List.fold_left (fun accu (id, _) -> Fresh.add id accu) Fresh.empty metas in
+  (metas,subst_notation_constr subst (Namegen.Generator.fresh, bound) pat)
 
 (**********************************************************************)
 (* Pattern-matching a [glob_constr] against a [notation_constr]       *)

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -118,7 +118,7 @@ let revert_reserved_type t =
     let reserved = KeyMap.find (constr_key env t) !reserve_revtable in
     let t = EConstr.of_constr t in
     let evd = Evd.from_env env in
-    let t = Detyping.detype Detyping.Now Id.Set.empty env evd t in
+    let t = Detyping.detype Detyping.Now env evd t in
     (* pedrot: if [Notation_ops.match_notation_constr] may raise [Failure _]
         then I've introduced a bug... *)
     let filter _ pat =

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -448,7 +448,7 @@ let cc_tactic depth additional_terms b =
         let env = Proofview.Goal.env gl in
         let hole = DAst.make @@ GHole (GInternalHole) in
         let pr_missing (c, missing) =
-          let c = Detyping.detype Detyping.Now Id.Set.empty env sigma c in
+          let c = Detyping.detype Detyping.Now env sigma c in
           let holes = List.init missing (fun _ -> hole) in
           Printer.pr_glob_constr_env env sigma (DAst.make @@ GApp (c, holes))
         in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -417,7 +417,7 @@ let rec pattern_to_term_and_type env typ =
           (Array.init
              (cst_narg - List.length patternl)
              (fun i ->
-               Detyping.detype Detyping.Now Id.Set.empty env
+               Detyping.detype Detyping.Now env
                  (Evd.from_env env)
                  csta.(i)))
       in
@@ -507,7 +507,7 @@ let rec build_entry_lc env sigma funnames avoid rt :
       let rt_as_constr, ctx = Pretyping.understand env (Evd.from_env env) rt in
       let rt_typ = Retyping.get_type_of env (Evd.from_env env) rt_as_constr in
       let res_raw_type =
-        Detyping.detype Detyping.Now Id.Set.empty env (Evd.from_env env)
+        Detyping.detype Detyping.Now env (Evd.from_env env)
           rt_typ
       in
       let res = fresh_id args_res.to_avoid "_res" in
@@ -764,7 +764,7 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
             (fun id acc ->
               let typ_of_id = Typing.type_of_variable env_with_pat_ids id in
               let raw_typ_of_id =
-                Detyping.detype Detyping.Now Id.Set.empty env_with_pat_ids
+                Detyping.detype Detyping.Now env_with_pat_ids
                   (Evd.from_env env) typ_of_id
               in
               mkGProd (Name id, raw_typ_of_id, acc))
@@ -801,7 +801,7 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
            (fun pat e typ_as_constr ->
              let this_pat_ids = ids_of_pat pat in
              let typ =
-               Detyping.detype Detyping.Now Id.Set.empty new_env
+               Detyping.detype Detyping.Now new_env
                  (Evd.from_env env) typ_as_constr
              in
              let pat_as_term = pattern_to_term pat in
@@ -817,7 +817,7 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
                    ( Prod (Name id)
                    , let typ_of_id = Typing.type_of_variable new_env id in
                      let raw_typ_of_id =
-                       Detyping.detype Detyping.Now Id.Set.empty new_env
+                       Detyping.detype Detyping.Now new_env
                          (Evd.from_env env) typ_of_id
                      in
                      raw_typ_of_id )
@@ -978,7 +978,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
                ( DAst.make @@ GRef (GlobRef.IndRef (fst ind), None)
                , List.map
                    (fun p ->
-                     Detyping.detype Detyping.Now Id.Set.empty env
+                     Detyping.detype Detyping.Now env
                        (Evd.from_env env) p)
                    params
                  @ Array.to_list
@@ -1013,12 +1013,12 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
                   | Anonymous -> acc
                   | Name id' ->
                     ( id'
-                    , Detyping.detype Detyping.Now Id.Set.empty env
+                    , Detyping.detype Detyping.Now env
                         (Evd.from_env env) arg )
                     :: acc
                 else if EConstr.isVar sigma var_as_constr then
                   (EConstr.destVar sigma var_as_constr
-                  , Detyping.detype Detyping.Now Id.Set.empty env
+                  , Detyping.detype Detyping.Now env
                       (Evd.from_env env) arg )
                   :: acc
                 else acc)

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -611,7 +611,7 @@ let resolve_and_replace_implicits exptyp env sigma rt =
     match Evd.evar_body evi with
     | Evar_defined c ->
       (* we just have to lift the solution in glob_term *)
-      Detyping.detype Detyping.Now Id.Set.empty env ctx (f c)
+      Detyping.detype Detyping.Now env ctx (f c)
     | Evar_empty ->
       (* the hole was not solved : we do nothing *)
       default

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -161,7 +161,7 @@ let newssrcongrtac arg ist =
   (fun sigma' ->
     let x = List.find_map_exn (fun (n, x, _) -> if n = 0 then Some x else None) eq_args in
     let ty = fs sigma' x in
-    congrtac (arg, Detyping.detype Detyping.Now Id.Set.empty env sigma ty) ist)
+    congrtac (arg, Detyping.detype Detyping.Now env sigma ty) ist)
   (fun () ->
     try
     let sigma, t_lhs = Evarutil.new_Type sigma in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -375,7 +375,7 @@ let interp_index ist env sigma idx =
         | None ->
         begin match Tacinterp.Value.to_constr v with
         | Some c ->
-          let rc = Detyping.detype Detyping.Now Id.Set.empty env sigma c in
+          let rc = Detyping.detype Detyping.Now env sigma c in
           begin match Notation.uninterp_prim_token rc ([], []) with
           | Constrexpr.Number n, _ when NumTok.Signed.is_int n ->
             int_of_string (NumTok.Signed.to_string n)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -115,6 +115,8 @@ let branch env sigma (ind, i) u params (nas, br) =
 
 end
 
+let genset = Generator.idset
+
 module Avoid :
 sig
   type t
@@ -163,8 +165,8 @@ match avoid with
     else RenamingElsewhereFor (fst env, c)
   in
   let na, avoid =
-    if let_in then compute_displayed_let_name_in (Global.env ()) sigma flags avoid na
-    else compute_displayed_name_in (Global.env ()) sigma flags avoid na c
+    if let_in then compute_displayed_let_name_in genset (Global.env ()) sigma flags avoid na
+    else compute_displayed_name_in genset (Global.env ()) sigma flags avoid na c
   in
   na, Nice avoid
 | Fast avoid ->
@@ -420,11 +422,11 @@ let computable sigma (nas, ccl) =
 let lookup_name_as_displayed env sigma t s =
   let rec lookup avoid n c = match EConstr.kind sigma c with
     | Prod (name,_,c') ->
-        (match compute_displayed_name_in (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
+        (match compute_displayed_name_in genset (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
            | (Name id,avoid') -> if Id.equal id s then Some n else lookup avoid' (n+1) c'
            | (Anonymous,avoid') -> lookup avoid' (n+1) (pop c'))
     | LetIn (name,_,_,c') ->
-        (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
+        (match Namegen.compute_displayed_name_in genset (Global.env ()) sigma RenamingForGoal avoid name.binder_name c' with
            | (Name id,avoid') -> if Id.equal id s then Some n else lookup avoid' (n+1) c'
            | (Anonymous,avoid') -> lookup avoid' (n+1) (pop c'))
     | Cast (c,_,_) -> lookup avoid n c
@@ -434,7 +436,7 @@ let lookup_name_as_displayed env sigma t s =
 let lookup_index_as_renamed env sigma t n =
   let rec lookup n d c = match EConstr.kind sigma c with
     | Prod (name,_,c') ->
-          (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
+          (match Namegen.compute_displayed_name_in genset (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
                (Name _,_) -> lookup n (d+1) c'
              | (Anonymous,_) ->
                  if Int.equal n 0 then
@@ -444,7 +446,7 @@ let lookup_index_as_renamed env sigma t n =
                  else
                    lookup (n-1) (d+1) c')
     | LetIn (name,_,_,c') ->
-          (match Namegen.compute_displayed_name_in (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
+          (match Namegen.compute_displayed_name_in genset (Global.env ()) sigma RenamingForGoal Id.Set.empty name.binder_name c' with
              | (Name _,_) -> lookup n (d+1) c'
              | (Anonymous,_) ->
                  if Int.equal n 0 then

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -55,9 +55,9 @@ val detype_rel_context : 'a delay -> constr option -> Id.Set.t -> (names_context
   evar_map -> rel_context -> 'a glob_decl_g list
 
 val share_pattern_names :
-  (Id.Set.t -> names_context -> 'c -> 'd Pattern.constr_pattern_r -> 'a) -> int ->
+  ('g Namegen.Generator.input -> names_context -> 'c -> 'd Pattern.constr_pattern_r -> 'a) -> int ->
   (Name.t * 'e option * binding_kind * 'b option * 'a) list ->
-  Id.Set.t -> names_context -> 'c -> 'd Pattern.constr_pattern_r ->
+  'g Namegen.Generator.input -> names_context -> 'c -> 'd Pattern.constr_pattern_r ->
   'd Pattern.constr_pattern_r ->
   (Name.t * 'e option * binding_kind * 'b option * 'a) list * 'a * 'a
 

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -47,11 +47,11 @@ val factorize_eqns : 'a cases_clauses_g -> 'a disjunctive_cases_clauses_g
    [isgoal] tells if naming must avoid global-level synonyms as intro does
    [ctx] gives the names of the free variables *)
 
-val detype : 'a delay -> ?isgoal:bool -> Id.Set.t -> env -> evar_map -> constr -> 'a glob_constr_g
+val detype : 'a delay -> ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> env -> evar_map -> constr -> 'a glob_constr_g
 
 val detype_sort : evar_map -> Sorts.t -> glob_sort
 
-val detype_rel_context : 'a delay -> constr option -> Id.Set.t -> (names_context * env) ->
+val detype_rel_context : 'a delay -> constr option -> ?avoid:'g Namegen.Generator.input -> (names_context * env) ->
   evar_map -> rel_context -> 'a glob_decl_g list
 
 val share_pattern_names :
@@ -61,7 +61,7 @@ val share_pattern_names :
   'd Pattern.constr_pattern_r ->
   (Name.t * 'e option * binding_kind * 'b option * 'a) list * 'a * 'a
 
-val detype_closed_glob :  ?isgoal:bool -> Id.Set.t -> env -> evar_map -> closed_glob_constr -> glob_constr
+val detype_closed_glob : ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> env -> evar_map -> closed_glob_constr -> glob_constr
 
 (** look for the index of a named var or a nondep var as it is renamed *)
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1529,7 +1529,7 @@ let vernac_reserve bl =
     let sigma = Evd.from_env env in
     let t,ctx = Constrintern.interp_type env sigma c in
     let t = Flags.without_option Detyping.print_universes (fun () ->
-        Detyping.detype Detyping.Now Id.Set.empty env (Evd.from_ctx ctx) t)
+        Detyping.detype Detyping.Now env (Evd.from_ctx ctx) t)
         ()
     in
     let t,_ = Notation_ops.notation_constr_of_glob_constr (default_env ()) t in


### PR DESCRIPTION
We expose a generalized API in Namegen to allow choosing the fresh name algorithm in the upper layers. This new API is used in detyping and externalization to turn the binding generation process from quadratic to quasilinear.

This makes printing of terms with many nested bound variables way faster. Here is a degenerated but convincing example:
```coq
Fixpoint letn n (x : nat) (k : nat -> Prop) :=
  match n with
  | O => k x
  | S n =>
    let x := S x in
    letn n x k
  end.

Goal let n := 10 * 1000 in letn n 0 (fun _ => True).
Proof.
intros n.
vm_compute in n; unfold n.
cbv beta iota delta [letn].
Time Show. (* 0.4s on this PR, 14s on master *)
Abort.
```
This example is not completely crazy, it is extracted from the performance-test repo.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/682
- https://github.com/coq-tactician/coq-tactician/pull/89
- https://github.com/ejgallego/coq-serapi/pull/424