### PR TITLE
prove UIP for None and nil in Eqdep_dec

### DIFF
--- a/doc/changelog/11-standard-library/19483-UIP-None-nil.rst
+++ b/doc/changelog/11-standard-library/19483-UIP-None-nil.rst
@@ -1,0 +1,9 @@
+- **Added:** lemmas
+  :g:`UIP_None_l`,
+  :g:`UIP_None_r`,
+  :g:`UIP_None_None`,
+  :g:`UIP_nil_l`,
+  :g:`UIP_nil_r`,
+  :g:`UIP_nil_nil` in :g:`Logic.Eqdep_dec`
+  (`#19483 <https://github.com/coq/coq/pull/19483>`_,
+  by Andres Erbsen).

--- a/theories/Logic/Eqdep_dec.v
+++ b/theories/Logic/Eqdep_dec.v
@@ -384,3 +384,23 @@ Proof.
   pattern (S n) at 2 3, x.
   destruct x; reflexivity.
 Defined.
+
+
+Lemma UIP_None_l {A} (x : option A) (p1 p2 : None = x) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.
+
+Lemma UIP_None_r {A} (x : option A) (p1 p2 : x = None) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.
+
+Lemma UIP_None_None {A} (p1 p2 : None = None :> option A) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.
+
+
+Lemma UIP_nil_l {A} (x : list A) (p1 p2 : nil = x) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.
+
+Lemma UIP_nil_r {A} (x : list A) (p1 p2 : x = nil) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.
+
+Lemma UIP_nil_nil {A} (p1 p2 : nil = nil :> list A) : p1 = p2.
+Proof. apply eq_proofs_unicity_on. intros []; constructor; congruence. Qed.


### PR DESCRIPTION
This is a standard hott-style proof that is sometimes useful in non-hott work when `x = None` appears as an argument to a dependently typed function. It is also a relatively self-contained example about how to prove UIP for decidable cases of a type that does not necessarily have decidable equality.

- [x] Added **changelog**.