### PR TITLE
Fix ltac2 unused variable checking for repeated name in binder list

### DIFF
--- a/test-suite/output/ltac2_unused_var.out
+++ b/test-suite/output/ltac2_unused_var.out
@@ -24,3 +24,5 @@ File "./output/ltac2_unused_var.v", line 30, characters 18-55:
 Warning: Unused variable: y. [ltac2-unused-variable,ltac2,default]
 File "./output/ltac2_unused_var.v", line 42, characters 37-39:
 Warning: Unused variable: x. [ltac2-unused-variable,ltac2,default]
+File "./output/ltac2_unused_var.v", line 49, characters 6-20:
+Warning: Unused variable: a. [ltac2-unused-variable,ltac2,default]

--- a/test-suite/output/ltac2_unused_var.v
+++ b/test-suite/output/ltac2_unused_var.v
@@ -44,3 +44,6 @@ Ltac2 foo16 () := ltac1:(ltac2:(x |- ())).
 (* no warning for y even though it's bound in the ltac2 context
    (ltac2 can't tell that the notation isn't eg "ltac2:(...) + y") *)
 Notation foo17 x y := ltac2:(exact $preterm:x) (only parsing).
+
+(* the usage of the second "a" binder should not prevent warning for the first "a" *)
+Ltac2 foo18 a a := a.


### PR DESCRIPTION
Fix #19485