### PR TITLE
Cleanup debug printer loading

### DIFF
--- a/dev/db
+++ b/dev/db
@@ -21,11 +21,8 @@ load_printer parsing.cma
 load_printer printing.cma
 load_printer tactics.cma
 load_printer vernac.cma
-load_printer sysinit.cma
-load_printer coqworkmgrlib.cma
-load_printer stm.cma
-load_printer toplevel.cma
 
+load_printer cc_core_plugin.cma
 load_printer ltac_plugin.cma
 load_printer ltac2_plugin.cma
 

--- a/dev/dune
+++ b/dev/dune
@@ -4,7 +4,10 @@
  (synopsis "Coq's Debug Printers")
  (wrapped false)
  (modules top_printers vm_printers)
- (libraries coq-core.toplevel coq-core.plugins.ltac))
+ ; NB currently we have no "install_printer" using ltac2,
+ ; but we still want to load_printer ltac2
+ ; so that its genarg printers are present in the debugger's printer process
+ (libraries coq-core.vernac coq-core.plugins.ltac coq-core.plugins.ltac2))
 
 (library
  (name debugger_support)
@@ -42,10 +45,8 @@
     %{lib:coq-core.printing:printing.cma}
     %{lib:coq-core.tactics:tactics.cma}
     %{lib:coq-core.vernac:vernac.cma}
-    %{lib:coq-core.stm:stm.cma}
-    %{lib:coq-core.sysinit:sysinit.cma}
-    %{lib:coq-core.toplevel:toplevel.cma}
     %{lib:coq-core.plugins.ltac:ltac_plugin.cma}
+    %{lib:coq-core.plugins.ltac2:ltac2_plugin.cma}
     %{lib:coq-core.dev:dev.cma}
     %{lib:coq-core.debugger_support:debugger_support.cmi}
     %{lib:coq-core.debugger_support:debugger_support.cma}

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -583,3 +583,8 @@ let f_equal =
         | e -> Proofview.tclZERO ~info e
       end
   end
+
+(* we need to be registered in case we are statically linked to avoid double loading
+   (in practice we are statically linked in coqtop.byte:
+    coqtop.byte -> coq-core.dev -> ltac2 -> cc_core) *)
+let () = Mltop.add_known_module "cc_core_plugin:coq-core.plugins.cc_core"

--- a/plugins/cc/dune
+++ b/plugins/cc/dune
@@ -3,7 +3,7 @@
  (public_name coq-core.plugins.cc_core)
  (synopsis "Coq's congruence closure plugin")
  (modules (:standard \ g_congruence))
- (libraries coq-core.tactics))
+ (libraries coq-core.vernac))
 
 (library
  (name cc_plugin)


### PR DESCRIPTION
- remove AFAICT unused loading of sysinit/coqworkmgrlib/stm/toplevel

- fix loading of cc_core dependency of ltac2 (this requires an explicit dep on ltac2 in dev/dune as this is used to control the -I passed to ocamldebug)