### PR TITLE
Protecting against Not_found in "use" option of deprecation attribute

### DIFF
--- a/test-suite/output/Qf_deprecated.out
+++ b/test-suite/output/Qf_deprecated.out
@@ -16,3 +16,6 @@ Replace File "./output/Qf_deprecated.v", line 25, characters 17-18 with M1.w
 File "./output/Qf_deprecated.v", line 27, characters 0-69:
 The command has indeed failed with message:
 Attribute use not allowed
+File "./output/Qf_deprecated.v", line 30, characters 22-33:
+The command has indeed failed with message:
+nonexisting not found.

--- a/test-suite/output/Qf_deprecated.v
+++ b/test-suite/output/Qf_deprecated.v
@@ -26,3 +26,6 @@ Definition d2 := v = 3.
 
 Fail #[deprecated(use=w)]
 Notation "a +++ b" := (a + b) (at level 2).
+
+Fail #[deprecated(use=nonexisting)]
+Definition y := 2.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -324,7 +324,10 @@ let no_use_allowed ?since ?note = function
 let extended_globref_allowed ?since ?note = function
   | None -> Deprecation.make_with_qf ?since ?note ()
   | Some (FlagQualid p) ->
-      let use_instead = Nametab.locate_extended p in
+      let use_instead =
+        try Nametab.locate_extended p
+        with Not_found -> CErrors.user_err ?loc:p.CAst.loc Pp.(Libnames.pr_qualid p ++ str " not found.")
+      in
       Deprecation.make_with_qf ?since ?note ~use_instead ()
   | Some _ -> CErrors.user_err Pp.(str "Attribute \"use\" should be a (qualified) identifier")
 


### PR DESCRIPTION
A quick PR in passing to protect the `locate_extended` done by the `use` option of the `deprecate` attribute.

- [x] Added / updated **test-suite**.
