### PR TITLE
Ncring_tac: avoid generating temporary pairs in main loop

### DIFF
--- a/doc/changelog/04-tactics/19501-ncring-tac-speed.rst
+++ b/doc/changelog/04-tactics/19501-ncring-tac-speed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  `Ncring_tac.extra_reify` is expected to return `tt` on failure and
+  the reification result on success, instead of `(false, anything)` on failure
+  and `(true, result)` on success
+  (this only matters to users overriding it to extend the Ncring reification)
+  (`#19501 <https://github.com/coq/coq/pull/19501>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/success/Nsatz.v
+++ b/test-suite/success/Nsatz.v
@@ -1,4 +1,4 @@
-Require Import TestSuite.admit.
+
 (* compile en user    3m39.915s sur cachalot *)
 Require Import Nsatz.
 Require List.
@@ -534,4 +534,3 @@ Qed.
 
 
 End Geometry.
-

--- a/theories/nsatz/Nsatz.v
+++ b/theories/nsatz/Nsatz.v
@@ -68,13 +68,13 @@ try (try apply Rsth;
 Defined.
 
 Ltac extra_reify term ::=
-  match term with
+  lazymatch term with
   | IZR ?z =>
-      match isZcst z with
-      | true => open_constr:((true, PEc z))
-      | false => open_constr:((false,tt))
+      lazymatch isZcst z with
+      | true => open_constr:(PEc z)
+      | false => open_constr:(tt)
       end
-  | _ => open_constr:((false,tt))
+  | _ => open_constr:(tt)
   end.
 
 Lemma R_one_zero: 1%R <> 0%R.

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -50,7 +50,9 @@ Ltac close_varlist lvar :=
   | _ => let _ := constr:(eq_refl : lvar = @nil _) in idtac
   end.
 
-Ltac extra_reify term := open_constr:((false,tt)).
+(* extensibility: override to add ways to reify a term.
+   Return [tt] for terms which aren't handled (tt doesn't have type PExpr so is unambiguous) *)
+Ltac extra_reify term := open_constr:(tt).
 
 Ltac reify_term Tring lvar term :=
   match open_constr:((Tring, term)) with
@@ -112,10 +114,10 @@ Ltac reify_term Tring lvar term :=
   | _ =>
       let extra := extra_reify term in
       lazymatch extra with
-      | (false,_) =>
+      | tt =>
         let n := reify_as_var lvar term in
         open_constr:(PEX Z (Pos.of_succ_nat n))
-      | (true,?v) => v
+      | ?v => v
       end
   end.
 

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -32,7 +32,7 @@ Ltac reify_as_var_aux n lvar term :=
         | _ => open_constr:(false)
         end
       in
-      match conv with
+      lazymatch conv with
       | true => n
       | false => reify_as_var_aux open_constr:(S n) tl term
       end
@@ -44,7 +44,7 @@ Ltac reify_as_var_aux n lvar term :=
 Ltac reify_as_var lvar term := reify_as_var_aux Datatypes.O lvar term.
 
 Ltac close_varlist lvar :=
-  match lvar with
+  lazymatch lvar with
   | @nil _ => idtac
   | @cons _ _ ?tl => close_varlist tl
   | _ => let _ := constr:(eq_refl : lvar = @nil _) in idtac
@@ -64,10 +64,10 @@ Ltac reify_term R ring0 ring1 add mul sub opp lvar term :=
 
   (* ring constants *)
   | _ =>
-    let _ := match goal with _ => convert ring0 term end in
+    let _ := lazymatch goal with _ => convert ring0 term end in
     open_constr:(PEc 0%Z)
   | _ =>
-    let _ := match goal with _ => convert ring1 term end in
+    let _ := lazymatch goal with _ => convert ring1 term end in
     open_constr:(PEc 1%Z)
 
   (* binary operators *)
@@ -77,18 +77,18 @@ Ltac reify_term R ring0 ring1 add mul sub opp lvar term :=
     let _ := open_constr:(t2 : R) in
     match tt with
     | _ =>
-      let _ := match goal with _ => convert add op end in
+      let _ := lazymatch goal with _ => convert add op end in
       (* NB: don't reify before we recognize the operator in case we can't recognire it *)
       let et1 := reify_term t1 in
       let et2 := reify_term t2 in
       open_constr:(PEadd et1 et2)
     | _ =>
-      let _ := match goal with _ => convert mul op end in
+      let _ := lazymatch goal with _ => convert mul op end in
       let et1 := reify_term t1 in
       let et2 := reify_term t2 in
       open_constr:(PEmul et1 et2)
     | _ =>
-      let _ := match goal with _ => convert sub op end in
+      let _ := lazymatch goal with _ => convert sub op end in
       let et1 := reify_term t1 in
       let et2 := reify_term t2 in
       open_constr:(PEsub et1 et2)
@@ -96,7 +96,7 @@ Ltac reify_term R ring0 ring1 add mul sub opp lvar term :=
 
   (* unary operator (opposite) *)
   | ?op ?t =>
-    let _ := match goal with _ => convert opp op end in
+    let _ := lazymatch goal with _ => convert opp op end in
     let et := reify_term t in
     open_constr:(PEopp et)
 
@@ -123,7 +123,7 @@ Ltac reify_term R ring0 ring1 add mul sub opp lvar term :=
   end.
 
 Ltac list_reifyl_core Tring lvar lterm :=
-  match lterm with
+  lazymatch lterm with
   | @nil _ => open_constr:(@nil (PExpr Z))
   | @cons _ ?t ?tl =>
       lazymatch Tring with
@@ -136,17 +136,17 @@ Ltac list_reifyl_core Tring lvar lterm :=
   end.
 
 Ltac list_reifyl lvar lterm :=
-  match lterm with
+  lazymatch lterm with
   | @cons ?R _ _ =>
       let R_ring := constr:(_ :> Ring (T:=R)) in
       let Tring := type of R_ring in
       let lexpr := list_reifyl_core Tring lvar lterm in
-      let _ := match goal with _ => close_varlist lvar end in
+      let _ := lazymatch goal with _ => close_varlist lvar end in
       constr:((lvar,lexpr))
   end.
 
 Ltac list_reifyl0 lterm :=
-  match lterm with
+  lazymatch lterm with
   | @cons ?R _ _ =>
       let lvar := open_constr:(_ :> list R) in
       list_reifyl lvar lterm

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -55,71 +55,75 @@ Ltac close_varlist lvar :=
 Ltac extra_reify term := open_constr:(tt).
 
 Ltac reify_term Tring lvar term :=
-  match open_constr:((Tring, term)) with
+  lazymatch Tring with
+  | Ring (T:=?R) (ring0:=?ring0) (ring1:=?ring1)
+    (add:=?add) (mul:=?mul) (sub:=?sub) (opp:=?opp)
+    =>
+  match term with
   (* int literals *)
-  | (_, Z0) => open_constr:(PEc 0%Z)
-  | (_, Zpos ?p) => open_constr:(PEc (Zpos p))
-  | (_, Zneg ?p) => open_constr:(PEc (Zneg p))
+  | Z0 => open_constr:(PEc 0%Z)
+  | Zpos ?p => open_constr:(PEc (Zpos p))
+  | Zneg ?p => open_constr:(PEc (Zneg p))
 
   (* ring constants *)
-  | (Ring (ring0:=?op), _) =>
-      let _ := match goal with _ => convert op term end in
-      open_constr:(PEc 0%Z)
-  | (Ring (ring1:=?op), _) =>
-      let _ := match goal with _ => convert op term end in
-      open_constr:(PEc 1%Z)
+  | _ =>
+    let _ := match goal with _ => convert ring0 term end in
+    open_constr:(PEc 0%Z)
+  | _ =>
+    let _ := match goal with _ => convert ring1 term end in
+    open_constr:(PEc 1%Z)
 
   (* binary operators *)
-  | (Ring (T:=?R) (add:=?add) (mul:=?mul) (sub:=?sub), ?op ?t1 ?t2) =>
-      (* quick(?) check op is of th right type? TODO try without this check *)
-      let _ := open_constr:(t1 : R) in
-      let _ := open_constr:(t2 : R) in
-      match tt with
-      | _ =>
-          let _ := match goal with _ => convert add op end in
-          (* NB: don't reify before we recognize the operator in case we can't recognire it *)
-          let et1 := reify_term Tring lvar t1 in
-          let et2 := reify_term Tring lvar t2 in
-          open_constr:(PEadd et1 et2)
-      | _ =>
-          let _ := match goal with _ => convert mul op end in
-          let et1 := reify_term Tring lvar t1 in
-          let et2 := reify_term Tring lvar t2 in
-          open_constr:(PEmul et1 et2)
-      | _ =>
-          let _ := match goal with _ => convert sub op end in
-          let et1 := reify_term Tring lvar t1 in
-          let et2 := reify_term Tring lvar t2 in
-          open_constr:(PEsub et1 et2)
-      end
+  | ?op ?t1 ?t2 =>
+    (* quick(?) check op is of the right type? TODO try without this check *)
+    let _ := open_constr:(t1 : R) in
+    let _ := open_constr:(t2 : R) in
+    match tt with
+    | _ =>
+      let _ := match goal with _ => convert add op end in
+      (* NB: don't reify before we recognize the operator in case we can't recognire it *)
+      let et1 := reify_term Tring lvar t1 in
+      let et2 := reify_term Tring lvar t2 in
+      open_constr:(PEadd et1 et2)
+    | _ =>
+      let _ := match goal with _ => convert mul op end in
+      let et1 := reify_term Tring lvar t1 in
+      let et2 := reify_term Tring lvar t2 in
+      open_constr:(PEmul et1 et2)
+    | _ =>
+      let _ := match goal with _ => convert sub op end in
+      let et1 := reify_term Tring lvar t1 in
+      let et2 := reify_term Tring lvar t2 in
+      open_constr:(PEsub et1 et2)
+    end
 
   (* unary operator (opposite) *)
-  | (Ring (T:=?R) (opp:=?opp), ?op ?t) =>
-      let _ := match goal with _ => convert opp op end in
-      let et := reify_term Tring lvar t in
-      open_constr:(PEopp et)
+  | ?op ?t =>
+    let _ := match goal with _ => convert opp op end in
+    let et := reify_term Tring lvar t in
+    open_constr:(PEopp et)
 
   (* special cases (XXX can/should we be less syntactic?) *)
-  | (_, @multiplication Z _ _ ?z ?t) =>
-      let et := reify_term Tring lvar t in
-      open_constr:(PEmul (PEc z) et)
-  | (_, pow_N ?t ?n) =>
-      let et := reify_term Tring lvar t in
-      open_constr:(PEpow et n)
-  | (_, @power _ _ power_ring ?t ?n) =>
-      let et := reify_term Tring lvar t in
-      open_constr:(PEpow et (ZN n))
+  | @multiplication Z _ _ ?z ?t =>
+    let et := reify_term Tring lvar t in
+    open_constr:(PEmul (PEc z) et)
+  | pow_N ?t ?n =>
+    let et := reify_term Tring lvar t in
+    open_constr:(PEpow et n)
+  | @power _ _ power_ring ?t ?n =>
+    let et := reify_term Tring lvar t in
+    open_constr:(PEpow et (ZN n))
 
   (* extensibility and variable case *)
   | _ =>
-      let extra := extra_reify term in
-      lazymatch extra with
-      | tt =>
-        let n := reify_as_var lvar term in
-        open_constr:(PEX Z (Pos.of_succ_nat n))
-      | ?v => v
-      end
-  end.
+    let extra := extra_reify term in
+    lazymatch extra with
+    | tt =>
+      let n := reify_as_var lvar term in
+      open_constr:(PEX Z (Pos.of_succ_nat n))
+    | ?v => v
+    end
+  end end.
 
 Ltac list_reifyl_core Tring lvar lterm :=
   match lterm with


### PR DESCRIPTION
Should be more efficient especially with https://github.com/coq/coq/pull/19228