### PR TITLE
CI for coq_wasm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -888,6 +888,14 @@ library:ci-trakt:
   - plugin:ci-elpi_hb
   stage: build-2
 
+library:ci-wasm:
+  extends: .ci-template
+  needs:
+  - library: ci-compcert
+  - library: ci-ext-lib
+  - library: ci-mathcomp
+  stage: build-3+
+  
 # Plugins are by definition the projects that depend on Coq's ML API
 
 plugin:ci-aac_tactics:
@@ -1048,6 +1056,7 @@ plugin:ci-stalmarck:
 
 plugin:ci-tactician:
   extends: .ci-template-flambda
+
 
 plugin:ci-waterproof:
   extends: .ci-template-flambda

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -892,7 +892,7 @@ library:ci-wasm:
   extends: .ci-template
   needs:
   - library: ci-compcert
-  - library: ci-ext-lib
+  - library: ci-ext_lib
   - library: ci-mathcomp
   stage: build-3+
   

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -102,7 +102,8 @@ CI_TARGETS= \
     ci-verdi_raft \
     ci-vscoq \
     ci-vst \
-    ci-waterproof
+    ci-wasm \
+    ci-waterproof 
 
 CI_VIRTUAL_TARGETS= \
     ci-elpi_hb

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -557,3 +557,8 @@ project autosubst_ocaml "https://github.com/uds-psl/autosubst-ocaml" "master"
 ########################################################################
 project trakt "https://github.com/ecranceMERCE/trakt" "coq-master"
 # Contact @ckeller, @louiseddp on github
+
+########################################################################
+# WasmCert-Coq
+########################################################################
+project coq_wasm "https://github.com/WasmCert/WasmCert-Coq" "master"

--- a/dev/ci/dev/ci/ci-wasm.sh
+++ b/dev/ci/dev/ci/ci-wasm.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download coq_wasm
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+export COQEXTRAFLAGS='-native-compiler no'
+
+( cd "${CI_BUILD_DIR}/coq_wasm"
+  make
+)


### PR DESCRIPTION
Submitting the [coq_wasm](https://github.com/WasmCert/WasmCert-Coq) library to Coq's CI.