### PR TITLE
Check for user interrupt in "autorewrite" to escape infinite loops

### DIFF
--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -371,6 +371,7 @@ let one_base where conds tac_main bas =
   in
   let try_rewrite h tc =
   Proofview.Goal.enter begin fun gl ->
+    Control.check_for_interrupt ();
     let sigma = Proofview.Goal.sigma gl in
     let subst, ctx' = UnivGen.fresh_universe_context_set_instance h.rew_ctx in
     let subst = Sorts.QVar.Map.empty, subst in


### PR DESCRIPTION
Naively chosen rewrite hints may lead to an infinite loop in `autorewrite`.  Currently the only way to recover is by terminating the Coq process, e.g. by closing the buffer in CoqIDE.  This change lets the user terminate the loop with the "Interrupt" button.

Example of an infinite loop:
```
Require Import PeanoNat.

Goal 1 + 2 = 3.
Hint Rewrite Nat.add_comm : x.
autorewrite with x.
```
