### PR TITLE
Add `Profile` control flag printing a summary of profiling info

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/19517-profile-control.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19517-profile-control.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  :cmd:`Profile` command modifier to get profiling information for a given command
+  (`#19517 <https://github.com/coq/coq/pull/19517>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -871,6 +871,18 @@ Quitting and debugging
    message in the place of the instruction count.
 
 
+.. cmd:: Profile {? @string } @sentence
+
+   Executes :n:`@sentence` and displays profiling information. If
+   :n:`@string` is given, a full trace is written to
+   ":n:`@string`.json".
+
+   If :n:`@string` is a relative filename, it refers to the directory
+   specified by the :ref:`command line option <command-line-options>`
+   `-output-directory`, if set and otherwise, the current directory.
+   Use :cmd:`Pwd` to display the current directory.
+
+
 .. cmd:: Redirect @string @sentence
 
    Executes :n:`@sentence`, redirecting its

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1577,6 +1577,8 @@ vernac_control: [
 | WITH "Time" sentence
 | REPLACE "Instructions" vernac_control
 | WITH "Instructions" sentence
+| REPLACE "Profile" OPT STRING vernac_control
+| WITH "Profile" OPT STRING sentence
 | REPLACE "Redirect" ne_string vernac_control
 | WITH "Redirect" ne_string sentence
 | REPLACE "Timeout" natural vernac_control

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -816,6 +816,7 @@ red_expr: [
 vernac_control: [
 | "Time" vernac_control
 | "Instructions" vernac_control
+| "Profile" OPT STRING vernac_control
 | "Redirect" ne_string vernac_control
 | "Timeout" natural vernac_control
 | "Fail" vernac_control

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1002,6 +1002,7 @@ command: [
 | "Hint" "Extern" natural OPT one_pattern "=>" ltac_expr OPT ( ":" LIST1 ident )
 | "Time" sentence
 | "Instructions" sentence
+| "Profile" OPT string sentence
 | "Redirect" string sentence
 | "Timeout" natural sentence
 | "Fail" sentence

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -16,6 +16,22 @@ module MiniJson : sig
     | `Assoc of (string * t) list
     | `List of t list
   ]
+
+  val pr : Format.formatter -> t -> unit
+end
+
+module Counters : sig
+  type t
+
+  val get : unit -> t
+
+  val zero : t
+
+  val (+) : t -> t -> t
+
+  val (-) : t -> t -> t
+
+  val print : t -> Pp.t
 end
 
 val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> unit -> 'a
@@ -51,8 +67,12 @@ val resume : accu -> unit
 (** Profiling must not be active.
     Activates profiling with the given state. *)
 
-type sums
-(** Timings for sub-events *)
+type sums = (float * int) CString.Map.t
+(** Timings for sub-events: for each event, how long it took and how many times it was called. *)
+
+val empty_sums : sums
+
+val sums_union : sums -> sums -> sums
 
 val with_profiling : (unit -> 'a) -> MiniJson.t list * sums * 'a
 (** Runs the given function with profiling active and returns the
@@ -61,3 +81,14 @@ val with_profiling : (unit -> 'a) -> MiniJson.t list * sums * 'a
 val insert_results : MiniJson.t list -> sums -> unit
 (** Profiling must be active.
     Outputs the given events and includes the sum times in the current event. *)
+
+val pptime : Format.formatter -> float -> unit
+(** Pretty print a time given in seconds using smaller units as needed. *)
+
+(** Custom outputs *)
+
+val format_header : Format.formatter -> unit
+(** Output header for profile files *)
+
+val format_footer : Format.formatter -> unit
+(** Output footer for profile files and flushes the formatter. *)

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -103,6 +103,8 @@ GRAMMAR EXTEND Gram
         { add_control_flag ~loc ~flag:ControlTime c }
       | IDENT "Instructions"; c = vernac_control ->
         { add_control_flag ~loc ~flag:ControlInstructions c }
+      | IDENT "Profile"; f = OPT STRING; c = vernac_control ->
+        { add_control_flag ~loc ~flag:(ControlProfile f) c }
       | IDENT "Redirect"; s = ne_string; c = vernac_control ->
         { add_control_flag ~loc ~flag:(ControlRedirect s) c }
       | IDENT "Timeout"; n = natural; c = vernac_control ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1413,6 +1413,7 @@ let pr_control_flag (p : control_flag) =
   let w = match p with
     | ControlTime -> keyword "Time"
     | ControlInstructions -> keyword "Instructions"
+    | ControlProfile f -> keyword "Profile" ++ pr_opt qstring f
     | ControlRedirect s -> keyword "Redirect" ++ spc() ++ qs s
     | ControlTimeout n -> keyword "Timeout " ++ int n
     | ControlFail -> keyword "Fail"

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -519,6 +519,7 @@ type vernac_expr = synterp_vernac_expr vernac_expr_gen
 type control_flag =
   | ControlTime
   | ControlInstructions
+  | ControlProfile of string option
   | ControlRedirect of string
   | ControlTimeout of int
   | ControlFail


### PR DESCRIPTION
It can also print the full trace to a file if given a filename.

For instance:
~~~coq
Goal bool * nat.
split.
Time Profile Time par:
  match goal with
  | |- bool => exact true
  | |- nat => try (timeout 1 (repeat pose proof I)); exact 0
end.
(*
Finished transaction in 1.132 secs (0.026u,0.007s) (successful)
major words: 1.08E+06 words
minor words: 2.04E+05 words
major collections: 0
minor collections: 0
instructions: 185414

with_profile:        001s 133ms, 1 calls
partac.perform:      001s 010ms, 2 calls
intern:              021ms 555us, 2779 calls
pretyping:           017ms 587us, 2765 calls
unfreeze_full_state: 008ms 444us, 2 calls
kernel:              071us 287ns, 12 calls
partac.assign:       066us 042ns, 1 calls
unification:         016us 451ns, 11 calls
Finished transaction in 1.133 secs (0.027u,0.007s) (successful)
No more goals.
*)
~~~

note the `Time Profile Time` to see the overhead of the Profile postprocessing, with a file output on my machine it seems to add 5ish µs / line:
- inner Time 1.128s, outer Time 1.184s -> difference 0.056s, 
- `timeout 1 (repeat pose proof I)` -> a bit more than 2.5k pose proof run -> x2 for intern/pretyping -> x2 for enter/leave -> about 11k lines
- 0.056 / 11k = 5 * 10^-6


Depends:
- https://github.com/coq/coq/pull/19513

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/834 (should be backwards compatible)