### PR TITLE
Use uids to build hconstr maps instead of hashes after reification

### DIFF
--- a/kernel/hConstr.mli
+++ b/kernel/hConstr.mli
@@ -42,20 +42,22 @@ val of_kind_nohashcons : (t,t,Sorts.t,UVars.Instance.t,Sorts.relevance) kind_of_
 
     This is intended for the reconstruction of the inductive type when checking CaseInvert. *)
 
-module Tbl : sig
-  (** Imperative tables indexed by [HConstr.t].
-      The interfaces exposed are the same as [Hashtbl]
-      but are not guaranteed to be implemented by [Hashtbl]. *)
-
+module Map :  sig
   type key = t
 
-  type 'a t
+  (** Map from [HConstr.t] to ['a]. Keys added and looked up in a
+      given map should all be from the same [of_constr] run.
 
-  val find_opt : 'a t -> key -> 'a option
+      Results of [of_kind_nohashcons] are also not allowed except in
+      the degenerate case where the kind is [App (x,[||])] and [x] is allowed
+      (checking [refcount result > 1] is enough to ensure this). *)
+  type +'a t
 
-  val add : 'a t -> key -> 'a -> unit
+  val empty : 'a t
 
-  val create : unit -> 'a t
+  val add : key -> 'a -> 'a t -> 'a t
+
+  val find_opt : key -> 'a t -> 'a option
 end
 
 val hcons : t -> Constr.t

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -620,11 +620,11 @@ let push_rec_types (lna,typarray,_) env =
 (* The typing machine. *)
 let rec execute tbl env cstr =
   if Int.equal (HConstr.refcount cstr) 1 then execute_aux tbl env cstr
-  else begin match HConstr.Tbl.find_opt tbl cstr with
+  else begin match HConstr.Map.find_opt cstr !tbl with
     | Some v -> v
     | None ->
       let v = execute_aux tbl env cstr in
-      HConstr.Tbl.add tbl cstr v;
+      tbl := HConstr.Map.add cstr v !tbl;
       v
   end
 
@@ -841,7 +841,7 @@ and execute_array tbl env cs =
   Array.map (fun c -> execute tbl env c) cs
 
 let execute env c =
-  NewProfile.profile "Typeops.execute" (fun () -> execute (HConstr.Tbl.create ()) env c) ()
+  NewProfile.profile "Typeops.execute" (fun () -> execute (ref HConstr.Map.empty) env c) ()
 
 (* Derived functions *)
 


### PR DESCRIPTION
The API is more fragile (cf comment in the mli) so this should probably not be merged in its current state, but let's see if it gains us anything first.
