### PR TITLE
Fix tag used for docker-boot in untagged-runners mode (ie gitlab.com)

### DIFF
--- a/dev/ci/gitlab-modes/untagged-runners.yml
+++ b/dev/ci/gitlab-modes/untagged-runners.yml
@@ -3,4 +3,5 @@
 
 .auto-use-docker-tags:
   tags:
-    - docker
+    # https://docs.gitlab.com/ee/ci/runners/hosted_runners/linux.html#docker-in-docker-support
+    - saas-linux-small-amd64


### PR DESCRIPTION
cf
https://docs.gitlab.com/ee/update/deprecations.html?removal_milestone=17.0#removal-of-tags-from-small-saas-runners-on-linux (`docker` tag removed)

https://docs.gitlab.com/ee/ci/runners/hosted_runners/linux.html#docker-in-docker-support (saas-linux-* support docker-in-docker)
