### PR TITLE
Context.map_annot{,_relevance}: make "smart", add _het version

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -417,7 +417,7 @@ let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
   match Evd.MiniEConstr.unsafe_relevance_eq with
   | Refl -> fun x -> x
 
-let to_binder_annot sigma x = Context.map_annot_relevance (ERelevance.kind sigma) x
+let to_binder_annot sigma x = Context.map_annot_relevance_het (ERelevance.kind sigma) x
 
 let to_rel_decl sigma d =
   Context.Rel.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -417,17 +417,29 @@ let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
   match Evd.MiniEConstr.unsafe_relevance_eq with
   | Refl -> fun x -> x
 
-let to_binder_annot sigma x = Context.map_annot_relevance_het (ERelevance.kind sigma) x
+let to_binder_annot sigma (x:_ binder_annot) : _ Constr.binder_annot =
+  let Refl = unsafe_relevance_eq in
+  Context.map_annot_relevance (ERelevance.kind sigma) x
 
-let to_rel_decl sigma d =
-  Context.Rel.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+let to_rel_decl sigma (d:rel_declaration) : Constr.rel_declaration =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  Context.Rel.Declaration.map_constr_with_relevance (ERelevance.kind sigma) (to_constr sigma) d
 
-let to_rel_context sigma ctx = List.map (to_rel_decl sigma) ctx
+let to_rel_context sigma (ctx:rel_context) : Constr.rel_context =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  List.Smart.map (to_rel_decl sigma) ctx
 
-let to_named_decl sigma d =
-  Context.Named.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+let to_named_decl sigma (d:named_declaration) : Constr.named_declaration =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  Context.Named.Declaration.map_constr_with_relevance (ERelevance.kind sigma) (to_constr sigma) d
 
-let to_named_context sigma ctx = List.map (to_named_decl sigma) ctx
+let to_named_context sigma (ctx:named_context) : Constr.named_context =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  List.Smart.map (to_named_decl sigma) ctx
 
 let map_branches f br =
   let f c = unsafe_to_constr (f (of_constr c)) in

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -47,9 +47,6 @@ let map_annot_relevance fr {binder_name=na;binder_relevance=r} =
 
 let make_annot x r = {binder_name=x;binder_relevance=r}
 
-let map_binder_relevance f {binder_name=na;binder_relevance=r} =
-  {binder_name=na;binder_relevance=f r}
-
 let binder_name x = x.binder_name
 let binder_relevance x = x.binder_relevance
 
@@ -178,11 +175,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (na, ty) as decl ->
-          let na' = map_binder_relevance g na in
+          let na' = map_annot_relevance g na in
           let ty' = f ty in
           if na == na' && ty == ty' then decl else LocalAssum (na', ty')
       | LocalDef (na, v, ty) as decl ->
-          let na' = map_binder_relevance g na in
+          let na' = map_annot_relevance g na in
           let v' = f v in
           let ty' = f ty in
           if na == na' && v == v' && ty == ty' then decl else LocalDef (na', v', ty')
@@ -437,11 +434,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (id, ty) as decl ->
-          let id' = map_binder_relevance g id in
+          let id' = map_annot_relevance g id in
           let ty' = f ty in
           if id == id' && ty == ty' then decl else LocalAssum (id', ty')
       | LocalDef (id, v, ty) as decl ->
-          let id' = map_binder_relevance g id in
+          let id' = map_annot_relevance g id in
           let v' = f v in
           let ty' = f ty in
           if id == id' && v == v' && ty == ty' then decl else LocalDef (id', v', ty')

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -40,10 +40,16 @@ let hash_annot h {binder_name=n;binder_relevance=r} =
   Hashset.Combine.combinesmall (Sorts.relevance_hash r) (h n)
 
 let map_annot f {binder_name=na;binder_relevance} =
-  {binder_name=f na;binder_relevance}
+  let na' = f na in
+  {binder_name=na';binder_relevance}
 
-let map_annot_relevance fr {binder_name=na;binder_relevance=r} =
-  {binder_name=na;binder_relevance=fr r}
+let map_annot_relevance fr ({binder_name=na;binder_relevance=r} as a) =
+  let r' = fr r in
+  if r == r' then a else {binder_name=na;binder_relevance=r'}
+
+let map_annot_relevance_het fr {binder_name=na;binder_relevance=r} =
+  let r' = fr r in
+  {binder_name=na;binder_relevance=r'}
 
 let make_annot x r = {binder_name=x;binder_relevance=r}
 
@@ -187,11 +193,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (na, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance fr na, ty')
+          LocalAssum (map_annot_relevance_het fr na, ty')
       | LocalDef (na, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance fr na, v', ty')
+          LocalDef (map_annot_relevance_het fr na, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -446,11 +452,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (id, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance fr id, ty')
+          LocalAssum (map_annot_relevance_het fr id, ty')
       | LocalDef (id, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance fr id, v', ty')
+          LocalDef (map_annot_relevance_het fr id, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -477,9 +483,9 @@ struct
 
     let of_rel_decl f = function
       | Rel.Declaration.LocalAssum (na,t) ->
-          LocalAssum (map_annot f na, t)
+        LocalAssum (map_annot f na, t)
       | Rel.Declaration.LocalDef (na,v,t) ->
-          LocalDef (map_annot f na, v, t)
+        LocalDef (map_annot f na, v, t)
 
     let to_rel_decl =
       let name x = {binder_name=Name x.binder_name;binder_relevance=x.binder_relevance} in

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -33,7 +33,9 @@ val hash_annot : ('a -> int) -> ('a,Sorts.relevance) pbinder_annot -> int
 
 val map_annot : ('a -> 'b) -> ('a,'r) pbinder_annot -> ('b,'r) pbinder_annot
 
-val map_annot_relevance : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
+val map_annot_relevance : ('r -> 'r) -> ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot
+
+val map_annot_relevance_het : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
 
 val make_annot : 'a -> 'r -> ('a,'r) pbinder_annot
 

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -224,8 +224,8 @@ let map_ptype_error fr f = function
   CantApplyBadType ((n, f c1, f c2), on_judgment f j, Array.map (on_judgment f) vj)
 | CantApplyNonFunctional (j, jv) -> CantApplyNonFunctional (on_judgment f j, Array.map (on_judgment f) jv)
 | IllFormedRecBody (ge, na, n, env, jv) ->
-  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance fr) na, n, env, Array.map (on_judgment f) jv)
+  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance_het fr) na, n, env, Array.map (on_judgment f) jv)
 | IllTypedRecBody (n, na, jv, t) ->
-  IllTypedRecBody (n, Array.map (Context.map_annot_relevance fr) na, Array.map (on_judgment f) jv, Array.map f t)
+  IllTypedRecBody (n, Array.map (Context.map_annot_relevance_het fr) na, Array.map (on_judgment f) jv, Array.map f t)
 | BadBinderRelevance (rlv, decl) -> BadBinderRelevance (fr rlv, Context.Rel.Declaration.map_constr_het fr f decl)
 | BadCaseRelevance (rlv, case) -> BadCaseRelevance (fr rlv, f case)

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -66,7 +66,7 @@ let compute_new_princ_type_from_rel env rel_to_fun sorts princ_type =
       if princ_type_info.indarg_in_concl then List.tl args else args
     in
     let na = map_annot Nameops.Name.get_id (Context.Rel.Declaration.get_annot decl) in
-    let na = map_annot_relevance EConstr.Unsafe.to_relevance na in
+    let na = EConstr.Unsafe.to_binder_annot na in
     Context.Named.Declaration.LocalAssum (na, Term.it_mkProd_or_LetIn (mkSort new_sort) real_args)
   in
   let new_predicates =


### PR DESCRIPTION

Should help preserve sharing (in all unmodified users of the mappers)

See also #19529
