### PR TITLE
SSR pf_interp_ty use typing constraint instead of inserting cast

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -951,9 +951,9 @@ let interp_constr_with_bindings ist env sigma (c,bl) =
   let sigma, c = interp_constr ist env sigma c in
   sigma, (c,bl)
 
-let interp_open_constr_with_bindings ist env sigma (c,bl) =
+let interp_open_constr_with_bindings ?expected_type ist env sigma (c,bl) =
   let sigma, bl = interp_bindings ist env sigma bl in
-  let sigma, c = interp_open_constr ist env sigma c in
+  let sigma, c = interp_open_constr ?expected_type ist env sigma c in
   sigma, (c, bl)
 
 let loc_of_bindings = function

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -108,7 +108,8 @@ val interp_open_constr_with_classes : ?expected_type:Pretyping.typing_constraint
   interp_sign -> Environ.env -> Evd.evar_map ->
   glob_constr_and_expr -> Evd.evar_map * EConstr.constr
 
-val interp_open_constr_with_bindings : interp_sign -> Environ.env -> Evd.evar_map ->
+val interp_open_constr_with_bindings : ?expected_type:Pretyping.typing_constraint ->
+  interp_sign -> Environ.env -> Evd.evar_map ->
   glob_constr_and_expr with_bindings -> Evd.evar_map * EConstr.constr with_bindings
 
 (** Initial call for interpretation *)

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -88,7 +88,7 @@ val intern_term :
   Tacinterp.interp_sign -> env ->
     ssrterm -> Glob_term.glob_constr
 
-val interp_term :
+val interp_term : ?expected_type:Pretyping.typing_constraint ->
   Environ.env -> Evd.evar_map ->
   Tacinterp.interp_sign ->
     ssrterm -> evar_map * EConstr.t
@@ -100,7 +100,7 @@ val interp_refine :
   Environ.env -> Evd.evar_map -> Tacinterp.interp_sign -> concl:EConstr.constr ->
     Glob_term.glob_constr -> evar_map * EConstr.constr
 
-val interp_open_constr :
+val interp_open_constr : ?expected_type:Pretyping.typing_constraint ->
   Environ.env -> Evd.evar_map ->
   Tacinterp.interp_sign ->
     Genintern.glob_constr_and_expr -> evar_map * EConstr.t

--- a/test-suite/bugs/bug_19507.v
+++ b/test-suite/bugs/bug_19507.v
@@ -1,0 +1,18 @@
+Require Import StrictProp ssreflect.
+
+Goal False.
+
+have h : sUnit := stt. (* works *)
+have h' : sUnit. (* doesn't work *)
+
+Abort.
+
+
+Axiom b : bool.
+
+Goal False.
+
+have: match b with true | false => True end.
+{ change ?P with (P : Prop).
+
+Abort.


### PR DESCRIPTION
This makes it compatible with non-Type sorts, ie fix #19507
