### PR TITLE
Nicer NewProfile.profile API

### DIFF
--- a/checker/analyze.ml
+++ b/checker/analyze.ml
@@ -437,9 +437,8 @@ let parse chan =
   (ans.(0), memory)
 
 let parse chan : _ * _ =
-  NewProfile.profile "analyze"
-    (fun () -> parse chan)
-    ()
+  NewProfile.profile "analyze" @@ fun () ->
+  parse chan
 
 end
 
@@ -511,4 +510,4 @@ let instantiate (p, mem) =
   get_data p
 
 let instantiate pmem : Obj.t =
-  NewProfile.profile "instantiate" (fun () -> instantiate pmem) ()
+  NewProfile.profile "instantiate" @@ fun () -> instantiate pmem

--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -182,6 +182,9 @@ let check_same_record r1 r2 = match r1, r2 with
   | (NotRecord | FakeRecord | PrimRecord _), _ -> false
 
 let check_inductive env mind mb =
+  NewProfile.profile "check_inductive"
+    ~args:(fun () -> [("name", `String (MutInd.to_string mind))])
+  @@ fun () ->
   let entry = to_entry mind mb in
   let { mind_packets; mind_record; mind_finite; mind_ntypes; mind_hyps; mind_univ_hyps;
         mind_nparams; mind_nparams_rec; mind_params_ctxt;
@@ -218,9 +221,3 @@ let check_inductive env mind mb =
   (* TODO non oracle flags *)
 
   add_mind mind mb env
-
-let check_inductive env mind mb : Environ.env =
-  NewProfile.profile "check_inductive"
-    ~args:(fun () -> [("name", `String (MutInd.to_string mind))])
-    (fun () -> check_inductive env mind mb)
-    ()

--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -264,8 +264,7 @@ let lib_to_string = function
 let try_locate_qualified_library lib : _ * _ =
   NewProfile.profile "try_locate_qualified_library"
     ~args:(fun () -> [("name", `String (lib_to_string lib))])
-    (fun () -> try_locate_qualified_library lib)
-    ()
+    @@ fun () -> try_locate_qualified_library lib
 
 (************************************************************************)
 (*s Low-level interning of libraries from files *)
@@ -378,8 +377,7 @@ let intern_from_file ~intern_mode ~enable_VM (dir, f) =
 let intern_from_file ~intern_mode ~enable_VM dirf : library_t =
   NewProfile.profile "intern_from_file"
     ~args:(fun () -> [("name", `String (DirPath.to_string (fst dirf)))])
-    (fun () -> intern_from_file ~intern_mode ~enable_VM dirf)
-    ()
+    @@ fun () -> intern_from_file ~intern_mode ~enable_VM dirf
 
 (* Read a compiled library and all dependencies, in reverse order.
    Do not include files that are already in the context. *)

--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -103,6 +103,7 @@ let set_include d p =
 
 (* Initializes the LoadPath *)
 let init_load_path () =
+  NewProfile.profile "init_load_path" @@ fun () ->
   let coqenv = Boot.Env.init () in
   (* the to_string casting won't be necessary once Boot handles
      include paths *)
@@ -126,11 +127,6 @@ let init_load_path () =
   List.iter (fun s -> add_rec_path ~unix_path:s ~coq_root:CheckLibrary.default_root_prefix) coqpath;
   (* then current directory *)
   add_path ~unix_path:"." ~coq_root:CheckLibrary.default_root_prefix
-
-let init_load_path () : unit =
-  NewProfile.profile "init_load_path"
-    init_load_path
-    ()
 
 let impredicative_set = ref false
 let set_impredicative_set () = impredicative_set := true
@@ -416,11 +412,11 @@ let init_with_argv argv =
     Flags.if_verbose print_header ();
     if not !boot then init_load_path ();
     (* additional loadpath, given with -R/-Q options *)
-    NewProfile.profile "add_load_paths" (fun () ->
-        List.iter
-          (fun (unix_path, coq_root) -> add_rec_path ~unix_path ~coq_root)
-          (List.rev !includes))
-      ();
+    let () = NewProfile.profile "add_load_paths" @@ fun () ->
+      List.iter
+        (fun (unix_path, coq_root) -> add_rec_path ~unix_path ~coq_root)
+        (List.rev !includes)
+    in
     includes := [];
     make_senv ()
   with e ->

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -33,6 +33,9 @@ let register_opacified_constant env opac kn cb =
 exception BadConstant of Constant.t * Pp.t
 
 let check_constant_declaration env opac kn cb opacify =
+  NewProfile.profile "check_constant" ~args:(fun () ->
+      [("name", `String (Constant.to_string kn))])
+  @@ fun () ->
   Flags.if_verbose Feedback.msg_notice (str "  checking cst:" ++ Constant.print kn);
   let env = CheckFlags.set_local_flags cb.const_typing_flags env in
   let poly, env =
@@ -79,11 +82,7 @@ let check_constant_declaration env opac kn cb opacify =
   | Some _ | None -> opac
 
 let check_constant_declaration env opac kn cb opacify =
-  let opac = NewProfile.profile "check_constant" ~args:(fun () ->
-      [("name", `String (Constant.to_string kn))])
-      (fun () -> check_constant_declaration env opac kn cb opacify)
-      ()
-  in
+  let opac = check_constant_declaration env opac kn cb opacify in
   Environ.add_constant kn cb env, opac
 
 let check_quality_mask env qmask lincheck =
@@ -304,5 +303,4 @@ and check_signature env opac sign mp_mse res opacify = match sign with
 let check_module env opac mp mb =
   NewProfile.profile "check_module"
     ~args:(fun () -> [("name", `String (ModPath.to_string mp))])
-    (fun () -> check_module env opac mp mb Cset.empty)
-    ()
+    @@ fun () -> check_module env opac mp mb Cset.empty

--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -29,8 +29,8 @@ let import senv opac clib vmtab digest : _ * _ =
           | _ -> assert false
         in
         [("name", `String (Names.DirPath.to_string dp))])
-    (fun () ->import senv opac clib vmtab digest)
-    ()
+  @@ fun () ->
+  import senv opac clib vmtab digest
 
 let unsafe_import senv clib vmtab digest =
   let (_,senv) = Safe_typing.import clib vmtab digest senv in senv

--- a/checker/validate.ml
+++ b/checker/validate.ml
@@ -234,7 +234,7 @@ let print_frame = function
 | CtxTag i -> Printf.sprintf "tag=%i" i
 
 let validate v (o, mem) : unit =
-  try NewProfile.profile "validate" (fun () -> val_gen v mem mt_ec o) ()
+  try NewProfile.profile "validate" @@ fun () -> val_gen v mem mt_ec o
   with ValidObjError(msg,ctx,obj) ->
     let rctx = List.rev_map print_frame ctx in
     print_endline ("Context: "^String.concat"/"rctx);

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2650,9 +2650,8 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
       a :: intern_args env subscopes args
 
   in
-  NewProfile.profile "intern" (fun () ->
-      intern env c)
-    ()
+  NewProfile.profile "intern" @@ fun () ->
+  intern env c
 
 (**************************************************************************)
 (* Functions to translate constr_expr into glob_constr                    *)

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1481,7 +1481,7 @@ and hash_term_array ct t =
   let h = !accu in
   (HashsetTermArray.repr h ct term_array_table, h)
 
-let hcons t = NewProfile.profile "Constr.hcons" (fun () -> fst (sh_rec t)) ()
+let hcons t = NewProfile.profile "Constr.hcons" @@ fun () -> fst (sh_rec t)
 
 let hcons t =
   steps := 0;

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -912,24 +912,23 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
 | _, _ -> raise NotConvertible
 
 let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 =
-  NewProfile.profile "Conversion" begin fun () ->
-      let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
-      let infos = create_conv_infos ~univs:graph ~evars reds env in
-      let module Error = struct type payload += Error of err end in
-      let box e = Error.Error e in
-      let infos = {
-        cnv_inf = infos;
-        cnv_typ = typed;
-        lft_tab = create_tab ();
-        rgt_tab = create_tab ();
-        err_ret = box;
-      } in
-      try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
-      with
-      | NotConvertible -> Result.Error None
-      | NotConvertibleTrace (Error.Error e) -> Result.Error (Some e)
-      | NotConvertibleTrace _ -> assert false
-  end ()
+  NewProfile.profile "Conversion" @@ fun () ->
+  let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
+  let infos = create_conv_infos ~univs:graph ~evars reds env in
+  let module Error = struct type payload += Error of err end in
+  let box e = Error.Error e in
+  let infos = {
+    cnv_inf = infos;
+    cnv_typ = typed;
+    lft_tab = create_tab ();
+    rgt_tab = create_tab ();
+    err_ret = box;
+  } in
+  try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
+  with
+  | NotConvertible -> Result.Error None
+  | NotConvertibleTrace (Error.Error e) -> Result.Error (Some e)
+  | NotConvertibleTrace _ -> assert false
 
 let check_eq univs u u' =
   if UGraph.check_eq_sort univs u u' then Result.Ok univs else Result.Error None

--- a/kernel/hConstr.ml
+++ b/kernel/hConstr.ml
@@ -426,7 +426,7 @@ let tree_size c =
 let of_constr env c =
   let henv = empty_env env in
   let henv = iterate push_unknown_rel (Environ.nb_rel env) henv in
-  let c = NewProfile.profile "HConstr.of_constr" (fun () -> of_constr henv c) () in
+  let c = NewProfile.profile "HConstr.of_constr" @@ fun () -> of_constr henv c in
   dbg Pp.(fun () ->
       let stats = Tbl.stats henv.tbl in
       let tree_size = tree_size (self c) in

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -841,7 +841,8 @@ and execute_array tbl env cs =
   Array.map (fun c -> execute tbl env c) cs
 
 let execute env c =
-  NewProfile.profile "Typeops.execute" (fun () -> execute (HConstr.Tbl.create ()) env c) ()
+  NewProfile.profile "Typeops.execute" @@ fun () ->
+  execute (HConstr.Tbl.create ()) env c
 
 (* Derived functions *)
 
@@ -860,7 +861,8 @@ let check_wellformed_universes env c =
   | Error u -> error_undeclared_universes env u
 
 let check_wellformed_universes env c =
-  NewProfile.profile "check-wf-univs" (fun () -> check_wellformed_universes env c) ()
+  NewProfile.profile "check-wf-univs" @@ fun () ->
+  check_wellformed_universes env c
 
 let infer_hconstr env hconstr =
   let constr = HConstr.self hconstr in

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -537,9 +537,8 @@ let sort_and_universes_of_constr ?(init=Sorts.QVar.Set.empty,Univ.Level.Set.empt
   aux init c
 
 let sort_and_universes_of_constr ?init c =
-  NewProfile.profile "sort_and_universes_of_constr" (fun () ->
-      sort_and_universes_of_constr ?init c)
-    ()
+  NewProfile.profile "sort_and_universes_of_constr" @@ fun () ->
+  sort_and_universes_of_constr ?init c
 
 let universes_of_constr ?(init=Univ.Level.Set.empty) c =
   snd (sort_and_universes_of_constr ~init:(Sorts.QVar.Set.empty,init) c)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -248,9 +248,8 @@ let vm_conv cv_pb env t1 t2 =
   else
     let state = (univs, checked_universes) in
     let ans : (UGraph.t, 'a option) result =
-      NewProfile.profile "vm_conv" (fun () ->
-          vm_conv_gen cv_pb (Genlambda.empty_evars env) env state t1 t2)
-        ()
+      NewProfile.profile "vm_conv" @@ fun () ->
+      vm_conv_gen cv_pb (Genlambda.empty_evars env) env state t1 t2
     in
     match ans with
     | Result.Ok (_ : UGraph.t)-> Result.Ok ()

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -953,7 +953,8 @@ let warn_compile_error =
     Vmerrors.pr_error
 
 let compile ~fail_on_error ?universes env sigma c =
-  try NewProfile.profile "vm_compile" (fun () -> Some (compile ?universes env sigma c)) ()
+  NewProfile.profile "vm_compile" @@ fun () ->
+  try Some (compile ?universes env sigma c)
   with Vmerrors.CompileError msg as exn ->
     let exn = Exninfo.capture exn in
     if fail_on_error then

--- a/lib/newProfile.ml
+++ b/lib/newProfile.ml
@@ -218,7 +218,7 @@ let components =
       CString.Pred.empty
       (String.split_on_char ',' s)
 
-let profile name ?args f () =
+let profile name ?args f =
   if not (is_profiling ()) then f ()
   else if CString.Pred.mem name components then begin
     let args = Option.map (fun f -> f()) args in

--- a/lib/newProfile.mli
+++ b/lib/newProfile.mli
@@ -18,7 +18,7 @@ module MiniJson : sig
   ]
 end
 
-val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> unit -> 'a
+val profile : string -> ?args:(unit -> (string * MiniJson.t) list) -> (unit -> 'a) -> 'a
 (** Profile the given function.
 
     [args] is called only if profiling is active, it is used to

--- a/library/global.ml
+++ b/library/global.ml
@@ -55,23 +55,22 @@ let env () = Safe_typing.env_of_safe_env (safe_env ())
 
 (** Turn ops over the safe_environment state monad to ops on the global env *)
 
-let prof f () =
-  NewProfile.profile "kernel" f ()
+let prof f =
+  NewProfile.profile "kernel" f
 
-let globalize0 f = prof (fun () -> GlobalSafeEnv.set_safe_env (f (safe_env ()))) ()
+let globalize0 f = prof @@ fun () -> GlobalSafeEnv.set_safe_env (f (safe_env ()))
 
 let globalize f =
-  prof (fun () ->
-      let res,env = f (safe_env ()) in GlobalSafeEnv.set_safe_env env; res)
-    ()
+  prof @@ fun () ->
+  let res,env = f (safe_env ()) in GlobalSafeEnv.set_safe_env env; res
 
 let globalize0_with_summary fs f =
-  let env = prof (fun () -> f (safe_env ())) () in
+  let env = prof @@ fun () -> f (safe_env ()) in
   Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env
 
 let globalize_with_summary fs f =
-  let res,env = prof (fun () -> f (safe_env ())) () in
+  let res,env = prof @@ fun () -> f (safe_env ()) in
   Summary.Interp.unfreeze_summaries fs;
   GlobalSafeEnv.set_safe_env env;
   res

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1936,9 +1936,8 @@ let solve_unif_constraints_with_heuristics env
 exception UnableToUnify of evar_map * unification_error
 
 let evar_conv_x flags env evd pb x1 x2 : unification_result =
-  NewProfile.profile "unification" (fun () ->
-      evar_conv_x flags env evd pb x1 x2)
-    ()
+  NewProfile.profile "unification" @@ fun () ->
+  evar_conv_x flags env evd pb x1 x2
 
 let unify_delay ?flags env evd t1 t2 =
   let flags =

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1606,9 +1606,8 @@ let ise_pretype_gen (flags : inference_flags) env sigma lvar kind c =
   process_inference_flags flags !!env sigma (sigma',c',c'_ty)
 
 let ise_pretype_gen flags env sigma lvar kind c : _ * _ * _ =
-  NewProfile.profile "pretyping" (fun () ->
-      ise_pretype_gen flags env sigma lvar kind c)
-    ()
+  NewProfile.profile "pretyping" @@ fun () ->
+  ise_pretype_gen flags env sigma lvar kind c
 
 let default_inference_flags fail = {
   use_coercions = true;

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1071,8 +1071,8 @@ module Search = struct
   let typeclasses_eauto env evd ~goals ?depth ~unique ~best_effort st hints =
     let only_classes = true in
     let dep = unique in
-    NewProfile.profile "typeclass search" (fun () ->
-      run_on_goals env evd (eauto_tac_stuck st ~unique ~only_classes ~best_effort ~depth ~dep hints) ~goals) ()
+    NewProfile.profile "typeclass search" @@ fun () ->
+    run_on_goals env evd (eauto_tac_stuck st ~unique ~only_classes ~best_effort ~depth ~dep hints) ~goals
 
   let typeclasses_resolve : solver = { solver = fun env evd ~depth ~unique ~best_effort ~goals ->
     let db = searchtable_map typeclasses_db in

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -109,10 +109,9 @@ let load_vernac_core ~echo ~check ~state ?source file =
   let rec loop state ids =
     let tstart = System.get_time () in
     match
-      NewProfile.profile "parse_command" (fun () ->
-          Stm.parse_sentence
-            ~doc:state.doc ~entry:Pvernac.main_entry state.sid in_pa)
-        ()
+      NewProfile.profile "parse_command" @@ fun () ->
+      Stm.parse_sentence
+        ~doc:state.doc ~entry:Pvernac.main_entry state.sid in_pa
     with
     | None ->
       input_cleanup ();
@@ -134,8 +133,8 @@ let load_vernac_core ~echo ~check ~state ?source file =
                    in
                    [("cmd", `String (Pp.string_of_ppcmds (Topfmt.pr_cmd_header ast)));
                     ("line", `String lnum)])
-               (fun () ->
-             Flags.silently (interp_vernac ~check ~state) ast) ())
+             @@ fun () ->
+             Flags.silently (interp_vernac ~check ~state) ast)
           ()
           (fun () ->
              let tend = System.get_time () in

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -156,8 +156,12 @@ let interp_gen ~verbosely ~st ~interp_fn cmd =
 let interp ~intern ?(verbosely=true) ~st cmd =
   Vernacstate.unfreeze_full_state st;
   vernac_pperr_endline Pp.(fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr cmd.CAst.v.expr);
-  let entry = NewProfile.profile "synterp" (fun () -> Synterp.synterp_control ~intern cmd) () in
-  let interp = NewProfile.profile "interp" (fun () -> interp_gen ~verbosely ~st ~interp_fn:interp_control entry) () in
+  let entry = NewProfile.profile "synterp" @@ fun () ->
+    Synterp.synterp_control ~intern cmd
+  in
+  let interp = NewProfile.profile "interp" @@ fun () ->
+    interp_gen ~verbosely ~st ~interp_fn:interp_control entry
+  in
   Vernacstate.{ synterp = Vernacstate.Synterp.freeze (); interp }
 
 let interp_entry ?(verbosely=true) ~st entry =
@@ -181,7 +185,6 @@ end
 let fs_intern = Intern.fs_intern
 
 let interp_qed_delayed_proof ~proof ~st ~control (CAst.{loc; v = pe } as e) : Vernacstate.Interp.t =
-  NewProfile.profile "interp-delayed-qed" (fun () ->
-      interp_gen ~verbosely:false ~st
-        ~interp_fn:(interp_qed_delayed_control ~proof ~control) e)
-    ()
+  NewProfile.profile "interp-delayed-qed" @@ fun () ->
+  interp_gen ~verbosely:false ~st
+    ~interp_fn:(interp_qed_delayed_control ~proof ~control) e

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -165,10 +165,9 @@ let freeze_full_state () =
   }
 
 let unfreeze_full_state st =
-  NewProfile.profile "unfreeze_full_state" (fun () ->
-      Synterp.unfreeze st.synterp;
-      Interp.unfreeze_interp_state st.interp)
-    ()
+  NewProfile.profile "unfreeze_full_state" @@ fun () ->
+  Synterp.unfreeze st.synterp;
+  Interp.unfreeze_interp_state st.interp
 
 (* Compatibility module *)
 module Declare_ = struct
@@ -225,14 +224,12 @@ module Declare_ = struct
   let return_proof () = cc Declare.Proof.return_proof
 
   let close_future_proof ~feedback_id pf =
-    NewProfile.profile "close_future_proof" (fun () ->
-        cc (fun pt -> Declare.Proof.close_future_proof ~feedback_id pt pf))
-      ()
+    NewProfile.profile "close_future_proof" @@ fun () ->
+    cc (fun pt -> Declare.Proof.close_future_proof ~feedback_id pt pf)
 
   let close_proof ~opaque ~keep_body_ucst_separate =
-    NewProfile.profile "close_proof" (fun () ->
-        cc (fun pt -> Declare.Proof.close_proof ~opaque ~keep_body_ucst_separate pt))
-      ()
+    NewProfile.profile "close_proof" @@ fun () ->
+    cc (fun pt -> Declare.Proof.close_proof ~opaque ~keep_body_ucst_separate pt)
 
   let discard_all () = s_lemmas := None
   let update_sigma_univs ugraph = dd (Declare.Proof.update_sigma_univs ugraph)


### PR DESCRIPTION
By removing the trailing `unit` argument it becomes possible to use it like

~~~ocaml
let foo args =
  NewProfile.profile "foo" @@ fun () ->
  code of foo
~~~

where before we would need

~~~ocaml
let foo args =
  NewProfile.profile "foo" (fun () ->
    code of foo)
  ()
~~~

or

~~~ocaml
let foo args =
  code of foo

let foo args =
  NewProfile.profile "foo" (fun () -> foo args) ()
~~~
