### PR TITLE
Experiment: optimized elaboration of application to avoid generating evars and univs in some cases

### DIFF
--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -22,6 +22,7 @@ install_printer Top_printers.pp_fconstr_parray
 install_printer Top_printers.ppconstr
 install_printer Top_printers.ppeconstr
 install_printer Top_printers.ppconstr_expr
+install_printer Top_printers.ppsubstituend
 install_printer Top_printers.ppglob_constr
 install_printer Top_printers.pppattern
 install_printer Top_printers.ppfconstr

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -80,6 +80,8 @@ let pppattern = (fun x -> pp(envpp pr_constr_pattern_env x))
 let pptype = (fun x -> try pp(envpp (fun env evm t -> pr_ltype_env env evm t) x) with e -> pp (str (Printexc.to_string e)))
 let ppfconstr c = ppconstr (CClosure.term_of_fconstr c)
 
+let ppsubstituend x = ppconstr (Vars.lift_substituend 0 x)
+
 let ppuint63 i = pp (str (Uint63.to_string i))
 
 let pp_parray pr a =

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -46,6 +46,8 @@ val ppevar : Evar.t -> unit
 val ppconstr : Constr.t -> unit (* by Termops printer *)
 val ppconstr_univ : Constr.t -> unit
 
+val ppsubstituend : Vars.substituend -> unit
+
 val pp_constr_parray : Constr.t Parray.t -> unit
 val pp_fconstr_parray : CClosure.fconstr Parray.t -> unit
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1077,7 +1077,7 @@ struct
       | ArgInHole (arg,i,u) :: args ->
         assert (univs.(u) == dummy_univ && vs.(depth - i)  == dummy);
         let sigma, {uj_val=arg; uj_type=argt} = pretype empty_tycon env sigma arg in
-        let sigma, argt = Evarsolve.refresh_universes ~onlyalg:true (Some false) !!env sigma argt in
+        let sigma, argt = Evarsolve.refresh_universes ~status:Evd.univ_flexible ~onlyalg:true (Some false) !!env sigma argt in
         let s = Retyping.get_sort_of !!env sigma argt in
         let sigma = match ESorts.kind sigma s with
           | SProp -> CErrors.user_err Pp.(str "sprop not allowed here")

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1083,8 +1083,9 @@ struct
       | ArgInHole (arg,i,u) :: args ->
         assert (univs.(u) == dummy_univ && vs.(depth - i)  == dummy);
         let sigma, {uj_val=arg; uj_type=argt} = pretype empty_tycon env sigma arg in
-        let sigma, argt = Evarsolve.refresh_universes ~status:Evd.univ_flexible ~onlyalg:true (Some false) !!env sigma argt in
         let argt = whd_betaiota !!env sigma argt in
+        (* this is what evarsolve does, but maybe refresh onlyalg flexible would work fine *)
+        let sigma, argt = Evarsolve.refresh_universes (Some false) !!env sigma argt in
         let s = Retyping.get_sort_of !!env sigma argt in
         let sigma = match ESorts.kind sigma s with
           | SProp -> CErrors.user_err Pp.(str "sprop not allowed here")

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1084,6 +1084,7 @@ struct
         assert (univs.(u) == dummy_univ && vs.(depth - i)  == dummy);
         let sigma, {uj_val=arg; uj_type=argt} = pretype empty_tycon env sigma arg in
         let sigma, argt = Evarsolve.refresh_universes ~status:Evd.univ_flexible ~onlyalg:true (Some false) !!env sigma argt in
+        let argt = whd_betaiota !!env sigma argt in
         let s = Retyping.get_sort_of !!env sigma argt in
         let sigma = match ESorts.kind sigma s with
           | SProp -> CErrors.user_err Pp.(str "sprop not allowed here")

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1043,14 +1043,15 @@ struct
   let dummy_univ =
     Univ.Level.make (Univ.UGlobal.make DirPath.empty "dummy" (-42))
 
-  (* like [substn_many [sub lamv 0 depth] 0 c] *)
+  (* like [substn_many [rev (sub lamv 0 depth)] 0 c] *)
   let simple_subst lv lamv c =
     if Int.equal lv 0 then c
     else
       let rec substrec depth c = match Constr.kind c with
         | Constr.Rel k     ->
           if k<=depth then c
-          else if k-depth <= lv then CVars.lift_substituend depth (Array.unsafe_get lamv (k-depth-1))
+          else if k-depth <= lv
+          then CVars.lift_substituend depth (Array.get lamv (lv - (k-depth)))
           else Constr.mkRel (k-lv)
         | _ -> Constr.map_with_binders succ substrec depth c in
       substrec 0 c

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1083,7 +1083,7 @@ struct
           | SProp -> CErrors.user_err Pp.(str "sprop not allowed here")
           | Prop | Set -> Array.set univs u Univ.Level.set; sigma
           | Type u' -> begin match Univ.Universe.level u' with
-              | Some u' -> Array.set univs u u'; sigma
+              | Some u' -> Array.set univs u u'; Evd.make_nonalgebraic_variable sigma u'
               | None ->
                 let sigma, u' = Evd.new_univ_level_variable ?loc:floc Evd.univ_flexible sigma in
                 let sigma = Evd.set_leq_sort !!env sigma s
@@ -1094,7 +1094,7 @@ struct
             end
           | QSort (q,u') ->
             let sigma, u' = match Univ.Universe.level u' with
-              | Some u' -> sigma, u'
+              | Some u' -> Evd.make_nonalgebraic_variable sigma u', u'
               | None -> Evd.new_univ_level_variable ?loc:floc Evd.univ_flexible sigma
             in
             let sigma, u'' = Evd.new_univ_level_variable ?loc:floc Evd.univ_flexible sigma in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1084,8 +1084,7 @@ struct
         assert (univs.(u) == dummy_univ && vs.(depth - i)  == dummy);
         let sigma, {uj_val=arg; uj_type=argt} = pretype empty_tycon env sigma arg in
         let argt = whd_betaiota !!env sigma argt in
-        (* this is what evarsolve does, but maybe refresh onlyalg flexible would work fine *)
-        let sigma, argt = Evarsolve.refresh_universes (Some false) !!env sigma argt in
+        let sigma, argt = Evarsolve.refresh_universes (Some false) !!env sigma argt ~onlyalg:true ~status:Evd.univ_flexible in
         let s = Retyping.get_sort_of !!env sigma argt in
         let sigma = match ESorts.kind sigma s with
           | SProp -> CErrors.user_err Pp.(str "sprop not allowed here")

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1102,7 +1102,10 @@ struct
         assert ((match u with Some u -> univs.(u) == dummy_univ | None -> true) && vs.(depth - i)  == dummy);
         let sigma, {uj_val=arg; uj_type=argt} = pretype empty_tycon env sigma arg in
         let argt = whd_betaiota !!env sigma argt in
-        let sigma, argt = Evarsolve.refresh_universes (Some false) !!env sigma argt ~onlyalg:true ~status:Evd.univ_flexible in
+        (* refresh like unifying with an evar would *)
+        (* with onlyalg and univ_flexible, setoid_test fails.
+           with only_alg or univ_flexible, bug 5208 fails (but maybe not in a bad way) *)
+        let sigma, argt = Evarsolve.refresh_universes (Some false) !!env sigma argt in
         let sigma = match u with
           | None -> (* template *) sigma
           | Some u ->

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -112,9 +112,16 @@ let type_of_var env id =
   with Not_found -> retype_error (BadVariable id)
 
 let decomp_sort env sigma t =
-  match EConstr.kind sigma (whd_all env sigma t) with
+  let t = whd_all env sigma t in
+  match EConstr.kind sigma t with
   | Sort s -> s
-  | _ -> retype_error NotASort
+  | _ ->
+    let t = try get_type_from_constraints env sigma t
+      with Not_found -> retype_error NotASort
+    in
+    match EConstr.kind sigma (whd_all env sigma t) with
+    | Sort s -> s
+    | _ -> retype_error NotASort
 
 let betazetaevar_applist sigma n c l =
   let rec stacklam n env t stack =

--- a/test-suite/output-coqtop/DependentEvars3.out
+++ b/test-suite/output-coqtop/DependentEvars3.out
@@ -26,7 +26,7 @@ x < 2 focused goals (shelved: 1)
 goal 2 is:
  exists m : nat, m = 6 \/ True
 
-(dependent evars: ?X10:?n; in current goal: ?X10)
+(dependent evars: ?X8:?n; in current goal: ?X8)
 
 x < 2 focused goals (shelved: 1)
   
@@ -36,6 +36,6 @@ x < 2 focused goals (shelved: 1)
 goal 2 is:
  exists m : nat, m = 6 \/ True
 
-(dependent evars: ?X10:?n; in current goal:)
+(dependent evars: ?X8:?n; in current goal:)
 
 x < 

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -42,5 +42,5 @@ cannot be applied to the terms
  "n" : "Type"
  "n" : "Type"
 The 2nd term has type "Type" which should be a subtype of 
-"Set". (universe inconsistency: Cannot enforce Errors.35 <= Set)
+"Set". (universe inconsistency: Cannot enforce Errors.29 <= Set)
 

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -108,10 +108,10 @@ tele (t : Type) (y := nat) (x : t) (z : y) := (y, z)
          ((nat -> nat) * ((nat -> nat) * ((nat -> nat) * (nat -> nat))))))
 foo5 x nat x
      : nat -> nat
-fun x : ?A => x === x
-     : forall x : ?A, x = x
+fun x : ?T => x === x
+     : forall x : ?T, x = x
 where
-?A : [x : ?A |- Type] (x cannot be used)
+?T : [ |- Type]
 {{0, 1}}
      : nat * nat
 {{0, 1, 2}}

--- a/test-suite/output/Show.out
+++ b/test-suite/output/Show.out
@@ -1,10 +1,10 @@
-3 goals (ID 27)
+3 goals (ID 25)
   
   H : 0 = 0
   ============================
   1 = 1
 
-goal 2 (ID 31) is:
+goal 2 (ID 29) is:
  1 = S (S m')
-goal 3 (ID 18) is:
+goal 3 (ID 16) is:
  S (S n') = S m


### PR DESCRIPTION
eg in `a = b` ie `@eq _ a b`, instead of generating a fresh univ `u` and an evar `?A : Type@{u}` then elaborating `a : ?A`, we infer the type of `a` without constraint and use it to fill the hole
(although it won't work with `eq` currently since it's not template poly)