### PR TITLE
Evarsolve.recheck_applications: use Typing.checked_appvect

### DIFF
--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -178,3 +178,5 @@ val remove_instance_local_defs :
 val get_type_of_refresh :
   ?polyprop:bool -> ?lax:bool -> env -> evar_map -> constr
   -> evar_map * types
+
+val checked_appvect_hook : (env -> evar_map -> constr -> constr array -> evar_map * constr) Hook.t

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -112,7 +112,10 @@ let judge_of_apply_core env sigma funj argjv =
         let (_, c1, c2) = destProd sigma t in
         sigma, c1, subs, c2
       | _ ->
-        error_cant_apply_not_functional env sigma funj argjv
+        let seen, rest = Array.chop (n-1) argjv in
+        error_cant_apply_not_functional env sigma
+          (make_judge (mkApp (funj.uj_val, Array.map j_val seen)) typ)
+          rest
     in
     match Evarconv.unify_leq_delay env sigma hj.uj_type c1 with
     | sigma ->
@@ -166,6 +169,8 @@ let checked_appvect env sigma f args =
   let mk c = Retyping.get_judgment_of env sigma c in
   let sigma, j = judge_of_apply env sigma (mk f) (Array.map mk args) in
   sigma, j.uj_val
+
+let () = Hook.set Evarsolve.checked_appvect_hook checked_appvect
 
 let checked_applist env sigma f args = checked_appvect env sigma f (Array.of_list args)
 

--- a/test-suite/bugs/bug_19556.v
+++ b/test-suite/bugs/bug_19556.v
@@ -1,0 +1,17 @@
+
+Section Lists.
+
+  Universe ua.
+
+  Variable A : Type@{ua}.
+
+  Definition tl (l:list A) :=
+    match l with
+      | nil => nil
+      | cons a m => m
+    end.
+
+  (* unification used to force the opposite constraint *)
+  Constraint list.u0 < ua.
+
+End Lists.

--- a/test-suite/bugs/bug_19557_1.v
+++ b/test-suite/bugs/bug_19557_1.v
@@ -1,0 +1,41 @@
+Require Import List Morphisms Setoid.
+Import ListNotations.
+
+Global Generalizable All Variables.
+
+Class Equiv A := equiv: relation A.
+
+Section ops.
+  Context (M : Type -> Type).
+
+  Class MonadReturn := ret: forall {A}, A -> M A.
+
+End ops.
+
+Arguments ret {M MonadReturn A} _.
+
+
+Class Monad (M : Type -> Type) `{forall A, Equiv A -> Equiv (M A)}
+  `{MonadReturn M} : Prop :=
+  {
+    mon_ret_proper `{Equiv A} :: Proper (equiv ==> equiv) (@ret _ _ A)
+  }.
+
+
+Section S.
+  Context `{Equivalence A eqA}.
+
+  Inductive PermutationA : list A -> list A -> Prop := .
+
+  Global Instance: Equivalence PermutationA.
+  Admitted.
+
+  Global Instance PermutationA_cons :
+    Proper (eqA ==> PermutationA ==> PermutationA) (@cons A).
+  Admitted.
+
+  Lemma foo a l x (IHl : PermutationA (x::l) (l ++ [x])) : PermutationA (x::a::l) (a::l++[x]).
+  Proof.
+    rewrite <-IHl.
+  Abort.
+End S.

--- a/test-suite/bugs/bug_19557_2.v
+++ b/test-suite/bugs/bug_19557_2.v
@@ -1,0 +1,21 @@
+
+Definition not (A : Type) := A -> False.
+
+Record HProp := {
+  hprop_type : Type ;
+}.
+
+Coercion hprop_type : HProp >-> Sortclass.
+
+Definition merely (A : Type) : HProp.
+Admitted.
+
+Section SwapTypes.
+
+  Context (A B : Type).
+
+  Lemma foo X (p:merely (X = B)) :
+    sigT (fun p0 : not (merely (X = A)) => merely (X = B)).
+    refine (existT _ (fun q => _) p).
+  Abort.
+End SwapTypes.


### PR DESCRIPTION
Fix #19556 (the adhoc implementation did not understand template poly)
