### PR TITLE
Adding Map.fold_left_map and Map.fold_right_map

### DIFF
--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -111,6 +111,12 @@ module type ExtS = sig
 
   val fold_right : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
   (** Folding keys in decreasing order. *)
+
+  val fold_left_map : (key -> 'a -> 'b -> 'b * 'c) -> 'a t -> 'b -> 'b * 'c t
+  (** Combination of fold_left and map *)
+
+  val fold_right_map : (key -> 'a -> 'b -> 'b * 'c) -> 'a t -> 'b -> 'b * 'c t
+  (** Combination of fold_right and map *)
 end
 
 module Make(M : Map.OrderedType) : ExtS with


### PR DESCRIPTION
This is extracted from #19404 (see discussion [there](https://github.com/coq/coq/pull/19404/files#r1762544100)).

Note: the order of arguments for CMap.fold_left_map follows the CMap.fold_left convention, not the CList.fold_left_map convention.