### PR TITLE
Mark fcsl-pcm as passing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -664,7 +664,6 @@ library:ci-fcsl_pcm:
   - build:edge+flambda
   - library:ci-mathcomp
   stage: build-2
-  allow_failure: true # See https://github.com/coq/coq/pull/19516
 
 library:ci-fiat_crypto:
   extends: .ci-template-flambda


### PR DESCRIPTION
As continuation of #19516, we have fixed the issue with building on coq.dev, so we can remove the `allow_failure` flag.