### PR TITLE
Evarconv: don't use canonical structure to solve [proj (ctor ...) == ...]

### DIFF
--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -316,6 +316,13 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
       match Reductionops.Stack.strip_n_app structure.nparams sk1 with
       | Some (params1, c1, extra_args1) -> (Option.get @@ Reductionops.Stack.list_of_app_stack params1), c1, extra_args1
       | _ -> raise Not_found in
+  let () =
+    (* [proj (ctor ...)]: don't use CS *)
+    match kind sigma c1 with
+    | App (h,_) when isConstruct sigma h -> raise Not_found
+    | Construct _ -> raise Not_found
+    | _ -> ()
+  in
   let h2, sk2' = decompose_app sigma (shrink_eta sigma t2) in
   let sk2 = Stack.append_app sk2' sk2 in
   let k = Reductionops.Stack.args_size sk2 - Reductionops.Stack.args_size extra_args1 in

--- a/test-suite/bugs/bug_19564.v
+++ b/test-suite/bugs/bug_19564.v
@@ -1,0 +1,15 @@
+Structure myType := MyType { myType_X :> Type }.
+
+Canonical Structure myType_CS X := MyType X.
+
+Require Import ssreflect.
+
+Axiom A1 : (unit * myType) -> Prop.
+
+Lemma dummy (s' : (MyType (unit * unit))) : True.
+Proof.
+  move:s' => [? ?]; exact I.
+Qed.
+
+Axiom f : myType -> unit -> Prop.
+Axiom ax : forall x, (fun '(M, t) => f M t) x.


### PR DESCRIPTION
It seems better / less constraining to reduce.

Not sure if we actually want this though.

Fix #19564
