### PR TITLE
(8.20) Add Context.map_annot_relevance_smart (preserving sharing) and use where appropriate 

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -417,7 +417,7 @@ let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
   match Evd.MiniEConstr.unsafe_relevance_eq with
   | Refl -> fun x -> x
 
-let to_binder_annot sigma x = Context.map_annot_relevance (ERelevance.kind sigma) x
+let to_binder_annot sigma x = Context.map_annot_relevance_het (ERelevance.kind sigma) x
 
 let to_rel_decl sigma d =
   Context.Rel.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -419,7 +419,7 @@ let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
 
 let to_binder_annot sigma (x:_ binder_annot) : _ Constr.binder_annot =
   let Refl = unsafe_relevance_eq in
-  Context.map_annot_relevance (ERelevance.kind sigma) x
+  Context.map_annot_relevance_smart (ERelevance.kind sigma) x
 
 let to_rel_decl sigma (d:rel_declaration) : Constr.rel_declaration =
   let Refl = unsafe_eq in

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -417,17 +417,29 @@ let of_binder_annot : 'a Constr.binder_annot -> 'a binder_annot =
   match Evd.MiniEConstr.unsafe_relevance_eq with
   | Refl -> fun x -> x
 
-let to_binder_annot sigma x = Context.map_annot_relevance_het (ERelevance.kind sigma) x
+let to_binder_annot sigma (x:_ binder_annot) : _ Constr.binder_annot =
+  let Refl = unsafe_relevance_eq in
+  Context.map_annot_relevance (ERelevance.kind sigma) x
 
-let to_rel_decl sigma d =
-  Context.Rel.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+let to_rel_decl sigma (d:rel_declaration) : Constr.rel_declaration =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  Context.Rel.Declaration.map_constr_with_relevance (ERelevance.kind sigma) (to_constr sigma) d
 
-let to_rel_context sigma ctx = List.map (to_rel_decl sigma) ctx
+let to_rel_context sigma (ctx:rel_context) : Constr.rel_context =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  List.Smart.map (to_rel_decl sigma) ctx
 
-let to_named_decl sigma d =
-  Context.Named.Declaration.map_constr_het (ERelevance.kind sigma) (to_constr sigma) d
+let to_named_decl sigma (d:named_declaration) : Constr.named_declaration =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  Context.Named.Declaration.map_constr_with_relevance (ERelevance.kind sigma) (to_constr sigma) d
 
-let to_named_context sigma ctx = List.map (to_named_decl sigma) ctx
+let to_named_context sigma (ctx:named_context) : Constr.named_context =
+  let Refl = unsafe_eq in
+  let Refl = unsafe_relevance_eq in
+  List.Smart.map (to_named_decl sigma) ctx
 
 let map_branches f br =
   let f c = unsafe_to_constr (f (of_constr c)) in

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -166,7 +166,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
   let frel = Sorts.relevance_subst_fn fqual in
   let flevel = fqual, level_subst_of funiv in
   let aux_rec ((nas, tys, bds) as rc) =
-    let nas' = Array.Smart.map (Context.map_annot_relevance frel) nas in
+    let nas' = Array.Smart.map (Context.map_annot_relevance_smart frel) nas in
     let tys' = Array.Fun1.Smart.map aux k tys in
     let k' = iterate next (Array.length tys') k in
     let bds' = Array.Fun1.Smart.map aux k' bds in
@@ -174,7 +174,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     else (nas', tys', bds')
   in
   let aux_ctx ((nas, c) as p) =
-    let nas' = Array.Smart.map (Context.map_annot_relevance frel) nas in
+    let nas' = Array.Smart.map (Context.map_annot_relevance_smart frel) nas in
     let k' = iterate next (Array.length nas) k in
     let c' = aux k' c in
     if nas' == nas && c' == c then p
@@ -211,19 +211,19 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     if u == u' && elems == elems' && def == def' && ty == ty' then c
     else mkArray (u',elems',def',ty')
   | Prod (na, t, u) ->
-    let na' = Context.map_annot_relevance frel na in
+    let na' = Context.map_annot_relevance_smart frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkProd (na', t', u')
   | Lambda (na, t, u) ->
-    let na' = Context.map_annot_relevance frel na in
+    let na' = Context.map_annot_relevance_smart frel na in
     let t' = aux k t in
     let u' = aux (next k) u in
     if na' == na && t' == t && u' == u then c
     else mkLambda (na', t', u')
   | LetIn (na, b, t, u) ->
-    let na' = Context.map_annot_relevance frel na in
+    let na' = Context.map_annot_relevance_smart frel na in
     let b' = aux k b in
     let t' = aux k t in
     let u' = aux (next k) u in

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -47,9 +47,6 @@ let map_annot_relevance fr {binder_name=na;binder_relevance=r} =
 
 let make_annot x r = {binder_name=x;binder_relevance=r}
 
-let map_binder_relevance f {binder_name=na;binder_relevance=r} =
-  {binder_name=na;binder_relevance=f r}
-
 let binder_name x = x.binder_name
 let binder_relevance x = x.binder_relevance
 
@@ -178,11 +175,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (na, ty) as decl ->
-          let na' = map_binder_relevance g na in
+          let na' = map_annot_relevance g na in
           let ty' = f ty in
           if na == na' && ty == ty' then decl else LocalAssum (na', ty')
       | LocalDef (na, v, ty) as decl ->
-          let na' = map_binder_relevance g na in
+          let na' = map_annot_relevance g na in
           let v' = f v in
           let ty' = f ty in
           if na == na' && v == v' && ty == ty' then decl else LocalDef (na', v', ty')
@@ -437,11 +434,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (id, ty) as decl ->
-          let id' = map_binder_relevance g id in
+          let id' = map_annot_relevance g id in
           let ty' = f ty in
           if id == id' && ty == ty' then decl else LocalAssum (id', ty')
       | LocalDef (id, v, ty) as decl ->
-          let id' = map_binder_relevance g id in
+          let id' = map_annot_relevance g id in
           let v' = f v in
           let ty' = f ty in
           if id == id' && v == v' && ty == ty' then decl else LocalDef (id', v', ty')

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -40,10 +40,16 @@ let hash_annot h {binder_name=n;binder_relevance=r} =
   Hashset.Combine.combinesmall (Sorts.relevance_hash r) (h n)
 
 let map_annot f {binder_name=na;binder_relevance} =
-  {binder_name=f na;binder_relevance}
+  let na' = f na in
+  {binder_name=na';binder_relevance}
 
-let map_annot_relevance fr {binder_name=na;binder_relevance=r} =
-  {binder_name=na;binder_relevance=fr r}
+let map_annot_relevance fr ({binder_name=na;binder_relevance=r} as a) =
+  let r' = fr r in
+  if r == r' then a else {binder_name=na;binder_relevance=r'}
+
+let map_annot_relevance_het fr {binder_name=na;binder_relevance=r} =
+  let r' = fr r in
+  {binder_name=na;binder_relevance=r'}
 
 let make_annot x r = {binder_name=x;binder_relevance=r}
 
@@ -187,11 +193,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (na, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance fr na, ty')
+          LocalAssum (map_annot_relevance_het fr na, ty')
       | LocalDef (na, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance fr na, v', ty')
+          LocalDef (map_annot_relevance_het fr na, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -446,11 +452,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (id, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance fr id, ty')
+          LocalAssum (map_annot_relevance_het fr id, ty')
       | LocalDef (id, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance fr id, v', ty')
+          LocalDef (map_annot_relevance_het fr id, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -477,9 +483,9 @@ struct
 
     let of_rel_decl f = function
       | Rel.Declaration.LocalAssum (na,t) ->
-          LocalAssum (map_annot f na, t)
+        LocalAssum (map_annot f na, t)
       | Rel.Declaration.LocalDef (na,v,t) ->
-          LocalDef (map_annot f na, v, t)
+        LocalDef (map_annot f na, v, t)
 
     let to_rel_decl =
       let name x = {binder_name=Name x.binder_name;binder_relevance=x.binder_relevance} in

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -47,7 +47,7 @@ let map_annot_relevance_smart fr ({binder_name=na;binder_relevance=r} as a) =
   let r' = fr r in
   if r == r' then a else {binder_name=na;binder_relevance=r'}
 
-let map_annot_relevance_het fr {binder_name=na;binder_relevance=r} =
+let map_annot_relevance fr {binder_name=na;binder_relevance=r} =
   let r' = fr r in
   {binder_name=na;binder_relevance=r'}
 
@@ -193,11 +193,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (na, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance_het fr na, ty')
+          LocalAssum (map_annot_relevance fr na, ty')
       | LocalDef (na, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance_het fr na, v', ty')
+          LocalDef (map_annot_relevance fr na, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
@@ -452,11 +452,11 @@ struct
     let map_constr_het fr f = function
       | LocalAssum (id, ty) ->
           let ty' = f ty in
-          LocalAssum (map_annot_relevance_het fr id, ty')
+          LocalAssum (map_annot_relevance fr id, ty')
       | LocalDef (id, v, ty) ->
           let v' = f v in
           let ty' = f ty in
-          LocalDef (map_annot_relevance_het fr id, v', ty')
+          LocalDef (map_annot_relevance fr id, v', ty')
 
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -43,7 +43,7 @@ let map_annot f {binder_name=na;binder_relevance} =
   let na' = f na in
   {binder_name=na';binder_relevance}
 
-let map_annot_relevance fr ({binder_name=na;binder_relevance=r} as a) =
+let map_annot_relevance_smart fr ({binder_name=na;binder_relevance=r} as a) =
   let r' = fr r in
   if r == r' then a else {binder_name=na;binder_relevance=r'}
 
@@ -181,11 +181,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (na, ty) as decl ->
-          let na' = map_annot_relevance g na in
+          let na' = map_annot_relevance_smart g na in
           let ty' = f ty in
           if na == na' && ty == ty' then decl else LocalAssum (na', ty')
       | LocalDef (na, v, ty) as decl ->
-          let na' = map_annot_relevance g na in
+          let na' = map_annot_relevance_smart g na in
           let v' = f v in
           let ty' = f ty in
           if na == na' && v == v' && ty == ty' then decl else LocalDef (na', v', ty')
@@ -440,11 +440,11 @@ struct
     (** Map all terms in a given declaration. *)
     let map_constr_with_relevance g f = function
       | LocalAssum (id, ty) as decl ->
-          let id' = map_annot_relevance g id in
+          let id' = map_annot_relevance_smart g id in
           let ty' = f ty in
           if id == id' && ty == ty' then decl else LocalAssum (id', ty')
       | LocalDef (id, v, ty) as decl ->
-          let id' = map_annot_relevance g id in
+          let id' = map_annot_relevance_smart g id in
           let v' = f v in
           let ty' = f ty in
           if id == id' && v == v' && ty == ty' then decl else LocalDef (id', v', ty')

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -35,7 +35,7 @@ val map_annot : ('a -> 'b) -> ('a,'r) pbinder_annot -> ('b,'r) pbinder_annot
 
 val map_annot_relevance_smart : ('r -> 'r) -> ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot
 
-val map_annot_relevance_het : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
+val map_annot_relevance : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
 
 val make_annot : 'a -> 'r -> ('a,'r) pbinder_annot
 

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -33,7 +33,9 @@ val hash_annot : ('a -> int) -> ('a,Sorts.relevance) pbinder_annot -> int
 
 val map_annot : ('a -> 'b) -> ('a,'r) pbinder_annot -> ('b,'r) pbinder_annot
 
-val map_annot_relevance : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
+val map_annot_relevance : ('r -> 'r) -> ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot
+
+val map_annot_relevance_het : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
 
 val make_annot : 'a -> 'r -> ('a,'r) pbinder_annot
 

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -33,7 +33,7 @@ val hash_annot : ('a -> int) -> ('a,Sorts.relevance) pbinder_annot -> int
 
 val map_annot : ('a -> 'b) -> ('a,'r) pbinder_annot -> ('b,'r) pbinder_annot
 
-val map_annot_relevance : ('r -> 'r) -> ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot
+val map_annot_relevance_smart : ('r -> 'r) -> ('a,'r) pbinder_annot -> ('a,'r) pbinder_annot
 
 val map_annot_relevance_het : ('r1 -> 'r2) -> ('a,'r1) pbinder_annot -> ('a,'r2) pbinder_annot
 

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -224,8 +224,8 @@ let map_ptype_error fr f = function
   CantApplyBadType ((n, f c1, f c2), on_judgment f j, Array.map (on_judgment f) vj)
 | CantApplyNonFunctional (j, jv) -> CantApplyNonFunctional (on_judgment f j, Array.map (on_judgment f) jv)
 | IllFormedRecBody (ge, na, n, env, jv) ->
-  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance fr) na, n, env, Array.map (on_judgment f) jv)
+  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance_het fr) na, n, env, Array.map (on_judgment f) jv)
 | IllTypedRecBody (n, na, jv, t) ->
-  IllTypedRecBody (n, Array.map (Context.map_annot_relevance fr) na, Array.map (on_judgment f) jv, Array.map f t)
+  IllTypedRecBody (n, Array.map (Context.map_annot_relevance_het fr) na, Array.map (on_judgment f) jv, Array.map f t)
 | BadBinderRelevance (rlv, decl) -> BadBinderRelevance (fr rlv, Context.Rel.Declaration.map_constr_het fr f decl)
 | BadCaseRelevance (rlv, case) -> BadCaseRelevance (fr rlv, f case)

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -224,8 +224,8 @@ let map_ptype_error fr f = function
   CantApplyBadType ((n, f c1, f c2), on_judgment f j, Array.map (on_judgment f) vj)
 | CantApplyNonFunctional (j, jv) -> CantApplyNonFunctional (on_judgment f j, Array.map (on_judgment f) jv)
 | IllFormedRecBody (ge, na, n, env, jv) ->
-  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance_het fr) na, n, env, Array.map (on_judgment f) jv)
+  IllFormedRecBody (map_pguard_error f ge, Array.map (Context.map_annot_relevance fr) na, n, env, Array.map (on_judgment f) jv)
 | IllTypedRecBody (n, na, jv, t) ->
-  IllTypedRecBody (n, Array.map (Context.map_annot_relevance_het fr) na, Array.map (on_judgment f) jv, Array.map f t)
+  IllTypedRecBody (n, Array.map (Context.map_annot_relevance fr) na, Array.map (on_judgment f) jv, Array.map f t)
 | BadBinderRelevance (rlv, decl) -> BadBinderRelevance (fr rlv, Context.Rel.Declaration.map_constr_het fr f decl)
 | BadCaseRelevance (rlv, case) -> BadCaseRelevance (fr rlv, f case)

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -66,7 +66,7 @@ let compute_new_princ_type_from_rel env rel_to_fun sorts princ_type =
       if princ_type_info.indarg_in_concl then List.tl args else args
     in
     let na = map_annot Nameops.Name.get_id (Context.Rel.Declaration.get_annot decl) in
-    let na = map_annot_relevance EConstr.Unsafe.to_relevance na in
+    let na = EConstr.Unsafe.to_binder_annot na in
     Context.Named.Declaration.LocalAssum (na, Term.it_mkProd_or_LetIn (mkSort new_sort) real_args)
   in
   let new_predicates =


### PR DESCRIPTION
This is a backport of https://github.com/coq/coq/pull/19539: it contains that PR's 3 commits followed by renamings to restore ocaml API compatibility (unless someone somehow relies on `map_annot_relevance_smart` not existing).