### PR TITLE
`Admitted` does not emit univ constraints from the proof

### DIFF
--- a/test-suite/bugs/bug_18951.v
+++ b/test-suite/bugs/bug_18951.v
@@ -10,4 +10,5 @@ Proof.
 Fail Admitted. (* Has still evars *)
 Unshelve.
 3:exact nat.
-Admitted.
+Fail Admitted.
+Abort.

--- a/test-suite/bugs/bug_19566.v
+++ b/test-suite/bugs/bug_19566.v
@@ -1,0 +1,7 @@
+
+Universes u v.
+Lemma foo : Type@{v}.
+  exact Type@{u}.
+Admitted.
+
+Check Type@{v} : Type@{u}.


### PR DESCRIPTION
Fix #19566

Reverts part 3b4cf49e39ccb506aeb317aab818dc2fdc828175
