### PR TITLE
record exit code in ci-wrapper.sh

### DIFF
--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -46,6 +46,9 @@ else
   bash "${DIR}/${CI_SCRIPT}" 2>&1 | tee "$CI_NAME.log"
 fi
 code=$?
+
+printf "\n%s exit code: %s\n" "$CI_NAME" "$code" >> "$CI_NAME.log"
+
 echo 'Aggregating timing log...'
 echo
 tools/make-one-time-file.py --real "$CI_NAME.log"


### PR DESCRIPTION
This allows for a rudimentary "build status" ~~using `! grep -v "^0$" *.exitcode`~~ without getting confunded by log output such as "Permutation_nth_error:" and thelike.