### PR TITLE
Revert "[CI] Make VST compile its own compcert"

### DIFF
--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -12,8 +12,7 @@ if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 # sometimes (rarely) CompCert master can break VST and it can take
 # weeks or months for VST to catch up, in this case, just uncomment
 # the line below to use the compcert version bundled in VST
-export COMPCERT=bundled
-# recomment above line whenever VST compiles again with compcert master
+# export COMPCERT=bundled
 
 # See ci-compcert.sh
 export COQEXTRAFLAGS='-native-compiler no'


### PR DESCRIPTION
This reverts commit https://github.com/proux01/coq/commit/b767680ca67f7576d84cf42bd8729a5e30a06e66 now that https://github.com/PrincetonUniversity/VST/pull/781 has been merged, making VST compile again with CompCert master.