### PR TITLE
Doc for late SSReflect view shortcut

### DIFF
--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -5485,6 +5485,23 @@ equivalences are indeed taken into account; otherwise only single
 ``Hint Views`` are used.
 
 
+Additional view shortcuts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following intro pattern ltac views are provided:
+
++ ``/[apply]`` shortcut for ``=> hyp {}/hyp``
++ ``/[swap]`` shortcut for ``=> x y; move: y x`` which swaps and preserves let
+  bindings
++ ``/[dup]`` shortcut for ``=> x; have copy := x; move: copy x`` which
+  copies and preserves let bindings
+
+One can call rewrite from an intro pattern, use with parsimony:
+
++ ``/[1! rules]`` shortcut for ``rewrite rules``
++ ``/[! rules]`` shortcut for ``rewrite !rules``
+
+
 Synopsis and Index
 ------------------
 


### PR DESCRIPTION
This PR add a small section in the SSReflect doc about the recent view shortcut such as `\[swap]` and `\[dup]`. Before the PR they were only mentioned at the beginning of the `coq/theory/ssr/ssreflect.v` file which makes them very hard to find.
It is only about making visible an already existing feature.
I hope that i didn't depart too much from the overall documentation style.
