### PR TITLE
local CI: do not set PATH, OCAMLPATH

### DIFF
--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -6,11 +6,6 @@ set -xe
 : "${NJOBS:=1}"
 export NJOBS
 
-# We add $PWD/_install_ci/lib unconditionally due to a hack in the
-# ci-menhir script, which will install some OCaml libraries outside
-# our docker-opam / Nix setup; we have to do this for all the 3 cases
-# below; would we fix ci-menhir, then we just do this for the first
-# branch [ci case]
 if which cygpath >/dev/null 2>&1; then OCAMLFINDSEP=\;; else OCAMLFINDSEP=:; fi
 
 # We can remove setting COQLIB and COQCORELIB from here, but better to

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -12,8 +12,6 @@ export NJOBS
 # below; would we fix ci-menhir, then we just do this for the first
 # branch [ci case]
 if which cygpath >/dev/null 2>&1; then OCAMLFINDSEP=\;; else OCAMLFINDSEP=:; fi
-export OCAMLPATH="$PWD/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
-export PATH="$PWD/_install_ci/bin:$PATH"
 
 # We can remove setting COQLIB and COQCORELIB from here, but better to
 # wait until we have merged the coq.boot patch so we can do this in a
@@ -22,6 +20,8 @@ if [ -n "${GITLAB_CI}" ];
 then
     # Gitlab build, Coq installed into `_install_ci`
     export COQBIN="$PWD/_install_ci/bin"
+    export OCAMLPATH="$PWD/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
+    export PATH="$PWD/_install_ci/bin:$PATH"
 
     # Where we install external binaries and ocaml libraries
     # also generally used for dune install --prefix so needs to match coq's expected user-contrib path


### PR DESCRIPTION
The directory set for those variables does not exist in local usage, and setting them seems to be a historical artifact ([Zulip discussion](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/OCAMLPATH.20in.20local.20ci)).