### PR TITLE
Resolve abbreviations in Ltac2 eval reduction flags

### DIFF
--- a/doc/changelog/06-Ltac2-language/19589-ltac2-eval-flags.rst
+++ b/doc/changelog/06-Ltac2-language/19589-ltac2-eval-flags.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  resolution of :ref:`abbreviations <Abbreviations>` in :n:`reference`
+  in :token:`ltac2_quotations`, for instance in eval tactic
+  delta-reduction flags :token:`ltac2_delta_reductions`
+  (`#19589 <https://github.com/coq/coq/pull/19589>`_,
+  fixes `#19590 <https://github.com/coq/coq/issues/19590>`_,
+  by Pierre Roux).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1751,7 +1751,7 @@ let () =
     GlbVal (GlobRef.VarRef id), gtypref t_reference
   | Tac2qexpr.QReference qid ->
     let gr =
-      try Nametab.locate qid
+      try Smartlocate.locate_global_with_alias qid
       with Not_found as exn ->
         let _, info = Exninfo.capture exn in
         Nametab.error_global_not_found ~info qid

--- a/test-suite/bugs/bug_19590.v
+++ b/test-suite/bugs/bug_19590.v
@@ -1,0 +1,9 @@
+From Ltac2 Require Import Ltac2.
+
+Definition a := 3.
+Notation b := a.
+
+Goal a = 3.
+let ea := eval cbv delta [b] in a in change a with $ea.
+(* Error: The reference b was not found in the current environment. *)
+Abort.


### PR DESCRIPTION
Noticed in https://github.com/mit-plv/rewriter/pull/159

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19590


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
