### PR TITLE
More complete handling of universe names

### DIFF
--- a/library/lib.mli
+++ b/library/lib.mli
@@ -95,18 +95,18 @@ type discharged_item =
   | DischargedExport of Libobject.ExportObj.t
   | DischargedLeaf of Libobject.discharged_obj
 
+type classified_objects = {
+  substobjs : Libobject.t list;
+  keepobjs : Libobject.t list;
+  escapeobjs : Libobject.t list;
+  anticipateobjs : Libobject.t list;
+}
+
 (** The [StagedLibS] abstraction describes operations and traversal for Lib at a
     given stage. *)
 module type StagedLibS = sig
 
   type summary
-
-  type classified_objects = {
-    substobjs : Libobject.t list;
-    keepobjs : Libobject.t list;
-    anticipateobjs : Libobject.t list;
-  }
-  val classify_segment : Libobject.t list -> classified_objects
 
   (** Returns the opening node of a given name *)
   val find_opening_node : ?loc:Loc.t -> Id.t -> summary node
@@ -162,9 +162,14 @@ module Interp : StagedLibS with type summary = Summary.Interp.frozen
 
 val start_compilation : DirPath.t -> ModPath.t -> unit
 
-(** Finalize the compilation of a library and return respectively the library
-    prefix, the regular objects, and the syntax-related objects. *)
-val end_compilation : DirPath.t -> Nametab.object_prefix * Library_info.t * Interp.classified_objects * Synterp.classified_objects
+type compilation_result = {
+  info : Library_info.t;
+  synterp_objects : classified_objects;
+  interp_objects : classified_objects;
+}
+
+(** Finalize the compilation of a library. *)
+val end_compilation : DirPath.t -> compilation_result
 
 (** The function [library_dp] returns the [DirPath.t] of the current
    compiling library (or [default_library]) *)

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -10,7 +10,7 @@
 
 module Dyn = Dyn.Make ()
 
-type substitutivity = Dispose | Substitute | Keep | Anticipate
+type substitutivity = Dispose | Substitute | Keep | Escape | Anticipate
 
 type object_name = Libnames.full_path * Names.KerName.t
 
@@ -132,6 +132,7 @@ and t =
   | ModuleTypeObject of Names.Id.t * substitutive_objects
   | IncludeObject of algebraic_objects
   | KeepObject of Names.Id.t * t list
+  | EscapeObject of Names.Id.t * t list
   | ExportObject of ExportObj.t
   | AtomicObject of obj
 
@@ -211,11 +212,7 @@ let subst_object (subs, Dyn.Dyn (tag, v)) =
 
 let classify_object (Dyn.Dyn (tag, v)) =
   let O decl = DynMap.find tag !cache_tab in
-  match decl.classify_function v with
-  | Dispose -> Dispose
-  | Substitute -> Substitute
-  | Keep -> Keep
-  | Anticipate -> Anticipate
+  decl.classify_function v
 
 type discharged_obj = Discharged : 'a Dyn.tag * 'd * ('d -> 'a) -> discharged_obj
 

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -12,13 +12,13 @@ end
 Arguments eqT_rect A%type_scope a P%function_scope f a0 e
 seq_rect =
 fun (A : Type@{seq.u0}) (a : A)
-  (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.30}) 
+  (P : forall a0 : A, seq a a0 -> Type@{seq_rect.u0}) 
   (f : P a (srefl a)) (a0 : A) (s : seq a a0) =>
 match s :> seq a a0 as s0 in (seq _ a1) return (P a1 s0) with
 | srefl _ => f
 end
      : forall (A : Type@{seq.u0}) (a : A)
-         (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.30}),
+         (P : forall a0 : A, seq a a0 -> Type@{seq_rect.u0}),
        P a (srefl a) -> forall (a0 : A) (s : seq a a0), P a0 s
 
 Arguments seq_rect A%type_scope a P%function_scope f a0 s

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -265,3 +265,6 @@ Universe u0 already exists.
 File "./output/UnivBinders.v", line 241, characters 6-26:
 The command has indeed failed with message:
 Tactic failure: Not equal (due to universes).
+eq_rect
+     : forall (A : Type@{eq.u0}) (x : A) (P : A -> Type@{eq_rect.u0}),
+       P x -> forall y : A, x = y -> P y

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -260,3 +260,9 @@ forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
 JMeq is template universe polymorphic on JMeq.u0
 Arguments JMeq [A]%type_scope x [B]%type_scope _
 Expands to: Inductive UnivBinders.PartialTemplate.JMeq
+File "./output/UnivBinders.v", line 232, characters 2-38:
+The command has indeed failed with message:
+Universe u0 already exists.
+File "./output/UnivBinders.v", line 239, characters 6-26:
+The command has indeed failed with message:
+Tactic failure: Not equal (due to universes).

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -75,10 +75,9 @@ File "./output/UnivBinders.v", line 70, characters 0-52:
 The command has indeed failed with message:
 Universe uu already exists.
 bobmorane =
-let tt := Type@{UnivBinders.52} in
-let ff := Type@{UnivBinders.54} in tt -> ff
-     : Type@{max(UnivBinders.51,UnivBinders.53)}
-File "./output/UnivBinders.v", line 85, characters 23-25:
+let tt := Type@{fooS.u1} in let ff := Type@{fooS.u3} in tt -> ff
+     : Type@{max(fooS.u0,fooS.u2)}
+File "./output/UnivBinders.v", line 87, characters 23-25:
 The command has indeed failed with message:
 Universe uu already bound.
 foo@{E M N} =
@@ -111,16 +110,16 @@ punwrap is a primitive projection of PWrap
 Arguments punwrap A%type_scope p
 punwrap is transparent
 Expands to: Constant UnivBinders.punwrap
-File "./output/UnivBinders.v", line 102, characters 0-19:
+File "./output/UnivBinders.v", line 104, characters 0-19:
 The command has indeed failed with message:
 Universe instance length is 3 but should be 1.
-File "./output/UnivBinders.v", line 103, characters 0-20:
+File "./output/UnivBinders.v", line 105, characters 0-20:
 The command has indeed failed with message:
 Universe instance length is 0 but should be 1.
-File "./output/UnivBinders.v", line 106, characters 0-33:
+File "./output/UnivBinders.v", line 108, characters 0-33:
 The command has indeed failed with message:
 This object does not support universe names.
-File "./output/UnivBinders.v", line 110, characters 0-50:
+File "./output/UnivBinders.v", line 112, characters 0-50:
 The command has indeed failed with message:
 Cannot enforce v < u because u < gU < gV < v
 insec@{v} = Type@{uu} -> Type@{v}
@@ -191,7 +190,7 @@ Arguments axfoo' _%type_scope
 *** [ axbar' : Type@{axfoo'.u1} -> Type@{axfoo'.i} ]
 
 Arguments axbar' _%type_scope
-File "./output/UnivBinders.v", line 156, characters 19-26:
+File "./output/UnivBinders.v", line 158, characters 19-26:
 The command has indeed failed with message:
 When declaring multiple assumptions in one command, only the first name is
 allowed to mention a universe binder (which will be shared by the whole
@@ -251,7 +250,7 @@ Arguments MutualI1' A%type_scope
 Arguments C1' A%type_scope p1
 Arguments MutualI2' A%type_scope
 Arguments C2' A%type_scope p2
-File "./output/UnivBinders.v", line 207, characters 0-33:
+File "./output/UnivBinders.v", line 209, characters 0-33:
 The command has indeed failed with message:
 Universe inconsistency. Cannot enforce a < a because a = a.
 JMeq :
@@ -260,9 +259,9 @@ forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
 JMeq is template universe polymorphic on JMeq.u0
 Arguments JMeq [A]%type_scope x [B]%type_scope _
 Expands to: Inductive UnivBinders.PartialTemplate.JMeq
-File "./output/UnivBinders.v", line 232, characters 2-38:
+File "./output/UnivBinders.v", line 234, characters 2-38:
 The command has indeed failed with message:
 Universe u0 already exists.
-File "./output/UnivBinders.v", line 239, characters 6-26:
+File "./output/UnivBinders.v", line 241, characters 6-26:
 The command has indeed failed with message:
 Tactic failure: Not equal (due to universes).

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -71,13 +71,15 @@ Fail Monomorphic Definition mono2@{uu} := Type@{uu}.
 
 Module SecLet.
   Unset Universe Polymorphism.
-  Section foo.
+  Section fooS.
     (* Fail Let foo@{} := Type@{uu}. (* doesn't parse: Let foo@{...} doesn't exist *) *)
+
     Unset Strict Universe Declaration.
-    Let tt : Type@{uu} := Type@{v}. (* names disappear in the ether *)
-    #[clearbody] Let ff : Type@{uu}. Proof. exact Type@{v}. Defined. (* names disappear into space *)
+    (* the names used disappear, and fresh names are generated instead of exposing raw ints *)
+    Let tt : Type@{uu} := Type@{v}.
+    #[clearbody] Let ff : Type@{uu}. Proof. exact Type@{v}. Defined.
     Definition bobmorane := tt -> ff.
-  End foo.
+  End fooS.
   Print bobmorane.
 End SecLet.
 

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -245,3 +245,7 @@ Module Collision.
     constr_eq_strict a b.
   Abort.
 End Collision.
+
+Module Schemes.
+  Check eq_rect.
+End Schemes.

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -220,3 +220,26 @@ Inductive JMeq (A:Type) (x:A) : forall B:Type, B -> Prop :=
 About JMeq.
 
 End PartialTemplate.
+
+Module Collision.
+  Unset Universe Polymorphism.
+
+  Module x.
+    Universe u0.
+    Definition a := Type@{u0}.
+  End x.
+
+  Fail Definition x@{u0} := Type@{u0}.
+  Definition x := Type.
+
+  Goal True.
+    Fail
+      let a := eval cbv in x.a in
+      let b := eval cbv in x in
+      constr_eq_strict a b.
+
+    let a := eval cbv in Type@{x.u1} in
+    let b := eval cbv in x in
+    constr_eq_strict a b.
+  Abort.
+End Collision.

--- a/test-suite/output/unidecls.out
+++ b/test-suite/output/unidecls.out
@@ -1,0 +1,94 @@
+Set < nat_rect.u0
+    < decls.a
+    < decls.b
+    < a
+a < decls.a
+
+Type@{a}
+     : Type@{a+1}
+Type@{decls.a}
+     : Type@{decls.a+1}
+Type@{decls.b}
+     : Type@{decls.b+1}
+File "./output/unidecls.v", line 25, characters 17-24:
+The command has indeed failed with message:
+Undeclared universe decls.c.
+File "./output/unidecls.v", line 27, characters 17-18:
+The command has indeed failed with message:
+Undeclared universe: i.
+Type@{foo}
+     : Type@{foo+1}
+Type@{bar}
+     : Type@{bar+1}
+Type@{Foo.bar}
+     : Type@{Foo.bar+1}
+Type@{Foo.foo}
+     : Type@{Foo.foo+1}
+Type@{foo}
+     : Type@{foo+1}
+Type@{foo}
+     : Type@{foo+1}
+File "./output/unidecls.v", line 52, characters 2-23:
+The command has indeed failed with message:
+Universe secfoo already exists.
+File "./output/unidecls.v", line 54, characters 19-31:
+The command has indeed failed with message:
+Undeclared universe Foo'.secfoo2.
+Type@{secfoo2}
+     : Type@{secfoo2+1}
+Type@{secfoo2}
+     : Type@{secfoo2+1}
+File "./output/unidecls.v", line 60, characters 21-46:
+The command has indeed failed with message:
+Unknown interpretation for notation "_ = _".
+File "./output/unidecls.v", line 72, characters 19-22:
+The command has indeed failed with message:
+Undeclared universe A.u.
+Type@{Arg.u}
+     : Type@{Arg.u+1}
+File "./output/unidecls.v", line 79, characters 59-60:
+The command has indeed failed with message:
+In environment
+A : Type@{v}
+The term "A" has type "Type@{v}" while it is expected to have type
+ "Type@{Arg.u}"
+(universe inconsistency: Cannot enforce v <= Arg.u because Arg.u < v).
+File "./output/unidecls.v", line 93, characters 17-24:
+The command has indeed failed with message:
+Undeclared universe FnApp.v.
+Type@{Fn.v}
+     : Type@{Fn.v+1}
+FnApp.foo
+     : Type@{Fn.v}
+FnApp.bar
+     : Type@{Arg.u}
+File "./output/unidecls.v", line 99, characters 17-26:
+The command has indeed failed with message:
+Undeclared universe ArgImpl.u.
+FnApp2.foo
+     : Type@{Fn.v}
+FnApp2.bar
+     : Type@{Arg.u}
+File "./output/unidecls.v", line 113, characters 17-21:
+The command has indeed failed with message:
+Undeclared universe: poly.
+Set < nat_rect.u0
+    < decls.a
+    < decls.b
+    < a
+    < foo
+    < Foo.foo
+    < Foo.bar
+    < bar
+    < secfoo
+    < secfoo2
+    < Arg.u
+    < Fn.v
+a < decls.a
+secfoo2 < a
+Arg.u < Fn.v
+
+id@{Set} nat
+     : nat -> nat
+id@{Set}
+     : forall A : Set, A -> A

--- a/test-suite/output/unidecls.v
+++ b/test-suite/output/unidecls.v
@@ -1,5 +1,10 @@
-(* -*- coq-prog-args: ("-top" "unidecls"); -*- *)
+(* -*- coq-prog-args: ("-noinit" "-top" "unidecls"); -*- *)
+Require Import Notations Ltac.
+Notation "a -> b" := (forall _:a, b).
+
 Set Printing Universes.
+
+Inductive nat := O | S : nat -> nat.
 
 Module decls.
   Universes a b.
@@ -27,7 +32,7 @@ Module Foo.
   Universe bar.
 
   Check Type@{Foo.foo}.
-  Definition bar := 0.
+  Definition bar := O.
 End Foo.
 
 (** Already declared in the module *)
@@ -79,7 +84,7 @@ Module ArgImpl : Arg.
 End ArgImpl.
 
 Module ArgImpl2 : Arg.
-  Definition T := bool.
+  Definition T := nat.
 End ArgImpl2.
 
 (** Two applications of the functor result in the exact same universes *)
@@ -107,5 +112,6 @@ End PS.
 (** The universe is polymorphic and discharged, does not persist *)
 Fail Check Type@{poly}.
 
+Print Universes.
 Check id nat.
 Check id@{Set}.

--- a/test-suite/success/unidecls.v
+++ b/test-suite/success/unidecls.v
@@ -63,13 +63,15 @@ End Arg.
 Module Fn(A : Arg).
   Universes v.
 
-  Check Type@{A.u}.
-  Constraint A.u < v.
+  (* univ names are not substitutive *)
+  Fail Check Type@{A.u}.
+  Check Type@{Arg.u}.
+  Constraint Arg.u < v.
 
   Definition foo : Type@{v} := nat.
-  Definition bar : Type@{A.u} := nat.
+  Definition bar : Type@{Arg.u} := nat.
 
-  Fail Definition foo(A : Type@{v}) : Type@{A.u} := A.
+  Definition foo'(A : Type@{v}) : Type@{Arg.u}. Fail exact A. Abort.
 End Fn.
 
 Module ArgImpl : Arg.
@@ -83,29 +85,17 @@ End ArgImpl2.
 (** Two applications of the functor result in the exact same universes *)
 Module FnApp := Fn(ArgImpl).
 
-Check Type@{FnApp.v}.
+Fail Check Type@{FnApp.v}.
+Check Type@{Fn.v}.
 Check FnApp.foo.
 Check FnApp.bar.
 
-Check (eq_refl : Type@{ArgImpl.u} = Type@{ArgImpl2.u}).
+(* "module M : T" does not produce a universe M.u from T.u *)
+Fail Check Type@{ArgImpl.u}.
 
 Module FnApp2 := Fn(ArgImpl).
-Check Type@{FnApp2.v}.
 Check FnApp2.foo.
 Check FnApp2.bar.
-
-Import ArgImpl2.
-(** Now u refers to ArgImpl.u and ArgImpl2.u *)
-Check FnApp2.bar.
-
-(** It can be shadowed *)
-Universe u.
-
-(** This refers to the qualified name *)
-Check FnApp2.bar.
-
-Constraint u = ArgImpl.u.
-Print Universes.
 
 Set Universe Polymorphism.
 
@@ -117,6 +107,5 @@ End PS.
 (** The universe is polymorphic and discharged, does not persist *)
 Fail Check Type@{poly}.
 
-Print Universes.
 Check id nat.
 Check id@{Set}.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -673,6 +673,10 @@ let declare_private_constant ?role ?(local = Locality.ImportDefaultBehavior) ~na
       OpaqueEff de, ctx
   in
   let kn, eff = Global.add_private_constant name ctx de in
+  let () = if Univ.Level.Set.is_empty (fst ctx) then ()
+    else DeclareUniv.declare_univ_binders (ConstRef kn)
+        (Monomorphic_entry ctx, UnivNames.empty_binders)
+  in
   let () = register_constant kn kind local in
   let seff_roles = match role with None -> Cmap.empty | Some r -> Cmap.singleton kn r in
   let eff = { Evd.seff_private = eff; Evd.seff_roles; } in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -712,7 +712,10 @@ let declare_variable ~name ~kind ~typing_flags d =
   let impl,opaque = match d with (* Fails if not well-typed *)
     | SectionLocalAssum {typ;impl;univs} ->
       let () = match fst univs with
-        | UState.Monomorphic_entry uctx -> Global.push_context_set uctx
+        | UState.Monomorphic_entry uctx ->
+          (* XXX [snd univs] is ignored, should we use it? *)
+          DeclareUniv.name_mono_section_univs (fst uctx);
+          Global.push_context_set uctx
         | UState.Polymorphic_entry uctx -> Global.push_section_context uctx
       in
       let () = Global.push_named_assum (name,typ) in
@@ -726,6 +729,7 @@ let declare_variable ~name ~kind ~typing_flags d =
          term. *)
       let univs = match fst de.proof_entry_universes with
         | UState.Monomorphic_entry uctx ->
+          DeclareUniv.name_mono_section_univs (fst uctx);
           Global.push_context_set (Univ.ContextSet.union uctx body_uctx);
           UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders
         | UState.Polymorphic_entry uctx ->

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -70,8 +70,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
       load_function = load_univ_names;
       open_function = simple_open open_univ_names;
       discharge_function = discharge_univ_names;
-      subst_function = (fun (subst, a) -> (* Actually the name is generated once and for all. *) a);
-      classify_function = (fun a -> Substitute) }
+      classify_function = (fun _ -> Escape) }
 
 let input_univ_names (src, l) =
   if CList.is_empty l then ()

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -27,11 +27,7 @@ type universe_source =
   | QualifiedUniv of Id.t (* global universe introduced by some global value *)
   | UnqualifiedUniv (* other global universe *)
 
-type universe_name_decl = {
-  udecl_src : universe_source;
-  udecl_named : (Id.t * UGlobal.t) list;
-  udecl_anon : UGlobal.t list;
-}
+type universe_name_decl = universe_source * (Id.t * UGlobal.t) list
 
 let check_exists_universe sp =
   if Nametab.exists_universe sp then
@@ -51,38 +47,20 @@ let do_univ_name ~check i dp src (id,univ) =
   if check then check_exists_universe sp;
   Nametab.push_universe i sp univ
 
-let get_names decl =
-  let fold accu (id, _) = Id.Set.add id accu in
-  let names = List.fold_left fold Id.Set.empty decl.udecl_named in
-  (* create fresh names for anonymous universes *)
-  let fold u ((names, cnt), accu) =
-    let rec aux i =
-      let na = Id.of_string ("u"^(string_of_int i)) in
-      if Id.Set.mem na names then aux (i+1) else (na, i)
-    in
-    let (id, cnt) = aux cnt in
-    ((Id.Set.add id names, cnt + 1), ((id, u) :: accu))
-  in
-  let _, univs = List.fold_right fold decl.udecl_anon ((names, 0), decl.udecl_named) in
-  univs
-
-let cache_univ_names (prefix, decl) =
+let cache_univ_names (prefix, (src, univs)) =
   let depth = Lib.sections_depth () in
   let dp = Libnames.pop_dirpath_n depth prefix.Nametab.obj_dir in
-  let names = get_names decl in
-  List.iter (do_univ_name ~check:true (Nametab.Until 1) dp decl.udecl_src) names
+  List.iter (do_univ_name ~check:true (Nametab.Until 1) dp src) univs
 
-let load_univ_names i (prefix, decl) =
-  let names = get_names decl in
-  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir decl.udecl_src) names
+let load_univ_names i (prefix, (src, univs)) =
+  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir src) univs
 
-let open_univ_names i (prefix, decl) =
-  let names = get_names decl in
-  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir decl.udecl_src) names
+let open_univ_names i (prefix, (src, univs)) =
+  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir src) univs
 
-let discharge_univ_names decl = match decl.udecl_src with
-  | BoundUniv -> None
-  | (QualifiedUniv _ | UnqualifiedUniv) -> Some decl
+let discharge_univ_names = function
+  | BoundUniv, _ -> None
+  | (QualifiedUniv _ | UnqualifiedUniv), _ as x -> Some x
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
   let open Libobject in
@@ -95,9 +73,17 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
       subst_function = (fun (subst, a) -> (* Actually the name is generated once and for all. *) a);
       classify_function = (fun a -> Substitute) }
 
-let input_univ_names (src, l, a) =
-  if CList.is_empty l && CList.is_empty a then ()
-  else Lib.add_leaf (input_univ_names { udecl_src = src; udecl_named = l; udecl_anon = a })
+let input_univ_names (src, l) =
+  if CList.is_empty l then ()
+  else Lib.add_leaf (input_univ_names (src, l))
+
+let invent_name (named,cnt) u =
+  let rec aux i =
+    let na = Id.of_string ("u"^(string_of_int i)) in
+    if Id.Map.mem na named then aux (i+1)
+    else na, (Id.Map.add na u named, i+1)
+  in
+  aux cnt
 
 let label_of = let open GlobRef in function
 | ConstRef c -> Label.to_id @@ Constant.label c
@@ -124,10 +110,14 @@ let declare_univ_binders gr (univs, pl) =
         named, univs)
         pl (Level.Set.empty,[])
     in
-    (* then keep the anonymous ones *)
-    let fold u accu = Option.get (Level.name u) :: accu in
-    let anonymous = Level.Set.fold fold (Level.Set.diff levels named) [] in
-    input_univ_names (QualifiedUniv l, univs, anonymous)
+    (* then invent names for the rest *)
+    let _, univs = Level.Set.fold (fun univ (aux,univs) ->
+        let id, aux = invent_name aux univ in
+        let univ = Option.get (Level.name univ) in
+        aux, (id,univ) :: univs)
+        (Level.Set.diff levels named) ((pl,0),univs)
+    in
+    input_univ_names (QualifiedUniv l, univs)
 
 let do_universe ~poly l =
   let in_section = Lib.sections_are_opened () in
@@ -138,7 +128,7 @@ let do_universe ~poly l =
   in
   let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_univ_global ())) l in
   let src = if poly then BoundUniv else UnqualifiedUniv in
-  let () = input_univ_names (src, l, []) in
+  let () = input_univ_names (src, l) in
   match poly with
   | false ->
     let ctx = List.fold_left (fun ctx (_,qid) -> Level.Set.add (Level.make qid) ctx)

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -77,10 +77,11 @@ let input_univ_names (src, l) =
   if CList.is_empty l then ()
   else Lib.add_leaf (input_univ_names (src, l))
 
-let invent_name (named,cnt) u =
+let invent_name prefix (named,cnt) u =
   let rec aux i =
     let na = Id.of_string ("u"^(string_of_int i)) in
-    if Id.Map.mem na named then aux (i+1)
+    let sp = Libnames.make_path prefix na in
+    if Id.Map.mem na named || Nametab.exists_universe sp then aux (i+1)
     else na, (Id.Map.add na u named, i+1)
   in
   aux cnt
@@ -111,8 +112,9 @@ let declare_univ_binders gr (univs, pl) =
         pl (Level.Set.empty,[])
     in
     (* then invent names for the rest *)
+    let prefix = DirPath.make (l :: DirPath.repr (Lib.cwd_except_section())) in
     let _, univs = Level.Set.fold (fun univ (aux,univs) ->
-        let id, aux = invent_name aux univ in
+        let id, aux = invent_name prefix aux univ in
         let univ = Option.get (Level.name univ) in
         aux, (id,univ) :: univs)
         (Level.Set.diff levels named) ((pl,0),univs)

--- a/vernac/declareUniv.mli
+++ b/vernac/declareUniv.mli
@@ -18,6 +18,9 @@ exception AlreadyDeclared of (string option * Id.t)
    constants/inductives. Noop on polymorphic references. *)
 val declare_univ_binders : GlobRef.t -> UState.named_universes_entry -> unit
 
+(** Internally used to name universes associated with no particular constant in a section. *)
+val name_mono_section_univs : Univ.Level.Set.t -> unit
+
 (** Command [Universes]. *)
 val do_universe : poly:bool -> lident list -> unit
 

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -713,7 +713,7 @@ let print_library_leaf env sigma ~with_values mp lobj =
     Some (Printmod.print_module ~with_body:(Option.has_some with_values) (MPdot (mp,Label.of_id id)))
   | ModuleTypeObject (id,_) ->
     Some (print_modtype (MPdot (mp, Label.of_id id)))
-  | IncludeObject _ | KeepObject _ | ExportObject _ -> None
+  | IncludeObject _ | KeepObject _ | EscapeObject _ | ExportObject _ -> None
 
 let decr = Option.map ((+) (-1))
 


### PR DESCRIPTION
After this AFAICT the only global universes still using raw ints are the ones from module types (because the name object doesn't escape)

- fix collision with generated names
- generate names for more global universes (from section variable and from private constants)
- universe names are now Keep instead of Substitute, this better matches how they work (also avoids collision when including modules which have universes)
- new libobject classification "Escape" for universe names

Depends:
- https://github.com/coq/coq/pull/19754

Overlays:
- https://github.com/JasonGross/coq-tools/pull/239