### PR TITLE
build-system.dune.md: mention 'make dunestrap'

### DIFF
--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -17,14 +17,26 @@ in `Makefile`, `make` will display help. Note that dune will call
 configure for you if needed, so no need to call `./configure` in the
 regular development workflow, unless you want to tweak options.
 
-4 common operations are:
+
+2 common operations are:
 
 - `make check` : build all ml targets as fast as possible
 - `make world` : build a complete Coq distribution
-- `dune exec -- dev/shim/coqtop` : build and launch coqtop + prelude [equivalent to `make states`].
+
+For more targeted builds, you can also call `dune` directly. First,
+call `make dunestrap` to generate necessary build files (the `make`
+targets above do it automatically). Then you can use:
+
+- `dune exec -- dev/shim/coqtop` : build and launch coqtop + prelude
+  [equivalent to `make states`].
+- `dune exec -- dev/shim/coqc <args...>`: build and launch `coqc` with
+  arguments of your choice
 - `dune build $target`: where `$target` can refer to the build
   directory or the source directory [but will be placed under
   `_build`]
+
+You need to run `make dunestrap` again if the dependencies between the
+standard library .v files have changed.
 
 `dune build @install` will build all the public Coq artifacts; `dune
 build` builds the `@default` alias, defined in the top level `dune` file.


### PR DESCRIPTION
I was reading the current [build documentation](https://github.com/coq/coq/blob/b68052328b65a3e85cd48a4718713fdd0c24f08d/dev/doc/build-system.dune.md), I tried to run `dune exec -- dev/shim/coqc` as documented (from a completely clean clone of the repository), and got a build failure:

```
Error: No rule found for theories/Init/Prelude.vo
```

The solution, pointed out to me by @ejgallego, is to run `make dunestrap` first.

The present PR updates the build documentation to mention this step.