### PR TITLE
introduce a sum type (GADT) for Stdarg predef types

### DIFF
--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -8,67 +8,124 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Loc
+open Names
+open EConstr
+open Libnames
+open Constrexpr
 open Genarg
+open Genintern
 open Geninterp
+open Locus
 
-let make0 ?dyn name =
+type (_, _, _) t =
+  | WUnit : (unit, unit, unit) t
+  | WBool : (bool, bool, bool) t
+  | WNat : (int, int, int) t
+  | WInt : (int, int, int) t
+  | WString : (string, string, string) t
+  | WPre_ident : (string, string, string) t
+  | WInt_or_var : (int or_var, int or_var, int) t
+  | WNat_or_var : (int or_var, int or_var, int) t
+  | WIdent : (Id.t, Id.t, Id.t) t
+  | WIdentref : (lident, lident, Id.t) t
+  | WHyp : (lident, lident, Id.t) t
+  | WRef : (qualid, GlobRef.t located or_var, GlobRef.t) t
+  | WSmart_global : (qualid or_by_notation, GlobRef.t located or_var, GlobRef.t) t
+  | WSort_family : (Sorts.family, unit, unit) t
+  | WConstr : (constr_expr, glob_constr_and_expr, constr) t
+  | WUconstr : (constr_expr, glob_constr_and_expr, Ltac_pretype.closed_glob_constr) t
+  | WOpen_constr : (constr_expr, glob_constr_and_expr, constr) t
+  | WClause_dft_concl :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) t
+  | WOpen_binders : (local_binder_expr list, local_binder_expr list, local_binder_expr list) t
+
+type any_t = Any : (_, _, _) t -> any_t
+
+let all_wits_ref : any_t list ref = ref []
+
+let make0 (type a b c) (code : (a, b, c) t) ?dyn name : (a, b, c) genarg_type =
   let wit = Genarg.make0 name in
   let () = register_val0 wit dyn in
+  let () = all_wits_ref := Any code :: !all_wits_ref in
   wit
 
 let wit_unit : unit uniform_genarg_type =
-  make0 "unit"
+  make0 WUnit "unit"
 
 let wit_bool : bool uniform_genarg_type =
-  make0 "bool"
+  make0 WBool "bool"
 
 let wit_int : int uniform_genarg_type =
-  make0 "int"
+  make0 WInt "int"
 
 let wit_nat : int uniform_genarg_type =
-  make0 "nat"
+  make0 WNat "nat"
 
 let wit_string : string uniform_genarg_type =
-  make0 "string"
+  make0 WString "string"
 
 let wit_pre_ident : string uniform_genarg_type =
-  make0 "preident"
+  make0 WPre_ident "preident"
 
 let wit_int_or_var =
-  make0 ~dyn:(val_tag (topwit wit_int)) "int_or_var"
+  make0 WInt_or_var ~dyn:(val_tag (topwit wit_int)) "int_or_var"
 
 let wit_nat_or_var =
-  make0 ~dyn:(val_tag (topwit wit_nat)) "nat_or_var"
+  make0 WNat_or_var ~dyn:(val_tag (topwit wit_nat)) "nat_or_var"
 
 let wit_ident =
-  make0 "ident"
+  make0 WIdent "ident"
 
 let wit_identref =
-  make0 "identref"
+  make0 WIdentref "identref"
 
 let wit_hyp =
-  make0 ~dyn:(val_tag (topwit wit_ident)) "hyp"
+  make0 WHyp ~dyn:(val_tag (topwit wit_ident)) "hyp"
 
 let wit_var = wit_hyp
 
-let wit_ref = make0 "ref"
+let wit_ref = make0 WRef "ref"
 
-let wit_smart_global = make0 ~dyn:(val_tag (topwit wit_ref)) "smart_global"
+let wit_smart_global = make0 WSmart_global ~dyn:(val_tag (topwit wit_ref)) "smart_global"
 
-let wit_sort_family = make0 "sort_family"
+let wit_sort_family = make0 WSort_family "sort_family"
 
 let wit_constr =
-  make0 "constr"
+  make0 WConstr "constr"
 
-let wit_uconstr = make0 "uconstr"
+let wit_uconstr = make0 WUconstr "uconstr"
 
-let wit_open_constr = make0 ~dyn:(val_tag (topwit wit_constr)) "open_constr"
+let wit_open_constr = make0 WOpen_constr ~dyn:(val_tag (topwit wit_constr)) "open_constr"
 
-let wit_clause_dft_concl  =
-  make0 "clause_dft_concl"
+let wit_clause_dft_concl =
+  make0 WClause_dft_concl "clause_dft_concl"
 
 let wit_open_binders =
-  make0 "open_binders"
+  make0 WOpen_binders "open_binders"
+
+let all_wits = !all_wits_ref
+
+let wit_for : type a b c . (a, b, c) t -> (a, b, c) genarg_type
+= function
+  | WUnit -> wit_unit
+  | WBool -> wit_bool
+  | WNat -> wit_nat
+  | WInt -> wit_int
+  | WString -> wit_string
+  | WPre_ident -> wit_pre_ident
+  | WInt_or_var -> wit_int_or_var
+  | WNat_or_var -> wit_nat_or_var
+  | WIdent -> wit_ident
+  | WIdentref -> wit_identref
+  | WHyp -> wit_hyp
+  | WRef -> wit_ref
+  | WSmart_global -> wit_smart_global
+  | WSort_family -> wit_sort_family
+  | WConstr -> wit_constr
+  | WUconstr -> wit_uconstr
+  | WOpen_constr -> wit_open_constr
+  | WClause_dft_concl -> wit_clause_dft_concl
+  | WOpen_binders -> wit_open_binders
 
 (** Aliases for compatibility *)
 

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -63,6 +63,35 @@ val wit_clause_dft_concl :  (lident Locus.clause_expr, lident Locus.clause_expr,
 
 val wit_open_binders : local_binder_expr list uniform_genarg_type
 
+(** {5 All generic arguments} *)
+
+type (_, _, _) t =
+  | WUnit : (unit, unit, unit) t
+  | WBool : (bool, bool, bool) t
+  | WNat : (int, int, int) t
+  | WInt : (int, int, int) t
+  | WString : (string, string, string) t
+  | WPre_ident : (string, string, string) t
+  | WInt_or_var : (int or_var, int or_var, int) t
+  | WNat_or_var : (int or_var, int or_var, int) t
+  | WIdent : (Id.t, Id.t, Id.t) t
+  | WIdentref : (lident, lident, Id.t) t
+  | WHyp : (lident, lident, Id.t) t
+  | WRef : (qualid, GlobRef.t located or_var, GlobRef.t) t
+  | WSmart_global : (qualid or_by_notation, GlobRef.t located or_var, GlobRef.t) t
+  | WSort_family : (Sorts.family, unit, unit) t
+  | WConstr : (constr_expr, glob_constr_and_expr, constr) t
+  | WUconstr : (constr_expr, glob_constr_and_expr, Ltac_pretype.closed_glob_constr) t
+  | WOpen_constr : (constr_expr, glob_constr_and_expr, constr) t
+  | WClause_dft_concl :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) t
+  | WOpen_binders : (local_binder_expr list, local_binder_expr list, local_binder_expr list) t
+
+val wit_for : ('a, 'b, 'c) t -> ('a, 'b, 'c) genarg_type
+
+type any_t = Any : (_, _, _) t -> any_t
+
+val all_wits : any_t list
+
 (** Aliases for compatibility *)
 
 val wit_natural : int uniform_genarg_type


### PR DESCRIPTION
I wanted to fix an easy bug in Coq and looked at #16807 which is labeled "good first issue" -- thanks for the labeling!

As @SkySkimmer points out, the bug comes from the fact that a certain kind of Coq type has no registered printer in parsing/pcoq.ml.

Presumably, all types declared in Stdarg should have a registered printer, but sometimes people add a new Stard predefined type and they think of adding a parser, but they forget to add a printer. To fix this issue in the long term, I propose to define a sum type of all predefined types in Stdarg, and refactor operations performed on all predef types to use a pattern-matching on this sum type. This way, if you add a new predef type, you get exhaustivity errors on all those pattern-matchings, and you cannot forget to update them.

In the present PR, I do *not* fix the bug in #16807, I merely introduce the sum type and use it in two places, ltac/pptactic.ml and parsing/pcoq.ml. There is no change in behavior, some predef types are not handled in each pattern-matching. I think that this is a good point to submit a PR and get feedback before going further.

Remarks:
- The sum type has to be a GADT, because these predefined types have a type with three parameters that are instantiated in interesting ways.
- There are other predefined types (`wit_<stuff>`) values defined not in Stdarg, but in ltac/tacarg.ml, and the code that handles them tend to mix both kind. One could ask for a sum type for Tacarg predef types as well (and other kinds, for example ssrparser has some). I would propose to leave this out of the scope of the current PR and discussion, to keep things manageable -- one change at a time. (From a distance it's not clear why a type would be defined in one or the other, my intuition is that there used to be a design distinction but it has been blurred by a few misclassifications in the past.)
- There are other places that could be changed to pattern-match on this new `Stdarg.t` type, for example in tacsubst.ml and tacinterp.ml. I would propose to also leave that out of the current scope, because each new place we transform adds more work and it could become painful to implement and review. Also, for those we probably want to have a sum type in ltac/tacarg.ml types as well.

If people like the idea, I would propose to try to complete all the missing cases in the printer (it looks somewhat easy and useful, and would in particular fix the bug in #16807), and try for the parser but maybe stop if there are some things I don't know how to do.
