### PR TITLE
Evarconv: save keys

### DIFF
--- a/doc/changelog/02-specification-language/19611-cs-save-key.rst
+++ b/doc/changelog/02-specification-language/19611-cs-save-key.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The unification algorithm does not solve unification problems of the
+  form `proj _ ~ _` using canonical structures when the LHS reduces or
+  is ground
+  (`#19611 <https://github.com/coq/coq/pull/19611>`_,
+  by ).

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -100,6 +100,14 @@ let has_undefined_evars evd t =
   try let _ = f h t in false
   with (Not_found | NotInstantiatedEvar) -> true
 
+let has_undefined_evars_or_metas evd t =
+  let rec has_ev t =
+    match EConstr.kind evd t with
+    | Evar _ | Meta _ -> raise NotInstantiatedEvar
+    | _ -> EConstr.iter evd has_ev t in
+  try let _ = has_ev t in false
+  with (Not_found | NotInstantiatedEvar) -> true
+
 let is_ground_term evd t =
   not (has_undefined_evars evd t)
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -75,6 +75,7 @@ val whd_head_evar :  evar_map -> constr -> constr
 
 (* An over-approximation of [has_undefined (nf_evars evd c)] *)
 val has_undefined_evars : evar_map -> constr -> bool
+val has_undefined_evars_or_metas : evar_map -> constr -> bool
 
 val is_ground_term :  evar_map -> constr -> bool
 val is_ground_env  :  evar_map -> env -> bool

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -90,10 +90,14 @@ val activate_hook : name:CString.Map.key -> unit
 
 val apply_hooks : hook
 
-(** Check if a canonical structure is applicable *)
+(** Check if a canonical structure is applicable. *)
 
-val check_conv_record : ?metas:(Constr.metavariable -> types option) -> env -> evar_map ->
-  state -> state ->
+val decompose_proj : ?metas:(Constr.metavariable -> types option) -> env -> evar_map -> state -> (Names.Constant.t * EConstr.EInstance.t) *
+            (EConstr.t list option * EConstr.t * Reductionops.Stack.t)
+val check_conv_record : env -> evar_map ->
+  (Names.Constant.t * EConstr.EInstance.t) *
+            (EConstr.t list option * EConstr.t * Reductionops.Stack.t) ->
+  state ->
   evar_map * (constr * constr)
   * constr * constr list * (EConstr.t list * EConstr.t list option) *
     (EConstr.t list * EConstr.t list) *
@@ -150,9 +154,12 @@ val evar_unify : Evarsolve.unifier
 
 (**/**)
 (* For debugging *)
+module Cs_keys_cache : sig type t end
+
 val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
-  env -> evar_map ->
-    conv_pb -> state -> state ->
+  env -> evar_map -> conv_pb ->
+  Cs_keys_cache.t ->
+  bool option -> state -> state ->
       Evarsolve.unification_result
 
 val occur_rigidly : Evarsolve.unify_flags ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1537,7 +1537,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
       | Clval (_, _, b) -> Some b.rebus
       | exception Not_found -> None
       in
-      try Evarconv.check_conv_record ~metas (fst curenvnb) sigma f1l1 f2l2
+      try Evarconv.check_conv_record (fst curenvnb) sigma (Evarconv.decompose_proj ~metas (fst curenvnb) sigma f1l1) f2l2
       with Not_found -> error_cannot_unify (fst curenvnb) sigma (cM,cN)
     in
     if Reductionops.Stack.compare_shape ts ts1 then

--- a/test-suite/success/telescope_canonical.v
+++ b/test-suite/success/telescope_canonical.v
@@ -19,7 +19,7 @@ Definition test_fix n := (refl_equal _ : W (my_getp _)  = W (n + 1)).
 Definition pred n := match n with 0 => 0 | S m => m end.
 Canonical Structure predSS n := mkP (pred n).
 Definition test_case x := (refl_equal _ : W (my_getp _)  = W (pred x)).
-Fail Definition test_case' := (refl_equal _ : W (my_getp _)  = W (pred 0)).
+Definition test_case' := (refl_equal _ : W (my_getp _)  = W (pred 0)).
 
 Canonical Structure letPnat' := mkP 0.
 Definition letin := (let n := 0 in n).


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Saves the head constant of a term before delta-reducing it, to be used during canonical structure resolution and to find matching heads.
Also prevents trying to solve canonical structure problems of the form `S.proj s ~ t` when `s` reduces to an applied constructor.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
#### Overlays (to be merged before the current PR)

  - mathcomp-analysis: https://github.com/math-comp/analysis/pull/1377
  - odd-order: https://github.com/math-comp/odd-order/pull/60
  - fcsl-pcm: https://github.com/imdea-software/fcsl-pcm/pull/45


<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
