### PR TITLE
[config] Re-enable use of configure option -bytecode-compiler

### DIFF
--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -106,6 +106,7 @@ type t = {
 
 let default_toplevel = Names.(DirPath.make [Id.of_string "Top"])
 
+let default_vm = Coq_config.bytecode_compiler
 let default_native = Coq_config.native_compiler
 
 let default_logic_config = {
@@ -120,7 +121,7 @@ let default_config = {
   logic        = default_logic_config;
   rcfile       = None;
   coqlib       = None;
-  enable_VM    = true;
+  enable_VM    = default_vm;
   native_compiler = default_native;
   native_output_dir = ".coq-native";
   native_include_dirs = [];


### PR DESCRIPTION
Since #16931 , `./configure -bytecode-compiler no` had no effect, as we stopped checking the flag.

We do instead like native and set default options flag. I wonder if these options defaults should better read from the kernel tho.

