### PR TITLE
[quickfix] Add quickfixes for Coq -> Stdlib deprecation warnings.

### DIFF
--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -266,4 +266,5 @@ module Modules : sig
   val summary_tag : t Summary.Dyn.tag
 end
 
+(** [warn_deprecated_dirpath_Coq ?loc dp id] internal. Note that [dp] is expected in reversed order *)
 val warn_deprecated_dirpath_Coq : ?loc:Loc.t -> module_ident list * Id.t -> unit

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -18,17 +18,18 @@ open Libnames
 open Pcoq.Prim
 
 let deprecated_Coq loc l id = match List.rev l with
-  | [] -> []
+  | [] -> make_qualid ~loc DirPath.empty id
   | s :: p ->
      match Id.to_string s with
      | "Coq" ->
-        let l' = List.rev (Id.of_string "Stdlib" :: p) in
-        Nametab.warn_deprecated_dirpath_Coq ~loc (l, id); l'
-     | _ -> l
+       let l' = List.rev (Id.of_string "Stdlib" :: p) in
+       let qid = make_qualid ~loc (DirPath.make l') id in
+       Nametab.warn_deprecated_dirpath_Coq ~loc (l, id);
+       qid
+     | _ ->
+       make_qualid ~loc (DirPath.make l) id
 
-let local_make_qualid loc l id =
-  let l = deprecated_Coq loc l id in
-  make_qualid ~loc (DirPath.make l) id
+let local_make_qualid loc l id = deprecated_Coq loc l id
 
 let my_int_of_string ?loc s =
   try

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -1,0 +1,28 @@
+File "./output/Qf_stdlib.v", line 8, characters 15-30:
+Warning: Coq.ssr.ssrbool has been replaced by Stdlib.ssr.ssrbool.
+[deprecated-dirpath-Coq,deprecated-since-8.21,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_stdlib.v", line 8, characters 15-30 with Stdlib.ssr.ssrbool
+File "./output/Qf_stdlib.v", line 9, characters 0-42:
+Warning: "From Coq" has been replaced by "From Stdlib".
+[deprecated-from-Coq,deprecated-since-8.21,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_stdlib.v", line 9, characters 5-8 with Stdlib
+File "./output/Qf_stdlib.v", line 12, characters 6-22:
+Warning: Coq.Init.Nat.add has been replaced by Stdlib.Init.Nat.add.
+[deprecated-dirpath-Coq,deprecated-since-8.21,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_stdlib.v", line 12, characters 6-22 with Stdlib.Init.Nat.add
+Nat.add : nat -> nat -> nat
+
+Nat.add is not universe polymorphic
+Arguments Nat.add (n m)%nat_scope
+Nat.add is transparent
+Expands to: Constant Stdlib.Init.Nat.add
+File "./output/Qf_stdlib.v", line 13, characters 6-22:
+Warning: Coq.Init.Nat.add has been replaced by Stdlib.Init.Nat.add.
+[deprecated-dirpath-Coq,deprecated-since-8.21,deprecated,default]
+Quickfix:
+Replace File "./output/Qf_stdlib.v", line 13, characters 6-22 with Stdlib.Init.Nat.add
+Nat.add
+     : nat -> nat -> nat

--- a/test-suite/output/Qf_stdlib.v
+++ b/test-suite/output/Qf_stdlib.v
@@ -1,0 +1,13 @@
+(* Example from coq-lsp: we need to test 3 methods where the quickfix
+  can come from for the Coq -> Stdlib transition:
+
+  - Coq appearing in require (tested in line 2 of code)
+  - Coq appearing in identifiers (tested in Check and Line 1)
+  - Coq being looked up via nametab (tested in About)
+*)
+Require Import Coq.ssr.ssrbool.
+From Coq Require Import ssreflect ssrbool.
+
+(* Note: this tests the two different lookup modes *)
+About Coq.Init.Nat.add.
+Check Coq.Init.Nat.add.

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -277,14 +277,17 @@ let _ = CErrors.register_handler begin function
 end
 
 let warn_deprecated_from_Coq =
-  CWarnings.create ~name:"deprecated-from-Coq"
+  CWarnings.create_with_quickfix ~name:"deprecated-from-Coq"
     ~category:Deprecation.Version.v8_21
     (fun () -> strbrk
         "\"From Coq\" has been replaced by \"From Stdlib\".")
 
 let deprecated_Coq p =
   if not (Libnames.qualid_eq p (Libnames.qualid_of_string "Coq")) then p else
-    let () = warn_deprecated_from_Coq () in
+    let quickfix = Option.map (fun loc ->
+        [Quickfix.make ~loc (Pp.str "Stdlib")]) p.loc
+    in
+    let () = warn_deprecated_from_Coq ?quickfix () in
     Libnames.qualid_of_ident (Id.of_string "Stdlib")
 
 let synterp_require ~intern from export qidl =


### PR DESCRIPTION
This PR should cover all the cases, AFAICT.

I have tested this patch with `coq-lsp`, seems to work fine.

Using the `fcc` compiler, it is possible to apply these fixes automatically to a file.

[Adaptation to QF API revealed the pitfalls of our API entry points
 w.r.t. feedback, errors, etc...]

