### PR TITLE
Global.push_context_set is always strict:true

### DIFF
--- a/dev/ci/user-overlays/19620-SkySkimmer-push-context-strict.sh
+++ b/dev/ci/user-overlays/19620-SkySkimmer-push-context-strict.sh
@@ -1,0 +1,13 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi push-context-strict 19620
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations push-context-strict 19620
+
+overlay metacoq https://github.com/SkySkimmer/metacoq push-context-strict 19620
+
+overlay lean_importer https://github.com/SkySkimmer/coq-lean-import push-context-strict 19620
+
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 push-context-strict 19620
+
+overlay rewriter https://github.com/SkySkimmer/rewriter push-context-strict 19620
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof push-context-strict 19620

--- a/library/global.ml
+++ b/library/global.ml
@@ -84,7 +84,7 @@ let push_named_assum a = globalize0 (Safe_typing.push_named_assum a)
 let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let push_section_context c = globalize0 (Safe_typing.push_section_context c)
 let add_constraints c = globalize0 (Safe_typing.add_constraints c)
-let push_context_set ~strict c = globalize0 (Safe_typing.push_context_set ~strict c)
+let push_context_set c = globalize0 (Safe_typing.push_context_set ~strict:true c)
 
 let set_impredicative_set c = globalize0 (Safe_typing.set_impredicative_set c)
 let set_indices_matter b = globalize0 (Safe_typing.set_indices_matter b)
@@ -203,7 +203,7 @@ let current_dirpath () =
 
 let with_global f =
   let (a, ctx) = f (env ()) (current_dirpath ()) in
-  push_context_set ~strict:true ctx; a
+  push_context_set ctx; a
 
 let register_inline c = globalize0 (Safe_typing.register_inline c)
 let register_inductive c r = globalize0 (Safe_typing.register_inductive c r)

--- a/library/global.mli
+++ b/library/global.mli
@@ -64,7 +64,7 @@ val add_mind :
 (** Extra universe constraints *)
 val add_constraints : Univ.Constraints.t -> unit
 
-val push_context_set : strict:bool -> Univ.ContextSet.t -> unit
+val push_context_set : Univ.ContextSet.t -> unit
 
 (** Non-interactive modules and module types *)
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -232,7 +232,7 @@ let add_rewrite_hint ~locality ~poly bases ort t lcsr =
         if poly then ctx
         else (* This is a global universe context that shouldn't be
                 refreshed at every use of the hint, declare it globally. *)
-          (Global.push_context_set ~strict:true ctx;
+          (Global.push_context_set ctx;
            Univ.ContextSet.empty)
     in
       CAst.make ?loc:(Constrexpr_ops.constr_loc ce) ((c, ctx), ort, Option.map (in_gen (rawwit wit_ltac)) t) in

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -176,7 +176,7 @@ let decl_constant name univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
   let univs = UState.restrict_universe_context univs vars in
-  let () = Global.push_context_set ~strict:true univs in
+  let () = Global.push_context_set univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
   let univs = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in
   (* UnsafeMonomorphic: we always do poly:false *)

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -114,7 +114,7 @@ let interp_hints ~poly h =
       let c =
         if poly then (c, Some (UState.sort_context_set uctx))
         else
-          let () = Global.push_context_set ~strict:true (UState.context_set uctx) in
+          let () = Global.push_context_set (UState.context_set uctx) in
           (c, None)
       in
       (Hints.hint_constr c) [@ocaml.warning "-3"]

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -858,7 +858,7 @@ let do_mutual_inductive ~flags ?typing_flags udecl indl ~private_ind ~uniform =
   | Polymorphic_ind_entry uctx -> (UState.Polymorphic_entry uctx, UnivNames.empty_binders)
   in
   (* Declare the global universes *)
-  Global.push_context_set ~strict:true uctx;
+  Global.push_context_set uctx;
   (* Declare the mutual inductive block with its associated schemes *)
   ignore (DeclareInd.declare_mutual_inductive_with_eliminations ~default_dep_elim ?typing_flags ~indlocs mie binders implicits);
   (* Declare the possible notations of inductive types *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -581,14 +581,14 @@ let declare_constant ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~typi
         let ubinders = make_ubinders ctx de.proof_entry_universes in
         (* We register the global universes after exporting side-effects, since
            the latter depend on the former. *)
-        let () = Global.push_context_set ~strict:true ctx in
+        let () = Global.push_context_set ctx in
         Entries.DefinitionEntry e, false, ubinders, None
       | Default { body = (body, eff); opaque = Opaque body_uctx } ->
         let body = ((body, body_uctx), eff.Evd.seff_private) in
         let de = { de with proof_entry_body = body } in
         let cd, ctx = cast_opaque_proof_entry ImmediateEffectEntry de in
         let ubinders = make_ubinders ctx de.proof_entry_universes in
-        let () = Global.push_context_set ~strict:true ctx in
+        let () = Global.push_context_set ctx in
         Entries.OpaqueEntry cd, false, ubinders, Some (Future.from_val body, None)
       | DeferredOpaque { body; feedback_id } ->
         let map (body, eff) = body, eff.Evd.seff_private in
@@ -596,12 +596,12 @@ let declare_constant ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~typi
         let de = { de with proof_entry_body = body } in
         let cd, ctx = cast_opaque_proof_entry DeferredEffectEntry de in
         let ubinders = make_ubinders ctx de.proof_entry_universes in
-        let () = Global.push_context_set ~strict:true ctx in
+        let () = Global.push_context_set ctx in
         Entries.OpaqueEntry cd, false, ubinders, Some (body, feedback_id))
     | ParameterEntry e ->
       let univ_entry, ctx = extract_monomorphic (fst e.parameter_entry_universes) in
       let ubinders = make_ubinders ctx e.parameter_entry_universes in
-      let () = Global.push_context_set ~strict:true ctx in
+      let () = Global.push_context_set ctx in
       let e = {
         Entries.parameter_entry_secctx = e.parameter_entry_secctx;
         Entries.parameter_entry_type = e.parameter_entry_type;
@@ -617,7 +617,7 @@ let declare_constant ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~typi
         let univ_entry, ctx = extract_monomorphic (fst entry_univs) in
         Some (typ, univ_entry), entry_univs, ctx
       in
-      let () = Global.push_context_set ~strict:true ctx in
+      let () = Global.push_context_set ctx in
       let e = {
         Entries.prim_entry_type = typ;
         Entries.prim_entry_content = e.prim_entry_content;
@@ -626,7 +626,7 @@ let declare_constant ?(local = Locality.ImportDefaultBehavior) ~name ~kind ~typi
       Entries.PrimitiveEntry e, false, ubinders, None
     | SymbolEntry { symb_entry_type=typ; symb_entry_unfold_fix=un_fix; symb_entry_universes=entry_univs } ->
       let univ_entry, ctx = extract_monomorphic (fst entry_univs) in
-      let () = Global.push_context_set ~strict:true ctx in
+      let () = Global.push_context_set ctx in
       let e = {
         Entries.symb_entry_type = typ;
         Entries.symb_entry_unfold_fix = un_fix;
@@ -703,7 +703,7 @@ let declare_variable ~name ~kind ~typing_flags d =
   let impl,opaque = match d with (* Fails if not well-typed *)
     | SectionLocalAssum {typ;impl;univs} ->
       let () = match fst univs with
-        | UState.Monomorphic_entry uctx -> Global.push_context_set ~strict:true uctx
+        | UState.Monomorphic_entry uctx -> Global.push_context_set uctx
         | UState.Polymorphic_entry uctx -> Global.push_section_context uctx
       in
       let () = Global.push_named_assum (name,typ) in
@@ -717,7 +717,7 @@ let declare_variable ~name ~kind ~typing_flags d =
          term. *)
       let univs = match fst de.proof_entry_universes with
         | UState.Monomorphic_entry uctx ->
-          Global.push_context_set ~strict:true (Univ.ContextSet.union uctx body_uctx);
+          Global.push_context_set (Univ.ContextSet.union uctx body_uctx);
           UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders
         | UState.Polymorphic_entry uctx ->
           Global.push_section_context uctx;

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -144,7 +144,7 @@ let do_universe ~poly l =
     let ctx = List.fold_left (fun ctx (_,qid) -> Level.Set.add (Level.make qid) ctx)
         Level.Set.empty l, Constraints.empty
     in
-    Global.push_context_set ~strict:true ctx
+    Global.push_context_set ctx
   | true ->
     let names = CArray.map_of_list (fun (na,_) -> Name na) l in
     let us = CArray.map_of_list (fun (_,l) -> Level.make l) l in
@@ -164,7 +164,7 @@ let do_constraint ~poly l =
   match poly with
   | false ->
     let uctx = ContextSet.add_constraints constraints ContextSet.empty in
-    Global.push_context_set ~strict:true uctx
+    Global.push_context_set uctx
   | true ->
     let uctx = UVars.UContext.make
         ([||],[||])

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -944,7 +944,7 @@ let build_subtypes env mp args mtys =
 let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
   let env = Global.env() in
   let (mty, cst') = Modintern.interp_module_ast env kind base mty in
-  let () = Global.push_context_set ~strict:true cst' in
+  let () = Global.push_context_set cst' in
   let () =
     let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
     let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state (Global.env ()) base inl ([], mty) in
@@ -984,12 +984,12 @@ let intern_args params =
 let start_module_core id args res =
   let mp = Global.start_module id in
   let params, ctx = intern_args args in
-  let () = Global.push_context_set ~strict:true ctx in
+  let () = Global.push_context_set ctx in
   let env = Global.env () in
   let res_entry_o, subtyps, ctx' = match res with
     | Enforce (mte, base, kind, inl) ->
         let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
-        let env = Environ.push_context_set ~strict:true ctx env in
+        let env = Environ.push_context_set ctx env in
         (* We check immediately that mte is well-formed *)
         let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
         let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
@@ -999,7 +999,7 @@ let start_module_core id args res =
       let typs, ctx = build_subtypes env mp params resl in
       None, typs, ctx
   in
-  let () = Global.push_context_set ~strict:true ctx' in
+  let () = Global.push_context_set ctx' in
   mp, res_entry_o, subtyps, params, Univ.ContextSet.union ctx ctx'
 
 let start_module export id args res =
@@ -1079,7 +1079,7 @@ let declare_module id args res mexpr_o =
       let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
       Some mte, inl, ctx
   in
-  let env = Environ.push_context_set ~strict:true ctx' env in
+  let env = Environ.push_context_set ctx' env in
   let ctx = Univ.ContextSet.union ctx ctx' in
   let entry, inl_res = match mexpr_entry_o, mty_entry_o with
     | None, None -> assert false (* No body, no type ... *)
@@ -1099,7 +1099,7 @@ let declare_module id args res mexpr_o =
   | None -> None
   | _ -> inl_res
   in
-  let () = Global.push_context_set ~strict:true ctx in
+  let () = Global.push_context_set ctx in
   let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst), _ = Mod_typing.translate_module state vm_state (Global.env ()) mp inl entry in
   let () = Global.add_constraints cst in
@@ -1181,10 +1181,10 @@ let openmodtype_info =
 let start_modtype_core id args mtys =
   let mp = Global.start_modtype id in
   let params, params_ctx = RawModOps.Interp.intern_args args in
-  let () = Global.push_context_set ~strict:true params_ctx in
+  let () = Global.push_context_set params_ctx in
   let env = Global.env () in
   let sub_mty_l, sub_mty_ctx = RawModOps.Interp.build_subtypes env mp params mtys in
-  let () = Global.push_context_set ~strict:true sub_mty_ctx in
+  let () = Global.push_context_set sub_mty_ctx in
   mp, params, sub_mty_l, Univ.ContextSet.union params_ctx sub_mty_ctx
 
 let start_modtype id args mtys =
@@ -1221,12 +1221,12 @@ let declare_modtype id args mtys (mte,base,kind,inl) =
   let mp, params, sub_mty_l, ctx = start_modtype_core id args mtys in
   let env = Global.env () in
   let mte, mte_ctx = Modintern.interp_module_ast env kind base mte in
-  let () = Global.push_context_set ~strict:true mte_ctx in
+  let () = Global.push_context_set mte_ctx in
   let env = Global.env () in
   (* We check immediately that mte is well-formed *)
   let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
   let _, (_, mte_cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
-  let () = Global.push_context_set ~strict:true (Univ.Level.Set.empty,mte_cst) in
+  let () = Global.push_context_set (Univ.Level.Set.empty,mte_cst) in
   let entry = params, mte in
   let env = Global.env () in
   let sobjs = RawModOps.Interp.get_functor_sobjs false env inl entry in
@@ -1238,9 +1238,9 @@ let declare_modtype id args mtys (mte,base,kind,inl) =
   Summary.Interp.unfreeze_summaries fs;
 
   (* We enrich the global environment *)
-  let () = Global.push_context_set ~strict:true ctx in
-  let () = Global.push_context_set ~strict:true mte_ctx in
-  let () = Global.push_context_set ~strict:true (Univ.Level.Set.empty,mte_cst) in
+  let () = Global.push_context_set ctx in
+  let () = Global.push_context_set mte_ctx in
+  let () = Global.push_context_set (Univ.Level.Set.empty,mte_cst) in
   let mp_env = Global.add_modtype id entry inl in
 
   (* Name consistency check : kernel vs. library *)
@@ -1328,7 +1328,7 @@ let type_of_incl env is_mod = function
 let declare_one_include_core (me,base,kind,inl) =
   let env = Global.env() in
   let me, cst = Modintern.interp_module_ast env kind base me in
-  let () = Global.push_context_set ~strict:true cst in
+  let () = Global.push_context_set cst in
   let env = Global.env () in
   let is_mod = (kind == Modintern.Module) in
   let cur_mp = Global.current_modpath () in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -821,7 +821,7 @@ let interp_structure ~flags udecl kind ~primitive_proj records =
   interp_structure_core ~cumulative finite ~univs ~variances ~primitive_proj impargs params template ~projections_kind ~indlocs data
 
 let declare_structure { Record_decl.mie; default_dep_elim; primitive_proj; impls; globnames; global_univ_decls; projunivs; ubinders; projections_kind; poly; records; indlocs } =
-  Option.iter (Global.push_context_set ~strict:true) global_univ_decls;
+  Option.iter Global.push_context_set global_univ_decls;
   let kn = DeclareInd.declare_mutual_inductive_with_eliminations mie globnames impls
       ~primitive_expected:primitive_proj ~indlocs ~default_dep_elim
   in


### PR DESCRIPTION
Safe_typing.push_context_set has 1 occurrence of strict:false, in Vernacentries.vernac_global_check, so I didn't change it.

Overlays:
- https://github.com/impermeable/coq-waterproof/pull/83
- https://github.com/mit-plv/rewriter/pull/160
- https://github.com/Mtac2/Mtac2/pull/405
- https://github.com/SkySkimmer/coq-lean-import/pull/20
- https://github.com/MetaCoq/metacoq/pull/1104
- https://github.com/mattam82/Coq-Equations/pull/619
- https://github.com/LPCIC/coq-elpi/pull/696