### PR TITLE
Show entries in Print HintDb in the order in which they'll be tried

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/19624-print_hintdb.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19624-print_hintdb.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The order of hints shown in the "For any goal" category in :cmd:`Print HintDb`
+  now matches the order in which they will be tried.
+  Previously the entries were misordered on their priority
+  (`#19624 <https://github.com/coq/coq/pull/19624>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -304,8 +304,8 @@ Hints used by :tacn:`auto`, :tacn:`eauto` and other tactics are stored in hint
 databases.  Each database maps head symbols to a list of hints.  Use the
 :cmd:`Print Hint` command to view a database.
 
-Each hint has a cost that is a nonnegative
-integer and an optional pattern. Hints with lower costs are tried first.
+Each hint has a cost and an optional pattern. Hints with lower
+cost are tried first.  (Cost is not used to limit the scope of searches.)
 :tacn:`auto` tries a hint when the conclusion of the current goal matches its
 pattern or when the hint has no pattern.
 
@@ -387,6 +387,13 @@ Creating Hints
    :n:`{? : {+ @ident } }` specifies the hint database(s) to add to.
    *(Deprecated since version 8.10:* If no :token:`ident`\s
    are given, the hint is added to the `core` database.)
+
+   Hints in hint databases are ordered, which is the order in which they're
+   tried, as shown by the :cmd:`Print HintDb` command.
+   Hints with lower costs are tried first.  Hints with the same cost are tried
+   in reverse of their order of definition, i.e., last to first.  When multiple hint
+   databases are specified in search tactics, all hints in the first database are
+   tried before any in the second database (and so forth).
 
    Outside of sections, these commands support the :attr:`local`, :attr:`export`
    and :attr:`global` attributes. :attr:`export` is the default.
@@ -715,7 +722,10 @@ Creating Hints
 
 .. cmd:: Print HintDb @ident
 
-   This command displays all hints from database :n:`@ident`.
+   This command displays all hints from database :n:`@ident`.  Hints
+   in each group ("For ... ->") are shown in the order in which they will be tried
+   (first to last).  Note that hints with the same cost are tried in
+   reverse of the order they're defined in, i.e., last to first.
 
 Hint locality
 `````````````

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1628,7 +1628,7 @@ let pr_id_hint env sigma (id, v) =
   | Some (ConstrPattern p | SyntacticPattern p) -> str", pattern " ++ pr_lconstr_pattern_env env sigma p
   | Some DefaultPattern -> str", pattern " ++ pr_leconstr_env env sigma (get_default_pattern v.code.obj)
   in
-  (pr_hint env sigma v.code ++ str" (level " ++ int v.pri ++ pr_pat v
+  (pr_hint env sigma v.code ++ str" (cost " ++ int v.pri ++ pr_pat v
    ++ str", id " ++ int id ++ str ")")
 
 let pr_hint_list env sigma hintlist =
@@ -1722,7 +1722,11 @@ let pr_hint_db_env env sigma db =
       | None -> str "For any goal"
       | Some head -> str "For " ++ pr_global head ++ pr_modes modes
       in
-      let hints = pr_hint_list env sigma (List.map (fun x -> (0, x)) hintlist) in
+      (* sort because db.hintdb_nopat isn't kept in priority sorted order;
+         "auto" sorts on priority before using the hintdb *)
+      let sorted = List.stable_sort (fun a b -> Int.compare a.pri b.pri) hintlist in
+      (* always prints "id 0" in Print HintDb *)
+      let hints = pr_hint_list env sigma (List.map (fun x -> (0, x)) sorted) in
       hov 0 (goal_descr ++ str " -> " ++ hints)
     in
     let hints =

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -40,7 +40,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
+For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -48,7 +48,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
+For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -65,7 +65,7 @@ Unfoldable constant definitions: all
 Unfoldable projection definitions: all
 Cut: emp
 For any goal ->   
-For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
+For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -94,7 +94,7 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   simple apply 0 ; trivial (level 1, pattern nat, id 0)
+For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 For S (modes !) ->   
 
 File "./output/HintLocality.v", line 92, characters 0-39:

--- a/test-suite/output/auto_order.out
+++ b/test-suite/output/auto_order.out
@@ -1,0 +1,17 @@
+Non-discriminated database
+Unfoldable variable definitions: none
+Unfoldable constant definitions: none
+Unfoldable projection definitions: none
+Cut: emp
+For any goal ->   (*external*) (idtac "second"; fail) (cost 1, id 0)
+                  (*external*) (idtac "first"; fail) (cost 1, id 0)
+                  (*external*) (idtac "fourth"; fail) (cost 2, id 0)
+                  (*external*) (idtac "third"; fail) (cost 2, id 0)
+
+(* info auto: *)
+second
+first
+fourth
+third
+fifth, different hintDb
+idtac.

--- a/test-suite/output/auto_order.v
+++ b/test-suite/output/auto_order.v
@@ -1,0 +1,13 @@
+Hint Extern 1 => idtac "first"; fail : plus.
+Hint Extern 1 => idtac "second"; fail : plus.
+
+Hint Extern 2 => idtac "third"; fail : plus.
+Hint Extern 2 => idtac "fourth"; fail : plus.
+
+Hint Extern 1 => idtac "fifth, different hintDb"; fail : plus2.
+
+Print HintDb plus.
+
+Goal False.
+info_auto with plus plus2 nocore.
+Abort.


### PR DESCRIPTION
This script illustrates the behavior after the change.  (It's unfortunate that the order in which 2 hints with the same priority are tried is the reverse of the order of the order they were defined--see first and second below, but I left it alone.)

```
Goal 1=2.

Hint Extern 1 => idtac "first"; fail : plus.
Hint Extern 1 => idtac "second"; fail : plus.
Hint Extern 2 => idtac "third"; fail : plus.
Print HintDb plus.
(* For any goal ->   (*external*) (idtac "second"; fail) (pri 1, id 0)
                    (*external*) (idtac "first"; fail) (pri 1, id 0)
                    (*external*) (idtac "third"; fail) (pri 2, id 0)
*)
info_auto with plus nocore.
(* info auto:
second
first
third
idtac.
*)
```

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
