### PR TITLE
Ltac2 add Control.hyp_value

### DIFF
--- a/doc/changelog/06-Ltac2-language/19630-ltac2-hyp-val.rst
+++ b/doc/changelog/06-Ltac2-language/19630-ltac2-hyp-val.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  `Ltac2.Control.hyp_value` to get the value (`v` in `H := v`) of an hypothesis
+  (`#19630 <https://github.com/coq/coq/pull/19630>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1133,6 +1133,15 @@ let () =
     (str "Hypothesis " ++ quote (Id.print id) ++ str " not found") (* FIXME: Do something more sensible *)
 
 let () =
+  define "hyp_value" (ident @-> tac (option constr)) @@ fun id ->
+  pf_apply @@ fun env _ ->
+  match EConstr.lookup_named id env with
+  | d -> return (Context.Named.Declaration.get_value d)
+  | exception Not_found ->
+    Tacticals.tclZEROMSG
+    (str "Hypothesis " ++ quote (Id.print id) ++ str " not found") (* FIXME: Do something more sensible *)
+
+let () =
   define "hyps" (unit @-> tac valexpr) @@ fun _ ->
   pf_apply @@ fun env _ ->
   let open Context in

--- a/test-suite/ltac2/control_tests.v
+++ b/test-suite/ltac2/control_tests.v
@@ -136,6 +136,9 @@ Goal 3 = 3 -> 1 = 1 /\ 2 = 2.
   pose (X := 2).
   if Constr.equal (hyp @X) '&X then () else throw Error.
 
+  if Option.equal Constr.equal (hyp_value @H) None then () else throw Error.
+  if Option.equal Constr.equal (hyp_value @X) (Some '2) then () else throw Error.
+
   Ltac2 Eval hyps().
   match hyps () with
   | [ (h, None, hty); (x, Some xbdy, xty) ] =>

--- a/user-contrib/Ltac2/Control.v
+++ b/user-contrib/Ltac2/Control.v
@@ -62,6 +62,13 @@ Ltac2 @ external hyp : ident -> constr := "coq-core.plugins.ltac2" "hyp".
     goal under focus, looks for the section variable with the given name.
     If there is one, looks for the hypothesis with the given name. *)
 
+Ltac2 @ external hyp_value : ident -> constr option := "coq-core.plugins.ltac2" "hyp_value".
+(** Panics if there is more than one goal under focus. If there is no
+    goal under focus, looks for the section variable with the given
+    name and return its value ("v" in "H := v") if there is one. If
+    there is one, looks for the hypothesis with the given name and
+    return its value if there is one. *)
+
 Ltac2 @ external hyps : unit -> (ident * constr option * constr) list := "coq-core.plugins.ltac2" "hyps".
 (** Panics if there is more than one goal under focus. If there is no
     goal under focus, returns the list of section variables.


### PR DESCRIPTION
more efficient than searching in the `hyps` list.
