### PR TITLE
Windows: fix path normalization in coqdep

### DIFF
--- a/tools/coqdep/lib/file_util.ml
+++ b/tools/coqdep/lib/file_util.ml
@@ -10,8 +10,9 @@
 
 let to_relative_path : string -> string = fun full_path ->
   if Filename.is_relative full_path then full_path else
-  let cwd  = String.split_on_char '/' (Sys.getcwd ()) in
-  let path = String.split_on_char '/' full_path in
+  let re_delim = if Sys.win32 then "[/\\]" else "/" in
+  let cwd = Str.split_delim (Str.regexp re_delim) (Sys.getcwd ()) in
+  let path = Str.split_delim (Str.regexp re_delim) full_path in
   let rec remove_common_prefix l1 l2 =
     match (l1, l2) with
     | (x1 :: l1, x2 :: l2) when x1 = x2 -> remove_common_prefix l1 l2


### PR DESCRIPTION
<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19579

This is a simple fix I had identically in Coq 8.18. It didn't get merged into 8.19 because there was a rework in these files (the file functions were moved to a separate file file_utils) overlapping with my fixes and then it somehow got lost.

See https://github.com/coq/platform/blob/main/opam/opam-repository/packages/coq-core/coq-core.8.18.0/files/0001-ocamldep-fix-to_relative_path-on-Windows.patch

The identical fix is well tested in Coq Platform 8.18 and it also fixed the issue with coq-quickchick in Coq Platform for 8.19.2.

Also note that the same method is used in another function in the same file.