### PR TITLE
Allow raw universes expressions (eg `"Stdlib.Init.Logic.1"`) in Print Universes Subgraph

### DIFF
--- a/dev/ci/user-overlays/19640-SkySkimmer-print-univ-subgraph-raw-univ.sh
+++ b/dev/ci/user-overlays/19640-SkySkimmer-print-univ-subgraph-raw-univ.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp print-univ-subgraph-raw-univ 19640

--- a/doc/changelog/08-vernac-commands-and-options/19640-print-univ-subgraph-raw-univ.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19640-print-univ-subgraph-raw-univ.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  :cmd:`Print Universes` `Subgraph` accepts raw universe names (which end in an integer instead of an identifier)
+  for debugging purposes, eg `Print Universes Subgraph ("foo.1" "foo.2")`.
+  The integer in raw universe expressions is extremely unstable,
+  so raw universe expressions should not be used outside debugging sessions
+  (`#19640 <https://github.com/coq/coq/pull/19640>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -590,15 +590,28 @@ Printing universes
    terms apparently identical but internally different in the Calculus of Inductive
    Constructions.
 
-.. cmd:: Print {? Sorted } Universes {? Subgraph ( {* @qualid } ) } {? @string }
+.. cmd:: Print {? Sorted } Universes {? Subgraph ( {* @debug_univ_name } ) } {? @string }
    :name: Print Universes
+
+   .. insertprodn debug_univ_name debug_univ_name
+
+   .. prodn::
+      debug_univ_name ::= @qualid
+      | @string
 
    This command can be used to print the constraints on the internal level
    of the occurrences of :math:`\Type` (see :ref:`Sorts`).
 
-   The :n:`Subgraph` clause limits the printed graph to the requested names (adjusting
-   constraints to preserve the implied transitive constraints between
-   kept universes).
+   The :n:`Subgraph` clause limits the printed graph to the requested
+   names (adjusting constraints to preserve the implied transitive
+   constraints between kept universes). :n:`@debug_univ_name` is
+   `:n:`@qualid` for named universes (e.g. `eq.u0`), and :n:`@string`
+   for raw universe expressions (e.g. `"Stdlib.Init.Logic.1"`).
+
+   .. note::
+
+      The integer in raw universe expressions is extremely unstable,
+      so raw universe expressions should not be used outside debugging sessions.
 
    The :n:`Sorted` clause makes each universe
    equivalent to a numbered label reflecting its level (with a linear

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1443,8 +1443,13 @@ printable: [
 | "Registered" "Schemes"
 ]
 
+debug_univ_name: [
+| reference
+| STRING
+]
+
 printunivs_subgraph: [
-| "Subgraph" "(" LIST0 reference ")"
+| "Subgraph" "(" LIST0 debug_univ_name ")"
 ]
 
 coercion_class: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -722,6 +722,11 @@ simple_reserv: [
 | LIST1 ident ":" type
 ]
 
+debug_univ_name: [
+| qualid
+| string
+]
+
 command: [
 | "Goal" type
 | "Pwd"
@@ -765,7 +770,7 @@ command: [
 | "Print" "Scope" scope_name
 | "Print" "Visibility" OPT scope_name
 | "Print" "Implicit" reference
-| "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 qualid ")" ) OPT string
+| "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 debug_univ_name ")" ) OPT string
 | "Print" "Assumptions" reference
 | "Print" "Opaque" "Dependencies" reference
 | "Print" "Transparent" "Dependencies" reference

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1182,8 +1182,13 @@ GRAMMAR EXTEND Gram
       | IDENT "Registered"; IDENT "Schemes" -> { PrintRegisteredSchemes }
     ] ]
   ;
+  debug_univ_name:
+    [ [ x = reference -> { NamedUniv x }
+      | x = STRING -> { RawUniv (CAst.make ~loc x) }
+    ] ]
+  ;
   printunivs_subgraph:
-    [ [ IDENT "Subgraph"; "("; l = LIST0 reference; ")" -> { l } ] ]
+    [ [ IDENT "Subgraph"; "("; l = LIST0 debug_univ_name; ")" -> { l } ] ]
   ;
   coercion_class:
     [ [ IDENT "Funclass" -> { FunClass }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -648,7 +648,11 @@ let pr_printable = function
       if b then "Print Sorted Universes"
       else "Print Universes"
     in
-    let pr_subgraph = prlist_with_sep spc pr_qualid in
+    let pr_debug_univ_name = function
+      | NamedUniv x -> pr_qualid x
+      | RawUniv { CAst.v = x } -> qstring x
+    in
+    let pr_subgraph = prlist_with_sep spc pr_debug_univ_name in
     keyword cmd ++ pr_opt pr_subgraph g ++ pr_opt str fopt
   | PrintName (qid,udecl) ->
     keyword "Print" ++ spc()  ++ pr_smart_global qid ++ pr_full_univ_name_list udecl

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -25,6 +25,10 @@ type goal_reference =
   | NthGoal of int
   | GoalId of Id.t
 
+type debug_univ_name =
+  | NamedUniv of qualid
+  | RawUniv of lstring
+
 type printable =
   | PrintTypingFlags
   | PrintTables
@@ -50,7 +54,7 @@ type printable =
   | PrintCoercions
   | PrintCoercionPaths of coercion_class * coercion_class
   | PrintCanonicalConversions of qualid or_by_notation list
-  | PrintUniverses of bool * qualid list option * string option
+  | PrintUniverses of bool * debug_univ_name list option * string option
   | PrintHint of qualid or_by_notation
   | PrintHintGoal
   | PrintHintDbName of string


### PR DESCRIPTION

I could not figure out how to get the parser to accept `Stdlib.Init.Logic.1` so they have to be quoted strings.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/858
