### PR TITLE
Make the output of info_auto be the list of tactics it finds

### DIFF
--- a/doc/changelog/04-tactics/19654-auto_info_output.rst
+++ b/doc/changelog/04-tactics/19654-auto_info_output.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The output of :tacn:`info_auto` and :tacn:`info_trivial` has been changed.
+  They now give the list of tactics they found, formatted
+  so it can be copied into the proof script
+  (`#19654 <https://github.com/coq/coq/pull/19654>`_,
+  by Jim Fehrle).

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -385,13 +385,14 @@ and tac_of_hint dbg db_list local_db concl =
       conclPattern concl p tacast
   in
   let pr_hint h env sigma =
-    let origin = match FullHint.database h with
-    | None -> mt ()
-    | Some n -> str " (in " ++ str n ++ str ")"
-    in
     let (lev,_,_,_) = dbg in
     let forinfo = lev = Info in
-    FullHint.print ~forinfo env sigma h ++ (if forinfo then str "." else origin)
+    let origin = match FullHint.database h with
+    | None -> mt ()
+    | Some n -> if forinfo then str "  (* in " ++ str n ++ str " *)"
+                           else str " (in " ++ str n ++ str ")"
+    in
+    FullHint.print ~forinfo env sigma h ++ origin
   in
   fun h -> tclLOG dbg (pr_hint h) (FullHint.run h tactic)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1611,7 +1611,7 @@ let push_resolve_hyp env sigma decl db =
 
 let pr_hint_elt env sigma h = pr_econstr_env env sigma h.hint_term
 
-let pr_hint ?(taconly=false) env sigma h = match h.obj with
+let pr_hint ?(forinfo=false) env sigma h = match h.obj with
   | Res_pf c -> (str"simple apply " ++ pr_hint_elt env sigma c)
   | ERes_pf c -> (str"simple eapply " ++ pr_hint_elt env sigma c)
   | Give_exact c -> (str"exact " ++ pr_hint_elt env sigma c)
@@ -1620,7 +1620,7 @@ let pr_hint ?(taconly=false) env sigma h = match h.obj with
   | Unfold_nth c ->
     str"unfold " ++  pr_evaluable_reference c
   | Extern (_, tac) ->
-    (if taconly then mt () else str "(*external*) ") ++
+    (if forinfo then mt () else str "(*external*) ") ++
       Pputils.pr_glb_generic env sigma tac
 
 let pr_id_hint env sigma (id, v) =
@@ -1853,7 +1853,7 @@ struct
   | Some (ConstrPattern p | SyntacticPattern p) -> Some p
   | Some DefaultPattern -> None
   let run (h : t) k = run_hint h.code k
-  let print ?(taconly=false) env sigma (h : t) = pr_hint ~taconly env sigma h.code
+  let print ?(forinfo=false) env sigma (h : t) = pr_hint ~forinfo env sigma h.code
   let name (h : t) = h.name
 
   let subgoals (h : t) = match h.code.obj with

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1611,7 +1611,7 @@ let push_resolve_hyp env sigma decl db =
 
 let pr_hint_elt env sigma h = pr_econstr_env env sigma h.hint_term
 
-let pr_hint env sigma h = match h.obj with
+let pr_hint ?(taconly=false) env sigma h = match h.obj with
   | Res_pf c -> (str"simple apply " ++ pr_hint_elt env sigma c)
   | ERes_pf c -> (str"simple eapply " ++ pr_hint_elt env sigma c)
   | Give_exact c -> (str"exact " ++ pr_hint_elt env sigma c)
@@ -1620,7 +1620,8 @@ let pr_hint env sigma h = match h.obj with
   | Unfold_nth c ->
     str"unfold " ++  pr_evaluable_reference c
   | Extern (_, tac) ->
-    str "(*external*) " ++ Pputils.pr_glb_generic env sigma tac
+    (if taconly then mt () else str "(*external*) ") ++
+      Pputils.pr_glb_generic env sigma tac
 
 let pr_id_hint env sigma (id, v) =
   let pr_pat p = match p.pat with
@@ -1852,7 +1853,7 @@ struct
   | Some (ConstrPattern p | SyntacticPattern p) -> Some p
   | Some DefaultPattern -> None
   let run (h : t) k = run_hint h.code k
-  let print env sigma (h : t) = pr_hint env sigma h.code
+  let print ?(taconly=false) env sigma (h : t) = pr_hint ~taconly env sigma h.code
   let name (h : t) = h.name
 
   let subgoals (h : t) = match h.code.obj with

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -60,7 +60,7 @@ sig
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> GlobRef.t option
-  val print : env -> evar_map -> t -> Pp.t
+  val print : ?taconly:bool -> env -> evar_map -> t -> Pp.t
   val subgoals : t -> int option
 
   (** This function is for backward compatibility only, not to use in newly

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -60,7 +60,7 @@ sig
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> GlobRef.t option
-  val print : ?taconly:bool -> env -> evar_map -> t -> Pp.t
+  val print : ?forinfo:bool -> env -> evar_map -> t -> Pp.t
   val subgoals : t -> int option
 
   (** This function is for backward compatibility only, not to use in newly

--- a/test-suite/output/auto.out
+++ b/test-suite/output/auto.out
@@ -1,7 +1,7 @@
 (* info auto: *)
-simple apply or_intror (in core).
- intro.
- assumption.
+simple apply or_intror.
+intro.
+assumption.
 (* debug auto: *)
 * assumption. (*fail*)
 * intro. (*fail*)
@@ -19,4 +19,4 @@ Debug: 1.1 depth=4 simple apply or_intror
 Debug: 1.1.1 depth=4 intro
 Debug: 1.1.1.1 depth=4 exact H
 (* info trivial: *)
-exact I (in core).
+exact I.

--- a/test-suite/output/auto.out
+++ b/test-suite/output/auto.out
@@ -1,5 +1,5 @@
 (* info auto: *)
-simple apply or_intror.
+simple apply or_intror.  (* in core *).
 intro.
 assumption.
 (* debug auto: *)
@@ -19,4 +19,4 @@ Debug: 1.1 depth=4 simple apply or_intror
 Debug: 1.1.1 depth=4 intro
 Debug: 1.1.1.1 depth=4 exact H
 (* info trivial: *)
-exact I.
+exact I.  (* in core *).


### PR DESCRIPTION
For example:

```
Hint Extern 1 => split : plus.
Goal 1=1 /\ 1=1 /\ 1=1 /\ 1=1.
info_auto 10 with nocore plus.

(* info auto: *)
split.
  split.
  split.
    split.
    split.
      split.
      split.
```

Goals that create multiple subgoals cause indentation of the subgoals.  (I tried to generate bullets, but when you get to the fourth level, you have to add curly braces.  Their behavior seems odd, so indenting without the bullets seems a reasonable compromise.)

IMO the current output can be very hard to read.  If people want to keep it nonetheless, I'll figure out how to make this new form of output available separately.  The readability issues in the current output occur when:
1. there are multiple subgoals - the amount of indentation is the number of tactics that have been applied to the goal.  New subgoals start the count again from 1
2. when successfully applied tactics are not part of the result

The current code only tracks the depth of the search, which is insufficient to construct an accurate proof script.  This PR saves the goal ids before and after each tactic is applied, which makes it simple to determine which successful tactics should be in the script (point 2 above) and to get the correct order and indentation.

FWIW, the current code gives this output for the example (which is simple enough that it's not too hard to read):

```
(* info auto: *)
(*external*) split (in plus).
 (*external*) split (in plus).
 (*external*) split (in plus).
  (*external*) split (in plus).
  (*external*) split (in plus).
   (*external*) split (in plus).
   (*external*) split (in plus).
```

This change also applies to `info_trivial`.  Updating `info_eauto` would be a separate PR.


- [ ] Added / updated **test-suite**.
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
