### PR TITLE
[stdlib] made Fin.case_L_R' and Fin.case_L_R computational

### DIFF
--- a/doc/changelog/11-standard-library/19655-fin_L_R.rst
+++ b/doc/changelog/11-standard-library/19655-fin_L_R.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Lemmas to ``Fin``: ``case_L_R'_L``, ``case_L_R'_R``, ``case_L_R_L``, ``case_L_R_R``;
+  and changed corresponding ``case_L_R'`` and ``case_L_R`` into transparent definitions.
+  (`#19655 <https://github.com/coq/coq/pull/19655>`_,
+  by Andrej Dudenhefner).


### PR DESCRIPTION
Now `Fin.case_L_R'` and `Fin.case_L_R` can be used in computation, similarly to `Fin.caseS'` and `Fin.caseS`.
Added lemmas `Fin.case_L_R'_L`, `Fin.case_L_R'_R`, `Fin.case_L_R_L`, `Fin.case_L_R_R`, which are now provable.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI:
- [ ] Opened **overlay** pull requests.  -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
