### PR TITLE
Replace forgotten Coq prefixes by Stdlib.

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -508,7 +508,7 @@ is equivalent to an instance declaration:
      [Equivalence_Transitive := trans].
 
 The declaration itself amounts to the definition of an object of the record type
-``Coq.Classes.RelationClasses.Equivalence`` and a hint added to the
+``Stdlib.Classes.RelationClasses.Equivalence`` and a hint added to the
 of a typeclass named ``Proper``` defined in ``Classes.Morphisms``. See the
 documentation on :ref:`typeclasses` and the theories files in Classes for
 further explanations.

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -350,11 +350,11 @@ are now available through the dot notation.
 .. cmd:: Print Namespace @dirpath
 
    Prints the names and types of all loaded constants whose fully qualified
-   names start with :n:`@dirpath`. For example, the command ``Print Namespace Coq.``
+   names start with :n:`@dirpath`. For example, the command ``Print Namespace Stdlib.``
    displays the names and types of all loaded constants in the standard library.
-   The command ``Print Namespace Coq.Init`` only shows constants defined in one
+   The command ``Print Namespace Stdlib.Init`` only shows constants defined in one
    of the files in the ``Init`` directory. The command ``Print Namespace
-   Coq.Init.Nat`` shows what is in the ``Nat`` library file inside the ``Init``
+   Stdlib.Init.Nat`` shows what is in the ``Nat`` library file inside the ``Init``
    directory. Module names may appear in :n:`@dirpath`.
 
    .. example::
@@ -552,7 +552,7 @@ While qualified names always consist of a series of dot-separated :n:`@ident`\s,
 
 **File part.** Files are identified by :gdef:`logical paths <logical path>`,
 which are prefixes in the form :n:`{* @ident__logical } {+ @ident__file }`, such
-as :n:`Coq.Init.Logic`, in which:
+as :n:`Stdlib.Init.Logic`, in which:
 
 - :n:`{* @ident__logical }`, the :gdef:`logical name`, maps to one or more
   directories (or :gdef:`physical paths <physical path>`) in the user's file system.
@@ -577,14 +577,14 @@ with the logical name :n:`Top` and there is no associated file system path.
 
 - :n:`@ident__base` is the base name used in the command defining
   the item.  For example, :n:`eq` in the :cmd:`Inductive` command defining it
-  in `Coq.Init.Logic` is the base name for `Coq.Init.Logic.eq`, the standard library
+  in `Stdlib.Init.Logic` is the base name for `Stdlib.Init.Logic.eq`, the standard library
   definition of :term:`Leibniz equality`.
 
 If :n:`@qualid` is the fully qualified name of an item, Coq
 always interprets :n:`@qualid` as a reference to that item.  If :n:`@qualid` is also a
 partially qualified name for another item, then you must provide a more-qualified
 name to uniquely identify that other item.  For example, if there are two
-fully qualified items named `Foo.Bar` and `Coq.X.Foo.Bar`, then `Foo.Bar` refers
+fully qualified items named `Foo.Bar` and `Stdlib.X.Foo.Bar`, then `Foo.Bar` refers
 to the first item and `X.Foo.Bar` is the shortest name for referring to the second item.
 
 Definitions with the :attr:`local` attribute are only accessible with

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -221,16 +221,16 @@ For example, you may see::
   Bignums /home/jef/coq/lib/coq/user-contrib/Bignums
   Bignums.BigZ /home/jef/coq/lib/coq/user-contrib/Bignums/BigZ
   Ltac2 /home/jef/coq/lib/coq/user-contrib/Ltac2
-  Coq /home/jef/coq/lib/coq/theories
-  Coq.Numbers /home/jef/coq/lib/coq/theories/Numbers
-  Coq.Numbers.Natural /home/jef/coq/lib/coq/theories/Numbers/Natural
-  Coq.Numbers.Natural.Binary /home/jef/coq/lib/coq/theories/Numbers/Natural/Binary
-  Coq.Numbers.Integer /home/jef/coq/lib/coq/theories/Numbers/Integer
-  Coq.Arith /home/jef/coq/lib/coq/theories/Arith
+  Stdlib /home/jef/coq/lib/coq/theories
+  Stdlib.Numbers /home/jef/coq/lib/coq/theories/Numbers
+  Stdlib.Numbers.Natural /home/jef/coq/lib/coq/theories/Numbers/Natural
+  Stdlib.Numbers.Natural.Binary /home/jef/coq/lib/coq/theories/Numbers/Natural/Binary
+  Stdlib.Numbers.Integer /home/jef/coq/lib/coq/theories/Numbers/Integer
+  Stdlib.Arith /home/jef/coq/lib/coq/theories/Arith
   <> /home/jef/myproj
 
 The components of each pair share suffixes, e.g. `Bignums.BigZ` and `Bignums/BigZ` or
-`Coq.Numbers.Natural` and `Numbers/Natural`.  Physical pathnames should
+`Stdlib.Numbers.Natural` and `Numbers/Natural`.  Physical pathnames should
 always use `/` rather than `\\`, even when running on Windows.
 Packages with a physical path containing `user-contrib` were installed
 with the Coq binaries (e.g. `Ltac2`), with the Coq Platform or with opam (e.g. `Bignums`)

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -62,7 +62,7 @@ Tactics for simple equalities
    form `R t u` where `R` is a reflexive relation registered with the `Equivalence`
    or `Reflexive` typeclasses.  See :cmd:`Class` and :cmd:`Instance`.
 
-   .. exn:: The relation @ident is not a declared reflexive relation. Maybe you need to require the Coq.Classes.RelationClasses library
+   .. exn:: The relation @ident is not a declared reflexive relation. Maybe you need to require the Stdlib.Classes.RelationClasses library
       :undocumented:
 
 .. tacn:: symmetry {? @simple_occurrences }
@@ -76,7 +76,7 @@ Tactics for simple equalities
    `R` is a symmetric relation registered with the `Equivalence` or `Symmetric`
    typeclasses.  See :cmd:`Class` and :cmd:`Instance`.
 
-   .. exn:: The relation @ident is not a declared symmetric relation. Maybe you need to require the Coq.Classes.RelationClasses library
+   .. exn:: The relation @ident is not a declared symmetric relation. Maybe you need to require the Stdlib.Classes.RelationClasses library
       :undocumented:
 
 .. tacn:: transitivity @one_term
@@ -95,7 +95,7 @@ Tactics for simple equalities
       This tactic behaves like :tacn:`transitivity`, using a fresh evar instead of
       a concrete :token:`one_term`.
 
-   .. exn:: The relation @ident is not a declared transitive relation. Maybe you need to require the Coq.Classes.RelationClasses library
+   .. exn:: The relation @ident is not a declared transitive relation. Maybe you need to require the Stdlib.Classes.RelationClasses library
       :undocumented:
 
 .. tacn:: f_equal

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -509,12 +509,12 @@ end
 let init_relation_classes () =
   if Coqlib.has_ref "rewrite.prop.relation" || Coqlib.has_ref "rewrite.type.relation" then ()
   else CErrors.user_err
-    (Pp.str "No bindings have been registered for relation classes in Prop or Type, maybe you need to require Coq.Classes.(C)RelationClasses.")
+    (Pp.str "No bindings have been registered for relation classes in Prop or Type, maybe you need to require Stdlib.Classes.(C)RelationClasses.")
 
 let init_rewrite () =
   if Coqlib.has_ref "rewrite.prop.Proper" || Coqlib.has_ref "rewrite.type.Proper" then ()
   else CErrors.user_err
-    (Pp.str "No bindings have been registered for morphisms in Prop or Type, maybe you need to require Coq.Classes.(C)Morphisms.")
+    (Pp.str "No bindings have been registered for morphisms in Prop or Type, maybe you need to require Stdlib.Classes.(C)Morphisms.")
 
 let get_type_of_refresh env evars t =
   let evars', tty = Evarsolve.get_type_of_refresh env (fst evars) t in
@@ -1904,7 +1904,7 @@ let () = CErrors.register_handler begin function
 | RelationNotDeclared (env, sigma, ty, concl) ->
   let rel, _, _, _, _, _ = decompose_app_rel_error env sigma concl in
   Some (str" The relation " ++ Printer.pr_econstr_env env sigma rel ++ str" is not a declared " ++
-    str ty ++ str" relation. Maybe you need to require the Coq.Classes.RelationClasses library")
+    str ty ++ str" relation. Maybe you need to require the Stdlib.Classes.RelationClasses library")
 | _ -> None
 end
 


### PR DESCRIPTION
Follow up of #19310.

cc @proux01 