### PR TITLE
Replace most occurrences of Coq into Rocq in the refman.

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -5,9 +5,9 @@ Program extraction
 
 :Authors: Jean-Christophe Filliâtre and Pierre Letouzey
 
-We present here the Coq extraction commands, used to build certified
+We present here the Rocq extraction commands, used to build certified
 and relatively efficient functional programs, extracting them from
-either Coq functions or Coq proofs of specifications. The
+either Rocq functions or Rocq proofs of specifications. The
 functional languages available as output are currently OCaml, Haskell
 and Scheme. In the following, "ML" will be used (abusively) to refer
 to any of the three.
@@ -29,15 +29,14 @@ Generating ML Code
 .. note::
 
   In the following, a qualified identifier :token:`qualid`
-  can be used to refer to any kind of Coq global "object" : :term:`constant`,
+  can be used to refer to any kind of global "object" : :term:`constant`,
   inductive type, inductive constructor or module name.
 
 .. cmd:: Extraction @qualid
          Recursive Extraction {+ @qualid }
          Extraction @string {+ @qualid }
 
-   The first two forms display the extracted term(s) in Coq as a convenient preview
-   of the extracted term(s):
+   The first two forms display the extracted term(s) as a convenient preview:
 
    - the first form extracts :n:`@qualid` and displays the resulting term;
    - the second form extracts the listed :n:`@qualid`\s and all their
@@ -57,14 +56,14 @@ the command :cmd:`Cd`.
   
 .. cmd:: Extraction Library @ident
 
-   Extraction of the whole Coq library :n:`@ident.v` to an ML module
+   Extraction of the whole Rocq library :n:`@ident.v` to an ML module
    :n:`@ident.ml`. In case of name clash, identifiers are here renamed
    using prefixes ``coq_``  or ``Coq_`` to ensure a session-independent
    renaming.
 
 .. cmd:: Recursive Extraction Library @ident
 
-   Extraction of the Coq library :n:`@ident.v` and all other modules
+   Extraction of the Rocq library :n:`@ident.v` and all other modules
    :n:`@ident.v` depends on.
 
 .. cmd:: Separate Extraction {+ @qualid }
@@ -72,24 +71,24 @@ the command :cmd:`Cd`.
    Recursive extraction of all the mentioned objects and all
    their dependencies, just as :n:`Extraction @string {+ @qualid }`,
    but instead of producing one monolithic file, this command splits
-   the produced code in separate ML files, one per corresponding Coq
+   the produced code in separate ML files, one per corresponding
    ``.v`` file. This command is hence quite similar to
    :cmd:`Recursive Extraction Library`, except that only the needed
-   parts of Coq libraries are extracted instead of the whole.
+   parts of Rocq libraries are extracted instead of the whole.
    The naming convention in case of name clash is the same one as
    :cmd:`Extraction Library`: identifiers are here renamed using prefixes
    ``coq_``  or ``Coq_``.
 
 The following command is meant to help automatic testing of
 the extraction, see for instance the ``test-suite`` directory
-in the Coq sources.
+in the Rocq sources.
 
 .. cmd:: Extraction TestCompile {+ @qualid }
 
    All the mentioned objects and all their dependencies are extracted
    to a temporary OCaml file, just as in ``Extraction "file"``. Then
    this temporary file and its signature are compiled with the same
-   OCaml compiler used to built Coq. This command succeeds only
+   OCaml compiler used to built Rocq. This command succeeds only
    if the extraction and the OCaml compilation succeed. It fails
    if the current target language of the extraction is not OCaml.
 
@@ -157,7 +156,7 @@ Concerning Haskell, type-preserving optimizations are less useful
 because of laziness. We still make some optimizations, for example in
 order to produce more readable code.
 
-The type-preserving optimizations are controlled by the following Coq flags
+The type-preserving optimizations are controlled by the following flags
 and commands:
 
 .. flag:: Extraction Optimize
@@ -165,7 +164,7 @@ and commands:
    Default is on. This :term:`flag` controls all type-preserving optimizations made on
    the ML terms (mostly reduction of dummy beta/iota redexes, but also
    simplifications on Cases, etc). Turn this flag off if you want a
-   ML term as close as possible to the Coq term.
+   ML term as close as possible to the Rocq term.
 
 .. flag:: Extraction Conservative Types
 
@@ -221,7 +220,7 @@ The user can explicitly ask for a :term:`constant` to be extracted by two means:
 
   * by mentioning it on the extraction command line
 
-  * by extracting the whole Coq module of this :term:`constant`.
+  * by extracting the whole Rocq module of this :term:`constant`.
 
 In both cases, the declaration of this :term:`constant` will be present in the
 produced file. But this same :term:`constant` may or may not be inlined in
@@ -352,7 +351,7 @@ Realizing inductive types
 
 The system also provides a mechanism to specify ML terms for inductive
 types and constructors. For instance, the user may want to use the ML
-native boolean type instead of the Coq one. The syntax is the following:
+native boolean type instead of the Rocq one. The syntax is the following:
 
 .. cmd:: Extract Inductive @qualid => {| @ident | @string } [ {* {| @ident | @string } } ] {? @string__match }
 
@@ -541,11 +540,11 @@ Avoiding conflicts with existing filenames
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using :cmd:`Extraction Library`, the names of the extracted files
-directly depend on the names of the Coq files. It may happen that
+directly depend on the names of the Rocq files. It may happen that
 these filenames are in conflict with already existing files, 
 either in the standard library of the target language or in other
 code that is meant to be linked with the extracted code. 
-For instance the module ``List`` exists both in Coq and in OCaml.
+For instance the module ``List`` exists both in Rocq and in OCaml.
 It is possible to instruct the extraction not to use particular filenames.
 
 .. cmd:: Extraction Blacklist {+ @ident }
@@ -576,7 +575,7 @@ Additional settings
 
    This :term:`option` controls which optimizations are used during extraction, providing a finer-grained
    control than :flag:`Extraction Optimize`.  The bits of :token:`natural` are used as a bit mask.
-   Keeping an option off keeps the extracted ML more similar to the Coq term.
+   Keeping an option off keeps the extracted ML more similar to the Rocq term.
    Values are:
 
    +-----+-------+----------------------------------------------------------------+
@@ -607,7 +606,7 @@ Additional settings
 
 .. flag:: Extraction TypeExpand
 
-   If this :term:`flag` is set, fully expand Coq types in ML.  See the Coq source code to learn more.
+   If this :term:`flag` is set, fully expand Rocq types in ML.  See the Rocq source code to learn more.
 
 .. opt:: Extraction Output Directory @string
 
@@ -616,10 +615,10 @@ Additional settings
    option :n:`-output-directory`, if set (see :ref:`command-line-options`) and
    otherwise, the current directory.  Use :cmd:`Pwd` to display the current directory.
 
-Differences between Coq and ML type systems
+Differences between Rocq and ML type systems
 ----------------------------------------------
 
-Due to differences between Coq and ML type systems,
+Due to differences between Rocq and ML type systems,
 some extracted programs are not directly typable in ML. 
 We now solve this problem (at least in OCaml) by adding
 when needed some unsafe casting ``Obj.magic``, which give
@@ -649,7 +648,7 @@ We now produce the following correct version::
 
    let dp x y f = Pair ((Obj.magic f () x), (Obj.magic f () y))
 
-Secondly, some Coq definitions may have no counterpart in ML. This
+Secondly, some Rocq definitions may have no counterpart in ML. This
 happens when there is a quantification over types inside the type
 of a constructor; for example:
 
@@ -664,23 +663,23 @@ In OCaml, we must cast any argument of the constructor dummy
 Even with those unsafe castings, you should never get error like
 ``segmentation fault``. In fact even if your program may seem
 ill-typed to the OCaml type checker, it can't go wrong : it comes
-from a Coq well-typed terms, so for example inductive types will always
+from a Rocq well-typed terms, so for example inductive types will always
 have the correct number of arguments, etc. Of course, when launching
 manually some extracted function, you should apply it to arguments
-of the right shape (from the Coq point-of-view).
+of the right shape (from the Rocq point-of-view).
 
 More details about the correctness of the extracted programs can be 
 found in :cite:`Let02`.
 
 We have to say, though, that in most "realistic" programs, these problems do not
-occur. For example all the programs of Coq library are accepted by the OCaml
+occur. For example all the programs of the Rocq Stdlib are accepted by the OCaml
 type checker without any ``Obj.magic`` (see examples below).
 
 Some examples
 -------------
 
 We present here two examples of extraction, taken from the
-Coq Standard Library. We choose OCaml as the target language,
+Rocq Stdlib. We choose OCaml as the target language,
 but everything, with slight modifications, can also be done in the
 other languages supported by extraction.
 We then indicate where to find other examples and tests of extraction.
@@ -709,7 +708,7 @@ We can now extract this program to OCaml:
 The inlining of ``gt_wf_rec`` and others is not
 mandatory. It only enhances readability of extracted code.
 You can then copy-paste the output to a file ``euclid.ml`` or let 
-Coq do it for you with the following command::
+Rocq do it for you with the following command::
 
    Extraction "euclid" eucl_dev.
 
@@ -753,16 +752,16 @@ Extraction's horror museum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some pathological examples of extraction are grouped in the file
-``test-suite/success/extraction.v`` of the sources of Coq.
+``test-suite/success/extraction.v`` of the sources of Rocq.
 
 Users' Contributions
 ~~~~~~~~~~~~~~~~~~~~
 
-Several of the Coq Users' Contributions use extraction to produce
+Several of user contributions use extraction to produce
 certified programs. In particular the following ones have an automatic
 extraction test:
 
- * ``additions`` : https://github.com/coq-contribs/additions
+ * ``additions-chains`` : https://github.com/coq-community/hydra-battles
  * ``bdds`` : https://github.com/coq-contribs/bdds
  * ``canon-bdds`` : https://github.com/coq-contribs/canon-bdds
  * ``chinese`` : https://github.com/coq-contribs/chinese
@@ -777,7 +776,7 @@ extraction test:
  * ``hardware`` : https://github.com/coq-contribs/hardware
  * ``multiplier`` : https://github.com/coq-contribs/multiplier
  * ``search-trees`` : https://github.com/coq-contribs/search-trees
- * ``stalmarck`` : https://github.com/coq-contribs/stalmarck
+ * ``stalmarck`` : https://github.com/coq-community/stalmarck
 
 Note that ``continuations`` and ``multiplier`` are a bit particular. They are
 examples of developments where ``Obj.magic`` is needed. This is

--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -35,7 +35,7 @@ the previous implementation in several ways:
   the new implementation, if one provides the proper morphisms. Again,
   most of the work is handled in the tactics.
 + First-class morphisms and signatures. Signatures and morphisms are
-  ordinary Coq terms, hence they can be manipulated inside Coq, put
+  ordinary Rocq terms, hence they can be manipulated inside Rocq, put
   inside structures and lemmas about them can be proved inside the
   system. Higher-order morphisms are also allowed.
 + Performance. The implementation is based on a depth-first search for
@@ -103,7 +103,7 @@ argument.
 Morphisms can also be contravariant in one or more of their arguments.
 A morphism is contravariant on an argument associated with the relation
 instance :math:`R` if it is covariant on the same argument when the inverse
-relation :math:`R^{−1}` (``inverse R`` in Coq) is considered. The special arrow ``-->``
+relation :math:`R^{−1}` (``inverse R`` in Rocq) is considered. The special arrow ``-->``
 is used in signatures for contravariant morphisms.
 
 Functions having arguments related by symmetric relations instances
@@ -144,7 +144,7 @@ always the intended equality for a given structure.
 
 In the next section we will describe the commands to register terms as
 parametric relations and morphisms. Several tactics that deal with
-equality in Coq can also work with the registered relations. The exact
+equality in Rocq can also work with the registered relations. The exact
 list of tactics will be given :ref:`in this section <tactics-enabled-on-user-provided-relations>`.
 For instance, the tactic reflexivity can be used to solve a goal ``R n n`` whenever ``R``
 is an instance of a registered reflexive relation. However, the

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -8,7 +8,7 @@ Implicit Coercions
 General Presentation
 ---------------------
 
-This section describes the inheritance mechanism of Coq. In Coq with
+This section describes one inheritance mechanism of the Rocq Prover. With
 inheritance, we are not interested in adding any expressive power to
 our theory, but only convenience. Given a term, possibly not typable,
 we are interested in the problem of determining if it can be well
@@ -73,7 +73,7 @@ We then write :g:`f : C >-> D`.
 .. _ambiguous-paths:
 
 When you declare a new coercion (e.g. with :cmd:`Coercion`), new coercion
-paths with the same classes as existing ones are ignored. Coq will generate
+paths with the same classes as existing ones are ignored. Rocq will generate
 a warning when the two paths may be non convertible. When the :g:`x₁..xₖ` are exactly
 the :g:`v₁..vₙ` (in the same order), the coercion is said to satisfy
 the :gdef:`uniform inheritance condition`. When possible, we recommend
@@ -90,24 +90,24 @@ then an object of ``D``.
 Reversible Coercions
 --------------------
 
-When a term cannot be coerced (directly) to its expected type, Coq tries to
+When a term cannot be coerced (directly) to its expected type, Rocq tries to
 use a :gdef:`reversible coercion` (see the :attr:`reversible` attribute). Intuitively,
-Coq synthesizes a new term of the right type that can be coerced
+Rocq synthesizes a new term of the right type that can be coerced
 to the original one. The new term is obtained by reversing the coercion, that
 is guessing its input given the output.
 
-More precisely, in order to coerce a term :g:`a : A` to type :g:`B`, Coq
+More precisely, in order to coerce a term :g:`a : A` to type :g:`B`, Rocq
 finds a reversible coercion :g:`f : B >-> A`, then synthesizes some :g:`?x : B`
 such that :g:`f ?x = a` (typically through :ref:`canonicalstructures` or
 :ref:`typeclasses`) and finally replaces :g:`a` with the value of :g:`?x`.
 
-If Coq doesn't find a reversible coercion :g:`f : B >-> A`, then it
+If Rocq doesn't find a reversible coercion :g:`f : B >-> A`, then it
 looks for a coercion class :g:`C` equipped with an incoming reversible coercion
 :g:`g : B >-> C` and a coercion :g:`h : A >-> C` (not necessarily reversible),
 then synthesizes some :g:`?x : B` such that :g:`g ?x = h a`, and finally
 replaces :g:`a` with the value of :g:`?x`.
 If there's another class :g:`D` with a coercion from :g:`C` to :g:`D` and
-incoming coercions from :g:`A` and :g:`B`, Coq tries :g:`C` before :g:`D`.
+incoming coercions from :g:`A` and :g:`B`, Rocq tries :g:`C` before :g:`D`.
 This ordering is well defined only if the coercion graph happens to be a semi
 lattice.  The intuition behind this ordering is that since coercions forget
 information, :g:`D` has less information that :g:`C`, and hence
@@ -194,7 +194,7 @@ Coercion Classes
 
   .. exn:: Cannot find the source class of @qualid.
 
-     Coq can not infer a valid source class.
+     Rocq can not infer a valid source class.
 
   .. exn:: Cannot recognize @coercion_class as a source class of @qualid.
 

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -312,7 +312,7 @@ proof by abstracting monomials by variables.
    that might miss a refutation.
 
    To illustrate the working of the tactic, consider we wish to prove the
-   following Coq goal:
+   following goal:
 
 .. needs csdp
 .. coqdoc::

--- a/doc/sphinx/addendum/miscellaneous-extensions.rst
+++ b/doc/sphinx/addendum/miscellaneous-extensions.rst
@@ -1,7 +1,7 @@
 Program derivation
 ==================
 
-Coq comes with an extension called ``Derive``, which supports program
+Rocq comes with an extension called ``Derive``, which supports program
 derivation. Typically in the style of Bird and Meertens formalism or derivations
 of program refinements. To use the Derive extension it must first be
 required with ``Require Stdlib.derive.Derive``. When the extension is loaded,
@@ -18,7 +18,7 @@ it provides the following command:
    existential variables are shelved goals, as
    described in :tacn:`shelve`).
 
-   When the proof is complete, Coq defines :term:`constants <constant>`
+   When the proof is complete, Rocq defines :term:`constants <constant>`
    for each :n:`@ident__i` and for :n:`@ident`:
 
    + The first ones, named :n:`@ident__i`, are defined as the proof of the

--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -6,8 +6,8 @@ Asynchronous and Parallel Proof Processing
 :Author: Enrico Tassi
 
 This chapter explains how proofs can be asynchronously processed by
-Coq. This feature improves the reactivity of the system when used in
-interactive mode via CoqIDE. In addition, it allows Coq to take
+Rocq. This feature improves the reactivity of the system when used in
+interactive mode via CoqIDE. In addition, it allows Rocq to take
 advantage of parallel hardware when used as a batch compiler by
 decoupling the checking of statements and definitions from the
 construction and checking of proofs objects.
@@ -20,7 +20,7 @@ This feature has some technical limitations that may make it
 unsuitable for some use cases.
 
 For example, in interactive mode, some errors coming from the kernel
-of Coq are signaled late. The type of errors belonging to this
+of Rocq are signaled late. The type of errors belonging to this
 category are universe inconsistencies.
 
 At the time of writing, only opaque proofs (ending with :cmd:`Qed` or
@@ -36,12 +36,12 @@ though doing so is not recommended.
 Proof annotations
 ----------------------
 
-To process a proof asynchronously Coq needs to know the precise
+To process a proof asynchronously Rocq needs to know the precise
 statement of the theorem without looking at the proof. This requires
 some annotations if the theorem is proved inside a Section (see
 Section :ref:`section-mechanism`).
 
-When a :ref:`section <section-mechanism>` ends, Coq looks at the proof object to decide which
+When a :ref:`section <section-mechanism>` ends, Rocq looks at the proof object to decide which
 section variables are actually used and hence have to be quantified in
 the statement of the theorem. To avoid making the construction of
 proofs mandatory when ending a section, one can start each proof with
@@ -87,7 +87,7 @@ an incorrect annotation.
 Automatic suggestion of proof annotations
 `````````````````````````````````````````
 
-The :flag:`Suggest Proof Using` flag makes Coq suggest, when a :cmd:`Qed`
+The :flag:`Suggest Proof Using` flag makes Rocq suggest, when a :cmd:`Qed`
 command is processed, a correct proof annotation. It is up to the user
 to modify the proof script accordingly.
 
@@ -96,16 +96,16 @@ Proof blocks and error resilience
 --------------------------------------
 
 In interactive
-mode Coq is able to completely check a document containing errors
+mode Rocq is able to completely check a document containing errors
 instead of bailing out at the first failure.
 
 Two kind of errors are handled: errors occurring in
 commands and errors occurring in proofs.
 
-To properly recover from a failing tactic, Coq needs to recognize the
+To properly recover from a failing tactic, Rocq needs to recognize the
 structure of the proof in order to confine the error to a sub proof.
 Proof block detection is performed by looking at the syntax of the
-proof script (i.e. also looking at indentation). Coq comes with four
+proof script (i.e. also looking at indentation). Rocq comes with four
 kind of proof blocks, and an ML API to add new ones.
 
 :curly: blocks are delimited by { and }, see Chapter :ref:`proofhandling`
@@ -145,7 +145,7 @@ Interactive mode
 
 CoqIDE and VsCoq support asynchronous proof processing.
 
-When CoqIDE is started and async mode is enabled, two or more Coq processes
+When CoqIDE is started and async mode is enabled, two or more Rocq processes
 are created. The master one
 follows the user, giving feedback as soon as possible by skipping
 proofs, which are delegated to the worker processes. The worker processes

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -8,25 +8,24 @@ Program
 :Author: Matthieu Sozeau
 
 We present here the |Program| tactic commands, used to build
-certified Coq programs, elaborating them from their algorithmic
+certified Rocq programs, elaborating them from their algorithmic
 skeleton and a rich specification :cite:`sozeau06`. It can be thought of as a
 dual of :ref:`Extraction <extraction>`. The goal of |Program| is to
 program as in a regular functional programming language whilst using
 as rich a specification as desired and proving that the code meets the
-specification using the whole Coq proof apparatus. This is done using
+specification using the whole Rocq proof apparatus. This is done using
 a technique originating from the “Predicate subtyping” mechanism of
 PVS :cite:`Rushby98`, which generates type checking conditions while typing a
 term constrained to a particular type. Here we insert existential
 variables in the term, which must be filled with proofs to get a
-complete Coq term. |Program| replaces the |Program| tactic by Catherine
+complete Rocq term. |Program| replaces the |Program| tactic by Catherine
 Parent :cite:`Parent95b` which had a similar goal but is no longer maintained.
 
-The languages available as input are currently restricted to Coq’s
-term language, but may be extended to OCaml, Haskell and
-others in the future. We use the same syntax as Coq and permit to use
+The languages available as input is Rocq's term language.
+We use the same syntax as Rocq and permit to use
 implicit arguments and the existing coercion mechanism. Input terms
-and types are typed in an extended system (Russell) and interpreted
-into Coq terms. The interpretation process may produce some proof
+and types are typed in an extended system (Russell) and elaborated
+into Rocq terms. The elaboration process may produce some proof
 obligations which need to be resolved to create the final term.
 
 
@@ -35,7 +34,7 @@ obligations which need to be resolved to create the final term.
 Elaborating programs
 --------------------
 
-The main difference from Coq is that an object in a type :g:`T : Set` can
+The main difference from plain Rocq is that an object in a type :g:`T : Set` can
 be considered as an object of type :g:`{x : T | P}` for any well-formed
 :g:`P : Prop`. If we go from :g:`T` to the subset of :g:`T` verifying property
 :g:`P`, we must prove that the object under consideration verifies it. Russell
@@ -86,7 +85,7 @@ coercions.
    This :term:`flag` controls the special treatment of pattern matching generating equalities
    and disequalities when using |Program| (it is on by default). All
    pattern-matches and let-patterns are handled using the standard algorithm
-   of Coq (see :ref:`extendedpatternmatching`) when this flag is
+   of Rocq (see :ref:`extendedpatternmatching`) when this flag is
    deactivated.
 
 .. flag:: Program Generalized Coercion
@@ -150,13 +149,13 @@ Program Definition
 A :cmd:`Definition` command with the :attr:`program` attribute types
 the value term in Russell and generates proof
 obligations. Once solved using the commands shown below, it binds the
-final Coq term to the name :n:`@ident` in the global environment.
+final Rocq term to the name :n:`@ident` in the global environment.
 
 :n:`Program Definition @ident_decl : @type := @term`
 
 Interprets the type :n:`@type`, potentially generating proof
-obligations to be resolved. Once done with them, we have a Coq
-type :n:`@type__0`. It then elaborates the preterm :n:`@term` into a Coq
+obligations to be resolved. Once done with them, we have a Rocq
+type :n:`@type__0`. It then elaborates the preterm :n:`@term` into a Rocq
 term :n:`@term__0`, checking that the type of :n:`@term__0` is coercible to
 :n:`@type__0`, and registers :n:`@ident` as being of type :n:`@type__0` once the
 set of obligations generated during the interpretation of :n:`@term__0`
@@ -305,7 +304,7 @@ optional tactic is replaced by the default one if not specified.
 
    Like :cmd:`Next Obligation`, starts the proof of the next unsolved
    obligation. Additionally, at :cmd:`Qed` time, after the
-   automatic solver has run on any remaining obligations, Coq checks
+   automatic solver has run on any remaining obligations, Rocq checks
    that no obligations remain for the given :token:`ident` when
    provided and otherwise in the current module.
 
@@ -348,7 +347,7 @@ Frequently Asked Questions
 .. exn:: Ill-formed recursive definition.
 
   This error can happen when one tries to define a function by structural
-  recursion on a subset object, which means the Coq function looks like:
+  recursion on a subset object, which means the Rocq function looks like:
 
   ::
 

--- a/doc/sphinx/addendum/rewrite-rules.rst
+++ b/doc/sphinx/addendum/rewrite-rules.rst
@@ -13,12 +13,12 @@ User-defined rewrite rules
    and manipulating these will most often result in inconsistencies and anomalies.
 
 
-This section describes the extension of Coq's reduction mechanisms with user-defined rewrite rules,
+This section describes the extension of Rocq's reduction mechanisms with user-defined rewrite rules,
 as a means to extend definitional equality. It should not be confused with the :ref:`rewrite tactic <rewritingexpressions>`
-or :ref:`setoid rewriting <generalizedrewriting>` which operate on propositional equality and other relations which are defined in Coq.
+or :ref:`setoid rewriting <generalizedrewriting>` which operate on propositional equality and other relations which are defined in Rocq.
 
 Rewrite rules need to be enabled by passing the option ``-allow-rewrite-rules``
-to the Coq program.
+to the Rocq program.
 
    .. exn:: Rewrite rule declaration requires passing the flag "-allow-rewrite-rules".
       :undocumented:

--- a/doc/sphinx/addendum/ring.rst
+++ b/doc/sphinx/addendum/ring.rst
@@ -102,7 +102,7 @@ Yes, building the variables map and doing the substitution after
 normalizing is automatically done by the tactic. So you can just
 forget this paragraph and use the tactic according to your intuition.
 
-Concrete usage in Coq
+Concrete usage
 --------------------------
 
 .. tacn:: ring {? [ {+ @one_term } ] }
@@ -436,10 +436,10 @@ How does it work?
 
 The code of ``ring`` is a good example of a tactic written using *reflection*.
 What is reflection? Basically, using it means that a part of a tactic is written
-in Gallina, Coq's language of terms, rather than |Ltac| or OCaml. From the
+in Gallina, Rocq's language of terms, rather than |Ltac| or OCaml. From the
 philosophical point of view, reflection is using the ability of the Calculus of
 Constructions to speak and reason about itself. For the ``ring`` tactic we used
-Coq as a programming language and also as a proof environment to build a tactic
+Rocq as a programming language and also as a proof environment to build a tactic
 and to prove its correctness.
 
 The interested reader is strongly advised to have a look at the
@@ -765,12 +765,12 @@ tactics using reflection.
 
 Another idea suggested by Benjamin Werner: reflection could be used to
 couple an external tool (a rewriting program or a model checker)
-with Coq. We define (in Coq) a type of terms, a type of *traces*, and
+with Rocq. We define (in Rocq) a type of terms, a type of *traces*, and
 prove a correctness theorem that states that *replaying traces* is safe
 with respect to some interpretation. Then we let the external tool do every
 computation (using side-effects, backtracking, exception, or others
 features that are not available in pure lambda calculus) to produce
-the trace. Now we can check in Coq that the trace has the expected
+the trace. Now we can check in Rocq that the trace has the expected
 semantics by applying the correctness theorem.
 
 

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -10,13 +10,13 @@ SProp (proof irrelevant propositions)
    In particular, conversion checking through bytecode or native code
    compilation currently does not understand proof irrelevance.
 
-This section describes the extension of Coq with definitionally
+This section describes the extension of Rocq with definitionally
 proof irrelevant propositions (types in the sort :math:`\SProp`, also
 known as strict propositions) as described in
 :cite:`Gilbert:POPL2019`.
 
 Use of |SProp| may be disabled by passing ``-disallow-sprop`` to the
-Coq program or by turning the :flag:`Allow StrictProp` flag off.
+Rocq program or by turning the :flag:`Allow StrictProp` flag off.
 
 .. flag:: Allow StrictProp
 
@@ -256,7 +256,7 @@ proof relevant.
 
   This is a developer warning, which is treated as an error by default. It is
   emitted by the kernel when it is passed a term with incorrect relevance marks.
-  This is always caused by a bug in Coq (or a plugin), which should thus be reported and
+  This is always caused by a bug in Rocq (or a plugin), which should thus be reported and
   fixed. In order to allow the user to work around such bugs, we leave the
   ability to unset the ``bad-relevance`` warning for the time being, so that the
   kernel will silently repair the proof term instead of failing.

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -3,7 +3,7 @@
 Typeclasses
 ===========
 
-Typeclasses are types whose values Coq can automatically infer by using user
+Typeclasses are types whose values Rocq can automatically infer by using user
 declared instances. It allows for a form of programmatic proof or term search.
 
 This chapter presents a quick reference of the commands related to typeclasses.
@@ -15,7 +15,7 @@ Typeclass and instance declarations
 -----------------------------------
 
 The syntax for typeclasses and instance declarations is the same as the record
-syntax of Coq:
+syntax:
 
 .. coqdoc::
 
@@ -63,7 +63,7 @@ Note that if you finish the proof with :cmd:`Qed` the entire instance
 will be opaque, including the fields given in the initial term.
 
 Alternatively, in :flag:`Program Mode` if one does not give all the
-members in the Instance declaration, Coq generates obligations for the
+members in the Instance declaration, Rocq generates obligations for the
 remaining fields, e.g.:
 
 .. coqtop:: in
@@ -242,7 +242,7 @@ modifier before typeclass binders. For example:
 
    Definition lt `{eqa : EqDec A, !Ord eqa} (x y : A) := andb (le x y) (neqb x y).
 
-The ``!`` modifier switches how Coq interprets a binder. In particular, it uses
+The ``!`` modifier switches how Rocq interprets a binder. In particular, it uses
 the implicit arguments mechanism if available, as shown in the example.
 
 Substructures

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -12,7 +12,7 @@ General Presentation
 
    The status of Universe Polymorphism is experimental.
 
-This section describes the universe polymorphic extension of Coq.
+This section describes the universe polymorphic extension of Rocq.
 Universe polymorphism makes it possible to write generic definitions
 making use of universes and reuse them at different and sometimes
 incompatible universe levels.
@@ -260,7 +260,7 @@ constraints by prefixing the level names with symbols.
 Because inductive subtypings are only produced by comparing inductives
 to themselves with universes changed, they amount to variance
 information: each universe is either invariant, covariant or
-irrelevant (there are no contravariant subtypings in Coq),
+irrelevant (there are no contravariant subtypings in Rocq),
 respectively represented by the symbols `=`, `+` and `*`.
 
 Here we see that :g:`list` binds an irrelevant universe, so any two
@@ -635,7 +635,7 @@ mode, introduced universe names can be referred to in terms. Note that
 local universe names shadow global universe names. During a proof, one
 can use :cmd:`Show Universes` to display the current context of universes.
 
-It is possible to provide only some universe levels and let Coq infer the others
+It is possible to provide only some universe levels and let Rocq infer the others
 by adding a :g:`+` in the list of bound universe levels:
 
 .. coqtop:: all

--- a/doc/sphinx/appendix/history-and-changes/index.rst
+++ b/doc/sphinx/appendix/history-and-changes/index.rst
@@ -7,9 +7,9 @@ History and recent changes
 This chapter is divided in two parts.  The first one is about the
 :ref:`early history of Coq <history>` and is presented in
 chronological order.  The second one provides :ref:`release notes
-about recent versions of Coq <changes>` and is presented in reverse
-chronological order.  When updating your copy of Coq to a new version
-(especially a new major version), it is strongly recommended that you
+about recent versions of the Rocq Prover <changes>` and is presented in reverse
+chronological order.  When updating your version of Rocq
+(especially to a new major version), it is strongly recommended that you
 read the corresponding release notes.  They may contain advice that
 will help you understand the differences with the previous version and
 upgrade your projects.

--- a/doc/sphinx/history.rst
+++ b/doc/sphinx/history.rst
@@ -4,6 +4,8 @@
 Early history of Coq
 ----------------------
 
+The Rocq Prover is the successor of Coq, whose history, up to version 7, is presented here.
+
 Historical roots
 ----------------
 

--- a/doc/sphinx/index.html.rst
+++ b/doc/sphinx/index.html.rst
@@ -25,7 +25,7 @@ Contents
    proofs/creating-tactics/index
 
 .. toctree::
-   :caption: Using Coq
+   :caption: Using the Rocq Prover
 
    using/libraries/index
    using/tools/index

--- a/doc/sphinx/index.latex.rst
+++ b/doc/sphinx/index.latex.rst
@@ -1,6 +1,6 @@
-==========================
- The Coq Reference Manual
-==========================
+==================================
+ The Rocq Prover Reference Manual
+==================================
 
 ------------
 Introduction
@@ -29,9 +29,9 @@ Proofs
    proofs/automatic-tactics/index
    proofs/creating-tactics/index
 
----------
-Using Coq
----------
+---------------------
+Using the Rocq Prover
+---------------------
 
 .. toctree::
 

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -1,8 +1,9 @@
-This is the reference manual of Coq.  Coq is an interactive theorem
+This is the reference manual of the Rocq Prover.
+Rocq is a proof assistant or interactive theorem
 prover.  It lets you formalize mathematical concepts and then helps
 you interactively generate machine-checked proofs of theorems.
 Machine checking gives users much more confidence that the proofs are
-correct compared to human-generated and -checked proofs.  Coq has been
+correct compared to human-generated and -checked proofs.  Rocq has been
 used in a number of flagship verification projects, including the
 `CompCert verified C compiler <http://compcert.inria.fr/>`_, and has
 served to verify the proof of the `four color theorem
@@ -18,49 +19,49 @@ arithmetic).  :ref:`Ltac <ltac>` and its planned replacement,
 combining existing tactics with looping and conditional constructs.
 These permit automation of large parts of proofs and sometimes entire
 proofs.  Furthermore, users can add novel tactics or functionality by
-creating Coq plugins using OCaml.
+creating Rocq plugins using OCaml.
 
-The Coq kernel, a small part of Coq, does the final verification that
+The Rocq kernel, a small part of the Rocq Prover, does the final verification that
 the tactic-generated proof is valid.  Usually the tactic-generated
 proof is indeed correct, but delegating proof verification to the
 kernel means that even if a tactic is buggy, it won't be able to
 introduce an incorrect proof into the system.
 
-Finally, Coq also supports extraction of verified programs to
+Finally, Rocq also supports extraction of verified programs to
 programming languages such as OCaml and Haskell.  This provides a way
-of executing Coq code efficiently and can be used to create verified
+of executing Rocq code efficiently and can be used to create verified
 software libraries.
 
-To learn Coq, beginners are advised to first start with a tutorial /
+To learn Rocq, beginners are advised to first start with a tutorial /
 book.  Several such tutorials / books are listed at
 https://coq.inria.fr/documentation.
 
 This manual is organized in three main parts, plus an appendix:
 
-- **The first part presents the specification language of Coq**, that
+- **The first part presents the specification language of the Rocq Prover**, that
   allows to define programs and state mathematical theorems.
-  :ref:`core-language` presents the language that the kernel of Coq
+  :ref:`core-language` presents the language that the kernel of Rocq
   understands.  :ref:`extensions` presents the richer language, with
   notations, implicits, etc. that a user can use and which is
   translated down to the language of the kernel by means of an
   "elaboration process".
 
 - **The second part presents proof mode**, the central
-  feature of Coq.  :ref:`writing-proofs` introduces this interactive
+  feature of the Rocq Prover.  :ref:`writing-proofs` introduces this interactive
   mode and the available proof languages.
   :ref:`automatic-tactics` presents some more advanced tactics, while
   :ref:`writing-tactics` is about the languages that allow a user to
   combine tactics together and develop new ones.
 
-- **The third part shows how to use Coq in practice.**
+- **The third part shows how to use the Rocq Prover in practice.**
   :ref:`libraries` presents some of the essential reusable blocks from
   the ecosystem and some particularly important extensions such as the
   program extraction mechanism.  :ref:`tools` documents important
-  tools that a user needs to build a Coq project.
+  tools that a user needs to build a Rocq project.
 
 - In the appendix, :ref:`history-and-changes` presents the history of
-  Coq and changes in recent releases.  This is an important reference
-  if you upgrade the version of Coq that you use.  The various
+  Rocq and changes in recent releases.  This is an important reference
+  if you upgrade the version of Rocq that you use.  The various
   :ref:`indexes <indexes>` are very useful to **quickly browse the
   manual and find what you are looking for.** They are often the main
   entry point to the manual.

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1,7 +1,7 @@
 Typing rules
 ====================================
 
-The underlying formal language of Coq is a
+The underlying formal language of the Rocq Prover is a
 :gdef:`Calculus of Inductive Constructions` (|Cic|) whose inference rules
 are presented in this
 chapter. The history of this formalism as well as pointers to related
@@ -34,7 +34,7 @@ the following rules.
 #. variables, hereafter ranged over by letters :math:`x`, :math:`y`, etc., are terms
 #. constants, hereafter ranged over by letters :math:`c`, :math:`d`, etc., are terms.
 #. if :math:`x` is a variable and :math:`T`, :math:`U` are terms then
-   :math:`∀ x:T,~U` (:g:`forall x:T, U`   in Coq concrete syntax) is a term.
+   :math:`∀ x:T,~U` (:g:`forall x:T, U`   in Rocq concrete syntax) is a term.
    If :math:`x` occurs in :math:`U`, :math:`∀ x:T,~U` reads as
    “for all :math:`x` of type :math:`T`, :math:`U`”.
    As :math:`U` depends on :math:`x`, one says that :math:`∀ x:T,~U` is
@@ -44,11 +44,11 @@ the following rules.
    written: :math:`T \rightarrow U`.
 #. if :math:`x` is a variable and :math:`T`, :math:`u` are terms then
    :math:`λ x:T .~u` (:g:`fun x:T => u`
-   in Coq concrete syntax) is a term. This is a notation for the
+   in Rocq concrete syntax) is a term. This is a notation for the
    λ-abstraction of λ-calculus :cite:`Bar81`. The term :math:`λ x:T .~u` is a function
    which maps elements of :math:`T` to the expression :math:`u`.
 #. if :math:`t` and :math:`u` are terms then :math:`(t~u)` is a term
-   (:g:`t u` in Coq concrete
+   (:g:`t u` in Rocq concrete
    syntax). The term :math:`(t~u)` reads as “:math:`t` applied to :math:`u`”.
 #. if :math:`x` is a variable, and :math:`t`, :math:`T` and :math:`u` are
    terms then :math:`\letin{x}{t:T}{u}` is
@@ -92,10 +92,10 @@ Let us assume that ``mult`` is a function of type :math:`\nat→\nat→\nat` and
 predicate of type :math:`\nat→\nat→ \Prop`. The λ-abstraction can serve to build
 “ordinary” functions as in :math:`λ x:\nat.~(\kw{mult}~x~x)` (i.e.
 :g:`fun x:nat => mult x x`
-in Coq notation) but may build also predicates over the natural
+in Rocq notation) but may build also predicates over the natural
 numbers. For instance :math:`λ x:\nat.~(\kw{eqnat}~x~0)`
 (i.e. :g:`fun x:nat => eqnat x 0`
-in Coq notation) will represent the predicate of one variable :math:`x` which
+in Rocq notation) will represent the predicate of one variable :math:`x` which
 asserts the equality of :math:`x` with :math:`0`. This predicate has type
 :math:`\nat → \Prop`
 and it can be applied to any expression of type :math:`\nat`, say :math:`t`, to give an
@@ -429,7 +429,7 @@ and ζ reductions or any combination of those can also be defined.
 The Calculus of Inductive Constructions with impredicative Set
 -----------------------------------------------------------------
 
-Coq can be used as a type checker for the Calculus of Inductive
+The Rocq Prover can be used as a type checker for the Calculus of Inductive
 Constructions with an impredicative sort :math:`\Set` by using the compiler
 option ``-impredicative-set``. For example, using the ordinary `coqtop`
 command, the following is rejected,

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -91,7 +91,7 @@ These terms are also useful:
 
 * `n : nat` is a :gdef:`dependent premise` of `forall n:nat, n + 0 = n` because
   `n` appears both in the binder of the `forall` and in the quantified statement
-  `n + 0 = n`.  Note that if `n` isn't used in the statement, Coq considers it
+  `n + 0 = n`.  Note that if `n` isn't used in the statement, Rocq considers it
   a non-dependent premise.  Similarly, :n:`let n := ... in @term` is a
   dependent premise only if `n` is used in :n:`@term`.
 
@@ -145,7 +145,7 @@ Assumptions
 
 Assumptions extend the global environment with axioms, parameters, hypotheses
 or variables. An assumption binds an :n:`@ident` to a :n:`@type`. It is accepted
-by Coq only if :n:`@type` is a correct type in the global environment
+by Rocq only if :n:`@type` is a correct type in the global environment
 before the declaration and if :n:`@ident` was not previously defined in
 the same module. This :n:`@type` is considered to be the type (or
 specification, or statement) assumed by :n:`@ident` and we say that :n:`@ident`

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -10,7 +10,7 @@ manual.  Then, we present the essential vocabulary necessary to read
 the rest of the manual.  Other terms are defined throughout the manual.
 The reader may refer to the :ref:`glossary index <glossary_index>`
 for a complete list of defined terms.  Finally, we describe the various types of
-settings that Coq provides.
+settings that Rocq provides.
 
 Syntax and lexical conventions
 ------------------------------
@@ -21,7 +21,7 @@ Syntax conventions
 ~~~~~~~~~~~~~~~~~~
 
 The syntax described in this documentation is equivalent to that
-accepted by the Coq parser, but the grammar has been edited
+accepted by the Rocq parser, but the grammar has been edited
 to improve readability and presentation.
 
 In the grammar presented in this manual, the terminal symbols are
@@ -49,13 +49,13 @@ graphically using the following kinds of blocks:
 
 `Precedence levels
 <https://en.wikipedia.org/wiki/Order_of_operations>`_ that are
-implemented in the Coq parser are shown in the documentation by
+implemented in the Rocq parser are shown in the documentation by
 appending the level to the nonterminal name (as in :n:`@term100` or
 :n:`@ltac_expr3`).
 
 .. note::
 
-   Coq uses an extensible parser.  Plugins and the :ref:`notation
+   Rocq uses an extensible parser.  Plugins and the :ref:`notation
    system <syntax-extensions-and-notation-scopes>` can extend the
    syntax at run time.  Some notations are defined in the :term:`prelude`,
    which is loaded by default.  The documented grammar doesn't include
@@ -71,9 +71,9 @@ appending the level to the nonterminal name (as in :n:`@term100` or
 
    Given the complexity of these parsing rules, it would be extremely
    difficult to create an external program that can properly parse a
-   Coq document.  Therefore, tool writers are advised to delegate
-   parsing to Coq, by communicating with it, for instance through
-   `SerAPI <https://github.com/ejgallego/coq-serapi>`_.
+   Rocq document.  Therefore, tool writers are advised to delegate
+   parsing to Rocq, by communicating with it, for instance through
+   `coq-lsp <https://github.com/ejgallego/coq-lsp>`_.
 
 .. seealso:: :cmd:`Print Grammar`
 
@@ -182,8 +182,8 @@ Strings
 .. _keywords:
 
 Keywords
-  The following character sequences are keywords defined in the main Coq grammar
-  that cannot be used as identifiers (even when starting Coq with the `-noinit`
+  The following character sequences are keywords defined in the main Rocq grammar
+  that cannot be used as identifiers (even when starting Rocq with the `-noinit`
   command-line flag)::
 
     _ Axiom CoFixpoint Definition Fixpoint Hypothesis Parameter Prop
@@ -200,8 +200,8 @@ Keywords
   :cmd:`Print Keywords` can be used to print the current keywords and tokens.
 
 Other tokens
-  The following character sequences are tokens defined in the main Coq grammar
-  (even when starting Coq with the `-noinit` command-line flag)::
+  The following character sequences are tokens defined in the main Rocq grammar
+  (even when starting Rocq with the `-noinit` command-line flag)::
 
     ! #[ % & ' ( () ) * + , - ->
     . .( .. ... / : ::= := :> ; < <+ <- <:
@@ -236,7 +236,7 @@ Essential vocabulary
 --------------------
 
 This section presents the most essential notions to understand the
-rest of the Coq manual: :term:`terms <term>` and :term:`types
+rest of the Rocq Prover manual: :term:`terms <term>` and :term:`types
 <type>` on the one hand, :term:`commands <command>` and :term:`tactics
 <tactic>` on the other hand.
 
@@ -244,14 +244,14 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
 
    term
 
-     Terms are the basic expressions of Coq.  Terms can represent
+     Terms are the basic expressions of Rocq.  Terms can represent
      mathematical expressions, propositions and proofs, but also
      executable programs and program types.
 
      Here is the top-level syntax of terms.  Each of the listed
      constructs is presented in a dedicated section.  Some of these
      constructs (like :n:`@term_forall_or_fun`) are part of the core
-     language that the kernel of Coq understands and are therefore
+     language that the kernel of Rocq understands and are therefore
      described in :ref:`this chapter <core-language>`, while
      others (like :n:`@term_if`) are language extensions that are
      presented in :ref:`the next chapter <extensions>`.
@@ -297,18 +297,18 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
 
    type
 
-     To be valid and accepted by the Coq kernel, a term needs an
+     To be valid and accepted by the Rocq kernel, a term needs an
      associated type.  We express this relationship by “:math:`x` *of
      type* :math:`T`”, which we write as “:math:`x:T`”.  Informally,
      “:math:`x:T`” can be thought as “:math:`x` *belongs to*
      :math:`T`”.
 
-     The Coq kernel is a type checker: it verifies that a term has
+     The Rocq kernel is a type checker: it verifies that a term has
      the expected type by applying a set of typing rules (see
      :ref:`Typing-rules`).  If that's indeed the case, we say that the
      term is :gdef:`well-typed`.
 
-     A special feature of the Coq language is that types can depend
+     A special feature of the Rocq language is that types can depend
      on terms (we say that the language is `dependently-typed
      <https://en.wikipedia.org/wiki/Dependent_type>`_).  Because of
      this, types and terms share a common syntax.  All types are :term:`terms <term>`,
@@ -333,13 +333,13 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
      mathematics alternative to the standard `"set theory"
      <https://en.wikipedia.org/wiki/Set_theory>`_: we call such
      logical foundations `"type theories"
-     <https://en.wikipedia.org/wiki/Type_theory>`_.  Coq is based on
+     <https://en.wikipedia.org/wiki/Type_theory>`_.  The Rocq Prover is based on
      the Calculus of Inductive Constructions, which is a particular
      instance of type theory.
 
    sentence
 
-     Coq documents are made of a series of sentences that contain
+     Rocq documents are made of a series of sentences that contain
      :term:`commands <command>` or :term:`tactics <tactic>`, generally
      terminated with a period and optionally decorated with
      :term:`attributes <attribute>`.
@@ -359,7 +359,7 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
 
    command
 
-     A :production:`command` can be used to modify the state of a Coq
+     A :production:`command` can be used to modify the state of a Rocq
      document, for instance by declaring a new object, or to get
      information about the current state.
 
@@ -378,7 +378,7 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
 
      A :production:`tactic` specifies how to transform the current proof state as a
      step in creating a proof.  They are syntactically valid only when
-     Coq is in :term:`proof mode`, such as after a :cmd:`Theorem` command
+     Rocq is in :term:`proof mode`, such as after a :cmd:`Theorem` command
      and before any subsequent proof-terminating command such as
      :cmd:`Qed`.  See :ref:`proofhandling` for more on proof mode.
 
@@ -390,11 +390,11 @@ rest of the Coq manual: :term:`terms <term>` and :term:`types
 Settings
 --------
 
-There are several mechanisms for changing the behavior of Coq.  The
+There are several mechanisms for changing the behavior of Rocq.  The
 :term:`attribute` mechanism is used to modify the default behavior of a
-:term:`sentence` or to attach information to Coq objects.
+:term:`sentence` or to attach information to Rocq objects.
 The :term:`flag`, :term:`option` and :term:`table`
-mechanisms are used to modify the behavior of Coq more globally in a
+mechanisms are used to modify the behavior of Rocq more globally in a
 document or project.
 
 .. _attributes:
@@ -403,7 +403,7 @@ Attributes
 ~~~~~~~~~~
 
 An :gdef:`attribute` is used to modify the default behavior of a
-sentence or to attach information to a Coq object.
+sentence or to attach information to a Rocq object.
 Syntactically, most commands and tactics can be decorated with
 attributes (cf. :n:`@sentence`), but attributes not supported by the
 command or tactic will trigger :warn:`This command does not support
@@ -520,7 +520,7 @@ Document-level attributes
 Flags, Options and Tables
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following types of settings can be used to change the behavior of Coq in
+The following types of settings can be used to change the behavior of Rocq in
 subsequent commands and tactics (see :ref:`set_unset_scope_qualifiers` for a
 more precise description of the scope of these settings):
 
@@ -562,10 +562,10 @@ they appear after a boldface label.  They are listed in the
       This warning message can be raised by :cmd:`Set` and
       :cmd:`Unset` when :n:`@setting_name` is unknown.  It is a
       warning rather than an error because this helps library authors
-      produce Coq code that is compatible with several Coq versions.
+      produce Rocq code that is compatible with several Rocq versions.
       To preserve the same behavior, they may need to set some
       compatibility flags or options that did not exist in previous
-      Coq versions.
+      Rocq versions.
 
 .. cmd:: Unset @setting_name
 

--- a/doc/sphinx/language/core/coinductive.rst
+++ b/doc/sphinx/language/core/coinductive.rst
@@ -198,7 +198,7 @@ Top-level definitions of corecursive functions
    As in the :cmd:`Fixpoint` command, the :n:`with` clause allows simultaneously
    defining several mutual cofixpoints.
 
-   If :n:`@term` is omitted, :n:`@type` is required and Coq enters proof mode.
+   If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.

--- a/doc/sphinx/language/core/conversion.rst
+++ b/doc/sphinx/language/core/conversion.rst
@@ -3,7 +3,7 @@
 Conversion rules
 ----------------
 
-Coq has conversion rules that can be used to determine if two
+The Rocq Prover has conversion rules that can be used to determine if two
 terms are equal by definition in |CiC|, or :term:`convertible`.
 Conversion rules consist of reduction rules and expansion rules.
 Equality is determined by
@@ -85,7 +85,7 @@ to other changes to the proof state.)
 Two terms are :gdef:`α-convertible <alpha-convertible>` if they are syntactically
 equal ignoring differences in the names of variables bound within the expression.
 For example `forall x, x + 0 = x` is α-convertible with `forall y, y + 0 = y`.
-(Internally, Coq represents these two terms using de Bruijn indices,
+(Internally, Rocq represents these two terms using de Bruijn indices,
 so explicit α-conversion is not necessary.)
 
 β-reduction

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -105,7 +105,7 @@ Section :ref:`typing-rules`.
    :attr:`bypass_check(universes)`, :attr:`bypass_check(guard)`, :attr:`deprecated`,
    :attr:`warn` and :attr:`using` attributes.
 
-   If :n:`@term` is omitted, :n:`@type` is required and Coq enters proof mode.
+   If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
@@ -133,7 +133,7 @@ Assertions and proofs
 
 An assertion states a proposition (or a type) for which the proof (or an
 inhabitant of the type) is interactively built using :term:`tactics <tactic>`.
-Assertions cause Coq to enter :term:`proof mode` (see :ref:`proofhandling`).
+Assertions cause Rocq to enter :term:`proof mode` (see :ref:`proofhandling`).
 Common tactics are described in the :ref:`writing-proofs` chapter.
 The basic assertion command is:
 
@@ -151,7 +151,7 @@ The basic assertion command is:
       | Proposition
       | Property
 
-   After the statement is asserted, Coq needs a proof. Once a proof of
+   After the statement is asserted, Rocq needs a proof. Once a proof of
    :n:`@type` under the assumptions represented by :n:`@binder`\s is given and
    validated, the proof is generalized into a proof of :n:`forall {* @binder }, @type` and
    the theorem is bound to the name :n:`@ident` in the global environment.
@@ -194,7 +194,7 @@ The basic assertion command is:
       This feature, called nested proofs, is disabled by default.
       To activate it, turn the :flag:`Nested Proofs Allowed` flag on.
 
-Proofs start with the keyword :cmd:`Proof`. Then Coq enters the proof mode
+Proofs start with the keyword :cmd:`Proof`. Then Rocq enters the proof mode
 until the proof is completed. In proof mode, the user primarily enters
 tactics (see :ref:`writing-proofs`). The user may also enter
 commands to manage the proof mode (see :ref:`proofhandling`).

--- a/doc/sphinx/language/core/index.rst
+++ b/doc/sphinx/language/core/index.rst
@@ -4,7 +4,7 @@
 Core language
 =============
 
-At the heart of the Coq proof assistant is the Coq kernel.  While
+At the heart of the Rocq Prover is the Rocq kernel.  While
 users have access to a language with many convenient features such as
 :ref:`notations <syntax-extensions-and-notation-scopes>`,
 :ref:`implicit arguments <ImplicitArguments>`, etc.  (presented in the

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -9,7 +9,7 @@ Inductive types include natural numbers,
 lists and well-founded trees. Inhabitants of inductive types can
 recursively nest only a finite number of constructors. So, they are
 well-founded. This distinguishes them from :cmd:`CoInductive` types,
-such as streams, whose constructors can be infinitely nested. In Coq,
+such as streams, whose constructors can be infinitely nested. In Rocq,
 :cmd:`Variant` types thus correspond to the common subset of inductive
 and coinductive types that are non-recursive.
 
@@ -33,7 +33,7 @@ Inductive types
       constructor ::= {* #[ {+, @attribute } ] } @ident {* @binder } {? @of_type_inst }
 
    Defines one or more
-   inductive types and its constructors.  Coq generates
+   inductive types and its constructors.  Rocq generates
    :gdef:`induction principles <induction principle>`
    depending on the universe that the inductive type belongs to.
 
@@ -493,7 +493,7 @@ constructions.
    It is especially useful when defining functions over mutually defined
    inductive types.  Example: :ref:`Mutual Fixpoints<example_mutual_fixpoints>`.
 
-   If :n:`@term` is omitted, :n:`@type` is required and Coq enters proof mode.
+   If :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally, in particular by relying on the :tacn:`refine` tactic.
    In this case, the proof should be terminated with :cmd:`Defined` in order to define a :term:`constant`
    for which the computational behavior is relevant.  See :ref:`proof-editing-mode`.
@@ -658,7 +658,7 @@ the sort of the inductive type :math:`t` (not to be confused with :math:`\Sort` 
       \end{array}
       \right]}
 
-   which corresponds to the result of the Coq declaration:
+   which corresponds to the result of the Rocq declaration:
 
    .. coqtop:: in reset
 
@@ -679,7 +679,7 @@ the sort of the inductive type :math:`t` (not to be confused with :math:`\Sort` 
                 \consf &:& \tree → \forest → \forest\\
                           \end{array}\right]}
 
-   which corresponds to the result of the Coq declaration:
+   which corresponds to the result of the Rocq declaration:
 
    .. coqtop:: in
 
@@ -702,7 +702,7 @@ the sort of the inductive type :math:`t` (not to be confused with :math:`\Sort` 
                 \oddS &:& ∀ n,~\even~n → \odd~(\nS~n)
                           \end{array}\right]}
 
-   which corresponds to the result of the Coq declaration:
+   which corresponds to the result of the Rocq declaration:
 
    .. coqtop:: in
 
@@ -1214,7 +1214,7 @@ Conversion is preserved as any (partial) instance :math:`I_j~q_1 … q_r` or
    inductive type to be template polymorphic, even if the :flag:`Auto
    Template Polymorphism` flag is on.
 
-In practice, the rule **Ind-Family** is used by Coq only when there is only one
+In practice, the rule **Ind-Family** is used by Rocq only when there is only one
 inductive type in the inductive definition and it is declared with an arity
 whose sort is in the Type hierarchy. Then, the polymorphism is over
 the parameters whose type is an arity of sort in the Type hierarchy.
@@ -1351,8 +1351,8 @@ the logical level it is a proof of the usual induction principle and
 at the computational level it implements a generic operator for doing
 primitive recursion over the structure.
 
-But this operator is rather tedious to implement and use. We choose in
-this version of Coq to factorize the operator for primitive recursion
+But this operator is rather tedious to implement and use. We choose
+to factorize the operator for primitive recursion
 into two more primitive operations as was first suggested by Th.
 Coquand in :cite:`Coq92`. One is the definition by pattern matching. The
 second one is a definition by guarded fixpoints.
@@ -1367,7 +1367,7 @@ The basic idea of this operator is that we have an object :math:`m` in an
 inductive type :math:`I` and we want to prove a property which possibly
 depends on :math:`m`. For this, it is enough to prove the property for
 :math:`m = (c_i~u_1 … u_{p_i} )` for each constructor of :math:`I`.
-The Coq term for this proof
+The Rocq term for this proof
 will be written:
 
 .. math::
@@ -1382,7 +1382,7 @@ Actually, for type checking a :math:`\Match…\with…\kwend` expression we also
 to know the predicate :math:`P` to be proved by case analysis. In the general
 case where :math:`I` is an inductively defined :math:`n`-ary relation, :math:`P` is a predicate
 over :math:`n+1` arguments: the :math:`n` first ones correspond to the arguments of :math:`I`
-(parameters excluded), and the last one corresponds to object :math:`m`. Coq
+(parameters excluded), and the last one corresponds to object :math:`m`. Rocq
 can sometimes infer this predicate but sometimes not. The concrete
 syntax for describing this predicate uses the :math:`\as…\In…\return`
 construction. For instance, let us assume that :math:`I` is an unary predicate

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -557,15 +557,15 @@ as :n:`Coq.Init.Logic`, in which:
 - :n:`{* @ident__logical }`, the :gdef:`logical name`, maps to one or more
   directories (or :gdef:`physical paths <physical path>`) in the user's file system.
   The logical name
-  is used so that Coq scripts don't depend on where files are installed.
-  For example, the directory associated with :n:`Coq` contains Coq's standard library.
+  is used so that Rocq scripts don't depend on where files are installed.
+  For example, the directory associated with :n:`Stdlib` contains Rocq's standard library.
   The logical name is generally a single :n:`@ident`.
 
 - :n:`{+ @ident__file }` corresponds to the file system path of the file relative
   to the directory that contains it.  For example, :n:`Init.Logic`
   corresponds to the file system path :n:`Init/Logic.v` on Linux)
 
-When Coq is processing a script that hasn't been saved in a file, such as a new
+When Rocq is processing a script that hasn't been saved in a file, such as a new
 buffer in CoqIDE or anything in coqtop, definitions in the script are associated
 with the logical name :n:`Top` and there is no associated file system path.
 
@@ -580,7 +580,7 @@ with the logical name :n:`Top` and there is no associated file system path.
   in `Coq.Init.Logic` is the base name for `Coq.Init.Logic.eq`, the standard library
   definition of :term:`Leibniz equality`.
 
-If :n:`@qualid` is the fully qualified name of an item, Coq
+If :n:`@qualid` is the fully qualified name of an item, Rocq
 always interprets :n:`@qualid` as a reference to that item.  If :n:`@qualid` is also a
 partially qualified name for another item, then you must provide a more-qualified
 name to uniquely identify that other item.  For example, if there are two

--- a/doc/sphinx/language/core/primitive.rst
+++ b/doc/sphinx/language/core/primitive.rst
@@ -52,12 +52,12 @@ applications of these primitive operations.
 
 The extraction of these primitives can be customized similarly to the extraction
 of regular axioms (see :ref:`extraction`). Nonetheless, the :g:`ExtrOCamlInt63`
-module can be used when extracting to OCaml: it maps the Coq primitives to types
+module can be used when extracting to OCaml: it maps the Rocq primitives to types
 and functions of a :g:`Uint63` module (including signed functions for
 :g:`Sint63` despite the name). That OCaml module is not produced by extraction.
 Instead, it has to be provided by the user (if they want to compile or execute
 the extracted code). For instance, an implementation of this module can be taken
-from the kernel of Coq.
+from the kernel of Rocq.
 
 Literal values (at type :g:`Uint63.int`) are extracted to literal OCaml values
 wrapped into the :g:`Uint63.of_int` (resp. :g:`Uint63.of_int64`) constructor on
@@ -102,11 +102,11 @@ to comply with the IEEE 754 standard for floating-point arithmetic.
 
 The extraction of these primitives can be customized similarly to the extraction
 of regular axioms (see :ref:`extraction`). Nonetheless, the :g:`ExtrOCamlFloats`
-module can be used when extracting to OCaml: it maps the Coq primitives to types
+module can be used when extracting to OCaml: it maps the Rocq primitives to types
 and functions of a :g:`Float64` module. Said OCaml module is not produced by
 extraction. Instead, it has to be provided by the user (if they want to compile
 or execute the extracted code). For instance, an implementation of this module
-can be taken from the kernel of Coq.
+can be taken from the kernel of Rocq.
 
 Literal values (of type :g:`Float64.t`) are extracted to literal OCaml
 values (of type :g:`float`) written in hexadecimal notation and
@@ -152,17 +152,17 @@ operations.
 
 The extraction of these primitives can be customized similarly to the extraction
 of regular axioms (see :ref:`extraction`). Nonetheless, the :g:`ExtrOCamlPArray`
-module can be used when extracting to OCaml: it maps the Coq primitives to types
+module can be used when extracting to OCaml: it maps the Rocq primitives to types
 and functions of a :g:`Parray` module. Said OCaml module is not produced by
 extraction. Instead, it has to be provided by the user (if they want to compile
 or execute the extracted code). For instance, an implementation of this module
-can be taken from the kernel of Coq (see ``kernel/parray.ml``).
+can be taken from the kernel of Rocq (see ``kernel/parray.ml``).
 
-Coq's primitive arrays are persistent data structures. Semantically, a set operation
+Rocq's primitive arrays are persistent data structures. Semantically, a set operation
 ``t.[i <- a]`` represents a new array that has the same values as ``t``, except
 at position ``i`` where its value is ``a``. The array ``t`` still exists, can
 still be used and its values were not modified. Operationally, the implementation
-of Coq's primitive arrays is optimized so that the new array ``t.[i <- a]`` does not
+of Rocq's primitive arrays is optimized so that the new array ``t.[i <- a]`` does not
 copy all of ``t``. The details are in section 2.3 of :cite:`ConchonFilliatre07wml`.
 In short, the implementation keeps one version of ``t`` as an OCaml native array and
 other versions as lists of modifications to ``t``. Accesses to the native array
@@ -208,11 +208,11 @@ operations.
 
 The extraction of these primitives can be customized similarly to the extraction
 of regular axioms (see :ref:`extraction`). Nonetheless, the :g:`ExtrOCamlPString`
-module can be used when extracting to OCaml: it maps the Coq primitives to types
+module can be used when extracting to OCaml: it maps the Rocq primitives to types
 and functions of a :g:`Pstring` module. Said OCaml module is not produced by
 extraction. Instead, it has to be provided by the user (if they want to compile
 or execute the extracted code). For instance, an implementation of this module
-can be taken from the kernel of Coq (see ``kernel/pstring.ml``).
+can be taken from the kernel of Rocq (see ``kernel/pstring.ml``).
 
 Literal values (of type :g:`Pstring.t`, or equivalently :g:`string`) are extracted
 to literal OCaml values (of type :g:`string`).

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -41,7 +41,7 @@ Defining record types
    See :ref:`proofschemes-induction-principles`.
 
    The :cmd:`Class` command can be used to define records that are also
-   :ref:`typeclasses`, which permit Coq to automatically infer the inhabitants of
+   :ref:`typeclasses`, which permit Rocq to automatically infer the inhabitants of
    the record.
 
    :n:`{? > }`

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -67,7 +67,7 @@ usable outside the section as shown in this :ref:`example <section_local_declara
    will be wrapped with a :n:`@term_let` with the same declaration.
 
    As for :cmd:`Definition`, :cmd:`Fixpoint` and :cmd:`CoFixpoint`,
-   if :n:`@term` is omitted, :n:`@type` is required and Coq enters proof mode.
+   if :n:`@term` is omitted, :n:`@type` is required and Rocq enters proof mode.
    This can be used to define a term incrementally,
    in particular by relying on the :tacn:`refine` tactic.
    See :ref:`proof-editing-mode`.

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -213,7 +213,7 @@ Manual declaration of implicit arguments
 Automatic declaration of implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   The ":n:`default implicits`" :token:`args_modifier` clause tells Coq to automatically determine the
+   The ":n:`default implicits`" :token:`args_modifier` clause tells Rocq to automatically determine the
    implicit arguments of the object.
 
    Auto-detection is governed by flags specifying whether strict,
@@ -418,7 +418,7 @@ Effects of :cmd:`Arguments` on unfolding
 Bidirectionality hints
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When type-checking an application, Coq normally does not use information from
+When type-checking an application, Rocq normally does not use information from
 the context to infer the types of the arguments. It only checks after the fact
 that the type inferred for the application is coherent with the expected type.
 Bidirectionality hints make it possible to specify that after type-checking the
@@ -435,7 +435,7 @@ the context to help inferring the types of the remaining arguments.
   * *type inference*, with is inferring the type of a construct by analyzing the construct.
 
   Methods that combine these approaches are known as *bidirectional typing*.
-  Coq normally uses only the first approach to infer the types of arguments,
+  Rocq normally uses only the first approach to infer the types of arguments,
   then later verifies that the inferred type is consistent with the expected type.
   *Bidirectionality hints* specify to use both methods: after type checking the
   first arguments of an application (appearing before the `&` in :cmd:`Arguments`),
@@ -457,7 +457,7 @@ type check the remaining arguments (in :n:`@arg_specs__2`).
       Definition b2n (b : bool) := if b then 1 else 0.
       Coercion b2n : bool >-> nat.
 
-   Coq cannot automatically coerce existential statements over ``bool`` to
+   Rocq cannot automatically coerce existential statements over ``bool`` to
    statements over ``nat``, because the need for inserting a coercion is known
    only from the expected type of a subterm:
 
@@ -472,7 +472,7 @@ type check the remaining arguments (in :n:`@arg_specs__2`).
       Arguments ex_intro _ _ & _ _.
       Check (ex_intro _ true _ : exists n : nat, n > 0).
 
-Coq will attempt to produce a term which uses the arguments you
+Rocq will attempt to produce a term which uses the arguments you
 provided, but in some cases involving Program mode the arguments after
 the bidirectionality starts may be replaced by convertible but
 syntactically different terms.

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -88,9 +88,9 @@ in :ref:`canonicalstructures`; here only a simple example is given.
       that keys :n:`x__i` to one of its own variables.
 
    A record field :n:`x__i` can only be keyed once to each key.
-   Coq prints a warning when :token:`qualid` keys :n:`x__i` to a term
+   Rocq prints a warning when :token:`qualid` keys :n:`x__i` to a term
    whose head symbol is already keyed by an existing canonical instance.
-   In this case, Coq will not register that :token:`qualid` as a canonical
+   In this case, Rocq will not register that :token:`qualid` as a canonical
    extension.
    (The remaining fields of the instance can still be used for canonical extension.)
 
@@ -203,7 +203,7 @@ of the terms that are compared.
     End theory.
   End EQ.
 
-We use Coq modules as namespaces. This allows us to follow the same
+We use Rocq modules as namespaces. This allows us to follow the same
 pattern and naming convention for the rest of the chapter. The base
 namespace contains the definitions of the algebraic structure. To
 keep the example small, the algebraic structure ``EQ.type`` we are
@@ -240,7 +240,7 @@ We amend that by equipping ``nat`` with a comparison relation.
    Check 3 == 3.
    Eval compute in 3 == 4.
 
-This last test shows that Coq is now not only able to type check ``3 == 3``,
+This last test shows that Rocq is now not only able to type check ``3 == 3``,
 but also that the infix relation was bound to the ``nat_eq`` relation.
 This relation is selected whenever ``==`` is used on terms of type nat.
 This can be read in the line declaring the canonical structure
@@ -267,8 +267,8 @@ example work:
 
   Fail Check forall (e : EQ.type) (a b : EQ.obj e), (a, b) == (a, b).
 
-The error message is telling that Coq has no idea on how to compare
-pairs of objects. The following construction is telling Coq exactly
+The error message is telling that Rocq has no idea on how to compare
+pairs of objects. The following construction is telling Rocq exactly
 how to do that.
 
 .. coqtop:: all
@@ -285,7 +285,7 @@ how to do that.
 
   Check forall n m : nat, (3, 4) == (n, m).
 
-Thanks to the ``pair_EQty`` declaration, Coq is able to build a comparison
+Thanks to the ``pair_EQty`` declaration, Rocq is able to build a comparison
 relation for pairs whenever it is able to build a comparison relation
 for each component of the pair. The declaration associates to the key ``*``
 (the type constructor of pairs) the canonical comparison
@@ -336,7 +336,7 @@ As before we register a canonical ``LE`` class for ``nat``.
 
   Canonical Structure nat_LEty : LE.type := LE.Pack nat nat_LEcl.
 
-And we enable Coq to relate pair of terms with ``<=``.
+And we enable Rocq to relate pair of terms with ``<=``.
 
 .. coqtop:: all
 
@@ -401,10 +401,10 @@ theory of this new class.
 
 
 The problem is that the two classes ``LE`` and ``LEQ`` are not yet related by
-a subclass relation. In other words Coq does not see that an object of
+a subclass relation. In other words Rocq does not see that an object of
 the ``LEQ`` class is also an object of the ``LE`` class.
 
-The following two constructions tell Coq how to canonically build the
+The following two constructions tell Rocq how to canonically build the
 ``LE.type`` and ``EQ.type`` structure given an ``LEQ.type`` structure on the same
 type.
 
@@ -459,7 +459,7 @@ setting to any concrete instate of the algebraic structure.
 
   Abort.
 
-Again one has to tell Coq that the type ``nat`` is in the ``LEQ`` class, and
+Again one has to tell Rocq that the type ``nat`` is in the ``LEQ`` class, and
 how the type constructor ``*`` interacts with the ``LEQ`` class. In the
 following proofs are omitted for brevity.
 
@@ -514,7 +514,7 @@ Note that no direct proof of ``n <= m -> m <= n -> n == m`` is provided by
 the user for ``n`` and m of type ``nat * nat``. What the user provides is a
 proof of this statement for ``n`` and ``m`` of type ``nat`` and a proof that the
 pair constructor preserves this property. The combination of these two
-facts is a simple form of proof search that Coq performs automatically
+facts is a simple form of proof search that Rocq performs automatically
 while inferring canonical structures.
 
 Compact declaration of Canonical Structures
@@ -553,7 +553,7 @@ instances: ``[find e | EQ.obj e ~ T | "is not an EQ.type" ]``. It should be
 read as: “find a class e such that its objects have type T or fail
 with message "T is not an EQ.type"”.
 
-The other utilities are used to ask Coq to solve a specific unification
+The other utilities are used to ask Rocq to solve a specific unification
 problem, that will in turn require the inference of some canonical structures.
 They are explained in more details in :cite:`CSwcu`.
 
@@ -578,7 +578,7 @@ The object ``Pack`` takes a type ``T`` (the key) and a mixin ``m``. It infers al
 the other pieces of the class ``LEQ`` and declares them as canonical
 values associated with the ``T`` key. All in all, the only new piece of
 information we add in the ``LEQ`` class is the mixin, all the rest is
-already canonical for ``T`` and hence can be inferred by Coq.
+already canonical for ``T`` and hence can be inferred by Rocq.
 
 ``Pack`` is a notation, hence it is not type checked at the time of its
 declaration. It will be type checked when it is used, an in that case ``T`` is

--- a/doc/sphinx/language/extensions/evars.rst
+++ b/doc/sphinx/language/extensions/evars.rst
@@ -16,7 +16,7 @@ values.
    | ?[ ?@ident ]
    | ?@ident {? @%{ {+; @ident := @term } %} }
 
-Coq terms can include existential variables that represent unknown
+Rocq terms can include existential variables that represent unknown
 subterms that are eventually replaced with actual subterms.
 
 Existential variables are generated in place of unsolved implicit
@@ -83,7 +83,7 @@ Inferable subterms
 
    :n:`@term`\s may use :gdef:`holes <hole>`, denoted by :n:`_`, for purposes such as:
 
-   * Omitting redundant subterms.  Redundant subterms that Coq is able to infer can
+   * Omitting redundant subterms.  Redundant subterms that Rocq is able to infer can
      be replaced with :n:`_`.  For example HELP ME HERE.
    * Indicating where existential variables should be created in e* tactics such as
      :tacn:`assert`.
@@ -91,7 +91,7 @@ Inferable subterms
    is it possible to see holes in the context for any of these?
 
 Expressions often contain redundant pieces of information. Subterms that can be
-automatically inferred by Coq can be replaced by the symbol ``_`` and Coq will
+automatically inferred by Rocq can be replaced by the symbol ``_`` and Rocq will
 guess the missing piece of information.
 
 e* tactics that can create existential variables

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -115,7 +115,7 @@ application will include that argument.  Otherwise, the argument is
 *non-maximally inserted* and the partial application will not include that argument.
 
 Each implicit argument can be declared to be inserted maximally or non
-maximally. In Coq, maximally inserted implicit arguments are written between curly braces
+maximally. In Rocq, maximally inserted implicit arguments are written between curly braces
 "{ }" and non-maximally inserted implicit arguments are written in square brackets "[ ]".
 
 .. seealso:: :flag:`Maximal Implicit Insertion`
@@ -146,7 +146,7 @@ by replacing it with `_`.
 .. exn:: Cannot infer a term for this placeholder.
    :name: Cannot infer a term for this placeholder. (Casual use of implicit arguments)
 
-   Coq was not able to deduce an instantiation of a “_”.
+   Rocq was not able to deduce an instantiation of a “_”.
 
 .. _declare-implicit-args:
 
@@ -291,8 +291,8 @@ Controlling contextual implicit arguments
 
 .. flag:: Contextual Implicit
 
-   By default, Coq does not automatically set implicit the contextual
-   implicit arguments. You can turn this :term:`flag` on to tell Coq to also
+   By default, Rocq does not automatically set implicit the contextual
+   implicit arguments. You can turn this :term:`flag` on to tell Rocq to also
    infer contextual implicit argument.
 
 .. _controlling-rev-pattern-implicit-args:
@@ -302,8 +302,8 @@ Controlling reversible-pattern implicit arguments
 
 .. flag:: Reversible Pattern Implicit
 
-   By default, Coq does not automatically set implicit the reversible-pattern
-   implicit arguments. You can turn this :term:`flag` on to tell Coq to also infer
+   By default, Rocq does not automatically set implicit the reversible-pattern
+   implicit arguments. You can turn this :term:`flag` on to tell Rocq to also infer
    reversible-pattern implicit argument.
 
 .. _controlling-insertion-implicit-args:

--- a/doc/sphinx/language/extensions/index.rst
+++ b/doc/sphinx/language/extensions/index.rst
@@ -4,7 +4,7 @@
 Language extensions
 ===================
 
-Elaboration extends the language accepted by the Coq kernel to make it
+Elaboration extends the language accepted by the Rocq kernel to make it
 easier to use.  For example, this lets the user omit most type
 annotations because they can be inferred, call functions with implicit
 arguments which will be inferred as well, extend the syntax with

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -5,7 +5,7 @@ Extended pattern matching
 
 :Authors: Cristina Cornes and Hugo Herbelin
 
-This section describes the full form of pattern matching in Coq terms.
+This section describes the full form of pattern matching in Rocq terms.
 
 .. |rhs| replace:: right hand sides
 
@@ -196,8 +196,8 @@ Printing nested patterns
 
    When this :term:`flag` is on (default), Coq’s printer tries to do such
    limited re-factorization.
-   Turning it off tells Coq to print only simple pattern matching problems
-   in the same way as the Coq kernel handles them.
+   Turning it off tells Rocq to print only simple pattern matching problems
+   in the same way as the Rocq kernel handles them.
 
 
 Factorization of clauses with same right-hand side
@@ -207,7 +207,7 @@ Factorization of clauses with same right-hand side
 
    When several patterns share the same right-hand side, it is additionally
    possible to share the clauses using disjunctive patterns. Assuming that the
-   printing matching mode is on, this :term:`flag` (on by default) tells Coq's
+   printing matching mode is on, this :term:`flag` (on by default) tells Rocq's
    printer to try to do this kind of factorization.
 
 Use of a default clause
@@ -219,7 +219,7 @@ Use of a default clause
    arguments of the patterns, yet an extra factorization is possible: the
    disjunction of patterns can be replaced with a `_` default clause. Assuming that
    the printing matching mode and the factorization mode are on, this :term:`flag` (on by
-   default) tells Coq's printer to use a default clause when relevant.
+   default) tells Rocq's printer to use a default clause when relevant.
 
 Printing of wildcard patterns
 ++++++++++++++++++++++++++++++
@@ -241,7 +241,7 @@ Printing of the elimination predicate
    In most of the cases, the type of the result of a matched term is
    mechanically synthesizable. Especially, if the result type does not
    depend of the matched term. When this :term:`flag` is on (default),
-   the result type is not printed when Coq knows that it can re-
+   the result type is not printed when Rocq knows that it can re-
    synthesize it.
 
 Printing of hidden subterms
@@ -707,7 +707,7 @@ Dependent pattern matching
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The examples given so far do not need an explicit elimination
-predicate because all the |rhs| have the same type and Coq
+predicate because all the |rhs| have the same type and Rocq
 succeeds to synthesize it. Unfortunately when dealing with dependent
 patterns it often happens that we need to write cases where the types
 of the |rhs| are different instances of the elimination predicate. The

--- a/doc/sphinx/license.rst
+++ b/doc/sphinx/license.rst
@@ -1,6 +1,6 @@
 .. note:: **License**
 
-   This material (the Coq Reference Manual) may be distributed only
+   This material (the Rocq Reference Manual) may be distributed only
    subject to the terms and conditions set forth in the Open
    Publication License, v1.0 or later (the latest version is presently
    available at http://www.opencontent.org/openpub). Options A and B

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -1,7 +1,7 @@
 .. _thecoqcommands:
 
-Coq commands
-====================
+The Rocq Prover commands
+========================
 
 There are several Coq commands:
 

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -1,34 +1,34 @@
 .. _utilities:
 
-----------------------
- Building Coq Projects
-----------------------
+------------------------
+ Building Rocq Projects
+------------------------
 
 .. _configuration_basics:
 
-Coq configuration basics
-------------------------
+Rocq configuration basics
+-------------------------
 
-Describes the basics of Coq configuration that affect
-running and compiling Coq scripts.  It recommends preferred ways to
-install Coq, manage installed packages and structure your project
+Describes the basics of Rocq configuration that affect
+running and compiling Rocq scripts.  It recommends preferred ways to
+install the Rocq Prover, manage installed packages and structure your project
 directories for ease of use.
 
-Installing Coq and Coq packages with opam
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installing the Rocq Prover and Rocq packages with opam
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The easiest way to install Coq is with the
+The easiest way to install the Rocq Prover is with the
 `Coq Platform <https://github.com/coq/platform>`_, which relies
 on the `opam package manager <https://coq.inria.fr/opam-using.html>`_.
 
 The Coq platform installation process provides options to automatically install
 some of the most frequently used packages at the
 same time.  While there's currently no guarantee that user-developed packages
-will compile on the current version of Coq, all packages
+will compile on the current version of Rocq, all packages
 that Coq platform installs should compile without difficulty--this is part of
 the Coq platform release process.
 
-Once you've installed Coq, you can search for additional user-developed packages
+Once you've installed Rocq, you can search for additional user-developed packages
 from the `package list <https://coq.inria.fr/opam/www/>`_ or other opam repositories.
 These commands may be helpful:
 
@@ -62,7 +62,7 @@ in :cmd:`Require` commands.  There are a couple ways to do this:
   installed user-contributed packages.  You should be able to guess which one you
   need.
 
-- Use the :cmd:`Print LoadPath` command when running Coq, which shows the mapping
+- Use the :cmd:`Print LoadPath` command when running Rocq, which shows the mapping
   from :term:`logical path`\s to directories.  Again, you should be able to guess.
 
 The last two methods work even if you didn't install with opam.  Perhaps in the
@@ -79,17 +79,17 @@ Setup for working on your own projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The working and master copies of source code for your own projects should
-not be in the directory tree where Coq is installed.  In particular, when you upgrade
-to a new version of Coq, any directories you created in the old version won't
+not be in the directory tree where Rocq is installed.  In particular, when you upgrade
+to a new version of Rocq, any directories you created in the old version won't
 be copied or moved.
 
 We encourage you to use a source code control system for any non-trivial
 project because it makes it easy to track the history of your changes.
-`git <https://git-scm.com/>`_ is the system most used by Coq projects.
+`git <https://git-scm.com/>`_ is the system most used by Rocq projects.
 Typically, each project has its own git repository.
 
 For a project that has only a single file, you can create the file wherever you like
-and then step through it in one of the IDEs for Coq, such as
+and then step through it in one of the IDEs for Rocq, such as
 :ref:`coqintegrateddevelopmentenvironment`,
 `ProofGeneral <https://proofgeneral.github.io/>`_,
 `vsCoq <https://github.com/coq-community/vscoq>`_
@@ -120,7 +120,7 @@ The `_CoqProject` file identifies the :term:`logical path` to associate with the
 directories containing your compiled files.  The `_CoqProject` file is normally
 in the top directory of the project.  Occasionally it may be useful to have
 additional `_CoqProject` files in subdirectories, for example in order to pass
-different startup parameters to Coq for particular scripts.
+different startup parameters to Rocq for particular scripts.
 
 .. _building_with_coqproject:
 
@@ -175,7 +175,7 @@ Or you can easily do a global replace, if necessary, on the package name
 before it is (widely) used.  After that, a name change may begin to impact
 a large number of users.  Alas, there's currently no easy way to discover what
 :term:`logical name`\s have already been used.  The :cmd:`Print LoadPath` command helps
-a bit; it shows the logical names defined in the Coq process.
+a bit; it shows the logical names defined in the Rocq process.
 
 Then:
 
@@ -194,10 +194,10 @@ in `_CoqProject`, update `_CoqProject` and re-run `coq_makefile` and `make`.
 
 We recommend checking `CoqMakefile` and `CoqMakefile.conf` into your source code
 control system.  Also we recommend updating them with `coq_makefile` when you switch
-to a new version of Coq.
+to a new version of Rocq.
 
 In CoqIDE, you must explicitly save modified buffers before running `make` and
-restart the Coq interpreter in any buffers in which you're running code.
+restart the Rocq interpreter in any buffers in which you're running code.
 More details :ref:`here <coqide_make_note>`.
 
 See :ref:`coq_makefile` for a complete description of `coq_makefile` and the
@@ -233,17 +233,17 @@ The components of each pair share suffixes, e.g. `Bignums.BigZ` and `Bignums/Big
 `Coq.Numbers.Natural` and `Numbers/Natural`.  Physical pathnames should
 always use `/` rather than `\\`, even when running on Windows.
 Packages with a physical path containing `user-contrib` were installed
-with the Coq binaries (e.g. `Ltac2`), with the Coq Platform or with opam (e.g. `Bignums`)
+with the Rocq binaries (e.g. `Ltac2`), with the Coq Platform or with opam (e.g. `Bignums`)
 or perhaps by other means.  Note that, for these entries, the entire logical path
 appears in the directory name.
-Packages that begin with `Coq` were installed with the Coq binaries.  Note
-that the :term:`logical name` `Coq` doesn't appear in the physical path.
+Packages that begin with `Stdlib` were installed with the Rocq binaries.  Note
+that the :term:`logical name` `Stdlib` doesn't appear in the physical path.
 
 The `<>` in the final entry represents an empty logical pathname, which
 permits loading files from the
 associated directory with just the basename of the script file,
 e.g. specify `Foo` to load `Foo.vo`.  This entry corresponds to the
-current directory when Coq was started.  Note that the :cmd:`Cd` command
+current directory when Rocq was started.  Note that the :cmd:`Cd` command
 doesn't change the associated directory--you would need to restart CoqIDE.
 
 With some exceptions noted below, the :term:`load path` is generated from files loaded
@@ -252,7 +252,7 @@ associated logical path is determined from the filesystem path, relative to the
 directory, e.g. the file `Foo/Bar/script.vo` becomes `Foo.Bar.script`:
 
 - directories specified with :ref:`-R and -Q command line options <-Q-option>`,
-- the current directory where the Coq process was launched (without
+- the current directory where the Rocq process was launched (without
   including subdirectories),
 - the directories listed in the `COQPATH` environment variable (separated with
   colons, or, on Windows, with semicolons)
@@ -264,9 +264,9 @@ directory, e.g. the file `Foo/Bar/script.vo` becomes `Foo.Bar.script`:
   <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_).
   However, CoqIDE relies on the default setting; therefore we recommend not
   setting this variable.
-- installed packages from the `user-contrib` directory in the Coq installation,
-- the Coq standard library from the `theories` directory in the Coq installation
-  (with `Coq` prepended to the logical path),
+- installed packages from the `user-contrib` directory in the Rocq installation,
+- the Rocq standard library from the `theories` directory in the Rocq installation
+  (with `Stdlib` prepended to the logical path),
 
 .. todo: XDG* with example(s) and suggest best practices for their use
 
@@ -279,7 +279,7 @@ is often sufficient in :cmd:`Require` instead of a fully qualified
 name.
 
 In :cmd:`Require` commands referring to the current package (if `_CoqProject`
-uses `-R`) or Coq's standard library can be referenced with a short name without
+uses `-R`) can be referenced with a short name without
 a `From` clause provided that the logical path is unambiguous (as if they are
 available through `-R`).  In contrast, :cmd:`Require` commands that load files from other
 locations such as `user-contrib` must either use an exact logical path
@@ -291,7 +291,7 @@ Note that if you use a `_CoqProject` file, the `COQPATH` environment variable is
 If you use `COQPATH` without a `_CoqProject`, a file in `MyPackage/theories/SubDir/File.v` will be
 loaded with the logical name `MyPackage/theories/SubDir.File`, which may not be what you want.
 
-If you associate the same logical name with more than one directory, Coq
+If you associate the same logical name with more than one directory, Rocq
 looks for the `.vo` file in the most recently added path first (i.e., the one
 that appears earlier in the :cmd:`Print LoadPath` output).
 
@@ -324,7 +324,7 @@ Installed and uninstalled packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The directory structure of installed packages (i.e., in the `user-contrib` directory
-of the Coq installation) differs from that generally used for the project source tree.
+of the Rocq installation) differs from that generally used for the project source tree.
 The installed directory structure omits the pathname given in the `-R` and `-Q`
 parameters that aren't part of the logical name of a script.  For example, the `theories`
 pathname used in this `_CoqProject` file is omitted from the installed pathname::
@@ -339,9 +339,7 @@ pathname used in this `_CoqProject` file is omitted from the installed pathname:
 Use :n:`make -f CoqMakefile install` to install a project from a directory.
 
 If you try to step through scripts in installed packages (e.g. to understand
-the proofs therein), you may get unexpected failures for two reasons (which
-don't apply to scripts in the standard library, which have logical paths
-beginning with `Coq`):
+the proofs therein), you may get unexpected failures for two reasons:
 
 * `_CoqProject` files often have at least one `-R` parameter, while
   installed packages are loaded with the less-permissive `-Q` option described in
@@ -351,37 +349,37 @@ beginning with `Coq`):
   need to list all the source files.
 
 * Sometimes, the `_CoqProject` file specifies options that affect the
-  behavior of Coq, such as `-impredicative-set`.  These can similarly be
+  behavior of Rocq, such as `-impredicative-set`.  These can similarly be
   added in `_CoqProject` files in `user-contrib`.
 
 Another way to get around these problems is to download the source tree for the
 project in a new directory and compile it before stepping through its scripts.
 
-Upgrading to a new version of Coq
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upgrading to a new version of Rocq
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`.vo` files are specific to the version of Coq that compiled them.  When you
-upgrade to a new version of Coq, you must recompile all the projects
+`.vo` files are specific to the version of Rocq that compiled them.  When you
+upgrade to a new version of Rocq, you must recompile all the projects
 that you want to run in the new version.  This is necessary to assure that
 your proofs still work in the new version.  Once their projects build on the
 new version, most users no longer have a need to run on the old version.
 
 If, however, you want to overlap working on your project on both the old and new
 versions, you'll need to create separate source directories for your project
-for the different Coq versions.  Currently the compiled `.vo` files are kept
+for the different Rocq versions.  Currently the compiled `.vo` files are kept
 in the same directory as their corresponding `.v` file.
 
 .. todo: Making your packages available with opam
 
 .. _coq_makefile:
 
-Building a Coq project with coq_makefile (details)
---------------------------------------------------
+Building a Rocq project with coq_makefile (details)
+---------------------------------------------------
 
-The ``coq_makefile`` tool is included with Coq and is based on generating a makefile.
+The ``coq_makefile`` tool is included with Rocq and is based on generating a makefile.
 
-The majority of Coq projects are very similar: a collection of ``.v``
-files and possibly some ``.ml`` ones (a Coq plugin). The main piece of
+The majority of Rocq projects are very similar: a collection of ``.v``
+files and possibly some ``.ml`` ones (a Rocq plugin). The main piece of
 metadata needed in order to build the project are the command line
 options to ``coqc`` (e.g. ``-R``, ``-Q``, ``-I``, see :ref:`command
 line options <command-line-options>`). Collecting the list of files
@@ -441,10 +439,10 @@ The ``-native-compiler`` option given in the ``_CoqProject`` file overrides
 the global one passed at configure time.
 
 CoqIDE, Proof General, VsCoq and Coqtail all
-understand ``_CoqProject`` files and can be used to invoke Coq with the desired options.
+understand ``_CoqProject`` files and can be used to invoke Rocq with the desired options.
 
 The ``coq_makefile`` utility can be used to set up a build infrastructure
-for the Coq project based on makefiles. We recommend
+for the Rocq project based on makefiles. We recommend
 invoking ``coq_makefile`` this way:
 
 ::
@@ -457,13 +455,13 @@ This command generates the following files:
 CoqMakefile
   is a makefile for ``GNU Make`` with targets to build the project
   (e.g. generate .vo or .html files from .v or compile .ml* files)
-  and install it in the ``user-contrib`` directory where the Coq
+  and install it in the ``user-contrib`` directory where the Rocq
   library is installed.
 
 CoqMakefile.conf
   contains make variables assignments that reflect
   the contents of the ``_CoqProject`` file as well as the path relevant to
-  Coq.
+  Rocq.
 
 Run ``coq_makefile --help`` for a description of command line options.
 
@@ -502,9 +500,9 @@ The recommended approach is to invoke ``CoqMakefile`` from a standard
 
 The advantage of a wrapper, compared to directly calling the generated
 ``Makefile``, is that it
-provides a target independent of the version of Coq to regenerate a
-``Makefile`` specific to the current version of Coq. Additionally, the
-master ``Makefile`` can be extended with targets not specific to Coq.
+provides a target independent of the version of Rocq to regenerate a
+``Makefile`` specific to the current version of Rocq. Additionally, the
+master ``Makefile`` can be extended with targets not specific to Rocq.
 Including the generated makefile with an include directive is
 discouraged, since the contents of this file, including variable names and
 status of rules, may change in the future.
@@ -532,7 +530,7 @@ The extensions of files listed in ``_CoqProject`` determine
 how they are built. In particular:
 
 
-+ Coq files must use the ``.v`` extension
++ Rocq files must use the ``.v`` extension
 + OCaml files must use the ``.ml`` or ``.mli`` extension
 + OCaml files that require pre processing for syntax
   extensions (like ``VERNAC EXTEND``) must use the ``.mlg`` extension
@@ -579,7 +577,7 @@ Warning: No common logical root
 +++++++++++++++++++++++++++++++
 When a ``_CoqProject`` file contains something like ``-R theories Foo
 theories/Bar.v``, the ``install-doc`` target installs the documentation
-generated by ``coqdoc`` into ``user-contrib/Foo/``, in the folder where Coq was
+generated by ``coqdoc`` into ``user-contrib/Foo/``, in the folder where Rocq was
 installed.
 
 But if the ``_CoqProject`` file contains something like:
@@ -591,7 +589,7 @@ But if the ``_CoqProject`` file contains something like:
     theories/Foo/Foo.v
     theories/Bar/Bar.v
 
-the Coq files of the project don’t have a :term:`logical path` in common and
+the Rocq files of the project don’t have a :term:`logical path` in common and
 ``coq_makefile`` doesn’t know where to install the documentation. It will give
 a warning: "No common logical root" and generate a Makefile that installs the
 documentation in some folder beginning with "orphan", in the above example,
@@ -623,7 +621,7 @@ section of the generated makefile. These include:
 :OCAMLWARN:
    it contains a default of ``-warn-error +a-3``, useful to modify
    this setting; beware this is not recommended for projects in
-   Coq's CI.
+   Rocq's CI.
 :COQC, COQDEP, COQDOC:
    can be set in order to use alternative binaries
    (e.g. wrappers)
@@ -645,7 +643,7 @@ section of the generated makefile. These include:
 :COQDOCEXTRAFLAGS:
    extend the flags passed to ``coqdoc``
 :COQLIBINSTALL, COQPLUGININSTALL, COQDOCINSTALL:
-   specify where the Coq libraries, plugins and documentation will be installed.
+   specify where the Rocq libraries, plugins and documentation will be installed.
    By default a combination of ``$(DESTDIR)`` (if defined) with
    ``$(COQLIB)/user-contrib``, ``$(COQCORELIB)/..`` and ``$(DOCDIR)/coq/user-contrib``.
 
@@ -707,9 +705,9 @@ file ``CoqMakefile``.  The following is a partial list of accessible variables:
 
 :COQ_VERSION:
    the version of ``coqc`` being used, which can be used to
-   provide different behavior depending on the Coq version
+   provide different behavior depending on the Rocq version
 :COQMAKEFILE_VERSION:
-   the version of Coq used to generate the
+   the version of Rocq used to generate the
    Makefile, which can be used to detect version mismatches
 :ALLDFILES:
    the list of generated dependency files, which can be used,
@@ -729,7 +727,7 @@ variables are already accessible in recipes for rules added in
 :COQC, COQDEP, COQDOC, CAMLC, CAMLOPTC:
    compiler binaries
 :COQFLAGS, CAMLFLAGS, COQLIBS, COQDEBUG, OCAMLLIBS:
-   flags passed to the Coq or OCaml compilers
+   flags passed to the Rocq or OCaml compilers
 
 Timing targets and performance testing
 ++++++++++++++++++++++++++++++++++++++
@@ -992,7 +990,7 @@ Precompiling for ``native_compute``
 +++++++++++++++++++++++++++++++++++
 
 To compile files for ``native_compute``, one can use the
-``-native-compiler yes`` option of Coq, by putting it in the ``_CoqProject``
+``-native-compiler yes`` option of Rocq, by putting it in the ``_CoqProject``
 file.
 
 The generated installation target of ``CoqMakefile`` will then take care of
@@ -1063,29 +1061,29 @@ In addition, it is impossible to pass strings containing ``'`` to coqc via
 
 .. _building_dune:
 
-Building a Coq project with Dune
---------------------------------
+Building a Rocq project with Dune
+---------------------------------
 
-Dune, the standard OCaml build tool, has supported building Coq libraries since version 1.9.
+Dune, the standard OCaml build tool, has supported building Rocq libraries since version 1.9.
 
 .. note::
 
-   Dune's Coq support is still experimental; we strongly recommend
+   Dune's Rocq support is still experimental; we strongly recommend
    using Dune 3.2 or later.
 
 .. note::
 
-   The canonical documentation for the Coq Dune extension is
+   The canonical documentation for the Rocq Dune extension is
    maintained upstream; please refer to the `Dune manual
    <https://dune.readthedocs.io/>`_ for up-to-date information. The
    documentation below is up to date for Dune 3.2
 
-Building a Coq project with Dune requires setting up a Dune project
+Building a Rocq project with Dune requires setting up a Dune project
 for your files. This involves adding a ``dune-project`` and
 ``pkg.opam`` file to the root (``pkg.opam`` can be empty or generated
 by Dune itself), and then providing ``dune`` files in the directories
 your ``.v`` files are placed. For the experimental version "0.3" of
-the Coq Dune language, Coq library stanzas look like:
+the Coq Dune language, Rocq library stanzas look like:
 
 .. code:: scheme
 
@@ -1102,12 +1100,12 @@ the library under ``<module_prefix>``. If you declare an
 ``<opam_package>``, an ``.install`` file for the library will be
 generated; the optional ``(modules <ordered_set_lang>)`` field allows
 you to filter the list of modules, and ``(libraries
-<ocaml_libraries>)`` allows the Coq theory depend on ML plugins. For
-the moment, Dune relies on Coq's standard mechanisms (such as
-``COQPATH``) to locate installed Coq libraries.
+<ocaml_libraries>)`` allows the Rocq theory depend on ML plugins. For
+the moment, Dune relies on Rocq's standard mechanisms (such as
+``COQPATH``) to locate installed Rocq libraries.
 
 By default Dune will skip ``.v`` files present in subdirectories. In
-order to enable the usual recursive organization of Coq projects add
+order to enable the usual recursive organization of Rocq projects add
 
 .. code:: scheme
 
@@ -1124,7 +1122,7 @@ syntax for `Declare ML Module`, see example below:
 
 .. example::
 
-   A typical stanza for a Coq plugin is split into two parts. An OCaml build directive, which is standard Dune:
+   A typical stanza for a Rocq plugin is split into two parts. An OCaml build directive, which is standard Dune:
 
    .. code:: scheme
 
@@ -1136,7 +1134,7 @@ syntax for `Declare ML Module`, see example below:
 
        (coq.pp (modules g_equations))
 
-   And a Coq-specific part that depends on it via the ``libraries`` field:
+   And a Rocq-specific part that depends on it via the ``libraries`` field:
 
    .. code:: scheme
 
@@ -1163,36 +1161,36 @@ coqdep: Computing Module dependencies
 -------------------------------------
 
 In order to compute module dependencies (to be used by ``make`` or
-``dune``), Coq provides the ``coqdep`` tool.
+``dune``), Rocq provides the ``coqdep`` tool.
 
-``coqdep`` computes inter-module dependencies for Coq
+``coqdep`` computes inter-module dependencies for Rocq
 programs, and prints the dependencies on the standard output in a
 format readable by make. When a directory is given as argument, it is
 recursively looked at.
 
-Dependencies of Coq modules are computed by looking at :cmd:`Require`
+Dependencies of Rocq modules are computed by looking at :cmd:`Require`
 and :cmd:`Declare ML Module` commands.
 
 See the man page of ``coqdep`` for more details and options.
 
 Both Dune and ``coq_makefile`` use ``coqdep`` to compute the
-dependencies among the files part of a Coq project.
+dependencies among the files part of a Rocq project.
 
 .. _coqnative:
 
 Split compilation of native computation files
 ---------------------------------------------
 
-Coq features a :tacn:`native_compute` tactic to provide fast computation in the
-kernel. This process performs compilation of Coq terms to OCaml programs using
+Rocq features a :tacn:`native_compute` tactic to provide fast computation in the
+kernel. This process performs compilation of Rocq terms to OCaml programs using
 the OCaml compiler, which may cause an important overhead. Hence native
 compilation is an opt-in configure flag.
 
-When native compilation is activated, Coq generates the compiled files upfront,
+When native compilation is activated, Rocq generates the compiled files upfront,
 i.e. during the ``coqc`` invocation on the corresponding ``.v`` file. This is
 impractical because it means one must chose in advance whether they will use
-a native-capable Coq installation. In particular, activating native compilation
-forces the recompilation of the whole Coq installation. See
+a native-capable Rocq installation. In particular, activating native compilation
+forces the recompilation of the whole Rocq installation. See
 :ref:`command line options <command-line-options>` for more details.
 
 Starting from Coq 8.14, a new binary ``coqnative`` is available. It allows
@@ -1200,7 +1198,7 @@ performing split native compilation by generating the native compute files out
 of the compiled ``.vo`` file rather than out of the source ``.v`` file.
 
 The ``coqnative`` command takes a name *file.vo* as argument and tries to
-perform native compilation on it. It assumes that the Coq libraries on which
+perform native compilation on it. It assumes that the Rocq libraries on which
 *file.vo* depends have been first compiled to their native files, and will fail
 otherwise. It accepts the ``-R``, ``-Q``, ``-I`` and ``-nI`` arguments with the
 same semantics as if the native compilation process had been performed through
@@ -1210,10 +1208,10 @@ same semantics as if the native compilation process had been performed through
 
 + ``-I`` is a no-op that is accepted only for scripting convenience
 
-Using Coq as a library
+Using Rocq as a library
 ------------------------
 
-It is possible to build custom Coq executables - for example for
+It is possible to build custom Rocq executables - for example for
 better debugging or custom static linking.
 
 The preferred method is to use ``dune``:
@@ -1238,21 +1236,21 @@ For example, to statically link |Ltac|, you can do:
 
 and similarly for other plugins.
 
-Embedded Coq phrases inside |Latex| documents
+Embedded Rocq phrases inside |Latex| documents
 -----------------------------------------------
 
 When writing documentation about a proof development, one may want
-to insert Coq phrases inside a |Latex| document, possibly together
+to insert Rocq phrases inside a |Latex| document, possibly together
 with the corresponding answers of the system. We provide a mechanical
-way to process such Coq phrases embedded in |Latex| files: the ``coq-tex``
-filter. This filter extracts Coq phrases embedded in |Latex| files,
+way to process such Rocq phrases embedded in |Latex| files: the ``coq-tex``
+filter. This filter extracts Rocq phrases embedded in |Latex| files,
 evaluates them, and insert the outcome of the evaluation after each
 phrase.
 
-Starting with a file ``file.tex`` containing Coq phrases, the ``coq-tex``
-filter produces a file named ``file.v.tex`` with the Coq outcome.
+Starting with a file ``file.tex`` containing Rocq phrases, the ``coq-tex``
+filter produces a file named ``file.v.tex`` with the Rocq outcome.
 
-There are options to produce the Coq parts in smaller font, italic,
+There are options to produce the Rocq parts in smaller font, italic,
 between horizontal rules, etc. See the man page of ``coq-tex`` for more
 details.
 

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -6,7 +6,7 @@ Ltac
 .. note::
 
    Writing automation using Ltac is discouraged.
-   Many alternatives are available as part of the Coq standard library
+   Many alternatives are available as part of the Rocq standard library
    or the `Coq Platform <https://github.com/coq/platform>`_, and some
    demonstration of their respective power is performed in the
    `metaprogramming Rosetta stone project <https://github.com/coq-community/metaprogramming-rosetta-stone>`_.
@@ -15,7 +15,7 @@ Ltac
    encourage users to use Ltac2 (or other alternatives) instead of Ltac
    for new projects and new automation code in existing projects.
    Reports about hindrances in using Ltac2 for writing automation are
-   welcome as issues on the `Coq bug tracker <https://github.com/coq/coq/issues>`_
+   welcome as issues on the `Rocq bug tracker <https://github.com/coq/coq/issues>`_
    or as discussions on the `Ltac2 Zulip stream <https://coq.zulipchat.com/#narrow/stream/278935-Ltac2>`_.
 
 This chapter documents the tactic language |Ltac|.
@@ -23,7 +23,7 @@ This chapter documents the tactic language |Ltac|.
 We start by giving the syntax followed by the informal
 semantics. To learn more about the language and
 especially about its foundations, please refer to :cite:`Del00`.
-(Note the examples in the paper won't work as-is; Coq has evolved
+(Note the examples in the paper won't work as-is; Rocq has evolved
 since the paper was written.)
 
 .. example:: Basic tactic macros
@@ -45,7 +45,7 @@ Defects
 -------
 
 The |Ltac| tactic language is probably one of the ingredients of the success of
-Coq, yet it is at the same time its Achilles' heel. Indeed, |Ltac|:
+Rocq, yet it is at the same time its Achilles' heel. Indeed, |Ltac|:
 
 - has often unclear semantics
 - is very non-uniform due to organic growth
@@ -83,7 +83,7 @@ higher precedence than `+`.  Usually `a/b/c` is given the :gdef:`left associativ
 interpretation `(a/b)/c` rather than the :gdef:`right associative` interpretation
 `a/(b/c)`.
 
-In Coq, the expression :n:`try repeat @tactic__1 || @tactic__2; @tactic__3; @tactic__4`
+In Rocq, the expression :n:`try repeat @tactic__1 || @tactic__2; @tactic__3; @tactic__4`
 is interpreted as :n:`(try (repeat (@tactic__1 || @tactic__2)); @tactic__3); @tactic__4`
 because `||` is part of :token:`ltac_expr2`, which has higher precedence than
 :tacn:`try` and :tacn:`repeat` (at the level of :token:`ltac_expr3`), which
@@ -409,7 +409,7 @@ behavior.)
       The number of workers can be controlled via the command line option
       :n:`-async-proofs-tac-j @natural` to specify the desired number of workers.
       In the special case where :n:`@natural` is 0, this completely prevents
-      Coq from spawning any new process, and `par` blocks are treated as a
+      Rocq from spawning any new process, and `par` blocks are treated as a
       variant of `all` that additionally checks that each subgoal is solved.
       Limitations: ``par:`` only works on goals that don't contain existential
       variables.  :n:`@ltac_expr` must either solve the goal completely or do
@@ -559,7 +559,7 @@ A sequence is an expression of the following form:
    :n:`v__2` is applied to all the goals produced by the prior
    application. Sequence is associative.
 
-   This construct uses backtracking: if :n:`@ltac_expr3__2` fails, Coq will
+   This construct uses backtracking: if :n:`@ltac_expr3__2` fails, Rocq will
    try each alternative success (if any) for :n:`@ltac_expr3__1`, retrying
    :n:`@ltac_expr3__2` for each until both tactics succeed or all alternatives
    have failed.  See :ref:`branching_and_backtracking`.
@@ -859,7 +859,7 @@ Success and failure
 Checking for success: assert_succeeds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coq defines an |Ltac| tactic in `Init.Tactics` to check that a tactic has *at least one*
+Rocq defines an |Ltac| tactic in `Init.Tactics` to check that a tactic has *at least one*
 success:
 
 .. tacn:: assert_succeeds @ltac_expr3
@@ -870,7 +870,7 @@ success:
 Checking for failure: assert_fails
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coq defines an |Ltac| tactic in `Init.Tactics` to check that a tactic *fails*:
+Rocq defines an |Ltac| tactic in `Init.Tactics` to check that a tactic *fails*:
 
 .. tacn:: assert_fails @ltac_expr3
 
@@ -930,7 +930,7 @@ Failing
 
    See the example for a comparison of the two constructs.
 
-   Note that if Coq terms have to be
+   Note that if Rocq terms have to be
    printed as part of the failure, term construction always forces the
    tactic into the goals, meaning that if there are no goals when it is
    evaluated, a tactic call like :tacn:`let` :n:`x := H in` :tacn:`fail` `0 x` will succeed.
@@ -1015,7 +1015,7 @@ single success:
 Checking for a single success: exactly_once
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coq provides an experimental way to check that a tactic has *exactly
+Rocq provides an experimental way to check that a tactic has *exactly
 one* success:
 
 .. tacn:: exactly_once @ltac_expr3
@@ -1075,7 +1075,7 @@ Pattern matching on terms: match
    then the :token:`ltac_expr` can't use `S` to refer to the constructor of `nat`
    without qualifying the constructor as `Datatypes.S`.
 
-   .. todo how does this differ from the 1-2 other unification routines elsewhere in Coq?
+   .. todo how does this differ from the 1-2 other unification routines elsewhere in Rocq?
       Does it use constr_eq or eq_constr_nounivs?
 
    Matching is non-linear: if a
@@ -1456,7 +1456,7 @@ produce subgoals but generates a term to be used in tactic expressions:
 Generating fresh hypothesis names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tactics sometimes need to generate new names for hypothesis.  Letting Coq
+Tactics sometimes need to generate new names for hypothesis.  Letting Rocq
 choose a name with the intro tactic is not so good since it is
 very awkward to retrieve that name. The following
 expression returns an identifier:
@@ -2030,7 +2030,7 @@ Proving that a list is a permutation of a second list
    From Section :ref:`ltac-syntax` we know that Ltac has a primitive
    notion of integers, but they are only used as arguments for
    primitive tactics and we cannot make computations with them. Thus,
-   instead, we use Coq's natural number type :g:`nat`.
+   instead, we use Rocq's natural number type :g:`nat`.
 
    .. coqtop:: in
 

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -22,7 +22,7 @@ In particular, Ltac2 is:
   * together with the Hindley-Milner type system
 
 - a language featuring meta-programming facilities for the manipulation of
-  Coq-side terms
+  Rocq-side terms
 - a language featuring notation facilities to help write palatable scripts
 
 We describe these in more detail in the remainder of this document.
@@ -40,14 +40,14 @@ that ML constitutes a sweet spot in PL design, as it is relatively expressive
 while not being either too lax (unlike dynamic typing) nor too strict
 (unlike, say, dependent types).
 
-The main goal of Ltac2 is to serve as a meta-language for Coq. As such, it
+The main goal of Ltac2 is to serve as a meta-language for Rocq. As such, it
 naturally fits in the ML lineage, just as the historical ML was designed as
 the tactic language for the LCF prover. It can also be seen as a general-purpose
-language, by simply forgetting about the Coq-specific features.
+language, by simply forgetting about the Rocq-specific features.
 
 Sticking to a standard ML type system can be considered somewhat weak for a
-meta-language designed to manipulate Coq terms. In particular, there is no
-way to statically guarantee that a Coq term resulting from an Ltac2
+meta-language designed to manipulate Rocq terms. In particular, there is no
+way to statically guarantee that a Rocq term resulting from an Ltac2
 computation will be well-typed. This is actually a design choice, motivated
 by backward compatibility with Ltac1. Instead, well-typedness is deferred to
 dynamic checks, allowing many primitive functions to fail whenever they are
@@ -542,7 +542,7 @@ is a proper one or referring to something in the Ltac context.
 
 Likewise, in Ltac1, constr parsing is implicit, so that ``foo 0`` is
 not ``foo`` applied to the Ltac integer expression ``0`` (|Ltac| does have a
-notion of integers, though it is not first-class), but rather the Coq term
+notion of integers, though it is not first-class), but rather the Rocq term
 :g:`Datatypes.O`.
 
 The implicit parsing is confusing to users and often gives unexpected results.
@@ -575,13 +575,13 @@ Built-in quotations
 The current implementation recognizes the following built-in quotations:
 
 - ``ident``, which parses identifiers (type ``Init.ident``).
-- ``constr``, which parses Coq terms and produces an-evar free term at runtime
+- ``constr``, which parses Rocq terms and produces an-evar free term at runtime
   (type ``Init.constr``).
-- ``open_constr``, which parses Coq terms and produces a term potentially with
+- ``open_constr``, which parses Rocq terms and produces a term potentially with
   holes at runtime (type ``Init.constr`` as well).
-- ``preterm``, which parses Coq terms and produces a value which must
+- ``preterm``, which parses Rocq terms and produces a value which must
   be typechecked with ``Constr.pretype`` (type ``Init.preterm``).
-- ``pat``, which parses Coq patterns and produces a pattern used for term
+- ``pat``, which parses Rocq patterns and produces a pattern used for term
   matching (type ``Init.pattern``).
 - ``reference``  Qualified names
   are globalized at internalization into the corresponding global reference,
@@ -626,7 +626,7 @@ Term Antiquotations
 Syntax
 ++++++
 
-One can also insert Ltac2 code into Coq terms, similar to what is possible in
+One can also insert Ltac2 code into Rocq terms, similar to what is possible in
 Ltac1.
 
 .. prodn::
@@ -638,7 +638,7 @@ for their side-effects.
 Semantics
 +++++++++
 
-A quoted Coq term is interpreted in two phases, internalization and
+A quoted Rocq term is interpreted in two phases, internalization and
 evaluation.
 
 - Internalization is part of the static semantics, that is, it is done at Ltac2
@@ -646,17 +646,17 @@ evaluation.
 - Evaluation is part of the dynamic semantics, that is, it is done when
   a term gets effectively computed by Ltac2.
 
-Note that typing of Coq terms is a *dynamic* process occurring at Ltac2
+Note that typing of Rocq terms is a *dynamic* process occurring at Ltac2
 evaluation time, and not at Ltac2 typing time.
 
 Static semantics
 ****************
 
-During internalization, Coq variables are resolved and antiquotations are
-type checked as Ltac2 terms, effectively producing a ``glob_constr`` in Coq
+During internalization, Rocq variables are resolved and antiquotations are
+type checked as Ltac2 terms, effectively producing a ``glob_constr`` in Rocq
 implementation terminology. Note that although it went through the
 type checking of **Ltac2**, the resulting term has not been fully computed and
-is potentially ill-typed as a runtime **Coq** term.
+is potentially ill-typed as a runtime **Rocq** term.
 
 .. example::
 
@@ -678,7 +678,7 @@ of the corresponding term expression.
       let x := '0 in constr:(1 + ltac2:(exact $x))
 
 Beware that the typing environment of antiquotations is **not**
-expanded by the Coq binders from the term.
+expanded by the Rocq binders from the term.
 
   .. example::
 
@@ -701,17 +701,17 @@ as follows.
 
 `constr:(fun x : nat => ltac2:(exact (hyp @x)))`
 
-This pattern is so common that we provide dedicated Ltac2 and Coq term notations
+This pattern is so common that we provide dedicated Ltac2 and Rocq term notations
 for it.
 
 - `&x` as an Ltac2 expression expands to `hyp @x`.
-- `&x` as a Coq constr expression expands to
+- `&x` as a Rocq constr expression expands to
   `ltac2:(Control.refine (fun () => hyp @x))`.
 
-In the special case where Ltac2 antiquotations appear inside a Coq term
+In the special case where Ltac2 antiquotations appear inside a Rocq term
 notation, the notation variables are systematically bound in the body
 of the tactic expression with type `Ltac2.Init.preterm`. Such a type represents
-untyped syntactic Coq expressions, which can by typed in the
+untyped syntactic Rocq expressions, which can by typed in the
 current context using the `Ltac2.Constr.pretype` function.
 
 .. example::
@@ -761,9 +761,9 @@ or equivalently
 
 .. prodn:: term += $constr:@lident
 
-In a Coq term, writing :g:`$x` is semantically equivalent to
+In a Rocq term, writing :g:`$x` is semantically equivalent to
 :g:`ltac2:(Control.refine (fun () => x))`, up to re-typechecking. It allows to
-insert in a concise way an Ltac2 variable of type :n:`constr` into a Coq term.
+insert in a concise way an Ltac2 variable of type :n:`constr` into a Rocq term.
 
 Similarly variables of type `preterm` have an antiquotation
 
@@ -811,7 +811,7 @@ in a less hard-wired way.
    In the :token:`ltac2_match_pattern`\s, metavariables have the form :n:`?@ident`, whereas
    in the :n:`@ltac2_expr`\s, the question mark is omitted.
 
-   .. todo how does this differ from the 1-2 other unification routines elsewhere in Coq?
+   .. todo how does this differ from the 1-2 other unification routines elsewhere in Rocq?
 
    Matching is non-linear: if a
    metavariable occurs more than once, each occurrence must match the same
@@ -1216,7 +1216,7 @@ Notations
    When the notation is used, the values are substituted
    into the right-hand side.  In the following example, `x` is the formal parameter name and
    `constr` is its :ref:`syntactic class<syntactic_classes>`.  `print` and `of_constr` are
-   functions provided by Coq through `Message.v`.
+   functions provided by Rocq through `Message.v`.
 
    .. flag:: Ltac2 Typed Notations
 
@@ -1306,7 +1306,7 @@ Abbreviations
 
    Introduces a special kind of notation, called an abbreviation,
    that does not add any parsing rules. It is similar in
-   spirit to Coq abbreviations (see :cmd:`Notation (abbreviation)`,
+   spirit to Rocq abbreviations (see :cmd:`Notation (abbreviation)`,
    insofar as its main purpose is to give an
    absolute name to a piece of pure syntax, which can be transparently referred to
    by this name as if it were a proper definition.
@@ -1335,7 +1335,7 @@ Abbreviations
 Defining tactics
 ~~~~~~~~~~~~~~~~
 
-Built-in tactics (those defined in OCaml code in the Coq executable) and Ltac1 tactics,
+Built-in tactics (those defined in OCaml code in the Rocq executable) and Ltac1 tactics,
 which are defined in `.v` files, must be defined through notations.  (Ltac2 tactics can be
 defined with :cmd:`Ltac2`.
 
@@ -1343,7 +1343,7 @@ Notations for many but not all built-in tactics are defined in `Notations.v`, wh
 loaded with Ltac2.  The Ltac2 syntax for these tactics is often identical or very similar to the
 tactic syntax described in other chapters of this documentation.  These notations rely on tactic functions
 declared in `Std.v`.  Functions corresponding to some built-in tactics may not yet be defined in the
-Coq executable or declared in `Std.v`.  Adding them may require code changes to Coq or defining
+Rocq executable or declared in `Std.v`.  Adding them may require code changes to Rocq or defining
 workarounds through Ltac1 (described below).
 
 Two examples of syntax differences:
@@ -1375,7 +1375,7 @@ Syntactic classes
 ~~~~~~~~~~~~~~~~~
 
 The simplest syntactic classes in Ltac2 notations represent individual nonterminals
-from the Coq grammar.  Only a few selected nonterminals are available as syntactic classes.
+from the Rocq grammar.  Only a few selected nonterminals are available as syntactic classes.
 In addition, there are metasyntactic operations for describing
 more complex syntax, such as making an item optional or representing a list of items.
 When parsing, each syntactic class expression returns a value that's bound to a name in the
@@ -1901,7 +1901,7 @@ Transition from Ltac1
 Owing to the use of a lot of notations, the transition should not be too
 difficult. In particular, it should be possible to do it incrementally. That
 said, we do *not* guarantee it will be a blissful walk either.
-Hopefully, owing to the fact Ltac2 is typed, the interactive dialogue with Coq
+Hopefully, owing to the fact Ltac2 is typed, the interactive dialogue with the Rocq Prover
 will help you.
 
 We list the major changes and the transition strategies hereafter.

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -13,12 +13,12 @@ Introduction
 This chapter describes a set of tactics known as |SSR| originally
 designed to provide support for the so-called *small scale reflection*
 proof methodology. Despite the original purpose, this set of tactics is
-of general interest and is available in Coq starting from version 8.7.
+of general interest and is available in Rocq starting from version 8.7.
 
 |SSR| was developed independently of the tactics described in
 Chapter :ref:`tactics`. Indeed the scope of the tactics part of |SSR| largely
 overlaps with the standard set of tactics. Eventually the overlap will
-be reduced in future releases of Coq.
+be reduced in future releases of Rocq.
 
 Proofs written in |SSR| typically look quite different from the
 ones written using only tactics as per Chapter :ref:`tactics`. We try to
@@ -112,7 +112,7 @@ Compatibility issues
 ~~~~~~~~~~~~~~~~~~~~
 
 Requiring the above modules creates an environment that is mostly
-compatible with the rest of Coq, up to a few discrepancies.
+compatible with the rest of Rocq, up to a few discrepancies.
 
 
 + New keywords (``is``) might clash with variable, constant, tactic or
@@ -124,11 +124,11 @@ compatible with the rest of Coq, up to a few discrepancies.
 + Identifiers with both leading and trailing ``_``, such as ``_x_``, are
   reserved by |SSR| and cannot appear in scripts.
 + The extensions to the :tacn:`rewrite` tactic are partly incompatible with those
-  available in current versions of Coq; in particular, ``rewrite .. in
+  available in current versions of Rocq; in particular, ``rewrite .. in
   (type of k)`` or ``rewrite .. in *`` or any other variant of :tacn:`rewrite`
   will not work, and the |SSR| syntax and semantics for occurrence selection
   and rule chaining are different. Use an explicit rewrite direction
-  (``rewrite <- …`` or ``rewrite -> …``) to access the Coq rewrite tactic.
+  (``rewrite <- …`` or ``rewrite -> …``) to access the Rocq rewrite tactic.
 + New symbols (``//``, ``/=``, ``//=``) might clash with adjacent
   existing symbols.
   This can be avoided by inserting white spaces.
@@ -158,23 +158,23 @@ compatible with the rest of Coq, up to a few discrepancies.
   generalized form, turn off the |SSR| Boolean ``if`` notation using the command:
   ``Close Scope boolean_if_scope``.
 + The following flags can be unset to make |SSR| more compatible with
-  parts of Coq.
+  parts of Rocq.
 
 .. flag:: SsrRewrite
 
    Controls whether the incompatible rewrite syntax is enabled (the default).
-   Disabling the :term:`flag` makes the syntax compatible with other parts of Coq.
+   Disabling the :term:`flag` makes the syntax compatible with other parts of Rocq.
 
 .. flag:: SsrIdents
 
    Controls whether tactics can refer to |SSR|-generated variables that are
    in the form _xxx_.  Scripts with explicit references to such variables
    are fragile; they are prone to failure if the proof is later modified or
-   if the details of variable name generation change in future releases of Coq.
+   if the details of variable name generation change in future releases of Rocq.
 
    The default is on, which gives an error message when the user tries to
    create such identifiers.  Disabling the :term:`flag` generates a warning instead,
-   increasing compatibility with other parts of Coq.
+   increasing compatibility with other parts of Rocq.
 
 Gallina extensions
 --------------------
@@ -227,7 +227,7 @@ construct differs from the latter as follows.
        Definition f u := let: (m, n) := u in m + n.
        Check f.
 
-    Using :g:`let:`, Coq infers a type for :g:`f`,
+    Using :g:`let:`, Rocq infers a type for :g:`f`,
     whereas with a usual ``let`` the same term requires an extra type
     annotation in order to type check.
 
@@ -357,13 +357,13 @@ Parametric polymorphism
 
 Unlike ML, polymorphism in core Gallina is explicit: the type
 parameters of polymorphic functions must be declared explicitly, and
-supplied at each point of use. However, Coq provides two features to
+supplied at each point of use. However, Rocq provides two features to
 suppress redundant parameters.
 
 
 + Sections are used to provide (possibly implicit) parameters for a
   set of definitions.
-+ Implicit arguments declarations are used to tell Coq to use type
++ Implicit arguments declarations are used to tell Rocq to use type
   inference to deduce some parameters from the context at each point of
   call.
 
@@ -392,11 +392,11 @@ expressions such as
       Definition all_null (s : list T) := all (@null T) s.
 
 Unfortunately, such higher-order expressions are quite frequent in
-representation functions, especially those that use Coq's
+representation functions, especially those that use Rocq's
 ``Structures`` to emulate Haskell typeclasses.
 
-Therefore, |SSR| provides a variant of Coq’s implicit argument
-declaration, which causes Coq to fill in some implicit parameters at
+Therefore, |SSR| provides a variant of Rocq's implicit argument
+declaration, which causes Rocq to fill in some implicit parameters at
 each point of use; e.g., the above definition can be written:
 
 .. example::
@@ -432,7 +432,7 @@ The syntax of the new declaration is
 
    As these prenex implicit arguments are ubiquitous and have often large
    display strings, it is strongly recommended to change the default
-   display settings of Coq so that they are not printed (except after
+   display settings of Rocq so that they are not printed (except after
    a ``Set Printing All`` command). All |SSR| library files thus start
    with the incantation
 
@@ -958,7 +958,7 @@ context. This is essential in the context of an interactive
 development environment (IDE), because it facilitates navigating the
 proof, allowing to instantly "jump back" to the point at which a
 questionable assumption was added, and to find relevant assumptions by
-browsing the pruned context. While novice or casual Coq users may find
+browsing the pruned context. While novice or casual Rocq users may find
 the automatic name selection feature convenient, the usage of such a
 feature severely undermines the readability and maintainability of
 proof scripts, much like automatic variable declaration in programming
@@ -974,7 +974,7 @@ the foundation of the |SSR| proof language.
 Bookkeeping
 ~~~~~~~~~~~
 
-During the course of a proof, Coq always presents the user with a
+During the course of a proof, Rocq always presents the user with a
 *sequent* whose general form is::
 
   ci : Ti
@@ -1084,7 +1084,7 @@ which simultaneously renames ``m`` and ``le_m_n`` into ``p`` and ``le_n_p``,
 respectively, by first turning them into unnamed variables, then
 turning these variables back into constants and facts.
 
-Furthermore, |SSR| redefines the basic Coq tactics ``case``, ``elim``,
+Furthermore, |SSR| redefines the basic Rocq tactics ``case``, ``elim``,
 and ``apply`` so that they can take better advantage of
 ``:`` and ``=>``. In these
 |SSR| variants, these tactics operate on the first variable or
@@ -1422,7 +1422,7 @@ Therefore, this tactic changes any goal ``G`` into
 
    forall n n0 : nat, n = n0 -> G.
 
-where the name ``n0`` is picked by the Coq display function, and assuming
+where the name ``n0`` is picked by the Rocq display function, and assuming
 ``n`` appeared only in ``G``.
 
 Finally, note that a discharge operation generalizes defined constants
@@ -1940,7 +1940,7 @@ When the top assumption of a goal has an inductive type, two specific
 operations are possible: the case analysis performed by the :tacn:`case`
 tactic, and the application of an induction principle, performed by
 the :tacn:`elim` tactic. When this top assumption has an inductive type, which
-is moreover an instance of a type family, Coq may need help from the
+is moreover an instance of a type family, Rocq may need help from the
 user to specify which occurrences of the parameters of the type should
 be substituted.
 
@@ -2068,7 +2068,7 @@ Control flow
 Indentation and bullets
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-A linear development of Coq scripts gives little information on the
+A linear development of Rocq scripts gives little information on the
 structure of the proof. In addition, replaying a proof after some
 changes in the statement to be proved will usually not display
 information to distinguish between the various branches of case
@@ -3402,7 +3402,7 @@ rewrite operations prescribed by the rules on the current goal.
 
   Indeed, rule ``eqab`` is the first to apply among the ones
   gathered in the tuple passed to the rewrite tactic. This multirule
-  ``(eqab, eqac)`` is actually a Coq term and we can name it with a
+  ``(eqab, eqac)`` is actually a Rocq term and we can name it with a
   definition:
 
   .. coqtop:: all
@@ -3540,11 +3540,11 @@ Anyway this tactic is *not* equivalent to
   lemma that was used, while the latter requires you prove the quantified
   form.
 
-When |SSR| rewrite fails on standard Coq licit rewrite
+When |SSR| rewrite fails on standard Rocq licit rewrite
 ````````````````````````````````````````````````````````
 
 In a few cases, the |SSR| rewrite tactic fails rewriting some
-redexes that standard Coq successfully rewrites. There are two main
+redexes that standard Rocq successfully rewrites. There are two main
 cases.
 
 
@@ -3561,7 +3561,7 @@ cases.
 
      Lemma fubar (x : unit) : (let u := x in u) = tt.
 
-+ The standard rewrite tactic provided by Coq uses a different algorithm
++ The standard rewrite tactic provided by Rocq uses a different algorithm
   to find instances of the rewrite rule.
 
   .. example::
@@ -3964,7 +3964,7 @@ together with “term tagging” operations.
 
 The first one uses auxiliary definitions to introduce a provably equal
 copy of any term ``t``. However this copy is (on purpose) *not
-convertible* to ``t`` in the Coq system [#8]_. The job is done by the
+convertible* to ``t`` in the Rocq system [#8]_. The job is done by the
 following construction:
 
 .. coqdoc::
@@ -4555,7 +4555,7 @@ is a synonym for:
    elim x using V; clear x; intro y.
 
 where ``x`` is a variable in the context, ``y`` a fresh name and ``V``
-any second order lemma; |SSR| relaxes the syntactic restrictions of the Coq
+any second order lemma; |SSR| relaxes the syntactic restrictions of the Rocq
 ``elim``. The first pattern following ``:`` can be a ``_`` wildcard if the
 conclusion of the view ``V`` specifies a pattern for its last argument
 (e.g., if ``V`` is a functional induction lemma generated by the
@@ -4995,8 +4995,8 @@ distinction between logical propositions and boolean values. On the
 one hand, logical propositions are objects of *sort* ``Prop``, which is
 the carrier of intuitionistic reasoning. Logical connectives in
 ``Prop`` are *types*, which give precise information on the structure
-of their proofs; this information is automatically exploited by Coq
-tactics.  For example, Coq knows that a proof of ``A \/ B`` is
+of their proofs; this information is automatically exploited by Rocq
+tactics.  For example, Rocq knows that a proof of ``A \/ B`` is
 either a proof of ``A`` or a proof of ``B``.  The tactics ``left`` and
 ``right`` change the goal ``A \/ B`` to ``A`` and ``B``, respectively;
 dually, the tactic ``case`` reduces the goal ``A \/ B => G`` to two
@@ -5055,7 +5055,7 @@ mechanism:
 
    Coercion is_true (b : bool) := b = true.
 
-This allows any boolean formula ``b`` to be used in a context where Coq
+This allows any boolean formula ``b`` to be used in a context where Rocq
 would expect a proposition, e.g., after ``Lemma … :``. It is then
 interpreted as ``(is_true b)``, i.e., the proposition ``b = true``. Coercions
 are elided by the pretty-printer; so they are essentially transparent
@@ -5090,9 +5090,9 @@ proposition ``b1 /\ b2`` hides two coercions. The conjunction of
 
 Expressing logical equivalences through this family of inductive types
 makes possible to take benefit from *rewritable equations* associated
-to the case analysis of Coq’s inductive types.
+to the case analysis of Rocq's inductive types.
 
-Since the equivalence predicate is defined in Coq as:
+Since the equivalence predicate is defined in Rocq as:
 
 .. coqdoc::
 
@@ -5525,7 +5525,7 @@ Natural number
 
 .. prodn:: nat_or_ident ::= {| @natural | @ident }
 
-where :token:`ident` is an Ltac variable denoting a standard Coq number
+where :token:`ident` is an Ltac variable denoting a standard Rocq number
 (should not be the name of a tactic that can be followed by a
 bracket ``[``, such as ``do``, ``have``,…)
 
@@ -5776,6 +5776,6 @@ Settings
 .. [#8] This is an implementation feature: there is no such obstruction
   in the metatheory.
 .. [#9] The current state of the proof shall be displayed by the ``Show
-  Proof`` command of Coq proof mode.
+  Proof`` command of Rocq proof mode.
 .. [#10] A simple proof context entry is a naked identifier (i.e., not between
   parentheses) designating a context entry that is not a section variable.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -18,7 +18,7 @@ In :gdef:`backward reasoning`, the proof begins with the theorem statement
 as the goal, which is then gradually transformed until every subgoal generated
 along the way has been proven.  In this case, the proof of `A /\\ B` begins
 with that formula as the goal.  This can be transformed into two subgoals,
-`A` and `B`, followed by the proofs of `A` and `B`.  Coq and its tactics
+`A` and `B`, followed by the proofs of `A` and `B`.  Rocq and its tactics
 primarily use backward reasoning.
 
 A tactic may fully prove a goal, in which case the goal is removed
@@ -193,11 +193,11 @@ The :n:`eqn:` construct in various tactics uses :n:`@naming_intropattern`.
 Use these elementary patterns to specify a name:
 
 * :n:`@ident` — use the specified name
-* :n:`?` — let Coq generate a fresh name
+* :n:`?` — let Rocq generate a fresh name
 * :n:`?@ident` — generate a name that begins with :n:`@ident`
 * :n:`_` — discard the matched part (unless it is required for another
   hypothesis)
-* if a disjunction pattern omits a name, such as :g:`[|H2]`, Coq will choose a name
+* if a disjunction pattern omits a name, such as :g:`[|H2]`, Rocq will choose a name
 
 **Splitting patterns**
 
@@ -979,7 +979,7 @@ Applying theorems
 
       Behaves like :tacn:`apply`, but creates
       :ref:`existential variables <Existential-Variables>`
-      when Coq is unable to deduce instantiations for variables, rather than failing.
+      when Rocq is unable to deduce instantiations for variables, rather than failing.
 
    .. tacn:: rapply @one_term
 
@@ -1112,7 +1112,7 @@ Managing the local context
    introduced in the context by removing certain constructs in the goal.
    If no item is found, the tactic fails.  The name used is
    :n:`@ident` (if specified) or from the construct, except that if the name from the
-   construct already exists in the :term:`local context`, Coq uses a fresh name
+   construct already exists in the :term:`local context`, Rocq uses a fresh name
    instead.  The constructs have these forms:
    (See examples :ref:`here <intro_examples>`.)
 
@@ -1131,7 +1131,7 @@ Managing the local context
 
    We recommend always specifying :n:`@ident` so that the names of hypotheses don't
    change as the proof is updated, making your proof easier to maintain.  For example,
-   if H exists in the context, Coq will consider using `H0`, `H1`, ... until it finds an
+   if H exists in the context, Rocq will consider using `H0`, `H1`, ... until it finds an
    unused name.  Modifications to a proof can change automatically assigned names
    that subsequent tactics likely refer to, making the proofs harder to maintain.  The
    :flag:`Mangle Names` flag gives some control over how fresh names are generated (see
@@ -1141,9 +1141,9 @@ Managing the local context
    the context with a single tactic.
 
    :n:`@ident`
-     The name to give to the introduced item.  If not given, Coq uses the
+     The name to give to the introduced item.  If not given, Rocq uses the
      variable name from the :n:`forall` or `H` for premises.
-     If a name such as `H` is already in use, Coq will consider using `H0`,
+     If a name such as `H` is already in use, Rocq will consider using `H0`,
      `H1`, ... until it finds a fresh name.
 
      .. note::
@@ -1528,7 +1528,7 @@ Controlling the proof flow
    with the added hypothesis (and otherwise fails).
 
    In the second form, if :n:`@as_ipat` isn't specified, the tactic adds a new
-   hypothesis :n:`@one_type` with a name chosen by Coq.  Otherwise, it transforms
+   hypothesis :n:`@one_type` with a name chosen by Rocq.  Otherwise, it transforms
    :n:`@one_type` as specified by :n:`@as_ipat` and adds the resulting new hypotheses.
    The :n:`@as_ipat` may also expand the current subgoal into multiple subgoals.
    Then, if :n:`@ltac_expr3` is specified, it is applied to and must succeed on all
@@ -1696,7 +1696,7 @@ Controlling the proof flow
    The :n:`evar` tactic creates a new :term:`local definition <context-local definition>`
    named :n:`@ident` with type :n:`@type` or :n:`@one_type` in the context.
    The body of this binding is a fresh existential variable.  If the second
-   form is used, Coq chooses the name.
+   form is used, Rocq chooses the name.
 
 .. tacn:: instantiate ( @ident := @term )
           instantiate ( @natural := @term ) {? @hloc }
@@ -1718,7 +1718,7 @@ Controlling the proof flow
              must have given the name explicitly (see :ref:`Existential-Variables`).
 
    .. note:: When you are referring to hypotheses which you did not name
-             explicitly, be aware that Coq may make a different decision on how to
+             explicitly, be aware that Rocq may make a different decision on how to
              name the variable in the current goal and in the context of the
              existential variable. This can lead to surprising behaviors.
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -408,7 +408,7 @@ Requests to the environment
       reference ::= @qualid
       | @string {? % @scope_key }
 
-   Displays the full name of objects from Coq's various qualified namespaces
+   Displays the full name of objects from Rocq's various qualified namespaces
    such as terms, modules and Ltac, thereby showing the module they are defined
    in.  It also displays notation definitions.
 
@@ -480,7 +480,7 @@ Printing flags
 
 .. flag:: Fast Name Printing
 
-   When this :term:`flag` is turned on, Coq uses an asymptotically faster algorithm for the
+   When this :term:`flag` is turned on, Rocq uses an asymptotically faster algorithm for the
    generation of unambiguous names of bound variables while printing terms.
    While faster, it is also less clever and results in a typically less elegant
    display, e.g. it will generate more names rather than reusing certain names
@@ -493,12 +493,12 @@ Printing flags
 Loading files
 -----------------
 
-Coq offers the possibility of loading different parts of a whole
+Rocq offers the possibility of loading different parts of a whole
 development stored in separate files. Their contents will be loaded as
 if they were entered from the keyboard. This means that the loaded
-files are text files containing sequences of commands for Coq’s
-toplevel. This kind of file is called a *script* for Coq. The standard
-(and default) extension of Coq’s script files is .v.
+files are text files containing sequences of commands for Rocq's
+toplevel. This kind of file is called a *script* for Rocq. The standard
+(and default) extension of Rocq's script files is .v.
 
 
 .. cmd:: Load {? Verbose } {| @string | @ident }
@@ -510,7 +510,7 @@ toplevel. This kind of file is called a *script* for Coq. The standard
 
    If :n:`@string` is specified, it must specify a complete filename.
    `~` and .. abbreviations are
-   allowed as well as shell variables. If no extension is specified, Coq
+   allowed as well as shell variables. If no extension is specified, Rocq
    will use the default extension ``.v``.
 
    Files loaded this way can't leave proofs open, nor can :cmd:`Load`
@@ -520,7 +520,7 @@ toplevel. This kind of file is called a *script* for Coq. The standard
    :cmd:`Require` loads `.vo` files that were previously
    compiled from `.v` files.
 
-   :n:`Verbose` displays the Coq output for each command and tactic
+   :n:`Verbose` displays the Rocq output for each command and tactic
    in the loaded file, as if the commands and tactics were entered interactively.
 
    .. exn:: Can’t find file @ident on loadpath.
@@ -549,7 +549,7 @@ file is a particular case of a module called a *library file*.
    .. prodn::
       dirpath ::= {* @ident . } @ident
 
-   Loads compiled files into the Coq environment. For the first
+   Loads compiled files into the Rocq environment. For the first
    :n:`@qualid` in each :n:`@filtered_import`, the command looks in the
    :term:`load path` for a compiled file :n:`@ident.vo` whose
    :term:`logical name` has the form :n:`@dirpath.{* @ident__implicit. }@qualid`
@@ -562,7 +562,7 @@ file is a particular case of a module called a *library file*.
    If a file is found, its logical name must be the same as the one
    used to compile the file. Then the file is loaded as well as all
    the files it depends on (recursively). All the files must have
-   been compiled with the same version of Coq.
+   been compiled with the same version of Rocq.
 
    * :n:`Import` - additionally does an :cmd:`Import` on the loaded module,
      making components defined in the module available by their short names
@@ -623,15 +623,15 @@ file is a particular case of a module called a *library file*.
 
       The command tried to load library file :n:`@ident`.vo that
       depends on some specific version of library :n:`@qualid` which is not the
-      one already loaded in the current Coq session. Probably :n:`@ident.v` was
+      one already loaded in the current Rocq session. Probably :n:`@ident.v` was
       not properly recompiled with the last version of the file containing
       module :token:`qualid`.
 
    .. exn:: Bad magic number.
 
       The file :n:`@ident.vo` was found but either it is not a
-      Coq compiled module, or it was compiled with an incompatible
-      version of Coq.
+      Rocq compiled module, or it was compiled with an incompatible
+      version of Rocq.
 
    .. exn:: The file @ident.vo contains library @qualid__1 and not library @qualid__2.
 
@@ -650,7 +650,7 @@ file is a particular case of a module called a *library file*.
 .. cmd:: Print Libraries
 
    This command displays the list of library files loaded in the
-   current Coq session.
+   current Rocq session.
 
 .. cmd:: Declare ML Module {+ @string }
 
@@ -679,7 +679,7 @@ file is a particular case of a module called a *library file*.
    helpers to do this: see :ref:`here for coq_makefile <coq_makefile>`,
    and :ref:`here for Dune <building_dune>`.
 
-   Note that the plugin loading system for Coq changed in 8.16 to use
+   Note that the plugin loading system for Rocq changed in 8.16 to use
    findlib. Previous Coq versions loaded OCaml dynamic objects by
    first locating the object file from ``-I`` directives, then
    directly invoking ``Dynlink.loadfile``. For compatibility purposes,
@@ -724,13 +724,13 @@ Load paths
 
 .. versionchanged:: 8.18
 
-   Commands to manage :term:`load paths <load path>` within Coq have been
-   removed. Load paths can be managed using Coq command line options or
+   Commands to manage :term:`load paths <load path>` within Rocq have been
+   removed. Load paths can be managed using Rocq command line options or
    enviroment variables (see :ref:`logical-paths-load-path`).
 
 .. cmd:: Print LoadPath {? @dirpath }
 
-   Displays the current Coq :term:`load path`.  If :n:`@dirpath` is specified,
+   Displays the current Rocq :term:`load path`.  If :n:`@dirpath` is specified,
    displays only the paths that extend that prefix.  In the output,
    the logical path `<>` represents an empty logical path.
 
@@ -756,7 +756,7 @@ follows:
    The file name :n:`@string` must exist relative to one of the top directories
    associated with :n:`@dirpath`.  :n:`@string` can include directory separators
    (``/``) to select a file in a subdirectory.
-   Path elements in :n:`@string` must be valid Coq identifiers, e.g. they cannot
+   Path elements in :n:`@string` must be valid Rocq identifiers, e.g. they cannot
    contain characters such as ``-`` or ``,``.  See :ref:`lexical-conventions`.
 
 When :n:`@ident` is provided, that name can be used by OCaml code, typically
@@ -775,7 +775,7 @@ Backtracking
 ------------
 
 The backtracking commands described in this section can only be used
-interactively, they cannot be part of a Coq file loaded via
+interactively, they cannot be part of a Rocq file loaded via
 ``Load`` or compiled by ``coqc``.
 
 
@@ -824,13 +824,13 @@ Quitting and debugging
 
 .. cmd:: Quit
 
-   Causes Coq to exit.  Valid only in coqtop.
+   Causes Rocq to exit.  Valid only in coqtop.
 
 
 .. cmd:: Drop
 
    This command temporarily enters the OCaml toplevel.
-   It is a debug facility used by Coq’s implementers.  Valid only in the
+   It is a debug facility used by Rocq's implementers.  Valid only in the
    bytecode version of coqtop.
    The OCaml command:
 
@@ -839,10 +839,10 @@ Quitting and debugging
       #use "include";;
 
    adds the right loadpaths and loads some toplevel printers for all
-   abstract types of Coq- section_path, identifiers, terms, judgments, ….
+   abstract types of Rocq- section_path, identifiers, terms, judgments, ….
    You can also use the file base_include instead, that loads only the
    pretty-printers for section_paths and identifiers. You can return back
-   to Coq with the command:
+   to Rocq with the command:
 
    ::
 
@@ -850,9 +850,9 @@ Quitting and debugging
 
    .. warning::
 
-      #. It only works with the bytecode version of Coq (i.e. `coqtop.byte`,
+      #. It only works with the bytecode version of Rocq (i.e. `coqtop.byte`,
          see Section `interactive-use`).
-      #. You must have compiled Coq from the source package and set the
+      #. You must have compiled Rocq from the source package and set the
          environment variable COQTOP to the root of your copy of the sources
          (see Section `customization-by-environment-variables`).
 
@@ -957,7 +957,7 @@ Controlling display
    multiple categories. The special category `all` contains all warnings, and
    the special category `default` contains the warnings enabled by default.
 
-   Coq defines a set of core warning categories, which may be extended by
+   Rocq defines a set of core warning categories, which may be extended by
    plugins, so this list is not exhaustive. The core categories are:
    `automation`,
    `bytecode-compiler`,
@@ -1228,8 +1228,8 @@ Registering primitive operations
 .. cmd:: Primitive @ident_decl {? : @term } := #@ident
 
    Makes the primitive type or primitive operator :n:`#@ident` defined in OCaml
-   accessible in Coq commands and tactics.
-   For internal use by implementors of Coq's standard library or standard library
+   accessible in Rocq commands and tactics.
+   For internal use by implementors of Rocq's standard library or standard library
    replacements.  No space is allowed after the `#`.  Invalid values give a syntax
    error.
 

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -335,14 +335,14 @@ and `Constants`, while implicitly created databases have the `Opaque` setting.
 
    By default, hint databases are undiscriminated.
 
-Hint databases defined in the Coq standard library
-``````````````````````````````````````````````````
+Hint databases defined in the Rocq standard library
+```````````````````````````````````````````````````
 
-Several hint databases are defined in the Coq standard library. The
+Several hint databases are defined in the Rocq standard library. The
 database contains all hints declared
 to belong to it in the currently loaded modules.
 In particular, requiring new modules may extend the database.
-At Coq startup, only the core database is nonempty and ready to be used immediately.
+At Rocq startup, only the core database is nonempty and ready to be used immediately.
 
 :core: This special database is automatically used by ``auto``, except when
        pseudo-database ``nocore`` is given to ``auto``. The core database

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -205,7 +205,7 @@ Solvers for logic and equality
    .. exn:: I don’t know how to handle dependent equality.
 
       The decision procedure managed to find a proof of the goal or of a
-      discriminable equality but this proof could not be built in Coq because of
+      discriminable equality but this proof could not be built in Rocq because of
       dependently-typed functions.
 
    .. exn:: Goal is solvable by congruence but some arguments are missing. Try congruence with {+ @term}, replacing metavariables by arbitrary terms.

--- a/doc/sphinx/proofs/creating-tactics/index.rst
+++ b/doc/sphinx/proofs/creating-tactics/index.rst
@@ -18,22 +18,22 @@ new tactics:
 
 - `Mtac2 <https://github.com/Mtac2/Mtac2>`_ is an external plugin
   which provides another typed tactic language.  While Ltac2 belongs
-  to the ML language family, Mtac2 reuses the language of Coq itself
-  as the language to build Coq tactics.
+  to the ML language family, Mtac2 reuses the language of Rocq itself
+  as the language to build Rocq tactics.
 
 - `Coq-Elpi <https://github.com/LPCIC/coq-elpi>`_ is an external plugin
   which provides an extension language based on λProlog, a programming
   language well suited to write code which manipulates syntax trees with
-  binders such as Coq terms.
+  binders such as Rocq terms.
   Elpi provides an extensive set of APIs to create commands (i.e. script
   the vernacular language) and tactics.
 
 - The most traditional way of building new complex tactics is to write
-  a Coq plugin in OCaml. Beware that this requires much more
-  effort. Furthermore, Coq's OCaml API can change from release
+  a Rocq plugin in OCaml. Beware that this requires much more
+  effort. Furthermore, Rocq's OCaml API can change from release
   to release without backward compatibility support, which can cause
   a significant ongoing maintenance burden.
-  A tutorial for writing Coq plugins is available in the Coq
+  A tutorial for writing Rocq plugins is available in the Rocq
   repository in `doc/plugin_tutorial
   <https://github.com/coq/coq/tree/master/doc/plugin_tutorial>`_.
 

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -2,10 +2,10 @@
 Reasoning with equalities
 =========================
 
-There are multiple notions of :gdef:`equality` in Coq:
+There are multiple notions of :gdef:`equality` in Rocq:
 
 - :gdef:`Leibniz equality` is the standard
-  way to define equality in Coq and the Calculus of Inductive Constructions,
+  way to define equality in Rocq and the Calculus of Inductive Constructions,
   which is in terms of a binary relation, i.e. a binary function that returns
   a `Prop`.  The standard library
   defines `eq` similar to this:
@@ -21,13 +21,13 @@ There are multiple notions of :gdef:`equality` in Coq:
   relation.  A :gdef:`setoid` is a set that is equipped with an equivalence relation
   (see https://en.wikipedia.org/wiki/Setoid).  These are needed to form a :gdef:`quotient set`
   or :gdef:`quotient`
-  (see https://en.wikipedia.org/wiki/Equivalence_class).  In Coq, users generally work
+  (see https://en.wikipedia.org/wiki/Equivalence_class).  In Rocq, users generally work
   with setoids rather than constructing quotients, for which there is no specific support.
 
 - :gdef:`Definitional equality <definitional equality>` is equality based on the
-  :ref:`conversion rules <Conversion-rules>`, which Coq can determine automatically.
+  :ref:`conversion rules <Conversion-rules>`, which Rocq can determine automatically.
   Two terms are definitionally equal when they reduce to syntactically identical terms
-  using the conversion rules.  When two terms are definitionally equal, Coq knows it can
+  using the conversion rules.  When two terms are definitionally equal, Rocq knows it can
   replace one with the other, such as with :tacn:`change` `X with Y`, among many
   other advantages.  ":term:`Convertible <convertible>`" is another way of saying that
   two terms are definitionally equal.
@@ -417,7 +417,7 @@ Rewriting with definitional equality
    it skips checking that :n:`@one_term__to` is convertible with the goal or
    :n:`@one_term__from`.
 
-   Recall that the Coq kernel typechecks proofs again when they are concluded to
+   Recall that the Rocq kernel typechecks proofs again when they are concluded to
    ensure correctness. Hence, using :tacn:`change` checks convertibility twice
    overall, while :tacn:`change_no_check` can produce ill-typed terms,
    but checks convertibility only once.
@@ -837,7 +837,7 @@ representation used in the ZINC virtual machine :cite:`Leroy90`. It is
 especially useful for intensive computation of algebraic values, such
 as numbers, and for reflection-based tactics.
 
-:tacn:`native_compute` is based on on converting the Coq code to OCaml.
+:tacn:`native_compute` is based on on converting the Rocq code to OCaml.
 
 Note that both these tactics ignore :cmd:`Opaque` markings
 (see issue `#4776 <https://github.com/coq/coq/issues/4776>`_), nor do they
@@ -845,7 +845,7 @@ apply unfolding strategies such as from :cmd:`Strategy`.
 
 :tacn:`native_compute` is typically two to five
 times faster than :tacn:`vm_compute` at applying conversion rules
-when Coq is running native code, but :tacn:`native_compute` requires
+when Rocq is running native code, but :tacn:`native_compute` requires
 considerably more overhead.  We recommend using :tacn:`native_compute`
 when all of the following are true (otherwise use :tacn:`vm_compute`):
 
@@ -985,7 +985,7 @@ which supports additional fine-tuning.
    This command accepts the :attr:`global` attribute.  By default, the scope
    of :cmd:`Opaque` is limited to the current section or module.
 
-   :cmd:`Opaque` also affects Coq's conversion algorithm, causing
+   :cmd:`Opaque` also affects Rocq's conversion algorithm, causing
    it to delay unfolding the specified constants as much as possible when it
    has to check that two distinct applied constants are convertible.
    See Section :ref:`conversion-rules`.
@@ -1134,7 +1134,7 @@ which supports additional fine-tuning.
 
       If we try to prove :g:`id (fact n) = fact n` by
       :tacn:`reflexivity`, it will now take time proportional to
-      :math:`n!`, because Coq will keep unfolding :g:`fact` and
+      :math:`n!`, because Rocq will keep unfolding :g:`fact` and
       :g:`*` and :g:`+` before it unfolds :g:`id`, resulting in a full
       computation of :g:`fact n` (in unary, because we are using
       :g:`nat`), which takes time :math:`n!`.  We can see this cross
@@ -1178,7 +1178,7 @@ which supports additional fine-tuning.
          Time Defined.
 
       On small examples this sort of behavior doesn't matter, but
-      because Coq is a super-linear performance domain in so many
+      because Rocq is a super-linear performance domain in so many
       places, unless great care is taken, tactic automation using
       :tacn:`with_strategy` may not be robustly performant when
       scaling the size of the input.

--- a/doc/sphinx/proofs/writing-proofs/index.rst
+++ b/doc/sphinx/proofs/writing-proofs/index.rst
@@ -4,7 +4,7 @@
 Basic proof writing
 ===================
 
-Coq is an interactive theorem prover, or proof assistant, which means
+The Rocq Prover is a proof assistant (or interactive theorem prover), which means
 that proofs can be constructed interactively through a dialog between
 the user and the assistant.  The building blocks for this dialog are
 tactics which the user will use to represent steps in the proof of a

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -5,15 +5,15 @@ Proof mode
 ----------
 
 :gdef:`Proof mode <proof mode>` is used to prove theorems.
-Coq enters proof mode when you begin a proof,
+Rocq enters proof mode when you begin a proof,
 such as with the :cmd:`Theorem` command.  It exits proof mode when
 you complete a proof, such as with the :cmd:`Qed` command.  Tactics,
 which are available only in proof mode, incrementally transform incomplete
 proofs to eventually generate a complete proof.
 
-When you run Coq interactively, such as through CoqIDE, Proof General or
-coqtop, Coq shows the current proof state (the incomplete proof) as you
-enter tactics.  This information isn't shown when you run Coq in batch
+When you run Rocq interactively, such as through CoqIDE, Proof General or
+coqtop, Rocq shows the current proof state (the incomplete proof) as you
+enter tactics.  This information isn't shown when you run Rocq in batch
 mode with `coqc`.
 
 Proof State
@@ -137,13 +137,13 @@ to make them visible.  Other tactics may automatically resolve these goals
 user usually doesn't need to think about.  See :ref:`existential-variables`
 and :ref:`this example <automatic-evar-resolution>`.
 
-Coq's kernel verifies the correctness of proof terms when it exits
+Rocq's kernel verifies the correctness of proof terms when it exits
 proof mode by checking that the proof term is :term:`well-typed` and
 that its type is the same as the theorem statement.
 
 After a proof is completed, :cmd:`Print` `<theorem_name>`
 shows the proof term and its type.  The type appears after
-the colon (`forall ...`), as for this theorem from Coq's standard library:
+the colon (`forall ...`), as for this theorem from Rocq's standard library:
 
 .. coqtop:: all
 
@@ -165,8 +165,8 @@ the colon (`forall ...`), as for this theorem from Coq's standard library:
 Entering and exiting proof mode
 -------------------------------
 
-Coq enters :term:`proof mode` when you begin a proof through
-commands such as :cmd:`Theorem` or :cmd:`Goal`.  Coq user interfaces
+Rocq enters :term:`proof mode` when you begin a proof through
+commands such as :cmd:`Theorem` or :cmd:`Goal`.  Rocq user interfaces
 usually have a way to indicate that you're in proof mode.
 
 :term:`Tactics <tactic>` are available only in proof mode (currently they give syntax
@@ -186,7 +186,7 @@ When the proof is completed, you can exit proof mode with commands such as
 
 .. cmd:: Qed
 
-   Passes a completed :term:`proof term` to Coq's kernel
+   Passes a completed :term:`proof term` to Rocq's kernel
    to check that the proof term is :term:`well-typed` and
    to verify that its type matches the theorem statement.  If it's verified, the
    proof term is added to the global environment as an :term:`opaque` constant
@@ -489,8 +489,8 @@ Proof modes
 -----------
 
 When entering proof mode through commands such as :cmd:`Goal` and :cmd:`Proof`,
-Coq picks by default the |Ltac| mode. Nonetheless, there exist other proof modes
-shipped in the standard Coq installation, and furthermore some plugins define
+Rocq picks by default the |Ltac| mode. Nonetheless, there exist other proof modes
+shipped in the standard Rocq installation, and furthermore some plugins define
 their own proof modes. The default proof mode used when opening a proof can
 be changed using the following option.
 
@@ -656,12 +656,12 @@ is made from ``-``, ``+`` or ``*`` characters (with no spaces and no period afte
    :undocumented:
    :name: bullet (- + *)
 
-When a focused goal is proved, Coq displays a message suggesting use of
+When a focused goal is proved, Rocq displays a message suggesting use of
 ``}`` or the correct matching bullet to unfocus the goal or focus the next subgoal.
 
 .. note::
 
-   In Proof General (``Emacs`` interface to Coq), you must use
+   In Proof General (``Emacs`` interface to Rocq), you must use
    bullets with the priority ordering shown above to have correct
    indentation. For example ``-`` must be the outer bullet and ``+`` the inner
    one in the example below.
@@ -1032,8 +1032,8 @@ Requesting information
 Showing differences between proof steps
 ---------------------------------------
 
-Coq can automatically highlight the differences between successive proof steps
-and between values in some error messages.  Coq can also highlight differences
+Rocq can automatically highlight the differences between successive proof steps
+and between values in some error messages.  Rocq can also highlight differences
 in the proof term.
 For example, the following screenshots of CoqIDE and coqtop show the application
 of the same :tacn:`intros` tactic.  The tactic creates two new hypotheses, highlighted in green.
@@ -1092,7 +1092,7 @@ How to enable diffs
 
 For coqtop, showing diffs can be enabled when starting coqtop with the
 ``-diffs on|off|removed`` command-line option or by setting the :opt:`Diffs` option
-within Coq.  You will need to provide the ``-color on|auto`` command-line option when
+within Rocq.  You will need to provide the ``-color on|auto`` command-line option when
 you start coqtop in either case.
 
 Colors for coqtop can be configured by setting the ``COQ_COLORS`` environment
@@ -1106,7 +1106,7 @@ command in CoqIDE.  You can change the background colors shown for diffs from th
 lets you control other attributes of the highlights, such as the foreground
 color, bold, italic, underline and strikeout.
 
-Proof General, VsCoq and Coqtail can also display Coq-generated proof diffs automatically.
+Proof General, VsCoq and Coqtail can also display Rocq-generated proof diffs automatically.
 Please see the PG documentation section
 `"Showing Proof Diffs" <https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General#Showing-Proof-Diffs>`_
 and Coqtail's `"Proof Diffs" <https://github.com/whonore/Coqtail#proof-diffs>`_
@@ -1232,14 +1232,14 @@ Proof maintenance
 
 *Experimental.*  Many tactics, such as :tacn:`intros`, can automatically generate names, such
 as "H0" or "H1" for a new hypothesis introduced from a goal.  Subsequent proof steps
-may explicitly refer to these names.  However, future versions of Coq may not assign
+may explicitly refer to these names.  However, future versions of Rocq may not assign
 names exactly the same way, which could cause the proof to fail because the
 new names don't match the explicit references in the proof.
 
 The following :flag:`Mangle Names` settings let users find all the
 places where proofs rely on automatically generated names, which can
 then be named explicitly to avoid any incompatibility.  These
-settings cause Coq to generate different names, producing errors for
+settings cause Rocq to generate different names, producing errors for
 references to automatically generated names.
 
 .. flag:: Mangle Names
@@ -1275,10 +1275,10 @@ Controlling proof mode
 
    When turned on (it is off by default), this :term:`flag` enables support for nested
    proofs: a new assertion command can be inserted before the current proof is
-   finished, in which case Coq will temporarily switch to the proof of this
+   finished, in which case Rocq will temporarily switch to the proof of this
    *nested lemma*. When the proof of the nested lemma is finished (with :cmd:`Qed`
    or :cmd:`Defined`), its statement will be made available (as if it had been
-   proved before starting the previous proof) and Coq will switch back to the
+   proved before starting the previous proof) and Rocq will switch back to the
    proof of the previous assertion.
 
 .. flag:: Printing Goal Names
@@ -1304,7 +1304,7 @@ Controlling memory usage
    Words are 8 bytes or 4 bytes, respectively, for 64- and 32-bit executables.
 
 When experiencing high memory usage the following commands can be used
-to force Coq to optimize some of its internal data structures.
+to force Rocq to optimize some of its internal data structures.
 
 .. cmd:: Optimize Proof
 

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -166,7 +166,7 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
       the variables and hypotheses introduced in each new subgoal.  The
       :token:`or_and_intropattern` must have one :n:`{* @intropattern }`
       for each constructor, given in the order in which the constructors are
-      defined.  If there are not enough names, Coq picks fresh names.
+      defined.  If there are not enough names, Rocq picks fresh names.
       Inner :n:`intropattern`\s can also split introduced hypotheses into
       multiple hypotheses or subgoals.
 
@@ -495,7 +495,7 @@ Induction
      are the names of the induction hypotheses. The identifiers
      :n:`@name` (in the `{ struct ... }` clauses) are the respective names of
      the premises on which the induction
-     is performed in the statements to be proved (if not given, Coq
+     is performed in the statements to be proved (if not given, Rocq
      guesses what they are).
 
 .. tacn:: cofix @ident {? with {+ ( @ident {* @simple_binder } : @type ) } }
@@ -807,7 +807,7 @@ This section describes some special purpose tactics to work with
      :token:`or_and_intropattern` must have one :n:`{* @intropattern }`
      for each constructor of the (co)inductive predicate, given in the order
      in which the constructors are defined.
-     If there are not enough names, Coq picks fresh names.
+     If there are not enough names, Rocq picks fresh names.
 
      If an equation splits into several
      equations (because ``inversion`` applies ``injection`` on the equalities it
@@ -822,7 +822,7 @@ This section describes some special purpose tactics to work with
       ``inversion`` generally behaves in a slightly more expected way than
       ``inversion`` (no artificial duplication of some hypotheses referring to
       other hypotheses). To take advantage of these improvements, it is enough to use
-      ``inversion … as []``, letting Coq choose fresh names.
+      ``inversion … as []``, letting Rocq choose fresh names.
 
    .. note::
       As ``inversion`` proofs may be large, we recommend
@@ -1263,7 +1263,7 @@ Automatic declaration of schemes
 
 .. warning::
 
-   You have to be careful with these flags since Coq may now reject well-defined
+   You have to be careful with these flags since Rocq may now reject well-defined
    inductive types because it cannot compute a Boolean equality for them.
 
 .. flag:: Rewriting Schemes
@@ -1382,8 +1382,6 @@ Generation of inversion principles with ``Derive`` ``Inversion``
     Check leminv.
 
   Then we can use the proven inversion lemma:
-
-  .. the original LaTeX did not have any Coq code to setup the goal
 
   .. coqtop:: none
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -3,7 +3,7 @@
 Syntax extensions and notation scopes
 =====================================
 
-In this chapter, we introduce advanced commands to modify the way Coq
+In this chapter, we introduce advanced commands to modify the way Rocq
 parses and prints objects, i.e. the translations between the concrete
 and internal representations of terms and commands.
 
@@ -13,7 +13,7 @@ The main commands to provide custom symbolic notations for terms are
 variant of :cmd:`Notation` which does not modify the parser; this provides a
 form of :ref:`abbreviation <Abbreviations>`. It is
 sometimes expected that the same symbolic notation has different meanings in
-different contexts; to achieve this form of overloading, Coq offers a notion
+different contexts; to achieve this form of overloading, Rocq offers a notion
 of :ref:`notation scopes <Scopes>`.
 The main command to provide custom notations for tactics is :cmd:`Tactic Notation`.
 
@@ -92,7 +92,7 @@ symbol starts with a double quote, it must be surrounded with single
 quotes to prevent confusion with the beginning of a string symbol.
 
 A notation binds a syntactic expression to a term, called its :gdef:`interpretation`. Unless the parser
-and pretty-printer of Coq already know how to deal with the syntactic
+and pretty-printer of Rocq already know how to deal with the syntactic
 expression (such as through :cmd:`Reserved Notation` or for notations
 that contain only literals), explicit precedences and
 associativity rules have to be given.
@@ -123,7 +123,7 @@ Precedences and associativity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mixing different symbolic notations in the same text may cause serious
-parsing ambiguity. To deal with the ambiguity of notations, Coq uses
+parsing ambiguity. To deal with the ambiguity of notations, Rocq uses
 precedence levels ranging from 0 to 100 (plus one extra level numbered
 200) and associativity rules.
 
@@ -134,7 +134,7 @@ Consider for example the new notation
    Notation "A \/ B" := (or A B).
 
 Clearly, an expression such as :g:`forall A:Prop, True /\ A \/ A \/ False`
-is ambiguous. To tell the Coq parser how to interpret the
+is ambiguous. To tell the Rocq parser how to interpret the
 expression, a priority between the symbols ``/\`` and ``\/`` has to be
 given. Assume for instance that we want conjunction to bind more than
 disjunction. This is expressed by assigning a precedence level to each
@@ -152,7 +152,7 @@ defaults to :g:`True /\ (False /\ False)` (right associativity) or to
 expression is not well-formed and that parentheses are mandatory (this is a “no
 associativity”) [#no_associativity]_. We do not know of a special convention for
 the associativity of disjunction and conjunction, so let us apply
-right associativity (which is the choice of Coq).
+right associativity (which is the choice of Rocq).
 
 Precedence levels and associativity rules of notations are specified with a list of
 parenthesized :n:`@syntax_modifier`\s.  Here is how the previous examples refine:
@@ -220,7 +220,7 @@ left. See the next section for more about factorization.
 Simple factorization rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Coq extensible parsing is performed by *Camlp5* which is essentially a LL1
+Rocq extensible parsing is performed by *Camlp5* which is essentially a LL1
 parser: it decides which notation to parse by looking at tokens from left to right.
 Hence, some care has to be taken not to hide already existing rules by new
 rules. Indeed notations with a common prefix but different levels can
@@ -254,10 +254,10 @@ Or better yet, simply let the defaults ensure the best factorization.
    Reserved Notation "x << y << z".
    Print Notation "_ << _ << _".
 
-For the sake of factorization with Coq predefined rules, simple rules
+For the sake of factorization with Rocq predefined rules, simple rules
 have to be observed for notations starting with a symbol, e.g., rules
 starting with “\ ``{``\ ” or “\ ``(``\ ” should be put at level 0. The list
-of Coq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
+of Rocq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
 
 .. warn:: Closed notations (i.e. starting and ending with a terminal symbol) should usually be at level 0 (default).
    :name: closed-notation-not-level-0
@@ -274,8 +274,8 @@ of Coq predefined notations can be found in the chapter on :ref:`thecoqlibrary`.
 Use of notations for printing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The command :cmd:`Notation` has an effect both on the Coq parser and on the
-Coq printer. For example:
+The command :cmd:`Notation` has an effect both on the Rocq parser and on the
+Rocq printer. For example:
 
 .. coqtop:: all
 
@@ -283,7 +283,7 @@ Coq printer. For example:
 
 However, printing, especially pretty-printing, also requires some
 care. We may want specific indentations, line breaks, alignment if on
-several lines, etc. For pretty-printing, Coq relies on OCaml
+several lines, etc. For pretty-printing, Rocq relies on OCaml
 formatting library, which provides indentation and automatic line
 breaks depending on page width by means of *formatting boxes*.
 
@@ -433,12 +433,12 @@ Reserving notations
 
 .. cmd:: Reserved Notation @string {? ( {+, @syntax_modifier } ) }
 
-   A given notation may be used in different contexts. Coq expects all
+   A given notation may be used in different contexts. Rocq expects all
    uses of the notation to be defined at the same precedence and with the
    same associativity. To avoid giving the precedence and associativity
    every time, this command declares a parsing rule (:token:`string`) in advance
    without giving its interpretation. Here is an example from the initial
-   state of Coq.
+   state of Rocq.
 
    .. coqtop:: in
 
@@ -734,7 +734,7 @@ Displaying information about notations
    definition where the nonterminal was referenced.  This command shows the original grammar,
    so it won't exactly match the documentation.
 
-   The Coq parser is based on Camlp5.  The documentation for
+   The Rocq parser is based on Camlp5.  The documentation for
    `Extensible grammars <http://camlp5.github.io/doc/htmlc/grammars.html>`_ is the
    most relevant but it assumes considerable knowledge.  Here are the essentials:
 
@@ -800,7 +800,7 @@ Displaying information about notations
    The file
    `doc/tools/docgram/fullGrammar <http://github.com/coq/coq/blob/master/doc/tools/docgram/fullGrammar>`_
    in the source tree extracts the full grammar for
-   Coq (not including notations and tactic notations defined in `*.v` files nor some optionally-loaded plugins)
+   Rocq (not including notations and tactic notations defined in `*.v` files nor some optionally-loaded plugins)
    in a single file with minor changes to handle nonterminals using multiple levels (described in
    `doc/tools/docgram/README.md <http://github.com/coq/coq/blob/master/doc/tools/docgram/README.md>`_).
    This is complete and much easier to read than the grammar source files.
@@ -975,7 +975,7 @@ in binding position and parsed as terms to be ``as name``.
 Binders bound in the notation and parsed as general binders
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-It is also possible to rely on Coq's syntax of binders using the
+It is also possible to rely on Rocq's syntax of binders using the
 `binder` modifier as follows:
 
 .. coqtop:: in
@@ -1069,7 +1069,7 @@ recursive patterns. The basic example is:
    Notation "[ x ; .. ; y ]" := (cons x .. (cons y nil) ..).
 
 On the right-hand side, an extra construction of the form ``.. t ..`` can
-be used. Notice that ``..`` is part of the Coq syntax and it must not be
+be used. Notice that ``..`` is part of the Rocq syntax and it must not be
 confused with the three-dots notation “``…``” used in this manual to denote
 a sequence of arbitrary size.
 
@@ -1272,7 +1272,7 @@ Custom entries
 Custom entries have levels, like the main grammar of terms and grammar
 of patterns have. The lower level is 0 and this is the level used by
 default to put rules delimited with tokens on both ends. The level is
-left to be inferred by Coq when using :n:`in custom @ident`. The
+left to be inferred by Rocq when using :n:`in custom @ident`. The
 level is otherwise given explicitly by using the syntax
 :n:`in custom @ident at level @natural`, where :n:`@natural` refers to the level.
 
@@ -1326,7 +1326,7 @@ associated with the custom entry ``expr``. The level can be omitted, as in
 
    Notation "[ e ]" := e (e custom expr).
 
-in which case Coq infer it. If the sub-expression is at a border of
+in which case Rocq infer it. If the sub-expression is at a border of
 the notation (as e.g. ``x`` and ``y`` in ``x + y``), the level is
 determined by the associativity. If the sub-expression is not at the
 border of the notation (as e.g. ``e`` in ``"[ e ]``), the level is
@@ -1453,7 +1453,7 @@ Note that `_` by itself is a valid :n:`@name` but is not a valid :n:`@ident`.
           time. Type checking is done only at the time of use of the notation.
 
 .. note:: Some examples of Notation may be found in the files composing
-          the initial state of Coq (see directory :file:`$COQLIB/theories/Init`).
+          the initial state of Rocq (see directory :file:`$COQLIB/theories/Init`).
 
 .. note:: The notation ``"{ x }"`` has a special status in the main grammars of
           terms and patterns so that
@@ -1478,7 +1478,7 @@ Note that `_` by itself is a valid :n:`@name` but is not a valid :n:`@ident`.
           .. warn:: Use of @string Notation is deprecated as it is inconsistent with pattern syntax.
 
              This warning is disabled by default to avoid spurious diagnostics
-             due to legacy notation in the Coq standard library.
+             due to legacy notation in the Rocq standard library.
              It can be turned on with the ``-w disj-pattern-notation`` flag.
 
 .. exn:: Unknown custom entry: @ident.
@@ -1516,7 +1516,7 @@ Most commands use :token:`scope_name`; :token:`scope_key`\s are used within :tok
 .. cmd:: Declare Scope @scope_name
 
    Declares a new notation scope. Note that the initial
-   state of Coq declares the following notation scopes:
+   state of Rocq declares the following notation scopes:
 
    ``bool_scope``, ``byte_scope``, ``core_scope``, ``dec_int_scope``,
    ``dec_uint_scope``, ``function_scope``, ``hex_int_scope``, ``hex_nat_scope``,
@@ -1533,7 +1533,7 @@ Global interpretation rules for notations
 
 At any time, the interpretation of a notation for a term is done within
 a *stack* of notation scopes and :term:`lonely notations <lonely notation>`. If a
-notation is defined in multiple scopes, Coq uses the interpretation from
+notation is defined in multiple scopes, Rocq uses the interpretation from
 the most recently opened notation scope or declared lonely notation.
 
 Note that "stack" is a misleading name.  Each scope or lonely notation can only appear in
@@ -1544,7 +1544,7 @@ stack, rather than through "pop" operations.
 
 Use the :cmd:`Print Visibility` command to display the current notation scope stack.
 
-The initial state of Coq has the following scopes opened: ``core_scope``,
+The initial state of Rocq has the following scopes opened: ``core_scope``,
 ``function_scope``, ``type_scope`` and ``nat_scope``, ``nat_scope`` being the
 top of the scopes stack.
 
@@ -1759,10 +1759,10 @@ recognized to be a ``Funclass`` instance, i.e., of type :g:`forall x:A, B` or
 
 .. _notation-scopes:
 
-Notation scopes used in the standard library of Coq
+Notation scopes used in the standard library of Rocq
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We give an overview of the scopes used in the standard library of Coq.
+We give an overview of the scopes used in the standard library of Rocq.
 For a complete list of notations in each scope, use the commands :cmd:`Print
 Scopes` or :cmd:`Print Scope`.
 
@@ -1828,7 +1828,7 @@ Scopes` or :cmd:`Print Scope`.
 
 ``string_scope``
   This scope includes notation for strings as elements of the type string.
-  Special characters and escaping follow Coq conventions on strings (see
+  Special characters and escaping follow Rocq conventions on strings (see
   :ref:`lexical-conventions`). Especially, there is no convention to visualize non
   printable characters of a string. The file :file:`String.v` shows an example
   that contains quotes, a newline and a beep (i.e. the ASCII character
@@ -1933,7 +1933,7 @@ Abbreviations
 
    An abbreviation expects no precedence nor associativity, since it
    is parsed as an usual application. Abbreviations are used as
-   much as possible by the Coq printers unless the modifier ``(only
+   much as possible by the Rocq printers unless the modifier ``(only
    parsing)`` is given.
 
    An abbreviation is bound to an absolute name as an ordinary definition is
@@ -2743,9 +2743,9 @@ Tactic notations allow customizing the syntax of tactics.
 .. rubric:: Footnotes
 
 .. [#and_or_levels] which are the levels effectively chosen in the current
-   implementation of Coq
+   implementation of Rocq
 
-.. [#no_associativity] Coq accepts notations declared as nonassociative but the parser on
-   which Coq is built, namely Camlp5, currently does not implement ``no associativity`` and
-   replaces it with ``left associativity``; hence it is the same for Coq: ``no associativity``
+.. [#no_associativity] Rocq accepts notations declared as nonassociative but the parser on
+   which Rocq is built, namely Camlp5, currently does not implement ``no associativity`` and
+   replaces it with ``left associativity``; hence it is the same for Rocq: ``no associativity``
    is in fact ``left associativity`` for the purposes of parsing

--- a/doc/sphinx/using/libraries/index.rst
+++ b/doc/sphinx/using/libraries/index.rst
@@ -4,40 +4,40 @@
 Libraries and plugins
 =====================
 
-Libraries and plugins contain compiled Coq scripts with useful definitions,
+Libraries and plugins contain compiled Rocq scripts with useful definitions,
 theorems, notations and settings that can be loaded at runtime.  In addition,
 plugins can add new tactics and commands written in OCaml.
 
-Coq is distributed with a standard library and a set of internal
+The Rocq Prover is distributed with a standard library and a set of internal
 plugins (most of which provide tactics that have already been
 presented in :ref:`writing-proofs`).  This chapter presents this
 standard library and some of these internal plugins which provide
 features that are not tactics.
 
-In addition, Coq has a rich ecosystem of external libraries and
+In addition, Rocq has a rich ecosystem of external libraries and
 plugins.  These libraries and plugins can be browsed online through
 the `Coq Package Index <https://coq.inria.fr/opam/www/>`_ and
 installed with the `opam package manager
 <https://coq.inria.fr/opam-using.html>`_.
 
-:gdef:`Libraries <library>` contain only compiled Coq scripts.
+:gdef:`Libraries <library>` contain only compiled Rocq scripts.
 :gdef:`Plugins <plugin>` can also include compiled OCaml code that can change
-the behavior of Coq.  Both are :term:`packages <package>`.
+the behavior of Rocq.  Both are :term:`packages <package>`.
 While users configure and load them identically, there are a few differences
 to consider:
 
 - Nearly all plugins add functionality that could not be added otherwise
   and they likely add new top-level commands or tactics.
-- Compared to libraries, plugins can change Coq's behavior in many possibly
+- Compared to libraries, plugins can change Rocq's behavior in many possibly
   unexpected ways. Therefore, using a plugin requires a higher degree of trust
   in its authors than is needed for libraries.  If desired, you can mitigate
-  trust issues by running :ref:`coqchk` on compiled files produced from Coq
+  trust issues by running :ref:`coqchk` on compiled files produced from Rocq
   scripts that load plugins.  (`coqchk` doesn't load plugins, so they won't be
   part of trusted code base.)
-- Plugins that aren't in Coq's
+- Plugins that aren't in Rocq's
   `CI (continuous integration) system <https://github.com/coq/coq/blob/master/dev/ci/README-users.md>`_
   are more likely
-  to break across major versions due to source code changes to Coq.  You may want to
+  to break across major versions due to source code changes to Rocq.  You may want to
   consider this before adopting a new plugin for your project.
 
 .. toctree::

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -1,9 +1,9 @@
-Writing Coq libraries and plugins
+Writing Rocq libraries and plugins
 ===================================
 
-This section presents the part of the Coq language that is useful only
-to library and plugin authors.  A tutorial for writing Coq plugins is
-available in the Coq repository in `doc/plugin_tutorial
+This section presents the part of the Rocq language that is useful only
+to library and plugin authors.  A tutorial for writing Rocq plugins is
+available in the Rocq repository in `doc/plugin_tutorial
 <https://github.com/coq/coq/tree/master/doc/plugin_tutorial>`_.
 
 Deprecating library objects, tactics or library files
@@ -60,12 +60,12 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
 
 .. note::
 
-   Coq and its standard library follow this deprecation policy:
+   Rocq and its standard library follow this deprecation policy:
 
-   * it should always be possible for a project written in Coq to be
+   * it should always be possible for a project written in Rocq to be
      compatible with two successive major versions,
    * features must be deprecated in one major version before removal,
-   * Coq developers should provide an estimate of the required effort
+   * Rocq developers should provide an estimate of the required effort
      to fix a project with respect to a given change,
    * breaking changes should be clearly documented in the public
      release notes, along with recommendations on how to fix a project

--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -2,14 +2,14 @@
 
 .. _coqdoc:
 
-Documenting Coq files with coqdoc
+Documenting Rocq files with coqdoc
 -----------------------------------
 
-coqdoc is a documentation tool for the proof assistant Coq, similar to
+coqdoc is a documentation tool for the Rocq Prover, similar to
 ``javadoc`` or ``ocamldoc``. The task of coqdoc is
 
 
-#. to produce a nice |Latex| and/or HTML document from Coq source files,
+#. to produce a nice |Latex| and/or HTML document from Rocq source files,
    readable for a human and not only for the proof assistant;
 #. to help users navigate their own (or third-party) sources.
 
@@ -18,9 +18,9 @@ coqdoc is a documentation tool for the proof assistant Coq, similar to
 Principles
 ~~~~~~~~~~
 
-Documentation is inserted into Coq files as *special comments*. Thus
+Documentation is inserted into Rocq files as *special comments*. Thus
 your files will compile as usual, whether you use coqdoc or not. coqdoc
-presupposes that the given Coq files are well-formed (at least
+presupposes that the given Rocq files are well-formed (at least
 lexically). Documentation starts with ``(**``, followed by a space, and
 ends with ``*)``. The documentation format is inspired by Todd
 A. Coram’s *Almost Free Text (AFT)* tool: it is mainly ``ASCII`` text with
@@ -29,10 +29,10 @@ shouldn’t fail, whatever the input is. But remember: “garbage in,
 garbage out”.
 
 
-Coq material inside documentation.
+Rocq material inside documentation.
 ++++++++++++++++++++++++++++++++++++
 
-Coq material is quoted between the delimiters ``[`` and ``]``. Square brackets
+Rocq material is quoted between the delimiters ``[`` and ``]``. Square brackets
 may be nested, the inner ones being understood as being part of the
 quoted code (thus you can quote a term like ``let id := fun [T : Type] (x : t) => x in id 0``
 by writing  ``[let id := fun [T : Type] (x : t) => x in id 0]``).
@@ -46,7 +46,7 @@ Pretty-printing.
 ++++++++++++++++
 
 coqdoc uses different faces for identifiers and keywords. The pretty-
-printing of Coq tokens (identifiers or symbols) can be controlled
+printing of Rocq tokens (identifiers or symbols) can be controlled
 using one of the following commands:
 
 ::
@@ -63,7 +63,7 @@ or
     (** printing  *token* $...LATEX math...$ #...html...# *)
 
 
-It gives the |Latex| and HTML texts to be produced for the given Coq
+It gives the |Latex| and HTML texts to be produced for the given Rocq
 token. Either the |Latex| or the HTML rule may be omitted, causing the
 default pretty-printing to be used for this token.
 
@@ -91,7 +91,7 @@ commands.
 
    The recognition of tokens is done by a (``ocaml``) lex
    automaton and thus applies the longest-match rule. For instance, `->~`
-   is recognized as a single token, where Coq sees two tokens. It is the
+   is recognized as a single token, where Rocq sees two tokens. It is the
    responsibility of the user to insert space between tokens *or* to give
    pretty-printing rules for the possible combinations, e.g.
 
@@ -225,7 +225,7 @@ Then invoke coqdoc or ``coqdoc --glob-from file`` to tell coqdoc to look
 for name resolutions in the file ``file`` (it will look in ``file.glob``
 by default).
 
-Identifiers from the Coq standard library are linked to the Coq website
+Identifiers from the Rocq standard library are linked to the Coq website
 `<http://coq.inria.fr/library/>`_. This behavior can be changed
 using command line options ``--no-externals`` and ``--coqlib_url``; see below.
 
@@ -242,7 +242,7 @@ and ``-l`` (see below), or using such comments:
 
 
     (* begin hide *)
-     *some Coq material*
+     *some Rocq material*
     (* end hide *)
 
 
@@ -253,7 +253,7 @@ shown using such comments:
 
 
     (* begin show *)
-     *some Coq material*
+     *some Rocq material*
     (* end show *)
 
 
@@ -261,14 +261,14 @@ The latter cannot be used around some inner parts of a proof, but can
 be used around a whole proof.
 
 Lastly, it is possible to adopt a middle-ground approach when the
-desired output is HTML, where a given snippet of Coq material is
+desired output is HTML, where a given snippet of Rocq material is
 hidden by default, but can be made visible with user interaction.
 
 ::
 
 
     (* begin details *)
-     *some Coq material*
+     *some Rocq material*
     (* end details *)
 
 
@@ -278,7 +278,7 @@ There is also an alternative syntax available.
 
 
     (* begin details : Some summary describing the snippet *)
-     *some Coq material*
+     *some Rocq material*
     (* end details *)
 
 
@@ -288,12 +288,12 @@ Usage
 coqdoc is invoked on a shell command line as follows:
 ``coqdoc <options and files>``.
 Any command line argument which is not an option is considered to be a
-file (even if it starts with a ``-``). Coq files are identified by the
+file (even if it starts with a ``-``). Rocq files are identified by the
 suffixes ``.v`` and ``.g`` and |Latex| files by the suffix ``.tex``.
 
 
 :HTML output: This is the default output format. One HTML file is created for
-  each Coq file given on the command line, together with a file
+  each Rocq file given on the command line, together with a file
   ``index.html`` (unless ``option-no-index is passed``). The HTML pages use a
   style sheet named ``style.css``. Such a file is distributed with coqdoc.
 :|Latex| output: A single |Latex| file is created, on standard
@@ -303,7 +303,7 @@ suffixes ``.v`` and ``.g`` and |Latex| files by the suffix ``.tex``.
   document . DVI and PostScript can be produced directly with the
   options ``-dvi`` and ``-ps`` respectively.
 :TEXmacs output: To translate the input files to TEXmacs format,
-  to be used by the TEXmacs Coq interface.
+  to be used by the TEXmacs Rocq interface.
 
 
 
@@ -367,18 +367,18 @@ Command line options
 
 **Hyperlink options**
 
-  :--glob-from file: Make references using Coq globalizations from file
-    file. (Such globalizations are obtained with Coq option ``-dump-glob``).
-  :--no-externals: Do not insert links to the Coq standard library.
+  :--glob-from file: Make references using Rocq globalizations from file
+    file. (Such globalizations are obtained with Rocq option ``-dump-glob``).
+  :--no-externals: Do not insert links to the Rocq standard library.
   :--external url coqdir: Use given URL for linking references whose
     name starts with prefix ``coqdir``.
-  :--coqlib_url url: Set base URL for the Coq standard library (default is
+  :--coqlib_url url: Set base URL for the Rocq standard library (default is
     `<http://coq.inria.fr/library/>`_). This is equivalent to ``--external url
-    Coq``.
-  :-R dir coqdir: Recursively map physical directory dir to Coq logical
-    directory  ``coqdir`` (similarly to Coq option ``-R``).
-  :-Q dir coqdir: Map physical directory dir to Coq logical
-    directory  ``coqdir`` (similarly to Coq option ``-Q``).
+    Stdlib``.
+  :-R dir coqdir: Recursively map physical directory dir to Rocq logical
+    directory  ``coqdir`` (similarly to Rocq option ``-R``).
+  :-Q dir coqdir: Map physical directory dir to Rocq logical
+    directory  ``coqdir`` (similarly to Rocq option ``-Q``).
 
     .. note::
 
@@ -430,7 +430,7 @@ Command line options
   :--plain-comments: Do not interpret comments, simply copy them as
     plain-text.
   :--interpolate: Use the globalization information to typeset
-    identifiers appearing in Coq escapings inside comments.
+    identifiers appearing in Rocq escapings inside comments.
 
 **Language options**
 

--- a/doc/sphinx/using/tools/index.rst
+++ b/doc/sphinx/using/tools/index.rst
@@ -5,10 +5,10 @@ Command-line and graphical tools
 ================================
 
 This chapter presents the command-line tools that users will need to
-build their Coq project, the documentation of the CoqIDE graphical
+build their Rocq project, the documentation of the CoqIDE graphical
 user interface and the documentation of the parallel proof processing
 feature that is supported by CoqIDE and several other GUIs.
-A list of available user interfaces to interact with Coq is available
+A list of available user interfaces to interact with Rocq is available
 on the `Coq website <https://coq.inria.fr/user-interfaces.html>`_.
 
 .. toctree::


### PR DESCRIPTION
Things left unchanged in this commit:
- references to Coq Platform, Coq website, Coq package index
- URLs
- CoqIDE chapter
- Most of the Coq commands chapter

A few occurrences of `Coq` are replaced by `Stdlib` when this was appropriate (i.e., could have been included in #19662) and it was too complicated to split the two types of changes (e.g., because they are on the same line).