### PR TITLE
Ensure that the binder (x:T|P) does not depend on the implicit status of Specif.sig.

### DIFF
--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -38,12 +38,11 @@ variable can be introduced at the same time. It is also possible to give
 the type of the variable as follows:
 :n:`(@ident : @type := @term)`.
 
-`(x : T | P)` is syntactic sugar for `(x : Stdlib.Init.Specif.sig (fun x : T => P))`,
+`(x : T | P)` is syntactic sugar for `(x : @Stdlib.Init.Specif.sig _ (fun x : T => P))`,
 which would more typically be written `(x : {x : T | P})`.
 Since `(x : T | P)` uses `sig` directly,
 changing the notation `{x : T | P}`
-will not change the meaning of `(x : T | P)`, while
-changing the implicit arguments of `sig` will break `(x : T | P)`).
+will not change the meaning of `(x : T | P)`.
 
 Lists of :n:`@binder`\s are allowed. In the case of :g:`fun` and :g:`forall`,
 it is intended that at least one binder of the list is an assumption otherwise

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -107,7 +107,7 @@ let force_quality ?loc = function
 
 (* XXX use registered ref? but currently constrexpr doesn't have a node for registered refs
    and we can't do [Rocqlib.lib_ref] at parsing time, it's only available in the interp phase. *)
-let sigref loc = mkRefC (Libnames.qualid_of_string ~loc "Stdlib.Init.Specif.sig")
+let sigref loc = Libnames.qualid_of_string ~loc "Stdlib.Init.Specif.sig"
 
 }
 
@@ -468,7 +468,7 @@ GRAMMAR EXTEND Gram
       | "("; id = name; ":"; t = lconstr; ":="; c = lconstr; ")" ->
         { [CLocalDef (id,None,c,Some t)] }
       | "("; id=name; ":"; t=lconstr; "|"; c=lconstr; ")" ->
-        { let typ = mkAppC (sigref loc, [mkLambdaC ([id], default_binder_kind, t, c)]) in
+        { let typ = CAst.make ~loc @@ CAppExpl ((sigref loc,None), [t; mkLambdaC ([id], default_binder_kind, t, c)]) in
           [CLocalAssum ([id], None, default_binder_kind, typ)] }
       | "{"; id = name; "}" ->
         { [CLocalAssum ([id], None, Default MaxImplicit, CAst.make ~loc @@ CHole (None))] }


### PR DESCRIPTION
Implementing a discussion from [#19645](https://github.com/coq/coq/pull/19645#discussion_r1793459020).

Not fully satisfactory yet:
- not use in printing
- the question of whether it should be bound to the notation `{x:T|P}` or to `sig` remains open

but a priori more robust as far as `sig` is concerned.