### PR TITLE
Fixes #19661: incorrect reduction of inner fixpoints with extra arguments in fixpoint guard checker

### DIFF
--- a/doc/changelog/01-kernel/19671-master+fix19661-guard-with-uniform-parameters.rst
+++ b/doc/changelog/01-kernel/19671-master+fix19661-guard-with-uniform-parameters.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Possible guard checker anomaly on fixpoints containing an inner
+  fixpoint that is reducible (because of its main argument reducing to a
+  constructor). This is a regression in 8.20
+  (`#19671 <https://github.com/coq/coq/pull/19671>`_,
+  fixes `#19661 <https://github.com/coq/coq/issues/19661>`_,
+  by Hugo Herbelin).

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1384,7 +1384,7 @@ let check_one_fix ?evars renv recpos trees def =
                 let fix_stack = if Int.equal i j then stack_this else stack_others in
                 check_nested_fix_body illformed renv' (recindx+1) fix_stack rs' body) rs' recindxs bodies in
             let needreduce_fix, rs = List.sep_first rs' in
-            let non_absorbed_stack = List.skipn nuniformparams stack in
+            let absorbed_stack, non_absorbed_stack = List.chop nuniformparams stack in
             check_rec_call_state renv needreduce_fix non_absorbed_stack rs (fun () ->
               (* we try hard to reduce the fix away by looking for a
                  constructor in [decrArg] (we unfold definitions too) *)
@@ -1395,7 +1395,7 @@ let check_one_fix ?evars renv recpos trees def =
               let c = whd_all ?evars renv.env (lift n recArg) in
               let hd, _ = decompose_app_list c in
               match kind hd with
-              | Construct _ -> Some (contract_fix fix, stack)
+              | Construct _ -> Some (contract_fix fix, absorbed_stack)
               | CoFix _ | Ind _ | Lambda _ | Prod _ | LetIn _
               | Sort _ | Int _ | Float _ | String _
               | Array _ -> assert false

--- a/test-suite/bugs/bug_19661.v
+++ b/test-suite/bugs/bug_19661.v
@@ -1,0 +1,54 @@
+Require Import Utf8.
+
+Inductive tele : Type :=
+  | TeleO : tele
+  | TeleS {X} (binder : X -> tele) : tele.
+
+Fixpoint tele_fun (TT : tele) (T : Type) : Type :=
+  match TT with
+  | TeleO => T
+  | TeleS b => forall x, tele_fun (b x) T
+  end.
+
+Notation "TT -t> A" := (tele_fun TT A) (at level 99, A at level 200, right associativity).
+
+Record tele_arg_cons {X : Type} (f : X → Type) : Type := TeleArgCons
+  { tele_arg_head : X;
+    tele_arg_tail : f tele_arg_head }.
+Global Arguments TeleArgCons {_ _} _ _.
+
+Fixpoint tele_arg (t : tele) : Type :=
+  match t with
+  | TeleO => unit
+  | TeleS f => tele_arg_cons (λ x, tele_arg (f x))
+  end.
+
+Fixpoint tele_app {TT : tele} {U} : (TT -t> U) → tele_arg TT → U :=
+  match TT as TT return (TT -t> U) → tele_arg TT → U with
+  | TeleO => λ F _, F
+  | TeleS r => λ (F : TeleS r -t> U) '(TeleArgCons x b),
+      tele_app (F x) b
+  end.
+Global Arguments tele_app {!_ _} & _ !_ /.
+
+Axiom PROP: Type.
+Axiom T : PROP.
+Axiom atomic_commit :
+  forall {TB : tele}
+         (_ : forall (_ : tele_arg TB), PROP)
+         (_ : forall (_ : tele_arg TB), PROP),
+    PROP.
+
+Fixpoint do_after_shatter  (next : nat) (d : nat) : PROP :=
+  match d with
+  | 0 => T
+  | S d =>
+  (@atomic_commit
+      (@TeleS _ (fun l' => TeleO))
+      ((@tele_app (@TeleS _ (fun l' => TeleO))
+          _ (fun l' => T)))
+      ((@tele_app (@TeleS _ (fun l' =>  TeleO))
+          _ (fun l' =>
+                      do_after_shatter (l'-1) d
+                    ))))
+  end.


### PR DESCRIPTION
Was introduced in 140908d, PR #17986, 8.20.0.

Fixes / closes #19661 

The original report raises an anomaly ~~but it is not excluded that the bug allows to bypass the guard condition without failing (one would need two nested beta-redexes across a `match`, each respectively on an argument in the same inductive type, one having a well-founded body, the other not, and the first one being wrongly used in place of the second one or something like that).~~ and seems otherwise kernel-safe (see next comment).

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.