### PR TITLE
Fix #19658 (spurious incompatible-prefix warning with recursive notations)

### DIFF
--- a/doc/changelog/03-notations/19673-fix_19658.rst
+++ b/doc/changelog/03-notations/19673-fix_19658.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  spurious warning about incompatible prefixes in presence of
+  recursive notations
+  (`#19673 <https://github.com/coq/coq/pull/19673>`_,
+  fixes `#19658 <https://github.com/coq/coq/issues/19658>`_,
+  by Pierre Roux).

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -151,11 +151,6 @@ exists_true (x : nat) (A : Type) (R : A -> A -> Prop)
      : Prop * Prop * Prop
 {{D 1, 2}}
      : nat * nat * (nat * nat * (nat * nat))
-File "./output/Notations3.v", line 236, characters 0-104:
-Warning: Notations "! _ .. _ , _" defined at level 200 with arguments binder,
-constr at next level and "! _ .. _ # _ #" defined at level 200 with arguments
-binder, constr have incompatible prefixes. One of them will likely not work.
-[notation-incompatible-prefix,parsing,default]
 ! a b : nat # True #
      : Prop * (Prop * Prop)
 {{forall x : nat, x = 0, nat}}

--- a/test-suite/output/bug_19658.v
+++ b/test-suite/output/bug_19658.v
@@ -1,0 +1,4 @@
+Reserved Notation "'<{' x1 .. xn '<<{' z '}>'"
+  (at level 0, z at level 50, x1 binder, xn binder).
+Reserved Notation "'<{' x1 .. xn '<{' z '}>'"
+  (at level 0, z at level 60, x1 binder, xn binder).


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19658 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- ~[ ] Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - ~[ ] Documented any new / changed **user messages**.~
  - ~[ ] Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- ~[ ] Opened **overlay** pull requests.~

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
