### PR TITLE
Recognize opaque primitive projections in `Hint Extern`

### DIFF
--- a/doc/changelog/04-tactics/19675-janno-fix-19668.rst
+++ b/doc/changelog/04-tactics/19675-janno-fix-19668.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Fix a regression in `Hint Extern` matching primitive projections
+  (`#19675 <https://github.com/coq/coq/pull/19675>`_,
+  fixes `#19668 <https://github.com/coq/coq/issues/19668>`_,
+  by Jan-Oliver Kaiser).

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -173,9 +173,9 @@ let constr_pat_discr_syntactic env p =
       let ref = Environ.QGlobRef.canonize env ref in
       Some (GRLabel ref, stack)
     | PRef ((VarRef _) as ref) -> Some (GRLabel ref, stack)
-    | PRef ((ConstRef _) as ref) ->
-      let ref = Environ.QGlobRef.canonize env ref in
-      Some (GRLabel ref, stack)
+    | PRef (ConstRef c) ->
+      let c = Environ.QConstant.canonize env c in
+      Some (label_of_opaque_constant c stack)
     | PVar v -> Some (GRLabel (VarRef v), stack)
     | PProd (_,d,c) when stack = [] -> Some (ProdLabel, [d ; c])
     | PSort s when stack = [] -> Some (SortLabel, [])

--- a/test-suite/success/primitive_tc.v
+++ b/test-suite/success/primitive_tc.v
@@ -79,3 +79,30 @@ Module Sections.
     typeclasses eauto with test. (* This will fail if [Hint Transparent v] is improperly discharged. *)
   Qed.
 End Sections.
+
+Module HintExtern.
+  #[projections(primitive)]
+  Record bi (x : True) : Type := BI {car : Type; foo : car}.
+  Axiom x : True.
+  Axiom PROP:bi x.
+  Inductive Fwd (P : car x PROP) : Prop := MKFWD.
+  Create HintDb db discriminated.
+  #[local] Hint Opaque foo : test.
+  Module ConstantPattern.
+    #[local] Hint Extern 0 (Fwd (@foo x PROP)) => constructor : test.
+    Goal Fwd (@foo x PROP).
+    Proof.
+      intros.
+      typeclasses eauto with test.
+    Qed.
+  End ConstantPattern.
+
+  Module ProjPattern.
+    #[local] Hint Extern 0 (Fwd (PROP.(@foo x))) => constructor : test.
+    Goal Fwd (@foo x PROP).
+    Proof.
+      intros.
+      typeclasses eauto with test.
+    Qed.
+  End ProjPattern.
+End HintExtern.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

A simple oversight introduced by yours truly in https://github.com/coq/coq/pull/18979. I am not sure why  `git bisect` did not lead me there directly. 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19668


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
