### PR TITLE
Bench: do not save profiles from OLD as artifacts

### DIFF
--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -22,7 +22,6 @@ bench:
       - _bench/opam.NEW/**/*.prof.json.gz
       - _bench/opam.OLD/**/*.log
       - _bench/opam.OLD/**/*.timing
-      - _bench/opam.OLD/**/*.prof.json.gz
     when: always
     expire_in: 1 year
   environment: bench


### PR DESCRIPTION
We are getting close to the 500MB compressed limit for artifacts, this should help.
