### PR TITLE
[CI] Reenable coq-json with its new dune build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -886,7 +886,6 @@ library:ci-http:
   - library:ci-itree_io
   - plugin:ci-quickchick
   stage: build-3+
-  allow_failure: true # C.f. https://github.com/coq/coq/pull/19672
 
 library:ci-trakt:
   extends: .ci-template-flambda

--- a/dev/ci/ci-json.sh
+++ b/dev/ci/ci-json.sh
@@ -10,6 +10,6 @@ git_download json
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/json"
-  make MENHIRFLAGS="--coq --coq-no-version-check"
-  make install
+  dune build -p coq-json @install
+  dune install -p coq-json --prefix=$CI_INSTALL_DIR
 )

--- a/dev/ci/ci-parsec.sh
+++ b/dev/ci/ci-parsec.sh
@@ -10,6 +10,6 @@ git_download parsec
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/parsec"
-  make
-  make install
+  dune build -p coq-parsec @install
+  dune install -p coq-parsec --prefix=$CI_INSTALL_DIR
 )


### PR DESCRIPTION
Following the recent merge of
https://github.com/liyishuai/coq-json/commit/b5a494fb16dee90d810cf34c41328cd5fa49b85c
