### PR TITLE
Refresh template levels in clenvs.

### DIFF
--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -32,7 +32,7 @@ let meta_type env evd mv =
     with Not_found -> anomaly (str "unknown meta ?" ++ str (Nameops.string_of_meta mv) ++ str ".") in
   meta_instance env evd ty
 
-let fresh_template_context env0 sigma indu (mib, mip as spec) args =
+let fresh_template_context env0 sigma ind (mib, mip as spec) args =
   let templ = match mib.Declarations.mind_template with
   | None -> assert false
   | Some t -> Array.of_list t.template_param_arguments
@@ -54,11 +54,11 @@ let fresh_template_context env0 sigma indu (mib, mip as spec) args =
         let s ~expected = match ESorts.kind sigma s with
         | Sorts.SProp ->
           let indty = EConstr.of_constr @@
-            Inductive.type_of_inductive (spec, Unsafe.to_instance @@ snd indu)
+            Inductive.type_of_inductive (spec, UVars.Instance.empty)
           in
           error_cant_apply_bad_type env0 sigma
             (i+1, mkType (Univ.Universe.make expected), args.(i).uj_type)
-            (make_judge (mkIndU indu) indty)
+            (make_judge (mkIndU (ind, EInstance.empty)) indty)
             args
         | Sorts.Prop -> TemplateProp
         | Sorts.Set -> TemplateUniv Univ.Universe.type0
@@ -73,6 +73,10 @@ let fresh_template_context env0 sigma indu (mib, mip as spec) args =
     freshen i (push_rel decl env) sigma (decl :: accu) sorts ctx
   in
   freshen 0 env0 sigma [] [] ctx
+
+let get_template_parameters env sigma ind args =
+  let spec = Inductive.lookup_mind_specif env ind in
+  fresh_template_context env sigma ind spec args
 
 let type_judgment env sigma j =
   match EConstr.kind sigma (whd_all env sigma j.uj_type) with
@@ -138,7 +142,7 @@ let judge_of_applied ~check env sigma funj argjv =
 let judge_of_applied_inductive_knowing_parameters ~check env sigma (ind, u) argjv =
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
   let () = if check then Reductionops.check_hyps_inclusion env sigma (GR.IndRef ind) mib.mind_hyps in
-  let sigma, paramstyp = fresh_template_context env sigma (ind, u) specif argjv in
+  let sigma, paramstyp = fresh_template_context env sigma ind specif argjv in
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_inductive_knowing_parameters (specif, u0) paramstyp in
   let sigma = Evd.add_constraints sigma csts in
@@ -148,7 +152,7 @@ let judge_of_applied_inductive_knowing_parameters ~check env sigma (ind, u) argj
 let judge_of_applied_constructor_knowing_parameters ~check env sigma ((ind, _ as cstr), u) argjv =
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
   let () = if check then Reductionops.check_hyps_inclusion env sigma (GR.IndRef ind) mib.mind_hyps in
-  let sigma, paramstyp = fresh_template_context env sigma (ind, u) specif argjv in
+  let sigma, paramstyp = fresh_template_context env sigma ind specif argjv in
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_constructor_knowing_parameters (cstr, u0) specif paramstyp in
   let sigma = Evd.add_constraints sigma csts in

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -77,3 +77,7 @@ type ('constr,'types,'r) bad_relevance =
 | BadRelevanceCase of 'r * 'constr
 
 val bad_relevance_msg : (Environ.env * evar_map * (constr, types, ERelevance.t) bad_relevance) CWarnings.msg
+
+(** Template typing *)
+
+val get_template_parameters : env -> evar_map -> inductive -> unsafe_judgment array -> evar_map * Inductive.param_univs

--- a/test-suite/bugs/bug_19680_1.v
+++ b/test-suite/bugs/bug_19680_1.v
@@ -1,0 +1,26 @@
+Axiom admit : False.
+
+Record CSetoid : Type := makeCSetoid {cs_crr :> Type}.
+
+Inductive QposInf : Set :=
+| Qpos2QposInf : QposInf
+| QposInfinity : QposInf.
+
+Axiom is_RegularFunction : forall {X:Type} (x:QposInf -> X), Prop.
+
+Record Complete (X:Type) : Type := {approximate : QposInf -> X ;regFun_prf : is_RegularFunction approximate }.
+
+Axiom Q_as_MetricSpace : Type.
+
+Definition CR : Type := Complete Q_as_MetricSpace.
+
+Axiom inject_Q_CR : CR.
+Definition CRasCSetoid : CSetoid := makeCSetoid CR.
+
+Goal forall (f : nat -> CRasCSetoid) (Hf : nat), Complete (Complete Q_as_MetricSpace).
+Proof.
+intros f Hf.
+exists (fun e:QposInf => match e with | QposInfinity => inject_Q_CR
+ | Qpos2QposInf => let n := Hf in f n end).
+elim admit.
+Qed. (* Anomaly here *)

--- a/test-suite/bugs/bug_19680_2.v
+++ b/test-suite/bugs/bug_19680_2.v
@@ -1,0 +1,7 @@
+#[local] Set Universe Polymorphism.
+#[local] Unset Universe Minimization ToSet.
+#[local] Set Decidable Equality Schemes.
+
+Inductive option (A:Type) : Type :=
+| Some : A -> option A
+| None : option A.

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -42,5 +42,5 @@ cannot be applied to the terms
  "n" : "Type"
  "n" : "Type"
 The 2nd term has type "Type" which should be a subtype of 
-"Set". (universe inconsistency: Cannot enforce Errors.35 <= Set)
+"Set". (universe inconsistency: Cannot enforce Errors.57 <= Set)
 

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -12,13 +12,13 @@ end
 Arguments eqT_rect A%type_scope a P%function_scope f a0 e
 seq_rect =
 fun (A : Type@{seq.u0}) (a : A)
-  (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.10}) 
+  (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.30}) 
   (f : P a (srefl a)) (a0 : A) (s : seq a a0) =>
 match s :> seq a a0 as s0 in (seq _ a1) return (P a1 s0) with
 | srefl _ => f
 end
      : forall (A : Type@{seq.u0}) (a : A)
-         (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.10}),
+         (P : forall a0 : A, seq a a0 -> Type@{PrintMatch.30}),
        P a (srefl a) -> forall (a0 : A) (s : seq a a0), P a0 s
 
 Arguments seq_rect A%type_scope a P%function_scope f a0 s

--- a/test-suite/output/ShowUnivs.out
+++ b/test-suite/output/ShowUnivs.out
@@ -14,19 +14,19 @@ Normalized constraints:
  {w v u} |= u <= v
             v <= w
 UNIVERSES:
- {ShowUnivs.8 ShowUnivs.7 ShowUnivs.6 ShowUnivs.5 ShowUnivs.4} |=
-   ShowUnivs.5 < ShowUnivs.6
-   ShowUnivs.6 < ShowUnivs.7
-   ShowUnivs.6 <= ShowUnivs.8
-   ShowUnivs.7 <= ShowUnivs.4
-   ShowUnivs.8 <= ShowUnivs.4
+ {ShowUnivs.28 ShowUnivs.27 ShowUnivs.26 ShowUnivs.25 ShowUnivs.24} |=
+   ShowUnivs.25 < ShowUnivs.26
+   ShowUnivs.26 < ShowUnivs.27
+   ShowUnivs.26 <= ShowUnivs.28
+   ShowUnivs.27 <= ShowUnivs.24
+   ShowUnivs.28 <= ShowUnivs.24
 ALGEBRAIC UNIVERSES:
- {ShowUnivs.8 ShowUnivs.7 ShowUnivs.4}
+ {ShowUnivs.28 ShowUnivs.27 ShowUnivs.24}
 FLEXIBLE UNIVERSES:
- ShowUnivs.8
- ShowUnivs.7
- ShowUnivs.6
- ShowUnivs.4
+ ShowUnivs.28
+ ShowUnivs.27
+ ShowUnivs.26
+ ShowUnivs.24
 SORTS:
  α1 := Type
  α2 := Type
@@ -35,4 +35,4 @@ WEAK CONSTRAINTS:
  
 
 Normalized constraints:
- {ShowUnivs.6 ShowUnivs.5} |= ShowUnivs.5 < ShowUnivs.6
+ {ShowUnivs.26 ShowUnivs.25} |= ShowUnivs.25 < ShowUnivs.26

--- a/test-suite/output/SortQuality.out
+++ b/test-suite/output/SortQuality.out
@@ -1,1 +1,1 @@
-Type@{α1 | SortQuality.1}
+Type@{α1 | SortQuality.21}

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -75,9 +75,9 @@ File "./output/UnivBinders.v", line 70, characters 0-52:
 The command has indeed failed with message:
 Universe uu already exists.
 bobmorane =
-let tt := Type@{UnivBinders.32} in
-let ff := Type@{UnivBinders.34} in tt -> ff
-     : Type@{max(UnivBinders.31,UnivBinders.33)}
+let tt := Type@{UnivBinders.52} in
+let ff := Type@{UnivBinders.54} in tt -> ff
+     : Type@{max(UnivBinders.51,UnivBinders.53)}
 File "./output/UnivBinders.v", line 85, characters 23-25:
 The command has indeed failed with message:
 Universe uu already bound.
@@ -199,9 +199,9 @@ block).
 foo@{i} = Type@{M.i} -> Type@{i}
      : Type@{max(M.i+1,i+1)}
 (* i |=  *)
-Type@{u0} -> Type@{UnivBinders.65}
-     : Type@{max(u0+1,UnivBinders.65+1)}
-(* {UnivBinders.65} |=  *)
+Type@{u0} -> Type@{UnivBinders.85}
+     : Type@{max(u0+1,UnivBinders.85+1)}
+(* {UnivBinders.85} |=  *)
 bind_univs.mono = Type@{bind_univs.mono.u}
      : Type@{bind_univs.mono.u+1}
 bind_univs.poly@{u} = Type@{u}

--- a/test-suite/output/prim_array.out
+++ b/test-suite/output/prim_array.out
@@ -4,6 +4,6 @@
      : array nat
 [| | 0 : nat |]@{Set}
      : array@{Set} nat
-[| bool; list nat | nat : Set |]@{prim_array.9}
-     : array@{prim_array.9} Set
-(* {prim_array.9} |= Set < prim_array.9 *)
+[| bool; list nat | nat : Set |]@{prim_array.29}
+     : array@{prim_array.29} Set
+(* {prim_array.29} |= Set < prim_array.29 *)

--- a/test-suite/output/sort_poly_elim_error.out
+++ b/test-suite/output/sort_poly_elim_error.out
@@ -1,7 +1,7 @@
 File "./output/sort_poly_elim_error.v", line 8, characters 0-108:
 The command has indeed failed with message:
 Incorrect elimination of "p" in the inductive type
-"sum@{Prop | sort_poly_elim_error.3 sort_poly_elim_error.4}":
+"sum@{Prop | sort_poly_elim_error.23 sort_poly_elim_error.24}":
 the return type has sort "Type" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Type"

--- a/test-suite/success/apply_template.v
+++ b/test-suite/success/apply_template.v
@@ -1,0 +1,10 @@
+Inductive T (A : Type) := tt.
+
+Universe u.
+
+Lemma dummy : forall (A : Type@{u}), T A.
+Proof.
+intros; apply tt.
+Qed.
+
+Constraint T.u0 < u. (* Check that there is no constraint u <= T.u0 *)


### PR DESCRIPTION
When creating a clenv out of a template polymorphic constructor, we now refresh the type of the arguments. This prevents adding spurious global constraints between the argument types and the global default template level when calling Clenv-based tactics such as apply. The implementation is a bit hackish because some callers fiddle with clenv evarmaps but in practice it seems to be mostly working.