### PR TITLE
Correctly recheck universes when change-ing partially applied template terms

### DIFF
--- a/test-suite/bugs/bug_19682.v
+++ b/test-suite/bugs/bug_19682.v
@@ -1,0 +1,10 @@
+Axiom admit : False.
+
+Inductive foo (A : Type) : Prop := I.
+
+Lemma bar : foo Type.
+Proof.
+change foo with (fun x : Type => foo x). (* We shouldn't lose the constraint here *)
+cbv beta.
+elim admit.
+Defined. (* Illegal application error *)


### PR DESCRIPTION
Fixes #19682.

The bug is post-8.20 as it was introduced by the redesign of the template typing rules.