### PR TITLE
(8.20) Correct syntax of Obligation in doc

### DIFF
--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -293,7 +293,7 @@ optional tactic is replaced by the default one if not specified.
 
    Displays all remaining obligations.
 
-.. cmd:: Obligation @natural {? of @ident } {? : @type {? with @ltac_expr } }
+.. cmd:: Obligation @natural {? of @ident } {? : @type } {? with @ltac_expr }
 
    Start the proof of obligation :token:`natural`.
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1321,7 +1321,7 @@ command: [
 | WITH "Final" "Obligation" OPT ( "of" identref ) withtac
 | DELETE "Final" "Obligation" withtac
 | REPLACE "Obligation" natural "of" identref ":" lglob withtac
-| WITH "Obligation" natural OPT ( "of" identref ) OPT ( ":" type withtac )
+| WITH "Obligation" natural OPT ( "of" identref ) OPT ( ":" type ) withtac
 | DELETE "Obligation" natural "of" identref withtac
 | DELETE "Obligation" natural ":" lglob withtac
 | DELETE "Obligation" natural withtac

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -843,7 +843,7 @@ command: [
 | "Attributes" LIST1 attribute SEP ","
 | "Declare" "Instance" ident_decl LIST0 binder ":" term OPT hint_info
 | "Declare" "Scope" scope_name
-| "Obligation" natural OPT ( "of" ident ) OPT ( ":" type OPT ( "with" ltac_expr ) )
+| "Obligation" natural OPT ( "of" ident ) OPT ( ":" type ) OPT ( "with" ltac_expr )
 | "Next" "Obligation" OPT ( "of" ident ) OPT ( "with" ltac_expr )
 | "Final" "Obligation" OPT ( "of" ident ) OPT ( "with" ltac_expr )
 | "Solve" "Obligations" OPT ( "of" ident ) OPT ( "with" ltac_expr )


### PR DESCRIPTION
In master the optional `: type` will be removed, cf https://github.com/coq/coq/pull/19678
