### PR TITLE
Update the remaining headers to reflect the fact Coq is now Rocq.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/dev/header.c
+++ b/dev/header.c
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/dev/header.py
+++ b/dev/header.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/sphinx/_static/ansi-dark.css
+++ b/doc/sphinx/_static/ansi-dark.css
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/_static/ansi.css
+++ b/doc/sphinx/_static/ansi.css
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/_static/coqdoc.css
+++ b/doc/sphinx/_static/coqdoc.css
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/_static/notations.js
+++ b/doc/sphinx/_static/notations.js
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/_static/pre-text.css
+++ b/doc/sphinx/_static/pre-text.css
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/__init__.py
+++ b/doc/tools/coqrst/__init__.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/checkdeps.py
+++ b/doc/tools/coqrst/checkdeps.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/coqdoc/__init__.py
+++ b/doc/tools/coqrst/coqdoc/__init__.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/coqdoc/main.py
+++ b/doc/tools/coqrst/coqdoc/main.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/Makefile
+++ b/doc/tools/coqrst/notations/Makefile
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/TacticNotations.g
+++ b/doc/tools/coqrst/notations/TacticNotations.g
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/doc/tools/coqrst/notations/fontsupport.py
+++ b/doc/tools/coqrst/notations/fontsupport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/html.py
+++ b/doc/tools/coqrst/notations/html.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/parsing.py
+++ b/doc/tools/coqrst/notations/parsing.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/plain.py
+++ b/doc/tools/coqrst/notations/plain.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/regexp.py
+++ b/doc/tools/coqrst/notations/regexp.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/notations/sphinx.py
+++ b/doc/tools/coqrst/notations/sphinx.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/repl/ansicolors.py
+++ b/doc/tools/coqrst/repl/ansicolors.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/coqrst/repl/coqtop.py
+++ b/doc/tools/coqrst/repl/coqtop.py
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/coqide_QUARTZ.ml.in
+++ b/ide/coqide/coqide_QUARTZ.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/coqide_WIN32.ml.in
+++ b/ide/coqide/coqide_WIN32.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/coqide_X11.ml.in
+++ b/ide/coqide/coqide_X11.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/shared_QUARTZ.ml.in
+++ b/ide/coqide/shared_QUARTZ.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/shared_WIN32.ml.in
+++ b/ide/coqide/shared_WIN32.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/ide/coqide/shared_X11.ml.in
+++ b/ide/coqide/shared_X11.ml.in
@@ -1,5 +1,5 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)
 (* <O___,, * (see version control and CREDITS file for authors & dates) *)
 (*   \VV/  **************************************************************)

--- a/kernel/byterun/coq_float64.c
+++ b/kernel/byterun/coq_float64.c
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/kernel/byterun/coq_uint63_emul.h
+++ b/kernel/byterun/coq_uint63_emul.h
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/kernel/byterun/coq_uint63_native.h
+++ b/kernel/byterun/coq_uint63_native.h
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/perf/perf.c
+++ b/perf/perf.c
@@ -1,5 +1,5 @@
 /************************************************************************/
-/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*         *      The Rocq Prover / The Rocq Development Team           */
 /*  v      *         Copyright INRIA, CNRS and contributors             */
 /* <O___,, * (see version control and CREDITS file for authors & dates) */
 /*   \VV/  **************************************************************/

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -1,5 +1,5 @@
 ##########################################################################
-##         #   The Coq Proof Assistant / The Coq Development Team       ##
+##         #      The Rocq Prover / The Rocq Development Team           ##
 ##  v      #         Copyright INRIA, CNRS and contributors             ##
 ## <O___,, # (see version control and CREDITS file for authors & dates) ##
 ##   \VV/  ###############################################################


### PR DESCRIPTION
Some files use a DOS line encoding for some reason, this is a bit ugly in the diff.