### PR TITLE
Rocqify plugins

### DIFF
--- a/plugins/btauto/dune
+++ b/plugins/btauto/dune
@@ -1,7 +1,7 @@
 (library
  (name btauto_plugin)
  (public_name coq-core.plugins.btauto)
- (synopsis "Coq's btauto plugin")
+ (synopsis "Rocq's btauto plugin")
  (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules g_btauto))

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -20,7 +20,7 @@ let lapp c v  = Constr.mkApp (Lazy.force c, v)
 let (===) = Constr.equal
 
 
-module CoqList = struct
+module RocqList = struct
   let _nil =  bt_lib_constr "core.list.nil"
   let _cons = bt_lib_constr "core.list.cons"
 
@@ -32,7 +32,7 @@ module CoqList = struct
 
 end
 
-module CoqPositive = struct
+module RocqPositive = struct
   let _xH = bt_lib_constr "num.pos.xH"
   let _xO = bt_lib_constr "num.pos.xO"
   let _xI = bt_lib_constr "num.pos.xI"
@@ -150,7 +150,7 @@ module Btauto = struct
   let soundness = bt_lib_constr "plugins.btauto.soundness"
 
   let rec convert = function
-  | Bool.Var n -> lapp f_var [|CoqPositive.of_int n|]
+  | Bool.Var n -> lapp f_var [|RocqPositive.of_int n|]
   | Bool.Const true -> Lazy.force f_top
   | Bool.Const false -> Lazy.force f_btm
   | Bool.Andb (b1, b2) -> lapp f_cnj [|convert b1; convert b2|]
@@ -160,7 +160,7 @@ module Btauto = struct
   | Bool.Ifb (b1, b2, b3) -> lapp f_ifb [|convert b1; convert b2; convert b3|]
 
   let convert_env env : Constr.t =
-    CoqList.of_list (Lazy.force Bool.typ) env
+    RocqList.of_list (Lazy.force Bool.typ) env
 
   let reify env t = lapp eval [|convert_env env; convert t|]
 
@@ -173,9 +173,9 @@ module Btauto = struct
     let var = EConstr.Unsafe.to_constr var in
     let rec to_list l = match decomp_term sigma l with
       | App (c, _)
-        when c === (Lazy.force CoqList._nil) -> []
+        when c === (Lazy.force RocqList._nil) -> []
       | App (c, [|_; h; t|])
-        when c === (Lazy.force CoqList._cons) ->
+        when c === (Lazy.force RocqList._cons) ->
         if h === (Lazy.force Bool.trueb) then (true :: to_list t)
         else if h === (Lazy.force Bool.falseb) then (false :: to_list t)
         else invalid_arg "to_list"

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* This file is the interface between the c-c algorithm and Coq *)
+(* This file is the interface between the c-c algorithm and Rocq *)
 
 open Names
 open Inductiveops

--- a/plugins/cc/dune
+++ b/plugins/cc/dune
@@ -1,14 +1,14 @@
 (library
  (name cc_core_plugin)
  (public_name coq-core.plugins.cc_core)
- (synopsis "Coq's congruence closure plugin")
+ (synopsis "Rocq's congruence closure plugin")
  (modules (:standard \ g_congruence))
  (libraries coq-core.vernac))
 
 (library
  (name cc_plugin)
  (public_name coq-core.plugins.cc)
- (synopsis "Coq's congruence closure plugin (Ltac1 syntax)")
+ (synopsis "Rocq's congruence closure plugin (Ltac1 syntax)")
  (modules g_congruence)
  (flags :standard -open Cc_core_plugin)
  (libraries coq-core.plugins.ltac coq-core.plugins.cc_core))

--- a/plugins/derive/dune
+++ b/plugins/derive/dune
@@ -1,7 +1,7 @@
 (library
  (name derive_plugin)
  (public_name coq-core.plugins.derive)
- (synopsis "Coq's derive plugin")
+ (synopsis "Rocq's derive plugin")
  (libraries coq-core.vernac))
 
 (coq.pp (modules g_derive))

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -502,7 +502,7 @@ let opened_libraries () =
    otherwise it contains the label of the reference to print.
    [rls] is the string list giving the qualified name, short name at the end. *)
 
-(* In Coq, we can qualify [M.t] even if we are inside [M], but in Ocaml we
+(* In Rocq, we can qualify [M.t] even if we are inside [M], but in Ocaml we
    cannot do that. So, if [t] gets hidden and we need a long name for it,
    we duplicate the _definition_ of t in a Coq__XXX module, and similarly
    for a sub-module [M.N] *)
@@ -696,7 +696,7 @@ let check_extract_string () =
     String.equal (find_custom @@ string_type_ref ()) string_type
   with Not_found -> false
 
-(* The argument is known to be of type Coq.Strings.String.string.
+(* The argument is known to be of type Strings.String.string.
    Check that it is built from constructors EmptyString and String
    with constant ascii arguments. *)
 

--- a/plugins/extraction/dune
+++ b/plugins/extraction/dune
@@ -1,7 +1,7 @@
 (library
  (name extraction_plugin)
  (public_name coq-core.plugins.extraction)
- (synopsis "Coq's extraction plugin")
+ (synopsis "Rocq's extraction plugin")
  (libraries coq-core.vernac))
 
 (coq.pp (modules g_extraction))

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -22,9 +22,9 @@ open Extraction
 open Modutil
 open Common
 
-(***************************************)
-(*S Part I: computing Coq environment. *)
-(***************************************)
+(****************************************)
+(*S Part I: computing Rocq environment. *)
+(****************************************)
 
 let toplevel_env () =
   let mp, struc = Safe_typing.flatten_env (Global.safe_env ()) in
@@ -573,7 +573,7 @@ let print_structure_to_file (fn,si,mo) dry struc =
        end;
        info_file si)
     (if dry then None else si);
-  (* Print the buffer content via Coq standard formatter (ok with coqide). *)
+  (* Print the buffer content via Rocq standard formatter (ok with coqide). *)
   if not (Int.equal (Buffer.length buf) 0) then begin
     Feedback.msg_notice (str (Buffer.contents buf));
     Buffer.reset buf
@@ -620,7 +620,7 @@ let rec locate_ref = function
            warning_ambiguous_name ?loc:qid.CAst.loc (qid,mp,r);
            let refs,mps = locate_ref l in refs,mp::mps
 
-(*s Recursive extraction in the Coq toplevel. The vernacular command is
+(*s Recursive extraction in the Rocq toplevel. The vernacular command is
     \verb!Recursive Extraction! [qualid1] ... [qualidn]. Also used when
     extracting to a file with the command:
     \verb!Extraction "file"! [qualid1] ... [qualidn]. *)
@@ -637,7 +637,7 @@ let full_extraction ~opaque_access f lr =
   full_extr opaque_access f (locate_ref lr)
 
 (*s Separate extraction is similar to recursive extraction, with the output
-   decomposed in many files, one per Coq .v file *)
+   decomposed in many files, one per Rocq .v file *)
 
 let separate_extraction ~opaque_access lr =
   init true false;
@@ -658,7 +658,7 @@ let separate_extraction ~opaque_access lr =
   List.iter print struc;
   reset ()
 
-(*s Simple extraction in the Coq toplevel. The vernacular command
+(*s Simple extraction in the Rocq toplevel. The vernacular command
     is \verb!Extraction! [qualid]. *)
 
 let simple_extraction ~opaque_access r =

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -47,7 +47,7 @@ let sort_of env sg c =
 
 (*S Generation of flags and signatures. *)
 
-(* The type [flag] gives us information about any Coq term:
+(* The type [flag] gives us information about any Rocq term:
    \begin{itemize}
    \item [TypeScheme] denotes a type scheme, that is
      something that will become a type after enough applications.
@@ -205,7 +205,7 @@ let sign_with_implicits r s nb_params =
 
 (*S Management of type variable contexts. *)
 
-(* A De Bruijn variable context (db) is a context for translating Coq [Rel]
+(* A De Bruijn variable context (db) is a context for translating Rocq [Rel]
    into ML type [Tvar]. *)
 
 (*s From a type signature toward a type variable context (db). *)
@@ -224,12 +224,12 @@ let rec db_from_ind dbmap i =
   if Int.equal i 0 then []
   else (try Int.Map.find i dbmap with Not_found -> 0)::(db_from_ind dbmap (i-1))
 
-(*s [parse_ind_args] builds a map: [i->j] iff the i-th Coq argument
+(*s [parse_ind_args] builds a map: [i->j] iff the i-th Rocq argument
   of a constructor corresponds to the j-th type var of the ML inductive. *)
 
 (* \begin{itemize}
    \item [si] : signature of the inductive
-   \item [i] :  counter of Coq args for [(I args)]
+   \item [i] :  counter of Rocq args for [(I args)]
    \item [j] : counter of ML type vars
    \item [relmax] : total args number of the constructor
    \end{itemize} *)
@@ -326,9 +326,9 @@ let fake_match_projection env p =
 (*S Extraction of a type. *)
 
 (* [extract_type env db c args] is used to produce an ML type from the
-   coq term [(c args)], which is supposed to be a Coq type. *)
+   coq term [(c args)], which is supposed to be a Rocq type. *)
 
-(* [db] is a context for translating Coq [Rel] into ML type [Tvar]. *)
+(* [db] is a context for translating Rocq [Rel] into ML type [Tvar]. *)
 
 (* [j] stands for the next ML type var. [j=0] means we do not
    generate ML type var anymore (in subterms for example). *)
@@ -437,12 +437,12 @@ and extract_type_app env sg db (r,s) args =
 
 (*S Extraction of a type scheme. *)
 
-(* [extract_type_scheme env db c p] works on a Coq term [c] which is
-  an informative type scheme. It means that [c] is not a Coq type, but will
+(* [extract_type_scheme env db c p] works on a Rocq term [c] which is
+  an informative type scheme. It means that [c] is not a Rocq type, but will
   be when applied to sufficiently many arguments ([p] in fact).
   This function decomposes p lambdas, with eta-expansion if needed. *)
 
-(* [db] is a context for translating Coq [Rel] into ML type [Tvar]. *)
+(* [db] is a context for translating Rocq [Rel] into ML type [Tvar]. *)
 
 and extract_type_scheme env sg db c p =
   if Int.equal p 0 then extract_type env sg db 0 c []
@@ -609,7 +609,7 @@ and extract_really_ind env kn mib =
 (*s [extract_type_cons] extracts the type of an inductive
   constructor toward the corresponding list of ML types.
 
-   - [db] is a context for translating Coq [Rel] into ML type [Tvar]
+   - [db] is a context for translating Rocq [Rel] into ML type [Tvar]
    - [dbmap] is a translation map (produced by a call to [parse_in_args])
    - [i] is the rank of the current product (initially [params_nb+1])
 *)
@@ -623,7 +623,7 @@ and extract_type_cons env sg db dbmap c i =
         (extract_type env sg db 0 t []) :: l
     | _ -> []
 
-(*s Recording the ML type abbreviation of a Coq type scheme constant. *)
+(*s Recording the ML type abbreviation of a Rocq type scheme constant. *)
 
 and mlt_env env r = let open GlobRef in match r with
   | IndRef _ | ConstructRef _ | VarRef _ -> None
@@ -860,7 +860,7 @@ and extract_cst_app env sg mle mlt kn args =
    \item In ML, constructor arguments are uncurryfied.
    \item We managed to suppress logical parts inside inductive definitions,
    but they must appears outside (for partial applications for instance)
-   \item We also suppressed all Coq parameters to the inductives, since
+   \item We also suppressed all Rocq parameters to the inductives, since
    they are fixed, and thus are not used for the computation.
    \end{itemize} *)
 
@@ -1061,7 +1061,7 @@ let extract_std_constant env sg kn body typ =
   let mle = List.fold_left Mlenv.push_std_type Mlenv.empty l in
   (* The lambdas names. *)
   let ids = List.map (fun (n,_) -> Id (id_of_name n.binder_name)) rels in
-  (* The according Coq environment. *)
+  (* The according Rocq environment. *)
   let env = push_rels_assum rels env in
   (* The real extraction: *)
   let e = extract_term env sg mle t' c [] in

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(*s Extraction from Coq terms to Miniml. *)
+(*s Extraction from Rocq terms to Miniml. *)
 
 open Names
 open Declarations

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -71,7 +71,7 @@ END
 (* Extraction commands *)
 
 VERNAC COMMAND EXTEND Extraction CLASSIFIED AS QUERY STATE opaque_access
-(* Extraction in the Coq toplevel *)
+(* Extraction in the Rocq toplevel *)
 | [ "Extraction" global(x) ] -> { simple_extraction x }
 | [ "Recursive" "Extraction" ne_global_list(l) ] -> { full_extraction None l }
 
@@ -90,7 +90,7 @@ VERNAC COMMAND EXTEND SeparateExtraction CLASSIFIED AS QUERY STATE opaque_access
   -> { separate_extraction l }
 END
 
-(* Modular extraction (one Coq library = one ML module) *)
+(* Modular extraction (one Rocq library = one ML module) *)
 VERNAC COMMAND EXTEND ExtractionLibrary CLASSIFIED AS QUERY STATE opaque_access
 | [ "Extraction" "Library" identref(m) ]
   -> { extraction_library false m }
@@ -152,7 +152,7 @@ END
 
 (* Commands for setting, printing and resetting callbacks extraction. *)
 
-(* Defining a Coq object as ML callback for FFI call target from C *)
+(* Defining a Rocq object as ML callback for FFI call target from C *)
 VERNAC COMMAND EXTEND ExtractionCallback CLASSIFIED AS SIDEFF
 | [ "Extract" "Callback" string_opt(o) global(x) ]
   -> { extract_callback o x }
@@ -181,13 +181,13 @@ VERNAC COMMAND EXTEND ResetExtractionForeign CLASSIFIED AS SIDEFF
 END
 *)
 
-(* Overriding of a Coq object by an ML one *)
+(* Overriding of a Rocq object by an ML one *)
 VERNAC COMMAND EXTEND ExtractionConstant CLASSIFIED AS SIDEFF
 | [ "Extract" "Constant" global(x) string_list(idl) "=>" mlname(y) ]
   -> { extract_constant_inline false x idl y }
 END
 
-(* Overriding of a Coq object by an ML one that will be a FFI call to C *)
+(* Overriding of a Rocq object by an ML one that will be a FFI call to C *)
 VERNAC COMMAND EXTEND ExtractionForeignConstant CLASSIFIED AS SIDEFF
 | [ "Extract" "Foreign" "Constant" global(x) "=>" string(y) ]
   -> { extract_constant_foreign x y }

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -413,7 +413,7 @@ let error_nb_cons () =
   err (str "Not the right number of constructors.")
 
 let error_module_clash mp1 mp2 =
-  err (str "The Coq modules " ++ pr_long_mp mp1 ++ str " and " ++
+  err (str "The Rocq modules " ++ pr_long_mp mp1 ++ str " and " ++
        pr_long_mp mp2 ++ str " have the same ML name.\n" ++
        str "This is not supported yet. Please do some renaming first.")
 

--- a/plugins/firstorder/dune
+++ b/plugins/firstorder/dune
@@ -1,14 +1,14 @@
 (library
  (name firstorder_core_plugin)
  (public_name coq-core.plugins.firstorder_core)
- (synopsis "Coq's first order logic solver plugin")
+ (synopsis "Rocq's first order logic solver plugin")
  (modules (:standard \ g_ground))
  (libraries coq-core.tactics))
 
 (library
  (name firstorder_plugin)
  (public_name coq-core.plugins.firstorder)
- (synopsis "Coq's first order logic solver plugin (Ltac1 syntax)")
+ (synopsis "Rocq's first order logic solver plugin (Ltac1 syntax)")
  (flags :standard -open Firstorder_core_plugin)
  (modules g_ground)
  (libraries coq-core.plugins.firstorder_core coq-core.plugins.ltac))

--- a/plugins/funind/dune
+++ b/plugins/funind/dune
@@ -1,7 +1,7 @@
 (library
  (name funind_plugin)
  (public_name coq-core.plugins.funind)
- (synopsis "Coq's functional induction plugin")
+ (synopsis "Rocq's functional induction plugin")
  (libraries coq-core.plugins.ltac coq-core.plugins.extraction))
 
 (coq.pp (modules g_indfun))

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -335,15 +335,15 @@ let rewrite_until_var arg_num eq_ids : unit Proofview.tactic =
 let rec_pte_id = Id.of_string "Hrec"
 
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
-  let coq_False =
+  let rocq_False =
     EConstr.of_constr
       (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.False.type")
   in
-  let coq_True =
+  let rocq_True =
     EConstr.of_constr
       (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.True.type")
   in
-  let coq_I =
+  let rocq_I =
     EConstr.of_constr
       (UnivGen.constr_of_monomorphic_global env @@ Coqlib.lib_ref "core.True.I")
   in
@@ -401,7 +401,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
             change_hyp_with_using "rec_hyp_tac" hyp_id real_type_of_hyp
               prove_new_type_of_hyp
           ; scan_type context popped_t' ]
-      else if eq_constr sigma t_x coq_False then
+      else if eq_constr sigma t_x rocq_False then
         (*          observe (str "Removing : "++ Ppconstr.pr_id hyp_id++  *)
         (*                     str " since it has False in its preconds " *)
         (*                  ); *)
@@ -409,7 +409,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
       else if is_incompatible_eq env sigma t_x then raise TOREMOVE
         (* t_x := C1 ... =  C2 ... *)
       else if
-        eq_constr sigma t_x coq_True (* Trivial => we remove this precons *)
+        eq_constr sigma t_x rocq_True (* Trivial => we remove this precons *)
       then
         (*          observe (str "In "++Ppconstr.pr_id hyp_id++  *)
         (*                     str " removing useless precond True" *)
@@ -430,7 +430,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
                   let to_refine =
                     applist
                       ( mkVar hyp_id
-                      , List.rev (coq_I :: List.map mkVar context_hyps) )
+                      , List.rev (rocq_I :: List.map mkVar context_hyps) )
                   in
                   Tactics.exact_check to_refine) ]
         in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -228,8 +228,8 @@ let mk_result ctxt value avoid =
   Some functions to deal with overlapping patterns
 **************************************************)
 
-let coq_True_ref = lazy (Coqlib.lib_ref "core.True.type")
-let coq_False_ref = lazy (Coqlib.lib_ref "core.False.type")
+let rocq_True_ref = lazy (Coqlib.lib_ref "core.True.type")
+let rocq_False_ref = lazy (Coqlib.lib_ref "core.False.type")
 
 (*
   [make_discr_match_el \[e1,...en\]] builds match e1,...,en with
@@ -254,8 +254,8 @@ let make_discr_match_brl i =
     (fun j {CAst.v = idl, patl, _} ->
       CAst.make
       @@
-      if Int.equal j i then (idl, patl, mkGRef (Lazy.force coq_True_ref))
-      else (idl, patl, mkGRef (Lazy.force coq_False_ref)))
+      if Int.equal j i then (idl, patl, mkGRef (Lazy.force rocq_True_ref))
+      else (idl, patl, mkGRef (Lazy.force rocq_False_ref)))
     0
 
 (*

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -72,14 +72,14 @@ let list_union_eq eq_fun l1 l2 =
   urec l1
 
 let list_add_set_eq eq_fun x l = if List.exists (eq_fun x) l then l else x :: l
-let coq_constant s = UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s
+let rocq_constant s = UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s
 
 let find_reference sl s =
   let dp = Names.DirPath.make (List.rev_map Id.of_string sl) in
   Nametab.locate (make_qualid dp (Id.of_string s))
 
-let eq = lazy (EConstr.of_constr (coq_constant "core.eq.type"))
-let refl_equal = lazy (EConstr.of_constr (coq_constant "core.eq.refl"))
+let eq = lazy (EConstr.of_constr (rocq_constant "core.eq.type"))
+let refl_equal = lazy (EConstr.of_constr (rocq_constant "core.eq.refl"))
 
 let with_full_print f a =
   let old_implicit_args = Impargs.is_implicit_args ()
@@ -383,15 +383,15 @@ let h_id = Id.of_string "h"
 let hrec_id = Id.of_string "hrec"
 
 let well_founded = function
-  | () -> EConstr.of_constr (coq_constant "core.wf.well_founded")
+  | () -> EConstr.of_constr (rocq_constant "core.wf.well_founded")
 
-let acc_rel = function () -> EConstr.of_constr (coq_constant "core.wf.acc")
+let acc_rel = function () -> EConstr.of_constr (rocq_constant "core.wf.acc")
 
 let acc_inv_id = function
-  | () -> EConstr.of_constr (coq_constant "core.wf.acc_inv")
+  | () -> EConstr.of_constr (rocq_constant "core.wf.acc_inv")
 
 let well_founded_ltof () =
-  EConstr.of_constr (coq_constant "num.nat.well_founded_ltof")
+  EConstr.of_constr (rocq_constant "num.nat.well_founded_ltof")
 
 let ltof_ref = function () -> find_reference ["Stdlib"; "Arith"; "Wf_nat"] "ltof"
 

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -37,10 +37,10 @@ open Context.Rel.Declaration
 
 (* Ugly things which should not be here *)
 
-let coq_constant s =
+let rocq_constant s =
   EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s
 
-let coq_init_constant s =
+let rocq_init_constant s =
   EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Coqlib.lib_ref s)
 
 let find_reference sl s =
@@ -108,10 +108,10 @@ let v_id = Id.of_string "v"
 let def_id = Id.of_string "def"
 let p_id = Id.of_string "p"
 let rec_res_id = Id.of_string "rec_res"
-let lt = function () -> coq_init_constant "num.nat.lt"
+let lt = function () -> rocq_init_constant "num.nat.lt"
 let le = function () -> Coqlib.lib_ref "num.nat.le"
-let ex = function () -> coq_init_constant "core.ex.type"
-let nat = function () -> coq_init_constant "num.nat.type"
+let ex = function () -> rocq_init_constant "core.ex.type"
+let nat = function () -> rocq_init_constant "num.nat.type"
 
 let iter_ref () =
   try find_reference ["Recdef"] "iter"
@@ -120,29 +120,29 @@ let iter_ref () =
 let iter_rd = function
   | () -> constr_of_monomorphic_global (Global.env ()) (delayed_force iter_ref)
 
-let eq = function () -> coq_init_constant "core.eq.type"
+let eq = function () -> rocq_init_constant "core.eq.type"
 let le_lt_SS = function () -> constant ["Recdef"] "le_lt_SS"
-let le_lt_n_Sm = function () -> coq_constant "num.nat.le_lt_n_Sm"
-let le_trans = function () -> coq_constant "num.nat.le_trans"
-let le_lt_trans = function () -> coq_constant "num.nat.le_lt_trans"
-let lt_S_n = function () -> coq_constant "num.nat.lt_S_n"
-let le_n = function () -> coq_init_constant "num.nat.le_n"
+let le_lt_n_Sm = function () -> rocq_constant "num.nat.le_lt_n_Sm"
+let le_trans = function () -> rocq_constant "num.nat.le_trans"
+let le_lt_trans = function () -> rocq_constant "num.nat.le_lt_trans"
+let lt_S_n = function () -> rocq_constant "num.nat.lt_S_n"
+let le_n = function () -> rocq_init_constant "num.nat.le_n"
 
-let coq_sig_ref = function
+let rocq_sig_ref = function
   | () -> find_reference ["Stdlib"; "Init"; "Specif"] "sig"
 
-let coq_proj1_sig = lazy (Coqlib.build_sigma ()).proj1
+let rocq_proj1_sig = lazy (Coqlib.build_sigma ()).proj1
 
-let coq_O = function () -> coq_init_constant "num.nat.O"
-let coq_S = function () -> coq_init_constant "num.nat.S"
-let lt_n_O = function () -> coq_constant "num.nat.nlt_0_r"
+let rocq_O = function () -> rocq_init_constant "num.nat.O"
+let rocq_S = function () -> rocq_init_constant "num.nat.S"
+let lt_n_O = function () -> rocq_constant "num.nat.nlt_0_r"
 let max_ref = function () -> find_reference ["Recdef"] "max"
 
 let max_constr = function
   | () ->
     EConstr.of_constr (constr_of_monomorphic_global (Global.env ()) (delayed_force max_ref))
 
-let f_S t = mkApp (delayed_force coq_S, [|t|])
+let f_S t = mkApp (delayed_force rocq_S, [|t|])
 
 let rec n_x_id ids n =
   if Int.equal n 0 then []
@@ -170,7 +170,7 @@ let (value_f : Constr.rel_context -> GlobRef.t -> Constr.t) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let env = Environ.push_rel_context context env in
-  let proj = Globnames.destConstRef (Lazy.force coq_proj1_sig) in
+  let proj = Globnames.destConstRef (Lazy.force rocq_proj1_sig) in
   let proj_body = constant_value_in env (proj, UVars.Instance.empty) in (* Why not to keep it named? *)
   let arg = mkApp (mkRef (fterm, EInstance.empty), Context.Rel.instance mkRel 0 context) in
   let t, p = Hipattern.match_sigma env sigma (Retyping.get_type_of env sigma arg) in
@@ -541,7 +541,7 @@ let rec destruct_bounds_aux infos (bound, hyple, rechyps) lbounds =
       match lbounds with
       | [] ->
         let ids = Tacmach.pf_ids_of_hyps g in
-        let s_max = mkApp (delayed_force coq_S, [|bound|]) in
+        let s_max = mkApp (delayed_force rocq_S, [|bound|]) in
         let k = next_ident_away_in_goal k_id ids in
         let ids = k :: ids in
         let h' = next_ident_away_in_goal h'_id ids in
@@ -620,7 +620,7 @@ let rec destruct_bounds_aux infos (bound, hyple, rechyps) lbounds =
 
 let destruct_bounds infos =
   destruct_bounds_aux infos
-    (delayed_force coq_O, [], [])
+    (delayed_force rocq_O, [], [])
     infos.values_and_bounds
 
 let terminate_app f_and_args expr_info continuation_tac infos =
@@ -1093,7 +1093,7 @@ let equation_app_rec (f, args) expr_info continuation_tac info =
             ; continuation_tac
                 { expr_info with
                   args_assoc =
-                    (args, delayed_force coq_O) :: expr_info.args_assoc }
+                    (args, delayed_force rocq_O) :: expr_info.args_assoc }
             ; observe_tac
                 (fun _ _ -> str "app_rec intros_values_eq")
                 (intros_values_eq expr_info []) ]
@@ -1106,7 +1106,7 @@ let equation_app_rec (f, args) expr_info continuation_tac info =
                 (continuation_tac
                    { expr_info with
                      args_assoc =
-                       (args, delayed_force coq_O) :: expr_info.args_assoc }) ])
+                       (args, delayed_force rocq_O) :: expr_info.args_assoc }) ])
 
 let equation_info =
   { message = "prove_equation with term "
@@ -1160,7 +1160,7 @@ let compute_terminate_type nb_args func =
   in
   let value =
     mkApp
-      ( constr_of_monomorphic_global (Global.env ()) (Util.delayed_force coq_sig_ref)
+      ( constr_of_monomorphic_global (Global.env ()) (Util.delayed_force rocq_sig_ref)
       , [|b; mkLambda (make_annot (Name v_id) Sorts.Relevant, b, nb_iter)|] )
   in
   compose_prod rev_args value
@@ -1275,7 +1275,7 @@ let whole_start concl_tac nb_args is_mes func input_type relation rec_arg_num :
             ; (* we are on the main branche (i.e. still on a match ... with .... end *)
               is_final = true
             ; (* and on leaf (more or less) *)
-              f_terminate = delayed_force coq_O
+              f_terminate = delayed_force rocq_O
             ; nb_arg = nb_args
             ; concl_tac
             ; rec_arg_id

--- a/plugins/ltac/dune
+++ b/plugins/ltac/dune
@@ -1,7 +1,7 @@
 (library
  (name ltac_plugin)
  (public_name coq-core.plugins.ltac)
- (synopsis "Coq's LTAC tactic language")
+ (synopsis "Rocq's LTAC tactic language")
  (modules :standard \ tauto)
  (modules_without_implementation tacexpr)
  (libraries coq-core.vernac))
@@ -9,7 +9,7 @@
 (library
  (name tauto_plugin)
  (public_name coq-core.plugins.tauto)
- (synopsis "Coq's tauto tactic")
+ (synopsis "Rocq's tauto tactic")
  (modules tauto)
  (libraries coq-core.plugins.ltac))
 

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -37,7 +37,7 @@ val replace_term : Geninterp.interp_sign -> bool option -> closed_glob_constr ->
 
 val discrHyp : Names.Id.t -> unit tactic
 val injHyp : Names.Id.t -> unit tactic
-(* TODO: remove these, they are not used from within Coq *)
+(* TODO: remove these, they are not used from within Rocq *)
 
 val refine_tac : Tacinterp.interp_sign -> simple:bool -> with_classes:bool ->
   closed_glob_constr -> unit tactic

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -106,7 +106,7 @@ let interp_entry_name interp symb =
   eval symb
 
 (**********************************************************************)
-(** Grammar declaration for Tactic Notation (Coq level)               *)
+(** Grammar declaration for Tactic Notation (Rocq level)               *)
 
 let get_tactic_entry n =
   if Int.equal n 0 then

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -89,7 +89,7 @@ val ml_tactic_extend : plugin:string -> name:string -> local:locality_flag ->
   ?deprecation:Deprecation.t -> ('r, unit Proofview.tactic) ml_ty_sig -> 'r -> unit
 (** Helper function to define directly an Ltac function in OCaml without any
     associated parsing rule nor further shenanigans. The Ltac function will be
-    defined as [name] in the Coq file that loads the ML plugin where this
+    defined as [name] in the Rocq file that loads the ML plugin where this
     function is called. It will have the arity given by the [ml_ty_sig]
     argument. *)
 

--- a/plugins/ltac/tacenv.mli
+++ b/plugins/ltac/tacenv.mli
@@ -45,14 +45,14 @@ val interp_alias : alias -> alias_tactic
 val check_alias : alias -> bool
 (** Returns [true] if an alias is defined, false otherwise. *)
 
-(** {5 Coq tactic definitions} *)
+(** {5 Rocq tactic definitions} *)
 
 val register_ltac : bool -> bool -> ?deprecation:Deprecation.t -> Id.t ->
   glob_tactic_expr -> unit
 (** Register a new Ltac with the given name and body.
 
     The first boolean indicates whether this is done from ML side, rather than
-    Coq side. If the second boolean flag is set to true, then this is a local
+    Rocq side. If the second boolean flag is set to true, then this is a local
     definition. It also puts the Ltac name in the nametab, so that it can be
     used unqualified. *)
 

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -82,7 +82,6 @@ let update_bpt fname offset opt =
 let upd_bpts updates =
   List.iter (fun op ->
     let ((file, offset), opt) = op in
-(*    Printf.printf "Coq upd_bpts %s %d %b\n%!" file offset opt;*)
     update_bpt file offset opt;
   ) updates
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -74,34 +74,34 @@ let format = repr_ext val_format
 let core_prefix path n = KerName.make path (Label.of_id (Id.of_string_soft n))
 
 let std_core n = core_prefix Tac2env.std_prefix n
-let coq_core n = core_prefix Tac2env.coq_prefix n
+let rocq_core n = core_prefix Tac2env.rocq_prefix n
 
 module Core =
 struct
 
-let t_unit = coq_core "unit"
+let t_unit = rocq_core "unit"
 let v_unit = Tac2ffi.of_unit ()
 
-let t_int = coq_core "int"
-let t_string = coq_core "string"
-let t_array = coq_core "array"
-let t_list = coq_core "list"
-let t_constr = coq_core "constr"
-let t_preterm = coq_core "preterm"
-let t_pattern = coq_core "pattern"
-let t_ident = coq_core "ident"
-let t_option = coq_core "option"
-let t_exn = coq_core "exn"
+let t_int = rocq_core "int"
+let t_string = rocq_core "string"
+let t_array = rocq_core "array"
+let t_list = rocq_core "list"
+let t_constr = rocq_core "constr"
+let t_preterm = rocq_core "preterm"
+let t_pattern = rocq_core "pattern"
+let t_ident = rocq_core "ident"
+let t_option = rocq_core "option"
+let t_exn = rocq_core "exn"
 let t_reference = std_core "reference"
 
-let c_nil = coq_core "[]"
-let c_cons = coq_core "::"
+let c_nil = rocq_core "[]"
+let c_cons = rocq_core "::"
 
-let c_none = coq_core "None"
-let c_some = coq_core "Some"
+let c_none = rocq_core "None"
+let c_some = rocq_core "Some"
 
-let c_true = coq_core "true"
-let c_false = coq_core "false"
+let c_true = rocq_core "true"
+let c_false = rocq_core "false"
 
 end
 
@@ -166,19 +166,19 @@ let projection = repr_ext val_projection
 (** Stdlib exceptions *)
 
 let err_notfocussed =
-  Tac2interp.LtacError (coq_core "Not_focussed", [||])
+  Tac2interp.LtacError (rocq_core "Not_focussed", [||])
 
 let err_outofbounds =
-  Tac2interp.LtacError (coq_core "Out_of_bounds", [||])
+  Tac2interp.LtacError (rocq_core "Out_of_bounds", [||])
 
 let err_notfound =
-  Tac2interp.LtacError (coq_core "Not_found", [||])
+  Tac2interp.LtacError (rocq_core "Not_found", [||])
 
 let err_matchfailure =
-  Tac2interp.LtacError (coq_core "Match_failure", [||])
+  Tac2interp.LtacError (rocq_core "Match_failure", [||])
 
 let err_division_by_zero =
-  Tac2interp.LtacError (coq_core "Division_by_zero", [||])
+  Tac2interp.LtacError (rocq_core "Division_by_zero", [||])
 
 (** Helper functions *)
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1247,7 +1247,7 @@ let call ~pstate g ~with_end_tac tac =
 let call_par ~pstate ~with_end_tac tac =
   ComTactic.solve_parallel ~pstate ~info:None (ltac2_interp tac) ~abstract:false ~with_end_tac
 
-(** Primitive algebraic types than can't be defined Coq-side *)
+(** Primitive algebraic types than can't be defined Rocq-side *)
 
 let register_prim_alg name params def =
   let id = Id.of_string name in

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1010,7 +1010,7 @@ let pr_frame = function
 
 let () = register_handler begin function
 | Tac2interp.LtacError (kn, args) ->
-  let t_exn = KerName.make Tac2env.coq_prefix (Label.make "exn") in
+  let t_exn = KerName.make Tac2env.rocq_prefix (Label.make "exn") in
   let v = Tac2ffi.of_open (kn, args) in
   let t = GTypRef (Other t_exn, []) in
   let c = Tac2print.pr_valexpr (Global.env ()) Evd.empty v t in
@@ -1266,7 +1266,7 @@ let register_prim_alg name params def =
   let def = { typdef_local = false; typdef_abstract = false; typdef_expr = def } in
   Lib.add_leaf (inTypDef id def)
 
-let coq_def n = KerName.make Tac2env.coq_prefix (Label.make n)
+let rocq_def n = KerName.make Tac2env.rocq_prefix (Label.make n)
 
 let def_unit = {
   typdef_local = false;
@@ -1274,7 +1274,7 @@ let def_unit = {
   typdef_expr = 0, GTydDef (Some (GTypRef (Tuple 0, [])));
 }
 
-let t_list = coq_def "list"
+let t_list = rocq_def "list"
 
 let () = Mltop.declare_cache_obj begin fun () ->
   let unit = Id.of_string "unit" in

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -344,8 +344,10 @@ let interp_ml_object t =
 
 (** Absolute paths *)
 
-let coq_prefix =
+let rocq_prefix =
   MPfile (DirPath.make (List.map Id.of_string ["Init"; "Ltac2"]))
+
+let coq_prefix = rocq_prefix
 
 let std_prefix =
   MPfile (DirPath.make (List.map Id.of_string ["Std"; "Ltac2"]))

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -169,7 +169,10 @@ val interp_ml_object : ('a, 'b) Tac2dyn.Arg.tag -> ('a, 'b) ml_object
 
 (** {5 Absolute paths} *)
 
-val coq_prefix : ModPath.t
+val rocq_prefix : ModPath.t
+(** Path where primitive datatypes are defined in Ltac2 plugin. *)
+
+val coq_prefix : ModPath.t [@@ocaml.deprecated "(9.0) Use rocq_prefix"]
 (** Path where primitive datatypes are defined in Ltac2 plugin. *)
 
 val std_prefix : ModPath.t

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -195,10 +195,10 @@ let evar = repr_ext val_evar
 
 let internal_err =
   let open Names in
-  let coq_prefix =
+  let rocq_prefix =
     MPfile (DirPath.make (List.map Id.of_string ["Init"; "Ltac2"]))
   in
-  KerName.make coq_prefix (Label.of_id (Id.of_string "Internal"))
+  KerName.make rocq_prefix (Label.of_id (Id.of_string "Internal"))
 
 let of_exninfo = of_ext val_exninfo
 let to_exninfo = to_ext val_exninfo

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -22,17 +22,17 @@ open Tac2typing_env
 
 (** Hardwired types and constants *)
 
-let coq_type n = KerName.make Tac2env.coq_prefix (Label.make n)
+let rocq_type n = KerName.make Tac2env.rocq_prefix (Label.make n)
 let ltac1_kn n = KerName.make Tac2env.ltac1_prefix (Label.make n)
 
-let t_int = coq_type "int"
-let t_string = coq_type "string"
-let t_constr = coq_type "constr"
+let t_int = rocq_type "int"
+let t_string = rocq_type "string"
+let t_constr = rocq_type "constr"
 let t_ltac1 = ltac1_kn "t"
 let ltac1_lamdba = ltac1_kn "lambda"
-let t_preterm = coq_type "preterm"
-let t_pattern = coq_type "pattern"
-let t_bool = coq_type "bool"
+let t_preterm = rocq_type "preterm"
+let t_pattern = rocq_type "pattern"
+let t_bool = rocq_type "bool"
 
 let ltac2_env : Tac2typing_env.t Genintern.Store.field =
   Genintern.Store.field "ltac2_env"

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -30,7 +30,7 @@ let change_kn_label kn id =
 let paren p = hov 2 (str "(" ++ p ++ str ")")
 
 let t_list =
-  KerName.make Tac2env.coq_prefix (Label.of_id (Id.of_string "list"))
+  KerName.make Tac2env.rocq_prefix (Label.of_id (Id.of_string "list"))
 
 let c_nil = change_kn_label t_list (Id.of_string_soft "[]")
 let c_cons = change_kn_label t_list (Id.of_string_soft "::")
@@ -45,7 +45,7 @@ type typ_level =
 | T0
 
 let t_unit =
-  KerName.make Tac2env.coq_prefix (Label.of_id (Id.of_string "unit"))
+  KerName.make Tac2env.rocq_prefix (Label.of_id (Id.of_string "unit"))
 
 let pr_typref kn =
   Libnames.pr_qualid (Tac2env.shortest_qualid_of_type kn)
@@ -850,7 +850,7 @@ and pr_val_list env sigma args tpe =
 let pr_valexpr env sigma v t = pr_valexpr_gen env sigma E5 v t
 
 let register_init n f =
-  let kn = KerName.make Tac2env.coq_prefix (Label.make n) in
+  let kn = KerName.make Tac2env.rocq_prefix (Label.make n) in
   register_val_printer kn { val_printer = fun env sigma v _ -> f env sigma v }
 
 let () = register_init "int" begin fun _ _ n ->
@@ -897,7 +897,7 @@ let () = register_init "err" begin fun _ _ e ->
 end
 
 let () =
-  let kn = KerName.make Tac2env.coq_prefix (Label.make "array") in
+  let kn = KerName.make Tac2env.rocq_prefix (Label.make "array") in
   let val_printer env sigma v arg = match arg with
   | [arg] ->
     let (_, v) = to_block v in

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -38,7 +38,7 @@ let format_prefix = MPdot (prefix_gen "Message", Label.make "Format")
 
 let kername prefix n = KerName.make prefix (Label.of_id (Id.of_string_soft n))
 let std_core n = kername Tac2env.std_prefix n
-let coq_core n = kername Tac2env.coq_prefix n
+let rocq_core n = kername Tac2env.rocq_prefix n
 let control_core n = kername control_prefix n
 let pattern_core n = kername pattern_prefix n
 
@@ -64,7 +64,7 @@ let std_proj ?loc name =
   AbsKn (std_core name)
 
 let thunk e =
-  let t_unit = coq_core "unit" in
+  let t_unit = rocq_core "unit" in
   let loc = e.loc in
   let ty = CAst.make?loc @@ CTypRef (AbsKn (Other t_unit), []) in
   let pat = CAst.make ?loc @@ CPatVar (Anonymous) in
@@ -89,8 +89,8 @@ let of_int {loc;v=n} =
   CAst.make ?loc @@ CTacAtm (AtmInt n)
 
 let of_option ?loc f opt = match opt with
-| None -> constructor ?loc (coq_core "None") []
-| Some e -> constructor ?loc (coq_core "Some") [f e]
+| None -> constructor ?loc (rocq_core "None") []
+| Some e -> constructor ?loc (rocq_core "Some") [f e]
 
 let inj_wit ?loc wit x =
   CAst.make ?loc @@ CTacExt (wit, x)
@@ -152,13 +152,13 @@ let of_open_constr_expected_istype ?delimiters c =
       c])
 
 let of_bool ?loc b =
-  let c = if b then coq_core "true" else coq_core "false" in
+  let c = if b then rocq_core "true" else rocq_core "false" in
   constructor ?loc c []
 
 let rec of_list ?loc f = function
-| [] -> constructor (coq_core "[]") []
+| [] -> constructor (rocq_core "[]") []
 | e :: l ->
-  constructor ?loc (coq_core "::") [f e; of_list ?loc f l]
+  constructor ?loc (rocq_core "::") [f e; of_list ?loc f l]
 
 let array_literal ?loc a =
   if CList.is_empty a then global_ref ?loc (kername array_prefix "empty")
@@ -314,7 +314,7 @@ let abstract_vars loc ?typ vars tac =
   let pat = match typ with
   | None -> pat
   | Some typ ->
-    let t_array = coq_core "array" in
+    let t_array = rocq_core "array" in
     let typ = CAst.make ?loc @@ CTypRef (AbsKn (Other t_array), [typ]) in
     CAst.make ?loc @@ CPatCnv (pat, typ)
   in
@@ -471,7 +471,7 @@ let of_constr_matching {loc;v=m} =
     let vars = List.map (fun (id, loc) -> CAst.make ?loc (Name id)) vars in
     (* Annotate the bound array variable with constr type *)
     let typ =
-      let t_constr = coq_core "constr" in
+      let t_constr = rocq_core "constr" in
       CAst.make ?loc @@ CTypRef (AbsKn (Other t_constr), [])
     in
     let e = abstract_vars loc ~typ vars tac in

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -15,7 +15,7 @@ open Genredexpr
 open Tac2types
 open Proofview
 
-(** Local reimplementations of tactics variants from Coq *)
+(** Local reimplementations of tactics variants from Rocq *)
 
 val intros_patterns : evars_flag -> intro_pattern list -> unit tactic
 

--- a/plugins/ltac2/tac2val.mli
+++ b/plugins/ltac2/tac2val.mli
@@ -18,7 +18,7 @@ open Names
     immediate integers (integers, constructors without arguments) and structured
     blocks (tuples, arrays, constructors with arguments), as well as a few other
     base cases, namely closures, strings, named constructors, and dynamic type
-    coming from the Coq implementation. *)
+    coming from the Rocq implementation. *)
 
 type tag = int
 

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -1010,7 +1010,7 @@ let nlia prfdepth sys =
     let sys3 = nlinear_preprocess (rev_concat [bnd1; sys1; sys2]) in
     xlia env sys3
 
-(* For regression testing, if bench = true generate a Coq goal *)
+(* For regression testing, if bench = true generate a Rocq goal *)
 
 let lia  prfdepth sys = gen_bench ("lia", lia)  prfdepth sys
 let nlia  prfdepth sys = gen_bench ("nia", nlia)  prfdepth sys

--- a/plugins/micromega/certificate.mli
+++ b/plugins/micromega/certificate.mli
@@ -14,10 +14,10 @@ type ('prf, 'model) res = Prf of 'prf | Model of 'model | Unknown
 type zres = (Mc.zArithProof, int * Mc.z list) res
 type qres = (Mc.q Mc.psatz, int * Mc.q list) res
 
-(** [q_cert_of_pos prf] converts a Sos proof into a rational Coq proof *)
+(** [q_cert_of_pos prf] converts a Sos proof into a rational Rocq proof *)
 val q_cert_of_pos : Sos_types.positivstellensatz -> Mc.q Mc.psatz
 
-(** [z_cert_of_pos prf] converts a Sos proof into an integer Coq proof *)
+(** [z_cert_of_pos prf] converts a Sos proof into an integer Rocq proof *)
 val z_cert_of_pos : Sos_types.positivstellensatz -> Mc.z Mc.psatz
 
 (** [lia depth sys] generates an unsat proof for the linear constraints in [sys]. *)

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -152,9 +152,9 @@ let selecti s m =
   xselecti 0 m
 
 (**
-  * MODULE: Mapping of the Coq data-strustures into Caml and Caml extracted
-  * code. This includes initializing Caml variables based on Coq terms, parsing
-  * various Coq expressions into Caml, and dumping Caml expressions into Coq.
+  * MODULE: Mapping of the Rocq data-strustures into Caml and Caml extracted
+  * code. This includes initializing Caml variables based on Rocq terms, parsing
+  * various Rocq expressions into Caml, and dumping Caml expressions into Rocq.
   *
   * Opened here and in csdpcert.ml.
   *)
@@ -317,13 +317,13 @@ let rocq_Build = lazy (constr_of_ref "micromega.Formula.Build_Formula")
 let rocq_Cstr = lazy (constr_of_ref "micromega.Formula.type")
 
 (**
-    * Parsing and dumping : transformation functions between Caml and Coq
+    * Parsing and dumping : transformation functions between Caml and Rocq
     * data-structures.
     *
-    * dump_*    functions go from Micromega to Coq terms
-    * undump_*  functions go from Coq to Micromega terms (reverse of dump_)
-    * parse_*   functions go from Coq to Micromega terms
-    * pp_*      functions pretty-print Coq terms.
+    * dump_*    functions go from Micromega to Rocq terms
+    * undump_*  functions go from Rocq to Micromega terms (reverse of dump_)
+    * parse_*   functions go from Rocq to Micromega terms
+    * pp_*      functions pretty-print Rocq terms.
     *)
 
 exception ParseError
@@ -1526,7 +1526,7 @@ let max_tag f =
    x <= y or (x and y are incomparable) *)
 
 (**
-  * Instantiate the current Coq goal with a Micromega formula, a varmap, and a
+  * Instantiate the current Rocq goal with a Micromega formula, a varmap, and a
   * witness.
   *)
 
@@ -1769,7 +1769,7 @@ let rec abstract_wrt_formula f1 f2 =
     | _ -> failwith "abstract_wrt_formula")
 
 (**
-  * This exception is raised by really_call_csdpcert if Coq's configure didn't
+  * This exception is raised by really_call_csdpcert if Rocq's configure didn't
   * find a CSDP executable.
   *)
 
@@ -2187,7 +2187,7 @@ end)
 (**
   * Build the command to call csdpcert, and launch it. This in turn will call
   * the sos driver to the csdp executable.
-  * Throw CsdpNotFound if Coq isn't aware of any csdp executable.
+  * Throw CsdpNotFound if Rocq isn't aware of any csdp executable.
   *)
 
 let require_csdp =

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -167,154 +167,154 @@ let selecti s m =
 let constr_of_ref str =
   EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref str))
 
-let coq_and = lazy (constr_of_ref "core.and.type")
-let coq_or = lazy (constr_of_ref "core.or.type")
-let coq_not = lazy (constr_of_ref "core.not.type")
-let coq_iff = lazy (constr_of_ref "core.iff.type")
-let coq_True = lazy (constr_of_ref "core.True.type")
-let coq_False = lazy (constr_of_ref "core.False.type")
-let coq_bool = lazy (constr_of_ref "core.bool.type")
-let coq_true = lazy (constr_of_ref "core.bool.true")
-let coq_false = lazy (constr_of_ref "core.bool.false")
-let coq_andb = lazy (constr_of_ref "core.bool.andb")
-let coq_orb = lazy (constr_of_ref "core.bool.orb")
-let coq_implb = lazy (constr_of_ref "core.bool.implb")
-let coq_eqb = lazy (constr_of_ref "core.bool.eqb")
-let coq_negb = lazy (constr_of_ref "core.bool.negb")
-let coq_cons = lazy (constr_of_ref "core.list.cons")
-let coq_nil = lazy (constr_of_ref "core.list.nil")
-let coq_list = lazy (constr_of_ref "core.list.type")
-let coq_O = lazy (constr_of_ref "num.nat.O")
-let coq_S = lazy (constr_of_ref "num.nat.S")
-let coq_nat = lazy (constr_of_ref "num.nat.type")
-let coq_unit = lazy (constr_of_ref "core.unit.type")
+let rocq_and = lazy (constr_of_ref "core.and.type")
+let rocq_or = lazy (constr_of_ref "core.or.type")
+let rocq_not = lazy (constr_of_ref "core.not.type")
+let rocq_iff = lazy (constr_of_ref "core.iff.type")
+let rocq_True = lazy (constr_of_ref "core.True.type")
+let rocq_False = lazy (constr_of_ref "core.False.type")
+let rocq_bool = lazy (constr_of_ref "core.bool.type")
+let rocq_true = lazy (constr_of_ref "core.bool.true")
+let rocq_false = lazy (constr_of_ref "core.bool.false")
+let rocq_andb = lazy (constr_of_ref "core.bool.andb")
+let rocq_orb = lazy (constr_of_ref "core.bool.orb")
+let rocq_implb = lazy (constr_of_ref "core.bool.implb")
+let rocq_eqb = lazy (constr_of_ref "core.bool.eqb")
+let rocq_negb = lazy (constr_of_ref "core.bool.negb")
+let rocq_cons = lazy (constr_of_ref "core.list.cons")
+let rocq_nil = lazy (constr_of_ref "core.list.nil")
+let rocq_list = lazy (constr_of_ref "core.list.type")
+let rocq_O = lazy (constr_of_ref "num.nat.O")
+let rocq_S = lazy (constr_of_ref "num.nat.S")
+let rocq_nat = lazy (constr_of_ref "num.nat.type")
+let rocq_unit = lazy (constr_of_ref "core.unit.type")
 
-(*  let coq_option = lazy (init_constant "option")*)
-let coq_None = lazy (constr_of_ref "core.option.None")
-let coq_tt = lazy (constr_of_ref "core.unit.tt")
-let coq_Inl = lazy (constr_of_ref "core.sum.inl")
-let coq_Inr = lazy (constr_of_ref "core.sum.inr")
-let coq_N0 = lazy (constr_of_ref "num.N.N0")
-let coq_Npos = lazy (constr_of_ref "num.N.Npos")
-let coq_xH = lazy (constr_of_ref "num.pos.xH")
-let coq_xO = lazy (constr_of_ref "num.pos.xO")
-let coq_xI = lazy (constr_of_ref "num.pos.xI")
-let coq_Z = lazy (constr_of_ref "num.Z.type")
-let coq_ZERO = lazy (constr_of_ref "num.Z.Z0")
-let coq_POS = lazy (constr_of_ref "num.Z.Zpos")
-let coq_NEG = lazy (constr_of_ref "num.Z.Zneg")
-let coq_Q = lazy (constr_of_ref "rat.Q.type")
-let coq_Qmake = lazy (constr_of_ref "rat.Q.Qmake")
-let coq_R = lazy (constr_of_ref "reals.R.type")
-let coq_Rcst = lazy (constr_of_ref "micromega.Rcst.type")
-let coq_C0 = lazy (constr_of_ref "micromega.Rcst.C0")
-let coq_C1 = lazy (constr_of_ref "micromega.Rcst.C1")
-let coq_CQ = lazy (constr_of_ref "micromega.Rcst.CQ")
-let coq_CZ = lazy (constr_of_ref "micromega.Rcst.CZ")
-let coq_CPlus = lazy (constr_of_ref "micromega.Rcst.CPlus")
-let coq_CMinus = lazy (constr_of_ref "micromega.Rcst.CMinus")
-let coq_CMult = lazy (constr_of_ref "micromega.Rcst.CMult")
-let coq_CPow = lazy (constr_of_ref "micromega.Rcst.CPow")
-let coq_CInv = lazy (constr_of_ref "micromega.Rcst.CInv")
-let coq_COpp = lazy (constr_of_ref "micromega.Rcst.COpp")
-let coq_R0 = lazy (constr_of_ref "reals.R.R0")
-let coq_R1 = lazy (constr_of_ref "reals.R.R1")
-let coq_proofTerm = lazy (constr_of_ref "micromega.ZArithProof.type")
-let coq_doneProof = lazy (constr_of_ref "micromega.ZArithProof.DoneProof")
-let coq_ratProof = lazy (constr_of_ref "micromega.ZArithProof.RatProof")
-let coq_cutProof = lazy (constr_of_ref "micromega.ZArithProof.CutProof")
-let coq_splitProof = lazy (constr_of_ref "micromega.ZArithProof.SplitProof")
-let coq_enumProof = lazy (constr_of_ref "micromega.ZArithProof.EnumProof")
-let coq_ExProof = lazy (constr_of_ref "micromega.ZArithProof.ExProof")
-let coq_IsProp = lazy (constr_of_ref "micromega.kind.isProp")
-let coq_IsBool = lazy (constr_of_ref "micromega.kind.isBool")
-let coq_Zgt = lazy (constr_of_ref "num.Z.gt")
-let coq_Zge = lazy (constr_of_ref "num.Z.ge")
-let coq_Zle = lazy (constr_of_ref "num.Z.le")
-let coq_Zlt = lazy (constr_of_ref "num.Z.lt")
-let coq_Zgtb = lazy (constr_of_ref "num.Z.gtb")
-let coq_Zgeb = lazy (constr_of_ref "num.Z.geb")
-let coq_Zleb = lazy (constr_of_ref "num.Z.leb")
-let coq_Zltb = lazy (constr_of_ref "num.Z.ltb")
-let coq_Zeqb = lazy (constr_of_ref "num.Z.eqb")
-let coq_eq = lazy (constr_of_ref "core.eq.type")
-let coq_Zplus = lazy (constr_of_ref "num.Z.add")
-let coq_Zminus = lazy (constr_of_ref "num.Z.sub")
-let coq_Zopp = lazy (constr_of_ref "num.Z.opp")
-let coq_Zmult = lazy (constr_of_ref "num.Z.mul")
-let coq_Zpower = lazy (constr_of_ref "num.Z.pow")
-let coq_Qle = lazy (constr_of_ref "rat.Q.Qle")
-let coq_Qlt = lazy (constr_of_ref "rat.Q.Qlt")
-let coq_Qeq = lazy (constr_of_ref "rat.Q.Qeq")
-let coq_Qplus = lazy (constr_of_ref "rat.Q.Qplus")
-let coq_Qminus = lazy (constr_of_ref "rat.Q.Qminus")
-let coq_Qopp = lazy (constr_of_ref "rat.Q.Qopp")
-let coq_Qmult = lazy (constr_of_ref "rat.Q.Qmult")
-let coq_Qpower = lazy (constr_of_ref "rat.Q.Qpower")
-let coq_Rgt = lazy (constr_of_ref "reals.R.Rgt")
-let coq_Rge = lazy (constr_of_ref "reals.R.Rge")
-let coq_Rle = lazy (constr_of_ref "reals.R.Rle")
-let coq_Rlt = lazy (constr_of_ref "reals.R.Rlt")
-let coq_Rplus = lazy (constr_of_ref "reals.R.Rplus")
-let coq_Rminus = lazy (constr_of_ref "reals.R.Rminus")
-let coq_Ropp = lazy (constr_of_ref "reals.R.Ropp")
-let coq_Rmult = lazy (constr_of_ref "reals.R.Rmult")
-let coq_Rinv = lazy (constr_of_ref "reals.R.Rinv")
-let coq_Rpower = lazy (constr_of_ref "reals.R.pow")
-let coq_powerZR = lazy (constr_of_ref "reals.R.powerRZ")
-let coq_IZR = lazy (constr_of_ref "reals.R.IZR")
-let coq_IQR = lazy (constr_of_ref "reals.R.Q2R")
-let coq_PEX = lazy (constr_of_ref "micromega.PExpr.PEX")
-let coq_PEc = lazy (constr_of_ref "micromega.PExpr.PEc")
-let coq_PEadd = lazy (constr_of_ref "micromega.PExpr.PEadd")
-let coq_PEopp = lazy (constr_of_ref "micromega.PExpr.PEopp")
-let coq_PEmul = lazy (constr_of_ref "micromega.PExpr.PEmul")
-let coq_PEsub = lazy (constr_of_ref "micromega.PExpr.PEsub")
-let coq_PEpow = lazy (constr_of_ref "micromega.PExpr.PEpow")
-let coq_PX = lazy (constr_of_ref "micromega.Pol.PX")
-let coq_Pc = lazy (constr_of_ref "micromega.Pol.Pc")
-let coq_Pinj = lazy (constr_of_ref "micromega.Pol.Pinj")
-let coq_OpEq = lazy (constr_of_ref "micromega.Op2.OpEq")
-let coq_OpNEq = lazy (constr_of_ref "micromega.Op2.OpNEq")
-let coq_OpLe = lazy (constr_of_ref "micromega.Op2.OpLe")
-let coq_OpLt = lazy (constr_of_ref "micromega.Op2.OpLt")
-let coq_OpGe = lazy (constr_of_ref "micromega.Op2.OpGe")
-let coq_OpGt = lazy (constr_of_ref "micromega.Op2.OpGt")
-let coq_PsatzLet = lazy (constr_of_ref "micromega.Psatz.PsatzLet")
-let coq_PsatzIn = lazy (constr_of_ref "micromega.Psatz.PsatzIn")
-let coq_PsatzSquare = lazy (constr_of_ref "micromega.Psatz.PsatzSquare")
-let coq_PsatzMulE = lazy (constr_of_ref "micromega.Psatz.PsatzMulE")
-let coq_PsatzMultC = lazy (constr_of_ref "micromega.Psatz.PsatzMulC")
-let coq_PsatzAdd = lazy (constr_of_ref "micromega.Psatz.PsatzAdd")
-let coq_PsatzC = lazy (constr_of_ref "micromega.Psatz.PsatzC")
-let coq_PsatzZ = lazy (constr_of_ref "micromega.Psatz.PsatzZ")
+(*  let rocq_option = lazy (init_constant "option")*)
+let rocq_None = lazy (constr_of_ref "core.option.None")
+let rocq_tt = lazy (constr_of_ref "core.unit.tt")
+let rocq_Inl = lazy (constr_of_ref "core.sum.inl")
+let rocq_Inr = lazy (constr_of_ref "core.sum.inr")
+let rocq_N0 = lazy (constr_of_ref "num.N.N0")
+let rocq_Npos = lazy (constr_of_ref "num.N.Npos")
+let rocq_xH = lazy (constr_of_ref "num.pos.xH")
+let rocq_xO = lazy (constr_of_ref "num.pos.xO")
+let rocq_xI = lazy (constr_of_ref "num.pos.xI")
+let rocq_Z = lazy (constr_of_ref "num.Z.type")
+let rocq_ZERO = lazy (constr_of_ref "num.Z.Z0")
+let rocq_POS = lazy (constr_of_ref "num.Z.Zpos")
+let rocq_NEG = lazy (constr_of_ref "num.Z.Zneg")
+let rocq_Q = lazy (constr_of_ref "rat.Q.type")
+let rocq_Qmake = lazy (constr_of_ref "rat.Q.Qmake")
+let rocq_R = lazy (constr_of_ref "reals.R.type")
+let rocq_Rcst = lazy (constr_of_ref "micromega.Rcst.type")
+let rocq_C0 = lazy (constr_of_ref "micromega.Rcst.C0")
+let rocq_C1 = lazy (constr_of_ref "micromega.Rcst.C1")
+let rocq_CQ = lazy (constr_of_ref "micromega.Rcst.CQ")
+let rocq_CZ = lazy (constr_of_ref "micromega.Rcst.CZ")
+let rocq_CPlus = lazy (constr_of_ref "micromega.Rcst.CPlus")
+let rocq_CMinus = lazy (constr_of_ref "micromega.Rcst.CMinus")
+let rocq_CMult = lazy (constr_of_ref "micromega.Rcst.CMult")
+let rocq_CPow = lazy (constr_of_ref "micromega.Rcst.CPow")
+let rocq_CInv = lazy (constr_of_ref "micromega.Rcst.CInv")
+let rocq_COpp = lazy (constr_of_ref "micromega.Rcst.COpp")
+let rocq_R0 = lazy (constr_of_ref "reals.R.R0")
+let rocq_R1 = lazy (constr_of_ref "reals.R.R1")
+let rocq_proofTerm = lazy (constr_of_ref "micromega.ZArithProof.type")
+let rocq_doneProof = lazy (constr_of_ref "micromega.ZArithProof.DoneProof")
+let rocq_ratProof = lazy (constr_of_ref "micromega.ZArithProof.RatProof")
+let rocq_cutProof = lazy (constr_of_ref "micromega.ZArithProof.CutProof")
+let rocq_splitProof = lazy (constr_of_ref "micromega.ZArithProof.SplitProof")
+let rocq_enumProof = lazy (constr_of_ref "micromega.ZArithProof.EnumProof")
+let rocq_ExProof = lazy (constr_of_ref "micromega.ZArithProof.ExProof")
+let rocq_IsProp = lazy (constr_of_ref "micromega.kind.isProp")
+let rocq_IsBool = lazy (constr_of_ref "micromega.kind.isBool")
+let rocq_Zgt = lazy (constr_of_ref "num.Z.gt")
+let rocq_Zge = lazy (constr_of_ref "num.Z.ge")
+let rocq_Zle = lazy (constr_of_ref "num.Z.le")
+let rocq_Zlt = lazy (constr_of_ref "num.Z.lt")
+let rocq_Zgtb = lazy (constr_of_ref "num.Z.gtb")
+let rocq_Zgeb = lazy (constr_of_ref "num.Z.geb")
+let rocq_Zleb = lazy (constr_of_ref "num.Z.leb")
+let rocq_Zltb = lazy (constr_of_ref "num.Z.ltb")
+let rocq_Zeqb = lazy (constr_of_ref "num.Z.eqb")
+let rocq_eq = lazy (constr_of_ref "core.eq.type")
+let rocq_Zplus = lazy (constr_of_ref "num.Z.add")
+let rocq_Zminus = lazy (constr_of_ref "num.Z.sub")
+let rocq_Zopp = lazy (constr_of_ref "num.Z.opp")
+let rocq_Zmult = lazy (constr_of_ref "num.Z.mul")
+let rocq_Zpower = lazy (constr_of_ref "num.Z.pow")
+let rocq_Qle = lazy (constr_of_ref "rat.Q.Qle")
+let rocq_Qlt = lazy (constr_of_ref "rat.Q.Qlt")
+let rocq_Qeq = lazy (constr_of_ref "rat.Q.Qeq")
+let rocq_Qplus = lazy (constr_of_ref "rat.Q.Qplus")
+let rocq_Qminus = lazy (constr_of_ref "rat.Q.Qminus")
+let rocq_Qopp = lazy (constr_of_ref "rat.Q.Qopp")
+let rocq_Qmult = lazy (constr_of_ref "rat.Q.Qmult")
+let rocq_Qpower = lazy (constr_of_ref "rat.Q.Qpower")
+let rocq_Rgt = lazy (constr_of_ref "reals.R.Rgt")
+let rocq_Rge = lazy (constr_of_ref "reals.R.Rge")
+let rocq_Rle = lazy (constr_of_ref "reals.R.Rle")
+let rocq_Rlt = lazy (constr_of_ref "reals.R.Rlt")
+let rocq_Rplus = lazy (constr_of_ref "reals.R.Rplus")
+let rocq_Rminus = lazy (constr_of_ref "reals.R.Rminus")
+let rocq_Ropp = lazy (constr_of_ref "reals.R.Ropp")
+let rocq_Rmult = lazy (constr_of_ref "reals.R.Rmult")
+let rocq_Rinv = lazy (constr_of_ref "reals.R.Rinv")
+let rocq_Rpower = lazy (constr_of_ref "reals.R.pow")
+let rocq_powerZR = lazy (constr_of_ref "reals.R.powerRZ")
+let rocq_IZR = lazy (constr_of_ref "reals.R.IZR")
+let rocq_IQR = lazy (constr_of_ref "reals.R.Q2R")
+let rocq_PEX = lazy (constr_of_ref "micromega.PExpr.PEX")
+let rocq_PEc = lazy (constr_of_ref "micromega.PExpr.PEc")
+let rocq_PEadd = lazy (constr_of_ref "micromega.PExpr.PEadd")
+let rocq_PEopp = lazy (constr_of_ref "micromega.PExpr.PEopp")
+let rocq_PEmul = lazy (constr_of_ref "micromega.PExpr.PEmul")
+let rocq_PEsub = lazy (constr_of_ref "micromega.PExpr.PEsub")
+let rocq_PEpow = lazy (constr_of_ref "micromega.PExpr.PEpow")
+let rocq_PX = lazy (constr_of_ref "micromega.Pol.PX")
+let rocq_Pc = lazy (constr_of_ref "micromega.Pol.Pc")
+let rocq_Pinj = lazy (constr_of_ref "micromega.Pol.Pinj")
+let rocq_OpEq = lazy (constr_of_ref "micromega.Op2.OpEq")
+let rocq_OpNEq = lazy (constr_of_ref "micromega.Op2.OpNEq")
+let rocq_OpLe = lazy (constr_of_ref "micromega.Op2.OpLe")
+let rocq_OpLt = lazy (constr_of_ref "micromega.Op2.OpLt")
+let rocq_OpGe = lazy (constr_of_ref "micromega.Op2.OpGe")
+let rocq_OpGt = lazy (constr_of_ref "micromega.Op2.OpGt")
+let rocq_PsatzLet = lazy (constr_of_ref "micromega.Psatz.PsatzLet")
+let rocq_PsatzIn = lazy (constr_of_ref "micromega.Psatz.PsatzIn")
+let rocq_PsatzSquare = lazy (constr_of_ref "micromega.Psatz.PsatzSquare")
+let rocq_PsatzMulE = lazy (constr_of_ref "micromega.Psatz.PsatzMulE")
+let rocq_PsatzMultC = lazy (constr_of_ref "micromega.Psatz.PsatzMulC")
+let rocq_PsatzAdd = lazy (constr_of_ref "micromega.Psatz.PsatzAdd")
+let rocq_PsatzC = lazy (constr_of_ref "micromega.Psatz.PsatzC")
+let rocq_PsatzZ = lazy (constr_of_ref "micromega.Psatz.PsatzZ")
 
-(*  let coq_GT     = lazy (m_constant "GT")*)
+(*  let rocq_GT     = lazy (m_constant "GT")*)
 
-let coq_DeclaredConstant =
+let rocq_DeclaredConstant =
   lazy (constr_of_ref "micromega.DeclaredConstant.type")
 
-let coq_TT = lazy (constr_of_ref "micromega.GFormula.TT")
-let coq_FF = lazy (constr_of_ref "micromega.GFormula.FF")
-let coq_AND = lazy (constr_of_ref "micromega.GFormula.AND")
-let coq_OR = lazy (constr_of_ref "micromega.GFormula.OR")
-let coq_NOT = lazy (constr_of_ref "micromega.GFormula.NOT")
-let coq_Atom = lazy (constr_of_ref "micromega.GFormula.A")
-let coq_X = lazy (constr_of_ref "micromega.GFormula.X")
-let coq_IMPL = lazy (constr_of_ref "micromega.GFormula.IMPL")
-let coq_IFF = lazy (constr_of_ref "micromega.GFormula.IFF")
-let coq_EQ = lazy (constr_of_ref "micromega.GFormula.EQ")
-let coq_Formula = lazy (constr_of_ref "micromega.BFormula.type")
-let coq_eKind = lazy (constr_of_ref "micromega.eKind")
+let rocq_TT = lazy (constr_of_ref "micromega.GFormula.TT")
+let rocq_FF = lazy (constr_of_ref "micromega.GFormula.FF")
+let rocq_AND = lazy (constr_of_ref "micromega.GFormula.AND")
+let rocq_OR = lazy (constr_of_ref "micromega.GFormula.OR")
+let rocq_NOT = lazy (constr_of_ref "micromega.GFormula.NOT")
+let rocq_Atom = lazy (constr_of_ref "micromega.GFormula.A")
+let rocq_X = lazy (constr_of_ref "micromega.GFormula.X")
+let rocq_IMPL = lazy (constr_of_ref "micromega.GFormula.IMPL")
+let rocq_IFF = lazy (constr_of_ref "micromega.GFormula.IFF")
+let rocq_EQ = lazy (constr_of_ref "micromega.GFormula.EQ")
+let rocq_Formula = lazy (constr_of_ref "micromega.BFormula.type")
+let rocq_eKind = lazy (constr_of_ref "micromega.eKind")
 
 (**
     * Initialization : a few Caml symbols are derived from other libraries;
     * QMicromega, ZArithRing, RingMicromega.
     *)
 
-let coq_QWitness = lazy (constr_of_ref "micromega.QWitness.type")
-let coq_Build = lazy (constr_of_ref "micromega.Formula.Build_Formula")
-let coq_Cstr = lazy (constr_of_ref "micromega.Formula.type")
+let rocq_QWitness = lazy (constr_of_ref "micromega.QWitness.type")
+let rocq_Build = lazy (constr_of_ref "micromega.Formula.Build_Formula")
+let rocq_Cstr = lazy (constr_of_ref "micromega.Formula.type")
 
 (**
     * Parsing and dumping : transformation functions between Caml and Coq
@@ -352,8 +352,8 @@ let rec parse_nat sigma term =
 
 let rec dump_nat x =
   match x with
-  | Mc.O -> Lazy.force coq_O
-  | Mc.S p -> EConstr.mkApp (Lazy.force coq_S, [|dump_nat p|])
+  | Mc.O -> Lazy.force rocq_O
+  | Mc.S p -> EConstr.mkApp (Lazy.force rocq_S, [|dump_nat p|])
 
 let rec parse_positive sigma term =
   let i, c = get_left_construct sigma term in
@@ -365,9 +365,9 @@ let rec parse_positive sigma term =
 
 let rec dump_positive x =
   match x with
-  | Mc.XH -> Lazy.force coq_xH
-  | Mc.XO p -> EConstr.mkApp (Lazy.force coq_xO, [|dump_positive p|])
-  | Mc.XI p -> EConstr.mkApp (Lazy.force coq_xI, [|dump_positive p|])
+  | Mc.XH -> Lazy.force rocq_xH
+  | Mc.XO p -> EConstr.mkApp (Lazy.force rocq_xO, [|dump_positive p|])
+  | Mc.XI p -> EConstr.mkApp (Lazy.force rocq_xI, [|dump_positive p|])
 
 let parse_n sigma term =
   let i, c = get_left_construct sigma term in
@@ -378,8 +378,8 @@ let parse_n sigma term =
 
 let dump_n x =
   match x with
-  | Mc.N0 -> Lazy.force coq_N0
-  | Mc.Npos p -> EConstr.mkApp (Lazy.force coq_Npos, [|dump_positive p|])
+  | Mc.N0 -> Lazy.force rocq_N0
+  | Mc.Npos p -> EConstr.mkApp (Lazy.force rocq_Npos, [|dump_positive p|])
 
 (** [is_ground_term env sigma term] holds if the term [term]
       is an instance of the typeclass [DeclConstant.GT term]
@@ -396,7 +396,7 @@ let is_declared_term env evd t =
     try
       ignore
         (Class_tactics.resolve_one_typeclass env evd
-           (EConstr.mkApp (Lazy.force coq_DeclaredConstant, [|typ; t|])));
+           (EConstr.mkApp (Lazy.force rocq_DeclaredConstant, [|typ; t|])));
       true
     with Not_found -> false )
   | _ -> false
@@ -418,20 +418,20 @@ let parse_z sigma term =
 
 let dump_z x =
   match x with
-  | Mc.Z0 -> Lazy.force coq_ZERO
-  | Mc.Zpos p -> EConstr.mkApp (Lazy.force coq_POS, [|dump_positive p|])
-  | Mc.Zneg p -> EConstr.mkApp (Lazy.force coq_NEG, [|dump_positive p|])
+  | Mc.Z0 -> Lazy.force rocq_ZERO
+  | Mc.Zpos p -> EConstr.mkApp (Lazy.force rocq_POS, [|dump_positive p|])
+  | Mc.Zneg p -> EConstr.mkApp (Lazy.force rocq_NEG, [|dump_positive p|])
 
 
 let dump_q q =
   EConstr.mkApp
-    ( Lazy.force coq_Qmake
+    ( Lazy.force rocq_Qmake
     , [|dump_z q.Micromega.qnum; dump_positive q.Micromega.qden|] )
 
 let parse_q sigma term =
   match EConstr.kind sigma term with
   | App (c, args) ->
-    if EConstr.eq_constr sigma c (Lazy.force coq_Qmake) then
+    if EConstr.eq_constr sigma c (Lazy.force rocq_Qmake) then
       {Mc.qnum = parse_z sigma args.(0); Mc.qden = parse_positive sigma args.(1)}
     else raise ParseError
   | _ -> raise ParseError
@@ -451,38 +451,38 @@ let rec pp_Rcst o cst =
 
 let rec dump_Rcst cst =
   match cst with
-  | Mc.C0 -> Lazy.force coq_C0
-  | Mc.C1 -> Lazy.force coq_C1
-  | Mc.CQ q -> EConstr.mkApp (Lazy.force coq_CQ, [|dump_q q|])
-  | Mc.CZ z -> EConstr.mkApp (Lazy.force coq_CZ, [|dump_z z|])
+  | Mc.C0 -> Lazy.force rocq_C0
+  | Mc.C1 -> Lazy.force rocq_C1
+  | Mc.CQ q -> EConstr.mkApp (Lazy.force rocq_CQ, [|dump_q q|])
+  | Mc.CZ z -> EConstr.mkApp (Lazy.force rocq_CZ, [|dump_z z|])
   | Mc.CPlus (x, y) ->
-    EConstr.mkApp (Lazy.force coq_CPlus, [|dump_Rcst x; dump_Rcst y|])
+    EConstr.mkApp (Lazy.force rocq_CPlus, [|dump_Rcst x; dump_Rcst y|])
   | Mc.CMinus (x, y) ->
-    EConstr.mkApp (Lazy.force coq_CMinus, [|dump_Rcst x; dump_Rcst y|])
+    EConstr.mkApp (Lazy.force rocq_CMinus, [|dump_Rcst x; dump_Rcst y|])
   | Mc.CMult (x, y) ->
-    EConstr.mkApp (Lazy.force coq_CMult, [|dump_Rcst x; dump_Rcst y|])
+    EConstr.mkApp (Lazy.force rocq_CMult, [|dump_Rcst x; dump_Rcst y|])
   | Mc.CPow (x, y) ->
     EConstr.mkApp
-      ( Lazy.force coq_CPow
+      ( Lazy.force rocq_CPow
       , [| dump_Rcst x
          ; ( match y with
            | Mc.Inl z ->
              EConstr.mkApp
-               ( Lazy.force coq_Inl
-               , [|Lazy.force coq_Z; Lazy.force coq_nat; dump_z z|] )
+               ( Lazy.force rocq_Inl
+               , [|Lazy.force rocq_Z; Lazy.force rocq_nat; dump_z z|] )
            | Mc.Inr n ->
              EConstr.mkApp
-               ( Lazy.force coq_Inr
-               , [|Lazy.force coq_Z; Lazy.force coq_nat; dump_nat n|] ) ) |] )
-  | Mc.CInv t -> EConstr.mkApp (Lazy.force coq_CInv, [|dump_Rcst t|])
-  | Mc.COpp t -> EConstr.mkApp (Lazy.force coq_COpp, [|dump_Rcst t|])
+               ( Lazy.force rocq_Inr
+               , [|Lazy.force rocq_Z; Lazy.force rocq_nat; dump_nat n|] ) ) |] )
+  | Mc.CInv t -> EConstr.mkApp (Lazy.force rocq_CInv, [|dump_Rcst t|])
+  | Mc.COpp t -> EConstr.mkApp (Lazy.force rocq_COpp, [|dump_Rcst t|])
 
 let rec dump_list typ dump_elt l =
   match l with
-  | [] -> EConstr.mkApp (Lazy.force coq_nil, [|typ|])
+  | [] -> EConstr.mkApp (Lazy.force rocq_nil, [|typ|])
   | e :: l ->
     EConstr.mkApp
-      (Lazy.force coq_cons, [|typ; dump_elt e; dump_list typ dump_elt l|])
+      (Lazy.force rocq_cons, [|typ; dump_elt e; dump_list typ dump_elt l|])
 
 
 let undump_var = parse_positive
@@ -493,16 +493,16 @@ let undump_expr undump_constant sigma e =
   let is c c' = EConstr.eq_constr sigma c (Lazy.force c') in
   let rec xundump e =
     match EConstr.kind sigma e with
-    | App (c, [|_; n|]) when is c coq_PEX -> Mc.PEX (undump_var sigma n)
-    | App (c, [|_; z|]) when is c coq_PEc -> Mc.PEc (undump_constant sigma z)
-    | App (c, [|_; e1; e2|]) when is c coq_PEadd ->
+    | App (c, [|_; n|]) when is c rocq_PEX -> Mc.PEX (undump_var sigma n)
+    | App (c, [|_; z|]) when is c rocq_PEc -> Mc.PEc (undump_constant sigma z)
+    | App (c, [|_; e1; e2|]) when is c rocq_PEadd ->
       Mc.PEadd (xundump e1, xundump e2)
-    | App (c, [|_; e1; e2|]) when is c coq_PEsub ->
+    | App (c, [|_; e1; e2|]) when is c rocq_PEsub ->
       Mc.PEsub (xundump e1, xundump e2)
-    | App (c, [|_; e|]) when is c coq_PEopp -> Mc.PEopp (xundump e)
-    | App (c, [|_; e1; e2|]) when is c coq_PEmul ->
+    | App (c, [|_; e|]) when is c rocq_PEopp -> Mc.PEopp (xundump e)
+    | App (c, [|_; e1; e2|]) when is c rocq_PEmul ->
       Mc.PEmul (xundump e1, xundump e2)
-    | App (c, [|_; e; n|]) when is c coq_PEpow ->
+    | App (c, [|_; e; n|]) when is c rocq_PEpow ->
       Mc.PEpow (xundump e, parse_n sigma n)
     | _ -> raise ParseError
   in
@@ -511,29 +511,29 @@ let undump_expr undump_constant sigma e =
 let dump_expr typ dump_z e =
   let rec dump_expr e =
     match e with
-    | Mc.PEX n -> EConstr.mkApp (Lazy.force coq_PEX, [|typ; dump_var n|])
-    | Mc.PEc z -> EConstr.mkApp (Lazy.force coq_PEc, [|typ; dump_z z|])
+    | Mc.PEX n -> EConstr.mkApp (Lazy.force rocq_PEX, [|typ; dump_var n|])
+    | Mc.PEc z -> EConstr.mkApp (Lazy.force rocq_PEc, [|typ; dump_z z|])
     | Mc.PEadd (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PEadd, [|typ; dump_expr e1; dump_expr e2|])
+      EConstr.mkApp (Lazy.force rocq_PEadd, [|typ; dump_expr e1; dump_expr e2|])
     | Mc.PEsub (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PEsub, [|typ; dump_expr e1; dump_expr e2|])
-    | Mc.PEopp e -> EConstr.mkApp (Lazy.force coq_PEopp, [|typ; dump_expr e|])
+      EConstr.mkApp (Lazy.force rocq_PEsub, [|typ; dump_expr e1; dump_expr e2|])
+    | Mc.PEopp e -> EConstr.mkApp (Lazy.force rocq_PEopp, [|typ; dump_expr e|])
     | Mc.PEmul (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PEmul, [|typ; dump_expr e1; dump_expr e2|])
+      EConstr.mkApp (Lazy.force rocq_PEmul, [|typ; dump_expr e1; dump_expr e2|])
     | Mc.PEpow (e, n) ->
-      EConstr.mkApp (Lazy.force coq_PEpow, [|typ; dump_expr e; dump_n n|])
+      EConstr.mkApp (Lazy.force rocq_PEpow, [|typ; dump_expr e; dump_n n|])
   in
   dump_expr e
 
 let dump_pol typ dump_c e =
   let rec dump_pol e =
     match e with
-    | Mc.Pc n -> EConstr.mkApp (Lazy.force coq_Pc, [|typ; dump_c n|])
+    | Mc.Pc n -> EConstr.mkApp (Lazy.force rocq_Pc, [|typ; dump_c n|])
     | Mc.Pinj (p, pol) ->
-      EConstr.mkApp (Lazy.force coq_Pinj, [|typ; dump_positive p; dump_pol pol|])
+      EConstr.mkApp (Lazy.force rocq_Pinj, [|typ; dump_positive p; dump_pol pol|])
     | Mc.PX (pol1, p, pol2) ->
       EConstr.mkApp
-        ( Lazy.force coq_PX
+        ( Lazy.force rocq_PX
         , [|typ; dump_pol pol1; dump_positive p; dump_pol pol2|] )
   in
   dump_pol e
@@ -556,19 +556,19 @@ let dump_psatz typ dump_z e =
   let rec dump_cone e =
     match e with
     | Mc.PsatzLet (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PsatzLet, [|z; dump_cone e1; dump_cone e2|])
-    | Mc.PsatzIn n -> EConstr.mkApp (Lazy.force coq_PsatzIn, [|z; dump_nat n|])
+      EConstr.mkApp (Lazy.force rocq_PsatzLet, [|z; dump_cone e1; dump_cone e2|])
+    | Mc.PsatzIn n -> EConstr.mkApp (Lazy.force rocq_PsatzIn, [|z; dump_nat n|])
     | Mc.PsatzMulC (e, c) ->
       EConstr.mkApp
-        (Lazy.force coq_PsatzMultC, [|z; dump_pol z dump_z e; dump_cone c|])
+        (Lazy.force rocq_PsatzMultC, [|z; dump_pol z dump_z e; dump_cone c|])
     | Mc.PsatzSquare e ->
-      EConstr.mkApp (Lazy.force coq_PsatzSquare, [|z; dump_pol z dump_z e|])
+      EConstr.mkApp (Lazy.force rocq_PsatzSquare, [|z; dump_pol z dump_z e|])
     | Mc.PsatzAdd (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PsatzAdd, [|z; dump_cone e1; dump_cone e2|])
+      EConstr.mkApp (Lazy.force rocq_PsatzAdd, [|z; dump_cone e1; dump_cone e2|])
     | Mc.PsatzMulE (e1, e2) ->
-      EConstr.mkApp (Lazy.force coq_PsatzMulE, [|z; dump_cone e1; dump_cone e2|])
-    | Mc.PsatzC p -> EConstr.mkApp (Lazy.force coq_PsatzC, [|z; dump_z p|])
-    | Mc.PsatzZ -> EConstr.mkApp (Lazy.force coq_PsatzZ, [|z|])
+      EConstr.mkApp (Lazy.force rocq_PsatzMulE, [|z; dump_cone e1; dump_cone e2|])
+    | Mc.PsatzC p -> EConstr.mkApp (Lazy.force rocq_PsatzC, [|z; dump_z p|])
+    | Mc.PsatzZ -> EConstr.mkApp (Lazy.force rocq_PsatzZ, [|z|])
   in
   dump_cone e
 
@@ -584,17 +584,17 @@ let undump_op sigma c =
   | _ -> raise ParseError
 
 let dump_op = function
-  | Mc.OpEq -> Lazy.force coq_OpEq
-  | Mc.OpNEq -> Lazy.force coq_OpNEq
-  | Mc.OpLe -> Lazy.force coq_OpLe
-  | Mc.OpGe -> Lazy.force coq_OpGe
-  | Mc.OpGt -> Lazy.force coq_OpGt
-  | Mc.OpLt -> Lazy.force coq_OpLt
+  | Mc.OpEq -> Lazy.force rocq_OpEq
+  | Mc.OpNEq -> Lazy.force rocq_OpNEq
+  | Mc.OpLe -> Lazy.force rocq_OpLe
+  | Mc.OpGe -> Lazy.force rocq_OpGe
+  | Mc.OpGt -> Lazy.force rocq_OpGt
+  | Mc.OpLt -> Lazy.force rocq_OpLt
 
 let undump_cstr undump_constant sigma c =
   let is c c' = EConstr.eq_constr sigma c (Lazy.force c') in
   match EConstr.kind sigma c with
-  | App (c, [|_; e1; o; e2|]) when is c coq_Build ->
+  | App (c, [|_; e1; o; e2|]) when is c rocq_Build ->
     {Mc.flhs = undump_expr undump_constant sigma e1;
      Mc.fop = undump_op sigma o;
      Mc.frhs = undump_expr undump_constant sigma e2}
@@ -602,7 +602,7 @@ let undump_cstr undump_constant sigma c =
 
 let dump_cstr typ dump_constant {Mc.flhs = e1; Mc.fop = o; Mc.frhs = e2} =
   EConstr.mkApp
-    ( Lazy.force coq_Build
+    ( Lazy.force rocq_Build
     , [| typ
        ; dump_expr typ dump_constant e1
        ; dump_op o
@@ -614,26 +614,26 @@ let assoc_const sigma x l =
   with Not_found -> raise ParseError
 
 let zop_table_prop =
-  [ (coq_Zgt, Mc.OpGt)
-  ; (coq_Zge, Mc.OpGe)
-  ; (coq_Zlt, Mc.OpLt)
-  ; (coq_Zle, Mc.OpLe) ]
+  [ (rocq_Zgt, Mc.OpGt)
+  ; (rocq_Zge, Mc.OpGe)
+  ; (rocq_Zlt, Mc.OpLt)
+  ; (rocq_Zle, Mc.OpLe) ]
 
 let zop_table_bool =
-  [ (coq_Zgtb, Mc.OpGt)
-  ; (coq_Zgeb, Mc.OpGe)
-  ; (coq_Zltb, Mc.OpLt)
-  ; (coq_Zleb, Mc.OpLe)
-  ; (coq_Zeqb, Mc.OpEq) ]
+  [ (rocq_Zgtb, Mc.OpGt)
+  ; (rocq_Zgeb, Mc.OpGe)
+  ; (rocq_Zltb, Mc.OpLt)
+  ; (rocq_Zleb, Mc.OpLe)
+  ; (rocq_Zeqb, Mc.OpEq) ]
 
 let rop_table_prop =
-  [ (coq_Rgt, Mc.OpGt)
-  ; (coq_Rge, Mc.OpGe)
-  ; (coq_Rlt, Mc.OpLt)
-  ; (coq_Rle, Mc.OpLe) ]
+  [ (rocq_Rgt, Mc.OpGt)
+  ; (rocq_Rge, Mc.OpGe)
+  ; (rocq_Rlt, Mc.OpLt)
+  ; (rocq_Rle, Mc.OpLe) ]
 
 let rop_table_bool = []
-let qop_table_prop = [(coq_Qlt, Mc.OpLt); (coq_Qle, Mc.OpLe); (coq_Qeq, Mc.OpEq)]
+let qop_table_prop = [(rocq_Qlt, Mc.OpLt); (rocq_Qle, Mc.OpLe); (rocq_Qeq, Mc.OpEq)]
 let qop_table_bool = []
 
 type gl = Environ.env * Evd.evar_map
@@ -651,15 +651,15 @@ let parse_operator table_prop table_bool has_equality typ (env, sigma) k
   | [|ty; a1; a2|] ->
     if
       has_equality
-      && EConstr.eq_constr sigma op (Lazy.force coq_eq)
+      && EConstr.eq_constr sigma op (Lazy.force rocq_eq)
       && is_convertible env sigma ty (Lazy.force typ)
     then (Mc.OpEq, args.(1), args.(2))
     else raise ParseError
   | _ -> raise ParseError
 
-let parse_zop = parse_operator zop_table_prop zop_table_bool true coq_Z
-let parse_rop = parse_operator rop_table_prop [] true coq_R
-let parse_qop = parse_operator qop_table_prop [] false coq_R
+let parse_zop = parse_operator zop_table_prop zop_table_bool true rocq_Z
+let parse_rop = parse_operator rop_table_prop [] true rocq_R
+let parse_qop = parse_operator qop_table_prop [] false rocq_R
 
 type 'a op =
   | Binop of ('a Mc.pExpr -> 'a Mc.pExpr -> 'a Mc.pExpr)
@@ -796,25 +796,25 @@ let parse_expr (genv, sigma) parse_constant parse_exp ops_spec env term =
   parse_expr env term
 
 let zop_spec =
-  [ (coq_Zplus, Binop (fun x y -> Mc.PEadd (x, y)))
-  ; (coq_Zminus, Binop (fun x y -> Mc.PEsub (x, y)))
-  ; (coq_Zmult, Binop (fun x y -> Mc.PEmul (x, y)))
-  ; (coq_Zopp, Opp)
-  ; (coq_Zpower, Power) ]
+  [ (rocq_Zplus, Binop (fun x y -> Mc.PEadd (x, y)))
+  ; (rocq_Zminus, Binop (fun x y -> Mc.PEsub (x, y)))
+  ; (rocq_Zmult, Binop (fun x y -> Mc.PEmul (x, y)))
+  ; (rocq_Zopp, Opp)
+  ; (rocq_Zpower, Power) ]
 
 let qop_spec =
-  [ (coq_Qplus, Binop (fun x y -> Mc.PEadd (x, y)))
-  ; (coq_Qminus, Binop (fun x y -> Mc.PEsub (x, y)))
-  ; (coq_Qmult, Binop (fun x y -> Mc.PEmul (x, y)))
-  ; (coq_Qopp, Opp)
-  ; (coq_Qpower, Power) ]
+  [ (rocq_Qplus, Binop (fun x y -> Mc.PEadd (x, y)))
+  ; (rocq_Qminus, Binop (fun x y -> Mc.PEsub (x, y)))
+  ; (rocq_Qmult, Binop (fun x y -> Mc.PEmul (x, y)))
+  ; (rocq_Qopp, Opp)
+  ; (rocq_Qpower, Power) ]
 
 let rop_spec =
-  [ (coq_Rplus, Binop (fun x y -> Mc.PEadd (x, y)))
-  ; (coq_Rminus, Binop (fun x y -> Mc.PEsub (x, y)))
-  ; (coq_Rmult, Binop (fun x y -> Mc.PEmul (x, y)))
-  ; (coq_Ropp, Opp)
-  ; (coq_Rpower, Power) ]
+  [ (rocq_Rplus, Binop (fun x y -> Mc.PEadd (x, y)))
+  ; (rocq_Rminus, Binop (fun x y -> Mc.PEsub (x, y)))
+  ; (rocq_Rmult, Binop (fun x y -> Mc.PEmul (x, y)))
+  ; (rocq_Ropp, Opp)
+  ; (rocq_Rpower, Power) ]
 
 let parse_constant parse ((genv : Environ.env), sigma) t = parse sigma t
 
@@ -856,17 +856,17 @@ and parse_zconstant gl e =
 *)
 
 let rconst_assoc =
-  [ (coq_Rplus, fun x y -> Mc.CPlus (x, y))
-  ; (coq_Rminus, fun x y -> Mc.CMinus (x, y))
-  ; (coq_Rmult, fun x y -> Mc.CMult (x, y))
-    (*      coq_Rdiv   , (fun x y -> Mc.CMult(x,Mc.CInv y)) ;*) ]
+  [ (rocq_Rplus, fun x y -> Mc.CPlus (x, y))
+  ; (rocq_Rminus, fun x y -> Mc.CMinus (x, y))
+  ; (rocq_Rmult, fun x y -> Mc.CMult (x, y))
+    (*      rocq_Rdiv   , (fun x y -> Mc.CMult(x,Mc.CInv y)) ;*) ]
 
 let rconstant (genv, sigma) term =
   let rec rconstant term =
     match EConstr.kind sigma term with
     | Const x ->
-      if EConstr.eq_constr sigma term (Lazy.force coq_R0) then Mc.C0
-      else if EConstr.eq_constr sigma term (Lazy.force coq_R1) then Mc.C1
+      if EConstr.eq_constr sigma term (Lazy.force rocq_R0) then Mc.C0
+      else if EConstr.eq_constr sigma term (Lazy.force rocq_R1) then Mc.C1
       else raise ParseError
     | App (op, args) -> (
       try
@@ -877,18 +877,18 @@ let rconstant (genv, sigma) term =
         f a b
       with ParseError -> (
         match op with
-        | op when EConstr.eq_constr sigma op (Lazy.force coq_Rinv) ->
+        | op when EConstr.eq_constr sigma op (Lazy.force rocq_Rinv) ->
           let arg = rconstant args.(0) in
           if Mc.qeq_bool (Mc.q_of_Rcst arg) {Mc.qnum = Mc.Z0; Mc.qden = Mc.XH}
           then raise ParseError (* This is a division by zero -- no semantics *)
           else Mc.CInv arg
-        | op when EConstr.eq_constr sigma op (Lazy.force coq_Rpower) ->
+        | op when EConstr.eq_constr sigma op (Lazy.force rocq_Rpower) ->
           Mc.CPow
             ( rconstant args.(0)
             , Mc.Inr (parse_more_constant nconstant (genv, sigma) args.(1)) )
-        | op when EConstr.eq_constr sigma op (Lazy.force coq_IQR) ->
+        | op when EConstr.eq_constr sigma op (Lazy.force rocq_IQR) ->
           Mc.CQ (qconstant (genv, sigma) args.(0))
-        | op when EConstr.eq_constr sigma op (Lazy.force coq_IZR) ->
+        | op when EConstr.eq_constr sigma op (Lazy.force rocq_IZR) ->
           Mc.CZ (parse_more_constant zconstant (genv, sigma) args.(0))
         | _ -> raise ParseError ) )
     | _ -> raise ParseError
@@ -977,22 +977,22 @@ type formula_op =
 let prop_op =
   lazy
     { op_impl = None (* implication is Prod *)
-    ; op_and = Lazy.force coq_and
-    ; op_or = Lazy.force coq_or
-    ; op_iff = Lazy.force coq_iff
-    ; op_not = Lazy.force coq_not
-    ; op_tt = Lazy.force coq_True
-    ; op_ff = Lazy.force coq_False }
+    ; op_and = Lazy.force rocq_and
+    ; op_or = Lazy.force rocq_or
+    ; op_iff = Lazy.force rocq_iff
+    ; op_not = Lazy.force rocq_not
+    ; op_tt = Lazy.force rocq_True
+    ; op_ff = Lazy.force rocq_False }
 
 let bool_op =
   lazy
-    { op_impl = Some (Lazy.force coq_implb)
-    ; op_and = Lazy.force coq_andb
-    ; op_or = Lazy.force coq_orb
-    ; op_iff = Lazy.force coq_eqb
-    ; op_not = Lazy.force coq_negb
-    ; op_tt = Lazy.force coq_true
-    ; op_ff = Lazy.force coq_false }
+    { op_impl = Some (Lazy.force rocq_implb)
+    ; op_and = Lazy.force rocq_andb
+    ; op_or = Lazy.force rocq_orb
+    ; op_iff = Lazy.force rocq_eqb
+    ; op_not = Lazy.force rocq_negb
+    ; op_tt = Lazy.force rocq_true
+    ; op_ff = Lazy.force rocq_false }
 
 let is_implb sigma l o =
   match o with None -> false | Some c -> EConstr.eq_constr sigma l c
@@ -1006,8 +1006,8 @@ let parse_formula (genv, sigma) parse_atom env tg term =
   in
   let prop_op = Lazy.force prop_op in
   let bool_op = Lazy.force bool_op in
-  let eq = Lazy.force coq_eq in
-  let bool = Lazy.force coq_bool in
+  let eq = Lazy.force rocq_eq in
+  let bool = Lazy.force rocq_bool in
   let rec xparse_formula op k env tg term =
     match EConstr.kind sigma term with
     | App (l, rst) -> (
@@ -1051,37 +1051,37 @@ let parse_formula (genv, sigma) parse_atom env tg term =
   in
   xparse_formula prop_op Mc.IsProp env tg (*Reductionops.whd_zeta*) term
 
-(*  let dump_bool b = Lazy.force (if b then coq_true else coq_false)*)
+(*  let dump_bool b = Lazy.force (if b then rocq_true else rocq_false)*)
 
 let undump_kind sigma k =
-  if EConstr.eq_constr sigma k (Lazy.force coq_IsProp) then Mc.IsProp
+  if EConstr.eq_constr sigma k (Lazy.force rocq_IsProp) then Mc.IsProp
   else Mc.IsBool
 
 let dump_kind k =
-  Lazy.force (match k with Mc.IsProp -> coq_IsProp | Mc.IsBool -> coq_IsBool)
+  Lazy.force (match k with Mc.IsProp -> rocq_IsProp | Mc.IsBool -> rocq_IsBool)
 
 let undump_formula undump_atom tg sigma f =
   let is c c' = EConstr.eq_constr sigma c (Lazy.force c') in
   let kind k = undump_kind sigma k in
   let rec xundump f =
     match EConstr.kind sigma f with
-    | App (c, [|_; _; _; _; k|]) when is c coq_TT -> Mc.TT (kind k)
-    | App (c, [|_; _; _; _; k|]) when is c coq_FF -> Mc.FF (kind k)
-    | App (c, [|_; _; _; _; k; f1; f2|]) when is c coq_AND ->
+    | App (c, [|_; _; _; _; k|]) when is c rocq_TT -> Mc.TT (kind k)
+    | App (c, [|_; _; _; _; k|]) when is c rocq_FF -> Mc.FF (kind k)
+    | App (c, [|_; _; _; _; k; f1; f2|]) when is c rocq_AND ->
       Mc.AND (kind k, xundump f1, xundump f2)
-    | App (c, [|_; _; _; _; k; f1; f2|]) when is c coq_OR ->
+    | App (c, [|_; _; _; _; k; f1; f2|]) when is c rocq_OR ->
       Mc.OR (kind k, xundump f1, xundump f2)
-    | App (c, [|_; _; _; _; k; f1; _; f2|]) when is c coq_IMPL ->
+    | App (c, [|_; _; _; _; k; f1; _; f2|]) when is c rocq_IMPL ->
       Mc.IMPL (kind k, xundump f1, None, xundump f2)
-    | App (c, [|_; _; _; _; k; f|]) when is c coq_NOT ->
+    | App (c, [|_; _; _; _; k; f|]) when is c rocq_NOT ->
       Mc.NOT (kind k, xundump f)
-    | App (c, [|_; _; _; _; k; f1; f2|]) when is c coq_IFF ->
+    | App (c, [|_; _; _; _; k; f1; f2|]) when is c rocq_IFF ->
       Mc.IFF (kind k, xundump f1, xundump f2)
-    | App (c, [|_; _; _; _; f1; f2|]) when is c coq_EQ ->
+    | App (c, [|_; _; _; _; f1; f2|]) when is c rocq_EQ ->
       Mc.EQ (xundump f1, xundump f2)
-    | App (c, [|_; _; _; _; k; x; _|]) when is c coq_Atom ->
+    | App (c, [|_; _; _; _; k; x; _|]) when is c rocq_Atom ->
       Mc.A (kind k, undump_atom sigma x, tg)
-    | App (c, [|_; _; _; _; k; x|]) when is c coq_X ->
+    | App (c, [|_; _; _; _; k; x|]) when is c rocq_X ->
       Mc.X (kind k, x)
     | _ -> raise ParseError
   in
@@ -1092,27 +1092,27 @@ let dump_formula typ dump_atom f =
     EConstr.mkApp
       ( Lazy.force c
       , Array.of_list
-          ( typ :: Lazy.force coq_eKind :: Lazy.force coq_unit
-          :: Lazy.force coq_unit :: args ) )
+          ( typ :: Lazy.force rocq_eKind :: Lazy.force rocq_unit
+          :: Lazy.force rocq_unit :: args ) )
   in
   let rec xdump f =
     match f with
-    | Mc.TT k -> app_ctor coq_TT [dump_kind k]
-    | Mc.FF k -> app_ctor coq_FF [dump_kind k]
-    | Mc.AND (k, x, y) -> app_ctor coq_AND [dump_kind k; xdump x; xdump y]
-    | Mc.OR (k, x, y) -> app_ctor coq_OR [dump_kind k; xdump x; xdump y]
+    | Mc.TT k -> app_ctor rocq_TT [dump_kind k]
+    | Mc.FF k -> app_ctor rocq_FF [dump_kind k]
+    | Mc.AND (k, x, y) -> app_ctor rocq_AND [dump_kind k; xdump x; xdump y]
+    | Mc.OR (k, x, y) -> app_ctor rocq_OR [dump_kind k; xdump x; xdump y]
     | Mc.IMPL (k, x, _, y) ->
-      app_ctor coq_IMPL
+      app_ctor rocq_IMPL
         [ dump_kind k
         ; xdump x
-        ; EConstr.mkApp (Lazy.force coq_None, [|Lazy.force coq_unit|])
+        ; EConstr.mkApp (Lazy.force rocq_None, [|Lazy.force rocq_unit|])
         ; xdump y ]
-    | Mc.NOT (k, x) -> app_ctor coq_NOT [dump_kind k; xdump x]
-    | Mc.IFF (k, x, y) -> app_ctor coq_IFF [dump_kind k; xdump x; xdump y]
-    | Mc.EQ (x, y) -> app_ctor coq_EQ [xdump x; xdump y]
+    | Mc.NOT (k, x) -> app_ctor rocq_NOT [dump_kind k; xdump x]
+    | Mc.IFF (k, x, y) -> app_ctor rocq_IFF [dump_kind k; xdump x; xdump y]
+    | Mc.EQ (x, y) -> app_ctor rocq_EQ [xdump x; xdump y]
     | Mc.A (k, x, _) ->
-      app_ctor coq_Atom [dump_kind k; dump_atom x; Lazy.force coq_tt]
-    | Mc.X (k, t) -> app_ctor coq_X [dump_kind k; t]
+      app_ctor rocq_Atom [dump_kind k; dump_atom x; Lazy.force rocq_tt]
+    | Mc.X (k, t) -> app_ctor rocq_X [dump_kind k; t]
   in
   xdump f
 
@@ -1169,13 +1169,13 @@ type 'cst dump_expr =
 
 let dump_zexpr =
   lazy
-    { interp_typ = Lazy.force coq_Z
+    { interp_typ = Lazy.force rocq_Z
     ; dump_cst = dump_z
-    ; dump_add = Lazy.force coq_Zplus
-    ; dump_sub = Lazy.force coq_Zminus
-    ; dump_opp = Lazy.force coq_Zopp
-    ; dump_mul = Lazy.force coq_Zmult
-    ; dump_pow = Lazy.force coq_Zpower
+    ; dump_add = Lazy.force rocq_Zplus
+    ; dump_sub = Lazy.force rocq_Zminus
+    ; dump_opp = Lazy.force rocq_Zopp
+    ; dump_mul = Lazy.force rocq_Zmult
+    ; dump_pow = Lazy.force rocq_Zpower
     ; dump_pow_arg = (fun n -> dump_z (CamlToCoq.z (CoqToCaml.n n)))
     ; dump_op_prop = List.map (fun (x, y) -> (y, Lazy.force x)) zop_table_prop
     ; dump_op_bool = List.map (fun (x, y) -> (y, Lazy.force x)) zop_table_bool
@@ -1183,13 +1183,13 @@ let dump_zexpr =
 
 let dump_qexpr =
   lazy
-    { interp_typ = Lazy.force coq_Q
+    { interp_typ = Lazy.force rocq_Q
     ; dump_cst = dump_q
-    ; dump_add = Lazy.force coq_Qplus
-    ; dump_sub = Lazy.force coq_Qminus
-    ; dump_opp = Lazy.force coq_Qopp
-    ; dump_mul = Lazy.force coq_Qmult
-    ; dump_pow = Lazy.force coq_Qpower
+    ; dump_add = Lazy.force rocq_Qplus
+    ; dump_sub = Lazy.force rocq_Qminus
+    ; dump_opp = Lazy.force rocq_Qopp
+    ; dump_mul = Lazy.force rocq_Qmult
+    ; dump_pow = Lazy.force rocq_Qpower
     ; dump_pow_arg = (fun n -> dump_z (CamlToCoq.z (CoqToCaml.n n)))
     ; dump_op_prop = List.map (fun (x, y) -> (y, Lazy.force x)) qop_table_prop
     ; dump_op_bool = List.map (fun (x, y) -> (y, Lazy.force x)) qop_table_bool
@@ -1197,34 +1197,34 @@ let dump_qexpr =
 
 let rec dump_Rcst_as_R cst =
   match cst with
-  | Mc.C0 -> Lazy.force coq_R0
-  | Mc.C1 -> Lazy.force coq_R1
-  | Mc.CQ q -> EConstr.mkApp (Lazy.force coq_IQR, [|dump_q q|])
-  | Mc.CZ z -> EConstr.mkApp (Lazy.force coq_IZR, [|dump_z z|])
+  | Mc.C0 -> Lazy.force rocq_R0
+  | Mc.C1 -> Lazy.force rocq_R1
+  | Mc.CQ q -> EConstr.mkApp (Lazy.force rocq_IQR, [|dump_q q|])
+  | Mc.CZ z -> EConstr.mkApp (Lazy.force rocq_IZR, [|dump_z z|])
   | Mc.CPlus (x, y) ->
-    EConstr.mkApp (Lazy.force coq_Rplus, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
+    EConstr.mkApp (Lazy.force rocq_Rplus, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
   | Mc.CMinus (x, y) ->
-    EConstr.mkApp (Lazy.force coq_Rminus, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
+    EConstr.mkApp (Lazy.force rocq_Rminus, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
   | Mc.CMult (x, y) ->
-    EConstr.mkApp (Lazy.force coq_Rmult, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
+    EConstr.mkApp (Lazy.force rocq_Rmult, [|dump_Rcst_as_R x; dump_Rcst_as_R y|])
   | Mc.CPow (x, y) -> (
     match y with
     | Mc.Inl z ->
-      EConstr.mkApp (Lazy.force coq_powerZR, [|dump_Rcst_as_R x; dump_z z|])
+      EConstr.mkApp (Lazy.force rocq_powerZR, [|dump_Rcst_as_R x; dump_z z|])
     | Mc.Inr n ->
-      EConstr.mkApp (Lazy.force coq_Rpower, [|dump_Rcst_as_R x; dump_nat n|]) )
-  | Mc.CInv t -> EConstr.mkApp (Lazy.force coq_Rinv, [|dump_Rcst_as_R t|])
-  | Mc.COpp t -> EConstr.mkApp (Lazy.force coq_Ropp, [|dump_Rcst_as_R t|])
+      EConstr.mkApp (Lazy.force rocq_Rpower, [|dump_Rcst_as_R x; dump_nat n|]) )
+  | Mc.CInv t -> EConstr.mkApp (Lazy.force rocq_Rinv, [|dump_Rcst_as_R t|])
+  | Mc.COpp t -> EConstr.mkApp (Lazy.force rocq_Ropp, [|dump_Rcst_as_R t|])
 
 let dump_rexpr =
   lazy
-    { interp_typ = Lazy.force coq_R
+    { interp_typ = Lazy.force rocq_R
     ; dump_cst = dump_Rcst_as_R
-    ; dump_add = Lazy.force coq_Rplus
-    ; dump_sub = Lazy.force coq_Rminus
-    ; dump_opp = Lazy.force coq_Ropp
-    ; dump_mul = Lazy.force coq_Rmult
-    ; dump_pow = Lazy.force coq_Rpower
+    ; dump_add = Lazy.force rocq_Rplus
+    ; dump_sub = Lazy.force rocq_Rminus
+    ; dump_opp = Lazy.force rocq_Ropp
+    ; dump_mul = Lazy.force rocq_Rmult
+    ; dump_pow = Lazy.force rocq_Rpower
     ; dump_pow_arg = (fun n -> dump_nat (CamlToCoq.nat (CoqToCaml.n n)))
     ; dump_op_prop = List.map (fun (x, y) -> (y, Lazy.force x)) rop_table_prop
     ; dump_op_bool = List.map (fun (x, y) -> (y, Lazy.force x)) rop_table_bool
@@ -1248,7 +1248,7 @@ let prodn n env b =
 
 let eKind = function
   | Mc.IsProp -> EConstr.mkProp
-  | Mc.IsBool -> Lazy.force coq_bool
+  | Mc.IsBool -> Lazy.force rocq_bool
 
 let make_goal_of_formula gl dexpr form =
   let vars_idx =
@@ -1289,7 +1289,7 @@ let make_goal_of_formula gl dexpr form =
   let mkop_prop op e1 e2 =
     try EConstr.mkApp (List.assoc op dexpr.dump_op_prop, [|e1; e2|])
     with Not_found ->
-      EConstr.mkApp (Lazy.force coq_eq, [|dexpr.interp_typ; e1; e2|])
+      EConstr.mkApp (Lazy.force rocq_eq, [|dexpr.interp_typ; e1; e2|])
   in
   let dump_cstr_prop i {Mc.flhs; Mc.fop; Mc.frhs} =
     mkop_prop fop (dump_expr i flhs) (dump_expr i frhs)
@@ -1297,55 +1297,55 @@ let make_goal_of_formula gl dexpr form =
   let mkop_bool op e1 e2 =
     try EConstr.mkApp (List.assoc op dexpr.dump_op_bool, [|e1; e2|])
     with Not_found ->
-      EConstr.mkApp (Lazy.force coq_eq, [|dexpr.interp_typ; e1; e2|])
+      EConstr.mkApp (Lazy.force rocq_eq, [|dexpr.interp_typ; e1; e2|])
   in
   let dump_cstr_bool i {Mc.flhs; Mc.fop; Mc.frhs} =
     mkop_bool fop (dump_expr i flhs) (dump_expr i frhs)
   in
   let rec xdump_prop pi xi f =
     match f with
-    | Mc.TT _ -> Lazy.force coq_True
-    | Mc.FF _ -> Lazy.force coq_False
+    | Mc.TT _ -> Lazy.force rocq_True
+    | Mc.FF _ -> Lazy.force rocq_False
     | Mc.AND (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_and, [|xdump_prop pi xi x; xdump_prop pi xi y|])
+        (Lazy.force rocq_and, [|xdump_prop pi xi x; xdump_prop pi xi y|])
     | Mc.OR (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_or, [|xdump_prop pi xi x; xdump_prop pi xi y|])
+        (Lazy.force rocq_or, [|xdump_prop pi xi x; xdump_prop pi xi y|])
     | Mc.IFF (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_iff, [|xdump_prop pi xi x; xdump_prop pi xi y|])
+        (Lazy.force rocq_iff, [|xdump_prop pi xi x; xdump_prop pi xi y|])
     | Mc.IMPL (_, x, _, y) ->
       EConstr.mkArrow (xdump_prop pi xi x) ERelevance.relevant
         (xdump_prop (pi + 1) (xi + 1) y)
     | Mc.NOT (_, x) ->
-      EConstr.mkArrow (xdump_prop pi xi x) ERelevance.relevant (Lazy.force coq_False)
+      EConstr.mkArrow (xdump_prop pi xi x) ERelevance.relevant (Lazy.force rocq_False)
     | Mc.EQ (x, y) ->
       EConstr.mkApp
-        ( Lazy.force coq_eq
-        , [|Lazy.force coq_bool; xdump_bool pi xi x; xdump_bool pi xi y|] )
+        ( Lazy.force rocq_eq
+        , [|Lazy.force rocq_bool; xdump_bool pi xi x; xdump_bool pi xi y|] )
     | Mc.A (_, x, _) -> dump_cstr_prop xi x
     | Mc.X (_, t) ->
       let idx = Env.get_rank props t in
       EConstr.mkRel (pi + idx)
   and xdump_bool pi xi f =
     match f with
-    | Mc.TT _ -> Lazy.force coq_true
-    | Mc.FF _ -> Lazy.force coq_false
+    | Mc.TT _ -> Lazy.force rocq_true
+    | Mc.FF _ -> Lazy.force rocq_false
     | Mc.AND (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_andb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
+        (Lazy.force rocq_andb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
     | Mc.OR (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_orb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
+        (Lazy.force rocq_orb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
     | Mc.IFF (_, x, y) ->
       EConstr.mkApp
-        (Lazy.force coq_eqb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
+        (Lazy.force rocq_eqb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
     | Mc.IMPL (_, x, _, y) ->
       EConstr.mkApp
-        (Lazy.force coq_implb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
+        (Lazy.force rocq_implb, [|xdump_bool pi xi x; xdump_bool pi xi y|])
     | Mc.NOT (_, x) ->
-      EConstr.mkApp (Lazy.force coq_negb, [|xdump_bool pi xi x|])
+      EConstr.mkApp (Lazy.force rocq_negb, [|xdump_bool pi xi x|])
     | Mc.EQ (x, y) -> assert false
     | Mc.A (_, x, _) -> dump_cstr_bool xi x
     | Mc.X (_, t) ->
@@ -1388,18 +1388,18 @@ let set sigma l concl =
   in
   xset concl l
 
-let coq_Branch = lazy (constr_of_ref "micromega.VarMap.Branch")
-let coq_Elt = lazy (constr_of_ref "micromega.VarMap.Elt")
-let coq_Empty = lazy (constr_of_ref "micromega.VarMap.Empty")
-let coq_VarMap = lazy (constr_of_ref "micromega.VarMap.type")
+let rocq_Branch = lazy (constr_of_ref "micromega.VarMap.Branch")
+let rocq_Elt = lazy (constr_of_ref "micromega.VarMap.Elt")
+let rocq_Empty = lazy (constr_of_ref "micromega.VarMap.Empty")
+let rocq_VarMap = lazy (constr_of_ref "micromega.VarMap.type")
 
 let rec dump_varmap typ m =
   match m with
-  | Mc.Empty -> EConstr.mkApp (Lazy.force coq_Empty, [|typ|])
-  | Mc.Elt v -> EConstr.mkApp (Lazy.force coq_Elt, [|typ; v|])
+  | Mc.Empty -> EConstr.mkApp (Lazy.force rocq_Empty, [|typ|])
+  | Mc.Elt v -> EConstr.mkApp (Lazy.force rocq_Elt, [|typ; v|])
   | Mc.Branch (l, o, r) ->
     EConstr.mkApp
-      (Lazy.force coq_Branch, [|typ; dump_varmap typ l; o; dump_varmap typ r|])
+      (Lazy.force rocq_Branch, [|typ; dump_varmap typ l; o; dump_varmap typ r|])
 
 let vm_of_list env =
   match env with
@@ -1410,30 +1410,30 @@ let vm_of_list env =
       Mc.Empty env
 
 let rec dump_proof_term = function
-  | Micromega.DoneProof -> Lazy.force coq_doneProof
+  | Micromega.DoneProof -> Lazy.force rocq_doneProof
   | Micromega.RatProof (cone, rst) ->
     EConstr.mkApp
-      ( Lazy.force coq_ratProof
-      , [|dump_psatz coq_Z dump_z cone; dump_proof_term rst|] )
+      ( Lazy.force rocq_ratProof
+      , [|dump_psatz rocq_Z dump_z cone; dump_proof_term rst|] )
   | Micromega.CutProof (cone, prf) ->
     EConstr.mkApp
-      ( Lazy.force coq_cutProof
-      , [|dump_psatz coq_Z dump_z cone; dump_proof_term prf|] )
+      ( Lazy.force rocq_cutProof
+      , [|dump_psatz rocq_Z dump_z cone; dump_proof_term prf|] )
   | Micromega.SplitProof (p, prf1, prf2) ->
     EConstr.mkApp
-      ( Lazy.force coq_splitProof
-      , [| dump_pol (Lazy.force coq_Z) dump_z p
+      ( Lazy.force rocq_splitProof
+      , [| dump_pol (Lazy.force rocq_Z) dump_z p
          ; dump_proof_term prf1
          ; dump_proof_term prf2 |] )
   | Micromega.EnumProof (c1, c2, prfs) ->
     EConstr.mkApp
-      ( Lazy.force coq_enumProof
-      , [| dump_psatz coq_Z dump_z c1
-         ; dump_psatz coq_Z dump_z c2
-         ; dump_list (Lazy.force coq_proofTerm) dump_proof_term prfs |] )
+      ( Lazy.force rocq_enumProof
+      , [| dump_psatz rocq_Z dump_z c1
+         ; dump_psatz rocq_Z dump_z c2
+         ; dump_list (Lazy.force rocq_proofTerm) dump_proof_term prfs |] )
   | Micromega.ExProof (p, prf) ->
     EConstr.mkApp
-      (Lazy.force coq_ExProof, [|dump_positive p; dump_proof_term prf|])
+      (Lazy.force rocq_ExProof, [|dump_positive p; dump_proof_term prf|])
 
 let rec size_of_psatz = function
   | Micromega.PsatzIn _ -> 1
@@ -1497,22 +1497,22 @@ type ('synt_c, 'prf) domain_spec =
 
 let zz_domain_spec =
   lazy
-    { typ = Lazy.force coq_Z
-    ; coeff = Lazy.force coq_Z
+    { typ = Lazy.force rocq_Z
+    ; coeff = Lazy.force rocq_Z
     ; dump_coeff = dump_z
     ; undump_coeff = parse_z
-    ; proof_typ = Lazy.force coq_proofTerm
+    ; proof_typ = Lazy.force rocq_proofTerm
     ; dump_proof = dump_proof_term
     ; coeff_eq = Mc.zeq_bool }
 
 let qq_domain_spec =
   lazy
-    { typ = Lazy.force coq_Q
-    ; coeff = Lazy.force coq_Q
+    { typ = Lazy.force rocq_Q
+    ; coeff = Lazy.force rocq_Q
     ; dump_coeff = dump_q
     ; undump_coeff = parse_q
-    ; proof_typ = Lazy.force coq_QWitness
-    ; dump_proof = dump_psatz coq_Q dump_q
+    ; proof_typ = Lazy.force rocq_QWitness
+    ; dump_proof = dump_psatz rocq_Q dump_q
     ; coeff_eq = Mc.qeq_bool }
 
 let max_tag f =
@@ -1533,7 +1533,7 @@ let max_tag f =
 let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
     =
   (* let ids = Util.List.map_i (fun i _ -> (Names.Id.of_string ("__v"^(string_of_int i)))) 0 env in *)
-  let formula_typ = EConstr.mkApp (Lazy.force coq_Cstr, [|spec.coeff|]) in
+  let formula_typ = EConstr.mkApp (Lazy.force rocq_Cstr, [|spec.coeff|]) in
   let ff = dump_formula formula_typ (dump_cstr spec.coeff spec.dump_coeff) ff in
   let vm = dump_varmap spec.typ (vm_of_list env) in
   (* todo : directly generate the proof term - or generalize before conversion? *)
@@ -1545,11 +1545,11 @@ let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
                [ ( "__ff"
                  , ff
                  , EConstr.mkApp
-                     ( Lazy.force coq_Formula
-                     , [|formula_typ; Lazy.force coq_IsProp|] ) )
+                     ( Lazy.force rocq_Formula
+                     , [|formula_typ; Lazy.force rocq_IsProp|] ) )
                ; ( "__varmap"
                  , vm
-                 , EConstr.mkApp (Lazy.force coq_VarMap, [|spec.typ|]) )
+                 , EConstr.mkApp (Lazy.force rocq_VarMap, [|spec.typ|]) )
                ; ("__wit", cert, cert_typ) ]
                (Tacmach.pf_concl gl)) ])
 
@@ -1700,50 +1700,50 @@ let abstract_formula : TagSet.t -> 'a formula -> 'a formula =
   let to_constr =
     Mc.
       { mkTT =
-          (let coq_True = Lazy.force coq_True in
-           let coq_true = Lazy.force coq_true in
-           function Mc.IsProp -> coq_True | Mc.IsBool -> coq_true)
+          (let rocq_True = Lazy.force rocq_True in
+           let rocq_true = Lazy.force rocq_true in
+           function Mc.IsProp -> rocq_True | Mc.IsBool -> rocq_true)
       ; mkFF =
-          (let coq_False = Lazy.force coq_False in
-           let coq_false = Lazy.force coq_false in
-           function Mc.IsProp -> coq_False | Mc.IsBool -> coq_false)
+          (let rocq_False = Lazy.force rocq_False in
+           let rocq_false = Lazy.force rocq_false in
+           function Mc.IsProp -> rocq_False | Mc.IsBool -> rocq_false)
       ; mkA = (fun k a (tg, t) -> t)
       ; mkAND =
-          (let coq_and = Lazy.force coq_and in
-           let coq_andb = Lazy.force coq_andb in
+          (let rocq_and = Lazy.force rocq_and in
+           let rocq_andb = Lazy.force rocq_andb in
            fun k x y ->
              EConstr.mkApp
-               ( (match k with Mc.IsProp -> coq_and | Mc.IsBool -> coq_andb)
+               ( (match k with Mc.IsProp -> rocq_and | Mc.IsBool -> rocq_andb)
                , [|x; y|] ))
       ; mkOR =
-          (let coq_or = Lazy.force coq_or in
-           let coq_orb = Lazy.force coq_orb in
+          (let rocq_or = Lazy.force rocq_or in
+           let rocq_orb = Lazy.force rocq_orb in
            fun k x y ->
              EConstr.mkApp
-               ( (match k with Mc.IsProp -> coq_or | Mc.IsBool -> coq_orb)
+               ( (match k with Mc.IsProp -> rocq_or | Mc.IsBool -> rocq_orb)
                , [|x; y|] ))
       ; mkIMPL =
           (fun k x y ->
             match k with
             | Mc.IsProp -> EConstr.mkArrow x ERelevance.relevant y
-            | Mc.IsBool -> EConstr.mkApp (Lazy.force coq_implb, [|x; y|]))
+            | Mc.IsBool -> EConstr.mkApp (Lazy.force rocq_implb, [|x; y|]))
       ; mkIFF =
-          (let coq_iff = Lazy.force coq_iff in
-           let coq_eqb = Lazy.force coq_eqb in
+          (let rocq_iff = Lazy.force rocq_iff in
+           let rocq_eqb = Lazy.force rocq_eqb in
            fun k x y ->
              EConstr.mkApp
-               ( (match k with Mc.IsProp -> coq_iff | Mc.IsBool -> coq_eqb)
+               ( (match k with Mc.IsProp -> rocq_iff | Mc.IsBool -> rocq_eqb)
                , [|x; y|] ))
       ; mkNOT =
-          (let coq_not = Lazy.force coq_not in
-           let coq_negb = Lazy.force coq_negb in
+          (let rocq_not = Lazy.force rocq_not in
+           let rocq_negb = Lazy.force rocq_negb in
            fun k x ->
              EConstr.mkApp
-               ( (match k with Mc.IsProp -> coq_not | Mc.IsBool -> coq_negb)
+               ( (match k with Mc.IsProp -> rocq_not | Mc.IsBool -> rocq_negb)
                , [|x|] ))
       ; mkEQ =
-          (let coq_eq = Lazy.force coq_eq in
-           fun x y -> EConstr.mkApp (coq_eq, [|Lazy.force coq_bool; x; y|])) }
+          (let rocq_eq = Lazy.force rocq_eq in
+           fun x y -> EConstr.mkApp (rocq_eq, [|Lazy.force rocq_bool; x; y|])) }
   in
   Mc.abst_form to_constr (fun (t, _) -> TagSet.mem t hyps) true Mc.IsProp f
 
@@ -1945,7 +1945,7 @@ let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
               ; intro_props
               ; intro_vars
               ; micromega_order_change spec res'
-                  (EConstr.mkApp (Lazy.force coq_list, [|spec.proof_typ|]))
+                  (EConstr.mkApp (Lazy.force rocq_list, [|spec.proof_typ|]))
                   env' ff_arith ]
           in
           let goal_props =
@@ -1980,7 +1980,7 @@ let micromega_wit_gen pre_process cnf spec prover wit_id ff =
       try
         let spec = Lazy.force spec in
         let undump_cstr = undump_cstr spec.undump_coeff in
-        let tg = Tag.from 0, Lazy.force coq_tt in
+        let tg = Tag.from 0, Lazy.force rocq_tt in
         let ff = undump_formula undump_cstr tg sigma ff in
         match
           micromega_tauto ~abstract:false pre_process cnf spec prover [] ff
@@ -1991,20 +1991,20 @@ let micromega_wit_gen pre_process cnf spec prover wit_id ff =
         | Model (m, e) ->
           Tacticals.tclFAIL (Pp.str " Cannot find witness")
         | Prf (_ids, _ff', res') ->
-          let tres' = EConstr.mkApp (Lazy.force coq_list, [|spec.proof_typ|]) in
+          let tres' = EConstr.mkApp (Lazy.force rocq_list, [|spec.proof_typ|]) in
           Tactics.letin_tac
             None (Names.Name wit_id) res' (Some tres') Locusops.nowhere
       with CsdpNotFound -> fail_csdp_not_found ())
 
 let micromega_order_changer cert env ff =
   (*let ids = Util.List.map_i (fun i _ -> (Names.Id.of_string ("__v"^(string_of_int i)))) 0 env in *)
-  let coeff = Lazy.force coq_Rcst in
+  let coeff = Lazy.force rocq_Rcst in
   let dump_coeff = dump_Rcst in
-  let typ = Lazy.force coq_R in
+  let typ = Lazy.force rocq_R in
   let cert_typ =
-    EConstr.mkApp (Lazy.force coq_list, [|Lazy.force coq_QWitness|])
+    EConstr.mkApp (Lazy.force rocq_list, [|Lazy.force rocq_QWitness|])
   in
-  let formula_typ = EConstr.mkApp (Lazy.force coq_Cstr, [|coeff|]) in
+  let formula_typ = EConstr.mkApp (Lazy.force rocq_Cstr, [|coeff|]) in
   let ff = dump_formula formula_typ (dump_cstr coeff dump_coeff) ff in
   let vm = dump_varmap typ (vm_of_list env) in
   Proofview.Goal.enter (fun gl ->
@@ -2015,9 +2015,9 @@ let micromega_order_changer cert env ff =
                [ ( "__ff"
                  , ff
                  , EConstr.mkApp
-                     ( Lazy.force coq_Formula
-                     , [|formula_typ; Lazy.force coq_IsProp|] ) )
-               ; ("__varmap", vm, EConstr.mkApp (Lazy.force coq_VarMap, [|typ|]))
+                     ( Lazy.force rocq_Formula
+                     , [|formula_typ; Lazy.force rocq_IsProp|] ) )
+               ; ("__varmap", vm, EConstr.mkApp (Lazy.force rocq_VarMap, [|typ|]))
                ; ("__wit", cert, cert_typ) ]
                (Tacmach.pf_concl gl))
           (*      Tacticals.tclTHENLIST (List.map (fun id ->  (Tactics.introduction id)) ids)*)
@@ -2027,12 +2027,12 @@ let micromega_genr prover tac =
   let parse_arith = parse_rarith in
   let spec =
     lazy
-      { typ = Lazy.force coq_R
-      ; coeff = Lazy.force coq_Rcst
+      { typ = Lazy.force rocq_R
+      ; coeff = Lazy.force rocq_Rcst
       ; dump_coeff = dump_q
       ; undump_coeff = parse_q
-      ; proof_typ = Lazy.force coq_QWitness
-      ; dump_proof = dump_psatz coq_Q dump_q
+      ; proof_typ = Lazy.force rocq_QWitness
+      ; dump_proof = dump_psatz rocq_Q dump_q
       ; coeff_eq = Mc.qeq_bool }
   in
   Proofview.Goal.enter (fun gl ->

--- a/plugins/micromega/coq_micromega.mli
+++ b/plugins/micromega/coq_micromega.mli
@@ -58,5 +58,5 @@ val wpsatz_Z : int -> Names.Id.t -> EConstr.t -> unit Proofview.tactic
 
 (** {5 Use Micromega independently from tactics. } *)
 
-(** [dump_proof_term] generates the Coq representation of a Micromega proof witness *)
+(** [dump_proof_term] generates the Rocq representation of a Micromega proof witness *)
 val dump_proof_term : Micromega.zArithProof -> EConstr.t

--- a/plugins/micromega/csdpcert.ml
+++ b/plugins/micromega/csdpcert.ml
@@ -59,7 +59,7 @@ let partition_expr l =
         (* e > 0 == e >= 0 /\ e <> 0 *)
         (eq, (e, Axiom_lt i) :: ge, (e, Axiom_lt i) :: neq)
       | Mc.NonEqual -> (eq, ge, (e, Axiom_eq i) :: neq) )
-    (* Not quite sure -- Coq interface has changed *)
+    (* Not quite sure -- Rocq interface has changed *)
   in
   f 0 l
 

--- a/plugins/micromega/dune
+++ b/plugins/micromega/dune
@@ -2,7 +2,7 @@
  (name micromega_core_plugin)
  (public_name coq-core.plugins.micromega_core)
  (modules micromega numCompat mutils sos_types sos_lib sos)
- (synopsis "Coq's micromega core plugin")
+ (synopsis "Rocq's micromega core plugin")
  (libraries zarith coq-core.clib))
 
 (library
@@ -11,7 +11,7 @@
  ; be careful not to link the executable to the plugin!
  (modules (:standard \ micromega numCompat mutils sos_types sos_lib sos csdpcert g_zify zify))
  (flags :standard -open Micromega_core_plugin)
- (synopsis "Coq's micromega plugin")
+ (synopsis "Rocq's micromega plugin")
  (libraries coq-core.plugins.ltac coq-core.plugins.micromega_core))
 
 (executable
@@ -26,7 +26,7 @@
  (name zify_plugin)
  (public_name coq-core.plugins.zify)
  (modules g_zify zify)
- (synopsis "Coq's zify plugin")
+ (synopsis "Rocq's zify plugin")
  (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules g_micromega g_zify))

--- a/plugins/micromega/g_micromega.mlg
+++ b/plugins/micromega/g_micromega.mlg
@@ -10,9 +10,9 @@
 (*                                                                      *)
 (* Micromega: A reflexive tactic using the Positivstellensatz           *)
 (*                                                                      *)
-(* * Mappings from Coq tactics to Caml function calls                   *)
+(* * Mappings from Rocq tactics to Caml function calls                  *)
 (*                                                                      *)
-(*  Frédéric Besson (Irisa/Inria) 2006-2008			        *)
+(*  Frédéric Besson (Irisa/Inria) 2006-2008			                    *)
 (*                                                                      *)
 (************************************************************************)
 

--- a/plugins/micromega/mutils.ml
+++ b/plugins/micromega/mutils.ml
@@ -119,7 +119,7 @@ let rec app_funs l x =
   | f :: fl -> ( match f x with None -> app_funs fl x | Some x' -> Some x' )
 
 (**
-  * MODULE: Coq to Caml data-structure mappings
+  * MODULE: Rocq to Caml data-structure mappings
   *)
 
 module CoqToCaml = struct
@@ -159,7 +159,7 @@ module CoqToCaml = struct
 end
 
 (**
-  * MODULE: Caml to Coq data-structure mappings
+  * MODULE: Caml to Rocq data-structure mappings
   *)
 
 module CamlToCoq = struct
@@ -236,7 +236,7 @@ end
 (**
   * MODULE: Labels for atoms in propositional formulas.
   * Tags are used to identify unused atoms in CNFs, and propagate them back to
-  * the original formula. The translation back to Coq then ignores these
+  * the original formula. The translation back to Rocq then ignores these
   * superfluous items, which speeds the translation up a bit.
   *)
 

--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -15,7 +15,7 @@
 (************************************************************************)
 
 (** Last PR that requires the regeneration of caches.
-    It is stored and checked after the Coq magic number.
+    It is stored and checked after the Rocq magic number.
     Incompatible caches are thrown away.
 *)
 let pcache_version = 15584l

--- a/plugins/micromega/polynomial.ml
+++ b/plugins/micromega/polynomial.ml
@@ -247,7 +247,7 @@ let pp_mon o (m, i) =
 module Poly : (* A polynomial is a map of monomials *)
               (*
     This is probably a naive implementation
-    (expected to be fast enough - Coq is probably the bottleneck)
+    (expected to be fast enough - Rocq is probably the bottleneck)
     *The new ring contribution is using a sparse Horner representation.
     *)
 sig
@@ -679,7 +679,7 @@ module ProofFormat = struct
       max (max (max i j) k) (proof_max_def prf)
 
   (** [pr_rule_def_cut id pr] gives an explicit [id] to cut rules.
-      This is because the Coq proof format only accept they as a proof-step *)
+      This is because the Rocq proof format only accept they as a proof-step *)
   let pr_rule_def_cut m id p =
     let rec pr_rule_def_cut m id = function
       | Annot (_, p) -> pr_rule_def_cut m id p

--- a/plugins/micromega/polynomial.ml
+++ b/plugins/micromega/polynomial.ml
@@ -420,7 +420,7 @@ module LinPoly = struct
       (fun p vr n -> Poly.add (MonT.retrieve vr) n p)
       (Poly.constant Q.zero) v
 
-  let coq_poly_of_linpol cst p =
+  let rocq_poly_of_linpol cst p =
     let pol_of_mon m =
       Monomial.fold
         (fun x v p ->
@@ -968,9 +968,9 @@ module ProofFormat = struct
       | AddPrf (p1, p2) -> Mc.PsatzAdd (cmpl env p1, cmpl env p2)
       | LetPrf (p1, p2) -> Mc.PsatzLet (cmpl env p1, cmpl (Env.push_ref env) p2)
       | MulC (lp, p) ->
-        let lp = norm (LinPoly.coq_poly_of_linpol cst lp) in
+        let lp = norm (LinPoly.rocq_poly_of_linpol cst lp) in
         Mc.PsatzMulC (lp, cmpl env p)
-      | Square lp -> Mc.PsatzSquare (norm (LinPoly.coq_poly_of_linpol cst lp))
+      | Square lp -> Mc.PsatzSquare (norm (LinPoly.rocq_poly_of_linpol cst lp))
       | _ -> failwith "Cuts should already be compiled"
     in
     cmpl env prf
@@ -981,7 +981,7 @@ module ProofFormat = struct
   let cmpl_pol_z lp =
     try
       let cst x = CamlToCoq.bigint (Q.num x) in
-      Mc.normZ (LinPoly.coq_poly_of_linpol cst lp)
+      Mc.normZ (LinPoly.rocq_poly_of_linpol cst lp)
     with x ->
       Printf.printf "cmpl_pol_z %s %a\n" (Printexc.to_string x) LinPoly.pp lp;
       raise x

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -202,13 +202,13 @@ module LinPoly : sig
   (** [pp o p] pretty-prints a polynomial. *)
   val pp : out_channel -> t -> unit
 
-  (** [pp_goal typ o l] pretty-prints the list of constraints as a Coq goal. *)
+  (** [pp_goal typ o l] pretty-prints the list of constraints as a Rocq goal. *)
   val pp_goal : string -> out_channel -> (t * op) list -> unit
 end
 
 module ProofFormat : sig
   (** Proof format used by the proof-generating procedures.
-      It is fairly close to Coq format but a bit more liberal.
+      It is fairly close to Rocq format but a bit more liberal.
 
       It is used for proofs over Z, Q, R.
       However, certain constructions e.g. [CutPrf] are only relevant for Z.
@@ -340,7 +340,7 @@ module WithProof : sig
   (** [sort sys] sorts constraints according to the lexicographic order (number of variables, size of the smallest coefficient *)
   val sort : t list -> ((int * (Q.t * var)) * t) list
 
-  (** [subst sys] performs the equivalent of the 'subst' tactic of Coq.
+  (** [subst sys] performs the equivalent of the 'subst' tactic of Rocq.
     For every p=0 \in sys such that p is linear in x with coefficient +/- 1
                                i.e. p = 0 <-> x = e and x \notin e.
     Replace x by e in sys
@@ -351,7 +351,7 @@ module WithProof : sig
 
   val subst : t list -> t list
 
-  (** [subst_constant b sys] performs the equivalent of the 'subst' tactic of Coq
+  (** [subst_constant b sys] performs the equivalent of the 'subst' tactic of Rocq
       only if there is an equation a.x = c for a,c a constant and a divides c if b= true*)
   val subst_constant : bool -> t list -> t list
 

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -26,17 +26,17 @@ let zify str =
        (Coqlib.lib_ref ("ZifyClasses." ^ str)))
 
 (** classes *)
-let coq_InjTyp = lazy (Coqlib.lib_ref "ZifyClasses.InjTyp")
+let rocq_InjTyp = lazy (Coqlib.lib_ref "ZifyClasses.InjTyp")
 
-let coq_BinOp = lazy (Coqlib.lib_ref "ZifyClasses.BinOp")
-let coq_UnOp = lazy (Coqlib.lib_ref "ZifyClasses.UnOp")
-let coq_CstOp = lazy (Coqlib.lib_ref "ZifyClasses.CstOp")
-let coq_BinRel = lazy (Coqlib.lib_ref "ZifyClasses.BinRel")
-let coq_PropBinOp = lazy (Coqlib.lib_ref "ZifyClasses.PropBinOp")
-let coq_PropUOp = lazy (Coqlib.lib_ref "ZifyClasses.PropUOp")
-let coq_BinOpSpec = lazy (Coqlib.lib_ref "ZifyClasses.BinOpSpec")
-let coq_UnOpSpec = lazy (Coqlib.lib_ref "ZifyClasses.UnOpSpec")
-let coq_Saturate = lazy (Coqlib.lib_ref "ZifyClasses.Saturate")
+let rocq_BinOp = lazy (Coqlib.lib_ref "ZifyClasses.BinOp")
+let rocq_UnOp = lazy (Coqlib.lib_ref "ZifyClasses.UnOp")
+let rocq_CstOp = lazy (Coqlib.lib_ref "ZifyClasses.CstOp")
+let rocq_BinRel = lazy (Coqlib.lib_ref "ZifyClasses.BinRel")
+let rocq_PropBinOp = lazy (Coqlib.lib_ref "ZifyClasses.PropBinOp")
+let rocq_PropUOp = lazy (Coqlib.lib_ref "ZifyClasses.PropUOp")
+let rocq_BinOpSpec = lazy (Coqlib.lib_ref "ZifyClasses.BinOpSpec")
+let rocq_UnOpSpec = lazy (Coqlib.lib_ref "ZifyClasses.UnOpSpec")
+let rocq_Saturate = lazy (Coqlib.lib_ref "ZifyClasses.Saturate")
 
 (* morphism like lemma *)
 
@@ -405,7 +405,7 @@ module EInj = struct
   type elt = EInjT.t
 
   let name = "EInj"
-  let gref = coq_InjTyp
+  let gref = rocq_InjTyp
   let table = table
   let cast x = InjTyp x
   let dest = function InjTyp x -> Some x | _ -> None
@@ -459,7 +459,7 @@ module EBinOp = struct
   open EBinOpT
 
   let name = "BinOp"
-  let gref = coq_BinOp
+  let gref = rocq_BinOp
   let table = table
 
   let mk_elt evd i a =
@@ -501,7 +501,7 @@ module ECstOp = struct
   open ECstOpT
 
   let name = "CstOp"
-  let gref = coq_CstOp
+  let gref = rocq_CstOp
   let table = table
   let cast x = CstOp x
   let dest = function CstOp x -> Some x | _ -> None
@@ -528,7 +528,7 @@ module EUnOp = struct
   open EUnOpT
 
   let name = "UnOp"
-  let gref = coq_UnOp
+  let gref = rocq_UnOp
   let table = table
   let cast x = UnOp x
   let dest = function UnOp x -> Some x | _ -> None
@@ -561,7 +561,7 @@ module EBinRel = struct
   open EBinRelT
 
   let name = "BinRel"
-  let gref = coq_BinRel
+  let gref = rocq_BinRel
   let table = table
   let cast x = BinRel x
   let dest = function BinRel x -> Some x | _ -> None
@@ -588,7 +588,7 @@ module EPropBinOp = struct
   open EPropBinOpT
 
   let name = "PropBinOp"
-  let gref = coq_PropBinOp
+  let gref = rocq_PropBinOp
   let table = table
   let cast x = PropOp x
   let dest = function PropOp x -> Some x | _ -> None
@@ -602,7 +602,7 @@ module EPropUnOp = struct
   open EPropUnOpT
 
   let name = "PropUOp"
-  let gref = coq_PropUOp
+  let gref = rocq_PropUOp
   let table = table
   let cast x = PropUnOp x
   let dest = function PropUnOp x -> Some x | _ -> None
@@ -719,7 +719,7 @@ module ESat = struct
   open ESatT
 
   let name = "Saturate"
-  let gref = coq_Saturate
+  let gref = rocq_Saturate
   let table = saturate
   let cast x = Saturate x
   let dest = function Saturate x -> Some x | _ -> None
@@ -733,7 +733,7 @@ module EUnopSpec = struct
   type elt = ESpecT.t
 
   let name = "UnopSpec"
-  let gref = coq_UnOpSpec
+  let gref = rocq_UnOpSpec
   let table = specs
   let cast x = UnOpSpec x
   let dest = function UnOpSpec x -> Some x | _ -> None
@@ -747,7 +747,7 @@ module EBinOpSpec = struct
   type elt = ESpecT.t
 
   let name = "BinOpSpec"
-  let gref = coq_BinOpSpec
+  let gref = rocq_BinOpSpec
   let table = specs
   let cast x = BinOpSpec x
   let dest = function BinOpSpec x -> Some x | _ -> None

--- a/plugins/nsatz/dune
+++ b/plugins/nsatz/dune
@@ -1,14 +1,14 @@
 (library
  (name nsatz_core_plugin)
  (public_name coq-core.plugins.nsatz_core)
- (synopsis "Coq's nsatz solver plugin")
+ (synopsis "Rocq's nsatz solver plugin")
  (modules (:standard \ g_nsatz))
  (libraries coq-core.tactics))
 
 (library
  (name nsatz_plugin)
  (public_name coq-core.plugins.nsatz)
- (synopsis "Coq's nsatz solver plugin (Ltac1 syntax)")
+ (synopsis "Rocq's nsatz solver plugin (Ltac1 syntax)")
  (modules g_nsatz)
  (flags :standard -open Nsatz_core_plugin)
  (libraries coq-core.plugins.nsatz_core coq-core.plugins.ltac))

--- a/plugins/ring/dune
+++ b/plugins/ring/dune
@@ -1,7 +1,7 @@
 (library
  (name ring_plugin)
  (public_name coq-core.plugins.ring)
- (synopsis "Coq's ring plugin")
+ (synopsis "Rocq's ring plugin")
  (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules g_ring))

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -236,13 +236,13 @@ let exec_tactic env sigma n f args =
 let gen_constant n = lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref n)))
 let gen_reference n = lazy (Coqlib.lib_ref n)
 
-let coq_mk_Setoid = gen_constant "plugins.ring.Build_Setoid_Theory"
-let coq_None = gen_reference "core.option.None"
-let coq_Some = gen_reference "core.option.Some"
-let coq_eq = gen_constant "core.eq.type"
+let rocq_mk_Setoid = gen_constant "plugins.ring.Build_Setoid_Theory"
+let rocq_None = gen_reference "core.option.None"
+let rocq_Some = gen_reference "core.option.Some"
+let rocq_eq = gen_constant "core.eq.type"
 
-let coq_cons = gen_reference "core.list.cons"
-let coq_nil = gen_reference "core.list.nil"
+let rocq_cons = gen_reference "core.list.cons"
+let rocq_nil = gen_reference "core.list.nil"
 
 let lapp f args = mkApp(Lazy.force f,args)
 
@@ -280,31 +280,31 @@ let pol_cst s = mk_cst [plugin_dir;"Ring_polynom"] s
 (* Ring theory *)
 
 (* almost_ring defs *)
-let coq_almost_ring_theory = my_constant "almost_ring_theory"
+let rocq_almost_ring_theory = my_constant "almost_ring_theory"
 
 (* setoid and morphism utilities *)
-let coq_eq_setoid = my_reference "Eqsth"
-let coq_eq_morph = my_reference "Eq_ext"
-let coq_eq_smorph = my_reference "Eq_s_ext"
+let rocq_eq_setoid = my_reference "Eqsth"
+let rocq_eq_morph = my_reference "Eq_ext"
+let rocq_eq_smorph = my_reference "Eq_s_ext"
 
 (* ring -> almost_ring utilities *)
-let coq_ring_theory = my_constant "ring_theory"
-let coq_mk_reqe = my_constant "mk_reqe"
+let rocq_ring_theory = my_constant "ring_theory"
+let rocq_mk_reqe = my_constant "mk_reqe"
 
 (* semi_ring -> almost_ring utilities *)
-let coq_semi_ring_theory = my_constant "semi_ring_theory"
-let coq_mk_seqe = my_constant "mk_seqe"
+let rocq_semi_ring_theory = my_constant "semi_ring_theory"
+let rocq_mk_seqe = my_constant "mk_seqe"
 
-let coq_abstract = my_constant"Abstract"
-let coq_comp = my_constant"Computational"
-let coq_morph = my_constant"Morphism"
+let rocq_abstract = my_constant"Abstract"
+let rocq_comp = my_constant"Computational"
+let rocq_morph = my_constant"Morphism"
 
 (* power function *)
 let ltac_inv_morph_nothing = zltac"inv_morph_nothing"
 
 (* hypothesis *)
-let coq_mkhypo = my_reference "mkhypo"
-let coq_hypo = my_reference "hypo"
+let rocq_mkhypo = my_reference "mkhypo"
+let rocq_hypo = my_reference "hypo"
 
 (* Equality: do not evaluate but make recursive call on both sides *)
 let map_with_eq arg_map =
@@ -314,8 +314,8 @@ let map_without_eq arg_map =
   { with_eq = false; arguments = arg_map }
 
 let base_red = [
-  coq_cons, Arg (function 2->Rec|_->Prot);
-  coq_nil, Arg (function _ -> Prot);
+  rocq_cons, Arg (function 2->Rec|_->Prot);
+  rocq_nil, Arg (function _ -> Prot);
   my_reference "IDphi", Full;
   my_reference "gen_phiZ", Full;
 ]
@@ -430,24 +430,24 @@ let setoid_of_relation env sigma a r =
     let sigma, refl = Rewrite.get_reflexive_proof env sigma a r in
     let sigma, sym = Rewrite.get_symmetric_proof env sigma a r in
     let sigma, trans = Rewrite.get_transitive_proof env sigma a r in
-    sigma, lapp coq_mk_Setoid [|a ; r ; refl; sym; trans |]
+    sigma, lapp rocq_mk_Setoid [|a ; r ; refl; sym; trans |]
   with Not_found ->
     CErrors.user_err (str "Cannot find a setoid structure for relation " ++ pr_econstr_env env sigma r ++ str ".")
 
 let op_morph r add mul opp req m1 m2 m3 =
-  lapp coq_mk_reqe [| r; add; mul; opp; req; m1; m2; m3 |]
+  lapp rocq_mk_reqe [| r; add; mul; opp; req; m1; m2; m3 |]
 
 let op_smorph r add mul req m1 m2 =
-  lapp coq_mk_seqe [| r; add; mul; req; m1; m2 |]
+  lapp rocq_mk_seqe [| r; add; mul; req; m1; m2 |]
 
 let ring_equality env sigma (r,add,mul,opp,req) =
   match EConstr.kind sigma req with
-    | App (f, [| _ |]) when eq_constr_nounivs sigma f (Lazy.force coq_eq) ->
-        let sigma, setoid = plapp sigma coq_eq_setoid [|r|] in
+    | App (f, [| _ |]) when eq_constr_nounivs sigma f (Lazy.force rocq_eq) ->
+        let sigma, setoid = plapp sigma rocq_eq_setoid [|r|] in
         let sigma, op_morph =
           match opp with
-              Some opp -> plapp sigma coq_eq_morph [|r;add;mul;opp|]
-          | None -> plapp sigma coq_eq_smorph [|r;add;mul|] in
+              Some opp -> plapp sigma rocq_eq_morph [|r;add;mul;opp|]
+          | None -> plapp sigma rocq_eq_smorph [|r;add;mul|] in
         let sigma, setoid = Typing.solve_evars env sigma setoid in
         let sigma, op_morph = Typing.solve_evars env sigma op_morph in
         (setoid,op_morph)
@@ -498,13 +498,13 @@ let dest_ring env sigma th_spec =
   let th_typ = Retyping.get_type_of env sigma th_spec in
   match EConstr.kind sigma th_typ with
       App(f,[|r;zero;one;add;mul;sub;opp;req|])
-        when eq_constr_nounivs sigma f (Lazy.force coq_almost_ring_theory) ->
+        when eq_constr_nounivs sigma f (Lazy.force rocq_almost_ring_theory) ->
           (None,r,zero,one,add,mul,Some sub,Some opp,req)
     | App(f,[|r;zero;one;add;mul;req|])
-        when eq_constr_nounivs sigma f (Lazy.force coq_semi_ring_theory) ->
+        when eq_constr_nounivs sigma f (Lazy.force rocq_semi_ring_theory) ->
         (Some true,r,zero,one,add,mul,None,None,req)
     | App(f,[|r;zero;one;add;mul;sub;opp;req|])
-        when eq_constr_nounivs sigma f (Lazy.force coq_ring_theory) ->
+        when eq_constr_nounivs sigma f (Lazy.force rocq_ring_theory) ->
         (Some false,r,zero,one,add,mul,Some sub,Some opp,req)
     | _ -> error "bad ring structure"
 
@@ -512,9 +512,9 @@ let dest_ring env sigma th_spec =
 let reflect_coeff rkind =
   (* We build an ill-typed terms on purpose... *)
   match rkind with
-      Abstract -> Lazy.force coq_abstract
-    | Computational c -> lapp coq_comp [|c|]
-    | Morphism m -> lapp coq_morph [|m|]
+      Abstract -> Lazy.force rocq_abstract
+    | Computational c -> lapp rocq_comp [|c|]
+    | Morphism m -> lapp rocq_morph [|m|]
 
 let interp_cst_tac env sigma rk kind (zero,one,add,mul,opp) cst_tac =
   match cst_tac with
@@ -527,26 +527,26 @@ let interp_cst_tac env sigma rk kind (zero,one,add,mul,opp) cst_tac =
 
 let make_hyp env sigma c =
   let t = Retyping.get_type_of env sigma c in
-  plapp sigma coq_mkhypo [|t;c|]
+  plapp sigma rocq_mkhypo [|t;c|]
 
 let make_hyp_list env sigma lH =
-  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force rocq_hypo) in
   let sigma, l =
     List.fold_right
       (fun c (sigma,l) ->
         let sigma, c = make_hyp env sigma c in
-        plapp sigma coq_cons [|carrier; c; l|]) lH
-        (plapp sigma coq_nil [|carrier|])
+        plapp sigma rocq_cons [|carrier; c; l|]) lH
+        (plapp sigma rocq_nil [|carrier|])
   in
   let sigma, l' = Typing.solve_evars env sigma l in
   sigma, l'
 
 let interp_power env sigma pow =
-  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force rocq_hypo) in
   match pow with
   | None ->
       let t = ArgArg(Loc.tag (Lazy.force ltac_inv_morph_nothing)) in
-      let sigma, c = plapp sigma coq_None [|carrier|] in
+      let sigma, c = plapp sigma rocq_None [|carrier|] in
       sigma, (CAst.make (TacArg (TacCall (CAst.make (t,[])))), c)
   | Some (tac, spec) ->
       let tac =
@@ -556,25 +556,25 @@ let interp_power env sigma pow =
             closed_term_ast (List.map Smartlocate.global_with_alias lc) in
       let spec = ic_unsafe env sigma spec in
       let sigma, spec = make_hyp env sigma spec in
-      let sigma, pow = plapp sigma coq_Some [|carrier; spec|] in
+      let sigma, pow = plapp sigma rocq_Some [|carrier; spec|] in
       sigma, (tac, pow)
 
 let interp_sign env sigma sign =
-  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force rocq_hypo) in
   match sign with
-  | None -> plapp sigma coq_None [|carrier|]
+  | None -> plapp sigma rocq_None [|carrier|]
   | Some spec ->
       let sigma, spec = make_hyp env sigma (ic_unsafe env sigma spec) in
-      plapp sigma coq_Some [|carrier;spec|]
+      plapp sigma rocq_Some [|carrier;spec|]
        (* Same remark on ill-typed terms ... *)
 
 let interp_div env sigma div =
-  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force coq_hypo) in
+  let sigma, carrier = Evd.fresh_global env sigma (Lazy.force rocq_hypo) in
   match div with
-  | None -> plapp sigma coq_None [|carrier|]
+  | None -> plapp sigma rocq_None [|carrier|]
   | Some spec ->
       let sigma, spec = make_hyp env sigma (ic_unsafe env sigma spec) in
-      plapp sigma coq_Some [|carrier;spec|]
+      plapp sigma rocq_Some [|carrier;spec|]
        (* Same remark on ill-typed terms ... *)
 
 let add_theory0 env sigma name rth eqth morphth cst_tac (pre,post) power sign div =
@@ -674,8 +674,8 @@ let make_args_list sigma rl t =
 
 let make_term_list env sigma carrier rl =
   let sigma, l = List.fold_right
-    (fun x (sigma,l) -> plapp sigma coq_cons [|carrier;x;l|]) rl
-    (plapp sigma coq_nil [|carrier|])
+    (fun x (sigma,l) -> plapp sigma rocq_cons [|carrier;x;l|]) rl
+    (plapp sigma rocq_nil [|carrier|])
   in
   Typing.solve_evars env sigma l
 
@@ -857,7 +857,7 @@ let ftheory_to_obj : field_info -> obj =
 
 let field_equality env sigma r inv req =
   match EConstr.kind sigma req with
-    | App (f, [| _ |]) when eq_constr_nounivs sigma f (Lazy.force coq_eq) ->
+    | App (f, [| _ |]) when eq_constr_nounivs sigma f (Lazy.force rocq_eq) ->
         let c = UnivGen.constr_of_monomorphic_global (Global.env ()) Coqlib.(lib_ref "core.eq.congr") in
         let c = EConstr.of_constr c in
         mkApp(c,[|r;r;inv|])

--- a/plugins/rtauto/dune
+++ b/plugins/rtauto/dune
@@ -1,7 +1,7 @@
 (library
  (name rtauto_plugin)
  (public_name coq-core.plugins.rtauto)
- (synopsis "Coq's rtauto plugin")
+ (synopsis "Rocq's rtauto plugin")
  (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules g_rtauto))

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -323,7 +323,7 @@ let rtauto_tac =
                              str " steps" ++ fnl () ++
                              str "Proof term size : " ++ int (!step_count+ !node_count) ++
                              str " nodes (constants)" ++ fnl () ++
-                             str "Giving proof term to Coq ... ")
+                             str "Giving proof term to Rocq ... ")
         end in
     let tac_start_time = System.get_time () in
     let term = EConstr.of_constr term in

--- a/plugins/ssr/dune
+++ b/plugins/ssr/dune
@@ -1,7 +1,7 @@
 (library
  (name ssreflect_plugin)
  (public_name coq-core.plugins.ssreflect)
- (synopsis "Coq's ssreflect plugin")
+ (synopsis "Rocq's ssreflect plugin")
  (modules_without_implementation ssrast)
  (flags :standard -open Gramlib)
  (libraries coq-core.plugins.ssrmatching))

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -797,7 +797,7 @@ let saturate ?(beta=false) ?(bi_types=false) env sigma c ?(ty=Retyping.get_type_
 let dependent_apply_error =
   CErrors.UserError (Pp.str "Could not fill dependent hole in \"apply\"")
 
-(* TASSI: Sometimes Coq's apply fails. According to my experience it may be
+(* TASSI: Sometimes Rocq's apply fails. According to my experience it may be
  * related to goals that are products and with beta redexes. In that case it
  * guesses the wrong number of implicit arguments for your lemma. What follows
  * is just like apply, but with a user-provided number n of implicits.

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -236,7 +236,7 @@ val resolve_typeclasses :
   where:EConstr.t ->
   fail:bool -> Evd.evar_map
 
-(*********************** Wrapped Coq  tactics *****************************)
+(*********************** Wrapped Rocq tactics *****************************)
 
 val rewritetac : ?under:bool -> ssrdir -> EConstr.t -> unit Proofview.tactic
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -355,7 +355,7 @@ let converse_dir = function L2R -> R2L | R2L -> L2R
 
 let rw_progress rhs lhs ise = not (EConstr.eq_constr ise lhs (Evarutil.nf_evar ise rhs))
 
-(* Coq has a more general form of "equation" (any type with a single *)
+(* Rocq has a more general form of "equation" (any type with a single *)
 (* constructor with no arguments with_rect_r elimination lemmas).    *)
 (* However there is no clear way of determining the LHS and RHS of   *)
 (* such a generic Leibniz equation -- short of inspecting the type   *)

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -738,7 +738,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
   let sigma, c, cl = Ssrmatching.fill_rel_occ_pattern env sigma cl pat occ in
   let clr =
     Ssrcommon.interp_clr sigma (oclr, (Ssrmatching.tag_of_cpattern t,c)) in
-  (* Historically in Coq, and hence in ssr, [case t] accepts [t] of type
+  (* Historically in Rocq, and hence in ssr, [case t] accepts [t] of type
      [A.. -> Ind] and opens new goals for [A..] as well as for the branches
      of [Ind], see the [~to_ind] argument *)
   if not(Termops.occur_existential sigma c) then

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -43,7 +43,7 @@ open Libobject
 
 (** Ssreflect load check. *)
 
-(* To allow ssrcoq to be fully compatible with the "plain" Coq, we only *)
+(* To allow ssrcoq to be fully compatible with the "plain" Rocq, we only *)
 (* turn on its incompatible features (the new rewrite syntax, and the   *)
 (* reserved identifiers) when the theory library (ssreflect.v) has      *)
 (* has actually been required, or is being defined. Because this check  *)
@@ -1006,7 +1006,7 @@ let pr_ssrfwdidx _ _ _ = pr_ssrfwdid
 }
 
 (* We use a primitive parser for the head identifier of forward *)
-(* tactis to avoid syntactic conflicts with basic Coq tactics. *)
+(* tactis to avoid syntactic conflicts with basic Rocq tactics. *)
 ARGUMENT EXTEND ssrfwdid TYPED AS ident PRINTED BY { pr_ssrfwdidx }
 END
 
@@ -1632,7 +1632,7 @@ let ltac_expr = Pltac.ltac_expr
 
 (** Name generation *)
 
-(* Since Coq now does repeated internal checks of its external lexical *)
+(* Since Rocq now does repeated internal checks of its external lexical *)
 (* rules, we now need to carve ssreflect reserved identifiers out of   *)
 (* out of the user namespace. We use identifiers of the form _id_ for  *)
 (* this purpose, e.g., we "anonymize" an identifier id as _id_, adding *)

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -374,7 +374,7 @@ END
 (* Since all bookkeeping ssr commands have the same discharge-intro    *)
 (* argument format we use a single grammar entry point to parse them.  *)
 (* the entry point parses only non-empty arguments to avoid conflicts  *)
-(* with the basic Coq tactics.                                         *)
+(* with the basic Rocq tactics.                                         *)
 
 {
 
@@ -607,7 +607,7 @@ END
 
 (** 7. Rewriting tactics (rewrite, unlock) *)
 
-(** Coq rewrite compatibility flag *)
+(** Rocq rewrite compatibility flag *)
 
 (** Rewrite clear/occ switches *)
 

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -62,7 +62,7 @@ let () = Mltop.add_init_function "coq-core.plugins.ssreflect" (fun () ->
 (* in b       (*^--ALTERNATIVE INNER LET--------^ *)              *)
 
 (* Caveat : There is no pretty-printing support, since this would *)
-(* require a modification to the Coq kernel (adding a new match   *)
+(* require a modification to the Rocq kernel (adding a new match  *)
 (* display style -- why aren't these strings?); also, the v8.1    *)
 (* pretty-printer only allows extension hooks for printing        *)
 (* integer or string literals.                                    *)
@@ -325,9 +325,9 @@ END
 (* Coq v8.1 notation uses "by" and "of" quasi-keywords, i.e., reserved *)
 (* identifiers used as keywords. This is incompatible with ssreflect.v *)
 (* which makes "by" and "of" true keywords, because of technicalities  *)
-(* in the internal lexer-parser API of Coq. We patch this here by      *)
+(* in the internal lexer-parser API of Rocq. We patch this here by     *)
 (* adding new parsing rules that recognize the new keywords.           *)
-(*   To make matters worse, the Coq grammar for tactics fails to       *)
+(*   To make matters worse, the Rocq grammar for tactics fails to      *)
 (* export the non-terminals we need to patch. Fortunately, the CamlP5  *)
 (* API provides a backdoor access (with loads of Obj.magic trickery).  *)
 

--- a/plugins/ssrmatching/dune
+++ b/plugins/ssrmatching/dune
@@ -1,7 +1,7 @@
 (library
  (name ssrmatching_plugin)
  (public_name coq-core.plugins.ssrmatching)
- (synopsis "Coq ssrmatching plugin")
+ (synopsis "Rocq ssrmatching plugin")
  (libraries coq-core.plugins.ltac))
 
 (coq.pp (modules g_ssrmatching))

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -189,13 +189,13 @@ let unif_HO_args env ise0 pa i ca =
     if j = n then ise else loop (unif_HO env ise pa.(j) (ca.(i + j))) (j + 1) in
   loop ise0 0
 
-(* FO unification should boil down to calling w_unify with no_delta, but  *)
-(* alas things are not so simple: w_unify does partial type-checking,     *)
-(* which breaks down when the no-delta flag is on (as the Coq type system *)
-(* requires full convertibility. The workaround here is to convert all    *)
-(* evars into metas, since 8.2 does not TC metas. This means some lossage *)
-(* for HO evars, though hopefully Miller patterns can pick up some of     *)
-(* those cases, and HO matching will mop up the rest.                     *)
+(* FO unification should boil down to calling w_unify with no_delta, but   *)
+(* alas things are not so simple: w_unify does partial type-checking,      *)
+(* which breaks down when the no-delta flag is on (as the Rocq type system *)
+(* requires full convertibility. The workaround here is to convert all     *)
+(* evars into metas, since 8.2 does not TC metas. This means some lossage  *)
+(* for HO evars, though hopefully Miller patterns can pick up some of      *)
+(* those cases, and HO matching will mop up the rest.                      *)
 let flags_FO env =
   let oracle = Environ.oracle env in
   let ts = Conv_oracle.get_transp_state oracle in

--- a/plugins/syntax/dune
+++ b/plugins/syntax/dune
@@ -1,7 +1,7 @@
 (library
  (name number_string_notation_plugin)
  (public_name coq-core.plugins.number_string_notation)
- (synopsis "Coq number and string notation plugin")
+ (synopsis "Rocq number and string notation plugin")
  (modules g_number_string number_string)
  (libraries coq-core.vernac))
 


### PR DESCRIPTION
We replace occurrences of Coq to Rocq from the plugins in parts that are not observable from the OCaml compiler. This includes:
- Comments
- Internal names
- Dune synopses

The public APIs were not modified (except one case that was tweaked via a deprecation). Extraction relies on the `Coq` string for some name escaping in the produced code, I'm not touching that either and will leave this to people knowing what they're doing. I also did not change the internal extraction documentation, this feels like bits of a paper that have been put in there and it feels weird to perform the renaming there. 