### PR TITLE
flag "Info Micromega" to print used hypotheses

### DIFF
--- a/doc/changelog/04-tactics/19703-lia-print-used-hyps.rst
+++ b/doc/changelog/04-tactics/19703-lia-print-used-hyps.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  The :flag:`Info Micromega` flag (unset by default) makes :tacn:`lia`,
+  :tacn:`lra`, :tacn:`nia` and :tacn:`nra` print the names of
+  hypotheses used by the proof
+  (`#19703 <https://github.com/coq/coq/pull/19703>`_,
+  by Frédéric Besson).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -31,6 +31,12 @@ or only for reals by ``Require Import Lra``.
   generates a *proof cache* which makes it possible to rerun scripts
   even without CSDP.
 
+.. flag:: Info Micromega
+
+   When set, instructs the tactics :tacn:`lia`,
+   :tacn:`nia`, :tacn:`lra`, :tacn:`nra` and :tacn:`psatz` to print the
+   list of hypotheses needed by the proof. The default is unset.
+
 .. opt:: Dump Arith
 
    This :term:`option` (unset by default) may be set to a file path where

--- a/test-suite/output/InfoMicromega.out
+++ b/test-suite/output/InfoMicromega.out
@@ -1,0 +1,2 @@
+Micromega used hypotheses: H2, H0 and H
+Micromega used hypotheses: H2, H0 and H

--- a/test-suite/output/InfoMicromega.v
+++ b/test-suite/output/InfoMicromega.v
@@ -1,0 +1,17 @@
+Require Import Reals Lra.
+Open Scope R_scope.
+
+Set Info Micromega.
+
+Goal forall (x y z:R), x + y > 0 ->  x - y > 0 -> x + z = 0 -> x < 0 -> False.
+Proof.
+  intros.
+  lra.
+Qed.
+
+Goal forall (x y z:R), x + y > 0 ->  x - y > 0 -> x + z = 0 -> x < 0 -> False.
+Proof.
+  intros.
+  clear - H2 H0 H.
+  lra.
+Qed.


### PR DESCRIPTION
When set, the list of hypotheses needed by lia,nia,lra,nra  proofs are printed. It should be safe to clear them and therefore speed-up proof search.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->


- [x] Added **changelog**.
- [x] Added / updated **documentation**.
- [x] Added **test-suite**.