### PR TITLE
Show "For XXX ->" in alphabetic order in Print HintDb

### DIFF
--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -724,7 +724,8 @@ Creating Hints
 
    This command displays all hints from database :n:`@ident`.  Hints
    in each group ("For ... ->") are shown in the order in which they will be tried
-   (first to last).  Note that hints with the same cost are tried in
+   (first to last).  The groups are shown ordered alphabetically on the last component of
+   the symbol name.  Note that hints with the same cost are tried in
    reverse of the order they're defined in, i.e., last to first.
 
 Hint locality

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1730,8 +1730,15 @@ let pr_hint_db_env env sigma db =
       hov 0 (goal_descr ++ str " -> " ++ hints)
     in
     let hints =
+      let name x = Nametab.shortest_qualid_of_global Id.Set.empty x in
       let order (h1, _, _) (h2, _, _) =
-        Option.compare GlobRef.UserOrd.compare h1 h2 in
+        Option.compare (fun a b ->
+            let a = name a and b = name b in
+            let rv = Id.compare (qualid_basename a) (qualid_basename b) in
+            if rv <> 0 then rv else
+              String.compare (string_of_qualid a) (string_of_qualid b))
+          h1 h2
+      in
       let hints = Hint_db.fold (fun h m hl l -> (h, m, hl) :: l) db [] in
       List.stable_sort order hints in
     Pp.prlist pr_one hints

--- a/test-suite/output/HintLocality.out
+++ b/test-suite/output/HintLocality.out
@@ -4,8 +4,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -13,8 +13,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -22,8 +22,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -31,8 +31,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -56,8 +56,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -73,8 +73,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 File "./output/HintLocality.v", line 61, characters 0-38:
 The command has indeed failed with message:
@@ -85,8 +85,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   
 For S (modes !) ->   
+For nat ->   
 
 Non-discriminated database
 Unfoldable variable definitions: all
@@ -94,8 +94,8 @@ Unfoldable constant definitions: all except: id
 Unfoldable projection definitions: all
 Cut: _
 For any goal ->   
-For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 For S (modes !) ->   
+For nat ->   simple apply 0 ; trivial (cost 1, pattern nat, id 0)
 
 File "./output/HintLocality.v", line 92, characters 0-39:
 Warning: This hint is not local but depends on a section variable. It will


### PR DESCRIPTION
The items listed under "For XXX ->" were sorted using `GlobRef.UserOrd`, which IINM sorts first on the type (VarRef, ConstRef, IndRef or ConstructRef) and then alphabetically.  Since the output doesn't indicate the type, it seems it would be better to print this info strictly alphabetically.  @PRoux added the sort recently in #19310 though I don't understand the commit description:
"Fix order of entries in Print HintDb  Otherwise, it could even differ on different architectures, as revealed by the renaming Coq -> Stdlib."  Older versions are not alpha sorted.

I think alpha is best for usability.  If you disagree, please explain.

@proux01 WDYT?

- [ ] Added **changelog**.

Order with #19310
```
For any goal ->   
For CompSpec ->   unfold CompSpec (cost 4, id 0)
For CompSpecT ->   unfold CompSpecT (cost 4, id 0)
For ge ->   unfold ge (cost 4, id 0)
For gt ->   unfold gt (cost 4, id 0)
For lt ->   unfold lt (cost 4, id 0)
For not ->   simple apply n_Sn (cost 0, pattern ?M123 <> S ?M123, id 0)
             simple apply O_S (cost 0, pattern 0 <> S ?M122, id 0)
             simple apply not_eq_S (cost 1, pattern S ?M119 <> S ?M120, id 0)
             simple apply not_eq_sym ; trivial (cost 1, pattern ?M29 <> ?M28, id 0)
             unfold not (cost 4, id 0)
For BoolSpec ->   simple apply BoolSpecF (cost 1, pattern BoolSpec ?M42 ?M43 false, id 0)
                  simple apply BoolSpecT (cost 1, pattern BoolSpec ?M39 ?M40 true, id 0)
For CompareSpec ->   simple apply CompGt (cost 1, pattern CompareSpec ?M63 ?M64 ?M65 Gt, id 0)
                     simple apply CompLt (cost 1, pattern CompareSpec ?M59 ?M60 ?M61 Lt, id 0)
                     simple apply CompEq (cost 1, pattern CompareSpec ?M55 ?M56 ?M57 Eq, id 0)
For CompareSpecT ->   simple apply CompGtT (cost 1, pattern CompareSpecT ?M75 ?M76 ?M77 Gt, id 0)
                      simple apply CompLtT (cost 1, pattern CompareSpecT ?M71 ?M72 ?M73 Lt, id 0)
                      simple apply CompEqT (cost 1, pattern CompareSpecT ?M67 ?M68 ?M69 Eq, id 0)
For True ->   exact I (cost 0, pattern True, id 0)
For and ->   simple apply conj (cost 2, pattern ?M1 /\ ?M2, id 0)
For eq ->   simple apply mult_n_Sm (cost 0, pattern ?M144 * ?M145 + ?M144 = ?M144 * S ?M145, id 0)
            simple apply mult_n_O (cost 0, pattern 0 = ?M143 * 0, id 0)
            simple apply plus_n_Sm (cost 0, pattern S (?M135 + ?M136) = ?M135 + S ?M136, id 0)
            simple apply @eq_refl (cost 0, pattern ?M134 = ?M134, id 0)
            simple apply plus_n_O (cost 0, pattern ?M132 = ?M132 + 0, id 0)
            simple apply eq_add_S ; trivial (cost 1, pattern ?M116 = ?M117, id 0)
            simple apply f_equal_nat (cost 1, pattern ?M112 ?M113 = ?M112 ?M114, id 0)
            simple apply eq_sym ; trivial (cost 1, pattern ?M25 = ?M24, id 0)
            simple apply f_equal2_mult (cost 2, pattern ?M137 * ?M139 = ?M138 * ?M140, id 0)
            simple apply f_equal2_nat (cost 2, pattern ?M125 ?M126 ?M128 = ?M125 ?M127 ?M129, id 0)
For ex ->   simple eapply ex_intro (cost 2, pattern exists y, ?M14 y, id 0)
For ex2 ->   simple eapply ex_intro2 (cost 3, pattern exists2 x : ?M17, ?M18 x & ?M19 x, id 0)
For inhabited ->   simple apply inhabits (cost 1, pattern inhabited ?M31, id 0)
For le ->   simple apply le_n (cost 0, pattern ?M146 <= ?M146, id 0)
            simple apply le_S (cost 1, pattern ?M147 <= S ?M148, id 0)
For or ->   simple apply or_intror (cost 1, pattern ?M8 \/ ?M9, id 0)
            simple apply or_introl (cost 1, pattern ?M5 \/ ?M6, id 0)
For prod ->   simple apply @pair (cost 2, pattern (?M45 * ?M46)%type, id 0)
For sig ->   simple eapply exist (cost 2, pattern {x : ?M91 | ?M92 x}, id 0)
For sig2 ->   simple eapply exist2 (cost 3, pattern {x : ?M95 | ?M96 x & ?M97 x}, id 0)
For sigT ->   simple eapply existT (cost 2, pattern {x : ?M101 & ?M102 x}, id 0)
For sigT2 ->   simple eapply existT2 (cost 3, pattern {x : ?M105 & ?M106 x & ?M107 x}, id 0)
For sum ->   simple apply @inr (cost 1, pattern (?M52 + ?M53)%type, id 0)
             simple apply @inl (cost 1, pattern (?M49 + ?M50)%type, id 0)
For sumbool ->   simple apply @right (cost 1, pattern {?M82} + {?M83}, id 0)
                 simple apply @left (cost 1, pattern {?M79} + {?M80}, id 0)
For sumor ->   simple apply @inright (cost 1, pattern ?M88 + {?M89}, id 0)
               simple apply @inleft (cost 1, pattern ?M85 + {?M86}, id 0)
```

Order with this PR:
```
For any goal ->   
For BoolSpec ->   simple apply BoolSpecF (cost 1, pattern BoolSpec ?M42 ?M43 false, id 0)
                  simple apply BoolSpecT (cost 1, pattern BoolSpec ?M39 ?M40 true, id 0)
For CompSpec ->   unfold CompSpec (cost 4, id 0)
For CompSpecT ->   unfold CompSpecT (cost 4, id 0)
For CompareSpec ->   simple apply CompGt (cost 1, pattern CompareSpec ?M63 ?M64 ?M65 Gt, id 0)
                     simple apply CompLt (cost 1, pattern CompareSpec ?M59 ?M60 ?M61 Lt, id 0)
                     simple apply CompEq (cost 1, pattern CompareSpec ?M55 ?M56 ?M57 Eq, id 0)
For CompareSpecT ->   simple apply CompGtT (cost 1, pattern CompareSpecT ?M75 ?M76 ?M77 Gt, id 0)
                      simple apply CompLtT (cost 1, pattern CompareSpecT ?M71 ?M72 ?M73 Lt, id 0)
                      simple apply CompEqT (cost 1, pattern CompareSpecT ?M67 ?M68 ?M69 Eq, id 0)
For True ->   exact I (cost 0, pattern True, id 0)
For and ->   simple apply conj (cost 2, pattern ?M1 /\ ?M2, id 0)
For eq ->   simple apply mult_n_Sm (cost 0, pattern ?M144 * ?M145 + ?M144 = ?M144 * S ?M145, id 0)
            simple apply mult_n_O (cost 0, pattern 0 = ?M143 * 0, id 0)
            simple apply plus_n_Sm (cost 0, pattern S (?M135 + ?M136) = ?M135 + S ?M136, id 0)
            simple apply @eq_refl (cost 0, pattern ?M134 = ?M134, id 0)
            simple apply plus_n_O (cost 0, pattern ?M132 = ?M132 + 0, id 0)
            simple apply eq_add_S ; trivial (cost 1, pattern ?M116 = ?M117, id 0)
            simple apply f_equal_nat (cost 1, pattern ?M112 ?M113 = ?M112 ?M114, id 0)
            simple apply eq_sym ; trivial (cost 1, pattern ?M25 = ?M24, id 0)
            simple apply f_equal2_mult (cost 2, pattern ?M137 * ?M139 = ?M138 * ?M140, id 0)
            simple apply f_equal2_nat (cost 2, pattern ?M125 ?M126 ?M128 = ?M125 ?M127 ?M129, id 0)
For ex ->   simple eapply ex_intro (cost 2, pattern exists y, ?M14 y, id 0)
For ex2 ->   simple eapply ex_intro2 (cost 3, pattern exists2 x : ?M17, ?M18 x & ?M19 x, id 0)
For ge ->   unfold ge (cost 4, id 0)
For gt ->   unfold gt (cost 4, id 0)
For inhabited ->   simple apply inhabits (cost 1, pattern inhabited ?M31, id 0)
For le ->   simple apply le_n (cost 0, pattern ?M146 <= ?M146, id 0)
            simple apply le_S (cost 1, pattern ?M147 <= S ?M148, id 0)
For lt ->   unfold lt (cost 4, id 0)
For not ->   simple apply n_Sn (cost 0, pattern ?M123 <> S ?M123, id 0)
             simple apply O_S (cost 0, pattern 0 <> S ?M122, id 0)
             simple apply not_eq_S (cost 1, pattern S ?M119 <> S ?M120, id 0)
             simple apply not_eq_sym ; trivial (cost 1, pattern ?M29 <> ?M28, id 0)
             unfold not (cost 4, id 0)
For or ->   simple apply or_intror (cost 1, pattern ?M8 \/ ?M9, id 0)
            simple apply or_introl (cost 1, pattern ?M5 \/ ?M6, id 0)
For prod ->   simple apply @pair (cost 2, pattern (?M45 * ?M46)%type, id 0)
For sig ->   simple eapply exist (cost 2, pattern {x : ?M91 | ?M92 x}, id 0)
For sig2 ->   simple eapply exist2 (cost 3, pattern {x : ?M95 | ?M96 x & ?M97 x}, id 0)
For sigT ->   simple eapply existT (cost 2, pattern {x : ?M101 & ?M102 x}, id 0)
For sigT2 ->   simple eapply existT2 (cost 3, pattern {x : ?M105 & ?M106 x & ?M107 x}, id 0)
For sum ->   simple apply @inr (cost 1, pattern (?M52 + ?M53)%type, id 0)
             simple apply @inl (cost 1, pattern (?M49 + ?M50)%type, id 0)
For sumbool ->   simple apply @right (cost 1, pattern {?M82} + {?M83}, id 0)
                 simple apply @left (cost 1, pattern {?M79} + {?M80}, id 0)
For sumor ->   simple apply @inright (cost 1, pattern ?M88 + {?M89}, id 0)
               simple apply @inleft (cost 1, pattern ?M85 + {?M86}, id 0)
```