### PR TITLE
Update macos image used in CI

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Install system dependencies
         run: |
           brew install gnu-time opam gtksourceview3 adwaita-icon-theme expat libxml2 pkg-config
-          pip3 install macpack
 
       - name: Install OCaml dependencies
         run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   macOS:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Github said "The macOS 12 runner image will be removed by December 3rd, 2024"
