### PR TITLE
interp_context_gen: only solve locally created evars

### DIFF
--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -185,9 +185,10 @@ let find_binding_kind id impls =
   Option.default Explicit (CList.find_map find impls)
 
 let interp_context_gen ~program_mode ~kind ~autoimp_enable ~coercions env sigma l =
+  let initial = sigma in
   let sigma, (ienv, ((env, ctx), impls)) = interp_named_context_evars ~program_mode ~autoimp_enable env sigma l in
   (* Note, we must use the normalized evar from now on! *)
-  let sigma = solve_remaining_evars all_and_fail_flags env sigma in
+  let sigma = solve_remaining_evars all_and_fail_flags env ~initial sigma in
   let sigma, ctx = Evarutil.finalize sigma @@ fun nf ->
     List.map (NamedDecl.map_constr_het (fun x -> x) nf) ctx
   in


### PR DESCRIPTION
More context here: https://coq.zulipchat.com/#narrow/channel/253928-Elpi-users-.26-devs/topic/context-decl.20changes.20in.20Coq.208.2E20.3F/near/477391848

I don't think the bug can be triggered without a plugin

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
