### PR TITLE
Fix `#[global] (Hint) Opaque` for prim. projections in sections

### DIFF
--- a/library/lib.ml
+++ b/library/lib.ml
@@ -317,10 +317,16 @@ let library_part = function
   | GlobRef.VarRef id -> library_dp ()
   | ref -> ModPath.dp (mp_of_global ref)
 
-let discharge_proj_repr p =
+let discharge_section_proj_repr p =
   let ind = Projection.Repr.inductive p in
   let sec = section_segment_of_reference (GlobRef.IndRef ind) in
   Cooking.discharge_proj_repr sec p
+
+let discharge_proj_repr p =
+    if is_in_section (Names.GlobRef.IndRef (Names.Projection.Repr.inductive p)) then
+      discharge_section_proj_repr p
+    else
+      p
 
 (** The [LibActions] abstraction represent the set of operations on the Lib
     structure that is specific to a given stage. Two instances are defined below,

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -184,6 +184,9 @@ val is_in_section : GlobRef.t -> bool
 
 (** {6 Discharge: decrease the section level if in the current section } *)
 
+(** [discharge_proj_repr p] discharges projection [p] if the associated record
+    was defined in the current section. If that is not the case, it returns [p]
+    unchanged. *)
 val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t
 
 (** Compatibility layer *)

--- a/test-suite/bugs/bug_19712.v
+++ b/test-suite/bugs/bug_19712.v
@@ -1,0 +1,11 @@
+#[projections(primitive)]
+Record test : Type := { f : nat }.
+Section coercion.
+  Coercion f : test >-> nat.
+End coercion.
+Section reduction.
+  #[global] Opaque f.
+End reduction.
+Section hintopacity.
+  #[global] Hint Opaque f : typeclass_instances.
+End hintopacity.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19712 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.