### PR TITLE
Fix naming of universes for partially template inductive

### DIFF
--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -254,3 +254,9 @@ Arguments C2' A%type_scope p2
 File "./output/UnivBinders.v", line 207, characters 0-33:
 The command has indeed failed with message:
 Universe inconsistency. Cannot enforce a < a because a = a.
+JMeq :
+forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
+
+JMeq is template universe polymorphic on JMeq.u0
+Arguments JMeq [A]%type_scope x [B]%type_scope _
+Expands to: Inductive UnivBinders.PartialTemplate.JMeq

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -207,3 +207,16 @@ Definition g@{a b} := Type@{a} : Type@{b}.
 Fail Definition h@{a} := g@{a a}.
 
 End Inconsistency.
+
+Module PartialTemplate.
+
+Set Implicit Arguments.
+Unset Elimination Schemes.
+Unset Universe Polymorphism.
+
+Inductive JMeq (A:Type) (x:A) : forall B:Type, B -> Prop :=
+    JMeq_refl : JMeq x x.
+
+About JMeq.
+
+End PartialTemplate.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -854,7 +854,7 @@ let do_mutual_inductive ~flags ?typing_flags udecl indl ~private_ind ~uniform =
   (* Slightly hackish global universe declaration due to template types. *)
   let binders = match mie.mind_entry_universes with
   | Monomorphic_ind_entry -> (UState.Monomorphic_entry uctx, univ_binders)
-  | Template_ind_entry ctx -> (UState.Monomorphic_entry ctx, univ_binders)
+  | Template_ind_entry ctx -> (UState.Monomorphic_entry (Univ.ContextSet.union uctx ctx), univ_binders)
   | Polymorphic_ind_entry uctx -> (UState.Polymorphic_entry uctx, UnivNames.empty_binders)
   in
   (* Declare the global universes *)


### PR DESCRIPTION
Fix #19722

NB the API is a bit awkward, could probably be improved. It dates from when you could get the monomorphic univ context for an inductive from the global env which is why we need to rebuild a Monomorphic_entry.
