### PR TITLE
Make Hint Rewrite grammar for hintdbs match other Hint commands

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/19730-hint_rewrite_gram.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19730-hint_rewrite_gram.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The :cmd:`Hint Rewrite` command now requires a *non-empty* list of hintDbs
+  after the colon to be consistent with other Hint commands.  If your script
+  has an empty list of hintDbs, fix it by removing the colon
+  (`#19730 <https://github.com/coq/coq/pull/19730>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -679,7 +679,7 @@ Creating Hints
       argument with ``1``, typeclass resolution succeeds as the second declared mode is matched,
       and instantiates ``x`` with ``11``.
 
-.. cmd:: Hint Rewrite {? {| -> | <- } } {+ @one_term } {? using @ltac_expr } {? : {* @ident } }
+.. cmd:: Hint Rewrite {? {| -> | <- } } {+ @one_term } {? using @ltac_expr } {? : {+ @ident } }
 
    :n:`{? using @ltac_expr }`
      If specified, :n:`@ltac_expr` is applied to the generated subgoals, except for the

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1306,9 +1306,9 @@ command: [
 | WITH "Derive" "Inversion_clear" ident "with" constr OPT ( "Sort" sort_family )
 | DELETE "Derive" "Inversion_clear" ident "with" constr
 | EDIT "Focus" ADD_OPT natural
-| DELETE "Hint" "Rewrite" orient LIST1 constr ":" LIST0 preident
-| REPLACE "Hint" "Rewrite" orient LIST1 constr "using" tactic ":" LIST0 preident
-| WITH "Hint" "Rewrite" orient LIST1 constr OPT ( "using" tactic ) OPT ( ":" LIST0 preident )
+| DELETE "Hint" "Rewrite" orient LIST1 constr ":" LIST1 preident
+| REPLACE "Hint" "Rewrite" orient LIST1 constr "using" tactic ":" LIST1 preident
+| WITH "Hint" "Rewrite" orient LIST1 constr OPT ( "using" tactic ) OPT ( ":" LIST1 preident )
 | DELETE "Hint" "Rewrite" orient LIST1 constr
 | DELETE "Hint" "Rewrite" orient LIST1 constr "using" tactic
 | REPLACE "Next" "Obligation" "of" identref withtac

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -596,8 +596,8 @@ command: [
 | "Functional" "Scheme" LIST1 fun_scheme_arg SEP "with"      (* funind plugin *)
 | "Functional" "Case" fun_scheme_arg      (* funind plugin *)
 | "Generate" "graph" "for" reference      (* funind plugin *)
-| "Hint" "Rewrite" orient LIST1 constr ":" LIST0 preident
-| "Hint" "Rewrite" orient LIST1 constr "using" tactic ":" LIST0 preident
+| "Hint" "Rewrite" orient LIST1 constr ":" LIST1 preident
+| "Hint" "Rewrite" orient LIST1 constr "using" tactic ":" LIST1 preident
 | "Hint" "Rewrite" orient LIST1 constr
 | "Hint" "Rewrite" orient LIST1 constr "using" tactic
 | "Derive" "Inversion_clear" ident "with" constr "Sort" sort_family

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -897,7 +897,7 @@ command: [
 | "Functional" "Scheme" func_scheme_def LIST0 ( "with" func_scheme_def )
 | "Functional" "Case" func_scheme_def      (* funind plugin *)
 | "Generate" "graph" "for" qualid      (* funind plugin *)
-| "Hint" "Rewrite" OPT [ "->" | "<-" ] LIST1 one_term OPT ( "using" ltac_expr ) OPT ( ":" LIST0 ident )
+| "Hint" "Rewrite" OPT [ "->" | "<-" ] LIST1 one_term OPT ( "using" ltac_expr ) OPT ( ":" LIST1 ident )
 | "Derive" "Inversion_clear" ident "with" one_term OPT ( "Sort" sort_family )
 | "Derive" "Inversion" ident "with" one_term OPT ( "Sort" sort_family )
 | "Derive" "Dependent" "Inversion" ident "with" one_term "Sort" sort_family

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -245,10 +245,10 @@ let classify_hint _ = VtSideff ([], VtLater)
 }
 
 VERNAC COMMAND EXTEND HintRewrite CLASSIFIED BY { classify_hint }
-| #[ polymorphic; locality = hint_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ":" preident_list(bl) ] ->
+| #[ polymorphic; locality = hint_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ":" ne_preident_list(bl) ] ->
   { add_rewrite_hint ~locality ~poly:polymorphic bl o None l }
 | #[ polymorphic; locality = hint_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) "using" tactic(t)
-    ":" preident_list(bl) ] ->
+    ":" ne_preident_list(bl) ] ->
   { add_rewrite_hint ~locality ~poly:polymorphic bl o (Some t) l }
 | #[ polymorphic; locality = hint_locality; ] [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ] ->
   { add_rewrite_hint ~locality ~poly:polymorphic ["core"] o None l }


### PR DESCRIPTION
The current grammar allows an empty list of hintdbs after the `:`, which is inconsistent with all the other hint-generating commands.  Any Hint Rewrite that has an empty list of hintdbs can be fixed by removing the colon.  Since this corner case is likely used very rarely, if ever, and the fix is so easy, perhaps we can skip doing a deprecate now and a change in the subsequent release?

![image](https://github.com/user-attachments/assets/04c5b788-a791-430d-a94d-5c42e4999b70)


- [ ] Added **changelog**.
