### PR TITLE
Rocqify the checker.

### DIFF
--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -152,19 +152,19 @@ let remove_load_path dir =
   let physical, logical = !load_paths in
   load_paths := List.filter2 (fun p d -> p <> dir) physical logical
 
-let add_load_path (phys_path,coq_path) =
+let add_load_path (phys_path,rocq_path) =
   if CDebug.(get_flag misc) then
-    Feedback.msg_notice (str "path: " ++ pr_dirpath coq_path ++ str " ->" ++ spc() ++
+    Feedback.msg_notice (str "path: " ++ pr_dirpath rocq_path ++ str " ->" ++ spc() ++
            str phys_path);
   let phys_path = CUnix.canonical_path_name phys_path in
   let physical, logical = !load_paths in
     match List.filter2 (fun p d -> p = phys_path) physical logical with
       | _,[dir] ->
-          if coq_path <> dir
+          if rocq_path <> dir
             (* If this is not the default -I . to coqtop *)
             && not
             (phys_path = CUnix.canonical_path_name Filename.current_dir_name
-                && coq_path = default_root_prefix)
+                && rocq_path = default_root_prefix)
           then
             begin
               (* Assume the user is concerned by library naming *)
@@ -172,12 +172,12 @@ let add_load_path (phys_path,coq_path) =
                 Feedback.msg_warning
                   (str phys_path ++ strbrk " was previously bound to " ++
                    pr_dirpath dir ++ strbrk "; it is remapped to " ++
-                   pr_dirpath coq_path);
+                   pr_dirpath rocq_path);
               remove_load_path phys_path;
-              load_paths := (phys_path::fst !load_paths, coq_path::snd !load_paths)
+              load_paths := (phys_path::fst !load_paths, rocq_path::snd !load_paths)
             end
       | _,[] ->
-          load_paths := (phys_path :: fst !load_paths, coq_path :: snd !load_paths)
+          load_paths := (phys_path :: fst !load_paths, rocq_path :: snd !load_paths)
       | _ -> CErrors.anomaly (Pp.str ("Two logical paths are associated to "^phys_path^"."))
 
 let load_paths_of_dir_path dir =

--- a/checker/dune
+++ b/checker/dune
@@ -5,7 +5,7 @@
 (library
  (name coq_checklib)
  (public_name coq-core.checklib)
- (synopsis "Coq's Standalone Proof Checker")
+ (synopsis "Rocq's Standalone Proof Checker")
  (modules :standard \ coqchk votour)
  (wrapped true)
  (libraries coq-core.boot coq-core.kernel))

--- a/checker/values.mli
+++ b/checker/values.mli
@@ -33,7 +33,7 @@ type value =
   (** Adds a debug note to the inner value *)
 
   | Dyn
-  (** Coq's Dyn.t *)
+  (** Rocq's Dyn.t *)
 
   | Proxy of value ref
   (** Same as the inner value, used to define recursive types *)

--- a/checker/votour.ml
+++ b/checker/votour.ml
@@ -452,7 +452,7 @@ end
 
 let visit_vo f =
   Printf.printf "\nWelcome to votour !\n";
-  Printf.printf "Enjoy your guided tour of a Coq .vo or .vi file\n";
+  Printf.printf "Enjoy your guided tour of a Rocq .vo or .vi file\n";
   Printf.printf "Object sizes are in words (%d bits)\n" Sys.word_size;
   Printf.printf "Input h for help\n\n%!";
   let known_segments = [
@@ -496,5 +496,5 @@ let visit_vo f =
 let () =
   if not !Sys.interactive then
     Arg.parse [] visit_vo
-      ("votour: guided tour of a Coq .vo or .vi file\n"^
+      ("votour: guided tour of a Rocq .vo or .vi file\n"^
        "Usage: votour file.v[oi]")


### PR DESCRIPTION
This commit only touches comments and internal definitions. We do not attempt to modify user messages related to the name of the binaries nor to fiddle with the dune library names.