### PR TITLE
Remove deprecated coqlib API

### DIFF
--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -7,14 +7,19 @@ let constants = ref ([] : EConstr.t list)
  c_U *)
 let collect_constants () =
   if (!constants = []) then
+    let open Names in
     let open EConstr in
     let open UnivGen in
-    let find_reference = Coqlib.find_reference [@ocaml.warning "-3"] in
-    let gr_H = find_reference "Tuto3" ["Tuto3"; "Data"] "pack" in
-    let gr_M = find_reference "Tuto3" ["Tuto3"; "Data"] "packer" in
-    let gr_R = find_reference "Tuto3" ["Stdlib"; "Init"; "Datatypes"] "pair" in
-    let gr_P = find_reference "Tuto3" ["Stdlib"; "Init"; "Datatypes"] "prod" in
-    let gr_U = find_reference "Tuto3" ["Tuto3"; "Data"] "uncover" in
+    let find_reference path id =
+      let path = DirPath.make (List.rev_map Id.of_string path) in
+      let fp = Libnames.make_path path (Id.of_string id) in
+      Nametab.global_of_path fp
+    in
+    let gr_H = find_reference ["Tuto3"; "Data"] "pack" in
+    let gr_M = find_reference ["Tuto3"; "Data"] "packer" in
+    let gr_R = find_reference ["Stdlib"; "Init"; "Datatypes"] "pair" in
+    let gr_P = find_reference ["Stdlib"; "Init"; "Datatypes"] "prod" in
+    let gr_U = find_reference ["Tuto3"; "Data"] "uncover" in
     constants := List.map (fun x -> of_constr (constr_of_monomorphic_global (Global.env ()) x))
       [gr_H; gr_M; gr_R; gr_P; gr_U];
     !constants

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -22,13 +22,6 @@ let init_dir = [ coq; "Init"]
 
 let jmeq_module_name = [coq;"Logic";"JMeq"]
 
-let find_reference locstr dir s =
-  let dp = make_dir dir in
-  let sp = Libnames.make_path dp (Id.of_string s) in
-  Nametab.global_of_path sp
-
-let coq_reference locstr dir s = find_reference locstr (coq::dir) s
-
 let table : GlobRef.t CString.Map.t ref =
   Summary.ref ~name:"coqlib_registered" CString.Map.empty
 
@@ -75,30 +68,6 @@ let register_ref local s c =
 
 (************************************************************************)
 (* Generic functions to find Coq objects *)
-
-let has_suffix_in_dirs dirs ref =
-  let dir = Libnames.dirpath (Nametab.path_of_global ref) in
-  List.exists (fun d -> Libnames.is_dirpath_prefix_of d dir) dirs
-
-let gen_reference_in_modules locstr dirs s =
-  let dirs = List.map make_dir dirs in
-  let qualid = Libnames.qualid_of_string s in
-  let all = Nametab.locate_all qualid in
-  let all = List.sort_uniquize GlobRef.UserOrd.compare all in
-  let these = List.filter (has_suffix_in_dirs dirs) all in
-  match these with
-    | [x] -> x
-    | [] ->
-      CErrors.anomaly ~label:locstr Pp.(str "cannot find " ++ str s
-        ++ str " in module" ++ str (if List.length dirs > 1 then "s " else " ")
-        ++ prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
-    | l ->
-      CErrors.anomaly ~label:locstr
-        Pp.(str "ambiguous name " ++ str s ++ str " can represent "
-          ++ prlist_with_sep pr_comma (fun x ->
-            Libnames.pr_path (Nametab.path_of_global x)) l ++ str " in module"
-          ++ str (if List.length dirs > 1 then "s " else " ")
-          ++ prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
 
 (* For tactics/commands requiring vernacular libraries *)
 

--- a/library/coqlib.mli
+++ b/library/coqlib.mli
@@ -93,27 +93,3 @@ val logic_module_name : string list
 
 (* Used by tactics *)
 val jmeq_module_name : string list
-
-
-(*************************************************************************)
-(** {2 DEPRECATED}                                                            *)
-(*************************************************************************)
-
-(** All the functions below are deprecated and should go away in the
-    next coq version ... *)
-
-(** [find_reference caller_message [dir;subdir;...] s] returns a global
-   reference to the name dir.subdir.(...).s; the corresponding module
-   must have been required or in the process of being compiled so that
-   it must be used lazily; it raises an anomaly with the given message
-   if not found *)
-val find_reference : string -> string list -> string -> GlobRef.t
-[@@ocaml.deprecated "(8.10) Please use Coqlib.lib_ref"]
-
-(** This just prefixes find_reference with Stdlib... *)
-val coq_reference  : string -> string list -> string -> GlobRef.t
-[@@ocaml.deprecated "(8.10) Please use Coqlib.lib_ref"]
-
-(** Search in several modules (not prefixed by "Stdlib") *)
-val gen_reference_in_modules : string->string list list-> string -> GlobRef.t
-[@@ocaml.deprecated "(8.10) Please use Coqlib.lib_ref"]

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -47,23 +47,12 @@ let rewrite_attributes =
 
 (** Utility functions *)
 
-let find_reference dir s =
-  Coqlib.find_reference "generalized rewriting" dir s
-[@@warning "-3"]
-
-let lazy_find_reference dir s =
-  let gr = lazy (find_reference dir s) in
-  fun () -> Lazy.force gr
-
 module PropGlobal = struct
 
-  let morphisms = ["Stdlib"; "Classes"; "Morphisms"]
-
-  let respectful_ref = lazy_find_reference morphisms "respectful"
+  let respectful_ref () = Coqlib.lib_ref "rewrite.prop.respectful"
 
   let proper_class =
-    let r = lazy (find_reference morphisms "Proper") in
-    fun () -> Option.get (TC.class_info (Lazy.force r))
+    fun () -> Option.get (TC.class_info (Coqlib.lib_ref "rewrite.prop.Proper"))
 
   let proper_proj () =
     UnsafeMonomorphic.mkConst (Option.get (List.hd (proper_class ()).TC.cl_projs).TC.meth_const)

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -537,14 +537,13 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   end
 
 let lz_setoid_relation =
-  let sdir = ["Classes"; "RelationClasses"] in
   let last_srel = ref None in
   fun env -> match !last_srel with
   | Some (env', srel) when env' == env -> srel
   | _ ->
     let srel =
        try Some (UnivGen.constr_of_monomorphic_global (Global.env ()) @@
-                 Coqlib.find_reference "Class_setoid" ("Stdlib"::sdir) "RewriteRelation" [@ocaml.warning "-3"])
+                 Coqlib.lib_ref "rewrite.prop.RewriteRelation")
        with e when CErrors.noncritical e -> None in
     last_srel := Some (env, srel); srel
 

--- a/theories/setoid_ring/Field_tac.v
+++ b/theories/setoid_ring/Field_tac.v
@@ -582,3 +582,18 @@ Ltac field_lemmas set ext inv_m fspec pspec sspec dspec rk :=
        end
      | _ => fail 1 "field internal error : field_lemmas, please report"
      end).
+
+(** Registering for the ML plugin *)
+
+Register display_linear as plugins.field.display_linear.
+Register display_pow_linear as plugins.field.display_pow_linear.
+Register FEeval as plugins.field.FEeval.
+Register PCond as plugins.field.PCond.
+
+Register almost_field_theory as plugins.field.almost_field_theory.
+Register semi_field_theory as plugins.field.semi_field_theory.
+Register field_theory as plugins.field.field_theory.
+
+Register AF_AR as plugins.field.AF_AR.
+Register SF_SR as plugins.field.SF_SR.
+Register F_R as plugins.field.F_R.

--- a/theories/setoid_ring/InitialRing.v
+++ b/theories/setoid_ring/InitialRing.v
@@ -911,3 +911,39 @@ Ltac isZcst t :=
   (* *)
   | _ => constr:(false)
   end.
+
+(** Registering for the ML plugin *)
+
+Register PExpr as plugins.ring.pexpr.
+Register PEc as plugins.ring.const.
+Register PEX as plugins.ring.var.
+Register PEadd as plugins.ring.add.
+Register PEsub as plugins.ring.sub.
+Register PEmul as plugins.ring.mul.
+Register PEopp as plugins.ring.opp.
+Register PEpow as plugins.ring.pow.
+Register PEeval as plugins.ring.eval.
+
+Register almost_ring_theory as plugins.ring.almost_ring_theory.
+Register semi_ring_theory as plugins.ring.semi_ring_theory.
+Register ring_theory as plugins.ring.ring_theory.
+
+Register Eqsth as plugins.ring.Eqsth.
+Register Eq_ext as plugins.ring.Eq_ext.
+Register Eq_s_ext as plugins.ring.Eq_s_ext.
+
+Register Abstract as plugins.ring.Abstract.
+Register Computational as plugins.ring.Computational.
+Register Morphism as plugins.ring.Morphism.
+
+Register IDphi as plugins.ring.IDphi.
+Register gen_phiZ as plugins.ring.gen_phiZ.
+
+Register Pphi_dev as plugins.ring.Pphi_dev.
+Register Pphi_pow as plugins.ring.Pphi_pow.
+
+Register mk_reqe as plugins.ring.mk_reqe.
+Register mk_seqe as plugins.ring.mk_seqe.
+
+Register mkhypo as plugins.ring.mkhypo.
+Register hypo as plugins.ring.hypo.

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -20,7 +20,6 @@ Require Export Ncring.
 Require Import Ncring_polynom.
 Require Import Ncring_initial.
 
-
 Set Implicit Arguments.
 
 Ltac reify_as_var_aux n lvar term :=

--- a/theories/setoid_ring/Ring_polynom.v
+++ b/theories/setoid_ring/Ring_polynom.v
@@ -925,15 +925,6 @@ Section MakeRingPol.
   | PEopp : PExpr -> PExpr
   | PEpow : PExpr -> N -> PExpr.
 
- Register PExpr as plugins.ring.pexpr.
- Register PEc as plugins.ring.const.
- Register PEX as plugins.ring.var.
- Register PEadd as plugins.ring.add.
- Register PEsub as plugins.ring.sub.
- Register PEmul as plugins.ring.mul.
- Register PEopp as plugins.ring.opp.
- Register PEpow as plugins.ring.pow.
-
  (** evaluation of polynomial expressions towards R *)
  Definition mk_X j := mkPinj_pred j mkX.
 

--- a/theories/setoid_ring/Ring_tac.v
+++ b/theories/setoid_ring/Ring_tac.v
@@ -17,7 +17,6 @@ Require Export ListTactics.
 Require Import InitialRing.
 Declare ML Module "ring_plugin:coq-core.plugins.ring".
 
-
 (* adds a definition t' on the normal form of t and an hypothesis id
    stating that t = t' (tries to produces a proof as small as possible) *)
 Ltac compute_assertion eqn t' t :=


### PR DESCRIPTION
En passant we also use the registering mechanism for the ring/field tactics. Hopefully it will not be too disruptive.

Backwards compatible overlays:
- https://github.com/coq-community/atbr/pull/45
- https://github.com/damien-pous/relation-algebra/pull/46