### PR TITLE
Do not base asyncTaskQueue spawn arguments directly on Sys.argv

### DIFF
--- a/dev/ci/user-overlays/19741-SkySkimmer-async-positive.sh
+++ b/dev/ci/user-overlays/19741-SkySkimmer-async-positive.sh
@@ -1,0 +1,3 @@
+overlay vscoq https://github.com/SkySkimmer/vscoq async-positive 19741
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi async-positive 19741

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -687,9 +687,9 @@ coqidetop specific options:\n\
 \n  --help-XML-protocol    print documentation of the Coq XML protocol\n"
 }
 
-let islave_parse extra_args =
+let islave_parse opts extra_args =
   let open Coqtop in
-  let ({ run_mode; color_mode }, stm_opts), extra_args = coqtop_toplevel.parse_extra extra_args in
+  let ({ run_mode; color_mode }, stm_opts), extra_args = coqtop_toplevel.parse_extra opts extra_args in
   let extra_args = parse extra_args in
   (* One of the role of coqidetop is to find the name of buffers to open *)
   (* in the command line; Coqide is waiting these names on stdout *)

--- a/stm/asyncTaskQueue.mli
+++ b/stm/asyncTaskQueue.mli
@@ -147,7 +147,7 @@ module MakeQueue(T : Task) () : sig
   (** [create n pri] will initialize the queue with [n] workers having
       priority [pri]. If [n] is 0, the queue won't spawn any process,
       working in a lazy local manner. [not imposed by the this API] *)
-  val create : int -> CoqworkmgrApi.priority -> queue
+  val create : spawn_args:string list -> int -> CoqworkmgrApi.priority -> queue
 
   (** [destroy q] Deallocates [q], cancelling all pending tasks. *)
   val destroy : queue -> unit
@@ -205,7 +205,7 @@ module MakeQueue(T : Task) () : sig
 
   (** [with_n_workers n pri f] creates a queue, runs the function, destroys
       the queue. The user should call join *)
-  val with_n_workers : int -> CoqworkmgrApi.priority -> (queue -> 'a) -> 'a
+  val with_n_workers : spawn_args:string list -> int -> CoqworkmgrApi.priority -> (queue -> 'a) -> 'a
 
 end
 

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -189,11 +189,11 @@ let get_results res =
        str (CString.plural (List.length missing) "goal") ++
        spc () ++ prlist_with_sep spc int missing ++ str ")")
 
-let enable_par ~nworkers = ComTactic.set_par_implementation
+let enable_par ~spawn_args ~nworkers = ComTactic.set_par_implementation
   (fun ~pstate ~info t_ast ~abstract ~with_end_tac ->
     let t_state = Vernacstate.freeze_full_state () in
     let t_state = Vernacstate.Stm.make_shallow t_state in
-    TaskQueue.with_n_workers nworkers CoqworkmgrApi.High (fun queue ->
+    TaskQueue.with_n_workers ~spawn_args nworkers CoqworkmgrApi.High (fun queue ->
     Declare.Proof.map pstate ~f:(fun p ->
     let open TacTask in
     let results = (Proof.data p).Proof.goals |> CList.map_i (fun i g ->

--- a/stm/partac.mli
+++ b/stm/partac.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val enable_par : nworkers:int -> unit
+val enable_par : spawn_args:string list -> nworkers:int -> unit
 
 module TacTask : AsyncTaskQueue.Task

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -22,6 +22,8 @@ module AsyncOpts : sig
   type tac_error_filter = FNone | FOnly of string list | FAll
 
   type stm_opt = {
+    spawn_args : string list;
+
     async_proofs_n_workers : int;
     async_proofs_n_tacworkers : int;
 
@@ -38,7 +40,7 @@ module AsyncOpts : sig
     async_proofs_worker_priority : CoqworkmgrApi.priority;
   }
 
-  val default_opts : stm_opt
+  val default_opts : spawn_args:string list -> stm_opt
 
 end
 

--- a/stm/stmargs.ml
+++ b/stm/stmargs.ml
@@ -47,7 +47,45 @@ let get_cache opt = function
   | _ ->
     Coqargs.error_wrong_arg ("Error: force expected after "^opt)
 
-let parse_args ~init arglist : Stm.AsyncOpts.stm_opt * string list =
+let spawn_args (opts:Coqargs.t) =
+  (* Coqargs whose effect is not in the summary and matters for workers:
+
+     Flags.output_directory
+     Flags.test_mode
+     native output dir, native includes
+
+     Coqargs whose effect is used before the summary is installed and matter for workers:
+
+     -I, -boot
+
+     and we force -q -noinit otherwise the worker will try to require the
+     rcfile and prelude before receiving the summary
+
+     AFAICT that's all *)
+  let output_dir = match opts.config.output_directory with
+    | None -> []
+    | Some dir -> ["-output-directory";dir]
+  in
+  let test_mode = if opts.config.test_mode then ["-test-mode"] else [] in
+  let native_output = ["-native-output-dir"; opts.config.native_output_dir] in
+  let native_include ni = ["-nI";ni] in
+  let native_includes = CList.concat_map native_include opts.config.native_include_dirs in
+  let ml_include i = ["-I"; i] in
+  let ml_includes = CList.concat_map ml_include opts.pre.ml_includes in
+  let boot = if opts.pre.boot then ["-boot"] else [] in
+  List.concat [
+    output_dir;
+    test_mode;
+    native_output;
+    native_includes;
+    ml_includes;
+    boot;
+    ["-q"; "-noinit"]
+  ]
+
+
+let parse_args opts arglist : Stm.AsyncOpts.stm_opt * string list =
+  let init = Stm.AsyncOpts.default_opts ~spawn_args:(spawn_args opts) in
   let args = ref arglist in
   let extras = ref [] in
   let rec parse oval = match !args with
@@ -111,19 +149,24 @@ let parse_args ~init arglist : Stm.AsyncOpts.stm_opt * string list =
     |"-worker-id" -> set_worker_id opt (next ()); oval
 
     |"-main-channel" ->
-      Spawned.main_channel := get_host_port opt (next()); oval
+      let ch = next () in
+      Spawned.main_channel := get_host_port opt ch;
+      { oval with spawn_args = opt :: ch :: oval.spawn_args }
 
     |"-control-channel" ->
-      Spawned.control_channel := get_host_port opt (next()); oval
+      let ch = next () in
+      Spawned.control_channel := get_host_port opt ch;
+      { oval with spawn_args = opt :: ch :: oval.spawn_args }
 
     (* Options with zero arg *)
     |"-async-queries-always-delegate"
     |"-async-proofs-always-delegate"
     |"-async-proofs-never-reopen-branch" ->
       { oval with
-        Stm.AsyncOpts.async_proofs_never_reopen_branch = true
+        Stm.AsyncOpts.async_proofs_never_reopen_branch = true;
+        spawn_args = opt :: oval.spawn_args;
       }
-    |"-stm-debug" -> Stm.stm_debug := true; oval
+    |"-stm-debug" -> Stm.stm_debug := true; { oval with spawn_args = opt :: oval.spawn_args }
     (* Unknown option *)
     | s ->
       extras := s :: !extras;

--- a/stm/stmargs.mli
+++ b/stm/stmargs.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val parse_args : init:Stm.AsyncOpts.stm_opt -> string list -> Stm.AsyncOpts.stm_opt * string list
+val parse_args : Coqargs.t -> string list -> Stm.AsyncOpts.stm_opt * string list
 
 val usage : string

--- a/stm/workerPool.mli
+++ b/stm/workerPool.mli
@@ -19,7 +19,7 @@ type 'a cpanel = {
 module type PoolModel = sig
   (* this shall come from a Spawn.* model *)
   type process
-  val spawn : int -> CoqworkmgrApi.priority ->
+  val spawn : spawn_args:string list -> int -> CoqworkmgrApi.priority ->
     worker_id * process * CThread.thread_ic * out_channel
 
   (* this defines the main loop of the manager *)
@@ -32,7 +32,7 @@ module Make(Model : PoolModel) : sig
 
   type pool
 
-  val create : Model.extra -> size:int -> CoqworkmgrApi.priority -> pool
+  val create : spawn_args:string list -> Model.extra -> size:int -> CoqworkmgrApi.priority -> pool
 
   val is_empty : pool -> bool
   val n_workers : pool -> int

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -67,7 +67,8 @@ type coqargs_config = {
   native_output_dir : CUnix.physical_path;
   native_include_dirs : CUnix.physical_path list;
   output_directory : CUnix.physical_path option;
-  time        : time_config option;
+  time : time_config option;
+  test_mode : bool;
   profile : string option;
   print_emacs : bool;
 }
@@ -125,7 +126,8 @@ let default_config = {
   native_output_dir = ".coq-native";
   native_include_dirs = [];
   output_directory = None;
-  time         = None;
+  time = None;
+  test_mode = false;
   profile = None;
   print_emacs  = false;
 
@@ -382,7 +384,7 @@ let parse_args ~usage ~init arglist : t * string list =
       { oval with config = {oval.config with native_include_dirs = include_dir :: oval.config.native_include_dirs } }
 
     (* Options with zero arg *)
-    |"-test-mode" -> Flags.test_mode := true; oval
+    |"-test-mode" -> { oval with config = { oval.config with test_mode = true } }
     |"-beautify" -> Flags.beautify := true; Flags.record_comments := true; oval
     |"-config"|"--config" -> set_query oval PrintConfig
 

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -59,7 +59,8 @@ type coqargs_config = {
   native_output_dir : CUnix.physical_path;
   native_include_dirs : CUnix.physical_path list;
   output_directory : CUnix.physical_path option;
-  time        : time_config option;
+  time : time_config option;
+  test_mode : bool;
   profile : string option;
   print_emacs : bool;
 }

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -100,7 +100,7 @@ let parse_arguments ~parse_extra ~usage ?(initial_args=Coqargs.default) () =
   let opts, extras =
     Coqargs.parse_args ~usage ~init:initial_args
       (List.tl (Array.to_list Sys.argv)) in
-  let customopts, extras = parse_extra extras in
+  let customopts, extras = parse_extra opts extras in
   if not (CList.is_empty extras) then begin
     prerr_endline ("Don't know what to do with "^String.concat " " extras);
     prerr_endline "See -help for the list of supported options";

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -159,7 +159,7 @@ let init_runtime opts =
   init_coqlib opts;
   if opts.post.memory_stat then at_exit print_memory_stat;
 
-  (* Configuration *)
+  (* Kernel configuration *)
   Global.set_impredicative_set opts.config.logic.impredicative_set;
   Global.set_indices_matter opts.config.logic.indices_matter;
   Global.set_check_universes (not opts.config.logic.type_in_type);
@@ -173,6 +173,9 @@ let init_runtime opts =
 
   (* Default output dir *)
   Flags.output_directory := opts.config.output_directory;
+
+  (* Test mode *)
+  Flags.test_mode := opts.config.test_mode;
 
   (* Paths for loading stuff *)
   init_load_paths opts;

--- a/sysinit/coqinit.mli
+++ b/sysinit/coqinit.mli
@@ -31,7 +31,7 @@ val init_ocaml : unit -> unit
 
     [parse_extra] and [usage] can be used to parse/document more options. *)
 val parse_arguments :
-  parse_extra:(string list -> 'a * string list) ->
+  parse_extra:(Coqargs.t -> string list -> 'a * string list) ->
   usage:Boot.Usage.specific_usage ->
   ?initial_args:Coqargs.t ->
   unit ->

--- a/toplevel/colors.ml
+++ b/toplevel/colors.ml
@@ -71,7 +71,6 @@ let set_color = function
 let parse_extra_colors extras =
   let rec parse_extra color_mode = function
   | "-color" :: next :: rest -> parse_extra (set_color next) rest
-  | "-list-tags" :: rest -> parse_extra color_mode rest
   | x :: rest ->
     let color_mode, rest = parse_extra color_mode rest in color_mode, x :: rest
   | [] -> color_mode, [] in

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -78,9 +78,9 @@ let fix_stm_opts opts stm_opts = match opts.Coqcargs.compilation_mode with
 
 let custom_coqc : ((Coqcargs.t * Colors.color) * Stm.AsyncOpts.stm_opt, 'b) Coqtop.custom_toplevel
  = Coqtop.{
-  parse_extra = (fun extras ->
+  parse_extra = (fun opts extras ->
     let color_mode, extras = Colors.parse_extra_colors extras in
-    let stm_opts, extras = Stmargs.parse_args ~init:Stm.AsyncOpts.default_opts extras in
+    let stm_opts, extras = Stmargs.parse_args opts extras in
     let coqc_opts = Coqcargs.parse extras in
     let stm_opts = fix_stm_opts coqc_opts stm_opts in
     ((coqc_opts, color_mode), stm_opts), []);

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -48,7 +48,7 @@ let fatal_error_exn exn =
   exit exit_code
 
 type ('a,'b) custom_toplevel =
-  { parse_extra : string list -> 'a * string list
+  { parse_extra : Coqargs.t -> string list -> 'a * string list
   ; usage : Boot.Usage.specific_usage
   ; init_extra : 'a -> Coqargs.injection_command list -> opts:Coqargs.t -> 'b
   ; initial_args : Coqargs.t
@@ -145,16 +145,17 @@ let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
     });
   init_toploop opts async_opts injections
 
-let coqtop_parse_extra extras =
+let coqtop_parse_extra opts extras =
   let rec parse_extra run_mode  = function
   | "-batch" :: rest -> parse_extra Batch  rest
+  | "list-tags" :: rest -> Query PrintTags, []
   | "-print-mod-uid" :: rest -> Query (PrintModUid rest), []
   |   x :: rest ->
     let run_mode, rest = parse_extra run_mode rest in run_mode, x :: rest
   | [] -> run_mode, [] in
   let run_mode, extras = parse_extra Interactive extras in
   let color_mode, extras = Colors.parse_extra_colors extras in
-  let async_opts, extras = Stmargs.parse_args ~init:Stm.AsyncOpts.default_opts extras in
+  let async_opts, extras = Stmargs.parse_args opts extras in
   ({ run_mode; color_mode}, async_opts), extras
 
 let fix_windows_dirsep s =

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -14,7 +14,7 @@
 *)
 
 type ('a,'b) custom_toplevel =
-  { parse_extra : string list -> 'a * string list
+  { parse_extra : Coqargs.t -> string list -> 'a * string list
   ; usage : Boot.Usage.specific_usage
   ; init_extra : 'a -> Coqargs.injection_command list -> opts:Coqargs.t -> 'b
   ; initial_args : Coqargs.t

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -12,8 +12,8 @@ let kind_filter str =
   let kinds = [ "--kind=proof"; "--kind=tactic"; "--kind=query" ] in
   not (List.exists (String.equal str) kinds)
 
-let worker_parse_extra extra_args =
-  let stm_opts, extra_args = Stmargs.parse_args ~init:Stm.AsyncOpts.default_opts extra_args in
+let worker_parse_extra opts extra_args =
+  let stm_opts, extra_args = Stmargs.parse_args opts extra_args in
   let extra_args = List.filter kind_filter extra_args in
   ((),stm_opts), extra_args
 


### PR DESCRIPTION
Instead we generate the needed arguments from the parsed Coqargs and stm args.

As workers do not do certain operations like Require and get their state from the parent process's summary this turns out to be very few arguments (unless I made a mistake).

Overlays:
- https://github.com/ejgallego/coq-serapi/pull/428
- https://github.com/coq/vscoq/pull/931