### PR TITLE
add 11 list lemmas (for tl, filter, map, seq, Permutation)

### DIFF
--- a/doc/changelog/11-standard-library/19748-list-for-Zmod.rst
+++ b/doc/changelog/11-standard-library/19748-list-for-Zmod.rst
@@ -1,0 +1,16 @@
+- **Added:** list lemmas
+  :g:`length_tl`,
+  :g:`tl_map`,
+  :g:`filter_rev`,
+  :g:`filter_map_swap`,
+  :g:`filter_true`,
+  :g:`filter_false`,
+  :g:`list_prod_as_flat_map`,
+  :g:`skipn_seq`,
+  :g:`map_const`,
+  :g:`fst_list_prod`,
+  :g:`snd_list_prod`,
+  :g:`Injective_map_NoDup_in`,
+  and :g:`Permutation_map_same_l`
+  (`#19748 <https://github.com/coq/coq/pull/19748>`_,
+  by Andres Erbsen).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -360,6 +360,8 @@ Section Facts.
       right; unfold not; intros [Hc1| Hc2]; auto.
   Defined.
 
+  Lemma length_tl l : length (@tl A l) = length l - 1.
+  Proof. case l; cbn [length tl Nat.sub]; auto using Nat.sub_0_r. Qed.
 End Facts.
 
 #[global]
@@ -1197,6 +1199,9 @@ Section Map.
     intros n l d H. now rewrite nth_error_map, H.
   Qed.
 
+  Lemma tl_map l : tl (map l) = map (tl l).
+  Proof. case l; trivial. Qed.
+
   Lemma map_app : forall l l',
     map (l++l') = (map l)++(map l').
   Proof.
@@ -1616,6 +1621,13 @@ End Fold_Right_Recursor.
      destruct IN as [<-|IN]; auto.
     Qed.
 
+    Lemma filter_rev (l : list A) : filter (rev l) = rev (filter l).
+    Proof.
+      induction l; cbn [rev]; trivial.
+      rewrite filter_app, IHl; cbn [filter].
+      case f; cbn [app]; auto using app_nil_r.
+    Qed.
+
   (** [partition] *)
 
     Fixpoint partition (l:list A) : list A * list A :=
@@ -1680,7 +1692,18 @@ End Fold_Right_Recursor.
   (*******************************)
 
   Section Filtering.
+
+    Lemma filter_map_swap A B f g l :
+      filter f (@map A B g l) = @map A B g (filter (fun a => f (g a)) l).
+    Proof. induction l; cbn [map filter]; auto. rewrite IHl; case f; auto. Qed.
+
     Variables (A : Type).
+
+    Lemma filter_true l : filter (fun _ : A => true) l = l.
+    Proof. induction l; cbn [filter]; congruence. Qed.
+
+    Lemma filter_false l : filter (fun _ : A => false) l = nil.
+    Proof. induction l; cbn [filter]; congruence. Qed.
 
     Lemma filter_ext_in : forall (f g : A -> bool) (l : list A),
       (forall a, In a l -> f a = g a) -> filter f l = filter g l.
@@ -1945,6 +1968,9 @@ End Fold_Right_Recursor.
       intros. now rewrite length_app, length_map, IHl.
     Qed.
 
+    Lemma list_prod_as_flat_map : forall l l',
+      list_prod l l' = flat_map (fun a => map (pair a) l') l.
+    Proof. induction l; intros; cbn; rewrite ?IHl; trivial. Qed.
   End ListPairs.
 
 
@@ -2875,6 +2901,12 @@ Section NatSeq.
    change [start + len] with (seq (start + len) 1).
    rewrite <- seq_app.
    rewrite Nat.add_succ_r, Nat.add_0_r; reflexivity.
+  Qed.
+
+  Lemma skipn_seq n start len : skipn n (seq start len) = seq (start+n) (len-n).
+  Proof.
+    revert len; revert start; induction n, len;
+      cbn [skipn seq]; rewrite ?Nat.add_0_r, ?IHn; cbn [Nat.add]; auto.
   Qed.
 
   Lemma nth_error_seq start len n :
@@ -3820,6 +3852,10 @@ Proof.
   - cbn. f_equal. exact IHn.
 Qed.
 
+Lemma map_const (A B : Type) (b : B) (l : list A) :
+  map (fun _ => b) l = repeat b (length l).
+Proof. induction l; cbn [repeat map length]; congruence. Qed.
+
 Lemma rev_repeat A n (a:A):
   rev (repeat a n) = repeat a n.
 Proof.
@@ -3827,6 +3863,24 @@ Proof.
   - reflexivity.
   - cbn. rewrite IHn. symmetry. apply repeat_cons.
 Qed.
+
+Lemma fst_list_prod [A B] l l' : map fst (@list_prod A B l l') =
+  flat_map (fun a => repeat a (length l')) l.
+Proof.
+  revert l'; induction l; intros; trivial. cbn.
+  erewrite map_app, map_map, map_ext, map_const; eauto using f_equal2.
+Qed.
+#[deprecated(use = fst_list_prod)]
+Notation map_fst_list_prod := fst_list_prod (only parsing).
+
+Lemma snd_list_prod [A B] l l' : map snd (@list_prod A B l l') =
+  concat (repeat l' (length l)).
+Proof.
+  revert l'; induction l; intros; trivial. cbn.
+  erewrite map_app, map_map, map_ext, map_id; eauto using f_equal2.
+Qed.
+#[deprecated(use = snd_list_prod)]
+Notation map_snd_list_prod := snd_list_prod (only parsing).
 
 (** Sum of elements of a list of [nat]: [list_sum] *)
 

--- a/theories/Logic/FinFun.v
+++ b/theories/Logic/FinFun.v
@@ -79,6 +79,14 @@ Proof.
  rewrite in_map_iff. intros (y & E & Y). apply Ij in E. now subst.
 Qed.
 
+Lemma Injective_map_NoDup_in A B (f:A->B) (l:list A) :
+  (forall x y, In x l -> In y l -> f x = f y -> x = y) -> NoDup l -> NoDup (map f l).
+Proof.
+ pose proof @in_cons. pose proof @in_eq.
+ intros Ij N; revert Ij; induction N; cbn [map]; constructor; auto.
+ rewrite in_map_iff. intros (y & E & Y). apply Ij in E; auto; congruence.
+Qed.
+
 Lemma Injective_list_carac A B (d:decidable_eq A)(f:A->B) :
   Injective f <-> (forall l, NoDup l -> NoDup (map f l)).
 Proof.

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -694,6 +694,12 @@ Qed.
 
 End Permutation_map.
 
+Lemma Permutation_map_same_l {A} (f : A -> A) (l : list A) :
+  List.NoDup (List.map f l) -> List.incl (List.map f l) l -> Permutation (List.map f l) l.
+Proof.
+  intros; eapply Permutation.NoDup_Permutation_bis; rewrite ?List.length_map; trivial.
+Qed.
+
 Lemma nat_bijection_Permutation n f :
  bFun n f ->
  Injective f ->


### PR DESCRIPTION
These are generic list lemmas; I have proven most of them more than once for different projects & expect to keep needing them. The selection here is based on what I intend to use in Zmod.

- [x] Added **changelog**.

One question for reviewing is whether/how we should typo-squat in stdlib. Concretely, `fst_list_prod` is the name I chose for the lemma that could arguably also be named `map_fst_list_prod`. In the current PR, I added a deprecated alias with `use` but no `since`, and the intent would be to keep it around so that any user who types that name gets an instructive feedback message.