### PR TITLE
add lemmas relating bitwise operations on N to Z

### DIFF
--- a/doc/changelog/11-standard-library/19750-n2z-bitwise.rst
+++ b/doc/changelog/11-standard-library/19750-n2z-bitwise.rst
@@ -1,0 +1,9 @@
+- **Added:** lemmas relating bitwise operations on :g:`N` to those on :g:`Z`:
+  :g:`N2Z.inj_lxor`,
+  :g:`N2Z.inj_land`,
+  :g:`N2Z.inj_lor`,
+  :g:`N2Z.inj_ldiff`,
+  :g:`N2Z.inj_shiftl`,
+  and :g:`N2Z.inj_shiftr`
+  (`#19750 <https://github.com/coq/coq/pull/19750>`_,
+  by Andres Erbsen).

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -291,6 +291,18 @@ Lemma inj_testbit a n :
  Z.testbit (Z.of_N a) (Z.of_N n) = N.testbit a n.
 Proof. apply Z.testbit_of_N. Qed.
 
+Lemma inj_lxor n m : Z.of_N (N.lxor n m) = Z.lxor (Z.of_N n) (Z.of_N m).
+Proof. destruct n, m; reflexivity. Qed.
+
+Lemma inj_land n m : Z.of_N (N.land n m) = Z.land (Z.of_N n) (Z.of_N m).
+Proof. destruct n, m; reflexivity. Qed.
+
+Lemma inj_lor n m : Z.of_N (N.lor n m) = Z.lor (Z.of_N n) (Z.of_N m).
+Proof. destruct n, m; reflexivity. Qed.
+
+Lemma inj_ldiff n m : Z.of_N (N.ldiff n m) = Z.ldiff (Z.of_N n) (Z.of_N m).
+Proof. destruct n, m; reflexivity. Qed.
+
 End N2Z.
 
 Module Z2N.
@@ -446,6 +458,48 @@ Lemma inj_testbit a n : 0<=n ->
 Proof. apply Z.testbit_of_N'. Qed.
 
 End Z2N.
+
+Module Export MoreN2Z.
+Module N2Z.
+Export N2Z.
+
+Lemma inj_shiftl: forall x y, Z.of_N (N.shiftl x y) = Z.shiftl (Z.of_N x) (Z.of_N y).
+Proof.
+  intros x y.
+  apply Z.bits_inj_iff'; intros k Hpos.
+  rewrite Z2N.inj_testbit; [|assumption].
+  rewrite Z.shiftl_spec; [|assumption].
+
+  assert ((Z.to_N k) >= y \/ (Z.to_N k) < y)%N as g by (
+      unfold N.ge, N.lt; induction (N.compare (Z.to_N k) y); [left|auto|left];
+      intro H; inversion H).
+
+  destruct g as [g|g];
+  [ rewrite N.shiftl_spec_high; [|apply N2Z.inj_le; rewrite Z2N.id|apply N.ge_le]
+  | rewrite N.shiftl_spec_low]; try assumption.
+
+  - rewrite <- N2Z.inj_testbit; f_equal.
+      rewrite N2Z.inj_sub, Z2N.id; [reflexivity|assumption|apply N.ge_le; assumption].
+
+  - apply N2Z.inj_lt in g.
+      rewrite Z2N.id in g; [symmetry|assumption].
+      apply Z.testbit_neg_r, Z.lt_sub_0, g.
+Qed.
+
+Lemma inj_shiftr: forall x y, Z.of_N (N.shiftr x y) = Z.shiftr (Z.of_N x) (Z.of_N y).
+Proof.
+  intros.
+  apply Z.bits_inj_iff'; intros k Hpos.
+  rewrite Z2N.inj_testbit; [|assumption].
+  rewrite Z.shiftr_spec, N.shiftr_spec; [|apply N2Z.inj_le; rewrite Z2N.id|]; try assumption.
+  rewrite <- N2Z.inj_testbit; f_equal.
+  rewrite N2Z.inj_add; f_equal.
+  apply Z2N.id; assumption.
+Qed.
+
+End N2Z.
+End MoreN2Z.
+
 
 Module Zabs2N.
 


### PR DESCRIPTION
- [x] Added **changelog**.

Using modules for namespacing is getting painful here. Existing lemma `Z2N.inj_compare` uses `N2Z.inj_compare`, and the new `N2Z.inj_shiftl` uses `Z2N.inj_testbit`, so at module granularity we would have a circular dependency. We ought not to expose that dependency structure to the user, as these proof choices seem rather arbitrary and could perhaps be done exactly the other way around. Instead, I added a second module `N2Z` inside a `Module Export` wrapper. Please let me know if there is a better generic way to work around this problem. (While it may be possible to refactor the proofs here, I'd rather not spend time trying to satisfy constraints that shouldn't exist.)