### PR TITLE
add Zdiv_facts and more Z.modulo lemmas

### DIFF
--- a/doc/changelog/11-standard-library/19752-zdiv-facts.rst
+++ b/doc/changelog/11-standard-library/19752-zdiv-facts.rst
@@ -1,0 +1,19 @@
+- **Added:** lemmas about :g:`Z.modulo`, some in a new module :g:`Zdiv_facts`.
+  On its own, :g:`Z.mod_id_iff` generalizes :g:`Z.mod_small`, whereas
+  :g:`Z.diveq_iff` and :g:`Z.mod_diveq_iff` further genralize the same concept
+  to known quotients other than 0. Combinations of :g:`Z.modulo` with
+  :g:`Z.opp` or :g:`Z.abs` are the subject of
+  :g:`Z.mod_opp_mod_opp`,
+  :g:`Z.mod_mod_opp_r`,
+  :g:`Z.mod_opp_r_mod`,
+  :g:`Z.mod_mod_abs_r`,
+  :g:`Z.mod_abs_r_mod`,
+  :g:`Z.eq_mod_opp`,
+  :g:`Z.eq_mod_abs`.
+  Lemmas :g:`cong_iff_0` and :g:`cong_iff_ex` can be used to reduce congruence
+  equalities to equations where only one side is headed by :g:`Z.modulo`.
+  Lemmas :g:`Z.gcd_mod_l` and :g:`Z.gcd_mod_r` generalize :g:`Z.gcd_mod`.
+  Lemma :g:`Z.mod_mod_divide` generalizes :g:`Zmod_mod`.
+  Lemma :g:`Z.mod_pow_l` allows pushing modulo inside exponentiation
+  (`#19752 <https://github.com/coq/coq/pull/19752>`_,
+  by Andres Erbsen).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -185,6 +185,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/ZArith/Znumtheory.v
     theories/ZArith/Int.v
     theories/ZArith/Zpow_facts.v
+    theories/ZArith/Zdiv_facts.v
     theories/ZArith/Zbitwise.v
   </dd>
 

--- a/theories/ZArith/ZArith.v
+++ b/theories/ZArith/ZArith.v
@@ -24,6 +24,7 @@ Require Export ZArith_hints.
 Require Export Zcomplements.
 Require Export Zpower.
 Require Export Zdiv.
+Require Export Zdiv_facts.
 Require Export Zbitwise.
 
 Export ZArithRing.

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -734,3 +734,89 @@ Proof.
 Qed.
 
 Arguments Zdiv_eucl_extended : default implicits.
+
+Module Z.
+Lemma mod_id_iff a b : a mod b = a <-> 0 <= a < b \/ b = 0 \/ b < a <= 0.
+Proof. zero_or_not b; [|rewrite Z.mod_small_iff]; intuition idtac. Qed.
+
+Lemma gcd_mod_l a b : Z.gcd (a mod b) b = Z.gcd a b.
+Proof.
+  case (Z.eqb_spec b 0) as [->|];
+    rewrite ?Zmod_0_r, ?Z.gcd_mod, Z.gcd_comm; trivial.
+Qed.
+
+Lemma gcd_mod_r a b : Z.gcd a (b mod a) = Z.gcd a b.
+Proof. rewrite Z.gcd_comm, Z.gcd_mod_l, Z.gcd_comm; trivial. Qed.
+
+Lemma mod_pow_l a b c : (a mod c)^b mod c = ((a ^ b) mod c).
+Proof.
+  destruct (Z.ltb_spec b 0) as [|Hb]. { rewrite !Z.pow_neg_r; trivial. }
+  destruct (Z.eqb_spec c 0) as [|Hc]. { subst. rewrite !Zmod_0_r; trivial. }
+  generalize dependent b; eapply natlike_ind; trivial; intros x Hx IH.
+  rewrite !Z.pow_succ_r, <-Z.mul_mod_idemp_r, IH, Z.mul_mod_idemp_l, Z.mul_mod_idemp_r; trivial.
+Qed.
+
+Lemma cong_iff_0 a b m : a mod m = b mod m <-> (a - b) mod m = 0.
+Proof.
+  case (Z.eq_dec m 0) as [->|Hm].
+  { rewrite ?Zmod_0_r; rewrite Z.sub_move_0_r; reflexivity. }
+  split; intros H. { rewrite Zminus_mod, H, Z.sub_diag, Z.mod_0_l; trivial. }
+  apply Zmod_divides in H; trivial; case H as [c H].
+  assert (b = a + (-c) * m) as ->; rewrite ?Z.mod_add; trivial.
+  (* lia *) rewrite Z.mul_opp_l, Z.mul_comm, <-H; ring.
+Qed.
+
+Lemma cong_iff_ex a b m : a mod m = b mod m <-> exists n, a - b = n * m.
+Proof.
+  destruct (Z.eq_dec m 0) as [->|].
+  { rewrite !Zmod_0_r. setoid_rewrite Z.mul_0_r. setoid_rewrite Z.sub_move_0_r.
+    firstorder idtac. }
+  { rewrite cong_iff_0, Z.mod_divide by trivial; reflexivity. }
+Qed.
+
+Lemma mod_mod_divide a b c : (c | b) -> (a mod b) mod c = a mod c.
+Proof.
+  destruct (Z.eqb_spec b 0); subst. { rewrite Zmod_0_r; trivial. }
+  inversion_clear 1; subst.
+  destruct (Z.eqb_spec c 0); subst. { rewrite Z.mul_0_r, 2Zmod_0_r; trivial. }
+  apply cong_iff_ex; eexists (- x * (a/(x*c))); rewrite Z.mod_eq by auto.
+  ring_simplify; trivial.
+Qed.
+
+Lemma mod_opp_mod_opp a b : - (-a mod b) mod b = a mod b.
+Proof.
+  eapply cong_iff_0.
+  destruct (Z.eq_dec (a mod b) 0).
+  { rewrite !Z_mod_zero_opp_full; trivial. }
+  rewrite Z_mod_nz_opp_full by trivial.
+  rewrite <-Zminus_mod_idemp_r.
+  case (Z.eq_dec b 0) as [->|]; [rewrite Zmod_0_r; ring|].
+  rewrite <-Z.mod_add with (b:=1) by trivial.
+  change 0 with (0 mod b); f_equal; ring.
+Qed.
+
+Lemma mod_mod_opp_r a b : (a mod - b) mod b = a mod b.
+Proof.
+  replace a with (--a) at 1 by apply Z.opp_involutive.
+  rewrite Zmod_opp_opp, Z.mod_opp_mod_opp; trivial.
+Qed.
+
+Lemma mod_opp_r_mod a b : (a mod b) mod - b = a mod - b.
+Proof. rewrite <-(mod_mod_opp_r a (-b)), Z.opp_involutive; trivial. Qed.
+
+Lemma mod_mod_abs_r a b : (a mod Z.abs b) mod b = a mod b.
+Proof.
+  case b as []; cbn [Z.abs].
+  { rewrite ?Zmod_0_r; trivial. }
+  { apply Z.mod_mod; inversion 1. }
+  { rewrite <-Pos2Z.opp_pos. apply mod_opp_r_mod. }
+Qed.
+
+Lemma mod_abs_r_mod a b : (a mod b) mod Z.abs b = a mod Z.abs b.
+Proof.
+  case b as []; cbn [Z.abs].
+  { rewrite ?Zmod_0_r; trivial. }
+  { apply Z.mod_mod; inversion 1. }
+  { rewrite <-Pos2Z.opp_pos. apply mod_mod_opp_r. }
+Qed.
+End Z.

--- a/theories/ZArith/Zdiv_facts.v
+++ b/theories/ZArith/Zdiv_facts.v
@@ -1,0 +1,40 @@
+Require Import BinInt Zdiv Znumtheory PreOmega Lia.
+Local Open Scope Z_scope.
+
+Module Z.
+
+Lemma diveq_iff c a b :
+  (b = 0 /\ c = 0 \/ c*b <= a < c*b + b \/ c*b + b < a <= c*b) <-> a/b = c.
+Proof.
+  destruct (Z.eqb_spec b 0); [subst; rewrite Zdiv_0_r; intuition lia|].
+  rewrite <-(Z.sub_move_0_r (_/_)),  <-(Z.add_opp_r (_/_)).
+  rewrite <-Z.div_add, Z.div_small_iff; lia.
+Qed.
+
+Lemma mod_diveq_iff c a b :
+  (b = 0 \/ c*b <= a < c*b + b \/ c*b + b < a <= c*b) <-> a mod b = a-b*c.
+Proof.
+  destruct (Z.eqb_spec b 0); [subst; rewrite Zmod_0_r; intuition lia|].
+  rewrite Z.mod_eq by trivial; pose proof diveq_iff c a b; nia.
+Qed.
+
+(* Usage: rewrite (mod_diveq (-1)) by lia *)
+Definition mod_diveq c a b := proj1 (mod_diveq_iff c a b).
+
+Definition diveq c a b := proj1 (diveq_iff c a b).
+
+Lemma eq_mod_opp m x y : x mod -m = y mod -m <-> x mod m = y mod m.
+Proof.
+  intros.
+  case (Z.eq_dec (x mod m) 0), (Z.eq_dec (y mod m) 0) as [];
+    repeat rewrite ?Z_mod_zero_opp_r, ?Z_mod_nz_opp_r in * by lia.
+  all : (intuition try trivial); Z.div_mod_to_equations; lia.
+Qed.
+
+Lemma eq_mod_abs m x y : x mod (Z.abs m) = y mod (Z.abs m) <-> x mod m = y mod m.
+Proof.
+  case (Z.abs_eq_or_opp m) as [->| ->].
+  reflexivity.
+  apply eq_mod_opp.
+Qed.
+End Z.


### PR DESCRIPTION
- [x] Added **changelog**.

Most of the lemmas are pretty basic, and the changelog goes over them by category.

I believe "rewrite (diveq_mod some_literal) by lia" captures most cases of [Jason's advice](https://github.com/coq/coq/pull/8062#issuecomment-443910492) to characterize the quotient before calling lia; sometimes it ought to be posed instead thought

`mod_pow_l` omits a needless a precondition compared to the version already present in the repo (but not ZArith).

Some lemmas are in a new file Zdiv_facts so that they can depend on lia. ZArith exports that file. This is follows what we did for Zbitwise, and is in line with the vision that pre-lia parts of ZArith would decrease over time.

I struggled with naming some of these; e.g. `mod_opp_r_mod` does not feel quite right, and using "cong" to refer to "a mod m = b mod m" is new I believe. Suggestions welcome.