### PR TITLE
Fix incorrect increment in load_keep and open_keep + cleanups around declaremods and keep objects

### DIFF
--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -816,14 +816,6 @@ let end_module_core id (m_info : current_module_syntax_info) objects fs =
   (* We add the keep objects, if any, and if this isn't a functor *)
   let keep = if not (CList.is_empty m_info.cur_mbids) then [] else keep_objects id keep in
   let objects = special@[node]@keep in
-  (* Name consistency check : start_ vs. end_module *)
-  (*
-  Printf.eprintf "newoname=%s, oldoname=%s\n" (string_of_path (fst newoname)) (string_of_path (fst oldoname));
-  assert (DirPath.equal (Lib.prefix()).Nametab.obj_dir olddp);
-  assert (ModPath.equal oldprefix.Nametab.obj_mp mp);
-  *)
-  (* Printf.eprintf "newoname=%s, oldoname=%s\n" (string_of_path (fst newoname)) (string_of_path (fst oldoname)); *)
-  (* Printf.eprintf "newoname=%s, cur_mp=%s\n" (ModPath.debug_to_string (mp_of_kn (snd newoname))) (ModPath.debug_to_string m_info.cur_mp); *)
 
   m_info.cur_mp, objects
 
@@ -835,8 +827,6 @@ let end_module () =
 
   let () = SynterpVisitor.add_leaves objects in
 
-  (* Name consistency check : kernel vs. library *)
-  (* CDebug.debug_synterp (fun () -> Pp.(str"prefix=" ++ DirPath.print ((Lib.prefix()).Nametab.obj_dir) ++ str", olddp=" ++ DirPath.print olddp)); *)
   assert (DirPath.equal (Lib.prefix()).Nametab.obj_dir olddp);
   mp
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -82,6 +82,11 @@ let dir_of_sp sp =
   let dir,id = repr_path sp in
   add_dirpath_suffix dir id
 
+(* Avoid generating a KeepObject for nothing *)
+let keep_objects id = function
+  | [] -> []
+  | keep -> [KeepObject (id, keep)]
+
 (** The [ModActions] abstraction represent operations on modules
     that are specific to a given stage. Two instances are defined below,
     for Synterp and Interp. *)
@@ -203,7 +208,8 @@ module type StagedModS = sig
 
   val get_module_sobjs : bool -> env -> Entries.inline -> typexpr module_alg_expr -> substitutive_objects
 
-  val load_module : int -> DirPath.t -> ModPath.t -> substitutive_objects -> Libobject.t list -> unit
+  val load_keep : int -> DirPath.t -> ModPath.t -> Libobject.t list -> unit
+  val load_module : int -> DirPath.t -> ModPath.t -> substitutive_objects -> unit
   val import_modules : export:Lib.export_flag -> (open_filter * ModPath.t) list -> unit
 
   val add_leaf : Libobject.t -> unit
@@ -374,8 +380,8 @@ let rec load_object i (prefix, obj) =
   match obj with
   | AtomicObject o -> Libobject.load_object i (prefix, o)
   | ModuleObject (id,sobjs) ->
-    let sp, kn as name = Lib.make_oname prefix id in
-    load_module i (dir_of_sp sp) (mp_of_kn kn) sobjs []
+    let sp, kn = Lib.make_oname prefix id in
+    load_module i (dir_of_sp sp) (mp_of_kn kn) sobjs
   | ModuleTypeObject (id,sobjs) ->
     let name = Lib.make_oname prefix id in
     let (sp,kn) = name in
@@ -384,8 +390,8 @@ let rec load_object i (prefix, obj) =
     load_include i (prefix, aobjs)
   | ExportObject _ -> ()
   | KeepObject (id,objs) ->
-    let name = Lib.make_oname prefix id in
-    load_keep i (name, objs)
+    let sp, kn = Lib.make_oname prefix id in
+    load_keep i (dir_of_sp sp) (mp_of_kn kn) objs
 
 and load_objects i prefix objs =
   List.iter (fun obj -> load_object i (prefix, obj)) objs
@@ -394,9 +400,8 @@ and load_include i (prefix, aobjs) =
   let o = expand_aobjs aobjs in
   load_objects i prefix o
 
-and load_keep i ((sp,kn),kobjs) =
+and load_keep i obj_dir obj_mp kobjs =
   (* Invariant : seg isn't empty *)
-  let obj_dir = dir_of_sp sp and obj_mp  = mp_of_kn kn in
   let prefix = Nametab.{ obj_dir ; obj_mp; } in
   let modobjs =
     try ModObjs.get obj_mp
@@ -407,7 +412,7 @@ and load_keep i ((sp,kn),kobjs) =
   ModObjs.set obj_mp { modobjs with module_keep_objects = kobjs };
   load_objects (i+1) prefix kobjs
 
-and load_module i obj_dir obj_mp sobjs kobjs =
+and load_module i obj_dir obj_mp sobjs =
   let prefix = Nametab.{ obj_dir ; obj_mp; } in
   Actions.enter_module obj_mp obj_dir i;
   ModSubstObjs.set obj_mp sobjs;
@@ -417,12 +422,11 @@ and load_module i obj_dir obj_mp sobjs kobjs =
     let module_objects =
       { module_prefix = prefix;
         module_substituted_objects = objs;
-        module_keep_objects = kobjs;
+        module_keep_objects = [];
       }
     in
     ModObjs.set obj_mp module_objects;
-    load_objects (i+1) prefix objs;
-    load_objects (i+1) prefix kobjs
+    load_objects (i+1) prefix objs
   end
 
 (** {6 Implementation of Import and Export commands} *)
@@ -756,7 +760,7 @@ let intern_arg (idl,(typ,ann)) =
     let mp = MPbound mbid in
     (* We can use an empty delta resolver because we load only syntax objects *)
     let sobjs = subst_sobjs (map_mp mp0 mp empty_delta_resolver) sobjs in
-    SynterpVisitor.load_module 1 dir mp sobjs [];
+    SynterpVisitor.load_module 1 dir mp sobjs;
     mbid
   in
   List.map map idl, (mty, base, kind, inl)
@@ -810,10 +814,8 @@ let end_module_core id (m_info : current_module_syntax_info) objects fs =
   in
   let node = ModuleObject (id,sobjs) in
   (* We add the keep objects, if any, and if this isn't a functor *)
-  let objects = match keep, m_info.cur_mbids with
-    | [], _ | _, _ :: _ -> special@[node]
-    | _ -> special@[node;KeepObject (id,keep)]
-  in
+  let keep = if not (CList.is_empty m_info.cur_mbids) then [] else keep_objects id keep in
+  let objects = special@[node]@keep in
   (* Name consistency check : start_ vs. end_module *)
   (*
   Printf.eprintf "newoname=%s, oldoname=%s\n" (string_of_path (fst newoname)) (string_of_path (fst oldoname));
@@ -959,7 +961,7 @@ let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
     let mp = MPbound mbid in
     let resolver = Global.add_module_parameter mbid mty inl in
     let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
-    InterpVisitor.load_module 1 dir mp sobjs [];
+    InterpVisitor.load_module 1 dir mp sobjs;
     (mbid,mty,inl)::acc
   in
   let acc = List.fold_left fold acc mbidl in
@@ -1042,10 +1044,8 @@ let end_module_core id m_info objects fs =
   in
   let node = ModuleObject (id,sobjs) in
   (* We add the keep objects, if any, and if this isn't a functor *)
-  let objects = match keep, mbids with
-    | [], _ | _, _ :: _ -> special@[node]
-    | _ -> special@[node;KeepObject (id,keep)]
-  in
+  let keep = if not (CList.is_empty mbids) then [] else keep_objects id keep in
+  let objects = special@[node]@keep in
 
   mp, objects
 
@@ -1468,7 +1468,8 @@ let declare_include = RawIncludeOps.Synterp.declare_include
 let register_library dir (objs:library_objects) =
   let mp = MPfile dir in
   let sobjs,keepobjs = objs in
-  SynterpVisitor.load_module 1 dir mp ([],Objs sobjs) keepobjs
+  SynterpVisitor.load_module 1 dir mp ([],Objs sobjs);
+  SynterpVisitor.load_keep 2 dir mp keepobjs
 
 let import_modules = SynterpVisitor.import_modules
 
@@ -1555,7 +1556,8 @@ let register_library dir cenv (objs:library_objects) digest vmtab =
       end
   in
   let sobjs,keepobjs = objs in
-  InterpVisitor.load_module 1 dir mp ([],Objs sobjs) keepobjs
+  InterpVisitor.load_module 1 dir mp ([],Objs sobjs);
+  InterpVisitor.load_keep 1 dir mp keepobjs
 
 let import_modules = InterpVisitor.import_modules
 
@@ -1621,8 +1623,8 @@ let process_module_binding mbid me =
   let sobjs = InterpVisitor.get_module_sobjs false (Global.env()) (default_inline ()) me in
   let subst = map_mp (get_module_path me) mp empty_delta_resolver in
   let sobjs = subst_sobjs subst sobjs in
-  SynterpVisitor.load_module 1 dir mp sobjs [];
-  InterpVisitor.load_module 1 dir mp sobjs []
+  SynterpVisitor.load_module 1 dir mp sobjs;
+  InterpVisitor.load_module 1 dir mp sobjs
 
 (** Compatibility layer *)
 let import_module f ~export mp =

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -405,7 +405,7 @@ and load_keep i ((sp,kn),kobjs) =
   assert Nametab.(eq_op modobjs.module_prefix prefix);
   assert (List.is_empty modobjs.module_keep_objects);
   ModObjs.set obj_mp { modobjs with module_keep_objects = kobjs };
-  load_objects i prefix kobjs
+  load_objects (i+1) prefix kobjs
 
 and load_module i obj_dir obj_mp sobjs kobjs =
   let prefix = Nametab.{ obj_dir ; obj_mp; } in
@@ -526,7 +526,7 @@ and open_export f i mpl =
 and open_keep f i ((sp,kn),kobjs) =
   let obj_dir = dir_of_sp sp and obj_mp = mp_of_kn kn in
   let prefix = Nametab.{ obj_dir; obj_mp; } in
-  open_objects f i prefix kobjs
+  open_objects f (i+1) prefix kobjs
 
 let cache_include (prefix, aobjs) =
   let o = expand_aobjs aobjs in


### PR DESCRIPTION
I think the increment bug has no user visible effect currently has none of the current keep objects care about the increment.