### PR TITLE
Make Coqargs.parse_args pure 

### DIFF
--- a/dev/ci/user-overlays/19757-SkySkimmer-coqargs-pure.sh
+++ b/dev/ci/user-overlays/19757-SkySkimmer-coqargs-pure.sh
@@ -1,0 +1,3 @@
+overlay vscoq https://github.com/SkySkimmer/vscoq coqargs-pure 19757
+
+overlay serapi https://github.com/SkySkimmer/coq-serapi coqargs-pure 19757

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -670,6 +670,8 @@ let rec parse = function
         Xmlprotocol.document Xml_printer.to_string_fmt; exit 0
   | "--xml_format=Ppcmds" :: rest ->
         msg_format := (fun () -> Xmlprotocol.Ppcmds); parse rest
+  | "-xml-debug" :: rest ->
+    Flags.xml_debug := true; parse rest
   | x :: rest ->
      if String.length x > 0 && x.[0] = '-' then
        (prerr_endline ("Unknown option " ^ x); exit 1)
@@ -699,6 +701,11 @@ let islave_parse opts extra_args =
 
 let islave_init ( { Coqtop.run_mode; color_mode }, stm_opts) injections ~opts =
   if run_mode = Coqtop.Batch then Flags.quiet := true;
+  (* -xml-debug implies -debug. *)
+  let injections = if !Flags.xml_debug
+    then Coqargs.OptionInjection (["Debug"], OptionAppend "all") :: injections
+    else injections
+  in
   Coqtop.init_toploop opts stm_opts injections
 
 let islave_default_opts = Coqargs.default

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -520,7 +520,7 @@ end = struct (* {{{ *)
 
   let vcs : vcs ref = ref (empty Stateid.dummy)
 
-  let doc_type = ref (Interactive (Coqargs.TopLogical (Names.DirPath.make [])))
+  let doc_type = ref (Interactive (Coqargs.TopLogical ""))
   let ldir = ref Names.DirPath.empty
 
   let init dt id ps =
@@ -2250,16 +2250,16 @@ let new_doc { doc_type ; injections } =
 
   let top =
     match doc_type with
-    | Interactive top -> Coqargs.dirpath_of_top top
+    | Interactive top -> Coqinit.dirpath_of_top top
 
     | VoDoc f ->
-      let ldir = Coqargs.(dirpath_of_top (TopPhysical f)) in
+      let ldir = Coqargs.(Coqinit.dirpath_of_top (TopPhysical f)) in
       VCS.set_ldir ldir;
       set_compilation_hints f;
       ldir
 
     | VosDoc f ->
-      let ldir = Coqargs.(dirpath_of_top (TopPhysical f)) in
+      let ldir = Coqargs.(Coqinit.dirpath_of_top (TopPhysical f)) in
       VCS.set_ldir ldir;
       set_compilation_hints f;
       ldir

--- a/sysinit/coqinit.mli
+++ b/sysinit/coqinit.mli
@@ -22,6 +22,8 @@
     This API should be called up very early, or not at all. *)
 val init_ocaml : unit -> unit
 
+val dirpath_of_top : Coqargs.top -> Names.DirPath.t
+
 (** 2 parsing of Sys.argv
 
     This API parses command line options which are known by Coq components.
@@ -32,7 +34,6 @@ val init_ocaml : unit -> unit
     [parse_extra] and [usage] can be used to parse/document more options. *)
 val parse_arguments :
   parse_extra:(Coqargs.t -> string list -> 'a * string list) ->
-  usage:Boot.Usage.specific_usage ->
   ?initial_args:Coqargs.t ->
   unit ->
   Coqargs.t * 'a
@@ -48,7 +49,7 @@ val parse_arguments :
     The prelude is one of these (unless "-nois" is passed).
 
     This API must be called, typically jsut after parsing arguments. *)
-val init_runtime : Coqargs.t -> Coqargs.injection_command list
+val init_runtime : usage:Boot.Usage.specific_usage -> Coqargs.t -> Coqargs.injection_command list
 
 (** 4 Start a library (sets options and loads objects like the prelude)
 

--- a/sysinit/dune
+++ b/sysinit/dune
@@ -1,6 +1,16 @@
 (library
+ (name coqargs)
+ (public_name coq-core.coqargs)
+ (synopsis "Coq command line argument parsing")
+ (modules coqargs)
+ (wrapped false)
+ ; don't depend on coq-core.lib -> impossible to imperatively set random flags
+ (libraries coq-core.config coq-core.clib))
+
+(library
  (name sysinit)
  (public_name coq-core.sysinit)
  (synopsis "Coq's initialization")
  (wrapped false)
- (libraries coq-core.boot coq-core.vernac findlib))
+ (modules :standard \ coqargs)
+ (libraries coq-core.boot coq-core.vernac coqargs findlib))

--- a/toplevel/colors.ml
+++ b/toplevel/colors.ml
@@ -68,10 +68,14 @@ let set_color = function
     Coqargs.error_wrong_arg ("Error: on/off/auto expected after option color")
 
 
-let parse_extra_colors extras =
+let parse_extra_colors ~emacs extras =
   let rec parse_extra color_mode = function
   | "-color" :: next :: rest -> parse_extra (set_color next) rest
   | x :: rest ->
     let color_mode, rest = parse_extra color_mode rest in color_mode, x :: rest
   | [] -> color_mode, [] in
-  parse_extra `AUTO extras
+  let c, extras = parse_extra `AUTO extras in
+  (* we parse -color but ignore it when -emacs
+     maybe should be the other way (ignore -emacs for color printing if -color is given)? *)
+  let c = if emacs then `EMACS else c in
+  c, extras

--- a/toplevel/colors.mli
+++ b/toplevel/colors.mli
@@ -13,5 +13,5 @@
 type color = [`ON | `AUTO | `EMACS | `OFF]
 
 val init_color : color -> unit
-val parse_extra_colors : string list -> color * string list
+val parse_extra_colors : emacs:bool -> string list -> color * string list
 val print_style_tags : color -> unit

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -11,7 +11,7 @@
 let coqc_init ((_,color_mode),_) injections ~opts =
   Flags.quiet := true;
   System.trust_file_cache := true;
-  Colors.init_color (if opts.Coqargs.config.Coqargs.print_emacs then `EMACS else color_mode);
+  Colors.init_color color_mode;
   DebugHook.Intf.(set
     { read_cmd = Coqtop.ltac_debug_parse
     ; submit_answer = Coqtop.ltac_debug_answer
@@ -79,7 +79,7 @@ let fix_stm_opts opts stm_opts = match opts.Coqcargs.compilation_mode with
 let custom_coqc : ((Coqcargs.t * Colors.color) * Stm.AsyncOpts.stm_opt, 'b) Coqtop.custom_toplevel
  = Coqtop.{
   parse_extra = (fun opts extras ->
-    let color_mode, extras = Colors.parse_extra_colors extras in
+    let color_mode, extras = Colors.parse_extra_colors ~emacs:opts.config.print_emacs extras in
     let stm_opts, extras = Stmargs.parse_args opts extras in
     let coqc_opts = Coqcargs.parse extras in
     let stm_opts = fix_stm_opts coqc_opts stm_opts in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -58,9 +58,9 @@ type ('a,'b) custom_toplevel =
 (** Main init routine *)
 let init_toplevel { parse_extra; init_extra; usage; initial_args } =
   Coqinit.init_ocaml ();
-  let opts, customopts = Coqinit.parse_arguments ~parse_extra ~usage ~initial_args () in
+  let opts, customopts = Coqinit.parse_arguments ~parse_extra ~initial_args () in
   Stm.init_process (snd customopts);
-  let injections = Coqinit.init_runtime opts in
+  let injections = Coqinit.init_runtime ~usage opts in
   (* This state will be shared by all the documents *)
   Stm.init_core ();
   let customstate = init_extra ~opts customopts injections in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -136,7 +136,7 @@ let init_toploop opts stm_opts injections =
 
 let coqtop_init ({ run_mode; color_mode }, async_opts) injections ~opts =
   if run_mode != Interactive then Flags.quiet := true;
-  Colors.init_color (if opts.config.print_emacs then `EMACS else color_mode);
+  Colors.init_color color_mode;
   Flags.if_verbose (print_header ~boot:opts.pre.boot) ();
   DebugHook.Intf.(set
     { read_cmd = ltac_debug_parse
@@ -154,7 +154,7 @@ let coqtop_parse_extra opts extras =
     let run_mode, rest = parse_extra run_mode rest in run_mode, x :: rest
   | [] -> run_mode, [] in
   let run_mode, extras = parse_extra Interactive extras in
-  let color_mode, extras = Colors.parse_extra_colors extras in
+  let color_mode, extras = Colors.parse_extra_colors ~emacs:opts.config.print_emacs extras in
   let async_opts, extras = Stmargs.parse_args opts extras in
   ({ run_mode; color_mode}, async_opts), extras
 


### PR DESCRIPTION
We enforce it by removing the dependency on coq-core.lib (which
contains flags.ml) (just for the coqargs module).


Depends:
- https://github.com/coq/coq/pull/19741

Overlays:
- https://github.com/coq/vscoq/pull/933
- https://github.com/ejgallego/coq-serapi/pull/429