### PR TITLE
Push access to Sys.argv to the highest layers for main executables

### DIFF
--- a/dev/ci/user-overlays/19763-SkySkimmer-argv-topbin.sh
+++ b/dev/ci/user-overlays/19763-SkySkimmer-argv-topbin.sh
@@ -1,0 +1,1 @@
+overlay vscoq https://github.com/SkySkimmer/vscoq argv-topbin 19763

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -719,4 +719,4 @@ let () =
       init_extra = islave_init;
       run = loop;
       initial_args = islave_default_opts } in
-  start_coq custom
+  start_coq custom (List.tl (Array.to_list Sys.argv))

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -112,10 +112,8 @@ let dirpath_of_top = function
   | Coqargs.TopPhysical f -> dirpath_of_file f
   | TopLogical dp -> Libnames.dirpath_of_string dp
 
-let parse_arguments ~parse_extra ?(initial_args=Coqargs.default) () =
-  let opts, extras =
-    Coqargs.parse_args ~init:initial_args
-      (List.tl (Array.to_list Sys.argv)) in
+let parse_arguments ~parse_extra ?(initial_args=Coqargs.default) args =
+  let opts, extras = Coqargs.parse_args ~init:initial_args args in
   let customopts, extras = parse_extra opts extras in
   if not (CList.is_empty extras) then begin
     prerr_endline ("Don't know what to do with "^String.concat " " extras);

--- a/sysinit/coqinit.mli
+++ b/sysinit/coqinit.mli
@@ -31,11 +31,13 @@ val dirpath_of_top : Coqargs.top -> Names.DirPath.t
     on the spot instead of being represented as "injection commands" (a field
     of Coqargs.t).
 
+    The [string list] argument is typically [List.tl (Array.to_list Sys.argv)].
+
     [parse_extra] and [usage] can be used to parse/document more options. *)
 val parse_arguments :
   parse_extra:(Coqargs.t -> string list -> 'a * string list) ->
   ?initial_args:Coqargs.t ->
-  unit ->
+  string list ->
   Coqargs.t * 'a
 
 (** 3 initialization of global runtime data

--- a/topbin/coqc_bin.ml
+++ b/topbin/coqc_bin.ml
@@ -10,4 +10,4 @@
 
 (* Main coqc initialization *)
 let () =
-  Coqc.main ()
+  Coqc.main (List.tl (Array.to_list Sys.argv))

--- a/topbin/coqc_byte_bin.ml
+++ b/topbin/coqc_byte_bin.ml
@@ -10,4 +10,4 @@
 
 (* Main coqc initialization *)
 let () =
-  Coqc.main ()
+  Coqc.main (List.tl (Array.to_list Sys.argv))

--- a/topbin/coqtop_bin.ml
+++ b/topbin/coqtop_bin.ml
@@ -9,4 +9,4 @@
 (************************************************************************)
 
 (* Main coqtop entry point *)
-let () = Coqtop.(start_coq coqtop_toplevel)
+let () = Coqtop.(start_coq coqtop_toplevel (List.tl (Array.to_list Sys.argv)))

--- a/topbin/coqtop_byte_bin.ml
+++ b/topbin/coqtop_byte_bin.ml
@@ -56,4 +56,4 @@ let drop_setup () =
 (* Main coqtop initialization *)
 let _ =
   drop_setup ();
-  Coqtop.(start_coq coqtop_toplevel)
+  Coqtop.(start_coq coqtop_toplevel (List.tl (Array.to_list Sys.argv)))

--- a/topbin/coqworker_bin.ml
+++ b/topbin/coqworker_bin.ml
@@ -27,4 +27,4 @@ let () =
       | "--kind=tactic" -> WTactic.init_stdout, WTactic.main_loop
       | s -> error s ()
     in
-    WorkerLoop.start ~init ~loop
+    WorkerLoop.start ~init ~loop (List.tl (Array.to_list Sys.argv))

--- a/topbin/coqworker_bin.ml
+++ b/topbin/coqworker_bin.ml
@@ -20,11 +20,14 @@ let () =
   if Array.length Sys.argv < 2
   then error "no argument" ()
   else
+    let argv = List.tl (Array.to_list Sys.argv) in
+    let kind = List.hd argv in
+    let argv = List.tl argv in
     let init, loop =
-      match Sys.argv.(1) with
+      match kind with
       | "--kind=proof" -> WProof.init_stdout, WProof.main_loop
       | "--kind=query" -> WQuery.init_stdout, WQuery.main_loop
       | "--kind=tactic" -> WTactic.init_stdout, WTactic.main_loop
       | s -> error s ()
     in
-    WorkerLoop.start ~init ~loop (List.tl (Array.to_list Sys.argv))
+    WorkerLoop.start ~init ~loop argv

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -90,6 +90,6 @@ let custom_coqc : ((Coqcargs.t * Colors.color) * Stm.AsyncOpts.stm_opt, 'b) Coqt
   initial_args = Coqargs.default;
 }
 
-let main () =
+let main args =
   let () = Memtrace_init.init () in
-  Coqtop.start_coq custom_coqc
+  Coqtop.start_coq custom_coqc args

--- a/toplevel/coqc.mli
+++ b/toplevel/coqc.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val main : unit -> unit
+val main : string list -> unit

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -56,9 +56,9 @@ type ('a,'b) custom_toplevel =
   }
 
 (** Main init routine *)
-let init_toplevel { parse_extra; init_extra; usage; initial_args } =
+let init_toplevel { parse_extra; init_extra; usage; initial_args } args =
   Coqinit.init_ocaml ();
-  let opts, customopts = Coqinit.parse_arguments ~parse_extra ~initial_args () in
+  let opts, customopts = Coqinit.parse_arguments ~parse_extra ~initial_args args in
   Stm.init_process (snd customopts);
   let injections = Coqinit.init_runtime ~usage opts in
   (* This state will be shared by all the documents *)
@@ -66,11 +66,11 @@ let init_toplevel { parse_extra; init_extra; usage; initial_args } =
   let customstate = init_extra ~opts customopts injections in
   opts, customopts, customstate
 
-let start_coq custom =
+let start_coq custom args =
   let init_feeder = Feedback.add_feeder Coqloop.coqloop_feed in
   (* Init phase *)
   let opts, custom_opts, state =
-    try init_toplevel custom
+    try init_toplevel custom args
     with any ->
       flush_all();
       fatal_error_exn any in

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -25,8 +25,11 @@ type ('a,'b) custom_toplevel =
    print the banner, initialize the load path, load the input state,
    load the files given on the command line, load the resource file,
    produce the output state if any, and finally will launch
-   [custom.run]. *)
-val start_coq : ('a * Stm.AsyncOpts.stm_opt,'b) custom_toplevel -> unit
+   [custom.run].
+
+    The [string list] argument is typically [List.tl (Array.to_list Sys.argv)].
+*)
+val start_coq : ('a * Stm.AsyncOpts.stm_opt,'b) custom_toplevel -> string list -> unit
 
 (** Prepare state for interactive loop *)
 

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -29,7 +29,7 @@ let usage = Boot.Usage.{
 \n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\n");
 }
 
-let start ~init ~loop =
+let start ~init ~loop args =
   let open Coqtop in
   let custom = {
     parse_extra = worker_parse_extra;
@@ -40,4 +40,4 @@ let start ~init ~loop =
       (* the state is not used since the worker will receive one from master *)
       loop ());
   } in
-  start_coq custom
+  start_coq custom args

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -8,13 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let kind_filter str =
-  let kinds = [ "--kind=proof"; "--kind=tactic"; "--kind=query" ] in
-  not (List.exists (String.equal str) kinds)
-
 let worker_parse_extra opts extra_args =
   let stm_opts, extra_args = Stmargs.parse_args opts extra_args in
-  let extra_args = List.filter kind_filter extra_args in
   ((),stm_opts), extra_args
 
 let worker_init init ((),stm_opts)  injections ~opts : Vernac.State.t =

--- a/toplevel/workerLoop.mli
+++ b/toplevel/workerLoop.mli
@@ -11,4 +11,5 @@
 (* Register a STM worker of a given executable name *)
 val start :
   init:(unit -> unit) ->
-  loop:(unit -> unit) -> unit
+  loop:(unit -> unit) ->
+  string list -> unit


### PR DESCRIPTION
(except argv.(0) which is accessed in System.get_toplevel_path)

Overlays:
- https://github.com/coq/vscoq/pull/936