### PR TITLE
Fixes #19767: anomaly when printing functor with Strategy/Transparent in module parameter

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/19768-master+fixes19767-anomaly-print-functor-strategy.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19768-master+fixes19767-anomaly-print-functor-strategy.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Anomaly when printing a module functor with :cmd:`Strategy` or
+  :cmd:`Transparent` in one of its parameters
+  (`#19768 <https://github.com/coq/coq/pull/19768>`_,
+  fixes `#19767 <https://github.com/coq/coq/issues/19767>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/bug_19767.v
+++ b/test-suite/bugs/bug_19767.v
@@ -1,0 +1,11 @@
+Module A.
+  Module Type T. Definition c := 0. #[global] Strategy expand [c]. End T.
+  Module F (M:T). End F.
+  Print F.
+End A.
+
+Module B.
+  Module Type T. Definition c := 0. #[global] Transparent c. End T.
+  Module F (M:T). End F.
+  Print F.
+End B.


### PR DESCRIPTION
Fixes / closes #19767.

Printing functors is not working fully correctly because we are not able to replay the exact context in which the printer has to be called. This impacts printing functors dependent on a parameter containing `Strategy` and `Transparent`.

We weaken the limitation by ensuring that the cache method for `Strategy`/`Transparent` does not request the global environment of constants.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
