### PR TITLE
Fix scheme dependency duplicate definitions

### DIFF
--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -1521,7 +1521,7 @@ let make_eq_decidability env handle mind =
 
 let eq_dec_scheme_kind =
   Ind_tables.declare_mutual_scheme_object "eq_dec"
-  ~deps:(fun _ ind -> [SchemeMutualDep (ind, bl_scheme_kind); SchemeMutualDep (ind, lb_scheme_kind)])
+  ~deps:(fun _ ind -> [SchemeMutualDep (ind, beq_scheme_kind); SchemeMutualDep (ind, bl_scheme_kind); SchemeMutualDep (ind, lb_scheme_kind)])
   make_eq_decidability
 
 (* The eq_dec_scheme proofs depend on the equality and discr tactics


### PR DESCRIPTION
# Scheme Dependency Duplicate Definition

## The dependecy problem

While working on generalizing Coq’s Scheme command, I encountered an issue where Boolean Equality (```beq```) is a dependency of Decidable Equality (```eq_dec```), but it is not explicitly listed in the dependencies of ```eq_dec_scheme_kind``` (in vernac/auto_ind_decl.ml, line 1524). Instead, it is defined "by hand" before ```eq_dec``` in vernac/indschemes.ml (line 451). 
This results in Boolean Equality being internally defined in the background of the command ```Scheme Equality for a```, but without the expected prefix "internal_". This behavior differs from other schemes that follow the internal_ naming convention for dependencies.

I tried to implement the normal convention by adding ```beq``` as a dependencies of ```eq_dec``` but this failed. The issue seems to stem from how Coq handles ```side_effects```—the internal mechanism that stores scheme dependencies defined locally (in the type ```handle = Evd.side_effects``` in tactics/ind_tables.ml), but not yet introduced into the global environment.

To verify this, I modified the base version of Coq by:
- Removing the manual definition of ```beq``` before ```declare_eq_decidability``` in indschemes.ml (line 451).
  Replacing it with:
      ```
	if dec then declare_eq_decidability ?locmap mind
      	else declare_beq_scheme ?locmap mind
      ```
- Adding ```beq``` as a dependency of ```eq_dec_scheme_kind``` in auto_ind_decl.ml (line 1524).

For successful compilation after the change, we have to ensure that the implicitly generated beq schemes still don't have an internal_ name by adding the following now explicit Scheme declarations to theories/Init/Decimal.v:
```
Scheme Boolean Equality for uint.
Scheme Boolean Equality for int.
Scheme Boolean Equality for decimal.
```

However, running the test suite reveals multiple duplicated internal definitions like:
internal_uint_beq
internal_uint_beq0
internal_uint_beq1
internal_uint_beq2
...

This suggests that the Ind_tables.declare_scheme_dependence function is not correctly tracking when a dependency has already been defined. Specifically, it redefines Boolean Equality multiple times under new internal names.

## Proposed Solution

To fix this issue, I propose modifying the function ```define_mutual_scheme``` (line 206 in ind_tables.ml) to take an additional argument ```eff: handle```. This argument would be passed along to the mutually recursive calls between ```define_mutual_scheme``` and ```declare_scheme_dependence```, ensuring that the state of dependencies is preserved and correctly transmitted across recursive calls : 
- give ```eff``` instead of ```Evd.empty_side_effects``` to the call of fold_left with ```declare_scheme_dependence``` (file ind_tables.ml, line 211)
- give ```eff``` to the call of ```define_mutual_scheme``` in ```declare_scheme_dependence``` (file ind_tables.ml, line 224)
- give ```Evd.empty_side_effects``` to the call of ```define_mutual_scheme``` (file ind_tables.ml, line 255)
- do the same for individual

To replicate the mechanism where Boolean Equality is a dependency of Decidable Equality without the internal_ prefix (so that no changes are required in the test-suite or in theories/Init/Decimal.v), we can modify the ```scheme_dependency``` type in tactics/ind_tables.ml (line 44) to include an ```internal : bool``` flag:
```
type scheme_dependency =
  | SchemeMutualDep of MutInd.t * mutual scheme_kind * bool (* internal = true *)
  | SchemeIndividualDep of inductive * individual scheme_kind * bool (* internal = true *)
```
This modification allows ```Ind_tables.declare_scheme_dependence``` to use the internal value from each ```scheme_dependency``` instead of consistently setting ```~internal=true```.
For each dependency, we set ```internal = true``` by default, except for the dependency from Decidable Equality to Boolean Equality, where we set ```internal = false``` (in vernac/auto_ind_decl.ml, line 1524).

## Alternative solutions

No response

## Additional context

No response

