### PR TITLE
Fixes #10407: support Program-like pattern-matching in the presence of inductive types and constructors with let-in

### DIFF
--- a/doc/changelog/02-specification-language/19773-master+fix10407-program-match-when-ind-have-lets.rst
+++ b/doc/changelog/02-specification-language/19773-master+fix10407-program-match-when-ind-have-lets.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Pattern-matching in :attr:`Program` mode now supports inductive
+  types using :ref:`local definitions <let-in>` in their declaration
+  (`#19773 <https://github.com/coq/coq/pull/19773>`_,
+  fixes `#10407 <https://github.com/coq/coq/issues/10407>`_,
+  by Hugo Herbelin).

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -58,7 +58,7 @@ val constr_of_pat :
            Names.Id.Set.t ->
            Evd.evar_map * Glob_term.cases_pattern *
            (rel_context * constr *
-            (types * constr list) * Glob_term.cases_pattern) *
+            (types * Vars.substl) * Glob_term.cases_pattern) *
            Names.Id.Set.t
 
 type 'a rhs =

--- a/test-suite/bugs/bug_10407.v
+++ b/test-suite/bugs/bug_10407.v
@@ -1,0 +1,27 @@
+Require Coq.Program.Tactics.
+
+Module Example1.
+
+Inductive A : Type :=
+| C : forall (B := unit) (x : B) , A.
+
+Program Definition f (v : A) : unit :=
+  match v with
+  | C x => _
+  end.
+
+End Example1.
+
+Module Example2.
+
+(* A bit more complex *)
+
+Inductive A : Type :=
+| C : forall (B : Type) (C := unit) (x : B * C) (y:=0) , A.
+
+Program Definition f (v : A) : unit :=
+  match v with
+  | C B (x1,x2) => _
+  end.
+
+End Example2.

--- a/test-suite/bugs/bug_10407.v
+++ b/test-suite/bugs/bug_10407.v
@@ -25,3 +25,31 @@ Program Definition f (v : A) : unit :=
   end.
 
 End Example2.
+
+Module Example3.
+
+(* With local parameters and indices *)
+
+Inductive A (n:=0) : let p:=1 in Type :=
+| C : forall (B : Type) (C := unit) (x : B * C) (y:=0) , A.
+
+Program Definition f (v : A) : unit :=
+  match v with
+  | C B (x1,x2) => _
+  end.
+
+End Example3.
+
+Require Import JMeq.
+
+Module Example4.
+
+Inductive A (n:=0) : forall n, let p:=n in bool -> Type :=
+| C : forall (B : Type) (C := unit) (x : B * C) (y:=0) , A y true.
+
+Program Definition f n b (v : A n b) : unit :=
+  match v with
+  | C B (x1,x2) => _
+  end.
+
+End Example4.


### PR DESCRIPTION
Fixes / closes #10407 (presence of a constructor with a let-in)

We seize the opportunity to also include support for inductive types with let-in in indices.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
