### PR TITLE
ci/ci-fiat_crypto.sh: do not build "coq", just "lite"

### DIFF
--- a/dev/ci/ci-fiat_crypto.sh
+++ b/dev/ci/ci-fiat_crypto.sh
@@ -23,8 +23,6 @@ make_args=(EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 EXTERNAL_COQUTIL=1 EXTERNAL_B
 export COQEXTRAFLAGS='-native-compiler no' # following bedrock2
 ( cd "${CI_BUILD_DIR}/fiat_crypto"
   ulimit -s $stacksize
-  make "${make_args[@]}" pre-standalone-extracted printlite lite ||
-    make -j 1 "${make_args[@]}" pre-standalone-extracted printlite lite
-  make "${make_args[@]}" all-except-compiled ||
-    make -j 1 "${make_args[@]}" all-except-compiled
+  make "${make_args[@]}" pre-standalone-extracted printlite lite check-output ||
+    make -j 1 "${make_args[@]}" pre-standalone-extracted printlite lite check-output
 )


### PR DESCRIPTION
For https://github.com/mit-plv/fiat-crypto/pull/1954

I don't recall why "lite" wasn't the coq-ci target anymore, but I think that's what it is supposed to be for?

The addition of `check-output` is from https://github.com/mit-plv/fiat-crypto/blob/892e77bde485a0f5105927176aa4c55ed0043a68/Makefile#L162