### PR TITLE
Ltac2 use hashmaps instead of ordered maps in suspected hot paths

### DIFF
--- a/dev/ci/user-overlays/19783-SkySkimmer-ltac2-hashmaps.sh
+++ b/dev/ci/user-overlays/19783-SkySkimmer-ltac2-hashmaps.sh
@@ -1,0 +1,1 @@
+overlay rewriter https://github.com/SkySkimmer/rewriter ltac2-hashmaps 19783

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -437,7 +437,7 @@ GRAMMAR EXTEND Gram
   tac2def_ext:
     [ [ "@"; IDENT "external"; id = identref; ":"; t = ltac2_type LEVEL "5"; ":=";
         plugin = Prim.string; name = Prim.string ->
-      { let ml = { mltac_plugin = plugin; mltac_tactic = name } in
+        { let ml = Tac2env.ml_tactic_name ~plugin name in
         StrPrm (id, t, ml) }
     ] ]
   ;

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -206,7 +206,7 @@ let fail ?(info = Exninfo.null) e =
   Proofview.tclZERO ~info e
 
 let return x = Proofview.tclUNIT x
-let pname ?(plugin=ltac2_plugin) s = { mltac_plugin = plugin; mltac_tactic = s }
+let pname ?(plugin=ltac2_plugin) s = Tac2env.ml_tactic_name ~plugin s
 
 let catchable_exception = function
   | Logic_monad.Exception _ -> false

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -182,11 +182,15 @@ let compare r1 r2 = match r1, r2 with
 
 let equal r1 r2 = compare r1 r2 == 0
 
+let hash = function
+  | TacConstant c -> Hashset.Combine.combinesmall 1 (KerName.hash c)
+  | TacAlias c -> Hashset.Combine.combinesmall 2 (KerName.hash c)
+
 end
 
 module KnTab = Nametab.Make(FullPath)(KerName)
 module RfTab = Nametab.Make(FullPath)(TacRef)
-module RfMap = Map.Make(TacRef)
+module RfMap = HMap.Make(TacRef)
 
 type nametab = {
   tab_ltac : RfTab.t;

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -134,6 +134,12 @@ let define_notation kn tac =
 
 let interp_notation kn = KNmap.find kn !ltac_notations
 
+let ml_tactic_name ~plugin tactic = {
+  mltac_plugin = plugin;
+  mltac_tactic = tactic;
+  mltac_hash = Hashset.Combine.combine (CString.hash plugin) (CString.hash tactic);
+}
+
 module ML =
 struct
   type t = ml_tactic_name
@@ -141,9 +147,11 @@ struct
     let c = String.compare n1.mltac_plugin n2.mltac_plugin in
     if Int.equal c 0 then String.compare n1.mltac_tactic n2.mltac_tactic
     else c
+
+  let hash n = n.mltac_hash
 end
 
-module MLMap = Map.Make(ML)
+module MLMap = HMap.Make(ML)
 
 let primitive_map = ref MLMap.empty
 

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -138,6 +138,9 @@ val shortest_qualid_of_projection : ltac_projection -> qualid
 
 (** {5 Toplevel definitions of ML tactics} *)
 
+val ml_tactic_name : plugin:string -> string -> ml_tactic_name
+(** Generates the hash *)
+
 (** This state is not part of the summary, contrarily to the ones above. It is
     intended to be used from ML plugins to register ML-side functions. *)
 

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -37,6 +37,7 @@ type 'a or_relid =
 type ml_tactic_name = {
   mltac_plugin : string;
   mltac_tactic : string;
+  mltac_hash : int;
 }
 
 type 'a or_tuple =

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -10,7 +10,6 @@
 
 open Names
 open Genredexpr
-open Tac2expr
 open Tac2val
 open Tac2ffi
 open Tac2types
@@ -247,7 +246,7 @@ let generalize_arg = make_to_repr to_generalize_arg
 open Tac2externals
 
 let define s =
-  define { mltac_plugin = "coq-core.plugins.ltac2"; mltac_tactic = s }
+  define (Tac2env.ml_tactic_name ~plugin:"coq-core.plugins.ltac2" s)
 
 (** Tactics from Tacexpr *)
 

--- a/plugins/ltac2_ltac1/tac2core_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2core_ltac1.ml
@@ -22,7 +22,7 @@ open Tac2externals
 
 let ltac2_ltac1_plugin = "coq-core.plugins.ltac2_ltac1"
 
-let pname ?(plugin=ltac2_ltac1_plugin) s = { mltac_plugin = plugin; mltac_tactic = s }
+let pname ?(plugin=ltac2_ltac1_plugin) s = Tac2env.ml_tactic_name ~plugin s
 
 let define ?plugin s = define (pname ?plugin s)
 

--- a/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
@@ -14,13 +14,12 @@ open Geninterp
 open Ltac2_plugin
 open Tac2val
 open Tac2ffi
-open Tac2expr
 open Proofview.Notations
 open Tac2externals
 
 let ltac2_ltac1_plugin = "coq-core.plugins.ltac2_ltac1"
 
-let pname ?(plugin=ltac2_ltac1_plugin) s = { mltac_plugin = plugin; mltac_tactic = s }
+let pname ?(plugin=ltac2_ltac1_plugin) s = Tac2env.ml_tactic_name ~plugin s
 
 let define ?plugin s = define (pname ?plugin s)
 


### PR DESCRIPTION
cf https://coq.zulipchat.com/#narrow/channel/237656-Coq-devs-.26-plugin-devs/topic/Some.20performance.20numbers.20for.208.2E19.20-.3E.208.2E20.2C.208.2E19.20-.3E.20master/near/479472477

Overlays:
- https://github.com/mit-plv/rewriter/pull/163