### PR TITLE
reachability analysis for hconstr

### DIFF
--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1466,7 +1466,7 @@ and sh_rec_main t =
 
 and sh_rec t =
   incr steps;
-  if refcount t = 1 then sh_rec_main t
+  if refcount t <= 1 then sh_rec_main t
   else match Tbl.find_opt t with
     | Some res -> res
     | None ->

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -619,7 +619,7 @@ let push_rec_types (lna,typarray,_) env =
 
 (* The typing machine. *)
 let rec execute tbl env cstr =
-  if Int.equal (HConstr.refcount cstr) 1 then execute_aux tbl env cstr
+  if HConstr.refcount cstr <= 1 then execute_aux tbl env cstr
   else begin match HConstr.Tbl.find_opt tbl cstr with
     | Some v -> v
     | None ->


### PR DESCRIPTION
because of_constr recurses on binder types in matches, some of the terms it generates are not reachable

this means that eg (with `A` a closed term)
~~~
fun x : option A =>
match x with None => true | Some _ => false end
~~~
sees `A` twice (once in `option A`, then again
as the type of the anonymous argument of `Some`)
and before this commit would give it refcount 2.

Then typeops and hconsing would pointlessly cache their result on `A`.
