### PR TITLE
Deprecate providing an explicit pattern in Hint Resolve

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/19787-hint_resolve_pattern.rst
+++ b/doc/changelog/08-vernac-commands-and-options/19787-hint_resolve_pattern.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  Explicitly providing a pattern in Hint Resolve
+  (the default should always be correct)
+  (`#19787 <https://github.com/coq/coq/pull/19787>`_,
+  by Jim Fehrle).

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -44,6 +44,10 @@ let warn_deprecated_unfocus =
   CWarnings.create ~name:"deprecated-unfocus" ~category:Deprecation.Version.v8_8
          (fun () -> Pp.strbrk "The Unfocus command is deprecated")
 
+let warn_deprecated_hint_resolve_pattern =
+  CWarnings.create ~name:"deprecated-resolve" ~category:Deprecation.Version.v8_8
+         (fun () -> Pp.strbrk "Providing an explicit pattern on Hint Resolve is deprecated")
+
 }
 
 (* Proof commands *)
@@ -112,7 +116,9 @@ GRAMMAR EXTEND Gram
   ;
   hint:
     [ [ IDENT "Resolve"; lc = LIST1 reference_or_constr; info = hint_info ->
-          { HintsResolve (List.map (fun x -> (info, true, x)) lc) }
+          { if info.hint_pattern <> None then
+              warn_deprecated_hint_resolve_pattern ~loc ();
+            HintsResolve (List.map (fun x -> (info, true, x)) lc) }
       | IDENT "Resolve"; "->"; lc = LIST1 global; n = OPT natural ->
           { HintsResolveIFF (true, lc, n) }
       | IDENT "Resolve"; "<-"; lc = LIST1 global; n = OPT natural ->


### PR DESCRIPTION
By default, `Hint Resolve` sets the hint pattern automatically based on the theorem it refers to.  AFAICT there's no point in letting the user provide a different pattern.  The original use of `hint_info` in the grammar was probably more than intended.

- [x] Added **changelog**.
