### PR TITLE
split Zdivisibility from Znumtheory, deprecate most of Znumtheory

### DIFF
--- a/doc/changelog/11-standard-library/19789-HEAD.rst
+++ b/doc/changelog/11-standard-library/19789-HEAD.rst
@@ -1,0 +1,27 @@
+- **Deprecated:** most of :g:`Znumtheory` in favor of a new module
+  :g:`Zdivisibility`.
+  For now, :g:`Zdivisibility` is light on the theory of primality so that part
+  of :g:`Znumtheory` remains supported.
+  Reducing reliance on :g:`Znumtheory` within stdlib changed the internal
+  dependencies between files, code relying on files being transitively
+  required in stdlib may need to now explicitly ``Require``
+  :g:`Znumtheory`,
+  :g:`BinInt`,
+  :g:`Setoid`,
+  :g:`BinNat`,
+  :g:`Zpow_def`,
+  :g:`Znat`,
+  :g:`Zdiv`,
+  :g:`Zcomplements`,
+  :g:`Zbool`,
+  :g:`ZArithRing`,
+  :g:`ZArith`,
+  :g:`Wf_Z`,
+  :g:`Tauto`,
+  :g:`QArith`,
+  :g:`Lia`,
+  :g:`BinPos`,
+  :g:`BinNums`, or
+  :g:`BinList`
+  (`#19789 <https://github.com/coq/coq/pull/19789>`_,
+  by Andres Erbsen).

--- a/stdlib/doc/stdlib/index-list.html.template
+++ b/stdlib/doc/stdlib/index-list.html.template
@@ -159,6 +159,7 @@ through the <tt>Require Import</tt> command.</p>
     (theories/ZArith/ZArith.v)
     theories/ZArith/Zgcd_alt.v
     theories/ZArith/Zwf.v
+    theories/ZArith/Zdivisibility.v
     theories/ZArith/Znumtheory.v
     theories/ZArith/Int.v
     theories/ZArith/Zpow_facts.v

--- a/stdlib/theories/Numbers/Cyclic/Int63/Uint63.v
+++ b/stdlib/theories/Numbers/Cyclic/Int63/Uint63.v
@@ -543,10 +543,7 @@ Lemma eqm_sub x y : x ≡ y → x - y ≡ 0.
 Proof. intros h; unfold eqm; rewrite Zminus_mod, h, Z.sub_diag; reflexivity. Qed.
 
 Lemma eqmE x y : x ≡ y → ∃ k, x - y = k * wB.
-Proof.
-  intros h.
-  exact (Zmod_divide (x - y) wB (λ e, let 'eq_refl := e in I) (eqm_sub _ _ h)).
-Qed.
+Proof. intros h%Z.cong_iff_ex; trivial. Qed.
 
 Lemma eqm_subE x y : x ≡ y ↔ x - y ≡ 0.
 Proof.
@@ -963,11 +960,13 @@ Proof.
        assert (F2: 0 < wB) by (apply refl_equal).
        assert (F3: φ (bit x 0 + bit y 0) mod 2 = φ (bit x 0 || bit y 0) mod 2). {
          apply trans_equal with ((φ ((x>>1 + y>>1) << 1) + φ (bit x 0 + bit y 0)) mod 2).
-         - rewrite lsl_spec, Zplus_mod, <-Zmod_div_mod; auto with zarith.
+         - rewrite lsl_spec, Zplus_mod, Z.mod_mod_divide; auto with zarith.
            rewrite Z.pow_1_r, Z_mod_mult, Zplus_0_l, Zmod_mod; auto with zarith.
-         - rewrite (Zmod_div_mod 2 wB), <-add_spec, Heq; auto with zarith.
-           rewrite add_spec, <-Zmod_div_mod; auto with zarith.
-           rewrite lsl_spec, Zplus_mod, <-Zmod_div_mod; auto with zarith.
+         - assert (forall a, a mod 2 = (a mod wB) mod 2) as ->.
+           { intros. rewrite Z.mod_mod_divide; trivial. }
+           rewrite <-add_spec, Heq; auto with zarith.
+           rewrite add_spec, Z.mod_mod_divide; auto with zarith.
+           rewrite lsl_spec, Zplus_mod, Z.mod_mod_divide; auto with zarith.
            rewrite Z.pow_1_r, Z_mod_mult, Zplus_0_l, Zmod_mod; auto with zarith.
        }
        generalize F3; do 2 case bit; try discriminate; auto.

--- a/stdlib/theories/QArith/Qabs.v
+++ b/stdlib/theories/QArith/Qabs.v
@@ -88,7 +88,7 @@ intros [xn xd] [yn yd].
 unfold Qplus.
 unfold Qle.
 simpl.
-apply Z.mul_le_mono_nonneg_r;auto with *.
+apply Z.mul_le_mono_nonneg_r; auto using Pos2Z.is_nonneg.
 change (Zpos yd)%Z with (Z.abs (Zpos yd)).
 change (Zpos xd)%Z with (Z.abs (Zpos xd)).
 repeat rewrite <- Z.abs_mul.

--- a/stdlib/theories/QArith/Qround.v
+++ b/stdlib/theories/QArith/Qround.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Import QArith.
-Import Zdiv.
+Require Import Zdiv.
 
 (************)
 
@@ -78,7 +78,7 @@ replace (n / Zpos d * Zpos d + Zpos d)%Z with
   ((Zpos d * (n / Zpos d) + n mod Zpos  d) + Zpos  d - n mod Zpos d)%Z by ring.
 rewrite <- Z_div_mod_eq_full.
 rewrite <- Z.lt_add_lt_sub_r.
-destruct (Z_mod_lt n (Zpos d)); auto with *.
+apply Z.add_lt_mono_l, Z.mod_pos_bound, eq_refl.
 Qed.
 
 #[global]
@@ -92,7 +92,7 @@ replace (- Qfloor (- x) - 1)%Z with (-(Qfloor (-x) + 1))%Z by ring.
 change ((- (Qfloor (- x) + 1))%Z:Q) with (-(Qfloor (- x) + 1)%Z).
 apply Qlt_le_trans with (- - x); auto with *.
 rewrite Qopp_involutive.
-auto with *.
+apply Qle_refl.
 Qed.
 
 #[global]
@@ -106,7 +106,7 @@ simpl in *.
 rewrite <- (Zdiv_mult_cancel_r xn (Zpos xd) (Zpos yd)); auto with *.
 rewrite <- (Zdiv_mult_cancel_r yn (Zpos yd) (Zpos xd)); auto with *.
 rewrite (Z.mul_comm (Zpos yd) (Zpos xd)).
-apply Z_div_le; auto with *.
+apply Z.div_le_mono, Hxy; apply eq_refl.
 Qed.
 
 #[global]

--- a/stdlib/theories/ZArith/ZArith.v
+++ b/stdlib/theories/ZArith/ZArith.v
@@ -47,6 +47,7 @@ Require Export ZArith_hints.
 Require Export Zcomplements.
 Require Export Zpower.
 Require Export Zdiv.
+Require Export Zdivisibility.
 Require Export Zdiv_facts.
 Require Export Zbitwise.
 

--- a/stdlib/theories/ZArith/Zdivisibility.v
+++ b/stdlib/theories/ZArith/Zdivisibility.v
@@ -1,0 +1,136 @@
+Require Import BinInt Wf_Z ZArithRing Zdiv Lia.
+
+Module Z.
+Local Open Scope Z_scope.
+
+Lemma mod0_divide : forall a b, (b | a) -> a mod b = 0.
+Proof. intros a b (c,->); apply Z_mod_mult. Qed.
+
+Lemma absle_divide a b : (a | b) -> b <> 0 -> Z.abs a <= Z.abs b.
+Proof.
+ intros H Hb.
+ rewrite <- Z.divide_abs_l, <- Z.divide_abs_r in H.
+ apply Z.abs_pos in Hb.
+ now apply Z.divide_pos_le.
+Qed.
+
+Lemma BoolSpec_divide_nz a b (H : a <> 0) : BoolSpec (Z.divide a b) (~ Z.divide a b) (b mod a =? 0).
+Proof. case Z.eqb_spec; constructor; rewrite <-Z.mod_divide; trivial. Qed.
+
+Lemma BoolSpec_divide a b : BoolSpec (Z.divide a b) (~ Z.divide a b) ((b =? 0) || negb (a =? 0) && (b mod a =? 0))%bool.
+Proof.
+  case Z.eqb_spec; rewrite ?Bool.orb_true_l, ?Bool.orb_false_l; intros; subst.
+  { constructor. apply Z.divide_0_r. }
+  case Z.eqb_spec; rewrite ?Bool.orb_true_l, ?Bool.orb_false_l; intros; subst.
+  { constructor. intros ?%Z.divide_0_l; contradiction. }
+  apply BoolSpec_divide_nz; trivial.
+Qed.
+
+
+Definition coprime (a b:Z) : Prop := Z.gcd a b = 1.
+
+Lemma BoolSpec_coprime a b : BoolSpec (Z.coprime a b) (~ Z.coprime a b) (Z.gcd a b =? 1).
+Proof. case Z.eqb_spec; constructor; assumption. Qed.
+
+Lemma Bezout_coprime_iff a b : Z.coprime a b <-> Z.Bezout a b 1.
+Proof. split; try apply Z.gcd_bezout; try apply Z.bezout_1_gcd. Qed.
+
+Definition Bezout_coprime a b := proj1 (Bezout_coprime_iff a b).
+Definition coprime_Bezout a b := proj2 (Bezout_coprime_iff a b).
+
+#[global] Instance Symmetric_coprime : RelationClasses.Symmetric coprime.
+Proof. cbv [coprime]; intros ? ? ?; rewrite Z.gcd_comm; trivial. Qed.
+
+Lemma coprime_0_l_iff z : coprime 0 z <-> Z.abs z = 1.
+Proof. cbv [coprime]. rewrite Z.gcd_0_l. reflexivity. Qed.
+
+Lemma coprime_0_r_iff z : coprime z 0 <-> Z.abs z = 1.
+Proof. cbv [coprime]. rewrite Z.gcd_0_r. reflexivity. Qed.
+
+Lemma coprime_1_l z : coprime 1 z. Proof. apply Z.gcd_1_l. Qed.
+
+Lemma coprime_1_r z : coprime z 1. Proof. apply Z.gcd_1_r. Qed.
+
+Lemma coprime_mod_l_iff a b : coprime (a mod b) b <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_mod_l; reflexivity. Qed.
+
+Lemma coprime_mod_r_iff a b : coprime a (b mod a) <-> coprime a b.
+Proof. cbv [coprime]. rewrite Z.gcd_mod_r; reflexivity. Qed.
+
+Lemma coprime_mul_r a b c : coprime a b -> coprime a c -> coprime a (b * c).
+Proof.
+  setoid_rewrite Bezout_coprime_iff.
+  intros (u&v&H) (u0&v0&H0); exists (u*u0*a + v0*c*u + u0*v* b), (v*v0).
+  rewrite <- H, <-Z.mul_1_r, <- H0; ring.
+Qed.
+
+Lemma coprime_mul_l a b c : coprime a c -> coprime b c -> coprime (a * b) c.
+Proof. symmetry. apply coprime_mul_r; symmetry; trivial. Qed.
+
+Lemma coprime_pow_r a b n : 0 <= n -> coprime a b -> coprime a (b ^ n).
+Proof.
+  intros Hn H; pattern n; apply natlike_ind; auto using coprime_1_r; intros.
+  rewrite Z.pow_succ_r; auto using coprime_mul_r.
+Qed.
+
+Lemma coprime_pow_l a b n : 0 <= n -> coprime a b -> coprime (a ^ n) b.
+Proof. symmetry. apply coprime_pow_r; try symmetry; trivial. Qed.
+
+
+Definition prime p := 1 < p /\ forall n, 1 < n < p -> ~ (n|p).
+
+Lemma not_prime_0 : not (prime 0).
+Proof. intros []. lia. Qed.
+
+Lemma not_prime_1 : not (prime 1).
+Proof. intros []. lia. Qed.
+
+Lemma prime_2 : prime 2.
+Proof. split. lia. intros; intros []; nia. Qed.
+
+Lemma prime_3 : prime 3.
+Proof. split. lia. intros; intros []. assert (n = 2); nia. Qed.
+
+Lemma prime_ge_2 p : prime p ->  2 <= p.
+Proof. cbv [prime]. lia. Qed.
+
+Section extended_euclid_algorithm.
+Variables a b : Z.
+
+Local Lemma extgcd_rec_helper r1 r2 q :
+  Z.gcd r1 r2 = Z.gcd a b -> Z.gcd (r2 - q * r1) r1 = Z.gcd a b.
+Proof.
+  intros H; rewrite <-H, Z.gcd_comm.
+  rewrite <-(Z.gcd_add_mult_diag_r r1 r2 (-q)). f_equal; ring.
+Qed.
+
+Let f := S(S(Z.to_nat(Z.log2_up(Z.log2_up(Z.abs(a*b)))))). (* log2(fuel) *)
+
+Local Definition extgcd_rec : forall r1 u1 v1 r2 u2 v2,
+  (True -> 0 <= r1 /\ 0 <= r2 /\ r1 = u1 * a + v1 * b /\ r2 = u2 * a + v2 * b /\
+      Z.gcd r1 r2 = Z.gcd a b)
+   -> { '(u, v, d) | True -> u * a + v * b = d /\ d = Z.gcd a b}.
+Proof.
+  refine (Fix (Acc_intro_generator f (Z.lt_wf 0)) _ (fun r1 rec u1 v1  r2 u2 v2 H =>
+    if Z.eq_dec r1 0
+    then exist (fun '(u, v, d) => _) (u2, v2, r2) (fun _ => _)
+    else let q := r2 / r1 in
+         rec (r2 - q * r1) _ (u2 - q * u1) (v2 - q * v1) r1 u1 v1 (fun _ => _))).
+  all : abstract (intuition (solve
+    [ subst; rewrite ?Z.gcd_0_l_nonneg in *; auto using extgcd_rec_helper; ring
+    | subst q; rewrite <-Zmod_eq_full by trivial;
+      apply Z.mod_pos_bound, Z.le_neq; intuition congruence ])).
+Defined.
+
+Definition extgcd : Z*Z*Z.
+Proof.
+  refine (proj1_sig (extgcd_rec (Z.abs a) (Z.sgn a) 0 (Z.abs b) 0 (Z.sgn b) _)).
+  abstract (intuition (trivial using Z.abs_nonneg;
+    rewrite ?Z.gcd_abs_r, ?Z.gcd_abs_l, <-?Z.sgn_abs; ring)).
+Defined.
+
+Lemma extgcd_correct [u v d] : extgcd = (u, v, d) -> u * a + v * b = d /\ d = Z.gcd a b.
+Proof. cbv [extgcd proj1_sig]. case extgcd_rec as (([],?),?). intuition congruence. Qed.
+End extended_euclid_algorithm.
+
+End Z.

--- a/stdlib/theories/ZArith/Zgcd_alt.v
+++ b/stdlib/theories/ZArith/Zgcd_alt.v
@@ -73,6 +73,17 @@ Open Scope Z_scope.
 
  (** 1) We prove a weaker & easier bound. *)
 
+ Local Lemma Private_Zis_gcd_for_euclid2 :
+  forall b d q r:Z, Zis_gcd r b d -> Zis_gcd b (b * q + r) d.
+ Proof.
+   intros b d q r; destruct 1 as [? ? H]; constructor;
+     intuition auto using Z.divide_add_r, Z.divide_mul_l.
+   apply H; auto.
+   replace r with (b * q + r - b * q).
+   - auto with zarith.
+   - ring.
+ Qed.
+
  Lemma Zgcdn_linear_bound : forall n a b,
    Z.abs a < Z.of_nat n -> Zis_gcd a b (Zgcdn n a b).
  Proof.
@@ -89,9 +100,9 @@ Open Scope Z_scope.
        assert (IH:=IHn r (Zpos p) H2); clear IHn;
        simpl in IH |- *;
        rewrite H0.
-     + apply Zis_gcd_for_euclid2; auto.
+     + apply Private_Zis_gcd_for_euclid2; auto.
      + apply Zis_gcd_minus; apply Zis_gcd_sym.
-       apply Zis_gcd_for_euclid2; auto.
+       apply Private_Zis_gcd_for_euclid2; auto.
  Qed.
 
  (** 2) For Euclid's algorithm, the worst-case situation corresponds
@@ -155,7 +166,7 @@ Open Scope Z_scope.
        * assert (EQ' : r = Zpos a * (-q) + b) by (rewrite EQ; ring).
          rewrite EQ' at 1.
          apply Zis_gcd_sym.
-         apply Zis_gcd_for_euclid2; auto.
+         apply Private_Zis_gcd_for_euclid2; auto.
          apply Zis_gcd_sym; auto.
        * split.
          -- auto.
@@ -246,7 +257,7 @@ Open Scope Z_scope.
   generalize (Z_div_mod b (Zpos a) (eq_refl Gt)).
   destruct (Z.div_eucl b (Zpos a)) as (q,r).
   intros (->,(H1,H2)) H3.
-  apply Zis_gcd_for_euclid2.
+  apply Private_Zis_gcd_for_euclid2.
   Z.le_elim H1.
   + apply Zgcdn_ok_before_fibonacci; auto.
     apply Z.lt_le_trans with (fibonacci (S m));

--- a/stdlib/theories/ZArith/Znumtheory.v
+++ b/stdlib/theories/ZArith/Znumtheory.v
@@ -13,7 +13,11 @@ Require Import ZArith_base.
 Require Import ZArithRing.
 Require Import Zcomplements.
 Require Import Zdiv.
+Require Import Zdivisibility.
 Require Import Wf_nat.
+Require Import Lia Cring Ncring_tac.
+
+Local Set Warnings "-deprecated".
 
 (** For compatibility reasons, this Open Scope isn't local as it should *)
 
@@ -35,36 +39,53 @@ Local Ltac Tauto.intuition_solver ::= auto with zarith.
 
 (** Its former constructor is now a pseudo-constructor. *)
 
+#[deprecated(use=ex_intro, since="9.0")]
 Definition Zdivide_intro a b q (H:b=q*a) : Z.divide a b := ex_intro _ q H.
 
 (** Results concerning divisibility*)
 
+#[deprecated(use=Z.divide_1_l, since="9.0")]
 Notation Zone_divide := Z.divide_1_l (only parsing).
+#[deprecated(use=Z.divide_0_r, since="9.0")]
 Notation Zdivide_0 := Z.divide_0_r (only parsing).
+#[deprecated(use=Z.mul_divide_mono_l, since="9.0")]
 Notation Zmult_divide_compat_l := Z.mul_divide_mono_l (only parsing).
+#[deprecated(use=Z.mul_divide_mono_r, since="9.0")]
 Notation Zmult_divide_compat_r := Z.mul_divide_mono_r (only parsing).
+#[deprecated(use=Z.divide_add_r, since="9.0")]
 Notation Zdivide_plus_r := Z.divide_add_r (only parsing).
+#[deprecated(use=Z.divide_sub_r, since="9.0")]
 Notation Zdivide_minus_l := Z.divide_sub_r (only parsing).
+#[deprecated(use=Z.divide_mul_l, since="9.0")]
 Notation Zdivide_mult_l := Z.divide_mul_l (only parsing).
+#[deprecated(use=Z.divide_mul_r, since="9.0")]
 Notation Zdivide_mult_r := Z.divide_mul_r (only parsing).
+#[deprecated(use=Z.divide_factor_l, since="9.0")]
 Notation Zdivide_factor_r := Z.divide_factor_l (only parsing).
+#[deprecated(use=Z.divide_factor_r, since="9.0")]
 Notation Zdivide_factor_l := Z.divide_factor_r (only parsing).
 
+#[deprecated(use=Z.divide_opp_r, since="9.0")]
 Lemma Zdivide_opp_r a b : (a | b) -> (a | - b).
 Proof. apply Z.divide_opp_r. Qed.
 
+#[deprecated(use=Z.divide_opp_r, since="9.0")]
 Lemma Zdivide_opp_r_rev a b : (a | - b) -> (a | b).
 Proof. apply Z.divide_opp_r. Qed.
 
+#[deprecated(use=Z.divide_opp_l, since="9.0")]
 Lemma Zdivide_opp_l a b : (a | b) -> (- a | b).
 Proof. apply Z.divide_opp_l. Qed.
 
+#[deprecated(use=Z.divide_opp_l, since="9.0")]
 Lemma Zdivide_opp_l_rev a b : (- a | b) -> (a | b).
 Proof. apply Z.divide_opp_l. Qed.
 
+#[deprecated(use=Z.divide_abs_l, since="9.0")]
 Theorem Zdivide_Zabs_l a b : (Z.abs a | b) -> (a | b).
 Proof. apply Z.divide_abs_l. Qed.
 
+#[deprecated(use=Z.divide_abs_l, since="9.0")]
 Theorem Zdivide_Zabs_inv_l a b : (a | b) -> (Z.abs a | b).
 Proof. apply Z.divide_abs_l. Qed.
 
@@ -79,6 +100,7 @@ Hint Resolve Z.divide_add_r Zdivide_opp_r Zdivide_opp_r_rev Zdivide_opp_l
 
 (** Auxiliary result. *)
 
+#[deprecated(use=Z.eq_mul_1_nonneg, since="9.0")]
 Lemma Zmult_one x y : x >= 0 -> x * y = 1 -> x = 1.
 Proof.
  Z.swap_greater. apply Z.eq_mul_1_nonneg.
@@ -86,32 +108,30 @@ Qed.
 
 (** Only [1] and [-1] divide [1]. *)
 
+#[deprecated(use=Z.divide_1_r, since="9.0")]
 Notation Zdivide_1 := Z.divide_1_r (only parsing).
 
 (** If [a] divides [b] and [b<>0] then [|a| <= |b|]. *)
 
-Lemma Zdivide_bounds a b : (a | b) -> b <> 0 -> Z.abs a <= Z.abs b.
-Proof.
- intros H Hb.
- rewrite <- Z.divide_abs_l, <- Z.divide_abs_r in H.
- apply Z.abs_pos in Hb.
- now apply Z.divide_pos_le.
-Qed.
+#[deprecated(use=Z.absle_divide, since="9.0")]
+Notation Zdivide_bounds := Z.absle_divide (only parsing).
 
 (** [Z.divide] can be expressed using [Z.modulo]. *)
 
+#[deprecated(use=Z.mod0_divide, since="9.0")]
 Lemma Zmod_divide : forall a b, b<>0 -> a mod b = 0 -> (b | a).
 Proof.
  apply Z.mod_divide.
 Qed.
 
+#[deprecated(use=Z.mod0_divide, since="9.0")]
 Lemma Zdivide_mod : forall a b, (b | a) -> a mod b = 0.
 Proof.
  intros a b (c,->); apply Z_mod_mult.
 Qed.
 
 (** [Z.divide] is hence decidable *)
-
+#[deprecated(use=Z.BoolSpec_divide, since="9.0")]
 Lemma Zdivide_dec a b : {(a | b)} + {~ (a | b)}.
 Proof.
  destruct (Z.eq_dec a 0) as [Ha|Ha].
@@ -123,6 +143,7 @@ Proof.
    + right. now rewrite <- Z.mod_divide.
 Defined.
 
+#[deprecated(use=Z.lt_neq, since="9.0")]
 Lemma Z_lt_neq {x y: Z} : x < y -> y <> x.
 Proof. auto using Z.lt_neq, Z.neq_sym. Qed.
 
@@ -142,6 +163,7 @@ Proof.
  + auto with zarith.
 Qed.
 
+#[deprecated(use=Z.divide_pos_le, since="9.0")]
 Theorem Zdivide_le: forall a b : Z,
  0 <= a -> 0 < b -> (a | b) ->  a <= b.
 Proof.
@@ -159,6 +181,7 @@ Proof.
   + now apply Z.div_lt.
 Qed.
 
+#[deprecated(use=Z.mod_mod_divide, since="9.0")]
 Lemma Zmod_div_mod n m a:
  0 < n -> 0 < m -> (n | m) -> a mod n = (a mod m) mod n.
 Proof with auto using Z_lt_neq.
@@ -203,6 +226,7 @@ Inductive Zis_gcd (a b g:Z) : Prop :=
   (forall x, (x | a) -> (x | b) -> (x | g)) ->
   Zis_gcd a b g.
 
+#[deprecated(use=Z.gcd, since="9.0")]
 Lemma Zgcd_is_gcd : forall a b, Zis_gcd a b (Z.gcd a b).
 Proof.
  constructor.
@@ -223,11 +247,13 @@ Proof.
   constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.gcd_1_r, since="9.0")]
 Lemma Zis_gcd_1 : forall a, Zis_gcd a 1 1.
 Proof.
   constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.gcd_diag, since="9.0")]
 Lemma Zis_gcd_refl : forall a, Zis_gcd a a a.
 Proof.
   constructor; auto with zarith.
@@ -238,6 +264,7 @@ Proof.
   induction 1; constructor; intuition.
 Qed.
 
+#[deprecated(note="Z.cd is always non-negative", since="9.0")]
 Lemma Zis_gcd_opp : forall a b d, Zis_gcd a b d -> Zis_gcd b a (- d).
 Proof.
   induction 1; constructor; intuition.
@@ -253,6 +280,7 @@ Qed.
 #[global]
 Hint Resolve Zis_gcd_sym Zis_gcd_0 Zis_gcd_minus Zis_gcd_opp: zarith.
 
+#[deprecated(use=f_equal, note="Use Z.gcd", since="9.0")]
 Theorem Zis_gcd_unique: forall a b c d : Z,
  Zis_gcd a b c -> Zis_gcd a b d ->  c = d \/ c = (- d).
 Proof.
@@ -277,6 +305,7 @@ Qed.
 Notation Zis_gcd_for_euclid := deprecated_Zis_gcd_for_euclid (only parsing).
 
 (* this lemma is still used below and in Zgcd_alt *)
+#[deprecated(since="9.0")]
 Lemma Zis_gcd_for_euclid2 :
   forall b d q r:Z, Zis_gcd r b d -> Zis_gcd b (b * q + r) d.
 Proof.
@@ -287,56 +316,22 @@ Proof.
   - ring.
 Qed.
 
-(** We implement the extended version of Euclid's algorithm,
-    i.e. the one computing Bezout's coefficients as it computes
-    the [gcd]. We follow the algorithm given in Knuth's
-    "Art of Computer Programming", vol 2, page 325. *)
+#[deprecated(use=Z.extgcd, since="9.0")]
+Notation extgcd := Z.extgcd (only parsing).
+
+#[deprecated(use=Z.extgcd_correct, since="9.0")]
+Notation extgcd_correct := Z.extgcd_correct (only parsing).
 
 Section extended_euclid_algorithm.
 
   Variables a b : Z.
-
-  Local Lemma extgcd_rec_helper r1 r2 q :
-    Z.gcd r1 r2 = Z.gcd a b -> Z.gcd (r2 - q * r1) r1 = Z.gcd a b.
-  Proof.
-    intros H; rewrite <-H, Z.gcd_comm.
-    rewrite <-(Z.gcd_add_mult_diag_r r1 r2 (-q)). f_equal; ring.
-  Qed.
-
-  Let f := S(S(Z.to_nat(Z.log2_up(Z.log2_up(Z.abs(a*b)))))). (* log2(fuel) *)
-
-  Local Definition extgcd_rec : forall r1 u1 v1 r2 u2 v2,
-    (True -> 0 <= r1 /\ 0 <= r2 /\ r1 = u1 * a + v1 * b /\ r2 = u2 * a + v2 * b /\
-        Z.gcd r1 r2 = Z.gcd a b)
-     -> { '(u, v, d) | True -> u * a + v * b = d /\ d = Z.gcd a b}.
-  Proof.
-    refine (Fix (Acc_intro_generator f (Z.lt_wf 0)) _ (fun r1 rec u1 v1  r2 u2 v2 H =>
-      if Z.eq_dec r1 0
-      then exist (fun '(u, v, d) => _) (u2, v2, r2) (fun _ => _)
-      else let q := r2 / r1 in
-           rec (r2 - q * r1) _ (u2 - q * u1) (v2 - q * v1) r1 u1 v1 (fun _ => _))).
-    all : abstract (intuition (solve
-      [ subst; rewrite ?Z.gcd_0_l_nonneg in *; auto using extgcd_rec_helper; ring
-      | subst q; rewrite <-Zmod_eq_full by trivial;
-        apply Z.mod_pos_bound, Z.le_neq; intuition congruence ])).
-  Defined.
-
-  Definition extgcd : Z*Z*Z.
-  Proof.
-    refine (proj1_sig (extgcd_rec (Z.abs a) (Z.sgn a) 0 (Z.abs b) 0 (Z.sgn b) _)).
-    abstract (intuition (trivial using Z.abs_nonneg;
-      rewrite ?Z.gcd_abs_r, ?Z.gcd_abs_l, <-?Z.sgn_abs; ring)).
-  Defined.
-
-  Lemma extgcd_correct [u v d] : extgcd = (u, v, d) -> u * a + v * b = d /\ d = Z.gcd a b.
-  Proof. cbv [extgcd proj1_sig]. case extgcd_rec as (([],?),?). intuition congruence. Qed.
 
   Inductive deprecated_Euclid : Set :=
     deprecated_Euclid_intro :
     forall u v d:Z, u * a + v * b = d -> Zis_gcd a b d -> deprecated_Euclid.
 
   Lemma deprecated_euclid : deprecated_Euclid.
-  Proof. case extgcd as [[]?] eqn:H; case (extgcd_correct H); esplit; subst; eauto using Zgcd_is_gcd. Qed.
+  Proof. case (extgcd a b) as [[]?] eqn:H; case (Z.extgcd_correct a b H); esplit; subst; eauto using Zgcd_is_gcd. Qed.
 
   Lemma deprecated_euclid_rec :
     forall v3:Z,
@@ -358,6 +353,7 @@ Notation euclid := deprecated_euclid (only parsing).
 #[deprecated(since="8.17", note="Use Coq.ZArith.Znumtheory.extgcd")]
 Notation euclid_rec := deprecated_euclid_rec (only parsing).
 
+#[deprecated(use=Z.gcd_unique, since="9.0")]
 Theorem Zis_gcd_uniqueness_apart_sign :
   forall a b d d':Z, Zis_gcd a b d -> Zis_gcd a b d' -> d = d' \/ d = - d'.
 Proof.
@@ -370,11 +366,16 @@ Qed.
 
 (** * Bezout's coefficients *)
 
-Inductive Bezout (a b d:Z) : Prop :=
-  Bezout_intro : forall u v:Z, u * a + v * b = d -> Bezout a b d.
+Inductive Bezout_deprecated (a b d:Z) : Prop :=
+  Bezout_deprecated_intro : forall u v:Z, u * a + v * b = d -> Bezout_deprecated a b d.
+
+#[deprecated(use=Z.Bezout, since="9.0")]
+Notation Bezout := Bezout_deprecated (only parsing).
+#[deprecated(use=ex_intro, since="9.0")]
+Notation Bezout_intro := Bezout_deprecated_intro (only parsing).
 
 (** Existence of Bezout's coefficients for the [gcd] of [a] and [b] *)
-
+#[deprecated(use=Z.Bezout_coprime_iff, since="9.0")]
 Lemma Zis_gcd_bezout : forall a b d:Z, Zis_gcd a b d -> Bezout a b d.
 Proof.
   intros a b d Hgcd.
@@ -385,6 +386,7 @@ Qed.
 
 (** gcd of [ca] and [cb] is [c gcd(a,b)]. *)
 
+#[deprecated(use=Z.gcd_mul_mono_l, since="9.0")]
 Lemma Zis_gcd_mult :
   forall a b c d:Z, Zis_gcd a b d -> Zis_gcd (c * a) (c * b) (c * d).
 Proof.
@@ -405,14 +407,27 @@ Qed.
 
 Definition rel_prime (a b:Z) : Prop := Zis_gcd a b 1.
 
+Lemma rel_prime_iff_coprime  a b : rel_prime a b <-> Z.coprime a b.
+Proof.
+  symmetry; unfold rel_prime; split; intros H.
+  - rewrite <- H; apply Zgcd_is_gcd.
+  - case (Zis_gcd_unique a b (Z.gcd a b) 1); auto.
+    + apply Zgcd_is_gcd.
+    + intros H2; absurd (0 <= Z.gcd a b); auto with zarith.
+      * rewrite H2; red; auto.
+      * generalize (Z.gcd_nonneg a b); auto with zarith.
+Qed.
+
 (** Bezout's theorem: [a] and [b] are relatively prime if and
     only if there exist [u] and [v] such that [ua+vb = 1]. *)
 
+#[deprecated(use=Z.Bezout_coprime, since="9.0")]
 Lemma rel_prime_bezout : forall a b:Z, rel_prime a b -> Bezout a b 1.
 Proof.
   intros a b; exact (Zis_gcd_bezout a b 1).
 Qed.
 
+#[deprecated(use=Z.coprime_Bezout, since="9.0")]
 Lemma bezout_rel_prime : forall a b:Z, Bezout a b 1 -> rel_prime a b.
 Proof.
   simple induction 1; intros ? ? H0; constructor; auto with zarith.
@@ -422,6 +437,7 @@ Qed.
 (** Gauss's theorem: if [a] divides [bc] and if [a] and [b] are
     relatively prime, then [a] divides [c]. *)
 
+#[deprecated(use=Z.gauss, since="9.0")]
 Theorem Gauss : forall a b c:Z, (a | b * c) -> rel_prime a b -> (a | c).
 Proof.
   intros a b c H H0. elim (rel_prime_bezout a b H0); intros u v H1.
@@ -433,21 +449,12 @@ Qed.
 
 (** If [a] is relatively prime to [b] and [c], then it is to [bc] *)
 
+#[deprecated(use=Z.coprime_mul_r, since="9.0")]
 Lemma rel_prime_mult :
   forall a b c:Z, rel_prime a b -> rel_prime a c -> rel_prime a (b * c).
-Proof.
-  intros a b c Hb Hc.
-  elim (rel_prime_bezout a b Hb); intros u v H.
-  elim (rel_prime_bezout a c Hc); intros u0 v0 H0.
-  apply bezout_rel_prime.
-  apply (Bezout_intro _ _ _
-    (u * u0 * a + v0 * c * u + u0 * v * b) (v * v0)).
-  rewrite <- H.
-  replace (u * a + v * b) with ((u * a + v * b) * 1); [ idtac | ring ].
-  rewrite <- H0.
-  ring.
-Qed.
+Proof. setoid_rewrite rel_prime_iff_coprime; apply Z.coprime_mul_r. Qed.
 
+#[deprecated(note="Consider Z.gcd instead", since="9.0")]
 Lemma rel_prime_cross_prod :
   forall a b c d:Z,
     rel_prime a b ->
@@ -475,6 +482,7 @@ Qed.
 
 (** After factorization by a gcd, the original numbers are relatively prime. *)
 
+#[deprecated(use=Z.gcd_div_gcd, since="9.0")]
 Lemma Zis_gcd_rel_prime :
   forall a b g:Z,
     b > 0 -> g >= 0 -> Zis_gcd a b g -> rel_prime (a / g) (b / g).
@@ -510,6 +518,7 @@ Proof.
       exists x'; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.Symmetric_coprime, since="9.0")]
 Theorem rel_prime_sym: forall a b, rel_prime a b -> rel_prime b a.
 Proof.
   intros a b H; auto with zarith.
@@ -526,6 +535,7 @@ Proof.
   apply Z.divide_mul_r; auto.
 Qed.
 
+#[deprecated(use=Z.coprime_1_l, since="9.0")]
 Theorem rel_prime_1: forall n, rel_prime 1 n.
 Proof.
   intros n; red; apply Zis_gcd_intro; auto.
@@ -533,6 +543,7 @@ Proof.
   - exists n; rewrite Z.mul_1_r; reflexivity.
 Qed.
 
+#[deprecated(use=Z.coprime_0_l_iff, since="9.0")]
 Theorem not_rel_prime_0: forall n, 1 < n -> ~ rel_prime 0 n.
 Proof.
   intros n H H1; absurd (n = 1 \/ n = -1).
@@ -543,6 +554,7 @@ Proof.
     + exists 1; rewrite Z.mul_1_l; reflexivity.
 Qed.
 
+#[deprecated(use=Z.coprime_mod_l_iff, since="9.0")]
 Theorem rel_prime_mod: forall p q, 0 < q ->
  rel_prime p q -> rel_prime (p mod q) q.
 Proof.
@@ -556,6 +568,7 @@ Proof.
     pattern p at 3; rewrite (Z_div_mod_eq_full p q); ring.
 Qed.
 
+#[deprecated(use=Z.coprime_mod_l_iff, since="9.0")]
 Theorem rel_prime_mod_rev: forall p q, 0 < q ->
  rel_prime (p mod q) q -> rel_prime p q.
 Proof.
@@ -564,6 +577,7 @@ Proof.
   apply Zis_gcd_sym; apply Zis_gcd_for_euclid2; auto.
 Qed.
 
+#[deprecated(note="unfold Z.coprime", since="9.0")]
 Theorem Zrel_prime_neq_mod_0: forall a b, 1 < b -> rel_prime a b -> a mod b <> 0.
 Proof.
   intros a b H H1 H2.
@@ -575,6 +589,7 @@ Qed.
 
 (** * Primality *)
 
+(** Note: prefer Z.prime *)
 Inductive prime (p:Z) : Prop :=
   prime_intro :
     1 < p -> (forall n:Z, 1 <= n < p -> rel_prime n p) -> prime p.
@@ -687,11 +702,13 @@ Proof.
   right; apply Gauss with a; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.not_prime_0, since="9.0")]
 Lemma not_prime_0: ~ prime 0.
 Proof.
   intros H1; case (prime_divisors _ H1 2); auto with zarith; intuition; discriminate.
 Qed.
 
+#[deprecated(use=Z.not_prime_1, since="9.0")]
 Lemma not_prime_1: ~ prime 1.
 Proof.
   intros H1; absurd (1 < 1).
@@ -709,6 +726,7 @@ Proof.
     + subst n. constructor; auto with zarith.
 Qed.
 
+#[deprecated(use=Z.prime_3, since="9.0")]
 Theorem prime_3: prime 3.
 Proof.
   apply prime_intro; auto with zarith.
@@ -730,15 +748,17 @@ Proof.
   now intros (Hp,_); apply (Zlt_le_succ 1).
 Qed.
 
-Definition prime' p := 1<p /\ (forall n, 1<n<p -> ~ (n|p)).
+#[deprecated(use=Z.prime, since="9.0")]
+Notation prime' := Z.prime (only parsing).
 
+#[deprecated(note="Use lia", since="9.0")]
 Lemma Z_0_1_more x : 0<=x -> x=0 \/ x=1 \/ 1<x.
 Proof.
  intros H. Z.le_elim H; auto.
  apply Z.le_succ_l in H. change (1 <= x) in H. Z.le_elim H; auto.
 Qed.
 
-Theorem prime_alt p : prime' p <-> prime p.
+Theorem prime_alt p : Z.prime p <-> prime p.
 Proof.
   split; intros (Hp,H).
   - (* prime -> prime' *)
@@ -798,20 +818,24 @@ Proof.
       now rewrite Z.opp_involutive; apply Z.lt_le_incl.
 Qed.
 
+#[deprecated(use=Z.gcd_nonneg , since="9.0")]
 Notation Zgcd_is_pos := Z.gcd_nonneg (only parsing).
 
+#[deprecated(since="9.0")]
 Theorem Zgcd_spec : forall x y : Z, {z : Z | Zis_gcd x y z /\ 0 <= z}.
 Proof.
   intros x y; exists (Z.gcd x y).
   split; [apply Zgcd_is_gcd  | apply Z.gcd_nonneg].
 Qed.
 
+#[deprecated(use=Z.gcd_greatest, since="9.0")]
 Theorem Zdivide_Zgcd: forall p q r : Z,
  (p | q) -> (p | r) -> (p | Z.gcd q r).
 Proof.
  intros. now apply Z.gcd_greatest.
 Qed.
 
+#[deprecated(use=Z.gcd, since="9.0")]
 Theorem Zis_gcd_gcd: forall a b c : Z,
  0 <= c ->  Zis_gcd a b c -> Z.gcd a b = c.
 Proof.
@@ -826,9 +850,12 @@ Proof.
     + subst. now case (Z.gcd a b).
 Qed.
 
+#[deprecated(use=Z.gcd_eq_0_l , since="9.0")]
 Notation Zgcd_inv_0_l := Z.gcd_eq_0_l (only parsing).
+#[deprecated(use=Z.gcd_eq_0_r , since="9.0")]
 Notation Zgcd_inv_0_r := Z.gcd_eq_0_r (only parsing).
 
+#[deprecated(use=Z.gcd_div_swap, since="9.0")]
 Theorem Zgcd_div_swap0 : forall a b : Z,
  0 < Z.gcd a b ->
  0 < b ->
@@ -842,6 +869,7 @@ Proof.
   rewrite <- Zdivide_Zdiv_eq; auto.
 Qed.
 
+#[deprecated(use=Z.gcd_div_swap, since="9.0")]
 Theorem Zgcd_div_swap : forall a b c : Z,
  0 < Z.gcd a b ->
  0 < b ->
@@ -857,18 +885,23 @@ Proof.
   rewrite <- Zdivide_Zdiv_eq; auto.
 Qed.
 
+#[deprecated(use=Z.gcd_assoc, since="9.0")]
 Lemma Zgcd_ass a b c : Z.gcd (Z.gcd a b) c = Z.gcd a (Z.gcd b c).
 Proof.
  symmetry. apply Z.gcd_assoc.
 Qed.
 
+#[deprecated(use=Z.gcd_abs_l, since="9.0")]
 Notation Zgcd_Zabs := Z.gcd_abs_l (only parsing).
+#[deprecated(use=Z.gcd_0_r, since="9.0")]
 Notation Zgcd_0 := Z.gcd_0_r (only parsing).
+#[deprecated(use=Z.gcd_1_r, since="9.0")]
 Notation Zgcd_1 := Z.gcd_1_r (only parsing).
 
 #[global]
 Hint Resolve Z.gcd_0_r Z.gcd_1_r : zarith.
 
+#[deprecated(note="Use Z.gcd_greatest, Z.gcd_divide_l, or Z.gcd_divide_r", since="9.0")]
 Theorem Zgcd_1_rel_prime : forall a b,
  Z.gcd a b = 1 <-> rel_prime a b.
 Proof.
@@ -881,6 +914,7 @@ Proof.
       * generalize (Z.gcd_nonneg a b); auto with zarith.
 Qed.
 
+#[deprecated(use=Z.BoolSpec_coprime, since="9.0")]
 Definition rel_prime_dec: forall a b,
  { rel_prime a b }+{ ~ rel_prime a b }.
 Proof.
@@ -889,6 +923,7 @@ Proof.
   - right; contradict H1; apply <- Zgcd_1_rel_prime; auto.
 Defined.
 
+#[deprecated(since="9.0")]
 Definition prime_dec_aux:
  forall p m,
   { forall n, 1 < n < m -> rel_prime n p } +

--- a/stdlib/theories/ZArith/Zpow_facts.v
+++ b/stdlib/theories/ZArith/Zpow_facts.v
@@ -8,8 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import BinInt Znat ZArithRing Lia Wf_Z Zcomplements Zdiv Znumtheory.
+Require Import BinInt Znat ZArithRing Lia Wf_Z Zcomplements Zdiv Zdivisibility.
 Require Export Zpower.
+Require Znumtheory.
 Local Open Scope Z_scope.
 
 (** Properties of the power function over [Z] *)
@@ -169,22 +170,23 @@ Proof.
   rewrite Z.mul_comm, <- Z.pow_succ_r by lia; f_equal; lia.
 Qed.
 
+#[deprecated(use=Z.coprime_pow_r, since="9.0")]
 Theorem rel_prime_Zpower_r i p q :
- 0 <= i -> rel_prime p q -> rel_prime p (q^i).
+ 0 <= i -> Znumtheory.rel_prime p q -> Znumtheory.rel_prime p (q^i).
 Proof.
-  intros Hi Hpq; pattern i; apply natlike_ind; auto with zarith.
-  - simpl. apply rel_prime_sym, rel_prime_1.
-  - clear i Hi. intros i Hi Rec; rewrite Z.pow_succ_r; auto.
-    apply rel_prime_mult; auto.
+  setoid_rewrite Znumtheory.rel_prime_iff_coprime.
+  apply Z.coprime_pow_r.
 Qed.
 
+#[deprecated(use=Z.coprime_pow_l, since="9.0")]
 Theorem rel_prime_Zpower i j p q :
- 0 <= i ->  0 <= j -> rel_prime p q -> rel_prime (p^i) (q^j).
+ 0 <= i ->  0 <= j -> Znumtheory.rel_prime p q -> Znumtheory.rel_prime (p^i) (q^j).
 Proof.
- intros Hi Hj H. apply rel_prime_Zpower_r; trivial.
- apply rel_prime_sym. apply rel_prime_Zpower_r; trivial.
- now apply rel_prime_sym.
+  setoid_rewrite Znumtheory.rel_prime_iff_coprime.
+  intros. apply Z.coprime_pow_l; try apply Z.coprime_pow_r; trivial.
 Qed.
+
+Import Znumtheory.
 
 Theorem prime_power_prime p q n :
  0 <= n -> prime p -> prime q -> (p | q^n) -> p = q.
@@ -237,5 +239,7 @@ Qed.
 
 (** * Z.square: a direct definition of [z^2] *)
 
+#[deprecated(use=Pos.square_spec, since="9.0")]
 Notation Psquare_correct := Pos.square_spec (only parsing).
+#[deprecated(use=Z.square_spec, since="9.0")]
 Notation Zsquare_correct := Z.square_spec (only parsing).

--- a/stdlib/theories/ZArith/Zquot.v
+++ b/stdlib/theories/ZArith/Zquot.v
@@ -162,13 +162,7 @@ Definition Remainder_alt a b r :=
 Lemma Remainder_equiv : forall a b r,
  Remainder a b r <-> Remainder_alt a b r.
 Proof.
-  unfold Remainder, Remainder_alt; intuition auto with zarith.
-  - lia.
-  - lia.
-  - rewrite <-(Z.mul_opp_opp). apply Z.mul_nonneg_nonneg; lia.
-  - assert (0 <= Z.sgn r * Z.sgn a).
-    { rewrite <-Z.sgn_mul, Z.sgn_nonneg; auto. }
-    destruct r; simpl Z.sgn in *; lia.
+  unfold Remainder, Remainder_alt; lia.
 Qed.
 
 Theorem Zquot_mod_unique_full a b q r :
@@ -367,9 +361,9 @@ Lemma Zrem_divides : forall a b,
  Z.rem a b = 0 <-> exists c, a = b*c.
 Proof.
  intros. zero_or_not b.
- - firstorder.
+ - firstorder idtac.
  - rewrite Z.rem_divide; trivial.
-   split; intros (c,Hc); exists c; subst; auto with zarith.
+   split; intros (c,Hc); exists c; lia.
 Qed.
 
 (** Particular case : dividing by 2 is related with parity *)
@@ -377,11 +371,7 @@ Qed.
 Lemma Zquot2_odd_remainder : forall a,
  Remainder a 2 (if Z.odd a then Z.sgn a else 0).
 Proof.
- intros [ |p|p].
- - simpl.
-   left. simpl. auto with zarith.
- - left. destruct p; simpl; lia.
- - right. destruct p; simpl; split; now auto with zarith.
+  intros [ |[]|[]]; cbn; (left + right); lia.
 Qed.
 
 Lemma Zrem_odd : forall a, Z.rem a 2 = if Z.odd a then Z.sgn a else 0.

--- a/stdlib/theories/setoid_ring/Cring.v
+++ b/stdlib/theories/setoid_ring/Cring.v
@@ -12,7 +12,6 @@ Require Export List.
 Require Import Setoid.
 Require Import BinPos.
 Require Import BinList.
-Require Import Znumtheory.
 Require Export Morphisms Setoid Bool.
 Require Import BinInt.
 Require Export Algebra_syntax.

--- a/stdlib/theories/setoid_ring/Cring.v
+++ b/stdlib/theories/setoid_ring/Cring.v
@@ -19,6 +19,7 @@ Require Export Ncring.
 Require Export Ncring_initial.
 Require Export Ncring_tac.
 Require Import InitialRing.
+Require Import BinInt.
 
 Class Cring {R:Type}`{Rr:Ring R} :=
  cring_mul_comm: forall x y:R, x * y == y * x.
@@ -187,7 +188,6 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
             rewrite eq1;
             pattern (@Ring_polynom.Pphi_dev
             _ 0 1 _+_ _*_ _-_ -_
-
             Z 0%Z 1%Z Z.eqb
             Ncring_initial.gen_phiZ
             get_signZ fv t');

--- a/stdlib/theories/setoid_ring/Integral_domain.v
+++ b/stdlib/theories/setoid_ring/Integral_domain.v
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Require Import BinNatDef.
 Require Export Cring.
 Import BinNat.
 

--- a/stdlib/theories/setoid_ring/Ncring_initial.v
+++ b/stdlib/theories/setoid_ring/Ncring_initial.v
@@ -9,19 +9,8 @@
 (************************************************************************)
 
 Require Import BinInt.
-Require Import Zpow_def.
-Require Import BinInt.
-Require Import BinNat.
-Require Import Setoid.
-Require Import BinList.
-Require Import BinPos.
-Require Import BinNat.
-Require Import BinInt.
-Require Import Setoid.
 Require Export Ncring.
 Require Export Ncring_polynom.
-
-Require Zbool.
 
 Set Implicit Arguments.
 

--- a/stdlib/theories/setoid_ring/Ncring_tac.v
+++ b/stdlib/theories/setoid_ring/Ncring_tac.v
@@ -12,9 +12,8 @@ Require Import List.
 Require Import Setoid.
 Require Import BinPos.
 Require Import BinList.
-Require Import Znumtheory.
 Require Export Morphisms Setoid Bool.
-Require Import ZArith.
+Require Import BinInt.
 Require Import Algebra_syntax.
 Require Export Ncring.
 Require Import Ncring_polynom.

--- a/stdlib/theories/setoid_ring/Ncring_tac.v
+++ b/stdlib/theories/setoid_ring/Ncring_tac.v
@@ -18,6 +18,7 @@ Require Import Algebra_syntax.
 Require Export Ncring.
 Require Import Ncring_polynom.
 Require Import Ncring_initial.
+Require Import BinInt.
 
 Set Implicit Arguments.
 
@@ -207,6 +208,16 @@ Lemma comm: forall (R:Type)`{Ring R}(c : Z) (x : R),
     + simpl.  gen_rewrite.
 Qed.
 
+Local Definition Private_ring_correct_Z :=
+  @ring_correct Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (@gen_phiZ _ _ _ _ _ _ _ _ _) _
+    (@comm _ _ _ _ _ _ _ _ _ _)
+    Z.eqb
+    ltac:(apply Z.eqb_eq)
+    N
+    (fun n:N => n)
+    (@pow_N _ _ _ _ _ _ _ _ _).
+
 Ltac ring_gen :=
    match goal with
      |- ?g =>
@@ -233,6 +244,12 @@ Ltac ring_gen :=
 Ltac non_commutative_ring:=
   intros;
   ring_gen.
+
+Local Definition Private_polynom_norm_subst_ok_Z :=
+(@Ncring_polynom.norm_subst_ok
+          Z _ 0%Z 1%Z Z.add Z.mul Z.sub Z.opp (@eq Z)
+          _ _ 0 1 _+_ _*_ _-_ -_ _==_ _ _ Ncring_initial.gen_phiZ _
+          (@comm _ 0 1 _+_ _*_ _-_ -_ _==_ _ _) _ ltac:(apply Z.eqb_eq)).
 
 (* simplification *)
 

--- a/stdlib/theories/setoid_ring/Rings_Z.v
+++ b/stdlib/theories/setoid_ring/Rings_Z.v
@@ -11,6 +11,7 @@
 Require Export Cring.
 Require Export Integral_domain.
 Require Export Ncring_initial.
+Require Import BinInt.
 
 #[global]
 Instance Zcri: (Cring (Rr:=Zr)).


### PR DESCRIPTION
- [x] Added **changelog**.

Znumtheory contains so much morally deprecated functionality that it is hard to find the fresh parts. In particular, most of the content is duplicative of similar definitions in Numbers. I did a pass through Znumtheory, marked a bunch of deprecations, and cleaned up needless references to them. As of this PR,

- Qreduction now no longer depends on Znumtheory
- Zmicromega now no longer depends on Znumtheory
- Znumtheory can use lia
- Zdivisibility contains a sketch of what Znumethory could be replaced with (it is currently slightly incomplete on primality, but I'd be happy to fix that up if this direction is accepted)

The main blocker for deprecating the remaining Znumtheory entirely is Zgcd_alt, which is used in Uint63 and bignums. @coq/number-maintainers is there a vision for bringing these libraries up to date with the Numbers infrastructure, for example replacing Zis_gcd with Z.gcd?

More generally, I am looking for feedback on scoping here. Which of the remaining non-deprecated parts of Znumethory are actually used, useful, and worth keeping? Or am I proposing to deprecate too much already?