### PR TITLE
Reduce the dependency on metas in several parts of the code

### DIFF
--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -237,9 +237,6 @@ let coerce_var_to_ident fresh env sigma v =
    be fresh but suitable to be given to the fresh tactic. Works for
    vars, constants, inductive, constructors and sorts. *)
 let coerce_to_ident_not_fresh sigma v =
-let id_of_name = function
-  | Name.Anonymous -> Id.of_string "x"
-  | Name.Name x -> x in
   let fail () = raise (CannotCoerceTo "an identifier") in
   match is_intro_pattern v with
   | Some (IntroNaming (IntroIdentifier id)) -> id
@@ -253,7 +250,7 @@ let id_of_name = function
     | Some c ->
        match EConstr.kind sigma c with
        | Var id -> id
-       | Meta m -> id_of_name (Evd.meta_name sigma m)
+       | Meta m -> Id.of_string "x"
        | Evar (kn,_) ->
         begin match Evd.evar_ident kn sigma with
         | None -> fail ()

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -678,10 +678,7 @@ let whd_nothing_for_iota env sigma s =
           (match lookup_named id env with
              | LocalDef (_,body,_) -> whrec (body, stack)
              | _ -> s)
-      | Evar ev -> s
-      | Meta ev ->
-        (try whrec (Evd.meta_value sigma ev, stack)
-        with Not_found -> s)
+      | Evar _ | Meta _ -> s
       | Const (const, u) ->
           let u = EInstance.kind sigma u in
           (match constant_opt_value_in env (const, u) with

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -533,8 +533,7 @@ let check_binder_relevance env sigma s decl =
 let rec execute env sigma cstr =
   let cstr = whd_evar sigma cstr in
   match EConstr.kind sigma cstr with
-    | Meta n ->
-        sigma, { uj_val = cstr; uj_type = meta_type env sigma n }
+    | Meta n -> assert false (* Typing should always be performed on meta-free terms *)
 
     | Evar ev ->
         let ty = EConstr.existential_type sigma ev in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -159,6 +159,8 @@ let abstract_list_all_with_dependencies env evd typ c l =
   let () = assert (n <= SList.length (snd ev')) in
   let argoccs = set_occurrences_of_last_arg n in
   let evd,b =
+    if occur_meta evd c then evd, false
+    else
     Evarconv.second_order_matching
       (Evarconv.default_flags_of TransparentState.empty)
       env evd ev' (occurrence_test, argoccs) c in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -152,6 +152,7 @@ let clenv_refresh env sigma ctx clenv =
 
 let clenv_evd ce =  ce.evd
 let clenv_arguments c = List.map (fun arg -> arg.marg_meta) c.metas
+let clenv_meta_list c = Evd.meta_list c.evd
 
 let clenv_meta_type env sigma mv =
   let ty =

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -23,6 +23,7 @@ open Tactypes
 type clausenv
 
 val clenv_evd : clausenv -> Evd.evar_map
+val clenv_meta_list : clausenv -> clbinding Metamap.t
 
 (* Ad-hoc primitives *)
 val update_clenv_evd : clausenv -> evar_map -> clausenv

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -73,7 +73,6 @@ let exact h =
     let sigma, t = Typing.type_of env sigma c in
     let concl = Proofview.Goal.concl gl in
     if occur_existential sigma t || occur_existential sigma concl then
-      let sigma = Evd.clear_metas sigma in
       try
         let sigma = Unification.w_unify env sigma CONV ~flags:auto_unif_flags concl t in
         Proofview.Unsafe.tclEVARSADVANCE sigma <*>

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -403,10 +403,6 @@ end
 (*** Reduction Functions Operators ***)
 (*************************************)
 
-let safe_meta_value sigma ev =
-  try Some (Evd.meta_value sigma ev)
-  with Not_found -> None
-
 (*************************************)
 (*** Reduction using bindingss ***)
 (*************************************)
@@ -709,11 +705,7 @@ let whd_state_gen ?csts flags env sigma =
       | LocalDef (_,body,_) ->
         whrec (Cst_stack.add_cst (mkVar id) cst_l) (body, stack)
       | _ -> fold ())
-    | Evar ev -> fold ()
-    | Meta ev ->
-      (match safe_meta_value sigma ev with
-      | Some body -> whrec cst_l (body, stack)
-      | None -> fold ())
+    | Evar _ | Meta _ -> fold ()
     | Const (c,u as const) ->
       Reductionops.reduction_effect_hook env sigma c
          (lazy (EConstr.to_constr sigma (Stack.zip sigma (x,fst (Stack.strip_app stack)))));

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -261,7 +261,7 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
       (* we would have to take the clenv_value *)
       let newevars = lazy (Evarutil.undefined_evars_of_term sigma (Clenv.clenv_type rew)) in
       let flags = make_flags frzevars sigma flags newevars in
-      let metas = Evd.meta_list (Clenv.clenv_evd rew) in
+      let metas = Clenv.clenv_meta_list rew in
       let submetas = List.map (fun mv -> mv, Evd.Metamap.find mv metas) (Clenv.clenv_arguments rew) in
       general_elim_clause with_evars flags cls (submetas, c, Clenv.clenv_type rew) elim
       end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -543,7 +543,6 @@ let get_previous_hyp_position env sigma id =
 
 let clear_hyps2 env sigma ids sign t cl =
   try
-    let sigma = Evd.clear_metas sigma in
     Evarutil.clear_hyps2_in_evi env sigma sign t cl ids
   with Evarutil.ClearDependencyError (id,err,inglobal) ->
     error_replacing_dependency env sigma id err inglobal

--- a/test-suite/bugs/bug_19794.v
+++ b/test-suite/bugs/bug_19794.v
@@ -1,0 +1,9 @@
+Axiom nth_error : list nat -> unit.
+Axiom nth_error_value_length : forall (xs:list nat), nth_error xs = tt -> True.
+
+Axiom type : Set.
+
+Lemma foo (eta_ident_cps : forall {T : type -> Type} {t} (f : forall t', T t'), T t) : True.
+Proof.
+Fail apply nth_error_value_length in eta_ident_cps.
+Abort.


### PR DESCRIPTION
Metas nowadays exist only transiently during unification. Most of the tactic code used to be compatible with metas to support the old engine, but since Coq 8.4 metas should not occur outside of some internals of the legacy unification engine. This PR makes more explicit the fact that metas should only appear in these specific code paths.