### PR TITLE
Remove the meta state from evarmaps

### DIFF
--- a/dev/ci/user-overlays/19803-ppedrot-split-meta-state.sh
+++ b/dev/ci/user-overlays/19803-ppedrot-split-meta-state.sh
@@ -1,0 +1,3 @@
+overlay waterproof https://github.com/ppedrot/coq-waterproof split-meta-state 19803
+
+overlay relation_algebra https://github.com/ppedrot/relation-algebra split-meta-state 19803

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -56,6 +56,7 @@ install_printer Top_printers.pp_transparent_state
 install_printer Top_printers.pp_estack_t
 install_printer Top_printers.pp_state_t
 install_printer Top_printers.ppmetas
+install_printer Top_printers.ppmetamap
 install_printer Top_printers.ppevm
 install_printer Top_printers.ppexistentialset
 install_printer Top_printers.ppexistentialfilter

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -219,6 +219,10 @@ let pp_state_t n = pp (Reductionops.pr_state Global.(env()) Evd.empty n)
 (* proof printers *)
 let pr_evar ev = Pp.int (Evar.repr ev)
 let ppmetas metas = pp(Termops.pr_metaset metas)
+let ppmetamap metas =
+  let env = Global.env () in
+  let sigma = Evd.from_env env in
+  pp (Termops.pr_metamap env sigma metas)
 let ppevm evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes (Some 2) (Global.env ()) evd)
 let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes None (Global.env ()) evd)
 let pr_existentialset evars =

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -125,6 +125,7 @@ val pp_estack_t : Reductionops.Stack.t -> unit
 val pp_state_t : Reductionops.state -> unit
 
 val ppmetas : Evd.Metaset.t -> unit
+val ppmetamap : Evd.clbinding Evd.Metamap.t -> unit
 val ppevm : Evd.evar_map -> unit
 val ppevmall : Evd.evar_map -> unit
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -370,8 +370,6 @@ let map_fl f cfl = { cfl with rebus=f cfl.rebus }
 
 type instance_constraint = IsSuperType | IsSubType | Conv
 
-let eq_instance_constraint c1 c2 = c1 == c2
-
 (* Status of the unification of the type of an instance against the type of
      the meta it instantiates:
    - CoerceToType means that the unification of types has not been done
@@ -1516,13 +1514,6 @@ let set_metas evd metas = {
 
 let meta_list evd = evd.metas
 
-let map_metas_fvalue f evd =
-  let map = function
-  | Clval(id,(c,s),typ) -> Clval(id,(mk_freelisted (f c.rebus),s),typ)
-  | x -> x
-  in
-  set_metas evd (Metamap.Smart.map map evd.metas)
-
 let map_metas f evd =
   let map cl = map_clb f cl in
   set_metas evd (Metamap.Smart.map map evd.metas)
@@ -1575,32 +1566,11 @@ let meta_assign mv (v, pb) evd =
   let evd = use_meta_source evd mv v in
   set_metas evd metas
 
-let meta_reassign mv (v, pb) evd =
-  let modify _ = function
-  | Clval(na, _, ty) -> Clval (na, (mk_freelisted v, pb), ty)
-  | _ -> anomaly ~label:"meta_reassign" (Pp.str "not yet defined.")
-  in
-  let metas = Metamap.modify mv modify evd.metas in
-  set_metas evd metas
-
 let clear_metas evd = {evd with metas = Metamap.empty}
 
 let meta_merge metas sigma =
   let metas = Metamap.fold Metamap.add metas sigma.metas in
   { sigma with metas }
-
-type metabinding = metavariable * constr * instance_status
-
-let retract_coercible_metas evd =
-  let mc = ref [] in
-  let map n v = match v with
-  | Clval (na, (b, (Conv, CoerceToType as s)), typ) ->
-    let () = mc := (n, b.rebus, s) :: !mc in
-    Cltyp (na, typ)
-  | v -> v
-  in
-  let metas = Metamap.Smart.mapi map evd.metas in
-  !mc, set_metas evd metas
 
 end
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1492,6 +1492,9 @@ let update_source evd evk src =
 (**********************************************************)
 (* Accessing metas *)
 
+module Meta =
+struct
+
 (** We use this function to overcome OCaml compiler limitations and to prevent
     the use of costly in-place modifications. *)
 let set_metas evd metas = {
@@ -1598,6 +1601,8 @@ let retract_coercible_metas evd =
   in
   let metas = Metamap.Smart.mapi map evd.metas in
   !mc, set_metas evd metas
+
+end
 
 let dependent_evar_ident ev evd =
   let EvarInfo evi = find evd ev in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -564,29 +564,24 @@ val evars_of_filtered_evar_info : evar_map -> 'a evar_info -> Evar.Set.t
 module Meta :
 sig
 
-val meta_list : evar_map -> clbinding Metamap.t
+type t = clbinding Metamap.t
 
-val meta_value     : evar_map -> metavariable -> econstr
+val meta_value     : t -> metavariable -> econstr
 (** [meta_fvalue] raises [Not_found] if meta not in map or [Anomaly] if
    meta has no value *)
 
-val meta_opt_fvalue : evar_map -> metavariable -> (econstr freelisted * instance_status) option
-val meta_ftype     : evar_map -> metavariable -> etypes freelisted
-val meta_name      : evar_map -> metavariable -> Name.t
-val meta_declare   :
-  metavariable -> etypes -> ?name:Name.t -> evar_map -> evar_map
-val meta_assign    : metavariable -> econstr * instance_status -> evar_map -> evar_map
-
-val clear_metas : evar_map -> evar_map
+val meta_opt_fvalue : t -> metavariable -> (econstr freelisted * instance_status) option
+val meta_ftype     : t -> metavariable -> etypes freelisted
+val meta_name      : t -> metavariable -> Name.t
+val meta_declare   : metavariable -> etypes -> ?name:Name.t -> t -> t
+val meta_assign    : metavariable -> econstr * instance_status -> t -> evar_map -> evar_map * t
 
 (** [meta_merge evd1 evd2] returns [evd2] extended with the metas of [evd1] *)
-val meta_merge : clbinding Metamap.t -> evar_map -> evar_map
+val meta_merge : t -> t -> t
 
-val map_metas : (econstr -> econstr) -> evar_map -> evar_map
+val map_metas : (econstr -> econstr) -> t -> t
 
-val evar_source_of_meta : metavariable -> evar_map -> Evar_kinds.t located
-
-val set_metas : evar_map -> clbinding Metamap.t -> evar_map
+val evar_source_of_meta : metavariable -> t -> Evar_kinds.t located
 
 end
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -373,8 +373,6 @@ val evar_key : Id.t -> evar_map -> Evar.t
 
 val evar_names : evar_map -> Nameops.Fresh.t
 
-val evar_source_of_meta : metavariable -> evar_map -> Evar_kinds.t located
-
 val dependent_evar_ident : Evar.t -> evar_map -> Id.t
 
 (** {5 Side-effects} *)
@@ -567,6 +565,9 @@ val evars_of_named_context : evar_map -> (econstr, etypes, erelevance) Context.N
 val evars_of_filtered_evar_info : evar_map -> 'a evar_info -> Evar.Set.t
 
 (** Metas *)
+module Meta :
+sig
+
 val meta_list : evar_map -> clbinding Metamap.t
 
 val meta_value     : evar_map -> metavariable -> econstr
@@ -592,6 +593,10 @@ val map_metas : (econstr -> econstr) -> evar_map -> evar_map
 type metabinding = metavariable * econstr * instance_status
 
 val retract_coercible_metas : evar_map -> metabinding list * evar_map
+
+val evar_source_of_meta : metavariable -> evar_map -> Evar_kinds.t located
+
+end
 
 (** {5 FIXME: Nothing to do here} *)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -495,7 +495,6 @@ type 'a freelisted = {
 
 val metavars_of : econstr -> Metaset.t
 val mk_freelisted : econstr -> econstr freelisted
-val map_fl : ('a -> 'b) -> 'a freelisted -> 'b freelisted
 
 (** Status of an instance found by unification wrt to the meta it solves:
   - a supertype of the meta (e.g. the solution to ?X <= T is a supertype of ?X)
@@ -505,9 +504,6 @@ val map_fl : ('a -> 'b) -> 'a freelisted -> 'b freelisted
 *)
 
 type instance_constraint = IsSuperType | IsSubType | Conv
-
-val eq_instance_constraint :
-  instance_constraint -> instance_constraint -> bool
 
 (** Status of the unification of the type of an instance against the type of
      the meta it instantiates:
@@ -580,21 +576,17 @@ val meta_name      : evar_map -> metavariable -> Name.t
 val meta_declare   :
   metavariable -> etypes -> ?name:Name.t -> evar_map -> evar_map
 val meta_assign    : metavariable -> econstr * instance_status -> evar_map -> evar_map
-val meta_reassign  : metavariable -> econstr * instance_status -> evar_map -> evar_map
 
 val clear_metas : evar_map -> evar_map
 
 (** [meta_merge evd1 evd2] returns [evd2] extended with the metas of [evd1] *)
 val meta_merge : clbinding Metamap.t -> evar_map -> evar_map
 
-val map_metas_fvalue : (econstr -> econstr) -> evar_map -> evar_map
 val map_metas : (econstr -> econstr) -> evar_map -> evar_map
 
-type metabinding = metavariable * econstr * instance_status
-
-val retract_coercible_metas : evar_map -> metabinding list * evar_map
-
 val evar_source_of_meta : metavariable -> evar_map -> Evar_kinds.t located
+
+val set_metas : evar_map -> clbinding Metamap.t -> evar_map
 
 end
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -170,7 +170,7 @@ let pr_meta_map env sigma =
            str " : " ++ print_constr env sigma t.rebus ++
            spc () ++ pr_instance_status s ++ fnl ())
   in
-  prlist pr_meta_binding (Evd.Metamap.bindings (meta_list sigma))
+  prlist pr_meta_binding (Evd.Metamap.bindings (Meta.meta_list sigma))
 
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in
@@ -361,7 +361,7 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
       str "OBLIGATIONS:" ++ brk (0, 1) ++
       prlist_with_sep spc Evar.print (Evar.Set.elements evars) ++ fnl ()
   and metas =
-    if Evd.Metamap.is_empty (Evd.meta_list sigma) then mt ()
+    if Evd.Metamap.is_empty (Evd.Meta.meta_list sigma) then mt ()
     else
       str "METAS:" ++ brk (0, 1) ++ pr_meta_map env sigma
   and shelf =

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -152,7 +152,7 @@ let pr_instance_status (sc,typ) =
   | TypeProcessed -> str " [type is checked]"
   end
 
-let pr_meta_map env sigma =
+let pr_metamap env sigma metas =
   let open Evd in
   let print_constr = Internal.print_kconstr in
   let pr_name = function
@@ -170,7 +170,7 @@ let pr_meta_map env sigma =
            str " : " ++ print_constr env sigma t.rebus ++
            spc () ++ pr_instance_status s ++ fnl ())
   in
-  prlist pr_meta_binding (Evd.Metamap.bindings (Meta.meta_list sigma))
+  prlist pr_meta_binding (Evd.Metamap.bindings metas)
 
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in
@@ -360,16 +360,12 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
     else
       str "OBLIGATIONS:" ++ brk (0, 1) ++
       prlist_with_sep spc Evar.print (Evar.Set.elements evars) ++ fnl ()
-  and metas =
-    if Evd.Metamap.is_empty (Evd.Meta.meta_list sigma) then mt ()
-    else
-      str "METAS:" ++ brk (0, 1) ++ pr_meta_map env sigma
   and shelf =
     str "SHELF:" ++ brk (0, 1) ++ Evd.pr_shelf sigma ++ fnl ()
   and future_goals =
     str "FUTURE GOALS STACK:" ++ brk (0, 1) ++ Evd.pr_future_goals_stack sigma ++ fnl ()
   in
-  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ metas ++ shelf ++ future_goals
+  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ shelf ++ future_goals
 
 let pr_evar_list env sigma l =
   let open Evd in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -294,6 +294,7 @@ val pr_evar_map : ?with_univs:bool -> int option -> env -> evar_map -> Pp.t
 val pr_evar_map_filter : ?with_univs:bool -> (Evar.t -> any_evar_info -> bool) ->
   env -> evar_map -> Pp.t
 val pr_metaset : Metaset.t -> Pp.t
+val pr_metamap : env -> evar_map -> clbinding Metamap.t -> Pp.t
 val pr_evd_level : evar_map -> Univ.Level.t -> Pp.t
 val pr_evd_qvar : evar_map -> Sorts.QVar.t -> Pp.t
 

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -43,8 +43,10 @@ let whd env sigma t =
 let whd_delta env sigma t =
   Reductionops.clos_whd_flags RedFlags.all env sigma t
 
+let whd_all env sigma c = Reductionops.whd_all env sigma c
+
 let whd_in_concl =
-  reduct_in_concl ~cast:true ~check:false (Reductionops.whd_all, DEFAULTcast)
+  reduct_in_concl ~cast:true ~check:false (whd_all, DEFAULTcast)
 
 (* decompose member of equality in an applicative format *)
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -216,7 +216,7 @@ let flags_FO env =
   }
 
 let unif_FO env ise metas p c =
-  let ise = Metamap.fold (fun mv t accu -> Evd.meta_declare mv t accu) metas ise in
+  let ise = Metamap.fold (fun mv t accu -> Evd.Meta.meta_declare mv t accu) metas ise in
   let _ : Evd.evar_map = Unification.w_unify env ise Conversion.CONV ~flags:(flags_FO env) p c in
   ()
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -217,7 +217,8 @@ let flags_FO env =
 
 let unif_FO env ise metas p c =
   let ise = Metamap.fold (fun mv t accu -> Evd.Meta.meta_declare mv t accu) metas ise in
-  let _ : Evd.evar_map = Unification.w_unify env ise Conversion.CONV ~flags:(flags_FO env) p c in
+  let metas = Evd.Meta.meta_list ise in
+  let _ : Evd.evar_map = Unification.w_unify ~metas env ise Conversion.CONV ~flags:(flags_FO env) p c in
   ()
 
 (* Perform evar substitution in main term and prune substitution. *)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -216,9 +216,8 @@ let flags_FO env =
   }
 
 let unif_FO env ise metas p c =
-  let ise = Metamap.fold (fun mv t accu -> Evd.Meta.meta_declare mv t accu) metas ise in
-  let metas = Evd.Meta.meta_list ise in
-  let _ : Evd.evar_map = Unification.w_unify ~metas env ise Conversion.CONV ~flags:(flags_FO env) p c in
+  let metas = Metamap.fold (fun mv t accu -> Evd.Meta.meta_declare mv t accu) metas Metamap.empty in
+  let _ : _ * Evd.evar_map = Unification.w_unify ~metas env ise Conversion.CONV ~flags:(flags_FO env) p c in
   ()
 
 (* Perform evar substitution in main term and prune substitution. *)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -292,7 +292,7 @@ let apply_hooks env sigma proj pat =
    object c in structure R (since, if c1 were not an evar, the
    projection would have been reduced) *)
 
-let check_conv_record env sigma (t1,sk1) (t2,sk2) =
+let check_conv_record ?metas env sigma (t1,sk1) (t2,sk2) =
    (* I only recognize ConstRef projections since these are the only ones for which
       I know how to obtain the number of parameters. *)
   let (proji, u), arg =
@@ -305,8 +305,15 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
   let params1, c1, extra_args1 =
     match arg with
     | Some c -> (* A primitive projection applied to c *)
+      let meta_type mv = match metas with
+      | None -> None
+      | Some metas ->
+        match Metamap.find mv metas with
+        | Cltyp (_, b) -> Some b.Evd.rebus
+        | Clval (_, _, b) -> Some b.Evd.rebus
+      in
       let ty =
-        try Retyping.get_type_of ~lax:true env sigma c with
+        try Retyping.get_type_of ~metas:meta_type ~lax:true env sigma c with
         | Retyping.RetypeError _ -> raise Not_found
       in
       let ind_args =

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -92,7 +92,7 @@ val apply_hooks : hook
 
 (** Check if a canonical structure is applicable *)
 
-val check_conv_record : env -> evar_map ->
+val check_conv_record : ?metas:clbinding Metamap.t -> env -> evar_map ->
   state -> state ->
   evar_map * (constr * constr)
   * constr * constr list * (EConstr.t list * EConstr.t list option) *

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -159,11 +159,11 @@ let error_wrong_abstraction_type env sigma na a p l =
   raise (PretypeError (env, sigma,WrongAbstractionType (na,a,p,l)))
 
 let error_abstraction_over_meta env sigma hdmeta metaarg =
-  let m = Evd.meta_name sigma hdmeta and n = Evd.meta_name sigma metaarg in
+  let m = Evd.Meta.meta_name sigma hdmeta and n = Evd.Meta.meta_name sigma metaarg in
   raise (PretypeError (env, sigma,AbstractionOverMeta (m,n)))
 
 let error_non_linear_unification env sigma hdmeta t =
-  let m = Evd.meta_name sigma hdmeta in
+  let m = Evd.Meta.meta_name sigma hdmeta in
   raise (PretypeError (env, sigma,NonLinearUnification (m,t)))
 
 (*s Ml Case errors *)

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -158,12 +158,10 @@ let error_cannot_find_well_typed_abstraction env sigma p l e =
 let error_wrong_abstraction_type env sigma na a p l =
   raise (PretypeError (env, sigma,WrongAbstractionType (na,a,p,l)))
 
-let error_abstraction_over_meta env sigma hdmeta metaarg =
-  let m = Evd.Meta.meta_name sigma hdmeta and n = Evd.Meta.meta_name sigma metaarg in
+let error_abstraction_over_meta env sigma m n =
   raise (PretypeError (env, sigma,AbstractionOverMeta (m,n)))
 
-let error_non_linear_unification env sigma hdmeta t =
-  let m = Evd.Meta.meta_name sigma hdmeta in
+let error_non_linear_unification env sigma m t =
   raise (PretypeError (env, sigma,NonLinearUnification (m,t)))
 
 (*s Ml Case errors *)

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -147,10 +147,10 @@ val error_wrong_abstraction_type :  env -> Evd.evar_map ->
       Name.t -> constr -> types -> types -> 'b
 
 val error_abstraction_over_meta : env -> Evd.evar_map ->
-  metavariable -> metavariable -> 'b
+  Name.t -> Name.t -> 'b
 
 val error_non_linear_unification : env -> Evd.evar_map ->
-  metavariable -> constr -> 'b
+  Name.t -> constr -> 'b
 
 (** {6 Ml Case errors } *)
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -469,7 +469,7 @@ let pr_state env sigma (tm,sk) =
 (*************************************)
 
 let safe_meta_value sigma ev =
-  try Some (Evd.meta_value sigma ev)
+  try Some (Evd.Meta.meta_value sigma ev)
   with Not_found -> None
 
 (*************************************)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1421,46 +1421,6 @@ let check_hyps_inclusion env sigma x hyps =
 (*             Special-Purpose Reduction                            *)
 (********************************************************************)
 
-(* [instance] is used for [res_pf]; the call to [local_strong whd_betaiota]
-   has (unfortunately) different subtle side effects:
-
-   - ** Order of subgoals **
-     If the lemma is a case analysis with parameters, it will move the
-     parameters as first subgoals (e.g. "case H" applied on
-     "H:D->A/\B|-C" will present the subgoal |-D first while w/o
-     betaiota the subgoal |-D would have come last).
-
-   - ** Betaiota-contraction in statement **
-     If the lemma has a parameter which is a function and this
-     function is applied in the lemma, then the _strong_ betaiota will
-     contract the application of the function to its argument (e.g.
-     "apply (H (fun x => x))" in "H:forall f, f 0 = 0 |- 0=0" will
-     result in applying the lemma 0=0 in which "(fun x => x) 0" has
-     been contracted). A goal to rewrite may then fail or succeed
-     differently.
-
-   - ** Naming of hypotheses **
-     If a lemma is a function of the form "fun H:(forall a:A, P a)
-     => .. F H .." where the expected type of H is "forall b:A, P b",
-     then, without reduction, the application of the lemma will
-     generate a subgoal "forall a:A, P a" (and intro will use name
-     "a"), while with reduction, it will generate a subgoal "forall
-     b:A, P b" (and intro will use name "b").
-
-   - ** First-order pattern-matching **
-     If a lemma has the type "(fun x => p) t" then rewriting t may fail
-     if the type of the lemma is first beta-reduced (this typically happens
-     when rewriting a single variable and the type of the lemma is obtained
-     by meta_instance (with empty map) which itself calls instance with this
-     empty map).
- *)
-
-let instance env sigma c =
-  (* if s = [] then c else *)
-  (* No need to compute contexts under binders as whd_betaiota is local *)
-  let rec strongrec t = EConstr.map sigma strongrec (whd_betaiota env sigma t) in
-  strongrec c
-
 (* pseudo-reduction rule:
  * [hnf_prod_app env s (Prod(_,B)) N --> B[N]
  * with an HNF on the first argument to produce a product.
@@ -1719,15 +1679,6 @@ let is_arity env sigma c =
   match find_conclusion env sigma c with
     | Sort _ -> true
     | _ -> false
-
-(*************************************)
-(* Metas *)
-
-let meta_instance env sigma b =
-  let fm = b.freemetas in
-  if Metaset.is_empty fm then b.rebus
-  else
-    instance env sigma b.rebus
 
 module Infer = struct
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -468,9 +468,11 @@ let pr_state env sigma (tm,sk) =
 (*** Reduction Functions Operators ***)
 (*************************************)
 
-let safe_meta_value sigma ev =
-  try Some (Evd.Meta.meta_value sigma ev)
-  with Not_found -> None
+type meta_handler = { meta_value : metavariable -> EConstr.t option }
+
+let safe_meta_value metas ev = match metas with
+| None -> None
+| Some f -> f.meta_value ev
 
 (*************************************)
 (*** Reduction using bindingss ***)
@@ -817,7 +819,7 @@ let rec apply_rules whrec env sigma u r stk =
       (rhs', stk)
     with PatternFailure -> apply_rules whrec env sigma u rs stk
 
-let whd_state_gen flags env sigma =
+let whd_state_gen flags ?metas env sigma =
   let open Context.Named.Declaration in
   let rec whrec (x, stack) : state =
     let () =
@@ -846,7 +848,7 @@ let whd_state_gen flags env sigma =
       | _ -> fold ())
     | Evar ev -> fold ()
     | Meta ev ->
-      (match safe_meta_value sigma ev with
+      (match safe_meta_value metas ev with
       | Some body -> whrec (body, stack)
       | None -> fold ())
     | Const (c,u as const) ->
@@ -963,7 +965,7 @@ let whd_state_gen flags env sigma =
   whrec
 
 (** reduction machine without global env and refold machinery *)
-let local_whd_state_gen flags env sigma =
+let local_whd_state_gen flags ?metas env sigma =
   let rec whrec (x, stack) =
     let c0 = EConstr.kind sigma x in
     let s = (EConstr.of_kind c0, stack) in
@@ -991,7 +993,7 @@ let local_whd_state_gen flags env sigma =
 
     | Evar ev -> s
     | Meta ev ->
-      (match safe_meta_value sigma ev with
+      (match safe_meta_value metas ev with
         Some c -> whrec (c,stack)
       | None -> s)
 
@@ -1026,11 +1028,11 @@ let local_whd_state_gen flags env sigma =
   in
   whrec
 
-let stack_red_of_state_red f =
-  let f env sigma x = EConstr.decompose_app_list sigma (Stack.zip sigma (f env sigma (x, Stack.empty))) in
+let stack_red_of_state_red f ?metas =
+  let f env sigma x = EConstr.decompose_app_list sigma (Stack.zip sigma (f ?metas env sigma (x, Stack.empty))) in
   f
 
-let red_of_state_red ~delta f env sigma x =
+let red_of_state_red ?metas ~delta f env sigma x =
   let rec is_whnf c = match Constr.kind c with
     | Const _ | Var _ -> not delta
     | Construct _ | Ind _ | Int _ | Float _ | String _
@@ -1042,13 +1044,13 @@ let red_of_state_red ~delta f env sigma x =
      not sure if anything relies on reduction unfolding head evars
      for now use Unsafe.to_constr to keep such unfolds *)
   if is_whnf (EConstr.Unsafe.to_constr x) then x
-  else Stack.zip sigma (f env sigma (x,Stack.empty))
+  else Stack.zip sigma (f ?metas env sigma (x,Stack.empty))
 
 (* 0. No Reduction Functions *)
 
 let whd_nored_state = local_whd_state_gen RedFlags.nored
 let whd_nored_stack = stack_red_of_state_red whd_nored_state
-let whd_nored = red_of_state_red ~delta:false whd_nored_state
+let whd_nored ?metas = red_of_state_red ?metas ~delta:false whd_nored_state
 
 (* 1. Beta Reduction Functions *)
 
@@ -1063,9 +1065,9 @@ let whd_betalet = red_of_state_red ~delta:false whd_betalet_state
 (* 2. Delta Reduction Functions *)
 
 let whd_const_state c e = whd_state_gen RedFlags.(mkflags [fCONST c]) e
-let whd_const c = red_of_state_red ~delta:true (whd_const_state c)
+let whd_const c = red_of_state_red ~delta:true (fun ?metas -> whd_const_state c)
 
-let whd_delta_state e = whd_state_gen RedFlags.delta e
+let whd_delta_state = whd_state_gen RedFlags.delta
 let whd_delta_stack = stack_red_of_state_red whd_delta_state
 let whd_delta = red_of_state_red ~delta:true whd_delta_state
 
@@ -1077,15 +1079,15 @@ let whd_betadeltazeta = red_of_state_red ~delta:true whd_betadeltazeta_state
 
 let whd_betaiota_state = local_whd_state_gen RedFlags.betaiota
 let whd_betaiota_stack = stack_red_of_state_red whd_betaiota_state
-let whd_betaiota = red_of_state_red ~delta:false whd_betaiota_state
+let whd_betaiota ?metas = red_of_state_red ?metas ~delta:false whd_betaiota_state
 
 let whd_betaiotazeta_state = local_whd_state_gen RedFlags.betaiotazeta
 let whd_betaiotazeta_stack = stack_red_of_state_red whd_betaiotazeta_state
-let whd_betaiotazeta = red_of_state_red ~delta:false whd_betaiotazeta_state
+let whd_betaiotazeta ?metas = red_of_state_red ?metas ~delta:false whd_betaiotazeta_state
 
 let whd_all_state = whd_state_gen RedFlags.all
 let whd_all_stack = stack_red_of_state_red whd_all_state
-let whd_all = red_of_state_red ~delta:true whd_all_state
+let whd_all ?metas = red_of_state_red ?metas ~delta:true whd_all_state
 
 let whd_allnolet_state = whd_state_gen RedFlags.allnolet
 let whd_allnolet_stack = stack_red_of_state_red whd_allnolet_state
@@ -1114,11 +1116,7 @@ let shrink_eta sigma c =
           if noccurn sigma 1 u then pop u else x
         | _ -> x
       else x
-    | Meta ev ->
-      (match safe_meta_value sigma ev with
-        Some c -> whrec c
-      | None -> x)
-    | App _ | Case _ | Fix _ | Construct _ | CoFix _ | Evar _ | Rel _ | Var _ | Sort _ | Prod _
+    | Meta _ | App _ | Case _ | Fix _ | Construct _ | CoFix _ | Evar _ | Rel _ | Var _ | Sort _ | Prod _
     | LetIn _ | Const _  | Ind _ | Proj _ | Int _ | Float _ | String _ | Array _ -> x
   in
   whrec c
@@ -1611,7 +1609,7 @@ let is_sort env sigma t =
 (* reduction to head-normal-form allowing delta/zeta only in argument
    of case/fix (heuristic used by evar_conv) *)
 
-let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
+let whd_betaiota_deltazeta_for_iota_state ts ?metas env sigma s =
   let all' = RedFlags.red_add_transparent RedFlags.all ts in
   (* Unset the sharing flag to get a call-by-name reduction. This matters for
      the shape of the generated term. *)
@@ -1630,7 +1628,7 @@ let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
     | _ -> None
   in
   let rec whrec s =
-    let (t, stack as s) = whd_state_gen RedFlags.betaiota env sigma s in
+    let (t, stack as s) = whd_state_gen RedFlags.betaiota ?metas env sigma s in
     let rewrite_step =
       match kind sigma t with
       | Const (cst, u) when Environ.is_symbol env cst ->

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -311,9 +311,6 @@ val apply_rules : (state -> state) -> env -> evar_map -> EInstance.t ->
 
 val is_head_evar : env -> evar_map -> constr -> bool
 
-(** {6 Meta-related reduction functions } *)
-val meta_instance : env -> evar_map -> constr freelisted -> constr
-
 exception AnomalyInConversion of exn
 
 (* inferred_universes just gathers the constraints. *)

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -19,6 +19,8 @@ open Environ
 
 exception Elimconst
 
+type meta_handler = { meta_value : metavariable -> EConstr.t option }
+
 val debug_RAKAM : CDebug.t
 
 module CredNative : Primred.RedNative with
@@ -152,36 +154,36 @@ val nf_evar : evar_map -> constr -> constr
 (** Lazy strategy, weak head reduction *)
 
 val whd_evar :  evar_map -> constr -> constr
-val whd_nored : reduction_function
+val whd_nored : ?metas:meta_handler -> reduction_function
 val whd_beta : reduction_function
-val whd_betaiota : reduction_function
-val whd_betaiotazeta : reduction_function
-val whd_all :  reduction_function
+val whd_betaiota : ?metas:meta_handler -> reduction_function
+val whd_betaiotazeta : ?metas:meta_handler -> reduction_function
+val whd_all : ?metas:meta_handler -> reduction_function
 val whd_allnolet :  reduction_function
 val whd_betalet : reduction_function
 
 (** Removes cast and put into applicative form *)
-val whd_nored_stack : stack_reduction_function
-val whd_beta_stack : stack_reduction_function
-val whd_betaiota_stack : stack_reduction_function
-val whd_betaiotazeta_stack : stack_reduction_function
-val whd_all_stack : stack_reduction_function
-val whd_allnolet_stack : stack_reduction_function
-val whd_betalet_stack : stack_reduction_function
+val whd_nored_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_beta_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_betaiota_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_betaiotazeta_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_all_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_allnolet_stack : ?metas:meta_handler -> stack_reduction_function
+val whd_betalet_stack : ?metas:meta_handler -> stack_reduction_function
 
 (** {6 Head normal forms } *)
 
 val whd_const : Constant.t -> reduction_function
-val whd_delta_stack :  stack_reduction_function
+val whd_delta_stack : ?metas:meta_handler -> stack_reduction_function
 val whd_delta :  reduction_function
-val whd_betadeltazeta_stack :  stack_reduction_function
+val whd_betadeltazeta_stack : ?metas:meta_handler -> stack_reduction_function
 val whd_betadeltazeta :  reduction_function
-val whd_zeta_stack : stack_reduction_function
+val whd_zeta_stack : ?metas:meta_handler -> stack_reduction_function
 val whd_zeta : reduction_function
 
 val shrink_eta : evar_map -> constr -> constr
 
-val whd_stack_gen : RedFlags.reds -> stack_reduction_function
+val whd_stack_gen : RedFlags.reds -> ?metas:meta_handler -> stack_reduction_function
 
 (** Various reduction functions *)
 
@@ -300,10 +302,10 @@ type state_reduction_function =
 
 val pr_state : env -> evar_map -> state -> Pp.t
 
-val whd_nored_state : state_reduction_function
+val whd_nored_state : ?metas:meta_handler -> state_reduction_function
 
 val whd_betaiota_deltazeta_for_iota_state :
-  TransparentState.t -> state_reduction_function
+  TransparentState.t -> ?metas:meta_handler -> state_reduction_function
 
 exception PatternFailure
 val apply_rules : (state -> state) -> env -> evar_map -> EInstance.t ->

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -143,7 +143,7 @@ let retype ?(polyprop=true) sigma =
   let rec type_of env cstr =
     match EConstr.kind sigma cstr with
     | Meta n ->
-      (try strip_outer_cast sigma (Evd.meta_ftype sigma n).Evd.rebus
+      (try strip_outer_cast sigma (Evd.Meta.meta_ftype sigma n).Evd.rebus
        with Not_found -> retype_error (BadMeta n))
     | Rel n ->
       let ty = try RelDecl.get_type (lookup_rel n env)

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -28,6 +28,7 @@ type retype_error
 exception RetypeError of retype_error
 
 val get_type_of :
+  ?metas:(Constr.metavariable -> types option) ->
   ?polyprop:bool -> ?lax:bool -> env -> evar_map -> constr -> types
 
 (** No-evar version of [get_type_of] *)

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -378,7 +378,7 @@ let rec get_nth n = function
 
 let rec decompose_projection sigma c args =
   match EConstr.kind sigma c with
-  | Meta mv -> decompose_projection sigma (Evd.meta_value sigma mv) args
+  | Meta mv -> decompose_projection sigma (Evd.Meta.meta_value sigma mv) args
   | Cast (c, _, _) -> decompose_projection sigma c args
   | App (c, arg) -> decompose_projection sigma c (arg :: args)
   | Const (c, u) ->

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -131,6 +131,7 @@ val find :
     applied to term which is not a constructor. Used by evarconv not to
     unfold too much and lose a projection too early *)
 val is_open_canonical_projection :
+  ?metas:Reductionops.meta_handler ->
   Environ.env -> Evd.evar_map -> EConstr.t -> bool
 
 val print : Environ.env -> Evd.evar_map -> t -> Pp.t

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -28,7 +28,7 @@ module GR = Names.GlobRef
 
 let meta_type env evd mv =
   let ty =
-    try Evd.meta_ftype evd mv
+    try Evd.Meta.meta_ftype evd mv
     with Not_found -> anomaly (str "unknown meta ?" ++ str (Nameops.string_of_meta mv) ++ str ".") in
   meta_instance env evd ty
 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Pp
 open CErrors
 open Util
 open Term
@@ -25,12 +24,6 @@ open Pretype_errors
 open Context.Rel.Declaration
 
 module GR = Names.GlobRef
-
-let meta_type env evd mv =
-  let ty =
-    try Evd.Meta.meta_ftype evd mv
-    with Not_found -> anomaly (str "unknown meta ?" ++ str (Nameops.string_of_meta mv) ++ str ".") in
-  meta_instance env evd ty
 
 let fresh_template_context env0 sigma ind (mib, mip as spec) args =
   let templ = match mib.Declarations.mind_template with

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Constr
 open Environ
 open EConstr
 open Evd
@@ -29,9 +28,6 @@ val check : env -> evar_map -> constr -> types -> evar_map
 
 (** Type of a variable. *)
 val type_of_variable : env -> variable -> types
-
-(** Returns the instantiated type of a metavariable *)
-val meta_type : env -> evar_map -> metavariable -> types
 
 (** Solve existential variables using typing *)
 val solve_evars : env -> evar_map -> constr -> evar_map * constr

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -65,6 +65,55 @@ let retract_coercible_metas evd =
 
 end
 
+(* [instance] is used for [res_pf]; the call to [local_strong whd_betaiota]
+   has (unfortunately) different subtle side effects:
+
+   - ** Order of subgoals **
+     If the lemma is a case analysis with parameters, it will move the
+     parameters as first subgoals (e.g. "case H" applied on
+     "H:D->A/\B|-C" will present the subgoal |-D first while w/o
+     betaiota the subgoal |-D would have come last).
+
+   - ** Betaiota-contraction in statement **
+     If the lemma has a parameter which is a function and this
+     function is applied in the lemma, then the _strong_ betaiota will
+     contract the application of the function to its argument (e.g.
+     "apply (H (fun x => x))" in "H:forall f, f 0 = 0 |- 0=0" will
+     result in applying the lemma 0=0 in which "(fun x => x) 0" has
+     been contracted). A goal to rewrite may then fail or succeed
+     differently.
+
+   - ** Naming of hypotheses **
+     If a lemma is a function of the form "fun H:(forall a:A, P a)
+     => .. F H .." where the expected type of H is "forall b:A, P b",
+     then, without reduction, the application of the lemma will
+     generate a subgoal "forall a:A, P a" (and intro will use name
+     "a"), while with reduction, it will generate a subgoal "forall
+     b:A, P b" (and intro will use name "b").
+
+   - ** First-order pattern-matching **
+     If a lemma has the type "(fun x => p) t" then rewriting t may fail
+     if the type of the lemma is first beta-reduced (this typically happens
+     when rewriting a single variable and the type of the lemma is obtained
+     by meta_instance (with empty map) which itself calls instance with this
+     empty map).
+ *)
+
+let instance env sigma c =
+  (* if s = [] then c else *)
+  (* No need to compute contexts under binders as whd_betaiota is local *)
+  let rec strongrec t = EConstr.map sigma strongrec (whd_betaiota env sigma t) in
+  strongrec c
+
+(*************************************)
+(* Metas *)
+
+let meta_instance env sigma b =
+  let fm = b.freemetas in
+  if Metaset.is_empty fm then b.rebus
+  else
+    instance env sigma b.rebus
+
 let meta_type env evd mv =
   let ty =
     try Evd.Meta.meta_ftype evd mv

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2468,3 +2468,9 @@ let w_unify_meta_types ?metas env ?flags evd =
 let w_coerce_to_type ?metas env evd c cty mvty =
   let evd = set_metas metas evd in
   w_coerce_to_type env evd c cty mvty
+
+let pose_all_metas_as_evars ~metas env evd ty =
+  let evd = Evd.Meta.set_metas evd metas in
+  let sigma, c = pose_all_metas_as_evars env evd ty in
+  let metas = Evd.Meta.meta_list sigma in
+  Evd.Meta.clear_metas sigma, metas, c

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2305,7 +2305,10 @@ let w_unify_to_subterm_list env evd flags hdmeta oplist t =
       let op = whd_meta evd op in
       if isMeta evd op then
         if flags.allow_K_in_toplevel_higher_order_unification then (evd,op::l)
-        else error_abstraction_over_meta env evd hdmeta (destMeta evd op)
+        else
+          let hdname = Evd.Meta.meta_name evd hdmeta in
+          let argname = Evd.Meta.meta_name evd (destMeta evd op) in
+          error_abstraction_over_meta env evd hdname argname
       else
         let allow_K = flags.allow_K_in_toplevel_higher_order_unification in
         let flags =
@@ -2339,7 +2342,9 @@ let w_unify_to_subterm_list env evd flags hdmeta oplist t =
           if not allow_K &&
             (* ensure we found a different instance *)
             List.exists (fun op -> EConstr.eq_constr evd' op cl) l
-          then error_non_linear_unification env evd hdmeta cl
+          then
+            let hdname = Evd.Meta.meta_name evd hdmeta in
+            error_non_linear_unification env evd hdname cl
           else (evd',cl::l))
     oplist
     (evd,[])

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2445,10 +2445,26 @@ let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
       (* General case: try first order *)
       | _ -> w_typed_unify env evd cv_pb flags (ty1, Unknown) (ty2, Unknown)
 
-(* Profiling *)
+let set_metas metas evd = match metas with
+| Some metas -> Evd.Meta.set_metas evd metas
+| None -> Evd.Meta.clear_metas evd
 
-let w_unify env evd cv_pb flags ty1 ty2 =
-  w_unify env evd cv_pb ~flags:flags ty1 ty2
+let w_unify ?metas env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
+  let evd = set_metas metas evd in
+  w_unify env evd cv_pb ~flags ty1 ty2
 
-let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
-  w_unify env evd cv_pb flags ty1 ty2
+let w_unify_to_subterm ?metas env evd ?flags arg =
+  let evd = set_metas metas evd in
+  w_unify_to_subterm env evd ?flags arg
+
+let w_unify_to_subterm_all ?metas env evd ?flags arg =
+  let evd = set_metas metas evd in
+  w_unify_to_subterm_all env evd ?flags arg
+
+let w_unify_meta_types ?metas env ?flags evd =
+  let evd = set_metas metas evd in
+  w_unify_meta_types env ?flags evd
+
+let w_coerce_to_type ?metas env evd c cty mvty =
+  let evd = set_metas metas evd in
+  w_coerce_to_type env evd c cty mvty

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1557,8 +1557,11 @@ let is_mimick_head sigma ts f =
 
 let try_to_coerce env evd c cty tycon =
   let j = make_judge c cty in
+  let metas = Evd.Meta.meta_list evd in
+  let evd = Evd.Meta.clear_metas evd in
   let (evd',j',_trace) = Coercion.inh_conv_coerce_rigid_to ~program_mode:false ~resolve_tc:true env evd j tycon in
   let evd' = Evarconv.solve_unif_constraints_with_heuristics env evd' in
+  let evd' = Evd.Meta.set_metas evd' metas in
   let evd' = Meta.map_metas_fvalue (fun c -> nf_evar evd' c) evd' in
     (evd',j'.uj_val)
 

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -94,4 +94,7 @@ val pose_all_metas_as_evars : env -> evar_map -> constr -> evar_map * constr
 val abstract_list_all :
   env -> evar_map -> constr -> constr -> constr list -> evar_map * (constr * types)
 
+(** {5 Meta-related functions} *)
+
 val meta_type : env -> evar_map -> Constr.metavariable -> types
+val meta_instance : env -> evar_map -> constr freelisted -> constr

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -48,22 +48,29 @@ val is_keyed_unification : unit -> bool
 
 (** The "unique" unification function *)
 val w_unify :
+  ?metas:clbinding Metamap.t ->
   env -> evar_map -> conv_pb -> ?flags:unify_flags -> constr -> constr -> evar_map
 
 (** [w_unify_to_subterm env m (c,t)] performs unification of [c] with a
    subterm of [t]. Constraints are added to [m] and the matched
    subterm of [t] is also returned. *)
 val w_unify_to_subterm :
+  ?metas:clbinding Metamap.t ->
   env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map * constr
 
 val w_unify_to_subterm_all :
+  ?metas:clbinding Metamap.t ->
   env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map list
 
-val w_unify_meta_types : env -> ?flags:unify_flags -> evar_map -> evar_map
+val w_unify_meta_types :
+  ?metas:clbinding Metamap.t ->
+  env -> ?flags:unify_flags -> evar_map -> evar_map
 
 (** [w_coerce_to_type env evd c ctyp typ] tries to coerce [c] of type
    [ctyp] so that its gets type [typ]; [typ] may contain metavariables *)
-val w_coerce_to_type : env -> evar_map -> constr -> types -> types ->
+val w_coerce_to_type :
+  ?metas:clbinding Metamap.t ->
+  env -> evar_map -> constr -> types -> types ->
   evar_map * constr
 
 (* Looking for subterms in contexts at some occurrences, possibly with pattern*)

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -91,7 +91,7 @@ type 'r abstraction_result =
 val make_abstraction : env -> evar_map -> constr ->
   abstraction_request -> 'r abstraction_result
 
-val pose_all_metas_as_evars : env -> evar_map -> constr -> evar_map * constr
+val pose_all_metas_as_evars : metas:clbinding Metamap.t -> env -> evar_map -> constr -> evar_map * clbinding Metamap.t * constr
 
 (*i This should be in another module i*)
 

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -49,29 +49,29 @@ val is_keyed_unification : unit -> bool
 (** The "unique" unification function *)
 val w_unify :
   ?metas:clbinding Metamap.t ->
-  env -> evar_map -> conv_pb -> ?flags:unify_flags -> constr -> constr -> evar_map
+  env -> evar_map -> conv_pb -> ?flags:unify_flags -> constr -> constr -> clbinding Metamap.t * evar_map
 
 (** [w_unify_to_subterm env m (c,t)] performs unification of [c] with a
    subterm of [t]. Constraints are added to [m] and the matched
    subterm of [t] is also returned. *)
 val w_unify_to_subterm :
   ?metas:clbinding Metamap.t ->
-  env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map * constr
+  env -> evar_map -> ?flags:unify_flags -> constr * constr -> (clbinding Metamap.t * evar_map) * constr
 
 val w_unify_to_subterm_all :
   ?metas:clbinding Metamap.t ->
-  env -> evar_map -> ?flags:unify_flags -> constr * constr -> evar_map list
+  env -> evar_map -> ?flags:unify_flags -> constr * constr -> (clbinding Metamap.t * evar_map) list
 
 val w_unify_meta_types :
   ?metas:clbinding Metamap.t ->
-  env -> ?flags:unify_flags -> evar_map -> evar_map
+  env -> ?flags:unify_flags -> evar_map -> clbinding Metamap.t * evar_map
 
 (** [w_coerce_to_type env evd c ctyp typ] tries to coerce [c] of type
    [ctyp] so that its gets type [typ]; [typ] may contain metavariables *)
 val w_coerce_to_type :
   ?metas:clbinding Metamap.t ->
   env -> evar_map -> constr -> types -> types ->
-  evar_map * constr
+  evar_map * clbinding Metamap.t * constr
 
 (* Looking for subterms in contexts at some occurrences, possibly with pattern*)
 
@@ -103,5 +103,5 @@ val abstract_list_all :
 
 (** {5 Meta-related functions} *)
 
-val meta_type : env -> evar_map -> Constr.metavariable -> types
-val meta_instance : env -> evar_map -> constr freelisted -> constr
+val meta_type : metas:clbinding Metamap.t -> env -> evar_map -> Constr.metavariable -> types
+val meta_instance : metas:clbinding Metamap.t -> env -> evar_map -> constr freelisted -> constr

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -93,3 +93,5 @@ val pose_all_metas_as_evars : env -> evar_map -> constr -> evar_map * constr
    (exported for inv.ml) *)
 val abstract_list_all :
   env -> evar_map -> constr -> constr -> constr list -> evar_map * (constr * types)
+
+val meta_type : env -> evar_map -> Constr.metavariable -> types

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -883,10 +883,12 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
     let sigma = pose_dependent_evars ~with_evars clenv.env clenv.evd (clenv_type clenv) in
     let sigma =
       if with_classes then
+        let metas = Evd.Meta.meta_list sigma in
         let sigma =
           Typeclasses.resolve_typeclasses ~filter:Typeclasses.all_evars
-            ~fail:(not with_evars) clenv.env sigma
+            ~fail:(not with_evars) clenv.env (Evd.Meta.clear_metas sigma)
         in
+        let sigma = Evd.Meta.set_metas sigma metas in
         (* After an apply, all the subgoals including those dependent shelved ones are in
           the hands of the user and resolution won't be called implicitely on them. *)
         Typeclasses.make_unresolvables (fun x -> true) sigma

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -43,14 +43,15 @@ type meta_arg = {
 type clausenv = {
   env      : env;
   evd      : evar_map;
+  metam    : clbinding Metamap.t;
   metas    : meta_arg list;
   templval : constr;
   metaset : Metaset.t;
   templtyp : constr freelisted;
 }
 
-let mk_clausenv env evd metas templval metaset templtyp = {
-  env; evd; metas; templval; metaset; templtyp;
+let mk_clausenv env evd metam metas templval metaset templtyp = {
+  env; evd; metam; metas; templval; metaset; templtyp;
 }
 
 let merge_fsorts evd clenv =
@@ -69,9 +70,9 @@ let merge_fsorts evd clenv =
   let uctx = (fsorts, Univ.Constraints.empty) in
   Evd.merge_context_set Evd.univ_flexible evd uctx
 
-let update_clenv_evd clenv evd =
+let update_clenv_evd clenv evd metam =
   let evd = merge_fsorts evd clenv in
-  mk_clausenv clenv.env evd clenv.metas clenv.templval clenv.metaset clenv.templtyp
+  mk_clausenv clenv.env evd metam clenv.metas clenv.templval clenv.metaset clenv.templtyp
 
 let strip_params env sigma c =
   match EConstr.kind sigma c with
@@ -99,7 +100,7 @@ let meta_handler sigma =
 
 let clenv_strip_proj_params clenv =
   let templval = strip_params clenv.env clenv.evd clenv.templval in
-  mk_clausenv clenv.env clenv.evd clenv.metas templval clenv.metaset clenv.templtyp
+  mk_clausenv clenv.env clenv.evd clenv.metam clenv.metas templval clenv.metaset clenv.templtyp
 
 let get_template env sigma c =
   let (hd, args) = EConstr.decompose_app sigma c in
@@ -114,35 +115,34 @@ let get_template env sigma c =
   | _ -> None
   | exception DestKO -> None
 
-let get_type_of_with_metas env sigma c =
+let get_type_of_with_metas ~metas env sigma c =
   let metas n =
-    try Some (Evd.Meta.meta_ftype sigma n).Evd.rebus
+    try Some (Evd.Meta.meta_ftype metas n).Evd.rebus
     with Not_found -> None
   in
   Retyping.get_type_of ~metas env sigma c
 
-let refresh_template_constraints env sigma ind c =
+let refresh_template_constraints ~metas env sigma ind c =
   let (mib, _) as spec = Inductive.lookup_mind_specif env ind in
   let (_, cstrs0) = (Option.get mib.mind_template).template_context in
   if Univ.Constraints.is_empty cstrs0 then sigma
   else
     let _, allargs = decompose_app sigma c in
-    let map c = { uj_val = c; uj_type = get_type_of_with_metas env sigma c } in
+    let map c = { uj_val = c; uj_type = get_type_of_with_metas ~metas env sigma c } in
     let allargs = Array.map map allargs in
     let sigma, univs = Typing.get_template_parameters env sigma ind allargs in
     let cstrs, _, _ = Inductive.instantiate_template_universes spec univs in
     Evd.add_constraints sigma cstrs
 
 let clenv_refresh env sigma ctx clenv =
-  let evd = Evd.Meta.meta_merge (Evd.Meta.meta_list clenv.evd) (Evd.Meta.clear_metas sigma) in
   match ctx with
   | Some ctx ->
     let (subst, ctx) = UnivGen.fresh_sort_context_instance ctx in
     let emap c = Vars.subst_univs_level_constr subst c in
-    let evd = Evd.merge_sort_context_set Evd.univ_flexible evd ctx in
+    let sigma = Evd.merge_sort_context_set Evd.univ_flexible sigma ctx in
     (* Only metas are mentioning the old universes. *)
     let map_fl cfl = { cfl with rebus = emap cfl.rebus } in
-    mk_clausenv env (Evd.Meta.map_metas emap evd) clenv.metas
+    mk_clausenv env sigma (Evd.Meta.map_metas emap clenv.metam) clenv.metas
       (emap clenv.templval)
       clenv.metaset
       (map_fl clenv.templtyp)
@@ -150,36 +150,36 @@ let clenv_refresh env sigma ctx clenv =
     (* We also refresh template arguments. This assumes that callers of
        {!clenv_refresh} use a freshly minted clenv, but this is the case as this
        function is only used by auto-like tactics for hint refresh. *)
-    let fold sigma marg = match marg.marg_templ with
-    | None -> sigma, marg
+    let fold (metas, sigma) marg = match marg.marg_templ with
+    | None -> (metas, sigma), marg
     | Some (decls, _) ->
       let sigma, s = Evd.new_univ_level_variable Evd.univ_flexible_alg sigma in
       let t = it_mkProd_or_LetIn (mkType (Univ.Universe.make s)) decls in
-      let name = Meta.meta_name sigma marg.marg_meta in
-      let sigma = Meta.meta_declare marg.marg_meta t ~name sigma in
-      sigma, { marg with marg_templ = Some (decls, s) }
+      let name = Meta.meta_name clenv.metam marg.marg_meta in
+      let metas = Meta.meta_declare marg.marg_meta t ~name metas in
+      (metas, sigma), { marg with marg_templ = Some (decls, s) }
     in
-    let evd, metas = List.fold_left_map fold evd clenv.metas in
+    let (metam, evd), metas = List.fold_left_map fold (clenv.metam, sigma) clenv.metas in
     let evd = match get_template env sigma clenv.templval with
     | None -> evd
-    | Some (ind, _) -> refresh_template_constraints env evd ind clenv.templval
+    | Some (ind, _) -> refresh_template_constraints ~metas:metam env evd ind clenv.templval
     in
-    mk_clausenv env evd metas clenv.templval clenv.metaset clenv.templtyp
+    mk_clausenv env evd metam metas clenv.templval clenv.metaset clenv.templtyp
 
 let clenv_evd ce =  ce.evd
 let clenv_arguments c = List.map (fun arg -> arg.marg_meta) c.metas
-let clenv_meta_list c = Evd.Meta.meta_list c.evd
+let clenv_meta_list c = c.metam
 
-let clenv_meta_type env sigma mv =
+let clenv_meta_type ~metas env sigma mv =
   let ty =
-    try Evd.Meta.meta_ftype sigma mv
+    try Evd.Meta.meta_ftype metas mv
     with Not_found -> anomaly Pp.(str "unknown meta ?" ++ str (Nameops.string_of_meta mv) ++ str ".") in
-  meta_instance env sigma ty
-let clenv_value clenv = meta_instance clenv.env clenv.evd { rebus = clenv.templval; freemetas = clenv.metaset }
-let clenv_type clenv = meta_instance clenv.env clenv.evd clenv.templtyp
+  meta_instance ~metas env sigma ty
+let clenv_value clenv = meta_instance ~metas:clenv.metam clenv.env clenv.evd { rebus = clenv.templval; freemetas = clenv.metaset }
+let clenv_type clenv = meta_instance ~metas:clenv.metam clenv.env clenv.evd clenv.templtyp
 
 let clenv_push_prod cl =
-  let metas = meta_handler (clenv_evd cl) in
+  let metas = meta_handler cl.metam in
   let typ = whd_all ~metas cl.env (clenv_evd cl) (clenv_type cl) in
   let rec clrec typ = match EConstr.kind cl.evd typ with
     | Cast (t,_,_) -> clrec t
@@ -187,7 +187,7 @@ let clenv_push_prod cl =
         let mv = new_meta () in
         let dep = not (noccurn (clenv_evd cl) 1 u) in
         let na' = if dep then na.binder_name else Anonymous in
-        let e' = Meta.meta_declare mv t ~name:na' cl.evd in
+        let e' = Meta.meta_declare mv t ~name:na' cl.metam in
         let concl = if dep then subst1 (mkMeta mv) u else u in
         let templval = applist (cl.templval, [mkMeta mv]) in
         let metaset = Metaset.add mv cl.metaset in
@@ -199,7 +199,8 @@ let clenv_push_prod cl =
         } in
         Some (mv, dep, { templval; metaset;
           templtyp = mk_freelisted concl;
-          evd = e';
+          evd = cl.evd;
+          metam = e';
           env = cl.env;
           metas = cl.metas @ [marg]; })
     | _ -> None
@@ -221,10 +222,10 @@ let clenv_push_prod cl =
 let clenv_environments env sigma template bound t =
   let open EConstr in
   let open Vars in
-  let rec clrec templ sigma metas n t =
+  let rec clrec templ sigma metam metas n t =
     match n, EConstr.kind sigma t with
-      | (Some 0, _) -> (sigma, List.rev metas, t)
-      | (n, Cast (t,_,_)) -> clrec templ sigma metas n t
+      | (Some 0, _) -> (metam, sigma, List.rev metas, t)
+      | (n, Cast (t,_,_)) -> clrec templ sigma metam metas n t
       | (n, Prod (na,t1,t2)) ->
           let mv = new_meta () in
           let dep = not (noccurn sigma 1 t2) in
@@ -238,29 +239,30 @@ let clenv_environments env sigma template bound t =
             let t1 = EConstr.it_mkProd_or_LetIn (EConstr.mkType (Univ.Universe.make s)) decls in
             sigma, t1, templ, Some (decls, s)
           in
-          let sigma = Meta.meta_declare mv t1 ~name:na' sigma in
+          let metam = Meta.meta_declare mv t1 ~name:na' metam in
           let t2 = if dep then (subst1 (mkMeta mv) t2) else t2 in
-          clrec templ sigma ((mv, dep, tmpl) :: metas) (Option.map ((+) (-1)) n) t2
-      | (n, LetIn (na,b,_,t)) -> clrec templ sigma metas n (subst1 b t)
-      | (n, _) -> (sigma, List.rev metas, t)
+          clrec templ sigma metam ((mv, dep, tmpl) :: metas) (Option.map ((+) (-1)) n) t2
+      | (n, LetIn (na,b,_,t)) -> clrec templ sigma metam metas n (subst1 b t)
+      | (n, _) -> (metam, sigma, List.rev metas, t)
   in
-  clrec template sigma [] bound t
+  clrec template sigma Metamap.empty [] bound t
 
 let mk_clenv_from_env env sigma n (c,cty) =
-  let evd = Meta.clear_metas sigma in
+  let evd = sigma in
   let template = get_template env sigma c in
   let template_args = match template with Some (_, args) -> args | None -> [] in
-  let (evd, args, concl) = clenv_environments env evd template_args n cty in
+  let (metas, evd, args, concl) = clenv_environments env evd template_args n cty in
   let map (mv, _, _) = mkMeta mv in
   let templval = mkApp (c, Array.map_of_list map args) in
   let evd = match template with
   | None -> evd
-  | Some (ind, _) -> refresh_template_constraints env evd ind templval
+  | Some (ind, _) -> refresh_template_constraints ~metas env evd ind templval
   in
   let metaset = Metaset.of_list (List.map pi1 args) in
   let map (mv, dep, tmpl) = { marg_meta = mv; marg_chain = None; marg_dep = dep; marg_templ = tmpl } in
   { templval; metaset;
     templtyp = mk_freelisted concl;
+    metam = metas;
     evd = evd;
     env = env;
     metas = List.map map args;
@@ -297,20 +299,20 @@ let error_incompatible_inst sigma mv  =
     anomaly ~label:"clenv_assign" (Pp.str "non dependent metavar already assigned.")
 
 (* TODO: replace by clenv_unify (mkMeta mv) rhs ? *)
-let clenv_assign env sigma mv rhs =
+let clenv_assign ~metas env sigma mv rhs =
   let rhs_fls = mk_freelisted rhs in
-  if Metaset.exists (mentions sigma mv) rhs_fls.freemetas then
+  if Metaset.exists (mentions metas mv) rhs_fls.freemetas then
     user_err Pp.(str "clenv_assign: circularity in unification");
   try
-    begin match Meta.meta_opt_fvalue sigma mv with
+    begin match Meta.meta_opt_fvalue metas mv with
     | Some (body, _) ->
       if not (EConstr.eq_constr sigma body.rebus rhs) then
-        error_incompatible_inst sigma mv
+        error_incompatible_inst metas mv
       else
-        sigma
+        sigma, metas
     | None ->
       let st = (Conv,TypeNotProcessed) in
-      Meta.meta_assign mv (rhs_fls.rebus, st) sigma
+      Meta.meta_assign mv (rhs_fls.rebus, st) metas sigma
     end
   with Not_found ->
     user_err Pp.(str "clenv_assign: undefined meta")
@@ -355,37 +357,37 @@ let clenv_assign env sigma mv rhs =
    In any case, we respect the order given in A.
 *)
 
-let clenv_metas_in_type_of_meta env sigma mv =
-  (mk_freelisted (meta_instance env sigma (Meta.meta_ftype sigma mv))).freemetas
+let clenv_metas_in_type_of_meta ~metas env sigma mv =
+  (mk_freelisted (meta_instance ~metas env sigma (Meta.meta_ftype metas mv))).freemetas
 
-let dependent_in_type_of_metas env sigma mvs =
+let dependent_in_type_of_metas ~metas env sigma mvs =
   List.fold_right
-    (fun mv -> Metaset.union (clenv_metas_in_type_of_meta env sigma mv))
+    (fun mv -> Metaset.union (clenv_metas_in_type_of_meta ~metas env sigma mv))
     mvs Metaset.empty
 
-let dependent_closure env sigma mvs =
+let dependent_closure ~metas env sigma mvs =
   let rec aux mvs acc =
     Metaset.fold
       (fun mv deps ->
-        let metas_of_meta_type = clenv_metas_in_type_of_meta env sigma mv in
+        let metas_of_meta_type = clenv_metas_in_type_of_meta ~metas env sigma mv in
         aux metas_of_meta_type (Metaset.union deps metas_of_meta_type))
       mvs acc in
   aux mvs mvs
 
-let undefined_metas evd =
+let undefined_metas metas =
   let fold n b accu = match b with
   | Clval(_,_,typ) -> accu
   | Cltyp (_,typ)  -> n :: accu
   in
-  let m = Metamap.fold fold (Evd.Meta.meta_list evd) [] in
+  let m = Metamap.fold fold metas [] in
   List.sort Int.compare m
 
-let clenv_dependent_gen hyps_only ?(iter=true) env sigma concl =
-  let all_undefined = undefined_metas sigma in
+let clenv_dependent_gen hyps_only ?(iter=true) ~metas env sigma concl =
+  let all_undefined = undefined_metas metas in
   let deps_in_concl = (mk_freelisted concl).freemetas in
-  let deps_in_hyps = dependent_in_type_of_metas env sigma all_undefined in
+  let deps_in_hyps = dependent_in_type_of_metas ~metas env sigma all_undefined in
   let deps_in_concl =
-    if hyps_only && iter then dependent_closure env sigma deps_in_concl
+    if hyps_only && iter then dependent_closure ~metas env sigma deps_in_concl
     else deps_in_concl in
   List.filter
     (fun mv ->
@@ -396,27 +398,29 @@ let clenv_dependent_gen hyps_only ?(iter=true) env sigma concl =
     all_undefined
 
 let clenv_missing ce =
-  let miss = clenv_dependent_gen true ce.env ce.evd (clenv_type ce) in
-  let miss = List.map (Evd.Meta.meta_name ce.evd) miss in
+  let miss = clenv_dependent_gen ~metas:ce.metam true ce.env ce.evd (clenv_type ce) in
+  let miss = List.map (Evd.Meta.meta_name ce.metam) miss in
   (miss, List.count (fun arg -> not arg.marg_dep) ce.metas)
 
 (******************************************************************)
 
 let clenv_unify ?(flags=default_unify_flags ()) cv_pb t1 t2 clenv =
-  let metas = Evd.Meta.meta_list clenv.evd in
-  update_clenv_evd clenv (w_unify ~metas ~flags clenv.env clenv.evd cv_pb t1 t2)
+  let metas = clenv.metam in
+  let metas, sigma = w_unify ~metas ~flags clenv.env clenv.evd cv_pb t1 t2 in
+  update_clenv_evd clenv sigma metas
 
 let clenv_unify_meta_types ?(flags=default_unify_flags ()) clenv =
-  let metas = Evd.Meta.meta_list clenv.evd in
-  update_clenv_evd clenv (w_unify_meta_types ~metas ~flags:flags clenv.env clenv.evd)
+  let metas = clenv.metam in
+  let metas, sigma = w_unify_meta_types ~metas ~flags:flags clenv.env clenv.evd in
+  update_clenv_evd clenv sigma metas
 
 let clenv_unique_resolver ?(flags=default_unify_flags ()) clenv concl =
-  let metas = meta_handler clenv.evd in
+  let metas = meta_handler clenv.metam in
   let (hd, _) = decompose_app clenv.evd (whd_nored ~metas clenv.env clenv.evd clenv.templtyp.rebus) in
   let clenv = if isMeta clenv.evd hd then clenv_unify_meta_types ~flags clenv else clenv in
   clenv_unify CUMUL ~flags (clenv_type clenv) concl clenv
 
-let adjust_meta_source evd mv = function
+let adjust_meta_source ~metas evd mv = function
   | loc,Evar_kinds.VarInstance id ->
     let rec match_name c l =
       match EConstr.kind evd c, l with
@@ -430,12 +434,12 @@ let adjust_meta_source evd mv = function
         let f,l = decompose_app_list evd t.rebus in
         match EConstr.kind evd f with
         | Meta mv'' ->
-          (match Meta.meta_opt_fvalue evd mv'' with
+          (match Meta.meta_opt_fvalue metas mv'' with
           | Some (c,_) -> match_name c.rebus l
           | None -> None)
         | _ -> None
       else None in
-    let id = Option.default id (List.find_map f (Evd.Metamap.bindings (Evd.Meta.meta_list evd))) in
+    let id = Option.default id (List.find_map f (Evd.Metamap.bindings metas)) in
     loc,Evar_kinds.VarInstance id
   | src -> src
 
@@ -466,21 +470,21 @@ let adjust_meta_source evd mv = function
    then making the numeric order match the dependency order.
 *)
 
-let clenv_pose_metas_as_evars env sigma dep_mvs =
-  let rec fold sigma = function
-  | [] -> sigma
+let clenv_pose_metas_as_evars ~metas env sigma dep_mvs =
+  let rec fold metas sigma = function
+  | [] -> metas, sigma
   | mv::mvs ->
-      let ty = clenv_meta_type env sigma mv in
+      let ty = clenv_meta_type ~metas env sigma mv in
       (* Postpone the evar-ization if dependent on another meta *)
       (* This assumes no cycle in the dependencies - is it correct ? *)
-      if occur_meta sigma ty then fold sigma (mvs@[mv])
+      if occur_meta sigma ty then fold metas sigma (mvs@[mv])
       else
-        let src = Meta.evar_source_of_meta mv sigma in
-        let src = adjust_meta_source sigma mv src in
+        let src = Meta.evar_source_of_meta mv metas in
+        let src = adjust_meta_source ~metas sigma mv src in
         let (sigma, evar) = new_evar env sigma ~src ty in
-        let sigma = clenv_assign env sigma mv evar in
-        fold sigma mvs in
-  fold sigma dep_mvs
+        let sigma, metas = clenv_assign ~metas env sigma mv evar in
+        fold metas sigma mvs in
+  fold metas sigma dep_mvs
 
 (******************************************************************)
 
@@ -516,8 +520,9 @@ let clenv_instantiate ?(flags=fchain_flags ()) ?submetas mv clenv (c, ty) =
   let clenv, c = match submetas with
   | None -> clenv, c
   | Some metas ->
-    let evd = Meta.meta_merge (Metamap.of_list metas) clenv.evd in
-    let clenv = update_clenv_evd clenv evd in
+    let fold accu (mv, cl) = Metamap.add mv cl accu in
+    let metam = List.fold_left fold clenv.metam metas in
+    let clenv = update_clenv_evd clenv clenv.evd metam in
     let c = applist (c, List.map (fun (mv, _) -> mkMeta mv) metas) in
     let map arg =
       if Int.equal mv arg.marg_meta then
@@ -530,9 +535,9 @@ let clenv_instantiate ?(flags=fchain_flags ()) ?submetas mv clenv (c, ty) =
     { clenv with metas = metas }, c
   in
   (* unify the type of the template of [nextclenv] with the type of [mv] *)
-  let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type clenv.env clenv.evd mv) clenv in
-  let evd = clenv_assign clenv.env clenv.evd mv c in
-  update_clenv_evd clenv evd
+  let clenv = clenv_unify ~flags CUMUL ty (clenv_meta_type ~metas:clenv.metam clenv.env clenv.evd mv) clenv in
+  let evd, metam = clenv_assign ~metas:clenv.metam clenv.env clenv.evd mv c in
+  update_clenv_evd clenv evd metam
 
 (***************************************************************)
 (* Bindings *)
@@ -546,7 +551,7 @@ let clenv_instantiate ?(flags=fchain_flags ()) ?submetas mv clenv (c, ty) =
 let clenv_independent clenv =
   let mvs = collect_metas clenv.evd (clenv_value clenv) in
   let ctyp_mvs = (mk_freelisted (clenv_type clenv)).freemetas in
-  let deps = Metaset.union (dependent_in_type_of_metas clenv.env clenv.evd mvs) ctyp_mvs in
+  let deps = Metaset.union (dependent_in_type_of_metas ~metas:clenv.metam clenv.env clenv.evd mvs) ctyp_mvs in
   List.filter (fun mv -> not (Metaset.mem mv deps)) mvs
 
 let qhyp_eq h1 h2 = match h1, h2 with
@@ -575,7 +580,7 @@ let explain_no_such_bound_variable mvl {CAst.v=id;loc} =
   in
   user_err ?loc (str "No such bound variable " ++ Id.print id ++ spc () ++ expl)
 
-let meta_with_name evd ({CAst.v=id} as lid) =
+let meta_with_name metas ({CAst.v=id} as lid) =
   let na = Name id in
   let fold n clb (l1, l2 as l) =
     let (na',def) = match clb with
@@ -585,7 +590,7 @@ let meta_with_name evd ({CAst.v=id} as lid) =
     if Name.equal na na' then if def then (n::l1,l2) else (n::l1,n::l2)
     else l
   in
-  let (mvl, mvnodef) = Evd.Metamap.fold fold (Evd.Meta.meta_list evd) ([], []) in
+  let (mvl, mvnodef) = Evd.Metamap.fold fold metas ([], []) in
   match List.rev mvnodef, List.rev mvl with
     | _,[]  ->
       let fold n clb l =
@@ -595,13 +600,13 @@ let meta_with_name evd ({CAst.v=id} as lid) =
         in
         if na != Anonymous then Name.get_id na :: l else l
       in
-      let mvl = List.rev (Evd.Metamap.fold fold (Evd.Meta.meta_list evd) []) in
+      let mvl = List.rev (Evd.Metamap.fold fold metas []) in
       explain_no_such_bound_variable mvl lid
     | (n::_,_|_,n::_) ->
         n
 
 let meta_of_binder clause loc mvs = function
-  | NamedHyp s -> meta_with_name clause.evd s
+  | NamedHyp s -> meta_with_name clause.metam s
   | AnonHyp n ->
       try List.nth mvs (n-1)
       with (Failure _|Invalid_argument _) ->
@@ -617,29 +622,28 @@ let error_already_defined b =
         anomaly
           Pp.(str "Position " ++ int n ++ str" already defined.")
 
-let clenv_unify_binding_type env sigma c t u =
-  let metas = meta_handler sigma in
-  if isMeta sigma (fst (decompose_app sigma (whd_nored ~metas env sigma u))) then
+let clenv_unify_binding_type ~metas env sigma c t u =
+  if isMeta sigma (fst (decompose_app sigma (whd_nored ~metas:(meta_handler metas) env sigma u))) then
     (* Not enough information to know if some subtyping is needed *)
-    CoerceToType, sigma, c
+    CoerceToType, metas, sigma, c
   else
     (* Enough information so as to try a coercion now *)
     try
-      let metas = Evd.Meta.meta_list sigma in
-      let sigma, c = w_coerce_to_type ~metas env sigma c t u in
-      TypeProcessed, sigma, c
+      let sigma, metas, c = w_coerce_to_type ~metas env sigma c t u in
+      TypeProcessed, metas, sigma, c
     with
       | PretypeError (_,_,ActualTypeNotCoercible (_,_,
           (NotClean _ | ConversionFailed _))) as e ->
           raise e
       | e when precatchable_exception e ->
-          TypeNotProcessed, sigma, c
+          TypeNotProcessed, metas, sigma, c
 
 let clenv_assign_binding clenv k c =
-  let k_typ = hnf_constr clenv.env clenv.evd (clenv_meta_type clenv.env clenv.evd k) in
+  let k_typ = hnf_constr clenv.env clenv.evd (clenv_meta_type ~metas:clenv.metam clenv.env clenv.evd k) in
   let c_typ = nf_betaiota clenv.env clenv.evd (Retyping.get_type_of clenv.env clenv.evd c) in
-  let status, sigma, c = clenv_unify_binding_type clenv.env clenv.evd c c_typ k_typ in
-  update_clenv_evd clenv (Meta.meta_assign k (c, (Conv, status)) sigma)
+  let status, metas, sigma, c = clenv_unify_binding_type ~metas:clenv.metam clenv.env clenv.evd c c_typ k_typ in
+  let sigma, metas = Meta.meta_assign k (c, (Conv, status)) metas sigma in
+  update_clenv_evd clenv sigma metas
 
 let clenv_match_args bl clenv =
   if List.is_empty bl then
@@ -650,7 +654,7 @@ let clenv_match_args bl clenv =
     List.fold_left
       (fun clenv {CAst.loc;v=(b,c)} ->
         let k = meta_of_binder clenv loc mvs b in
-        match Meta.meta_opt_fvalue clenv.evd k with
+        match Meta.meta_opt_fvalue clenv.metam k with
         | Some (body, _) ->
           if EConstr.eq_constr clenv.evd body.rebus c then clenv
           else error_already_defined b
@@ -667,13 +671,13 @@ let clenv_constrain_dep_args hyps_only bl clenv =
   if List.is_empty bl then
     clenv
   else
-    let occlist = clenv_dependent_gen hyps_only clenv.env clenv.evd (clenv_type clenv) in
+    let occlist = clenv_dependent_gen ~metas:clenv.metam hyps_only clenv.env clenv.evd (clenv_type clenv) in
     if Int.equal (List.length occlist) (List.length bl) then
       List.fold_left2 clenv_assign_binding clenv occlist bl
     else
       if hyps_only then
         (* Tolerance for compatibility <= 8.3 *)
-        let occlist' = clenv_dependent_gen hyps_only ~iter:false clenv.env clenv.evd (clenv_type clenv) in
+        let occlist' = clenv_dependent_gen ~metas:clenv.metam hyps_only ~iter:false clenv.env clenv.evd (clenv_type clenv) in
         if Int.equal (List.length occlist') (List.length bl) then
           List.fold_left2 clenv_assign_binding clenv occlist' bl
         else
@@ -681,16 +685,16 @@ let clenv_constrain_dep_args hyps_only bl clenv =
       else
         error_not_right_number_missing_arguments (List.length occlist)
 
-let pose_dependent_evars ?(with_evars=false) env sigma concl =
-  let dep_mvs = clenv_dependent_gen false env sigma concl in
+let pose_dependent_evars ?(with_evars=false) ~metas env sigma concl =
+  let dep_mvs = clenv_dependent_gen ~metas false env sigma concl in
   if not (List.is_empty dep_mvs) && not with_evars then
     raise
-      (RefinerError (env, sigma, UnresolvedBindings (List.map (Meta.meta_name sigma) dep_mvs)));
-  clenv_pose_metas_as_evars env sigma dep_mvs
+      (RefinerError (env, sigma, UnresolvedBindings (List.map (Meta.meta_name metas) dep_mvs)));
+  clenv_pose_metas_as_evars ~metas env sigma dep_mvs
 
 let clenv_pose_dependent_evars ?with_evars clenv =
-  let sigma = pose_dependent_evars ?with_evars clenv.env clenv.evd (clenv_type clenv) in
-  update_clenv_evd clenv sigma
+  let metas, sigma = pose_dependent_evars ?with_evars ~metas:clenv.metam clenv.env clenv.evd (clenv_type clenv) in
+  update_clenv_evd clenv sigma metas
 
 type case_node = (case_info * EInstance.t * EConstr.t array * EConstr.case_return * EConstr.case_invert * EConstr.t)
 
@@ -763,13 +767,13 @@ let mk_goal evars hyps concl =
   let ev = EConstr.mkEvar (evk,inst) in
   (evk, ev, evars)
 
-let rec mk_refgoals env sigma goalacc conclty trm = match trm with
+let rec mk_refgoals ~metas env sigma goalacc conclty trm = match trm with
 | RfGround trm ->
   let ty = Retyping.get_type_of env sigma trm in
   (goalacc, ty, sigma, trm)
 | RfHole mv ->
   let conclty = match conclty with
-  | None -> Unification.meta_type env sigma mv
+  | None -> Unification.meta_type ~metas env sigma mv
   | Some conclty -> conclty
   in
   let conclty = nf_betaiota env sigma conclty in
@@ -786,24 +790,23 @@ let rec mk_refgoals env sigma goalacc conclty trm = match trm with
       type_of_global_reference_knowing_parameters env sigma f args
     in
     goalacc, ty, sigma, f
-  | _ -> mk_refgoals env sigma goalacc None f
+  | _ -> mk_refgoals ~metas env sigma goalacc None f
   in
-  let ((acc'',conclty',sigma), args) = mk_arggoals env sigma acc' hdty l in
+  let ((acc'',conclty',sigma), args) = mk_arggoals ~metas env sigma acc' hdty l in
   let ans = EConstr.applist (applicand, args) in
   (acc'', conclty', sigma, ans)
 | RfProj (p, r, c) ->
-  let (acc',cty,sigma,c') = mk_refgoals env sigma goalacc None c in
+  let (acc',cty,sigma,c') = mk_refgoals ~metas env sigma goalacc None c in
   let c = EConstr.mkProj (p, r, c') in
   let ty = get_type_of env sigma c in
   (acc',ty,sigma,c)
 
-and mk_arggoals env sigma goalacc funty allargs =
+and mk_arggoals ~metas env sigma goalacc funty allargs =
   let foldmap (goalacc, funty, sigma) harg =
-    let metas = meta_handler sigma in
-    let t = whd_all ~metas env sigma funty in
+    let t = whd_all ~metas:(meta_handler metas) env sigma funty in
     match EConstr.kind sigma t with
     | Prod (_, c1, b) ->
-      let (acc, hargty, sigma, arg) = mk_refgoals env sigma goalacc (Some c1) harg in
+      let (acc, hargty, sigma, arg) = mk_refgoals ~metas env sigma goalacc (Some c1) harg in
       (acc, EConstr.Vars.subst1 arg b, sigma), arg
     | _ ->
       raise (RefinerError (env,sigma,CannotApply (t, as_constr harg)))
@@ -825,9 +828,9 @@ let treat_case env sigma ci lbrty accu =
   in
   Array.fold_left_map fold (sigma, accu) lbrty
 
-let std_refine env sigma cl r =
+let std_refine ~metas env sigma cl r =
   let r = make_proof env sigma r in
-  let (sgl, _, sigma, trm) = mk_refgoals env sigma [] (Some cl) r in
+  let (sgl, _, sigma, trm) = mk_refgoals ~metas env sigma [] (Some cl) r in
   (sigma, sgl, trm)
 
 (***********************************************)
@@ -851,10 +854,8 @@ let refiner_gen is_case =
     let ans = EConstr.mkCase (ci, u, pms, p, iv, c, lf) in
     (sigma, accu, ans)
   | Std (metas, r) ->
-    let sigma = Evd.Meta.meta_merge metas sigma in
-    std_refine env sigma cl r
+    std_refine ~metas  env sigma cl r
   in
-  let sigma = Evd.Meta.clear_metas sigma in
   let map gl = Proofview.goal_with_state gl st in
   let sgl = List.rev_map map sgl in
   let evk = Proofview.Goal.goal gl in
@@ -870,8 +871,7 @@ let refiner_gen is_case =
 
 let refiner clenv =
   let r = clenv_value clenv in
-  let metas = Evd.Meta.meta_list clenv.evd in
-  refiner_gen (Std (metas, r))
+  refiner_gen (Std (clenv.metam, r))
 
 end
 
@@ -883,25 +883,22 @@ let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
   Proofview.Goal.enter begin fun gl ->
     let concl = Proofview.Goal.concl gl in
     let clenv = clenv_unique_resolver ~flags clenv concl in
-    let sigma = pose_dependent_evars ~with_evars clenv.env clenv.evd (clenv_type clenv) in
+    let metas, sigma = pose_dependent_evars ~with_evars ~metas:clenv.metam clenv.env clenv.evd (clenv_type clenv) in
     let sigma =
       if with_classes then
-        let metas = Evd.Meta.meta_list sigma in
         let sigma =
           Typeclasses.resolve_typeclasses ~filter:Typeclasses.all_evars
-            ~fail:(not with_evars) clenv.env (Evd.Meta.clear_metas sigma)
+            ~fail:(not with_evars) clenv.env sigma
         in
-        let sigma = Evd.Meta.set_metas sigma metas in
         (* After an apply, all the subgoals including those dependent shelved ones are in
           the hands of the user and resolution won't be called implicitely on them. *)
         Typeclasses.make_unresolvables (fun x -> true) sigma
       else sigma
     in
-    let clenv = update_clenv_evd clenv sigma in
-    let metas = Evd.Meta.meta_list clenv.evd in
+    let clenv = update_clenv_evd clenv sigma metas in
     let r = clenv_value clenv in
     Proofview.tclTHEN
-      (Proofview.Unsafe.tclEVARS (Evd.Meta.clear_metas sigma))
+      (Proofview.Unsafe.tclEVARS sigma)
       (Internal.refiner_gen (Std (metas, r)))
   end
 
@@ -969,7 +966,6 @@ let case_pf ?(with_evars=false) ~dep (indarg, typ) =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
-  let sigma = Meta.clear_metas sigma in
   (* Extract inductive data from the argument. *)
   let hd, args = decompose_app sigma typ in
   (* Workaround to #5645: reduce_to_atomic_ind produces ill-typed terms *)
@@ -988,15 +984,13 @@ let case_pf ?(with_evars=false) ~dep (indarg, typ) =
   (* Extract the return clause using unification with the conclusion *)
   let typP = Inductiveops.make_arity env sigma dep indf s in
   let mvP = new_meta () in
-  let sigma = Meta.meta_declare mvP typP sigma in
+  let metas = Meta.meta_declare mvP typP Metamap.empty in
   let depargs = Array.append indices [|indarg|] in
   let templtyp = if dep then mkApp (mkMeta mvP, depargs) else mkApp (mkMeta mvP, indices) in
   let flags = elim_flags () in
-  let metas = Evd.Meta.meta_list sigma in
-  let sigma = w_unify_meta_types ~metas ~flags env sigma in
-  let metas = Evd.Meta.meta_list sigma in
-  let sigma = w_unify ~metas ~flags env sigma CUMUL templtyp concl in
-  let pred = meta_instance env sigma (mk_freelisted (mkMeta mvP)) in
+  let metas, sigma = w_unify_meta_types ~metas ~flags env sigma in
+  let metas, sigma = w_unify ~metas ~flags env sigma CUMUL templtyp concl in
+  let pred = meta_instance ~metas env sigma (mk_freelisted (mkMeta mvP)) in
 
   (* Create the branch types *)
   let branches =
@@ -1025,8 +1019,7 @@ let case_pf ?(with_evars=false) ~dep (indarg, typ) =
   in
   let sigma = Typeclasses.make_unresolvables (fun x -> true) sigma in
   (* Note that the environment rel context does not matter for betaiota *)
-  let metas = meta_handler sigma in
-  let rec nf_betaiota c = EConstr.map sigma nf_betaiota (whd_betaiota ~metas env sigma c) in
+  let rec nf_betaiota c = EConstr.map sigma nf_betaiota (whd_betaiota ~metas:(meta_handler metas) env sigma c) in
   (* Call the legacy refiner on the result *)
   let arg = match body with
   | RealCase (ci, u, pms, (p,r), iv, c) ->
@@ -1037,12 +1030,11 @@ let case_pf ?(with_evars=false) ~dep (indarg, typ) =
   | PrimitiveEta args ->
     let mv = new_meta () in
     let (ctx, t) = branches.(0) in
-    let sigma = Meta.meta_declare mv (it_mkProd_or_LetIn t ctx) sigma in
-    let metas = Evd.Meta.meta_list sigma in
+    let metas = Meta.meta_declare mv (it_mkProd_or_LetIn t ctx) metas in
     Internal.Std (metas, mkApp (mkMeta mv, Array.map nf_betaiota args))
   in
   Proofview.tclTHEN
-    (Proofview.Unsafe.tclEVARS (Evd.Meta.clear_metas sigma))
+    (Proofview.Unsafe.tclEVARS sigma)
     (Internal.refiner_gen arg)
   end
 
@@ -1078,11 +1070,11 @@ let fail_quick_unif_flags = {
 let unify ?(flags=fail_quick_unif_flags) ~cv_pb m =
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.pf_env gl in
+    let sigma = Proofview.Goal.sigma gl in
     let n = Tacmach.pf_concl gl in
-    let evd = Meta.clear_metas (Tacmach.project gl) in
     try
-      let evd' = w_unify env evd cv_pb ~flags m n in
-        Proofview.Unsafe.tclEVARSADVANCE evd'
+      let _, sigma = w_unify ~metas:Metamap.empty env sigma cv_pb ~flags m n in
+      Proofview.Unsafe.tclEVARSADVANCE sigma
     with e when CErrors.noncritical e ->
       let info = Exninfo.reify () in
       Proofview.tclZERO ~info e

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -126,10 +126,11 @@ let clenv_refresh env sigma ctx clenv =
     let emap c = Vars.subst_univs_level_constr subst c in
     let evd = Evd.merge_sort_context_set Evd.univ_flexible evd ctx in
     (* Only metas are mentioning the old universes. *)
+    let map_fl cfl = { cfl with rebus = emap cfl.rebus } in
     mk_clausenv env (Evd.Meta.map_metas emap evd) clenv.metas
       (emap clenv.templval)
       clenv.metaset
-      (Evd.map_fl emap clenv.templtyp)
+      (map_fl clenv.templtyp)
   | None ->
     (* We also refresh template arguments. This assumes that callers of
        {!clenv_refresh} use a freshly minted clenv, but this is the case as this
@@ -747,7 +748,7 @@ let rec mk_refgoals env sigma goalacc conclty trm = match trm with
   (goalacc, ty, sigma, trm)
 | RfHole mv ->
   let conclty = match conclty with
-  | None -> Typing.meta_type env sigma mv
+  | None -> Unification.meta_type env sigma mv
   | Some conclty -> conclty
   in
   let conclty = nf_betaiota env sigma conclty in

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -26,7 +26,7 @@ val clenv_evd : clausenv -> Evd.evar_map
 val clenv_meta_list : clausenv -> clbinding Metamap.t
 
 (* Ad-hoc primitives *)
-val update_clenv_evd : clausenv -> evar_map -> clausenv
+val update_clenv_evd : clausenv -> evar_map -> clbinding Metamap.t -> clausenv
 val clenv_strip_proj_params : clausenv -> clausenv
 val clenv_refresh : env -> evar_map -> UnivGen.sort_context_set option -> clausenv -> clausenv
 val clenv_arguments : clausenv -> metavariable list

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -74,7 +74,7 @@ let exact h =
     let concl = Proofview.Goal.concl gl in
     if occur_existential sigma t || occur_existential sigma concl then
       try
-        let sigma = Unification.w_unify env sigma CONV ~flags:auto_unif_flags concl t in
+        let _, sigma = Unification.w_unify env sigma CONV ~flags:auto_unif_flags concl t in
         Proofview.Unsafe.tclEVARSADVANCE sigma <*>
         exact_no_check c
       with e when CErrors.noncritical e -> Proofview.tclZERO e

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1004,7 +1004,7 @@ module Search = struct
     in
     let evm = Evd.set_typeclass_evars evm Evar.Set.empty in
     let evm = Evd.push_future_goals evm in
-    evm, Evd.meta_list evm, sorted_goals
+    evm, Evd.Meta.meta_list evm, sorted_goals
 
 
   let run_on_goals env evm tac ~goals =
@@ -1056,7 +1056,7 @@ module Search = struct
     in
     (* FIXME: the need to merge metas seems to come from this being called
        internally from Unification. It should be handled there instead. *)
-    let sigma = Evd.meta_merge old_metas (Evd.clear_metas sigma) in
+    let sigma = Evd.Meta.meta_merge old_metas (Evd.Meta.clear_metas sigma) in
     let sigma = Evd.set_typeclass_evars sigma nongoals in
     let () = ppdebug 1 (fun () ->
         str"New typeclass evars are: " ++

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1004,7 +1004,7 @@ module Search = struct
     in
     let evm = Evd.set_typeclass_evars evm Evar.Set.empty in
     let evm = Evd.push_future_goals evm in
-    evm, Evd.Meta.meta_list evm, sorted_goals
+    evm, sorted_goals
 
 
   let run_on_goals env evm tac ~goals =
@@ -1036,7 +1036,7 @@ module Search = struct
     let evm' = Proofview.return pv' in
     (finished, evm')
 
-  let post_process_goals ~goals ~nongoals ~old_metas ~sigma ~finished =
+  let post_process_goals ~goals ~nongoals ~sigma ~finished =
     let _, sigma = Evd.pop_future_goals sigma in
     let tc_evars = Evd.get_typeclass_evars sigma in
     let () = ppdebug 1 (fun () ->
@@ -1054,9 +1054,6 @@ module Search = struct
           | Some ev -> Evar.Set.add ev acc
           | None -> acc) (Evar.Set.union goals nongoals) tc_evars
     in
-    (* FIXME: the need to merge metas seems to come from this being called
-       internally from Unification. It should be handled there instead. *)
-    let sigma = Evd.Meta.meta_merge old_metas (Evd.Meta.clear_metas sigma) in
     let sigma = Evd.set_typeclass_evars sigma nongoals in
     let () = ppdebug 1 (fun () ->
         str"New typeclass evars are: " ++
@@ -1230,9 +1227,9 @@ let resolve_all_evars depth unique env p oevd fail =
           match evars_to_goals p evd with
           | Some (goals, nongoals) ->
             let solver = find_solver env evd comp in
-            let evd, old_metas, sorted_goals = Search.preprocess_goals evd goals in
+            let evd, sorted_goals = Search.preprocess_goals evd goals in
             let finished, evd = solver.solver env evd ~goals:sorted_goals ~best_effort:true ~depth ~unique in
-            let evd = Search.post_process_goals ~goals ~nongoals ~old_metas ~sigma:evd ~finished in
+            let evd = Search.post_process_goals ~goals ~nongoals ~sigma:evd ~finished in
             if has_undefined p oevd evd then
               let () = if finished then ppdebug 1 (fun () ->
                   str"Proof is finished but there remain undefined evars: " ++

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -267,7 +267,7 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
       general_elim_clause with_evars flags cls (submetas, c, Clenv.clenv_type rew) elim
       end
     in
-    Proofview.Unsafe.tclEVARS (Evd.Meta.clear_metas (Clenv.clenv_evd rew)) <*>
+    Proofview.Unsafe.tclEVARS (Clenv.clenv_evd rew) <*>
     elim_wrapper cls rewrite_elim
   in
   let strat, tac =
@@ -286,8 +286,8 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
     in
     let ty = it_mkProd_or_LetIn (applist (eqn, args)) ctx in
     let eqclause = Clenv.make_clenv_binding env sigma (c, ty) l in
-    let try_clause evd' =
-      let clenv = Clenv.update_clenv_evd eqclause evd' in
+    let try_clause (metas, evd') =
+      let clenv = Clenv.update_clenv_evd eqclause evd' metas in
       let clenv = Clenv.clenv_pose_dependent_evars ~with_evars:true clenv in
       side_tac (general_elim_clause0 clenv) tac
     in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -137,7 +137,8 @@ let instantiate_lemma_all env flags eqclause l2r concl =
   let () = if arglen < 2 then user_err Pp.(str "The term provided is not an applied relation.") in
   let c1 = args.(arglen - 2) in
   let c2 = args.(arglen - 1) in
-  w_unify_to_subterm_all ~flags env (Clenv.clenv_evd eqclause)
+  let metas = Clenv.clenv_meta_list eqclause in
+  w_unify_to_subterm_all ~metas ~flags env (Clenv.clenv_evd eqclause)
     ((if l2r then c1 else c2),concl)
 
 let rewrite_conv_closed_core_unif_flags = {

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -266,7 +266,7 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
       general_elim_clause with_evars flags cls (submetas, c, Clenv.clenv_type rew) elim
       end
     in
-    Proofview.Unsafe.tclEVARS (Evd.clear_metas (Clenv.clenv_evd rew)) <*>
+    Proofview.Unsafe.tclEVARS (Evd.Meta.clear_metas (Clenv.clenv_evd rew)) <*>
     elim_wrapper cls rewrite_elim
   in
   let strat, tac =

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1297,8 +1297,9 @@ let use_bindings env sigma elim must_be_closed (c,lbind) typ =
       if must_be_closed && occur_meta (clenv_evd indclause) (clenv_value indclause) then
         error NeedFullyAppliedArgument;
       (* We lose the possibility of coercions in with-bindings *)
-      let sigma, term = pose_all_metas_as_evars env (clenv_evd indclause) (clenv_value indclause) in
-      let sigma, typ = pose_all_metas_as_evars env sigma (clenv_type indclause) in
+      let metas = Clenv.clenv_meta_list indclause in
+      let sigma, metas, term = pose_all_metas_as_evars ~metas env (clenv_evd indclause) (clenv_value indclause) in
+      let sigma, metas, typ = pose_all_metas_as_evars ~metas env sigma (clenv_type indclause) in
       sigma, term, typ
     with e when noncritical e ->
     match red_product env sigma typ with

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -713,7 +713,7 @@ let symmetry env sort rew =
 let unify_eqn (car, rel, prf, c1, c2, holes, sort) l2r flags env (sigma, cstrs) by t =
   try
     let left = if l2r then c1 else c2 in
-    let sigma = Unification.w_unify ~flags env sigma CONV left t in
+    let _, sigma = Unification.w_unify ~flags env sigma CONV left t in
     let sigma = TC.resolve_typeclasses ~filter:(no_constraints cstrs)
       ~fail:true env sigma in
     let sigma = solve_remaining_by env sigma holes by in
@@ -742,7 +742,7 @@ let unify_abs (car, rel, prf, c1, c2) l2r sort env (sigma, cstrs) t =
        basically an eq_constr, except when preexisting evars occur in
        either the lemma or the goal, in which case the eq_constr also
        solved this evars *)
-    let sigma = Unification.w_unify ~flags:rewrite_unif_flags env sigma CONV left t in
+    let _, sigma = Unification.w_unify ~flags:rewrite_unif_flags env sigma CONV left t in
     let rew_evars = sigma, cstrs in
     let rew_prf = RewPrf (rel, prf) in
     let rew = { rew_car = car; rew_from = c1; rew_to = c2; rew_prf; rew_evars; } in
@@ -1414,7 +1414,7 @@ module Strategies =
         | Some c -> c
         in
           try
-            let sigma = Unification.w_unify env sigma CONV ~flags:(Unification.elim_flags ()) unfolded t in
+            let _, sigma = Unification.w_unify env sigma CONV ~flags:(Unification.elim_flags ()) unfolded t in
             let c' = Reductionops.nf_evar sigma c in
               state, Success { rew_car = ty; rew_from = t; rew_to = c';
                                   rew_prf = RewCast DEFAULTcast;
@@ -1828,7 +1828,7 @@ let default_morphism env sigma sign m =
 
 (* Find a subterm which matches the pattern to rewrite for "rewrite" *)
 let unification_rewrite l2r c1 c2 sigma prf car rel but env =
-  let (sigma,c') =
+  let ((_, sigma), c') =
     try
       (* ~flags:(false,true) to allow to mark occurrences that must not be
          rewritten simply by replacing them with let-defined definitions

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1478,7 +1478,7 @@ let clenv_refine_in with_evars targetid replace env sigma0 clenv =
   if not with_evars then check_unresolved_evars_of_metas sigma0 clenv;
   let [@ocaml.warning "-3"] exact_tac = Clenv.Internal.refiner clenv in
   let naming = NamingMustBe (CAst.make targetid) in
-  Proofview.Unsafe.tclEVARS (clear_metas evd) <*>
+  Proofview.Unsafe.tclEVARS (Meta.clear_metas evd) <*>
   Proofview.Goal.enter begin fun gl ->
     let id = find_name replace (LocalAssum (make_annot Anonymous Sorts.Relevant, new_hyp_typ)) naming gl in
     Tacticals.tclTHENLAST (internal_cut replace id new_hyp_typ <*> Proofview.cycle 1) exact_tac
@@ -1586,7 +1586,7 @@ let general_elim with_evars clear_flag (c, lbindc) elim =
   let flags = elim_flags () in
   let metas = clenv_meta_list indclause in
   let submetas = List.map (fun mv -> mv, Metamap.find mv metas) (clenv_arguments indclause) in
-  Proofview.Unsafe.tclEVARS (Evd.clear_metas (clenv_evd indclause)) <*>
+  Proofview.Unsafe.tclEVARS (Evd.Meta.clear_metas (clenv_evd indclause)) <*>
   Tacticals.tclTHEN
     (general_elim_clause0 with_evars flags (submetas, c, clenv_type indclause) elim)
     (apply_clear_request clear_flag (use_clear_hyp_by_default ()) id)
@@ -1625,13 +1625,13 @@ let general_case_analysis_in_context with_evars clear_flag (c,lbindc) =
     let (sigma, ev) = Evarutil.new_evar env sigma argtype in
     let _, sigma = Evd.pop_future_goals sigma in
     let evk, _ = destEvar sigma ev in
-    let indclause = Clenv.update_clenv_evd indclause (meta_merge (Clenv.clenv_meta_list indclause) sigma) in
+    let indclause = Clenv.update_clenv_evd indclause (Meta.meta_merge (Clenv.clenv_meta_list indclause) sigma) in
     Proofview.Unsafe.tclEVARS sigma <*>
     Proofview.Unsafe.tclNEWGOALS ~before:true [Proofview.goal_with_state evk state] <*>
     Proofview.tclDISPATCH [Clenv.res_pf ~with_evars:true indclause; tclIDTAC] <*>
     Proofview.tclEXTEND [] tclIDTAC [Clenv.case_pf ~with_evars ~dep (ev, argtype)]
   in
-  let sigma = Evd.clear_metas (clenv_evd indclause) in
+  let sigma = Evd.Meta.clear_metas (clenv_evd indclause) in
   Tacticals.tclTHENLIST [
     Tacticals.tclWITHHOLES with_evars tac sigma;
     apply_clear_request clear_flag (use_clear_hyp_by_default ()) id;

--- a/test-suite/bugs/bug_19803.v
+++ b/test-suite/bugs/bug_19803.v
@@ -1,0 +1,54 @@
+Module Equality.
+
+Record type : Type := Pack { sort : Type }.
+
+End Equality.
+
+Module SubType.
+
+Record type (T : Type) : Type := Pack { sort : Type }.
+
+End SubType.
+
+Definition Top_SubType__canonical__Top_Equality (T : Equality.type) (sT : SubType.type (Equality.sort T)) : Equality.type :=
+  @Equality.Pack (@SubType.sort (Equality.sort T) sT).
+
+Module Topological.
+
+Record type : Type := Pack { sort : Type }.
+
+End Topological.
+
+Definition Top_Topological__to__Top_Equality (s : Topological.type) : Equality.type :=
+  @Equality.Pack (@Topological.sort s).
+
+Definition weak_topology (S : Type) : Type := S.
+
+Definition Top_weak_topology__canonical__Top_Topological (S : Equality.type) : Topological.type :=
+  @Topological.Pack (@weak_topology (Equality.sort S)).
+
+Axiom set_system : Type -> Prop.
+Structure filter_on T := FilterType { filter : set_system T; }.
+Axiom Filter : forall (T : Type) (F : set_system T), Type.
+Axiom filter_class : forall T (F : filter_on T), @Filter T (filter T F).
+Axiom nbhs : forall (U : Type) (s : Type), set_system U.
+
+Definition nbhs_filter_on {T : Topological.type} : filter_on (Topological.sort T) :=
+  FilterType (Topological.sort T)  (@nbhs (Topological.sort T) ((Topological.sort T))).
+
+Canonical Structure Top_Topological__to__Top_Equality.
+Canonical Structure Top_weak_topology__canonical__Top_Topological.
+Canonical Structure Top_SubType__canonical__Top_Equality.
+Canonical Structure nbhs_filter_on.
+
+Goal forall
+  {X : Topological.type}
+  {Y : @SubType.type (Topological.sort X)},
+  @Filter (@SubType.sort (Topological.sort (Topological.Pack (Topological.sort X))) Y)
+    (@nbhs (@SubType.sort (Topological.sort X) Y)
+       ( (weak_topology (@SubType.sort (Topological.sort X) Y)))).
+Proof.
+intros.
+(** Check that is_open_canonical_projection correctly expands defined metas *)
+autoapply filter_class with typeclass_instances.
+Qed.


### PR DESCRIPTION
Instead of threading it haphazardly in the evarmap, we pass it explicitly in the few places that matter. The two modules that legitimately manipulate this state are Unification and Clenv. They now expose it explicitly in the API and in their internal data structures.

Two additional code paths still rely on the metavariables being around, namely retyping and reductionops. We could probably get rid of the second one by expanding the metas before sending them to the reduction machine, but the first one is probably trickier. For now this PR doesn't try to do anything fancy with these two dubious callers, it just takes an optional argument.

Further API cleanup is now possible, but I'll defer this to another PR to keep the CI as total as possible.

Overlays:
- https://github.com/impermeable/coq-waterproof/pull/98
- https://github.com/damien-pous/relation-algebra/pull/47