### PR TITLE
Use the release Dune profile when running `configure` during opam package installation

### DIFF
--- a/configure
+++ b/configure
@@ -11,4 +11,11 @@ then
     exit 1
 fi
 
-dune exec --root . -- $configure "$@"
+if [ "x$1" = 'x-release' ]; then
+  shift 1
+  dune_release='--profile=release'
+else
+  dune_release=''
+fi
+
+dune exec $dune_release --root . -- $configure "$@"

--- a/coq.opam
+++ b/coq.opam
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
   [ "./configure"
+    "-release" # -release must be the first command line argument
     "-prefix" prefix
     "-mandir" man
     "-libdir" "%{lib}%/coq"

--- a/coq.opam.template
+++ b/coq.opam.template
@@ -1,6 +1,7 @@
 build: [
   ["dune" "subst"] {dev}
   [ "./configure"
+    "-release" # -release must be the first command line argument
     "-prefix" prefix
     "-mandir" man
     "-libdir" "%{lib}%/coq"

--- a/rocq-runtime.opam
+++ b/rocq-runtime.opam
@@ -39,6 +39,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
   [ "./configure"
+    "-release" # -release must be the first command line argument
     "-prefix" prefix
     "-mandir" man
     "-libdir" "%{lib}%/coq"

--- a/rocq-runtime.opam.template
+++ b/rocq-runtime.opam.template
@@ -1,6 +1,7 @@
 build: [
   ["dune" "subst"] {dev}
   [ "./configure"
+    "-release" # -release must be the first command line argument
     "-prefix" prefix
     "-mandir" man
     "-libdir" "%{lib}%/coq"


### PR DESCRIPTION
Spotted while doing some testing for opam-repository w.r.t. old(er) Coq releases and the `effect` keyword. In the opam files for Coq's packages, the `dune build` is always correctly `dune build -p ...`. Amongst other things, `-p` enables the release profile which disables warnings as errors.

The `configure` script contains a `dune exec` call which should also be enabling the release profile when executing as part of a package build. This minor tweak takes advantage of the fact that opam defines `OPAM_PACKAGE_NAME` and `OPAM_PACKAGE_VERSION` strictly during the building of a package, and uses that to add `--profile=release` to the `dune exec` call.