### PR TITLE
removed uses and of Zeq_bool in setoid_ring

### DIFF
--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -2672,22 +2672,22 @@ Qed.
 
 Lemma R_rm : ring_morph
   0%R 1%R Rplus Rmult Rminus Ropp eq
-  0%Z 1%Z Zplus Zmult Zminus Z.opp Zeq_bool IZR.
+  0%Z 1%Z Zplus Zmult Zminus Z.opp Z.eqb IZR.
 Proof.
   constructor; try easy.
   - exact plus_IZR.
   - exact minus_IZR.
   - exact mult_IZR.
   - exact opp_IZR.
-  - now intros x y H; f_equal; apply Zeq_bool_eq.
+  - intros x y H; f_equal; exact (proj1 (Z.eqb_eq x y) H).
 Qed.
 
 (* NOTE: keeping inconsistent variable names for backward compatibility. *)
-Lemma Zeq_bool_IZR : forall x y:Z, IZR x = IZR y -> Zeq_bool x y = true.
-Proof. now intros n m H; apply Zeq_is_eq_bool, eq_IZR. Qed.
+Lemma Zeqb_IZR : forall x y:Z, IZR x = IZR y -> Z.eqb x y = true.
+Proof. now intros n m H; apply (proj2 (Z.eqb_eq n m)), eq_IZR. Qed.
 
 Add Field RField : Rfield
-  (completeness Zeq_bool_IZR, morphism R_rm, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
+  (completeness Zeqb_IZR, morphism R_rm, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
 
 (*********************************************************)
 (** * Definitions of new types                           *)

--- a/theories/micromega/ZCoeff.v
+++ b/theories/micromega/ZCoeff.v
@@ -114,7 +114,7 @@ Qed.
 Lemma Zring_morph :
   ring_morph 0 1 rplus rtimes rminus ropp req
              0%Z 1%Z Z.add Z.mul Z.sub Z.opp
-             Zeq_bool gen_order_phi_Z.
+             Z.eqb gen_order_phi_Z.
 Proof.
 exact (gen_phiZ_morph (SORsetoid sor) ring_ops_wd (SORrt sor)).
 Qed.
@@ -159,14 +159,15 @@ Lemma Zcleb_morph : forall x y : Z, Z.leb x y = true -> [x] <= [y].
 Proof.
 unfold Z.leb; intros x y H.
 case_eq (x ?= y)%Z; intro H1; rewrite H1 in H.
-- le_equal. apply (morph_eq Zring_morph). unfold Zeq_bool; now rewrite H1.
+- le_equal. apply (morph_eq Zring_morph).
+  now rewrite Z.eqb_compare, H1.
 - le_less. now apply clt_morph.
 - discriminate.
 Qed.
 
-Lemma Zcneqb_morph : forall x y : Z, Zeq_bool x y = false -> [x] ~= [y].
+Lemma Zcneqb_morph : forall x y : Z, Z.eqb x y = false -> [x] ~= [y].
 Proof.
-intros x y H. unfold Zeq_bool in H.
+intros x y H. rewrite Z.eqb_compare in H.
 case_eq (Z.compare x y); intro H1; rewrite H1 in *; (discriminate || clear H).
 - apply (Rlt_neq sor). now apply clt_morph.
 - fold (x > y)%Z in H1. rewrite Z.gt_lt_iff in H1.

--- a/theories/nsatz/NsatzTactic.v
+++ b/theories/nsatz/NsatzTactic.v
@@ -70,15 +70,15 @@ Definition PEZ := PExpr Z.
 Definition P0Z : PolZ := P0 (C:=Z) 0%Z.
 
 Definition PolZadd : PolZ -> PolZ -> PolZ :=
-  @Padd  Z 0%Z Z.add Zeq_bool.
+  @Padd  Z 0%Z Z.add Z.eqb.
 
 Definition PolZmul : PolZ -> PolZ -> PolZ :=
-  @Pmul  Z 0%Z 1%Z Z.add Z.mul Zeq_bool.
+  @Pmul  Z 0%Z 1%Z Z.add Z.mul Z.eqb.
 
-Definition PolZeq := @Peq Z Zeq_bool.
+Definition PolZeq := @Peq Z Z.eqb.
 
 Definition norm :=
-  @norm_aux Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Zeq_bool.
+  @norm_aux Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb.
 
 Fixpoint mult_l (la : list PEZ) (lp: list PolZ) : PolZ :=
  match la, lp with

--- a/theories/setoid_ring/Cring.v
+++ b/theories/setoid_ring/Cring.v
@@ -68,7 +68,7 @@ Defined.
 
 Lemma cring_morph:
   ring_morph  zero one _+_ _*_ _-_ -_ _==_
-             0%Z 1%Z Z.add Z.mul Z.sub Z.opp Zeq_bool
+             0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb
              Ncring_initial.gen_phiZ.
 intros. apply mkmorph ; intros; simpl; try reflexivity.
 - rewrite Ncring_initial.gen_phiZ_add; reflexivity.
@@ -109,7 +109,7 @@ Ltac cring_gen :=
                         ring_setoid
                         cring_eq_ext
                         cring_almost_ring_theory
-                        Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Zeq_bool
+                        Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb
                         Ncring_initial.gen_phiZ
                         cring_morph
                         N
@@ -144,12 +144,12 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
     match lexpr with
       | ?e::?le =>
         let t := constr:(@Ring_polynom.norm_subst
-          Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Zeq_bool Z.quotrem O nil e) in
+          Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb Z.quotrem O nil e) in
         let te := 
           constr:(@Ring_polynom.Pphi_dev
             _ 0 1 _+_ _*_ _-_ -_ 
             
-            Z 0%Z 1%Z Zeq_bool
+            Z 0%Z 1%Z Z.eqb
             Ncring_initial.gen_phiZ
             get_signZ fv t) in
         let eq1 := fresh "ring" in
@@ -167,7 +167,7 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
             ring_setoid
             cring_eq_ext
             cring_almost_ring_theory
-            Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Zeq_bool
+            Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp Z.eqb
             Ncring_initial.gen_phiZ
             cring_morph
             N
@@ -190,7 +190,7 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
             pattern (@Ring_polynom.Pphi_dev
             _ 0 1 _+_ _*_ _-_ -_ 
             
-            Z 0%Z 1%Z Zeq_bool
+            Z 0%Z 1%Z Z.eqb
             Ncring_initial.gen_phiZ
             get_signZ fv t');
             match goal with
@@ -206,7 +206,7 @@ Ltac cring_simplify_aux lterm fv lexpr hyp :=
                pattern (@Ring_polynom.Pphi_dev
             _ 0 1 _+_ _*_ _-_ -_ 
             
-            Z 0%Z 1%Z Zeq_bool
+            Z 0%Z 1%Z Z.eqb
             Ncring_initial.gen_phiZ
             get_signZ fv t') in H; 
                match type of H with

--- a/theories/setoid_ring/Field_theory.v
+++ b/theories/setoid_ring/Field_theory.v
@@ -1813,12 +1813,11 @@ Qed.
 
 Lemma gen_phiZ_complete x y :
   gen_phiZ rO rI radd rmul ropp x == gen_phiZ rO rI radd rmul ropp y ->
-  Zeq_bool x y = true.
+  Z.eqb x y = true.
 Proof.
 intros.
  replace y with x.
-- unfold Zeq_bool.
-  rewrite Z.compare_refl; trivial.
+- rewrite Z.eqb_compare, Z.compare_refl; trivial.
 - apply gen_phiZ_inj; trivial.
 Qed.
 

--- a/theories/setoid_ring/InitialRing.v
+++ b/theories/setoid_ring/InitialRing.v
@@ -108,12 +108,12 @@ Section ZMORPHISM.
   | _ => None
   end.
 
- Lemma get_signZ_th : sign_theory Z.opp Zeq_bool get_signZ.
+ Lemma get_signZ_th : sign_theory Z.opp Z.eqb get_signZ.
  Proof.
   constructor.
   intros c;destruct c;intros ? H;try discriminate.
   injection H as [= <-].
-  simpl. unfold Zeq_bool. rewrite Z.compare_refl. trivial.
+  simpl. apply Pos.eqb_refl.
  Qed.
 
 
@@ -181,10 +181,10 @@ Section ZMORPHISM.
  Qed.
 
  Lemma gen_Zeqb_ok : forall x y,
-   Zeq_bool x y = true -> [x] == [y].
+   Z.eqb x y = true -> [x] == [y].
  Proof.
   intros x y H.
-  assert (H1 := Zeq_bool_eq x y H);unfold IDphi in H1.
+  assert (H1 := proj1 (Z.eqb_eq x y) H);unfold IDphi in H1.
   rewrite H1;rrefl.
  Qed.
 
@@ -227,10 +227,10 @@ Section ZMORPHISM.
 (*proof that [.] satisfies morphism specifications*)
  Lemma gen_phiZ_morph :
   ring_morph 0 1 radd rmul rsub ropp req Z0 (Zpos xH)
-   Z.add Z.mul Z.sub Z.opp Zeq_bool gen_phiZ.
+   Z.add Z.mul Z.sub Z.opp Z.eqb gen_phiZ.
  Proof.
   assert ( SRmorph : semi_morph 0 1 radd rmul req Z0 (Zpos xH)
-                  Z.add Z.mul Zeq_bool gen_phiZ).
+                  Z.add Z.mul Z.eqb gen_phiZ).
   - apply mkRmorph;simpl;try rrefl.
     + apply gen_phiZ_add.
     + apply gen_phiZ_mul.

--- a/theories/setoid_ring/Ncring_initial.v
+++ b/theories/setoid_ring/Ncring_initial.v
@@ -154,10 +154,10 @@ Ltac rsimpl := simpl.
  Qed.
 
  Lemma gen_Zeqb_ok : forall x y,
-   Zeq_bool x y = true -> [x] == [y].
+   Z.eqb x y = true -> [x] == [y].
  Proof.
   intros x y H7.
-  assert (H10 := Zeq_bool_eq x y H7);unfold IDphi in H10.
+  assert (H10 := proj1 (Z.eqb_eq x y) H7);unfold IDphi in H10.
   rewrite H10;reflexivity.
  Qed.
 

--- a/theories/setoid_ring/Ncring_tac.v
+++ b/theories/setoid_ring/Ncring_tac.v
@@ -165,8 +165,8 @@ Ltac lterm_goal g :=
   | (_ ?t1 ?t2) => constr:(t1::t2::nil)
   end.
 
-Lemma Zeqb_ok: forall x y : Z, Zeq_bool x y = true -> x == y.
- intros x y H. rewrite (Zeq_bool_eq x y H). reflexivity. Qed. 
+Lemma Zeqb_ok: forall x y : Z, Z.eqb x y = true -> x == y.
+ intros x y H. rewrite (proj1 (Z.eqb_eq x y) H). reflexivity. Qed.
 
 
 Ltac reify_goal lvar lexpr lterm:=
@@ -220,7 +220,7 @@ Ltac ring_gen :=
              |- ?g => 
                apply (@ring_correct Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
                        (@gen_phiZ _ _ _ _ _ _ _ _ _) _
-                 (@comm _ _ _ _ _ _ _ _ _ _) Zeq_bool Zeqb_ok N (fun n:N => n)
+                 (@comm _ _ _ _ _ _ _ _ _ _) Z.eqb Zeqb_ok N (fun n:N => n)
                  (@pow_N _ _ _ _ _ _ _ _ _));
                [apply mkpow_th; reflexivity
                  |vm_compute; reflexivity]
@@ -240,7 +240,7 @@ Ltac ring_simplify_aux lterm fv lexpr hyp :=
     match lexpr with
       | ?e::?le => (* e:PExpr Z est la réification de t0:R *)
         let t := constr:(@Ncring_polynom.norm_subst
-          Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp (@eq Z) Zops Zeq_bool e) in
+          Z 0%Z 1%Z Z.add Z.mul Z.sub Z.opp (@eq Z) Zops Z.eqb e) in
         (* t:Pol Z *)
         let te := 
           constr:(@Ncring_polynom.Pphi Z 

--- a/theories/setoid_ring/RealField.v
+++ b/theories/setoid_ring/RealField.v
@@ -110,10 +110,10 @@ rewrite H; intro.
 apply (Rlt_asym 0 0); trivial.
 Qed.
 
-Lemma Zeq_bool_complete : forall x y,
+Lemma Zeqb_complete : forall x y,
   InitialRing.gen_phiZ 0%R 1%R Rplus Rmult Ropp x =
   InitialRing.gen_phiZ 0%R 1%R Rplus Rmult Ropp y ->
-  Zeq_bool x y = true.
+  Z.eqb x y = true.
 Proof gen_phiZ_complete Rset Rext Rfield Rgen_phiPOS_not_0.
 
 Lemma Rdef_pow_add : forall (x:R) (n m:nat), pow x  (n + m) = pow x n * pow x m.
@@ -156,4 +156,4 @@ Ltac IZR_tac t :=
   end.
 
 Add Field RField : Rfield
-   (completeness Zeq_bool_complete, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
+   (completeness Zeqb_complete, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).

--- a/theories/setoid_ring/ZArithRing.v
+++ b/theories/setoid_ring/ZArithRing.v
@@ -47,8 +47,11 @@ Ltac Zpower_neg :=
     end
   end.
 
+Lemma Zeqb_imp_eq : forall x y, Z.eqb x y = true -> x = y.
+Proof. intros x y; exact (proj1 (Z.eqb_eq x y)). Qed.
+
 Add Ring Zr : Zth
-  (decidable Zeq_bool_eq, constants [Zcst], preprocess [Zpower_neg;unfold Z.succ],
+  (decidable Zeqb_imp_eq, constants [Zcst], preprocess [Zpower_neg;unfold Z.succ],
    power_tac Zpower_theory [Zpow_tac],
     (* The following two options are not needed; they are the default choice
        when the set of coefficient is the usual ring Z *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
