### PR TITLE
Fix primitive projection handling for `setoid_rewrite`

### DIFF
--- a/doc/changelog/04-tactics/19811-fix-setoid-proj-Changed.rst
+++ b/doc/changelog/04-tactics/19811-fix-setoid-proj-Changed.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  setoid rewriting now rewrites under primitive projections
+  (`#19811 <https://github.com/rocq-prover/rocq/pull/19811>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/success/setoid_rewrite_proj.v
+++ b/test-suite/success/setoid_rewrite_proj.v
@@ -1,5 +1,7 @@
 Require Export Corelib.Setoids.Setoid.
 
+Module Test1.
+
 #[projections(primitive=yes)]
 Structure Test := {
   test : unit
@@ -15,3 +17,45 @@ Proof.
   setoid_rewrite H.
   exact eq_refl.
 Qed.
+
+End Test1.
+
+Module Test2.
+
+#[projections(primitive=yes)]
+Structure Test (n : nat) := {
+  test : unit
+}.
+
+Axiom tst : Test 0.
+Axiom tst' : Test 0.
+Axiom H : tst = tst'.
+
+Theorem a :
+  test _ tst = test _ tst'.
+Proof.
+  setoid_rewrite H.
+  exact eq_refl.
+Qed.
+
+End Test2.
+
+Module Test3.
+
+#[projections(primitive=yes)]
+Structure Test (n : nat) := {
+  test : unit
+}.
+
+Axiom n : nat.
+Axiom tst : Test n.
+Axiom tst' : Test n.
+Axiom H : n = 0.
+
+Theorem a :
+  test _ tst = test _ tst'.
+Proof.
+  Fail setoid_rewrite H. (* no rewriting in parameters *)
+Abort.
+
+End Test3.

--- a/test-suite/success/setoid_rewrite_proj.v
+++ b/test-suite/success/setoid_rewrite_proj.v
@@ -1,0 +1,17 @@
+Require Export Corelib.Setoids.Setoid.
+
+#[projections(primitive=yes)]
+Structure Test := {
+  test : unit
+}.
+
+Axiom tst : Test.
+Axiom tst' : Test.
+Axiom H : tst = tst'.
+
+Theorem a :
+  test tst = test tst'.
+Proof.
+  setoid_rewrite H.
+  exact eq_refl.
+Qed.


### PR DESCRIPTION
While the kernel supports primitive projections properly, many subsystems are still not able to yield their full power:
- `setoid_rewrite`'s matching algorithm simply doesn't traverse under projections;
- neither `evarconv.ml` nor `unification.ml` exploit eta-expansion to solve `p ?e = t`;
- in the pretyper, the environment of the single branch of a destructuring let on a prim record contains a `LocalAssum` per field, whereas we would like them to be `LocalDef`, since the term ends up with a bunch of lets anyways. This is annoying when using evar-based refinement systems, e.g. Program or refine, where we get double the information in the context of the evar.

This is a draft as there are some issues with the current implementation:
- coercions to projected types do not work anymore (see `bug_3480.v`), as unification now succeeds with some unsolved evars when it used to just fail;
- nested pattern matches starting with a primitive record don't compile properly (see `bug_3584.v`).

I'm looking for some external suggestions of how to solve both issues. For the second one, I just don't know how `cases.ml` works intimately and how my change affects the rest of the pattern compilation mechanism.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
- [ ] Opened **overlay** pull requests.