### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,9 @@ The Coq development team and the user community are made up of a mixture of
 professionals and volunteers from all over the world.
 Diversity brings variety of perspectives that can be very valuable, but it can
 also lead to communication issues and unhappiness. Therefore, we have a few
-ground rules that we ask people to adhere to.
+ground rules that we ask people to adhere to in order to make
+participation in our community a positive experience for
+everyone.
 These rules apply equally to core developers (who should lead by example),
 occasional contributors and those seeking help and guidance.
 Their goal is that everyone feels safe and welcome when contributing to Coq or
@@ -62,6 +64,12 @@ affect a person's ability to participate within them.
   constructively. Remember that we are different. Different people
   have different perspectives on issues. Being unable to understand why someone
   holds a viewpoint doesn't mean that they're wrong.
+- **Be considerate of others' resources, including time and attention.**
+  Long messages, for example, take more time for others to read and respond to, and
+  make it harder to determine what the most important points are,
+  risking miscommunication when multiple participants have different
+  views about what issue is being discussed. Short, concise messages are often more
+  efficient and help prevent communication misunderstandings.
 - **It is human to make errors, and please try not to take things personally.**
   Please do not answer aggressively to problematic behavior and simply
   signal the issue. If actions have been taken with you (e.g. bans or simple
@@ -73,7 +81,17 @@ affect a person's ability to participate within them.
   bad day, so please take this opportunity to question yourself, cool down if
   necessary and do not persist in the exact same behavior you have been
   reported for.
-
+- **Default to using public rather than personal (member-to-member) communication.**
+  Personal communication channels (e.g., direct messages on Zulip or
+  personal emails) limit the visibility of interactions for other users and
+  contributors, preventing them from benefiting from shared
+  knowledge. Additionally, unsolicited private communication can
+  sometimes be perceived as too intrusive.
+- **Be mindful to avoid repeated actions that form a pattern of harassment.**
+  Harassment is not limited to any single source or type of
+  behavior. It typically arises from repeated actions that may seem
+  harmless individually but, over time, contribute to a hostile
+  environment.
 
 ## Interaction on Coq forums (Zulip, Discourse, etc.) ##
 
@@ -111,9 +129,17 @@ yourself with a behavior that you consider hurtful. This applies to members of
 the enforcement team as well, who shouldn't deal by themselves with violations
 in discussions in which they are a participant.
 
+The enforcement team will take all interactions into account when
+assessing potential code of conduct violations, including any personal
+communications brought to their attention.
+
 Depending on the violation, the team can choose to address a private or public
 warning to the offender, request an apology, or ban them for a short or a long
-period from interacting on one or all of our forums.
+period from interacting on one or all spaces managed by the Coq
+development team (both online and offline).
+The ban may apply to anyone, including members of the Coq development
+team, in which case the developer will lose their privileges for the
+duration of the ban and may need to rebuild trust to regain them.
 
 Except in case of serious violations, the team will always try a pedagogical
 approach first (the offender does not necessarily realize immediately why their


### PR DESCRIPTION
clarifications

Update CODE_OF_CONDUCT.md

Add missing rules about excessively long messages, pressing the answers, use of personal (member-to-member) communication and highlight that repeated actions may became harassment.

Also be more explicit that development team members are also subject to the code of conduct and may lose their privileges in case of violation.