### PR TITLE
Windows CI update upload-artifact version

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,7 +51,7 @@ jobs:
           .\dev\ci\platform\coq-pf-04-installer.bat
 
       - name: Upload Installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-installer
           path: artifacts


### PR DESCRIPTION
Github said v3 is deprecated
