### PR TITLE
Remove `dfs eauto`, deprecated in 8.16

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ before_script:
       - config/coq_config.ml
       - config/coq_byte_config.ml
       - config/dune.c_flags
-    expire_in: 1 month
+    expire_in: 1 week
   script:
     - PKGS=coq-core,coq-stdlib,coqide-server,coq
     - if [ "$COQIDE" != "no" ]; then PKGS=${PKGS},coqide; fi
@@ -119,7 +119,7 @@ before_script:
       - _build.tar.bz2
       - theories/dune
       - user-contrib/Ltac2/dune
-    expire_in: 1 month
+    expire_in: 1 week
 
 .doc-template:
   stage: build-1
@@ -157,8 +157,7 @@ before_script:
     when: on_failure
     paths:
       - test-suite/logs
-    # Gitlab doesn't support yet "expire_in: never" so we use the instance default
-    # expire_in: never
+    expire_in: 1 week
 
 # set "needs" when using
 .validate-template:
@@ -178,7 +177,7 @@ before_script:
     when: always
     paths:
       - coqchk.log
-    expire_in: 2 months
+    expire_in: 1 week
 
 # This template defaults to "needs: build:base"
 # Remember to include it as a transitive dependency if you want additional "needs:"
@@ -259,8 +258,7 @@ before_script:
     when: on_failure
     paths:
       - nix-build-coq.drv-0/*/test-suite/logs
-    # Gitlab doesn't support yet "expire_in: never" so we use the instance default
-    # expire_in: never
+    expire_in: 1 week
 
 ##############################################################################
 ########################## End of templates ##################################
@@ -516,8 +514,7 @@ test-suite:base:dev:
     when: on_failure
     paths:
       - _build/default/test-suite/logs
-    # Gitlab doesn't support yet "expire_in: never" so we use the instance default
-    # expire_in: never
+    expire_in: 1 week
 
 .test-suite:ocaml+beta+dune-template:
   stage: build-1 # even though it has no deps we put it with the other test suite jobs
@@ -540,7 +537,7 @@ test-suite:base:dev:
     paths:
       - _build/log
       - _build/default/test-suite/logs
-    expire_in: 2 week
+    expire_in: 1 week
   allow_failure: true
 
 test-suite:base+async:

--- a/doc/changelog/04-tactics/19817-remove_dfs_eauto.rst
+++ b/doc/changelog/04-tactics/19817-remove_dfs_eauto.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  `dfs eauto` tactic, which was deprecated in 8.16
+  (`#19817 <https://github.com/coq/coq/pull/19817>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -138,12 +138,6 @@ Tactics
       Behaves like :tacn:`eauto` but shows the tactics it tries to solve the goal,
       including failing paths.
 
-   .. tacn:: dfs eauto {? @nat_or_var } {? @auto_using } {? @hintbases }
-
-      .. deprecated:: 8.16
-
-      An alias for :tacn:`eauto`.
-
 .. tacn:: autounfold {? @hintbases } {? @simple_occurrences }
 
    Unfolds constants that were declared through a :cmd:`Hint Unfold`

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1832,7 +1832,6 @@ simple_tactic: [
 | "eauto" OPT nat_or_var auto_using hintbases
 | "debug" "eauto" OPT nat_or_var auto_using hintbases
 | "info_eauto" OPT nat_or_var auto_using hintbases
-| "dfs" "eauto" OPT nat_or_var auto_using hintbases
 | "autounfold" hintbases clause_dft_concl
 | "autounfold_one" hintbases "in" hyp
 | "autounfold_one" hintbases

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1496,7 +1496,6 @@ simple_tactic: [
 | "eauto" OPT nat_or_var OPT auto_using OPT hintbases
 | "debug" "eauto" OPT nat_or_var OPT auto_using OPT hintbases
 | "info_eauto" OPT nat_or_var OPT auto_using OPT hintbases
-| "dfs" "eauto" OPT nat_or_var OPT auto_using OPT hintbases
 | "autounfold" OPT hintbases OPT simple_occurrences
 | "autounfold_one" OPT hintbases OPT ( "in" ident )
 | "unify" one_term one_term OPT ( "with" ident )

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -130,11 +130,6 @@ TACTIC EXTEND info_eauto
   { Eauto.gen_eauto ~debug:Info ?depth (eval_uconstrs ist lems) db }
 END
 
-TACTIC EXTEND dfs_eauto DEPRECATED { Deprecation.make ~since:"8.16" ~note:"Use [eauto] instead." () }
-| [ "dfs" "eauto" nat_or_var_opt(depth) auto_using(lems) hintbases(db) ] ->
-  { Eauto.gen_eauto ?depth (eval_uconstrs ist lems) db }
-END
-
 TACTIC EXTEND autounfold
 | [ "autounfold" hintbases(db) clause_dft_concl(cl) ] -> { Eauto.autounfold_tac db cl }
 END


### PR DESCRIPTION
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
- [x] Updated **documented syntax** by running `make doc_gram_rsts`.
