### PR TITLE
rm problematic variables under beta-redexes and evars for evar instantiation

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1753,6 +1753,20 @@ let rec invert_definition unify flags choose imitate_defs
           map_constr_with_full_binders env' !evdref (fun d (env,k) -> push_rel d env, k+1)
                                         imitate envk t
         with _ -> progress := p; imitate envk (whd_beta env' !evdref t))
+    | App (f, args) when EConstr.isEvar !evdref f ->
+        progress := true;
+        (* Tries to imitate the arguments. If this fails, i is Some i' with i' the index of the last argument we fail to imitate *)
+        let i, args' = Array.fold_left_map_i (fun i k a ->
+          try let a' = imitate envk a in (k, a')
+          with ex -> (Some i, a)) None args in
+        (match i with
+        | None ->
+          let f' = imitate envk f in
+          if f' == f && Array.for_all2 (==) args args' then t else EConstr.mkApp (f', args')
+        | Some i ->
+          let args, args' = Array.chop (i+1) args in
+          let evd, e = Evardefine.evar_absorb_arguments env !evdref (EConstr.destEvar !evdref f) (Array.to_list args) in
+          evdref := evd; imitate envk (EConstr.mkApp (EConstr.mkEvar e, args')))
     | _ ->
         progress := true;
         match

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1746,13 +1746,6 @@ let rec invert_definition unify flags choose imitate_defs
               add_conv_oriented_pb (None,env',mkEvar ev'',mkEvar ev') evd in
           evdref := evd;
           evar'')
-    | App (f, args) when EConstr.isLambda !evdref f ->
-        let p = !progress in
-        progress := true;
-        (try
-          map_constr_with_full_binders env' !evdref (fun d (env,k) -> push_rel d env, k+1)
-                                        imitate envk t
-        with _ -> progress := p; imitate envk (whd_beta env' !evdref t))
     | App (f, args) when EConstr.isEvar !evdref f ->
         progress := true;
         (* Tries to imitate the arguments. If this fails, i is Some i' with i' the index of the last argument we fail to imitate *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
The unification algorithm sometimes fails on problems of the form `?a = t`  because variables that are not in the scope of `?a` appear in `t`. There are two cases where we can easily solve the problem, namely the one where the variable appears in a beta-redex, as in `(fun _ => t) x`, and the one where the variable appears in an argument of an evar, e.g. `?b x`, since we can instantiate the evar to forget the argument.
For instance, unifying `forall x : ?T, f (?a x)` and `forall _ : ?T, ?b` reduces to unifying `f (?a x)` and `?b`, which fails because `x` is not available when instantiating `?b`.
This PR adds these cases in `pretyping/evarsolve`.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

### Overlays (to be merged before this)
- https://github.com/UniMath/UniMath/pull/1955
- https://github.com/mit-pdos/perennial/pull/137
- https://github.com/mit-plv/rewriter/pull/165
- https://github.com/mit-plv/fiat/pull/115
- https://github.com/HoTT/Coq-HoTT/pull/2315

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
