### PR TITLE
Declare ML Module allow plugin names not containing `.`

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -662,7 +662,6 @@ file is a particular case of a module called a *library file*.
    Loads OCaml plugins and their dependencies dynamically.  The :n:`@string`
    arguments must be valid `findlib <http://projects.camlcity.org/projects/findlib.html>`_
    plugin names, for example ``coq-core.plugins.ltac``.
-   They must also contain a `.` to disambiguate against the removed non-findlib loading method.
 
    Effects (such as adding new commands) from the explicitly requested
    plugin are activated, but effects from implicitly loaded

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -321,30 +321,8 @@ let synterp_require ~intern from export qidl =
 let expand filename =
   Envars.expand_path_macros ~warn:(fun x -> Feedback.msg_warning (str x)) filename
 
-let warn_legacy_loading =
-  let name = "legacy-loading-removed" in
-  CWarnings.create ~name (fun name ->
-      Pp.(str "Legacy loading plugin method has been removed from Coq, \
-               and the `:` syntax is deprecated, and its first \
-               argument ignored; please remove \"" ++
-          str name ++ str ":\" from your Declare ML"))
-
-let inspect_legacy_decl l =
-  match String.split_on_char ':' l with
-  | [lib] -> lib
-  | [cmxs; lib] ->
-    warn_legacy_loading cmxs;
-    lib
-  | bad ->
-    let bad = String.concat ":" bad in
-    CErrors.user_err Pp.(str "bad package name: " ++ str bad ++ str " .")
-
-let remove_legacy_decls = List.map inspect_legacy_decl
-
 let synterp_declare_ml_module ~local l =
   let local = Option.default false local in
-  let l = remove_legacy_decls l in
-  let l = List.map expand l in
   Mltop.declare_ml_modules local l
 
 let warn_chdir = CWarnings.create ~name:"change-dir-deprecated" ~category:Deprecation.Version.v8_20


### PR DESCRIPTION
NB we stop calling `expand_path_macros` on the string as plugin names are not paths anymore.

Should fix https://github.com/coq/coq/issues/18647