### PR TITLE
CI: add elpi as dependency for CoRN

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -729,6 +729,7 @@ library:ci-corn:
   needs:
   - build:edge+flambda
   - plugin:ci-bignums
+  - plugin:ci-elpi_hb # CoRN uses elpi only (not HB) - depending on ci-elpi_hb reduces CI package count
   - library:ci-math_classes
   stage: build-3+
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -126,7 +126,7 @@ ci-coquelicot: ci-mathcomp
 ci-deriving: ci-mathcomp
 ci-math_classes: ci-bignums
 
-ci-corn: ci-math_classes
+ci-corn: ci-math_classes ci-elpi
 
 ci-mtac2: ci-unicoq
 


### PR DESCRIPTION
This PR is required to adjust Coq's CI to an additional dependency of CoRN introduced by me in https://github.com/coq-community/corn/pull/209.

As far as I understand I do not need to create an overlay - afaik this is for the reverse situation that a change in Coq breaks packages in CI and not that CI needs to be adjusted to changes in a package.