### PR TITLE
rm problematic variables under beta redexes for evar instantiation

### DIFF
--- a/doc/changelog/02-specification-language/19833-evd-inst-beta.rst
+++ b/doc/changelog/02-specification-language/19833-evd-inst-beta.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  When unification fails to instantiate an evar because
+  of a problem that occurs under a beta-redex, we reduce
+  this beta-redex and try again
+  (`#19833 <https://github.com/coq/coq/pull/19833>`_,
+  by Quentin Vermande).

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1746,6 +1746,13 @@ let rec invert_definition unify flags choose imitate_defs
               add_conv_oriented_pb (None,env',mkEvar ev'',mkEvar ev') evd in
           evdref := evd;
           evar'')
+    | App (f, args) when EConstr.isLambda !evdref f ->
+        let p = !progress in
+        progress := true;
+        (try
+          map_constr_with_full_binders env' !evdref (fun d (env,k) -> push_rel d env, k+1)
+                                        imitate envk t
+        with _ -> progress := p; imitate envk (whd_beta env' !evdref t))
     | _ ->
         progress := true;
         match

--- a/test-suite/bugs/bug_19833.v
+++ b/test-suite/bugs/bug_19833.v
@@ -1,0 +1,22 @@
+Class hasPt (T : Type) := Pt { pt_ : T }.
+Structure ptType := Pointed {
+  sort :> Type;
+  class : hasPt sort
+}.
+
+Definition pt (T : ptType) := @pt_ T (class T).
+
+Canonical nat_ptType := Pointed nat (Pt nat 0).
+Canonical forall_ptType (T : Type) (U : T -> ptType) :=
+  Pointed (forall t, U t) (Pt (forall t, U t) (fun t => pt (U t))).
+
+Definition constant {T U : Type} (f : T -> U) := forall (x y : T), f x = f y.
+Definition cst (T U : Type) (y : U) := fun _ : T => y.
+Lemma constant_cst (T U : Type) (y : U) : constant (cst T U y).
+Proof. intros x x'; reflexivity. Qed.
+
+Goal forall {T : Type} {U : ptType}, constant (pt (T -> U)).
+Proof.
+intros.
+exact (constant_cst _ _ _).
+Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Extracted from https://github.com/coq/coq/pull/19822 as suggested [here](https://github.com/coq/coq/pull/19822#pullrequestreview-2433929513). 
The unification algorithm sometimes fails on problems of the form ?a = t because variables that are not in the scope of ?a appear in t. We can easily solve the problem when the variable appears in a beta-redex, as in (fun _ => t) x.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
