### PR TITLE
Stop implicitly adding the current directory to ML paths

### DIFF
--- a/dev/ci/user-overlays/19834-SkySkimmer-no-ml-cwd.sh
+++ b/dev/ci/user-overlays/19834-SkySkimmer-no-ml-cwd.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp no-ml-cwd 19834

--- a/doc/changelog/14-misc/19834-no-ml-cwd.rst
+++ b/doc/changelog/14-misc/19834-no-ml-cwd.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  the current working directory is not implicitly added to the ML search path
+  (`#19834 <https://github.com/coq/coq/pull/19834>`_,
+  by Gaëtan Gilbert).

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -140,7 +140,6 @@ let to_vo_path (x:Coqargs.vo_path) : Loadpath.vo_path = {
   implicit = x.implicit;
   unix_path = x.unix_path;
   coq_path = Libnames.dirpath_of_string x.rocq_path;
-  has_ml = false;
   recursive = true;
   }
 

--- a/sysinit/coqloadpath.ml
+++ b/sysinit/coqloadpath.ml
@@ -14,10 +14,8 @@ open Pp
 (* Recursively puts `.v` files in the LoadPath *)
 let build_stdlib_vo_path ~unix_path ~rocq_path =
   let open Loadpath in
-  { unix_path; coq_path = rocq_path; has_ml = false; implicit = true; recursive = true }
+  { unix_path; coq_path = rocq_path; implicit = true; recursive = true }
 
-(* Note we don't use has_ml=true due to #12771 , we need to see if we
-   should just remove that option *)
 let build_userlib_path ~unix_path =
   let open Loadpath in
   if Sys.file_exists unix_path then
@@ -25,7 +23,6 @@ let build_userlib_path ~unix_path =
     let vo_path =
       { unix_path
       ; coq_path = Libnames.default_root_prefix
-      ; has_ml = false
       ; implicit = false
       ; recursive = true
       } in
@@ -75,7 +72,6 @@ let init_load_path ~coqenv =
     [ { unix_path = "."
       ; coq_path = Libnames.default_root_prefix
       ; implicit = false
-      ; has_ml = true
       ; recursive = false
       } ] @
 

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -282,8 +282,6 @@ type vo_path =
   ; implicit  : bool
   (** [implicit = true] avoids having to qualify with [coq_path]
       true for -R, false for -Q in command line *)
-  ; has_ml    : bool
-  (** If [has_ml] is true, the directory will also be added to the ml include path *)
   ; recursive : bool
   (** [recursive] will determine whether we explore sub-directories  *)
   }
@@ -321,15 +319,6 @@ let add_vo_path lp =
       with Exit -> None
     in
     let dirs = List.map_filter convert_dirs dirs in
-    let () =
-      if lp.has_ml && not lp.recursive then
-        Mltop.add_ml_dir unix_path
-      else if lp.has_ml && lp.recursive then
-        (List.iter (fun (lp,_) -> Mltop.add_ml_dir lp) dirs;
-         Mltop.add_ml_dir unix_path)
-      else
-        ()
-    in
     let root = (unix_path,lp.coq_path) in
     let add (path, dir) = add_load_path root path ~implicit dir in
     (* deeper dirs registered first and thus be found last *)

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -86,8 +86,6 @@ type vo_path =
   ; implicit  : bool
   (** [implicit = true] avoids having to qualify with [coq_path]
       true for -R, false for -Q in command line *)
-  ; has_ml    : bool
-  (** If [has_ml] is true, the directory will also be added to the ml include path *)
   ; recursive : bool
   (** [recursive] will determine whether we explore sub-directories  *)
   }


### PR DESCRIPTION
This is the only user of Loadpath.has_ml so we remove it.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/873