### PR TITLE
coq_makefile stop installing cmxs files in legacy location

### DIFF
--- a/doc/changelog/09-cli-tools/19841-coq-makefile-no-double-install-cmxs.rst
+++ b/doc/changelog/09-cli-tools/19841-coq-makefile-no-double-install-cmxs.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  `coq_makefile` generated makefiles only install plugin `.cmxs` files in findlib locations
+  and stop putting a copy in `user-contrib` (the copy should be useless after the removal of plugin legacy loading)
+  (`#19841 <https://github.com/coq/coq/pull/19841>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -28,7 +28,6 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/sub
 ./test/sub/.coq-native
 ./test/sub/.coq-native/Ntest_sub_testsub.cmi

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -26,7 +26,6 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/sub
 ./test/sub/.coq-native
 ./test/sub/.coq-native/Ntest_sub_testsub.cmi

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -19,7 +19,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -19,7 +19,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/multiroot/run.sh
+++ b/test-suite/coq-makefile/multiroot/run.sh
@@ -27,7 +27,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test2
 ./test2/.coq-native
 ./test2/.coq-native/Ntest2_test.cmi

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -26,7 +26,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native2/run.sh
+++ b/test-suite/coq-makefile/native2/run.sh
@@ -26,7 +26,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native3/run.sh
+++ b/test-suite/coq-makefile/native3/run.sh
@@ -26,7 +26,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/native4/run.sh
+++ b/test-suite/coq-makefile/native4/run.sh
@@ -29,7 +29,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/plugin1/run.sh
+++ b/test-suite/coq-makefile/plugin1/run.sh
@@ -20,7 +20,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/plugin2/run.sh
+++ b/test-suite/coq-makefile/plugin2/run.sh
@@ -20,7 +20,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/test-suite/coq-makefile/plugin3/run.sh
+++ b/test-suite/coq-makefile/plugin3/run.sh
@@ -20,7 +20,6 @@ sort > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test_plugin.cmxs
 EOT
 (coqc -config | grep -q "NATIVE_COMPILER_DEFAULT=yes") || sed -i.bak '/\.coq-native/d' desired
 diff -u desired actual

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -395,8 +395,7 @@ FILESTOINSTALL = \
 	$(VOFILES) \
 	$(VFILES) \
 	$(GLOBFILES) \
-	$(NATIVEFILES) \
-	$(CMXSFILES)		# to be removed when we remove legacy loading
+	$(NATIVEFILES)
 FINDLIBFILESTOINSTALL = \
 	$(CMIFILESTOINSTALL)
 ifeq '$(HASNATDYNLINK)' 'true'


### PR DESCRIPTION
Before this patch they get double installed in user-contrib and in findlib's install directory. After this patch they only get installed for findlib.
