### PR TITLE
Stop adding user-contrib, xgd dirs and COQPATH to ml loadpath

### DIFF
--- a/doc/changelog/14-misc/19842-no-ml-misc-dirs.rst
+++ b/doc/changelog/14-misc/19842-no-ml-misc-dirs.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  the `user-contrib`, XDG and `COQPATH` directories are not implicitly added to the ML loadpath
+  (`#19842 <https://github.com/coq/coq/pull/19842>`_,
+  by Gaëtan Gilbert).

--- a/sysinit/coqloadpath.ml
+++ b/sysinit/coqloadpath.ml
@@ -19,15 +19,14 @@ let build_stdlib_vo_path ~unix_path ~rocq_path =
 let build_userlib_path ~unix_path =
   let open Loadpath in
   if Sys.file_exists unix_path then
-    let ml_path = System.all_subdirs ~unix_path |> List.map fst in
     let vo_path =
       { unix_path
       ; coq_path = Libnames.default_root_prefix
       ; implicit = false
       ; recursive = true
       } in
-    ml_path, [vo_path]
-  else [], []
+    [vo_path]
+  else []
 
 (* LoadPath for Coq user libraries *)
 let init_load_path ~coqenv =
@@ -46,12 +45,12 @@ let init_load_path ~coqenv =
     else []
   in
   let stdlib = Boot.Env.stdlib coqenv |> Boot.Path.to_string in
-  let contrib_ml, contrib_vo = build_userlib_path ~unix_path:user_contrib in
+  let contrib_vo = build_userlib_path ~unix_path:user_contrib in
 
-  let misc_ml, misc_vo =
-    List.map (fun s -> build_userlib_path ~unix_path:s) (xdg_dirs @ rocqpath) |> List.split in
+  let misc_vo =
+    List.map (fun s -> build_userlib_path ~unix_path:s) (xdg_dirs @ rocqpath) in
 
-  let ml_loadpath = meta_dir @ contrib_ml @ List.concat misc_ml in
+  let ml_loadpath = meta_dir in
   let vo_loadpath =
     (* current directory (not recursively!) *)
     [ { unix_path = "."


### PR DESCRIPTION
We still add coq-core (actually coq-core/.. du to findlib limitations) for #15607 (coqc installed in a non-findlib location, typically calling _build/install/default/bin/coqc without going through `dune exec`)
