### PR TITLE
Typeops.type_of_apply fix empty stack check

### DIFF
--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -224,10 +224,10 @@ let type_of_apply env func funt argsv argstv =
     if Int.equal i len then term_of_fconstr typ
     else
       let typ, stk = whd_stack infos tab typ [] in
-      (** The return stack is known to be empty *)
-      let () = assert (check_empty_stack stk) in
       match fterm_of typ with
       | FProd (_, c1, c2, e) ->
+        (** The return stack is known to be empty *)
+        let () = assert (check_empty_stack stk) in
         let arg = argsv.(i) in
         let argt = argstv.(i) in
         let c1 = term_of_fconstr c1 in

--- a/test-suite/bugs/bug_19843.v
+++ b/test-suite/bugs/bug_19843.v
@@ -1,0 +1,5 @@
+Goal True.
+refine (_ 0).
+exact_no_check (@nil nat).
+Fail Qed.
+Abort.


### PR DESCRIPTION
We only know that the stack is empty when the head is FProd, not for arbitrary heads.

Fix #19843