### PR TITLE
Use `reference` nonterminal to parse references in terms

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -382,8 +382,7 @@ term1: [
 ]
 
 term0: [
-| DELETE ident univ_annot
-| DELETE ident Prim.fields univ_annot
+| DELETE reference univ_annot
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO number_or_string NUMBER

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -116,8 +116,7 @@ term1: [
 term0: [
 | atomic_constr
 | term_match
-| ident Prim.fields univ_annot
-| ident univ_annot
+| reference univ_annot
 | NUMBER
 | string
 | "(" term200 ")"

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -211,10 +211,8 @@ GRAMMAR EXTEND Gram
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }
-      | id = ident; f = Prim.fields; i = univ_annot ->
-        { let (l,id') = f in CAst.make ~loc @@ CRef (make_qualid ~loc (DirPath.make (l@[id])) id', i) }
-      | id = ident; i = univ_annot ->
-        { CAst.make ~loc @@ CRef (qualid_of_ident ~loc id, i) }
+      | id = reference; i = univ_annot ->
+        { CAst.make ~loc @@ CRef (id, i) }
       | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "("; c = term LEVEL "200"; ")" ->

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -140,8 +140,7 @@ Entry term is
   | NUMBER
   | atomic_constr
   | term_match
-  | ident; fields; univ_annot
-  | ident; univ_annot
+  | reference; univ_annot
   | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -65,8 +65,7 @@ Entry term is
   | NUMBER
   | atomic_constr
   | term_match
-  | ident; fields; univ_annot
-  | ident; univ_annot
+  | reference; univ_annot
   | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -1,28 +1,28 @@
-File "./output/Qf_stdlib.v", line 8, characters 15-30:
+File "./output/Qf_stdlib.v", line 12, characters 15-30:
 Warning: Coq.ssr.ssrbool has been replaced by Stdlib.ssr.ssrbool.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 8, characters 15-30 with Stdlib.ssr.ssrbool
-File "./output/Qf_stdlib.v", line 9, characters 0-42:
+Replace File "./output/Qf_stdlib.v", line 12, characters 15-30 with Stdlib.ssr.ssrbool
+File "./output/Qf_stdlib.v", line 13, characters 0-42:
 Warning: "From Coq" has been replaced by "From Stdlib".
 [deprecated-from-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 9, characters 5-8 with Stdlib
-File "./output/Qf_stdlib.v", line 12, characters 6-22:
+Replace File "./output/Qf_stdlib.v", line 13, characters 5-8 with Stdlib
+File "./output/Qf_stdlib.v", line 16, characters 6-22:
 Warning: Coq.Init.Nat.add has been replaced by Stdlib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 12, characters 6-22 with Stdlib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 16, characters 6-22 with Stdlib.Init.Nat.add
 Nat.add : nat -> nat -> nat
 
 Nat.add is not universe polymorphic
 Arguments Nat.add (n m)%nat_scope
 Nat.add is transparent
 Expands to: Constant Stdlib.Init.Nat.add
-File "./output/Qf_stdlib.v", line 13, characters 6-22:
+File "./output/Qf_stdlib.v", line 17, characters 6-22:
 Warning: Coq.Init.Nat.add has been replaced by Stdlib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 13, characters 6-22 with Stdlib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 17, characters 6-22 with Stdlib.Init.Nat.add
 Nat.add
      : nat -> nat -> nat

--- a/test-suite/output/Qf_stdlib.v
+++ b/test-suite/output/Qf_stdlib.v
@@ -1,3 +1,7 @@
+(* -*- coq-prog-args: ("-async-proofs" "off"); -*- *)
+(* async proofs off because the output order ends up different with
+   and without async *)
+
 (* Example from coq-lsp: we need to test 3 methods where the quickfix
   can come from for the Coq -> Stdlib transition:
 


### PR DESCRIPTION
instead of `id; OPT fields`
