### PR TITLE
Remove the unused PATTERNIDENT token.

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -220,7 +220,6 @@ let print_pat fmt = print_opt fmt print_string in
 function
 | "", Some s -> fprintf fmt "Tok.PKEYWORD (%a)" print_string s
 | "IDENT", s -> fprintf fmt "Tok.PIDENT (%a)" print_pat s
-| "PATTERNIDENT", s -> fprintf fmt "Tok.PPATTERNIDENT (%a)" print_pat s
 | "FIELD", s -> fprintf fmt "Tok.PFIELD (%a)" print_pat s
 | "NUMBER", None -> fprintf fmt "Tok.PNUMBER None"
 | "NUMBER", Some s -> fprintf fmt "Tok.PNUMBER (Some (NumTok.Unsigned.of_string %a))" print_string s

--- a/parsing/tok.mli
+++ b/parsing/tok.mli
@@ -12,7 +12,6 @@
 
 type 'c p =
   | PKEYWORD : string -> string p
-  | PPATTERNIDENT : string option -> string p
   | PIDENT : string option -> string p
   | PFIELD : string option -> string p
   | PNUMBER : NumTok.Unsigned.t option -> NumTok.Unsigned.t p
@@ -26,7 +25,6 @@ val pattern_strings : 'c p -> string * string option
 
 type t =
   | KEYWORD of string
-  | PATTERNIDENT of string
   | IDENT of string
   | FIELD of string
   | NUMBER of NumTok.Unsigned.t


### PR DESCRIPTION
Trivial cleanup. I don't know when this became dead code, though.