### PR TITLE
CClosure: absorb arguments in FConstruct

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -175,16 +175,15 @@ val skip_irrelevant_stack : clos_infos -> stack -> stack
 
 val eta_expand_stack : clos_infos -> Name.t binder_annot -> stack -> stack
 
-(** [eta_expand_ind_stack env ind c s t] computes stacks corresponding
-    to the conversion of the eta expansion of t, considered as an inhabitant
-    of ind, and the Constructor c of this inductive type applied to arguments
-    s.
+(** [eta_expand_ind_stack env ind c t] computes stacks corresponding
+    to the conversion of the eta expansion of [t], considered as an inhabitant
+    of [ind], and the Constructor [c] of this inductive type containing its arguments.
     Assumes [t] is a rigid term, and not a constructor. [ind] is the inductive
-    of the constructor term [c]
+    of the constructor term [c].
     @raise Not_found if the inductive is not a primitive record, or if the
     constructor is partially applied.
  *)
-val eta_expand_ind_stack : env -> pinductive -> fconstr -> stack ->
+val eta_expand_ind_stack : env -> pinductive -> fconstr ->
    (fconstr * stack) -> stack * stack
 
 (** Conversion auxiliary functions to do step by step normalisation *)

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -37,7 +37,7 @@ type fterm =
   | FAtom of constr (** Metas and Sorts *)
   | FFlex of table_key
   | FInd of pinductive
-  | FConstruct of pconstructor
+  | FConstruct of pconstructor * fconstr array
   | FApp of fconstr * fconstr array
   | FProj of Projection.t * Sorts.relevance * fconstr
   | FFix of fixpoint * usubs

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -227,12 +227,12 @@ let rec infer_fterm cv_pb infos variances hd stk =
       infer_inductive_instance cv_pb (info_env (fst infos)) variances ind nargs u
     in
     infer_stack infos variances stk
-  | FConstruct (ctor,u) ->
+  | FConstruct ((ctor,u),args) ->
     let variances =
-      let nargs = stack_args_size stk in
+      let nargs = Array.length args in
       infer_constructor_instance_eq (info_env (fst infos)) variances ctor nargs u
     in
-    infer_stack infos variances stk
+    infer_stack infos variances (append_stack args stk)
   | FFix ((_,(na,tys,cl)),e) | FCoFix ((_,(na,tys,cl)),e) ->
     let n = Array.length cl in
     let variances = infer_vect infos variances (Array.map (mk_clos e) tys) in

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -228,6 +228,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
     in
     infer_stack infos variances stk
   | FConstruct ((ctor,u),args) ->
+    assert (List.is_empty stk);
     let variances =
       let nargs = Array.length args in
       infer_constructor_instance_eq (info_env (fst infos)) variances ctor nargs u


### PR DESCRIPTION

I did a manual trace of lazy on `iseven (2 * 1)`
(https://gist.github.com/SkySkimmer/de2f10cfdbf4771ed792d77eaa7ff962)
and it seemed like we kept doing

~~~
KNH (S x) | some fix ; stack
KNR S | x ; some fix ; stack
KNH (unfolded fix) | (S x) ; stack
~~~

with constant splaying and rebuilding of applications with constructor heads.

This patch attempts to reduce such occurrences.
