### PR TITLE
Add natural number arithmetic lemmas centered around shiftr+shiftl

### DIFF
--- a/stdlib/theories/NArith/BinNat.v
+++ b/stdlib/theories/NArith/BinNat.v
@@ -225,6 +225,11 @@ Proof.
  destruct p; simpl; trivial. f_equal. apply Pos.succ_pred_double.
 Qed.
 
+Lemma succ_comm p : N.pos (Pos.succ p) = succ (N.pos p).
+Proof.
+  now unfold succ.
+Qed.
+
 (** Properties of successor and predecessor *)
 
 Theorem pred_succ n : pred (succ n) = n.

--- a/stdlib/theories/Numbers/NatInt/NZBase.v
+++ b/stdlib/theories/Numbers/NatInt/NZBase.v
@@ -62,6 +62,22 @@ intros n1 n2 H.
 apply pred_wd in H. now do 2 rewrite pred_succ in H.
 Qed.
 
+(* I cannot interpret this file at all. Error:
+    Cannot find a physical path bound to logical path
+    NZAxioms with prefix Stdlib.Numbers.NatInt.
+*) 
+Lemma Possucc_inj:
+  forall x y, x = y <-> Pos.succ x = Pos.succ y.
+Proof.
+  intros; split; intros.
+    + rewrite H; reflexivity.
+    + generalize dependent y. induction x using Pos.peano_ind; intros.
+      - repeat (discriminate || reflexivity || destruct y).
+      - rewrite <-Pos.add_1_r in H.
+        assert (H1: Pos.succ x = (Pos.succ y - 1)%positive). lia.
+        rewrite Pos.sub_1_r in H1. now rewrite Pos.pred_succ in H1.
+Qed.
+
 (* The following theorem is useful as an equivalence for proving
 bidirectional induction steps *)
 Theorem succ_inj_wd : forall n1 n2, S n1 == S n2 <-> n1 == n2.
@@ -78,6 +94,16 @@ Qed.
 
 (* We cannot prove that the predecessor is injective, nor that it is
 left-inverse to the successor at this point *)
+Lemma Pospred_inj:
+  forall x y, x <> 1%positive -> y <> 1%positive -> x = y <-> Pos.pred x = Pos.pred y.
+Proof.
+  intros; split; intros.
+  + rewrite H1; reflexivity.
+  + generalize dependent y. induction x using Pos.peano_ind; intros.
+      - repeat (discriminate || reflexivity || contradiction || destruct y).
+      - rewrite <-Pos.add_1_r in H.
+        assert (H2: Pos.succ x = (Pos.succ y - 1)%positive); try lia.
+Qed.
 
 Section CentralInduction.
 

--- a/stdlib/theories/Numbers/Natural/Abstract/NBits.v
+++ b/stdlib/theories/Numbers/Natural/Abstract/NBits.v
@@ -1138,7 +1138,7 @@ Proof.
  - now rewrite !shiftl_spec_low.
 Qed.
 
-Lemma   shiftr_lor : forall a b n,
+Lemma shiftr_lor : forall a b n,
  (lor a b) >> n == lor (a >> n) (b >> n).
 Proof.
  intros. bitwise. now rewrite !shiftr_spec', lor_spec.

--- a/stdlib/theories/Numbers/Natural/Abstract/NDiv.v
+++ b/stdlib/theories/Numbers/Natural/Abstract/NDiv.v
@@ -96,6 +96,43 @@ Proof. intros. apply div_mul; auto'. Qed.
 Lemma mod_mul : forall a b, b~=0 -> (a*b) mod b == 0.
 Proof. intros. apply mod_mul; auto'. Qed.
 
+(* Error:
+    setoid rewrite failed: UNDEFINED EVARS:
+    ... *)
+Lemma add_div_base:
+  forall a b, b <> 0 -> (b + a) / b =  N.succ (a / b).
+Proof.
+  intros. rewrite (N.div_mod a b) at 1; try assumption. rewrite N.add_assoc.
+  rewrite <-(N.mul_1_r b) at 1. rewrite <-(N.mul_add_distr_l b 1 (a/b)).
+  rewrite N.add_1_l. rewrite <- N.div_unique with (q:=N.succ (a/b)) (r:=a mod b). reflexivity.
+  apply N.mod_upper_bound; assumption.
+  reflexivity.
+Qed.
+
+Lemma pred_mul_mod:
+  forall w q, 0 < w -> 0 < w * q -> N.pred (w * q) mod w = N.pred w.
+Proof.
+  intros. rewrite N.pred_sub. 
+  enough (Hhelp: exists q', q = N.succ q'); try destruct Hhelp.
+  rewrite H1, N.mul_succ_r, <-N.add_sub_assoc, <-N.Div0.add_mod_idemp_l.
+  rewrite N.mul_comm, N.Div0.mod_mul, N.add_0_l.
+  rewrite N.mod_small. all: try lia.
+  exists (N.pred q); try lia.
+Qed.
+
+Lemma succ_mod_swap:
+  forall c b, N.succ c mod b = N.succ (c mod b) mod b.
+Proof.
+  intros c b. destruct (N.eq_dec b 0) as [H | H].
+  subst. now repeat rewrite N.mod_0_r. remember H as NZ. clear HeqNZ.
+  apply (N.div_mod c (b)) in H.
+  remember (c / b) as q; remember (c mod b) as r.
+  destruct (N.lt_trichotomy (N.succ r) (b)) as [Lt | [Eq | Gt]].
+  1,2: rewrite H, <-N.add_succ_r, N.add_comm, N.mul_comm, N.Div0.mod_add; reflexivity.
+  assert (Help: c mod b < b) by (apply N.mod_upper_bound; lia). rewrite <-Heqr in Help.
+  lia.
+Qed.
+
 
 (** * Order results about mod and div *)
 


### PR DESCRIPTION
monotonicity and modular operations with succ and pred.

Seeking early feedback and direction to guide my efforts. I know that the proofs are eyesores but I believe the theorems are valuable additions to the standard library to prevent people from duplicating my toil.

I'm not sure how to change the proofs to work within the standard library. For example when I tried executing my proof using N.peano_ind it was not found, in another case I got "setoid rewrite failed: UNDEFINED EVARS" when previously my simple rewrite worked.

- [ ] Added / updated **test-suite**.
- [ ] Documented any new / changed **user messages**.
- [ ] Updated **documented syntax** by running `make doc_gram_rsts`.



Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
