### PR TITLE
Update ci-macos.yml

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: homebrew outdated pkg-config fix
-        if: runner.os == 'Macos'
         run: |
           brew update
           brew upgrade

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,12 +12,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: homebrew outdated pkg-config fix
+        if: runner.os == 'Macos'
+        run: |
+          brew update
+          brew upgrade
+          brew install pkgconf
+          # work around https://github.com/actions/runner-images/issues/10984
+
       - name: Install system dependencies
         run: |
-          brew unlink pkg-config
-          brew install gnu-time opam gtksourceview3 adwaita-icon-theme expat libxml2 pkgconf
-          brew unlink pkgconf
-          brew link pkg-config
+          brew install gnu-time opam gtksourceview3 adwaita-icon-theme expat libxml2
 
       - name: Install OCaml dependencies
         run: |


### PR DESCRIPTION
This should fix the CI issue and not break once macos workers are fixed.
See https://github.com/ocaml/opam-repository/pull/26891