### PR TITLE
coqdep make explicit dependencies on deps of plugins

### DIFF
--- a/tools/coqdep/lib/dep_info.ml
+++ b/tools/coqdep/lib/dep_info.ml
@@ -13,6 +13,18 @@ module Dep = struct
   | Require of string (* one basename, to which we later append .vo or .vos *)
   | Ml of string
   | Other of string (* filenames of dependencies, separated by spaces *)
+
+  let compare a b = match a, b with
+    | Require a, Require b | Ml a, Ml b | Other a, Other b -> CString.compare a b
+    | Require _, _ -> -1
+    | _, Require _ -> 1
+    | Ml _, _ -> -1
+    | _, Ml _ -> 1
+
+  module Set = CSet.Make(struct
+      type nonrec t = t
+      let compare = compare
+    end)
 end
 
 type t =

--- a/tools/coqdep/lib/dune
+++ b/tools/coqdep/lib/dune
@@ -1,5 +1,16 @@
 (library
  (name coqdeplib)
+ (public_name coq-core.coqdeplib)
  (libraries coq-core.boot coq-core.lib findlib.internal))
 
 (ocamllex lexer)
+
+(rule
+ (targets static_toplevel_libs.ml)
+ (deps %{project_root}/_build/install/%{context_name}/lib/coq-core/META)
+ (action
+  (with-stdout-to %{targets}
+   (run ocamlfind query -recursive -predicates native coq-core.toplevel
+        -prefix "let static_toplevel_libs = [\n"
+        -format "\"%p\";"
+        -suffix "\n]\n"))))

--- a/tools/coqdep/lib/fl.mli
+++ b/tools/coqdep/lib/fl.mli
@@ -8,14 +8,17 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** [findlib_resolve ~file ~package ~plugin_name] tries to locate
-    a [.cmxs] for a given [package.plugin_name].
+(** [findlib_deep_resolve ~file ~package] tries to locate
+    a [.cmxs] for a given [package]. It also searches for its dependencies.
+
+    Dependencies of coq-core.toplevel (i.e. coqc) are ignored.
+
+    [file] is used for error messages.
 
     If a [META] file for [package] is found, it will try to use it to resolve
     the path to the [.cmxs], and return a relative path to both. If not, it
     errors. *)
-val findlib_resolve
+val findlib_deep_resolve
   :  file:string
   -> package:string
-  -> plugin_name:string list
-  -> string * string
+  -> string list * string list

--- a/tools/coqdep/lib/static_toplevel_libs.mli
+++ b/tools/coqdep/lib/static_toplevel_libs.mli
@@ -8,21 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Dep : sig
-  type t =
-  | Require of string
-  (** module basename, to which we later append .vo or .vos *)
-  | Ml of string
-  (** plugin basename and byte extension, resolved from Declare Ml Module *)
-  | Other of string
-  (** load, meta, and external dependencies *)
-
-  module Set : CSet.ExtS with type elt = t
-end
-
-type t =
-  { name : string  (* This should become [module : Coq_module.t] eventually *)
-  ; deps : Dep.t list
-  }
-
-val make : name:string -> deps:Dep.t list -> t
+val static_toplevel_libs : string list

--- a/tools/dune_rule_gen/dune
+++ b/tools/dune_rule_gen/dune
@@ -2,7 +2,7 @@
  (name coq_dune)
  (modules :standard \ gen_rules)
  (flags :standard -w +a-40-42)
- (libraries coqdeplib findlib))
+ (libraries coq-core.coqdeplib findlib))
 
 (executable
  (name gen_rules)

--- a/tools/dune_rule_gen/gen_rules.ml
+++ b/tools/dune_rule_gen/gen_rules.ml
@@ -120,7 +120,5 @@ let () =
   let _ : int = Feedback.add_feeder pr_feedback in
   try main ()
   with exn ->
-    let bt = Printexc.get_backtrace () in
-    let exn = Printexc.to_string exn in
-    Format.eprintf "[gen_rules] Fatal error: %s@\n%s@\n%!" exn bt;
+    Format.eprintf "[gen_rules] Fatal error:@ @[<2>%a@]@\n%!" Pp.pp_with (CErrors.print exn);
     exit 1


### PR DESCRIPTION
For #17490 (also needs #19886)

coqdep must filter out dependencies which are linked in coqc (otherwise if we add eg `extraction -> merlin` we recurse into `merlin -> str`, and `str` has a strange META with `directory = "^"`). Since I don't see a clear way to get the list of such libraries I hardcoded it.

Waiting for:
- https://github.com/coq/coq/pull/19863