### PR TITLE
Add -I support for dune-dbg

### DIFF
--- a/dev/dune-dbg.in
+++ b/dev/dune-dbg.in
@@ -8,6 +8,11 @@ while [[ $# -gt 0 ]]; do
             shift
             opts+=("-emacs")
             ;;
+        -I)
+          shift
+          opts+=("-I" "$1")
+          shift
+          ;;
         coqchk)
             shift
             exe=_build/default/checker/coqchk.bc


### PR DESCRIPTION
The goal is to be able to run ocamldebug with CI plugins

Instructions for elpi:

- `dune build dev/dune-dbg`
- `make ci-elpi`
- `dune exec --no-build  -- dev/dune-dbg -emacs -I $(pwd)/_build_ci/elpi coqc test.v`
where `test.v` contains eg
~~~coq
From elpi.apps Require Import NES.

NES.Begin This.Is.A.Long.Namespace.
~~~
- usual ocamldebug commands (setting breakpoints in elpi code won't work until it has been dynlinked)

Notes:
- if you forget `--no-build` or run any `dune build`, coq-elpi will be evicted from _build (not _build_ci/elpi/_build) so do `make ci-elpi` again
- add `-I $OPAM_SWITCH_PREFIX/.opam-switch/sources/elpi.$elpi_version` to the dune-dbg call (or do `directory` while in ocamldebug) if you want to step in elpi (as opposed to coq-elpi) code ($elpi_version currently should be 1.19.2) (IDK why it can't use the sources installed at the findlib location $OPAM_SWITCH_PREFIX/lib/elpi)
- Maybe it would also make sense to automatically add `-I` for every directory in _build_ci?
- it would be nice to not need --no-build, but I don't know how to achieve that.