### PR TITLE
Remove outdated comment in conversion.ml

### DIFF
--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -407,7 +407,6 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
                else raise NotConvertible
            | _ -> raise NotConvertible)
     | (FEvar (ev1, args1, env1, _), FEvar (ev2, args2, env2, _)) ->
-        (* TODO: handle irrelevance *)
         if Evar.equal ev1 ev2 then
           let el1 = el_stack lft1 v1 in
           let el2 = el_stack lft2 v2 in


### PR DESCRIPTION
irrelevance is handled by reduction turning irrelevant evars into FIrrelevant
