### PR TITLE
Remove add_known_module in cctac.ml

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -585,8 +585,3 @@ let f_equal =
         | e -> Proofview.tclZERO ~info e
       end
   end
-
-(* we need to be registered in case we are statically linked to avoid double loading
-   (in practice we are statically linked in coqtop.byte:
-    coqtop.byte -> coq-core.dev -> ltac2 -> cc_core) *)
-let () = Mltop.add_known_module "coq-core.plugins.cc_core"

--- a/plugins/cc/dune
+++ b/plugins/cc/dune
@@ -3,7 +3,7 @@
  (public_name coq-core.plugins.cc_core)
  (synopsis "Rocq's congruence closure plugin")
  (modules (:standard \ g_congruence))
- (libraries coq-core.vernac))
+ (libraries coq-core.tactics))
 
 (library
  (name cc_plugin)


### PR DESCRIPTION
It is not needed since the removal of legacy loading

(dune automatically generates Findlib.record_package calls for all statically linked packages in an executable)
