### PR TITLE
'Ltac2 Notation string := ...' is not abbreviation.

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1217,6 +1217,7 @@ Notations
    into the right-hand side.  In the following example, `x` is the formal parameter name and
    `constr` is its :ref:`syntactic class<syntactic_classes>`.  `print` and `of_constr` are
    functions provided by Rocq through `Message.v`.
+   (Also see :cmd:`Ltac2 Notation (abbreviation)`.)
 
    .. flag:: Ltac2 Typed Notations
 
@@ -1310,6 +1311,7 @@ Abbreviations
    insofar as its main purpose is to give an
    absolute name to a piece of pure syntax, which can be transparently referred to
    by this name as if it were a proper definition.
+   (See :cmd:`Ltac2 Notation` for the general description of notations.)
 
    The abbreviation can then be manipulated just like a normal Ltac2 definition,
    except that it is expanded at internalization time into the given expression.

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1301,7 +1301,7 @@ Notations
 Abbreviations
 ~~~~~~~~~~~~~
 
-.. cmd:: Ltac2 Notation {| @string | @ident } := @ltac2_expr
+.. cmd:: Ltac2 Notation @ident := @ltac2_expr
    :name: Ltac2 Notation (abbreviation)
 
    Introduces a special kind of notation, called an abbreviation,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2050,7 +2050,7 @@ ltac2_entry: [
 | WITH "Ltac2" tac2def_val
 | REPLACE tac2def_ext     (* Ltac2 plugin *)
 | WITH "Ltac2" tac2def_ext
-| "Ltac2" "Notation" [ string | ident ] ":=" ltac2_expr6 TAG Ltac2  (* variant *)
+| "Ltac2" "Notation" ident ":=" ltac2_expr6 TAG Ltac2  (* variant *)
 | MOVEALLBUT command
 (* todo: MOVEALLBUT should ignore tag on "but" prodns *)
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -988,7 +988,7 @@ command: [
 | "Ltac2" "@" "external" ident ":" ltac2_type ":=" string string
 | "Ltac2" "Notation" LIST1 ltac2_scope OPT ( ":" natural ) ":=" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Set" qualid OPT [ "as" ident ] ":=" ltac2_expr
-| "Ltac2" "Notation" [ string | ident ] ":=" ltac2_expr      (* Ltac2 plugin *)
+| "Ltac2" "Notation" ident ":=" ltac2_expr      (* Ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr      (* ltac2 plugin *)
 | "Print" "Ltac2" qualid      (* ltac2 plugin *)
 | "Print" "Ltac2" "Type" qualid      (* ltac2 plugin *)


### PR DESCRIPTION
Ltac2 abbreviation notation is specified only by identifier.
'Ltac2 Notation "foo" := ...' does not specify an abbreviation notation.

I use Coq 8.20.0.

The Coq manual describes that
both "Ltac2 Notation identifier := ..." and
"Ltac2 Notation string := ..." specify abbreviation notation.

https://coq.inria.fr/doc/V8.20.0/refman/proof-engine/ltac2.html#abbreviations

But they behave differently as follows.

"Ltac2 Notation foo := ..." fails:

```
From Ltac2 Require Import Ltac2.
Fail Ltac2 Notation foo := @bar.
(* Cannot globalize generic arguments of type ident *)
```

But 'Ltac2 Notation "foo" := ...' succeeds.

I asked about this difference in the Zulip chat.
https://coq.zulipchat.com/#narrow/channel/278935-Ltac2/topic/Ltac2.20Notation.20error.3A.20Cannot.20globalize.20generic.20arguments.20.2E.2E.2E

Pierre-Marie Pédrot answered that the document is wrong.

> The doc is wrong, this syntax entry should be restricted to identifiers.

https://coq.zulipchat.com/#narrow/channel/278935-Ltac2/topic/Ltac2.20Notation.20error.3A.20Cannot.20globalize.20generic.20arguments.20.2E.2E.2E/near/484424402

This pull-request fixes the problem.
It removes string from Ltac2 Notation syntax for abbreviations.
