### PR TITLE
[typeclasses] Fix #19728, typeclasse resolution vs unification heuristics

### DIFF
--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -64,10 +64,11 @@ val unify : ?flags:unify_flags -> ?with_ho:bool ->
    The with_ho option tells if higher-order unification should be tried
    to resolve the constraints.
 
-    @raises a PretypeError if it fails to resolve some problem *)
+   The [best_effort] flag allows some or all problems to remain, otherwise
+   @raises a PretypeError if it fails to resolve one of the problems *)
 
 val solve_unif_constraints_with_heuristics :
-  env -> ?flags:unify_flags -> ?with_ho:bool -> evar_map -> evar_map
+  env -> ?flags:unify_flags -> ?with_ho:bool -> ?best_effort:bool -> evar_map -> evar_map
 
 (** Check all pending unification problems relative to a set of evars
     are solved and raise a PretypeError otherwise *)


### PR DESCRIPTION
This fix allows some unification heurstics to apply before typeclass resolution in addition to after resolution

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #19728 

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
