### PR TITLE
Fix incorrect path normalization in coqdep on `//..`

### DIFF
--- a/tools/coqdep/lib/file_util.ml
+++ b/tools/coqdep/lib/file_util.ml
@@ -8,11 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+let re_delim = Str.regexp (if Sys.win32 then "[/\\]+" else "/+" )
+
 let to_relative_path : string -> string = fun full_path ->
   if Filename.is_relative full_path then full_path else
-  let re_delim = if Sys.win32 then "[/\\]" else "/" in
-  let cwd = Str.split_delim (Str.regexp re_delim) (Sys.getcwd ()) in
-  let path = Str.split_delim (Str.regexp re_delim) full_path in
+  let cwd = Str.split_delim re_delim (Sys.getcwd ()) in
+  let path = Str.split_delim re_delim full_path in
   let rec remove_common_prefix l1 l2 =
     match (l1, l2) with
     | (x1 :: l1, x2 :: l2) when x1 = x2 -> remove_common_prefix l1 l2
@@ -23,8 +24,7 @@ let to_relative_path : string -> string = fun full_path ->
   List.fold_left add_parent path cwd
 
 let normalize_path : string -> string = fun path ->
-  let re_delim = if Sys.win32 then "[/\\]" else "/" in
-  let path = Str.split_delim  (Str.regexp re_delim) path in
+  let path = Str.split_delim re_delim path in
   let rec normalize acc path =
     match (path, acc) with
     | ([]          , _          ) -> List.rev acc


### PR DESCRIPTION
`x/y//..` would get normalized to `x/y` instead of `x`

Fix #19862
