### PR TITLE
[build] Fix wrong use of %{project_root}/_build in config files

### DIFF
--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -91,7 +91,7 @@
   ; without this if the gtk libs are not available dune can try to use
   ; coqide from PATH instead of giving a nice error
   ; there is no problem with the other shims since they don't depend on optional build products
-  %{project_root}/ide/coqide/coqide_main.exe
+  %{project_root}/ide/coqide/rocqide_main.exe
   %{bin:coqworker.opt}
   %{project_root}/theories/Init/Prelude.vo
   %{project_root}/coqide-server.install

--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -18,7 +18,7 @@
   (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqtop} -I \"$(dirname \"$0\")/%{project_root}/../install/default/lib\" -coqlib \"$(dirname \"$0\")/%{project_root}\" \"$@\"'")
+    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqtop} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")/%{project_root}\" \"$@\"'")
     (run chmod +x %{targets})))))
 
 ; coqc
@@ -37,7 +37,7 @@
   (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqc} -I \"$(dirname \"$0\")/%{project_root}/../install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} -nI \"$(dirname \"$0\")\"/%{project_root}/kernel/.kernel.objs/byte \"$@\"'")
+    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqc} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} -nI \"$(dirname \"$0\")\"/%{project_root}/kernel/.kernel.objs/byte \"$@\"'")
     (run chmod +x %{targets})))))
 
 ; coqtop.byte
@@ -80,7 +80,7 @@
   (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqtop.byte} -I \"$(dirname \"$0\")/%{project_root}/../install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} \"$@\"'")
+    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqtop.byte} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} \"$@\"'")
     (run chmod +x %{targets})))))
 
 ; coqide
@@ -104,5 +104,5 @@
   (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqide} -I \"$(dirname \"$0\")/%{project_root}/../install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} \"$@\"'")
+    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqide} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")\"/%{project_root} \"$@\"'")
     (run chmod +x %{targets})))))

--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -21,6 +21,25 @@
     (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqtop} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")/%{project_root}\" \"$@\"'")
     (run chmod +x %{targets})))))
 
+; coqidetop
+
+(alias
+ (name coqidetop-prelude)
+ (deps
+  %{bin:coqidetop.opt}
+   ; XXX: bug, we are missing the dep on the _install meta file...
+  %{project_root}/theories/Init/Prelude.vo))
+
+(rule
+ (targets coqidetop.opt)
+ (deps (alias coqidetop-prelude))
+ (action
+  (with-stdout-to %{targets}
+   (progn
+    (echo "#!/usr/bin/env bash\n")
+    (bash "echo '\"$(dirname \"$0\")\"/%{bin:coqidetop.opt} -I \"$(dirname \"$0\")/%{workspace_root}/_build/install/default/lib\" -coqlib \"$(dirname \"$0\")/%{project_root}\" \"$@\"'")
+    (run chmod +x %{targets})))))
+
 ; coqc
 
 (alias

--- a/dune
+++ b/dune
@@ -41,7 +41,7 @@
   (source_tree plugins)
   (source_tree theories)
   (source_tree user-contrib)
-  %{project_root}/_build/install/%{context_name}/lib/coq-core/META)
+  %{workspace_root}/_build/install/%{context_name}/lib/coq-core/META)
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Corelib theories %{env:COQ_DUNE_EXTRA_OPT=}))))
@@ -52,7 +52,7 @@
   (source_tree plugins)
   (source_tree theories)
   (source_tree user-contrib)
-  %{project_root}/_build/install/%{context_name}/lib/coq-core/META)
+  %{workspace_root}/_build/install/%{context_name}/lib/coq-core/META)
  (action
   (with-stdout-to %{targets}
    (run tools/dune_rule_gen/gen_rules.exe Ltac2 user-contrib/Ltac2 %{env:COQ_DUNE_EXTRA_OPT=}))))

--- a/tools/coqdep/lib/dune
+++ b/tools/coqdep/lib/dune
@@ -7,7 +7,7 @@
 
 (rule
  (targets static_toplevel_libs.ml)
- (deps %{project_root}/_build/install/%{context_name}/lib/coq-core/META)
+ (deps %{workspace_root}/_build/install/%{context_name}/lib/coq-core/META)
  (action
   (with-stdout-to %{targets}
    (run ocamlfind query -recursive -predicates native coq-core.toplevel

--- a/tools/dune_rule_gen/coq_rules.ml
+++ b/tools/dune_rule_gen/coq_rules.ml
@@ -51,11 +51,11 @@ let path_of_dep ~vo_ext dep =
      path to be relative to the .v won't work
 
      (it would be relative to the .v in
-     project_root/_build/default/theories but dune would read it as
+     workspace_root/_build/default/theories but dune would read it as
      relative to the .v in project_root/theories, the number of .. to
      insert to get to project_root doesn't match) *)
   let file = if CString.is_prefix ".." file then
-      (Filename.concat "%{project_root}" "_build")
+      (Filename.concat "%{workspace_root}" "_build")
       ^ String.sub file 2 (String.length file - 2)
     else file
   in


### PR DESCRIPTION
In particular, imagine a build setup such as:

```
my-dir/dune-project
my-dir/coq/...
my-dir/coq-lsp/...
```

dune will create `my-dir/_build`, however, inside Coq dune files,
`%{project_root}` will resolve to `my-lib/coq/_build` which doesn't
exist.

Thanks to Rodolphe Lepigre for catching this bug.

cc: #19857

