### PR TITLE
ci-stdlib don't use --release

### DIFF
--- a/dev/ci/ci-stdlib.sh
+++ b/dev/ci/ci-stdlib.sh
@@ -8,6 +8,6 @@ ci_dir="$(dirname "$0")"
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "stdlib"
-  dune build -p coq-stdlib @install
+  dune build --root . --only-packages=coq-stdlib @install
   dune install --root . coq-stdlib --prefix="$CI_INSTALL_DIR"
 )


### PR DESCRIPTION
In particular this makes it respect the user's `display` setting
