### PR TITLE
Preserve line delimiters in comment of a generated file

### DIFF
--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -518,11 +518,10 @@ let formatter dry file =
   ft
 
 let get_comment () =
-  let s = file_comment () in
+  let s = String.trim (file_comment ()) in
   if String.is_empty s then None
   else
-    let split_comment = Str.split (Str.regexp "[ \t\n]+") s in
-    Some (prlist_with_sep spc str split_comment)
+    Some (str s)
 
 let print_structure_to_file (fn,si,mo) dry struc =
   Buffer.clear buf;

--- a/stdlib/test-suite/output/Extraction_Haskell_String_12258.out
+++ b/stdlib/test-suite/output/Extraction_Haskell_String_12258.out
@@ -1,9 +1,7 @@
 {-# OPTIONS_GHC -cpp -XMagicHash #-}
 {- For Hugs, use the option -F"cpp -P -traditional" -}
 
-{- IMPORTANT: If you change this file, make sure that running [cp
-   Extraction_Haskell_String_12258.out Extraction_Haskell_String_12258.hs &&
-   ghc -o test Extraction_Haskell_String_12258.hs] succeeds -}
+{- IMPORTANT: If you change this file, make sure that running [cp Extraction_Haskell_String_12258.out Extraction_Haskell_String_12258.hs && ghc -o test Extraction_Haskell_String_12258.hs] succeeds -}
 
 module Main where
 

--- a/test-suite/output/Extraction_Haskell_Multiline_File_Comment.out
+++ b/test-suite/output/Extraction_Haskell_Multiline_File_Comment.out
@@ -1,0 +1,14 @@
+{- IMPORTANT:
+Multi
+line
+comment -}
+
+module Main where
+
+import qualified Prelude
+
+data Nat =
+   O
+ | S Nat
+
+

--- a/test-suite/output/Extraction_Haskell_Multiline_File_Comment.v
+++ b/test-suite/output/Extraction_Haskell_Multiline_File_Comment.v
@@ -1,0 +1,9 @@
+Require Import Stdlib.extraction.Extraction.
+Extraction Language Haskell.
+Set Extraction File Comment "IMPORTANT:
+Multi
+line
+comment
+".
+
+Recursive Extraction nat.


### PR DESCRIPTION
Coq extraction feature can inject a comment into the header of generated file.
Line delimiters are stripped from the comment string.
It makes impossible to write multi-line comments.
Git blame for the lines explains this logic as a workaround for a hack:

> Extraction: avoid initial strange empty comments after Arnaud's hack


- [x] Added / updated **test-suite**.
output/Extraction_Haskell_Multiline_File_Comment.v
output/Extraction_Haskell_String_12258.v

