### PR TITLE
Fix opam --with-test

### DIFF
--- a/dune
+++ b/dune
@@ -80,7 +80,7 @@
 ; Use summary.log as the target
 (alias
  (name runtest)
- (package rocq-core)
+ (package coq)
  (deps test-suite/summary.log))
 
 ; For make compat


### PR DESCRIPTION
That I accidentally broke in https://github.com/coq/coq/pull/19530

See https://github.com/coq/opam/pull/3240 for the original issue
and https://github.com/coq/opam/pull/3241 for the green opam repo CI on this branch.
