### PR TITLE
CI: dune use display=short

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ before_script:
   - eval $(opam env)
   - opam list
   - opam config list
+  - printf '(display short)\n' >> ~/.config/dune/config
   - dune printenv --root .
   - dev/tools/check-cachekey.sh
   - dev/ci/gitlab-section.sh end before_script


### PR DESCRIPTION
To see if job artifacts are properly used or if we rebuild the results we should be getting from dependencies.
