### PR TITLE
-vok does not stop on the first error

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2670,7 +2670,7 @@ let query ~doc ~at ~route s =
   s
 
 let edit_at ~doc id =
-  assert (VCS.is_interactive());
+  (* assert (VCS.is_interactive()); Needed for recovery mode in coqc -vok *)
   !Hooks.document_edit id;
   if Stateid.equal id Stateid.dummy then anomaly(str"edit_at dummy.") else
   let vcs = VCS.backup () in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -48,10 +48,13 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
     create_empty_file long_f_dot_vok in
   match mode with
   | BuildVo | BuildVok ->
+      let recovery_mode = match mode with BuildVok -> true | _ -> false in
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
           Stm.{ doc_type = VoDoc long_f_dot_out; injections; } in
-      let state = { doc; sid; proof = None; time = Option.map Vernac.make_time_output opts.config.time } in
+      let state = { doc; sid; proof = None;
+            time = Option.map Vernac.make_time_output opts.config.time;
+            failed_proofs = []; in_recovery = false; recovery_mode} in
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       Aux_file.(start_aux_file
@@ -91,7 +94,9 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
           Stm.{ doc_type = VosDoc long_f_dot_out; injections;
               } in
 
-      let state = { doc; sid; proof = None; time = Option.map Vernac.make_time_output opts.config.time } in
+      let state = { doc; sid; proof = None;
+            time = Option.map Vernac.make_time_output opts.config.time;
+            failed_proofs = []; in_recovery = false; recovery_mode = false } in
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       let source = source ldir long_f_dot_in in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -128,7 +128,11 @@ let init_document opts stm_options injections =
            { doc_type = Interactive opts.config.logic.toplevel_name;
              injections;
            }) in
-  { doc; sid; proof = None; time = Option.map Vernac.make_time_output opts.config.time }
+  { doc; sid; proof = None;
+    time = Option.map Vernac.make_time_output opts.config.time;
+    failed_proofs = [];
+    in_recovery = false;
+    recovery_mode = false}
 
 let init_toploop opts stm_opts injections =
   let state = init_document opts stm_opts injections in

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -20,6 +20,9 @@ module State : sig
     sid : Stateid.t;
     proof : Proof.t option;
     time : time_output option;
+    failed_proofs : (Names.Id.t * Pp.t) list;
+    in_recovery : bool;
+    recovery_mode : bool
   }
 
 end


### PR DESCRIPTION
With this modification, compilation does not fail on the first error inside proof, but discards all commands to the end of that proof, which is admitted.  Subsequent lemmas in the same file can then be proved, and they can raise more errors.  This makes it possible to have several errors in the same file, but not in the same proof.

At the end of compilation, a report is generated, indicating how many proofs failed, the name of each proof, and the error message.  In the current version, no location information is provided.

This version is a request for comments.  One big cause of concern is the need to change a line in stm.ml, because we need to use a command that is usually reserved for interactive mode, while the compiler is a batch process.

An alternative choice would be to execute all commands until the end of the proof, so that there could be more than one error for each lemma.  Moreover, focusing information could be used to guide the recovery process, but this would require more heavyweight programming.

The example file on which this has been tested is:
```
Lemma L1 : False.
Proof.
exact I.
fail "any failure".
Qed.

Lemma L2 : True.
Proof.
exact I.
Qed.

Lemma L3 : True /\ False.
Proof.
split.
  exact L2.
exact L1.
Qed.

Lemma L4 : True /\ False.
Proof.
split.
  exact L2.
exact L2.
Qed.

Lemma L5 : False.
Proof.
Admitted.

Lemma L6 : False.
Proof.
exact L5.
Qed.
```
For this file, compilation with -vok reports 2 errors.
```
Error:
proofs failed in file ./trials/toto.v, number of failures: 2
L1
The term "I" has type "True" while it is expected to have type "False".
L4
The term "L2" has type "True" while it is expected to have type "False".
```
Note that there is no report for Lemma L3, which uses Lemma L1, in spite of the failure for that file.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11479


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
