### PR TITLE
Bypass warning override when possible

### DIFF
--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -978,8 +978,9 @@ let declare_possibly_mutual_definitions ~info ~cinfo ~obls ?(is_telescope=false)
   let () =
     (* For the recursive case, we override the temporary notations used while proving, now using the global names *)
     let local = info.scope=Locality.Discharge in
-    CWarnings.with_warn ("-"^Notation.warning_overridden_name)
-      (List.iter (Metasyntax.add_notation_interpretation ~local (Global.env()))) ntns
+    if ntns <> [] then
+      CWarnings.with_warn ("-"^Notation.warning_overridden_name)
+        (List.iter (Metasyntax.add_notation_interpretation ~local (Global.env()))) ntns
   in
   refs
 


### PR DESCRIPTION
I was confused about this showing up in profiles. The change shows a slight speedup on BlueRock files that contain lots of definitions.

| Relative | Master   | MR       | Change   | Filename
|---------:|---------:|---------:|---------:|----------
|   -0.25% |  30852.1 |  30774.6 |    -77.6 | cpp2v-generated
