### PR TITLE
GADT-based representation of module / module types.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -196,11 +196,11 @@ let lookup_module mp env =
 
 let mk_mtb mp sign delta =
   { mod_mp = mp;
-    mod_expr = ();
+    mod_expr = ModTypeNul;
     mod_type = sign;
     mod_type_alg = None;
     mod_delta = delta;
-    mod_retroknowledge = ModTypeRK; }
+    mod_retroknowledge = ModTypeNul; }
 
 let rec collect_constants_without_body sign mp accu =
   let collect_field s lab = function
@@ -243,7 +243,7 @@ let rec check_module env opac mp mb opacify =
   let opac =
     check_signature env opac mb.mod_type mb.mod_mp mb.mod_delta opacify
   in
-  let optsign, opac = match mb.mod_expr with
+  let optsign, opac = match Declareops.mod_expr mb with
     | Struct sign_struct ->
       let opacify = collect_constants_without_body mb.mod_type mb.mod_mp opacify in
       (* TODO: a bit wasteful, we recheck the types of parameters twice *)

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -481,7 +481,7 @@ let v_retro_action =
   |]
 
 let v_retroknowledge =
-  v_sum "module_retroknowledge" 1 [|[|v_list v_retro_action|]|]
+  v_sum "module_retroknowledge" 0 [|[|v_list v_retro_action|]|]
 
 let v_puniv = v_opt v_int
 
@@ -572,7 +572,7 @@ let [_v_sfb;_v_struc;_v_sign;_v_mexpr;_v_impl;v_module;_v_modtype] : _ Vector.t 
            [|v_struc|]|])  (* Struct *)
   and v_module =
     v_tuple_c ("module_body",
-           [|v_mp;v_impl;v_sign;v_opt v_mexpr;v_resolver;v_retroknowledge|])
+           [|v_mp;v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_resolver;v_retroknowledge|])
   and v_modtype =
     v_tuple_c ("module_type_body",
            [|v_mp;v_noimpl;v_sign;v_opt v_mexpr;v_resolver;v_unit|])

--- a/dev/ci/user-overlays/19943-ppedrot-module-expr-type-gadt.sh
+++ b/dev/ci/user-overlays/19943-ppedrot-module-expr-type-gadt.sh
@@ -1,0 +1,3 @@
+overlay coq_lsp https://github.com/ppedrot/coq-lsp module-expr-type-gadt 19943
+
+overlay paramcoq https://github.com/ppedrot/paramcoq module-expr-type-gadt 19943

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -77,6 +77,10 @@ val inductive_make_projection : Names.inductive -> mutual_inductive_body -> proj
 val inductive_make_projections : Names.inductive -> mutual_inductive_body ->
   (Names.Projection.Repr.t * Sorts.relevance) array option
 
+(** {6 Modules} *)
+
+val mod_expr : module_body -> module_implementation
+
 (** {6 Kernel flags} *)
 
 (** A default, safe set of flags for kernel type-checking *)
@@ -91,5 +95,6 @@ val safe_flags : Conv_oracle.oracle -> typing_flags
 val hcons_const_body : ?hbody:(Constr.t -> Constr.t) ->
   ('a, 'b) pconstant_body -> ('a, 'b) pconstant_body
 val hcons_mind : mutual_inductive_body -> mutual_inductive_body
+val hcons_generic_module_body : 'a generic_module_body -> 'a generic_module_body
 val hcons_module_body : module_body -> module_body
 val hcons_module_type : module_type_body -> module_type_body

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -35,7 +35,8 @@ val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 val implem_smart_map :
   (structure_body -> structure_body) ->
   (module_expression -> module_expression) ->
-  (module_implementation -> module_implementation)
+  ('a, module_implementation) when_mod_body ->
+  ('a, module_implementation) when_mod_body
 
 val annotate_module_expression : module_expression -> module_signature ->
   (module_type_body, (constr * UVars.AbstractContext.t option) module_alg_expr) functorize
@@ -62,7 +63,7 @@ val add_linked_module : module_body -> link_info -> env -> env
 (** same, for a module type *)
 val add_module_type : ModPath.t -> module_type_body -> env -> env
 
-val add_retroknowledge : module_implementation module_retroknowledge -> env -> env
+val add_retroknowledge : mod_body module_retroknowledge -> env -> env
 
 (** {6 Strengthening } *)
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1245,7 +1245,7 @@ let build_module_body params restype senv =
   in
   let senv = set_vm_library vmtab senv in
   let mb' = functorize_module params mb in
-  { mb' with mod_retroknowledge = ModBodyRK senv.local_retroknowledge }
+  { mb' with mod_retroknowledge = ModBodyVal senv.local_retroknowledge }
 
 (** Returning back to the old pre-interactive-module environment,
     with one extra component and some updated fields
@@ -1294,11 +1294,11 @@ let end_module l restype senv =
 
 let build_mtb mp sign delta =
   { mod_mp = mp;
-    mod_expr = ();
+    mod_expr = ModTypeNul;
     mod_type = sign;
     mod_type_alg = None;
     mod_delta = delta;
-    mod_retroknowledge = ModTypeRK }
+    mod_retroknowledge = ModTypeNul }
 
 let end_modtype l senv =
   let mp = senv.modpath in
@@ -1407,11 +1407,11 @@ let export ~output_native_objects senv dir =
   let str = NoFunctor (List.rev senv.revstruct) in
   let mb =
     { mod_mp = mp;
-      mod_expr = FullStruct;
+      mod_expr = ModBodyVal FullStruct;
       mod_type = str;
       mod_type_alg = None;
       mod_delta = senv.modresolver;
-      mod_retroknowledge = ModBodyRK senv.local_retroknowledge
+      mod_retroknowledge = ModBodyVal senv.local_retroknowledge
     }
   in
   let ast, symbols =

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -331,10 +331,10 @@ and check_modtypes (cst, ustate) trace env mtb1 mtb2 subst1 subst2 equiv =
           if Modops.is_functor body_t1 then env
           else add_module
             {mod_mp = mtb1.mod_mp;
-             mod_expr = Abstract;
+             mod_expr = ModBodyVal Abstract;
              mod_type = subst_signature subst1 body_t1;
              mod_type_alg = None;
-             mod_retroknowledge = ModBodyRK [];
+             mod_retroknowledge = ModBodyVal [];
              mod_delta = mtb1.mod_delta} env
         in
         check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 equiv subst1 subst2

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -393,7 +393,7 @@ and extract_module access env mp ~all mb =
      Since we look at modules from outside, we shouldn't have variables.
      But a Declare Module at toplevel seems legal (cf #2525). For the
      moment we don't support this situation. *)
-  let impl = match mb.mod_expr with
+  let impl = match Declareops.mod_expr mb with
     | Abstract -> error_no_module_expr mp
     | Algebraic me -> extract_mexpression access env mp mb.mod_type me
     | Struct sign ->
@@ -407,7 +407,7 @@ and extract_module access env mp ~all mb =
   (* Slight optimization: for modules without explicit signatures
      ([FullStruct] case), we build the type out of the extracted
      implementation *)
-  let typ = match mb.mod_expr with
+  let typ = match Declareops.mod_expr mb with
     | FullStruct ->
       assert (Option.is_empty mb.mod_type_alg);
       mtyp_of_mexpr impl

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -90,7 +90,7 @@ and fields_of_mp mp =
   in
   Modops.subst_structure subs fields
 
-and fields_of_mb subs mb args = match mb.mod_expr with
+and fields_of_mb subs mb args = match Declareops.mod_expr mb with
   | Algebraic expr -> fields_of_expression subs mb.mod_mp args mb.mod_type expr
   | Struct sign ->
     let sign = Modops.annotate_struct_body sign mb.mod_type in

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1381,11 +1381,11 @@ let declare_one_include_core (me,base,kind,inl) =
   let () = assert (ModPath.equal cur_mp (Global.current_modpath ())) in
   (* Include Self support  *)
   let mb = { mod_mp = cur_mp;
-  mod_expr = ();
+  mod_expr = ModTypeNul;
   mod_type = RawModOps.Interp.current_struct ();
   mod_type_alg = None;
   mod_delta = RawModOps.Interp.current_modresolver ();
-  mod_retroknowledge = ModTypeRK }
+  mod_retroknowledge = ModTypeNul }
   in
   let rec compute_sign sign =
     match sign with

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -396,7 +396,7 @@ let print_signature' is_type extent env mp me =
 let unsafe_print_module extent env mp with_body mb =
   let name = print_modpath [] mp in
   let pr_equals = spc () ++ str ":= " in
-  let body = match with_body, mb.mod_expr with
+  let body = match with_body, Declareops.mod_expr mb with
     | false, _
     | true, Abstract -> mt()
     | _, Algebraic me ->
@@ -407,7 +407,7 @@ let unsafe_print_module extent env mp with_body mb =
       pr_equals ++ print_signature' false extent env mp sign
     | _, FullStruct -> pr_equals ++ print_signature' false extent env mp mb.mod_type
   in
-  let modtype = match mb.mod_expr, mb.mod_type_alg with
+  let modtype = match Declareops.mod_expr mb, mb.mod_type_alg with
     | FullStruct, _ -> mt ()
     | _, Some ty ->
       let ty = Modops.annotate_module_expression ty mb.mod_type in


### PR DESCRIPTION
This reflects statically the fact that there are only two kinds of module-like expressions. Before we had a generic parameter, requiring passing around map functions and enforcing less invariants.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/884
- https://github.com/coq-community/paramcoq/pull/130