### PR TITLE
stdlib use custom wrapper to avoid depending on coq-core

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,14 +241,15 @@ before_script:
   script:
     - if [ "$COQ_CI_NATIVE" = true ]; then opam install -y coq-native; fi
     - opam pin add --kind=path rocq-runtime.dev .
-    - opam pin add --kind=path coq-core.dev .
     - opam pin add --kind=path rocq-core.dev .
     - opam pin add --kind=path coq-stdlib.dev stdlib/
+    - if command -v coqc; then exit 1; fi # coq-core didn't get autoinstalled
     - opam pin add --kind=path coqide-server.dev .
     - opam pin add --kind=path coqide.dev .
     - if [ "$COQ_CI_NATIVE" = true ]; then echo "Definition f x := x + x." > test_native.v; fi
-    - if [ "$COQ_CI_NATIVE" = true ]; then coqc test_native.v; fi
+    - if [ "$COQ_CI_NATIVE" = true ]; then rocq c test_native.v; fi
     - if [ "$COQ_CI_NATIVE" = true ]; then test -f .coq-native/Ntest_native.cmxs; fi
+    - opam pin add --kind=path coq-core.dev .
   after_script:
     - eval $(opam env)
     - du -ha "$(coqc -where)" > files.listing

--- a/dev/ci/ci-stdlib.sh
+++ b/dev/ci/ci-stdlib.sh
@@ -8,6 +8,6 @@ ci_dir="$(dirname "$0")"
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "stdlib"
-  dune build --root . --only-packages=coq-stdlib @install
-  dune install --root . coq-stdlib --prefix="$CI_INSTALL_DIR"
+  dev/with-rocq-wrap.sh dune build --root . --only-packages=coq-stdlib @install
+  dev/with-rocq-wrap.sh dune install --root . coq-stdlib --prefix="$CI_INSTALL_DIR"
 )

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,0 +1,1 @@
+/.wrappers

--- a/stdlib/coq-stdlib.opam
+++ b/stdlib/coq-stdlib.opam
@@ -24,14 +24,16 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "coq-core"
+  "rocq-runtime"
   "rocq-core" {= version}
   "odoc" {with-doc}
 ]
 depopts: ["coq-native"]
+dev-repo: "git+https://github.com/coq/coq.git"
 build: [
   ["dune" "subst"] {dev}
   [
+    "dev/with-rocq-wrap.sh"
     "dune"
     "build"
     "-p"
@@ -43,4 +45,3 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/coq/coq.git"

--- a/stdlib/coq-stdlib.opam.template
+++ b/stdlib/coq-stdlib.opam.template
@@ -1,0 +1,15 @@
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dev/with-rocq-wrap.sh"
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]

--- a/stdlib/dev/with-rocq-wrap.sh
+++ b/stdlib/dev/with-rocq-wrap.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -ex
+
+rocq=$(command -v rocq)
+rocqhash=$(md5sum "$rocq")
+
+rm -rf .wrappers
+mkdir .wrappers
+
+cat > .wrappers/coqc <<EOF
+#!/bin/sh
+# hash = $rocqhash
+exec rocq c "\$@"
+EOF
+
+cat > .wrappers/coqdep <<EOF
+#!/bin/sh
+# hash = $rocqhash
+exec rocq dep "\$@"
+EOF
+
+chmod +x .wrappers/coqc .wrappers/coqdep
+
+ln -s "$(ocamlfind query rocq-runtime.kernel)" .wrappers/kernel
+
+# fake coq-core.kernel for dune (mode native)
+cat > .wrappers/META.coq-core <<EOF
+package "kernel" (
+  directory = "kernel"
+  version = "dev"
+  description = "The Coq Kernel"
+  requires = "dynlink rocq-runtime.boot rocq-runtime.lib rocq-runtime.vm"
+  archive(byte) = "kernel.cma"
+  archive(native) = "kernel.cmxa"
+  plugin(byte) = "kernel.cma"
+  plugin(native) = "kernel.cmxs"
+)
+EOF
+
+export PATH="$PWD/.wrappers:$PATH"
+export OCAMLPATH="$PWD/.wrappers:$OCAMLPATH"
+
+"$@"

--- a/stdlib/dune-project
+++ b/stdlib/dune-project
@@ -23,7 +23,7 @@
 (package
  (name coq-stdlib)
  (depends
-  coq-core ; dune coq mode needs the coq compat binaries
+  rocq-runtime
   (rocq-core (= :version)))
  (depopts coq-native)
  (synopsis "The Coq Proof Assistant -- Standard Library")


### PR DESCRIPTION
The wrapper makes small shell scripts calling rocq for coqc and coqdep and puts them in PATH.

In CI, the opam job tests that this works by installing coq-core after stdlib.
