### PR TITLE
Stop reading env var COQ_CONFIGURE_PREFIX

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -36,6 +36,6 @@
    %{project_root}/dev/header.c
    ; Needed to generate include lists for coq_makefile
    plugin_list
-  (env_var PWD) ; used in the fallback of COQ_CONFIGURE_PREFIX
-  (env_var COQ_CONFIGURE_PREFIX))
+  ; used for the prefix
+  (env_var PWD))
  (action (chdir %{project_root} (run %{project_root}/tools/configure/configure.exe -no-ask))))

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -281,12 +281,8 @@ let install_dirs prefs arch =
   let prefix =
     match prefs.prefix with
     | None ->
-      begin
-        try Some (Sys.getenv "COQ_CONFIGURE_PREFIX")
-        with
-        | Not_found when prefs.interactive -> None
-        | Not_found -> Some Sys.(getcwd () ^ "/../install/default")
-      end
+      if prefs.interactive then None
+      else Some Sys.(getcwd () ^ "/../install/default")
     | p -> p
   in
   List.map (do_one_instdir ~prefix ~arch) (install prefs)


### PR DESCRIPTION
Discussion in https://github.com/coq/coq/pull/15459 indicates that it didn't work in opam (which is why we stopped using it), and with the renaming we want to stop reading COQ* env vars when possible.
