### PR TITLE
check all keys

### DIFF
--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -216,3 +216,15 @@ Module ExtraArgs.
   Check fun (f : nat -> nat) => eq_refl : apply _ 0 = f 0.
 
 End ExtraArgs.
+
+(* Testing that we unfold keys that match but do not unify *)
+Module TestKeys.
+Structure Dummy (b : bool) := {T : Type}.
+Definition boolF := bool.
+Canonical Dummy_boolF : Dummy false := {| T := boolF |}.
+Definition boolT := boolF.
+Canonical Dummy_boolT : Dummy true := {| T := boolT |}.
+
+Set Debug "unification".
+Check eq_refl : id (@T false _) = boolT.
+End TestKeys.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

https://github.com/coq/coq/pull/19611 stops checking keys at the first match in the canonical structure table, which is not exactly preserving the previous behavior, which was essentially trying all the keys until one leads to a successful unification problem.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
