### PR TITLE
ltac2-numgoals-ret-0 fix ltac2 eval before Qed

### DIFF
--- a/doc/changelog/06-Ltac2-language/19961-eval-with-zero-goals.rst
+++ b/doc/changelog/06-Ltac2-language/19961-eval-with-zero-goals.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  `Ltac2 Eval` does not require to be focussed in a goal
+  anymore (`#19961 <https://github.com/coq/coq/pull/19961>`_, by
+  Daniil Iaitskov).

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -942,21 +942,15 @@ let perform_eval ~pstate e =
   let env = Global.env () in
   let (e, ty) = Tac2intern.intern ~strict:false [] e in
   let v = Tac2interp.interp Tac2interp.empty_environment e in
-  let selector, proof =
+  let proof =
     match pstate with
     | None ->
       let sigma = Evd.from_env env in
       let name, poly = Id.of_string "ltac2", false in
-      Goal_select.SelectAll, Proof.start ~name ~poly sigma []
+      Proof.start ~name ~poly sigma []
     | Some pstate ->
-      Goal_select.get_default_goal_selector (),
       Declare.Proof.get pstate
   in
-  let nosuchgoal =
-    let info = Exninfo.reify () in
-    Proofview.tclZERO ~info (Proof.SuggestNoSuchGoals (1,proof))
-  in
-  let v = Goal_select.tclSELECT ~nosuchgoal selector v in
   let (proof, _, ans) = Proof.run_tactic (Global.env ()) v proof in
   let { Proof.sigma } = Proof.data proof in
   let name = int_name () in

--- a/test-suite/ltac2/numgoals.v
+++ b/test-suite/ltac2/numgoals.v
@@ -1,0 +1,7 @@
+From Ltac2 Require Import Ltac2.
+
+Lemma zero_numgoals : True.
+Proof.
+  reflexivity.
+  Ltac2 Eval Control.numgoals ().
+Qed.


### PR DESCRIPTION
Usefulness of removed check is not obvious, at least there is no a test broke by the change, 
but inability to eval an ltac2 expression not requiring a goal seems unreasonable.

