### PR TITLE
Fix typo: "documentors" to "documenters"

### DIFF
--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -6,7 +6,7 @@ It also updates `tacn` and `cmd` directives when they can be unambiguously match
 productions of the grammar (in practice, that's probably almost always).
 `tacv` and `cmdv` directives are not updated because matching them appears to require
 human judgement.  `doc_grammar` generates a few files that may be useful to
-developers and documentors.
+developers and documenters.
 
 The mlg grammars present several challenges to generating an accurate grammar
 for documentation purposes:


### PR DESCRIPTION
- Updated "developers and documentors" to "developers and documenters" for proper word usage.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes N/A

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**. *(Not applicable for this typo fix.)*

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**. *(Not applicable for this typo fix.)*
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**. *(Not applicable for this typo fix.)*
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests. *(Not applicable for this typo fix.)*

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->
