### PR TITLE
remove compat Requires of Ztac

### DIFF
--- a/stdlib/theories/Reals/R_Ifp.v
+++ b/stdlib/theories/Reals/R_Ifp.v
@@ -416,6 +416,3 @@ Proof.
     rewrite <- (Ropp_plus_distr (IZR (Int_part r1)) (IZR (Int_part r2)));
     unfold Rminus; trivial with zarith real.
 Qed.
-
-Local Set Warnings "-deprecated".
-Require Ztac. (* deprecated since 9.0 *)

--- a/stdlib/theories/Reals/Rfunctions.v
+++ b/stdlib/theories/Reals/Rfunctions.v
@@ -939,6 +939,3 @@ Definition infinite_sum (s:nat -> R) (l:R) : Prop :=
 
 (** Compatibility with previous versions *)
 Notation infinit_sum := infinite_sum (only parsing).
-
-Local Set Warnings "-deprecated".
-Require Ztac. (* deprecated since 9.0 *)

--- a/stdlib/theories/micromega/ZMicromega.v
+++ b/stdlib/theories/micromega/ZMicromega.v
@@ -1809,6 +1809,3 @@ Definition prod_pos_nat := prod positive nat.
 
 #[deprecated(use=Z.to_N, since="9.0")]
 Notation n_of_Z := Z.to_N (only parsing).
-
-Local Set Warnings "-deprecated".
-Require Ztac. (* deprecated since 9.0 *)


### PR DESCRIPTION
on top of https://github.com/coq/coq/pull/19801

Backwards-compatible overlays:

- [x] https://github.com/jasmin-lang/jasmin/pull/1005