### PR TITLE
Fix #20000: Uncaught exception Modops.ModuleTypingError.

### DIFF
--- a/test-suite/bugs/bug_20000.v
+++ b/test-suite/bugs/bug_20000.v
@@ -1,0 +1,17 @@
+Module Type A.
+End A.
+
+Module Type B.
+  Declare Module a : A.
+End B.
+
+Module Type C.
+  Declare Module b : B.
+  Module a := b.a.
+End C.
+
+Module D.
+  Declare Module aa: A.
+ (* Uncaught exception. Fixed by using "with Module b.a := aa" instead *)
+  Fail Module Type x := C with Module a := aa.
+End D.

--- a/test-suite/output/ErrorModuleWith.out
+++ b/test-suite/output/ErrorModuleWith.out
@@ -12,4 +12,4 @@ The command has indeed failed with message:
 Module A' of M not expected to be a functor.
 File "./output/ErrorModuleWith.v", line 13, characters 0-38:
 The command has indeed failed with message:
-Module M2 is not equal to M1.
+Module M2 is not equal to module M1.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1110,8 +1110,16 @@ let pr_modtype_subpath upper mp =
   in
   let mp, suff = aux mp in
   (if suff = [] then mt ()
-   else str (if upper then "Module " else "module ") ++ DirPath.print (DirPath.make suff) ++ str " of ") ++
+   else strbrk (if upper then "Module " else "module ") ++ DirPath.print (DirPath.make suff) ++ strbrk " of ") ++
   DirPath.print mp
+
+let pr_module_or_modtype_subpath mp = match Nametab.shortest_qualid_of_module mp with
+| qid ->
+  (* [mp] is bound to a proper module *)
+  strbrk "module " ++ Libnames.pr_qualid qid
+| exception Not_found ->
+  (* [mp] ought to be bound to a submodule of a module type *)
+  pr_modtype_subpath false mp
 
 open Modops
 
@@ -1246,7 +1254,7 @@ let explain_incompatible_module_types mexpr1 mexpr2 =
   else str "Incompatible module types."
 
 let explain_not_equal_module_paths mp1 mp2 =
-  str "Module " ++ pr_modpath mp1 ++ strbrk " is not equal to " ++ pr_modpath mp2 ++ str "."
+  str "Module " ++ pr_modpath mp1 ++ strbrk " is not equal to " ++ pr_module_or_modtype_subpath mp2 ++ str "."
 
 let explain_no_such_label l mp =
   str "No field named " ++ Label.print l ++ str " in " ++ pr_modtype_subpath false mp ++ str "."


### PR DESCRIPTION
Instead of trying to print a modpath that does not exist, we rely on a dedicated function that tries to extract the largest module type that contains the path.