### PR TITLE
Use custom helper instead of md5sum in with-rocq-wrap

### DIFF
--- a/stdlib/dev/tools/dune
+++ b/stdlib/dev/tools/dune
@@ -1,0 +1,2 @@
+(executable
+  (name hash))

--- a/stdlib/dev/tools/hash.ml
+++ b/stdlib/dev/tools/hash.ml
@@ -1,0 +1,2 @@
+let () =
+  Printf.printf "%s\n%!" Digest.(to_hex (file Sys.argv.(1)))

--- a/stdlib/dev/with-rocq-wrap.sh
+++ b/stdlib/dev/with-rocq-wrap.sh
@@ -3,7 +3,7 @@
 set -ex
 
 rocq=$(command -v rocq)
-rocqhash=$(md5sum "$rocq")
+rocqhash=$(dune exec --root . -- dev/tools/hash.exe "$rocq")
 
 rm -rf .wrappers
 mkdir .wrappers


### PR DESCRIPTION
Fix #19978

