### PR TITLE
build:base:dev artifact expire after 1 day instead of 1 week

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ before_script:
       - _build.tar.bz2
       - theories/dune
       - user-contrib/Ltac2/dune
-    expire_in: 1 week
+    expire_in: 1 day
 
 .doc-template:
   stage: build-1


### PR DESCRIPTION
This isn't used by the ci-* jobs so doesn't impact the minimzer.

This artifact is the main artifact in light CI so reducing its lifetime should be impactful.
