### PR TITLE
Fix with-rocq-wrap when called from unexpected directory

### DIFF
--- a/stdlib/dev/with-rocq-wrap.sh
+++ b/stdlib/dev/with-rocq-wrap.sh
@@ -3,7 +3,7 @@
 set -ex
 
 rocq=$(command -v rocq)
-rocqhash=$(dune exec --root . -- dev/tools/hash.exe "$rocq")
+rocqhash=$(dune exec --root "$(dirname "$0")"/.. -- dev/tools/hash.exe "$rocq")
 
 rm -rf .wrappers
 mkdir .wrappers


### PR DESCRIPTION
Fix windows CI / core-dev stdlib opam package

