### PR TITLE
test suite printers test ignore welcome message

### DIFF
--- a/test-suite/misc/printers.sh
+++ b/test-suite/misc/printers.sh
@@ -3,7 +3,7 @@
 f=$(mktemp)
 {
     printf 'Drop.\n#go;;\nQuit.\n' | "${BIN}rocq" repl-with-drop -q
-} 2>&1 | tee "$f"
+} 2>&1 | grep -a -v "Welcome to Coq" | tee "$f"
 
 # if there's an issue in `include_utilities`, `#go;;` won't be mentioned
 # if there's an issue in `include_printers`, it will be an undefined printer


### PR DESCRIPTION
The "Welcome to Coq" message can contain the current git branch which leads to a failure if the branch contains the string "error"

Gitlab CI seems to detach HEAD so this is not observable there, but macOS CI does show this issue
https://github.com/SkySkimmer/coq/actions/runs/12713505909/job/35442669137

(when compiling locally your `revision` is probably some old thing)
