### PR TITLE
Remove Detyping.Now from constrextern (mistakenly committed)

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1389,7 +1389,7 @@ let extern_glob_type ?impargs vars c =
 (* Main translation function from constr -> constr_expr *)
 
 let extern_constr ?(inctx=false) ?scope env sigma t =
-  let r = Detyping.detype Detyping.Now env sigma t in
+  let r = Detyping.detype Detyping.Later env sigma t in
   let vars = extern_env env sigma in
   let scope = Option.cata (fun x -> [x]) [] scope in
   extern inctx ((constr_some_level,None),(scope,[])) vars r
@@ -1411,7 +1411,7 @@ let extern_type ?(goal_concl_style=false) env sigma ?impargs t =
   (* those goal/section/rel variables that occurs in the subterm under *)
   (* consideration; see namegen.ml for further details *)
   let avoid = make_avoid goal_concl_style env in
-  let r = Detyping.detype Detyping.Now ~isgoal:goal_concl_style ~avoid env sigma t in
+  let r = Detyping.detype Detyping.Later ~isgoal:goal_concl_style ~avoid env sigma t in
   extern_glob_type ?impargs (extern_env env sigma) r
 
 let extern_sort sigma s = extern_glob_sort (Evd.universe_binders sigma) (detype_sort sigma s)
@@ -1588,7 +1588,7 @@ let extern_constr_pattern env sigma pat =
     (glob_of_pat (genset, Id.Set.empty) env sigma pat)
 
 let extern_rel_context where env sigma sign =
-  let a = detype_rel_context Detyping.Now where ([],env) sigma sign in
+  let a = detype_rel_context Detyping.Later where ([],env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
   pi3 (extern_local_binder ((constr_some_level,None),([],[])) vars a)


### PR DESCRIPTION
IIRC I used Now for debugging (ocamldebug can't print the delayed glob constrs) for #19845
