### PR TITLE
Rename Coq -> Rocq in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Guide to contributing to Coq #
+# Guide to contributing to Rocq #
 
 ## Foreword ##
 
 As with any documentation, this guide is most useful if it's promptly
-updated to reflect changes in processes, development tools, or the Coq
+updated to reflect changes in processes, development tools, or the Rocq
 ecosystem.  If you notice anything inaccurate or outdated, please
 signal it in a new issue, or fix it in a new pull request.  If you
 find some parts are not sufficiently clear, you may open an issue as
@@ -11,7 +11,7 @@ well.
 
 ## Table of contents ##
 
-- [Guide to contributing to Coq](#guide-to-contributing-to-coq)
+- [Guide to contributing to Rocq](#guide-to-contributing-to-coq)
   - [Foreword](#foreword)
   - [Table of contents](#table-of-contents)
   - [Introduction](#introduction)
@@ -19,8 +19,8 @@ well.
     - [Asking and answering questions](#asking-and-answering-questions)
     - [Writing tutorials and blog posts](#writing-tutorials-and-blog-posts)
     - [Contributing to the wiki](#contributing-to-the-wiki)
-    - [Creating and maintaining Coq packages](#creating-and-maintaining-coq-packages)
-      - [Distribution of Coq packages](#distribution-of-coq-packages)
+    - [Creating and maintaining Rocq packages](#creating-and-maintaining-coq-packages)
+      - [Distribution of Rocq packages](#distribution-of-coq-packages)
       - [Support for plugin and library authors](#support-for-plugin-and-library-authors)
       - [Standard libraries](#standard-libraries)
       - [Maintaining existing packages in coq-community](#maintaining-existing-packages-in-coq-community)
@@ -34,7 +34,7 @@ well.
   - [Code changes](#code-changes)
     - [Using GitHub pull requests](#using-github-pull-requests)
       - [Fixing bugs and performing small changes](#fixing-bugs-and-performing-small-changes)
-      - [Proposing large changes: Coq Enhancement Proposals](#proposing-large-changes-coq-enhancement-proposals)
+      - [Proposing large changes: RFCs](#proposing-large-changes-rocq-rfcs)
       - [Seeking early feedback on work-in-progress](#seeking-early-feedback-on-work-in-progress)
     - [Taking feedback into account](#taking-feedback-into-account)
       - [Understanding automatic feedback](#understanding-automatic-feedback)
@@ -53,11 +53,11 @@ well.
       - [Joining / leaving maintainer teams](#joining--leaving-maintainer-teams)
     - [Core development team](#core-development-team)
   - [Release management](#release-management)
-    - [Packaging Coq](#packaging-coq)
+    - [Packaging Rocq](#packaging-coq)
   - [Additional resources](#additional-resources)
     - [Developer documentation](#developer-documentation)
       - [Where to find the resources](#where-to-find-the-resources)
-      - [Building Coq](#building-coq)
+      - [Building Rocq](#building-rocq)
       - [Continuous integration](#continuous-integration)
         - [Restarting failed jobs](#restarting-failed-jobs)
       - [Code owners, issue and pull request templates](#code-owners-issue-and-pull-request-templates)
@@ -72,13 +72,13 @@ well.
       - [Merge script dependencies](#merge-script-dependencies)
       - [Coqbot](#coqbot)
     - [Online forum and chat to talk to developers](#online-forum-and-chat-to-talk-to-developers)
-    - [Coq calls](#coq-calls)
-    - [Coq remote working groups](#coq-remote-working-groups)
-    - [Coq Users and Developers Workshops](#coq-users-and-developers-workshops)
+    - [Rocq calls](#rocq-calls)
+    - [Rocq remote working groups](#rocq-remote-working-groups)
+    - [Rocq Users and Developers Workshops](#rocq-users-and-developers-workshops)
 
 ## Introduction ##
 
-Thank you for your interest in contributing to Coq!  There are many
+Thank you for your interest in contributing to Rocq!  There are many
 ways to contribute, and we appreciate all of them.
 
 People often begin by making small contributions, and contributions to
@@ -90,14 +90,14 @@ that you go through these steps in this order.  Feel free to use this
 guide as a reference and quickly jump to the part that is most
 relevant to you at the current time.
 
-We want to make sure that contributing to Coq is a fun and positive
+We want to make sure that contributing to Rocq is a fun and positive
 experience for everyone, so please make sure you read and abide by our
 [Code of Conduct][Code-of-conduct].
 
 ## Contributing to the ecosystem ##
 
-In this section, we present all the ways to contribute to Coq outside
-of the Coq repository itself.
+In this section, we present all the ways to contribute to Rocq outside
+of the Rocq repository itself.
 
 ### Asking and answering questions ###
 
@@ -108,7 +108,7 @@ problem-oriented, additional documentation.
 There are many platforms for this purpose:
 
 - Our [Zulip chat][Zulip], which contains a main "#Coq users" stream,
-  but also many other streams dedicated to specific Coq packages, such
+  but also many other streams dedicated to specific Rocq packages, such
   as Equations, MathComp, etc.
 - Our [Discourse forum][Discourse], which contains a main "Using Coq"
   category, but also categories dedicated to asking questions in other
@@ -116,9 +116,9 @@ There are many platforms for this purpose:
   hesitate to advertise them to people you know who might not be at
   ease with English.
 - The [Proof Assistants Stack Exchange][Proof-Assistants-SE], a Q&A
-  site for users of proof assistants, including Coq.
+  site for users of proof assistants, including Rocq.
 - Other [Stack Exchange][Stack-Exchange] sites, and particularly
-  [Stack Overflow][Stack-Overflow], receive questions about Coq.
+  [Stack Overflow][Stack-Overflow], receive questions about Rocq.
   Questions asked anywhere on Stack Exchange with the `coq` tag are
   automatically relayed to Zulip in a [dedicated topic][Stack-Exchange-to-Zulip].
 
@@ -128,17 +128,17 @@ mailing list, the [Coq IRC channel][IRC], the
 
 ### Writing tutorials and blog posts ###
 
-Writing about Coq, in the form of tutorials or blog posts, is also a
+Writing about Rocq, in the form of tutorials or blog posts, is also a
 very important contribution.  In particular, it can help new users get
-interested in Coq, and learn about it, and existing users learn about
+interested in Rocq, and learn about it, and existing users learn about
 advance features.  Our official resources, such as the [reference
-manual][refman] are not suited for learning Coq, but serve as
+manual][refman] are not suited for learning Rocq, but serve as
 reference documentation to which you can link from your tutorials.
 
-The Coq website has a page listing known
-[tutorials][Coq-documentation] and the [wiki][] home page contains a
+The Rocq website has a page listing known
+[tutorials][Rocq-documentation] and the [wiki][] home page contains a
 list too.  You can expand the former through a pull request on the
-[Coq website repository][Coq-website-repository], while the latter can
+[Rocq website repository][Rocq-website-repository], while the latter can
 be edited directly by anyone with a GitHub account.
 
 At the current time, we do not have a way of aggregating blog posts on
@@ -148,70 +148,70 @@ create it.  Some people use [Reddit][] for this purpose.
 
 ### Contributing to the wiki ###
 
-Coq's [wiki][] is an informal source of additional documentation which
+Rocq's [wiki][] is an informal source of additional documentation which
 anyone with a GitHub account can edit directly.  In particular, it
-contains the Coq [FAQ][] which has not seen so many updates in the
+contains the Rocq [FAQ][] which has not seen so many updates in the
 recent years.  You should feel free to fix it, expand it, and even
 refactor it (if you are not sure if some changes would be welcome, you
 can open an issue to discuss them before performing them).
 
-People who watch the Coq repository will see recent wiki edits in
+People who watch the Rocq repository will see recent wiki edits in
 their GitHub feed.  It is recommended to review them *a posteriori* to
 check no mistake was introduced.  The wiki is also a standard git
 repository, so people can follow the changes using any standard git
 tool.
 
-Coq's wiki is formatted using GitHub's flavored Markdown, with some
+Rocq's wiki is formatted using GitHub's flavored Markdown, with some
 wiki-specific extensions.  See:
 
 - [GitHub's Markdown guide][GitHub-markdown]
 - [GitHub's wiki extensions][GitHub-wiki-extensions]
 
-### Creating and maintaining Coq packages ###
+### Creating and maintaining Rocq packages ###
 
-*Note: this sub-section is about packages extending Coq, such as
+*Note: this sub-section is about packages extending Rocq, such as
 plugins or libraries.  A different, but also very valuable,
-contribution is to package Coq for your preferred package manager (see
-[Packaging Coq](#packaging-coq)).*
+contribution is to package Rocq for your preferred package manager (see
+[Packaging Rocq](#packaging-rocq)).*
 
 Sharing reusable assets in the form of new libraries, plugins, and
 tools is great so that others can start building new things on top.
 Having an extensive and healthy package ecosystem is key to the
-success of Coq.
+success of Rocq.
 
-#### Distribution of Coq packages ####
+#### Distribution of Rocq packages ####
 
-You can distribute your library or plugin through the [Coq package
-index][Coq-package-index]. Important packages and tools can be advertised on the [Awesome Coq][Awesome-Coq] list. Some packages are
-distributed along Coq, within the [Coq Platform][Coq-Platform]. Check
+You can distribute your library or plugin through the [Rocq package
+index][Rocq-package-index]. Important packages and tools can be advertised on the [Awesome Coq][Awesome-Coq] list. Some packages are
+distributed along Rocq, within the [Rocq Platform][Rocq-Platform]. Check
 the Platform's charter if you consider adding your package to it.
 
 #### Support for plugin and library authors ####
 
-You can find advice and best practices about maintaining a Coq project
+You can find advice and best practices about maintaining a Rocq project
 on the [coq-community wiki][coq-community-wiki].
 
-Learn how to write a Coq plugin, and about best practices, in the Coq
+Learn how to write a Rocq plugin, and about best practices, in the Rocq
 [plugin tutorial][plugin-tutorial].  This tutorial is still a work in
 progress, so do not hesitate to expand it, or ask questions.
 
 If you want quick feedback on best practices, or how to talk to the
-Coq API, a good place to hang out is the [Coq devs & plugin devs
+Rocq API, a good place to hang out is the [Coq devs & plugin devs
 stream][Zulip-dev] of our Zulip chat.
 
 Finally, we strongly encourage authors of plugins to submit their
-plugins to join Coq's continuous integration (CI) early on.  Indeed,
-the Coq API gets continuously reworked, so this is the best way of
-ensuring your plugin stays compatible with new Coq versions, as this
-means Coq developers will fix your plugin for you.  Learn more about
+plugins to join Rocq's continuous integration (CI) early on.  Indeed,
+the Rocq API gets continuously reworked, so this is the best way of
+ensuring your plugin stays compatible with new Rocq versions, as this
+means Rocq developers will fix your plugin for you.  Learn more about
 this in the [CI README (user part)][CI-README-users].
 
-Pure Coq libraries are also welcome to join Coq's CI, especially if
+Pure Rocq libraries are also welcome to join Rocq's CI, especially if
 they test underused / undertested features.
 
 #### Standard libraries ####
 
-There are many general purpose Coq libraries, so before you publish
+There are many general purpose Rocq libraries, so before you publish
 yours, consider whether you could contribute to an existing one
 instead (either the official [standard
 library][standard-library], or one of the many
@@ -219,7 +219,7 @@ library][standard-library], or one of the many
 
 #### Maintaining existing packages in coq-community ####
 
-Some Coq packages are not maintained by their initial authors anymore
+Some Rocq packages are not maintained by their initial authors anymore
 (for instance if they've moved on to new jobs or new projects) even if
 they were useful, or interesting.  The coq-community organization is a
 place for volunteers to take over the maintenance of such packages.
@@ -234,7 +234,7 @@ manifesto's README][coq-community-manifesto].
 
 Besides CoqIDE, whose sources are available in this repository, and to
 which you are welcome to contribute, there are a number of alternative
-user interfaces for Coq, more often as an editor support package.
+user interfaces for Rocq, more often as an editor support package.
 
 Here are the URLs of the repositories of the various editor support
 packages:
@@ -264,27 +264,27 @@ guides, but they don't have any at the time of writing this.
 
 ### Other ways of creating content ###
 
-There are many other ways of creating content and making the Coq
+There are many other ways of creating content and making the Rocq
 community thrive, including many which we might not have thought
 about.  Feel free to add more references / ideas to this sub-section.
 
-You can tweet about Coq, you can give talks about Coq both in
+You can tweet about Rocq, you can give talks about Rocq both in
 academic, and in non-academic venues (such as developer conferences).
 
 [Codewars][] is a platform where people can try to solve some
 programming challenges that were proposed by other community members.
-Coq is supported and the community is eager to get more challenges.
+Rocq is supported and the community is eager to get more challenges.
 
 ## Issues ##
 
 ### Reporting a bug, requesting an enhancement ###
 
-Bug reports are enormously useful to identify issues with Coq; we
+Bug reports are enormously useful to identify issues with Rocq; we
 can't fix what we don't know about.  To report a bug, please open an
-issue in the [Coq issue tracker][Coq-issue-tracker] (you'll need a
+issue in the [Rocq issue tracker][Rocq-issue-tracker] (you'll need a
 GitHub account).  You can file a bug for any of the following:
 
-- An anomaly. These are always considered bugs, so Coq will even ask
+- An anomaly. These are always considered bugs, so Rocq will even ask
   you to file a bug report!
 - An error you didn't expect. If you're not sure whether it's a bug or
   intentional, feel free to file a bug anyway. We may want to improve
@@ -294,8 +294,8 @@ GitHub account).  You can file a bug for any of the following:
   find or don't understand some bit of documentation.
 - An error message that wasn't as helpful as you'd like. Bonus points
   for suggesting what information would have helped you.
-- Bugs in CoqIDE should also be filed in the [Coq issue
-  tracker][Coq-issue-tracker].  Bugs in the Emacs plugin should be
+- Bugs in CoqIDE should also be filed in the [Rocq issue
+  tracker][Rocq-issue-tracker].  Bugs in the Emacs plugin should be
   filed against [ProofGeneral][ProofGeneral-issues], or against
   [company-coq][company-coq-issues] if they are specific to
   company-coq features.
@@ -307,7 +307,7 @@ ask on our [Discourse forum][Discourse] or [Zulip chat][Zulip]
 before, after, or while writing a bug report.
 
 It is better if you can test that your bug is still present in the
-current testing or development version of Coq (see the [next
+current testing or development version of Rocq (see the [next
 sub-section](#beta-testing)) before reporting it, but if you can't, it
 should not discourage you from reporting it.
 
@@ -319,29 +319,29 @@ tend to include the code in the bug description itself, but if you have a
 very large input file then you can add it as an attachment.
 
 If you want to minimize your bug (or help minimize someone else's) for
-more extra credit, then you can use the [Coq bug
+more extra credit, then you can use the [Rocq bug
 minimizer][JasonGross-coq-tools] (specifically, the bug minimizer is
 the `find-bug.py` script in that repo). Nowadays, the easiest way to
-use the Coq bug minimizer is to call it through `@coqbot`, as documented
+use the Rocq bug minimizer is to call it through `@coqbot`, as documented
 [here][coqbot-minimize].
 
 ### Beta testing ###
 
-Coq gets a new major release about every six months, which is then
-distributed through the [Coq Platform][Coq-Platform].
-New major versions of Coq are first made available for beta-testing,
-before being declared stable and the new default version of the Coq
+Rocq gets a new major release about every six months, which is then
+distributed through the [Rocq Platform][Rocq-Platform].
+New major versions of Rocq are first made available for beta-testing,
+before being declared stable and the new default version of the Rocq
 Platform. You can help make by testing the beta
 version, and trying to port your projects to it.  You should report
 any bug you notice, but also any change of behavior that is not
-documented in the changelog.  Then Coq developers will be able to
+documented in the changelog.  Then Rocq developers will be able to
 check if what you reported is a regression that needs to be fixed, or
 an expected change that needs to be mentioned in the changelog.
 
 You can go even further by using the development version (`master`
-branch) of Coq on a day by day basis, and report problems as soon as
-you notice them.  If you wish to do so, the easiest way to install Coq
-is through opam (using the `dev` version of the Coq package, available
+branch) of Rocq on a day by day basis, and report problems as soon as
+you notice them.  If you wish to do so, the easiest way to install Rocq
+is through opam (using the `dev` version of the Rocq package, available
 in the <https://coq.inria.fr/opam/core-dev> repository) or through
 [Nix][].  The documentation of the development version is [available
 online][master-doc], including the [unreleased
@@ -349,15 +349,15 @@ changelog][unreleased-changelog].
 
 ### Helping triage existing issues ###
 
-Coq has too many bug reports for its core developers alone to manage.
+Rocq has too many bug reports for its core developers alone to manage.
 You can help a lot by:
 
 - confirming that reported bugs are still active with the current
-  version of Coq;
+  version of Rocq;
 - determining if the bug is a regression (new, and unexpected,
-  behavior from a recent Coq version);
+  behavior from a recent Rocq version);
 - more generally, by reproducing a bug, on another system,
-  configuration, another version of Coq, and by documenting what you
+  configuration, another version of Rocq, and by documenting what you
   did;
 - giving a judgement about whether the reported behavior is really a
   bug, or is expected but just improperly documented, or expected and
@@ -369,7 +369,7 @@ You can help a lot by:
 - fixing the bug if you have an idea of how to do so (see the
   [following section](#code-changes)).
 
-Once you have some experience with the Coq issue tracker, you can
+Once you have some experience with the Rocq issue tracker, you can
 request to join the **@coq/contributors** team (any member of the
 **@coq/core** team can give you access using [this link][add-contributor]).
 Being in this team will grant you the following access:
@@ -427,7 +427,7 @@ projects.
 If you want to contribute a documentation update, bug fix or feature
 yourself, pull requests (PRs) on the [GitHub
 repository][coq-repository] are the way to contribute directly to the
-Coq implementation (all changes, even the smallest changes from core
+Rocq implementation (all changes, even the smallest changes from core
 developers, go through PRs).  You will need to create a fork of the
 repository on GitHub and push your changes to a new "topic branch" in
 that fork (instead of using an existing branch name like `master`).
@@ -462,7 +462,7 @@ assignee and the release manager to do so (see Section [Release
 management](#release-management)).  The milestone should give you an
 indication of when to expect your change to be released (this could be
 several months after your PR is merged).  That said, you can start
-using the latest Coq `master` branch to take advantage of all the new
+using the latest Rocq `master` branch to take advantage of all the new
 features, improvements, and fixes.
 
 #### Fixing bugs and performing small changes ####
@@ -494,7 +494,7 @@ or updated, user-facing features, and major bug fixes do.  See the
 on how to contribute to the documentation, and the README in
 [`doc/changelog`][user-changelog] for how to add a changelog entry.
 
-#### Proposing large changes: Coq Enhancement Proposals ####
+#### Proposing large changes: Rocq RFCs ####
 
 Please refrain to open very large PRs without discussing them first.
 Indeed, you should be aware that the larger the change, the higher
@@ -505,7 +505,7 @@ So it is recommended that before spending a lot of time coding, you
 seek feedback from maintainers to see if your change would be
 supported, and if they have recommendations about its implementation.
 You can do this informally by opening an issue, or more formally by
-producing a design document as a [Coq Enhancement Proposal][CEP].
+producing a design document as a [RFCs][RFCs].
 
 Another recommendation is that you do not put several unrelated
 changes in the same PR (even if you produced them together).  In
@@ -528,8 +528,7 @@ PR](#draft-pull-requests) mechanism.
 
 If you are looking for feedback on the design of your change, rather
 than on its implementation, then please refrain from opening a PR.
-You may open an issue to start a discussion, or create a [Coq
-Enhancement Proposal][CEP] if you have a clear enough view of the
+You may open an issue to start a discussion, or create a [Rocq RFC][RFCs] if you have a clear enough view of the
 design to write a document about it.
 
 ### Taking feedback into account ###
@@ -564,7 +563,7 @@ both the failure of the whole pipeline, and of the specific failed
 job.  Most of these failures indicate problems that should be
 addressed, but some can still be due to synchronization issues out of
 your control.  In particular, if you get a failure in one of the
-tested plugins but you didn't change the Coq API, it is probably a
+tested plugins but you didn't change the Rocq API, it is probably a
 transient issue and you shouldn't have to worry about it.  In case of
 doubt, ask the reviewers.
 
@@ -622,20 +621,20 @@ We have a linter that checks a few different things:
   won't do that for you, although it should detect in most cases if you
   have forgotten to add documentation for your new command or tactic,
   or if the documentation is not consistent with the parser.
-- **.opam files are up to date**. Coq's `*.opam` files are generated
+- **.opam files are up to date**. Rocq's `*.opam` files are generated
   automatically from metadata in `dune-project`. If the meta-data
   becomes out of sync, the linter will complain. This can be fixed
-  doing `dune build *.opam` at the root of Coq's repository.
+  doing `dune build *.opam` at the root of Rocq's repository.
 
 You may run the linter yourself with `dev/lint-repository.sh`.
 
 ##### Plugin failures #####
 
-If you did change the Coq API, then you may have broken a plugin.
+If you did change the Rocq API, then you may have broken a plugin.
 After ensuring that the failure comes from your change, you will have
 to provide a fix to the plugin, and the PR assignee will have to
 ensure that this fix is merged in the plugin simultaneously with your
-PR on the Coq repository.
+PR on the Rocq repository.
 
 If your changes to the API are not straightforward, you should also
 document them in `dev/doc/changes.md`.
@@ -651,7 +650,7 @@ change that you introduced voluntarily.  All such breaking changes
 should be properly documented in the [user changelog][user-changelog].
 Furthermore, a backward-compatible fix should be found, properly
 documented in the changelog when non-obvious, and this fix should be
-merged in the broken projects *before* your PR to the Coq repository
+merged in the broken projects *before* your PR to the Rocq repository
 can be.
 
 Note that once the breaking change is well understood, it should not
@@ -667,7 +666,7 @@ feedback and reconsider the impact of your change.
 If you need help figuring out why your PR is breaking a tested project,
 you may consider requesting automatic minimization of the failure with
 the bot. In principle, the bot should automatically propose this option
-to you if it is available (it needs to detect a failure in a Coq file
+to you if it is available (it needs to detect a failure in a Rocq file
 and it needs to confirm that the failure was not already present in the
 base branch to propose to run the minimization process).
 
@@ -724,7 +723,7 @@ commits fixing previously introduced bugs or failures.
 
 The documentation is usually a good place to start contributing,
 because you can get used to the pull request submitting and review
-process, without needing to learn about the code source of Coq at the
+process, without needing to learn about the code source of Rocq at the
 same time.
 
 The official documentation is formed of two components:
@@ -734,7 +733,7 @@ The official documentation is formed of two components:
 
 The sources of the reference manual are located in the
 [`doc/sphinx`][refman-sources] directory.  They are written in rst
-(Sphinx) format with some Coq-specific extensions, which are
+(Sphinx) format with some Rocq-specific extensions, which are
 documented in the [README][refman-README] in the above directory.
 This README was written to be read from begin to end.  As soon as your
 edits to the documentation are more than changing the textual content,
@@ -906,7 +905,7 @@ organization, because of a limitation of GitHub).
 - When a PR has [overlays][user-overlays], then:
 
   - the overlays that are backward-compatible (normally the case for
-    overlays fixing Coq code) should have been merged *before* the PR
+    overlays fixing Rocq code) should have been merged *before* the PR
     can be merged; it might be a good idea to ask the PR author to
     remove the overlay information from the PR to get a fresh CI run
     and ensure that all the overlays have been merged; the PR assignee
@@ -948,7 +947,7 @@ of a limitation of GitHub). They are also listed on the
 
 ## Release management ##
 
-Coq's major release cycles generally span about six months, with about
+Rocq's major release cycles generally span about six months, with about
 4-5 months of development, and 1-2 months of stabilization /
 release candidates.  The release manager (RM) role is a rolling position
 among core developers.  The [release plan][release-plan] is published
@@ -993,26 +992,26 @@ column to a "Shipped" column.
 More information about the RM tasks can be found in the [release
 process checklist][RM-checklist].
 
-### Packaging Coq ###
+### Packaging Rocq ###
 
-The RM role does not include the task of making Coq available through
+The RM role does not include the task of making Rocq available through
 the various package managers out there: several contributors (most
 often external to the development team) take care of this, and we
 thank them for this.  If your preferred package manager does not
-include Coq, it is a very worthy contribution to make it available
+include Rocq, it is a very worthy contribution to make it available
 there.  But be careful not to let a package get outdated, as this
-could lead some users to install an outdated version of Coq without
-even being aware of it. Beyond packaging Coq, you might want to
-consider packaging the rest of Coq packages available to users through
-the [Coq Platform][Coq-Platform]. In this case, it would be helpful if
-you try to favor the same versions as in the Coq Platform.
+could lead some users to install an outdated version of Rocq without
+even being aware of it. Beyond packaging Rocq, you might want to
+consider packaging the rest of Rocq packages available to users through
+the [Rocq Platform][Rocq-Platform]. In this case, it would be helpful if
+you try to favor the same versions as in the Rocq Platform.
 
-This [Repology page][repology-coq] lists the versions of Coq which are
+This [Repology page][repology-coq] lists the versions of Rocq which are
 packaged in many repositories, although it is missing information on
 some repositories, like opam.
 
 The Windows and macOS installers are created as part of the preparation
-of the Coq Platform.
+of the Rocq Platform.
 
 ## Additional resources ##
 
@@ -1025,28 +1024,28 @@ of the Coq Platform.
   [README][dev-README] in the `dev` directory lists what's available.
 
   For example, [`dev/doc/README.md`][dev-doc-README] is a beginner's
-  guide to hacking Coq, and documentation on debugging Coq can be
+  guide to hacking Rocq, and documentation on debugging Rocq can be
   found in [`dev/doc/debugging.md`][debugging-doc].
 
 - When it makes sense, the documentation is kept even closer to the
   sources, in README files in various directories (e.g. the test-suite
   [README][test-suite-README] or the refman [README][refman-README]).
 
-- Documentation of the Coq API is written directly in comments in
-  `.mli` files.  You can browse it on [the Coq website][api-doc], or
+- Documentation of the Rocq API is written directly in comments in
+  `.mli` files.  You can browse it on [the Rocq website][api-doc], or
   rebuild it locally (`make apidoc`, requires `odoc` and `dune`).
 
 - A plugin tutorial is located in
   [`doc/plugin_tutorial`][plugin-tutorial].
 
-- The Coq [wiki][] contains additional developer resources.
+- The Rocq [wiki][] contains additional developer resources.
 
-#### Building Coq ####
+#### Building Rocq ####
 
 The list of dependencies can be found in the first section of the
 [`INSTALL.md`](INSTALL.md) file.
 
-Coq is built using the `dune` build system. Run `make` to get help on
+Rocq is built using the `dune` build system. Run `make` to get help on
 the various available targets.  Additional documentation can be found
 in [`dev/doc/build-system.dune.md`][dev-doc-dune], and in [the
 official Dune documentation][dune-doc].
@@ -1069,7 +1068,7 @@ The main documentation resources on our CI are:
 - the README of the [user-overlays][] directory.
 
 Preparing an overlay (i.e. a patch to an external project that we test
-in our CI, to make it compile with the modified version of Coq in your
+in our CI, to make it compile with the modified version of Rocq in your
 branch) is a step that everyone goes through at some point.  All you
 need to know to prepare an overlay manually is in the README in the
 [user-overlays][] directory.  You might want to use some additional
@@ -1134,7 +1133,7 @@ Lots of resources about git, the version control system, are available
 on the web, starting with the [official website][git].
 
 We recommend a setup with two configured remotes, one for the official
-Coq repository, called `upstream`, and one for your fork, called
+Rocq repository, called `upstream`, and one for your fork, called
 `origin`.  Here is a way to do this for a clean clone:
 
 ``` shell
@@ -1264,7 +1263,7 @@ documentation is still a work-in-progress.
 
 ### Online forum and chat to talk to developers ###
 
-We have a [Discourse forum][Discourse] (see in particular the [Coq
+We have a [Discourse forum][Discourse] (see in particular the [Rocq
 development][Discourse-development-category] category) and a [Zulip
 chat][Zulip] (see in particular the [Coq devs & plugin devs][Zulip-dev]
 stream).  Feel free to join any of them and ask questions.
@@ -1274,15 +1273,15 @@ Obviously, the issue tracker is also a good place to ask questions,
 especially if the development processes are unclear, or the developer
 documentation should be improved.
 
-### Coq calls ###
+### Rocq calls ###
 
 We try to gather every week for one hour through video-conference to
 discuss current and urgent matters.  When longer discussions are
 needed, topics are left out for the next working group.  See the
-[wiki][wiki-calls] for more information about Coq calls, as well as
+[wiki][wiki-calls] for more information about Rocq calls, as well as
 notes of past ones.
 
-### Coq remote working groups ###
+### Rocq remote working groups ###
 
 We semi-regularly (up to every month) organize remote working groups,
 which can be accessed through video-conference, and are most often
@@ -1293,11 +1292,11 @@ These working groups are where important decisions are taken, most
 often by consensus, but also, if it is needed, by a vote of core
 developers.
 
-### Coq Users and Developers Workshops ###
+### Rocq Users and Developers Workshops ###
 
 We have an annual gathering late Spring in France where most core
 developers are present, and whose objective is to help new
-contributors get started with the Coq codebase, provide help to plugin
+contributors get started with the Rocq codebase, provide help to plugin
 and library authors, and more generally have fun together.
 
 The list of past (and upcoming, when it's already planned) workshops
@@ -1307,7 +1306,7 @@ can be found [on the wiki][wiki-CUDW].
 [api-doc]: https://coq.github.io/doc/master/api/
 [Awesome-Coq]: https://github.com/coq-community/awesome-coq
 [Benchmarking]: https://github.com/coq/coq/wiki/Benchmarking
-[CEP]: https://github.com/coq/ceps
+[RFCs]: https://github.com/coq/rfcs
 [CI-README-developers]: dev/ci/README-developers.md
 [CI-README-users]: dev/ci/README-users.md
 [Code-of-Conduct]: CODE_OF_CONDUCT.md
@@ -1321,14 +1320,14 @@ can be found [on the wiki][wiki-CUDW].
 [coq-community-wiki]: https://github.com/coq-community/manifesto/wiki
 [coq-core]: https://github.com/orgs/coq/teams/core/members
 [coqdoc-documentation]: https://coq.inria.fr/refman/practical-tools/utilities.html#documenting-coq-files-with-coqdoc
-[Coq-documentation]: https://coq.inria.fr/documentation
-[Coq-issue-tracker]: https://github.com/coq/coq/issues
-[Coq-package-index]: https://coq.inria.fr/packages
-[Coq-Platform]: https://github.com/coq/platform
+[Rocq-documentation]: https://coq.inria.fr/documentation
+[Rocq-issue-tracker]: https://github.com/coq/coq/issues
+[Rocq-package-index]: https://rocq-prover.org/packages
+[Rocq-Platform]: https://github.com/coq/platform
 [coq-pushers]: https://github.com/orgs/coq/teams/pushers/teams
 [coq-repository]: https://github.com/coq/coq
 [coq-team]: https://coq.inria.fr/coq-team.html
-[Coq-website-repository]: https://github.com/coq/www
+[Rocq-website-repository]: https://github.com/coq/rocq-prover.org
 [debugging-doc]: dev/doc/debugging.md
 [dev-ci-nix]: dev/ci/nix/README.md
 [dev-doc-README]: dev/doc/README.md


### PR DESCRIPTION
I did some conservative Coq -> Rocq renaming, so some things will require further iterations:
* some command names (`coqdoc` -> `rocq doc` for instance)
* website
