### PR TITLE
Rename Coq -> Rocq in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coq
+# Rocq
 
 [![GitLab CI][gitlab-badge]][gitlab-link]
 [![GitHub macOS CI][gh-macos-badge]][gh-macos-link]
@@ -25,7 +25,7 @@
 [doi-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.1003420.svg
 [doi-link]: https://doi.org/10.5281/zenodo.1003420
 
-Coq is a formal proof management system. It provides a formal language to write
+Rocq is a formal proof management system. It provides a formal language to write
 mathematical definitions, executable algorithms and theorems together with an
 environment for semi-interactive development of machine-checked proofs.
 
@@ -54,9 +54,9 @@ Information on how to build and install from sources can be found in
 The sources of the documentation can be found in directory [`doc`](doc).
 See [`doc/README.md`](/doc/README.md) to learn more about the documentation,
 in particular how to build it. The
-documentation of the last released version is available on the Coq
+documentation of the last released version is available on the Rocq
 web site at [coq.inria.fr/documentation](http://coq.inria.fr/documentation).
-See also [Cocorico](https://github.com/coq/coq/wiki) (the Coq wiki),
+See also [Cocorico](https://github.com/coq/coq/wiki) (the Rocq wiki),
 and the [Coq FAQ](https://github.com/coq/coq/wiki/The-Coq-FAQ),
 for additional user-contributed documentation.
 
@@ -74,7 +74,7 @@ The documentation of the master branch is continuously deployed.  See:
 The [Recent
 changes](https://coq.github.io/doc/master/refman/changes.html) chapter
 of the reference manual explains the differences and the
-incompatibilities of each new version of Coq. If you upgrade Coq,
+incompatibilities of each new version of Rocq. If you upgrade Rocq,
 please read it carefully as it contains important advice on how to
 approach some problems you may encounter.
 
@@ -95,19 +95,19 @@ lists several other active platforms.
 Please report any bug / feature request in [our issue tracker](https://github.com/coq/coq/issues).
 
 To be effective, bug reports should mention the OCaml version used
-to compile and run Coq, the Coq version (`coqtop -v`), the configuration
+to compile and run Rocq, the Rocq version (`coqtop -v`), the configuration
 used, and include a complete source example leading to the bug.
 
-## Contributing to Coq
+## Contributing to Rocq
 
-Guidelines for contributing to Coq in various ways are listed in the [contributor's guide](CONTRIBUTING.md).
+Guidelines for contributing to Rocq in various ways are listed in the [contributor's guide](CONTRIBUTING.md).
 
 Information about release plans is at https://github.com/coq/coq/wiki/Release-Plan
 
-## Supporting Coq
+## Supporting Rocq
 
-Help the Coq community grow and prosper by becoming a sponsor! The [Coq
+Help the Rocq community grow and prosper by becoming a sponsor! The [Rocq
 Consortium](https://coq.inria.fr/consortium) can establish sponsorship contracts
-or receive donations. If you want to take an active role in shaping Coq's
+or receive donations. If you want to take an active role in shaping Rocq's
 future, you can also become a Consortium member. If you are interested, please
 get in touch!


### PR DESCRIPTION
I did some conservative Coq -> Rocq renaming, so some things will require further iterations:

* URLs (`coq.inria.fr`,...)
