### PR TITLE
Fix with-rocq-wrap on cygwin

### DIFF
--- a/stdlib/dev/tools/hash.ml
+++ b/stdlib/dev/tools/hash.ml
@@ -1,2 +1,2 @@
 let () =
-  Printf.printf "%s\n%!" Digest.(to_hex (file Sys.argv.(1)))
+  Printf.printf "%s\n%!" Digest.(to_hex (input stdin))

--- a/stdlib/dev/with-rocq-wrap.sh
+++ b/stdlib/dev/with-rocq-wrap.sh
@@ -3,7 +3,10 @@
 set -ex
 
 rocq=$(command -v rocq)
-rocqhash=$(dune exec --root "$(dirname "$0")"/.. -- dev/tools/hash.exe "$rocq")
+# NB on cygwin "$rocq" is a cygwin path (/foo/bar)
+# but reading files from hash.exe needs windows paths (C:/cygwin/foo/bar)
+# we avoid the problem by going through stdin
+rocqhash=$(dune exec --root "$(dirname "$0")"/.. -- dev/tools/hash.exe < "$rocq")
 
 rm -rf .wrappers
 mkdir .wrappers


### PR DESCRIPTION
As with previous PRs CI will use stdlib master instead of this PR.