### PR TITLE
Fix CMorphisms partial_application_tactic to correctly leverage Params instances

### DIFF
--- a/doc/changelog/04-tactics/20045-cmorphisms-params-Fixed.rst
+++ b/doc/changelog/04-tactics/20045-cmorphisms-params-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``setoid_rewrite`` now correctly picks up ``Params`` instances when rewriting in ``Type``
+  (`#20045 <https://github.com/rocq-prover/rocq/pull/20045>`_,
+  fixes `#20044 <https://github.com/rocq-prover/rocq/issues/20044>`_,
+  by quarkcool).

--- a/test-suite/bugs/bug_20044.v
+++ b/test-suite/bugs/bug_20044.v
@@ -1,0 +1,35 @@
+Require Export
+  Corelib.Classes.CMorphisms.
+
+Definition R (x y : unit) : Type := unit.
+
+Instance :
+  Reflexive R.
+Proof.
+  intros x.
+  constructor.
+Qed.
+
+Instance :
+  Proper (R ==> R ==> flip arrow) R.
+Proof.
+  intros [] [] _ [] [] _ _.
+  constructor.
+Qed.
+
+Instance :
+  forall x, Proper (R ==> flip arrow) (R x).
+Proof.
+  intros x.
+  partial_application_tactic;
+    typeclasses eauto.
+Abort.
+
+Instance : Params R 1 := {}.
+Instance :
+  forall x, Proper (R ==> flip arrow) (R x).
+Proof.
+  intros x.
+  (* should fail in the presence of a params instance *)
+  Fail partial_application_tactic.
+Abort.

--- a/theories/Corelib/Classes/CMorphisms.v
+++ b/theories/Corelib/Classes/CMorphisms.v
@@ -490,7 +490,7 @@ Ltac partial_application_tactic :=
     end
   in
   let rec do_partial H ar m := 
-    match ar with
+    lazymatch ar with
       | 0%nat => do_partial_apps H m ltac:(fail 1)
       | S ?n' =>
         match m with
@@ -503,7 +503,7 @@ Ltac partial_application_tactic :=
      let n := fresh in evar (n:nat) ;
      let v := eval compute in n in clear n ;
       let H := fresh in
-        assert(H:Params m' v) by typeclasses eauto ;
+        assert(H:Params m' v) by (subst m'; once typeclasses eauto) ;
           let v' := eval compute in v in subst m';
             (sk H v' || fail 1))
     || fk


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20044 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
