### PR TITLE
Fix Rocq Proof Assistant -> Rocq Prover in rocq --version.

### DIFF
--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 let version () =
-  Printf.printf "The Rocq Proof Assistant, version %s\n" Coq_config.version;
+  Printf.printf "The Rocq Prover, version %s\n" Coq_config.version;
   Printf.printf "compiled with OCaml %s\n" Coq_config.caml_version
 
 let machine_readable_version () =


### PR DESCRIPTION
Extracted from #20049 because @proux01 predicted this would create trouble.

Backwards-compatible overlays:
- https://github.com/JasonGross/coq-scripts/pull/14
- https://github.com/AbsInt/CompCert/pull/544