### PR TITLE
Stop storing the module path in modules.

### DIFF
--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -12,21 +12,19 @@ open Environ
 
 let import senv opac clib vmtab digest =
   let senv = Safe_typing.check_flags_for_library clib senv in
+  let dp = Safe_typing.dirpath_of_library clib in
   let mb = Safe_typing.module_of_library clib in
   let env = Safe_typing.env_of_safe_env senv in
   let env = push_context_set ~strict:true (Safe_typing.univs_of_library clib) env in
   let env = Modops.add_retroknowledge (Mod_declarations.mod_retroknowledge mb) env in
   let env = Environ.link_vm_library vmtab env in
-  let opac = Mod_checking.check_module env opac (Mod_declarations.mod_mp mb) mb in
+  let opac = Mod_checking.check_module env opac (Names.ModPath.MPfile dp) mb in
   let (_,senv) = Safe_typing.import clib vmtab digest senv in senv, opac
 
 let import senv opac clib vmtab digest : _ * _ =
   NewProfile.profile "import"
     ~args:(fun () ->
-        let dp = match Mod_declarations.mod_mp (Safe_typing.module_of_library clib) with
-          | MPfile dp -> dp
-          | _ -> assert false
-        in
+        let dp = Safe_typing.dirpath_of_library clib in
         [("name", `String (Names.DirPath.to_string dp))])
     (fun () ->import senv opac clib vmtab digest)
     ()

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -572,10 +572,10 @@ let [_v_sfb;_v_struc;_v_sign;_v_mexpr;_v_impl;v_module;_v_modtype] : _ Vector.t 
            [|v_struc|]|])  (* Struct *)
   and v_module =
     v_tuple_c ("module_body",
-           [|v_mp;v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_resolver;v_retroknowledge|])
+           [|v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_resolver;v_retroknowledge|])
   and v_modtype =
     v_tuple_c ("module_type_body",
-           [|v_mp;v_noimpl;v_sign;v_opt v_mexpr;v_resolver;v_unit|])
+           [|v_noimpl;v_sign;v_opt v_mexpr;v_resolver;v_unit|])
   in
   [v_sfb;v_struc;v_sign;v_mexpr;v_impl;v_module;v_modtype])
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -854,14 +854,12 @@ let keep_hyps env needed =
 
 (* Modules *)
 
-let add_modtype mtb env =
-  let mp = mod_mp mtb in
+let add_modtype mp mtb env =
   let new_modtypes = MPmap.add mp mtb env.env_globals.Globals.modtypes in
   let new_globals = { env.env_globals with Globals.modtypes = new_modtypes } in
   { env with env_globals = new_globals }
 
-let shallow_add_module mb env =
-  let mp = mod_mp mb in
+let shallow_add_module mp mb env =
   let new_mods = MPmap.add mp mb env.env_globals.Globals.modules in
   let new_globals = { env.env_globals with Globals.modules = new_mods } in
   { env with env_globals = new_globals }

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -346,10 +346,10 @@ module QGlobRef : QNameS with type t = GlobRef.t
 
 (** {5 Modules } *)
 
-val add_modtype : module_type_body -> env -> env
+val add_modtype : ModPath.t -> module_type_body -> env -> env
 
 (** [shallow_add_module] does not add module components *)
-val shallow_add_module : module_body -> env -> env
+val shallow_add_module : ModPath.t -> module_body -> env -> env
 
 val lookup_module : ModPath.t -> env -> module_body
 val lookup_modtype : ModPath.t -> env -> module_type_body

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -60,7 +60,6 @@ type 'a module_retroknowledge = ('a, Retroknowledge.action list) when_mod_body
 
 (** {6 Accessors} *)
 
-val mod_mp : 'a generic_module_body -> ModPath.t
 val mod_expr : module_body -> module_implementation
 val mod_type : 'a generic_module_body -> module_signature
 val mod_type_alg : 'a generic_module_body -> module_expression option
@@ -69,10 +68,10 @@ val mod_retroknowledge : module_body -> Retroknowledge.action list
 
 (** {6 Builders} *)
 
-val make_module_body : ModPath.t -> module_signature -> Mod_subst.delta_resolver -> Retroknowledge.action list -> module_body
-val make_module_type : ModPath.t -> module_signature -> Mod_subst.delta_resolver -> module_type_body
+val make_module_body : module_signature -> Mod_subst.delta_resolver -> Retroknowledge.action list -> module_body
+val make_module_type : module_signature -> Mod_subst.delta_resolver -> module_type_body
 
-val strengthen_module_body : src:ModPath.t -> dst:ModPath.t option ->
+val strengthen_module_body : src:ModPath.t ->
   module_signature -> delta_resolver -> module_body -> module_body
 
 val strengthen_module_type :
@@ -81,7 +80,7 @@ val strengthen_module_type :
 val replace_module_body : structure_body -> delta_resolver -> module_body -> module_body
 
 val module_type_of_module : module_body -> module_type_body
-val module_body_of_type : ModPath.t -> module_type_body -> module_body
+val module_body_of_type : module_type_body -> module_body
 
 val functorize_module : (Names.MBId.t * module_type_body) list -> module_body -> module_body
 
@@ -101,22 +100,22 @@ val implem_smart_map :
   ('a, module_implementation) when_mod_body ->
   ('a, module_implementation) when_mod_body
 
-val functor_smart_map : ('a -> 'a) -> ('b -> 'b) ->
+val functor_smart_map : (MBId.t -> 'a -> 'a) -> ('b -> 'b) ->
   ('a, 'b) functorize -> ('a, 'b) functorize
 
 (** {6 Substitution} *)
 
 val subst_signature : substitution ->
-  (delta_resolver -> substitution -> delta_resolver) -> module_signature -> module_signature
+  (delta_resolver -> substitution -> delta_resolver) -> ModPath.t -> module_signature -> module_signature
 
 val subst_structure : substitution ->
-  (delta_resolver -> substitution -> delta_resolver) -> structure_body -> structure_body
+  (delta_resolver -> substitution -> delta_resolver) -> ModPath.t -> structure_body -> structure_body
 
 val subst_module : substitution ->
-  (delta_resolver -> substitution -> delta_resolver) -> module_body -> module_body
+  (delta_resolver -> substitution -> delta_resolver) -> ModPath.t -> module_body -> module_body
 
 val subst_modtype : substitution ->
-  (delta_resolver -> substitution -> delta_resolver) -> module_type_body -> module_type_body
+  (delta_resolver -> substitution -> delta_resolver) -> ModPath.t -> module_type_body -> module_type_body
 
 (** {6 Hashconsing} *)
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -29,7 +29,7 @@ val destr_nofunctor : ModPath.t -> ('ty,'a) functorize -> 'a
 (** Conversions between [module_body] and [module_type_body] *)
 
 val module_type_of_module : module_body -> module_type_body
-val module_body_of_type : ModPath.t -> module_type_body -> module_body
+val module_body_of_type : module_type_body -> module_body
 
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
@@ -40,8 +40,8 @@ val annotate_struct_body : structure_body -> module_signature -> module_signatur
 
 (** {6 Substitutions } *)
 
-val subst_signature : substitution -> module_signature -> module_signature
-val subst_structure : substitution -> structure_body -> structure_body
+val subst_signature : substitution -> ModPath.t -> module_signature -> module_signature
+val subst_structure : substitution -> ModPath.t -> structure_body -> structure_body
 
 (** {6 Adding to an environment } *)
 
@@ -49,11 +49,11 @@ val add_structure :
   ModPath.t -> structure_body -> delta_resolver -> env -> env
 
 (** adds a module and its components, but not the constraints *)
-val add_module : module_body -> env -> env
+val add_module : ModPath.t -> module_body -> env -> env
 
 (** same as add_module, but for a module whose native code has been linked by
 the native compiler. The linking information is updated. *)
-val add_linked_module : module_body -> link_info -> env -> env
+val add_linked_module : ModPath.t -> module_body -> link_info -> env -> env
 
 (** same, for a module type *)
 val add_module_type : ModPath.t -> module_type_body -> env -> env
@@ -64,7 +64,7 @@ val add_retroknowledge : Retroknowledge.action list -> env -> env
 
 val strengthen : module_type_body -> ModPath.t -> module_type_body
 
-val strengthen_and_subst_module_body : module_body -> ModPath.t -> bool -> module_body
+val strengthen_and_subst_module_body : ModPath.t -> module_body -> ModPath.t -> bool -> module_body
 
 val subst_modtype_signature_and_resolver : ModPath.t -> ModPath.t ->
   module_signature -> delta_resolver -> module_signature * delta_resolver

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -46,7 +46,6 @@ and translate_field mp env acc (l,x) =
      compile_rewrite_rules env l acc rrb
   | SFBmodule md ->
      let mp = MPdot (mp, l) in
-     let () = assert (ModPath.equal mp (mod_mp md)) in
      (debug_native_compiler (fun () ->
         let msg =
           Printf.sprintf "Compiling module %s..." (ModPath.to_string mp)
@@ -55,7 +54,6 @@ and translate_field mp env acc (l,x) =
      translate_mod mp env (mod_type md) acc
   | SFBmodtype mdtyp ->
      let mp = MPdot (mp, l) in
-     let () = assert (ModPath.equal mp (mod_mp mdtyp)) in
      (debug_native_compiler (fun () ->
         let msg =
           Printf.sprintf "Compiling module type %s..." (ModPath.to_string mp)

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -229,6 +229,7 @@ val current_dirpath : safe_environment -> DirPath.t
 
 type compiled_library
 
+val dirpath_of_library : compiled_library -> DirPath.t
 val module_of_library : compiled_library -> Mod_declarations.module_body
 val univs_of_library : compiled_library -> Univ.ContextSet.t
 val check_flags_for_library : compiled_library -> safe_transformer0

--- a/kernel/subtyping.mli
+++ b/kernel/subtyping.mli
@@ -8,7 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Names
 open Mod_declarations
 open Environ
 
-val check_subtypes : ('a, UGraph.univ_inconsistency) Conversion.universe_state -> env -> module_type_body -> module_type_body -> 'a
+val check_subtypes : ('a, UGraph.univ_inconsistency) Conversion.universe_state -> env -> ModPath.t -> module_type_body -> ModPath.t -> module_type_body -> 'a

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -224,13 +224,11 @@ let rec extract_structure_spec env mp reso = function
   | (l,SFBmodule mb) :: msig ->
       let specs = extract_structure_spec env mp reso msig in
       let mp = MPdot (mp, l) in
-      let () = assert (ModPath.equal mp (mod_mp mb)) in
       let spec = extract_mbody_spec env mp mb in
       (l,Smodule spec) :: specs
   | (l,SFBmodtype mtb) :: msig ->
       let specs = extract_structure_spec env mp reso msig in
       let mp = MPdot (mp, l) in
-      let () = assert (ModPath.equal mp (mod_mp mtb)) in
       let spec = extract_mbody_spec env mp mtb in
       (l,Smodtype spec) :: specs
 

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -84,13 +84,12 @@ and memoize_fields_of_mp mp =
 and fields_of_mp mp =
   let open Mod_subst in
   let mb = lookup_module_in_impl mp in
-  let () = assert (ModPath.equal mp (mod_mp mb)) in
   let fields,inner_mp,subs = fields_of_mb empty_subst mp mb [] in
   let subs =
     if ModPath.equal inner_mp mp then subs
     else add_mp inner_mp mp (mod_delta mb) subs
   in
-  Modops.subst_structure subs fields
+  Modops.subst_structure subs mp fields
 
 and fields_of_mb subs mp mb args = match Mod_declarations.mod_expr mb with
   | Algebraic expr -> fields_of_expression subs mp args (mod_type mb) expr
@@ -111,7 +110,6 @@ and fields_of_expr subs mp0 args = function
   | MEident mp ->
     let mp = Mod_subst.subst_mp subs mp in
     let mb = lookup_module_in_impl mp in
-    let () = assert (ModPath.equal mp (mod_mp mb)) in
     fields_of_mb subs mp mb args
   | MEapply (me1,mp2) -> fields_of_expr subs mp0 (mp2::args) me1
   | MEwith _ -> assert false (* no 'with' in [mod_expr] *)


### PR DESCRIPTION
This data does not belong semantically here. Instead, it should be derived from the context, as it is alway in sync with the name through which the module was added to the environment.

Depends on: #20058

Backwards compatible overlays:
- https://github.com/LPCIC/coq-elpi/pull/740
- https://github.com/MetaCoq/metacoq/pull/1134
- https://github.com/coq-community/paramcoq/pull/132