### PR TITLE
Remove "env" argument of Evd.set_(l)eq_sort

### DIFF
--- a/dev/ci/user-overlays/20069-SkySkimmer-set-leq-noenv.sh
+++ b/dev/ci/user-overlays/20069-SkySkimmer-set-leq-noenv.sh
@@ -1,0 +1,5 @@
+overlay equations https://github.com/SkySkimmer/Coq-Equations set-leq-noenv 20069
+
+overlay unicoq https://github.com/SkySkimmer/unicoq set-leq-noenv 20069
+
+overlay metacoq https://github.com/SkySkimmer/metacoq set-leq-noenv 20069

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1152,16 +1152,16 @@ let normalize_sort evars s =
   UState.nf_sort evars.universes s
 
 (* FIXME inefficient *)
-let set_eq_sort env d s1 s2 =
-  let s1 = normalize_sort d s1 and s2 = normalize_sort d s2 in
+let set_eq_sort evd s1 s2 =
+  let s1 = normalize_sort evd s1 and s2 = normalize_sort evd s2 in
   match is_eq_sort s1 s2 with
-  | None -> d
+  | None -> evd
   | Some (u1, u2) ->
-    if not (type_in_type env) then
-      add_universe_constraints d
+    if not (UGraph.type_in_type (UState.ugraph evd.universes)) then
+      add_universe_constraints evd
         (UnivProblem.Set.singleton (UnivProblem.UEq (u1,u2)))
     else
-      d
+      evd
 
 let set_eq_level d u1 u2 =
   add_constraints d (Univ.enforce_eq_level u1 u2 Univ.Constraints.empty)
@@ -1173,13 +1173,13 @@ let set_eq_instances ?(flex=false) d u1 u2 =
   add_universe_constraints d
     (UnivProblem.enforce_eq_instances_univs flex u1 u2 UnivProblem.Set.empty)
 
-let set_leq_sort env evd s1 s2 =
+let set_leq_sort evd s1 s2 =
   let s1 = normalize_sort evd s1
   and s2 = normalize_sort evd s2 in
   match is_eq_sort s1 s2 with
   | None -> evd
   | Some (u1, u2) ->
-     if not (type_in_type env) then
+    if not (UGraph.type_in_type (UState.ugraph evd.universes)) then
        add_universe_constraints evd (UnivProblem.Set.singleton (UnivProblem.ULe (u1,u2)))
      else evd
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -562,8 +562,8 @@ val is_flexible_level : evar_map -> Univ.Level.t -> bool
 
 val normalize_universe_instance : evar_map -> UVars.Instance.t -> UVars.Instance.t
 
-val set_leq_sort : env -> evar_map -> esorts -> esorts -> evar_map
-val set_eq_sort : env -> evar_map -> esorts -> esorts -> evar_map
+val set_leq_sort : evar_map -> esorts -> esorts -> evar_map
+val set_eq_sort : evar_map -> esorts -> esorts -> evar_map
 val set_eq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_leq_level : evar_map -> Univ.Level.t -> Univ.Level.t -> evar_map
 val set_eq_instances : ?flex:bool ->

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1934,7 +1934,7 @@ let build_inversion_problem ~program_mode loc env sigma tms t =
        example is in Vector.caseS', even if this one can probably be
        put in Prop too with some care) *)
     let sigma, s' = Evd.new_sort_variable univ_flexible sigma in
-    let sigma = Evd.set_leq_sort !!env sigma s s' in
+    let sigma = Evd.set_leq_sort sigma s s' in
     sigma, s') in
   let pb =
     { env       = pb_env;
@@ -2146,7 +2146,7 @@ let prepare_predicate ?loc ~program_mode typing_fun env sigma tomatchs arsign ty
       let sigma, rtnsort = Evd.new_sort_variable univ_flexible sigma in
       let sigma, predcclj = typing_fun (Some (mkSort rtnsort)) envar sigma rtntyp in
       let check_elim_sort sigma squash =
-        try Inductiveops.squash_elim_sort !!env sigma squash rtnsort
+        try Inductiveops.squash_elim_sort sigma squash rtnsort
         with UGraph.UniverseInconsistency _ ->
           (* Incompatible constraints are ignored and handled later
              when typing the pattern-matching. *)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1229,8 +1229,8 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
             (try
                let evd' =
                  if pbty == CONV
-                 then Evd.set_eq_sort env evd s1 s2
-                 else Evd.set_leq_sort env evd s1 s2
+                 then Evd.set_eq_sort evd s1 s2
+                 else Evd.set_leq_sort evd s1 s2
                in Success evd'
              with UGraph.UniverseInconsistency p ->
                UnifFailure (evd,UnifUnivInconsistency p)

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -98,7 +98,7 @@ let define_pure_evar_as_product env evd na evk =
           new_type_evar newenv evd1 status ~src ~filter
         in
         let prods = Typeops.sort_of_product env (ESorts.kind evd3 u1) (ESorts.kind evd3 srng) in
-        let evd3 = Evd.set_leq_sort evenv evd3 (ESorts.make prods) s in
+        let evd3 = Evd.set_leq_sort evd3 (ESorts.make prods) s in
           evd3, rng
   in
   let prod = mkProd (make_annot (Name id) rdom, dom, subst_var evd2 id rng) in
@@ -172,7 +172,7 @@ let define_evar_as_sort env evd (ev,args) =
   let concl = Reductionops.whd_all (evar_env env evi) evd (Evd.evar_concl evi) in
   let sort = destSort evd concl in
   let evd' = Evd.define ev (mkSort s) evd in
-  Evd.set_leq_sort env evd' (ESorts.super evd' s) sort, s
+  Evd.set_leq_sort evd' (ESorts.super evd' s) sort, s
 
 (* Unify with unknown array *)
 
@@ -196,7 +196,7 @@ let define_pure_evar_as_array env sigma evk =
   let concl = Reductionops.whd_all evenv sigma (Evd.evar_concl evi) in
   let s = destSort sigma concl in
   (* array@{u} ty : Type@{u} <= Type@{s} *)
-  let sigma = Evd.set_leq_sort env sigma s' s in
+  let sigma = Evd.set_leq_sort sigma s' s in
   let ar = Typeops.type_of_array env (UVars.Instance.of_array ([||],[|u|])) in
   let sigma = Evd.define evk (mkApp (EConstr.of_constr ar, [| ty |])) sigma in
   sigma

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -124,8 +124,8 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
     let s' = ESorts.make s' in
     evdref := sigma;
     let evd =
-      if direction then set_leq_sort env !evdref s' s
-      else set_leq_sort env !evdref s s'
+      if direction then set_leq_sort !evdref s' s
+      else set_leq_sort !evdref s s'
     in evdref := evd; mkSort s'
   in
   let rec refresh ~onlyalg status ~direction t =
@@ -1479,7 +1479,7 @@ let solve_evar_evar ?(force=false) f unify flags env evd pbty (evk1,args1 as ev1
           let evd, k = Evd.new_sort_variable univ_flexible_alg evd in
           let t1 = it_mkProd_or_LetIn (mkSort k) ctx1 in
           let t2 = it_mkProd_or_LetIn (mkSort k) ctx2 in
-          let evd = Evd.set_leq_sort env (Evd.set_leq_sort env evd k i) k j in
+          let evd = Evd.set_leq_sort (Evd.set_leq_sort evd k i) k j in
           downcast evk2 t2 (downcast evk1 t1 evd)
     with Reduction.NotArity ->
       evd in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -291,33 +291,33 @@ let is_squashed sigma ((_,mip),u) =
       then None
       else Some (SquashToQuality indq)
 
-let squash_elim_sort env sigma squash rtnsort = match squash with
+let squash_elim_sort sigma squash rtnsort = match squash with
 | SquashToSet ->
   (* Squashed inductive in Set, only happens with impredicative Set *)
   begin match ESorts.kind sigma rtnsort with
   | Set | SProp | Prop -> sigma
   | QSort _ | Type _ ->
-    Evd.set_eq_sort env sigma rtnsort ESorts.set
+    Evd.set_eq_sort sigma rtnsort ESorts.set
   end
 | SquashToQuality (QConstant QProp) ->
   (* Squashed inductive in Prop, return sort must be Prop or SProp *)
   begin match ESorts.kind sigma rtnsort with
   | SProp | Prop -> sigma
   | QSort _ | Type _ | Set ->
-    Evd.set_eq_sort env sigma rtnsort ESorts.prop
+    Evd.set_eq_sort sigma rtnsort ESorts.prop
   end
 | SquashToQuality (QConstant QSProp) ->
   (* Squashed inductive in SProp, return sort must be SProp. *)
   begin match ESorts.kind sigma rtnsort with
   | SProp -> sigma
   | Type _ | Set | Prop | QSort _ ->
-    Evd.set_eq_sort env sigma rtnsort ESorts.sprop
+    Evd.set_eq_sort sigma rtnsort ESorts.sprop
   end
 | SquashToQuality (QConstant QType) ->
   (* Sort poly squash to type *)
-  Evd.set_leq_sort env sigma ESorts.set rtnsort
+  Evd.set_leq_sort sigma ESorts.set rtnsort
 | SquashToQuality (QVar q) ->
-  Evd.set_leq_sort env sigma (ESorts.make (Sorts.qsort q Univ.Universe.type0)) rtnsort
+  Evd.set_leq_sort sigma (ESorts.make (Sorts.qsort q Univ.Universe.type0)) rtnsort
 
 let is_allowed_elimination sigma ((mib,_),_ as specifu) s =
   let open Sorts in
@@ -346,7 +346,7 @@ let make_allowed_elimination env sigma ((mib,_),_ as specifu) s =
       begin match EConstr.ESorts.kind sigma s with
       | SProp|Prop|Set -> Some sigma
       | QSort _ | Type _ ->
-        try Some (Evd.set_leq_sort env sigma s ESorts.set)
+        try Some (Evd.set_leq_sort sigma s ESorts.set)
         with UGraph.UniverseInconsistency _ -> None
       end
     | Some (SquashToQuality indq) ->
@@ -354,7 +354,7 @@ let make_allowed_elimination env sigma ((mib,_),_ as specifu) s =
       if quality_leq sq indq then Some sigma
       else
         let mk q = ESorts.make @@ Sorts.make q Univ.Universe.type0 in
-        try Some (Evd.set_leq_sort env sigma (mk sq) (mk indq))
+        try Some (Evd.set_leq_sort sigma (mk sq) (mk indq))
         with UGraph.UniverseInconsistency _ -> None
 
 (* XXX questionable for sort poly inductives *)
@@ -750,7 +750,7 @@ let rec instantiate_universes env evdref scl is = function
         else
           (* unconstrained sort: replace by fresh universe *)
           let evm, s = Evd.new_sort_variable Evd.univ_flexible !evdref in
-          let evm = Evd.set_leq_sort env evm s (EConstr.ESorts.make (Sorts.sort_of_univ u)) in
+          let evm = Evd.set_leq_sort evm s (EConstr.ESorts.make (Sorts.sort_of_univ u)) in
             evdref := evm; s
       in
       let ctx = EConstr.of_rel_context ctx in

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -136,7 +136,7 @@ val quality_leq : Sorts.Quality.t -> Sorts.Quality.t -> bool
 
 val is_squashed : evar_map -> (mind_specif * EInstance.t) -> squash option
 
-val squash_elim_sort : env -> evar_map -> squash -> ESorts.t -> evar_map
+val squash_elim_sort : evar_map -> squash -> ESorts.t -> evar_map
 (** Take into account elimination constraints. When there is an
     elimination constraint and the predicate is underspecified, i.e. a
     QSort, we make a non-canonical choice for the return type.

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1145,7 +1145,7 @@ struct
             let sigma, q = Evd.new_quality_variable sigma in
             (* make q in cumulativity with Prop/Type *)
             let sigma =
-              Evd.set_leq_sort !!env sigma
+              Evd.set_leq_sort sigma
                 ESorts.prop
                 (ESorts.make (Sorts.qsort q Univ.Universe.type0))
             in
@@ -1611,7 +1611,7 @@ let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.
       | Some u -> sigma, u
       | None -> Evd.new_univ_level_variable UState.univ_flexible sigma
     in
-    let sigma = Evd.set_leq_sort !!env sigma
+    let sigma = Evd.set_leq_sort sigma
         (* we retype because it may be an evar which has been defined, resulting in a lower sort
            cf #18480 *)
         (Retyping.get_sort_of !!env sigma jty.utj_val)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1263,16 +1263,16 @@ let is_conv_leq ?(reds=TransparentState.full) env sigma x y =
 let check_conv ?(pb=Conversion.CUMUL) ?(ts=TransparentState.full) env sigma x y =
   is_fconv ~reds:ts pb env sigma x y
 
-let sigma_compare_sorts env pb s0 s1 sigma =
+let sigma_compare_sorts _env pb s0 s1 sigma =
   match pb with
   | Conversion.CONV ->
     begin
-      try Result.Ok (Evd.set_eq_sort env sigma (ESorts.make s0) (ESorts.make s1))
+      try Result.Ok (Evd.set_eq_sort sigma (ESorts.make s0) (ESorts.make s1))
       with UGraph.UniverseInconsistency err -> Result.Error (Some err)
     end
   | Conversion.CUMUL ->
     begin
-      try Result.Ok (Evd.set_leq_sort env sigma (ESorts.make s0) (ESorts.make s1))
+      try Result.Ok (Evd.set_leq_sort sigma (ESorts.make s0) (ESorts.make s1))
       with UGraph.UniverseInconsistency err -> Result.Error (Some err)
     end
 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -198,7 +198,7 @@ let is_correct_arity env sigma c pj ind specif params =
       | None -> sigma, s
       | Some squash ->
         let sigma =
-          try squash_elim_sort env sigma squash s
+          try squash_elim_sort sigma squash s
           with UGraph.UniverseInconsistency _ -> error (Some s)
         in
         sigma, s
@@ -455,7 +455,7 @@ let judge_of_array env sigma u tj defj tyj =
     | [||], [|u|] -> u
     | _ -> assert false
   in
-  let sigma = Evd.set_leq_sort env sigma tyj.utj_type
+  let sigma = Evd.set_leq_sort sigma tyj.utj_type
       (ESorts.make (Sorts.sort_of_univ (Univ.Universe.make ulev)))
   in
   let check_one sigma j = check_actual_type env sigma j tyj.utj_val in
@@ -506,7 +506,7 @@ let check_binder_relevance env sigma s decl =
     | Trivial -> Some sigma
     | Impossible -> None
     | DummySort s' ->
-      match Evd.set_leq_sort env sigma s s' with
+      match Evd.set_leq_sort sigma s s' with
       | sigma -> Some sigma
       | exception UGraph.UniverseInconsistency _ -> None
   in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1174,8 +1174,8 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
             (try
                let sigma' =
                  if pb == CUMUL
-                 then Evd.set_leq_sort curenv sigma s1 s2
-                 else Evd.set_eq_sort curenv sigma s1 s2
+                 then Evd.set_leq_sort sigma s1 s2
+                 else Evd.set_eq_sort sigma s1 s2
                in push_sigma sigma' substn
              with e when CErrors.noncritical e ->
                error_cannot_unify curenv sigma (fst m,fst n))

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -58,7 +58,7 @@ let weaken_sort_scheme env evd sort npars term ty =
           let ctx = LocalAssum (n, t) :: ctx in
           if Int.equal np 0 then
             let osort, t' = change_sort_arity (EConstr.ESorts.kind !evdref sort) t in
-              evdref := (if false then Evd.set_eq_sort else Evd.set_leq_sort) env !evdref sort (EConstr.ESorts.make osort);
+              evdref := Evd.set_leq_sort !evdref sort (EConstr.ESorts.make osort);
               mkProd (n, t', c),
               mkLambda (n, t', mkApp(term, Context.Rel.instance mkRel 0 ctx))
           else

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -266,7 +266,7 @@ let prop_lowering_candidates evd ~arities_explicit inds =
   let candidates = spread_nonprop candidates in
   candidates
 
-let include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort =
+let include_constructor_argument evd ~poly ~ctor_sort ~inductive_sort =
   if poly then
     (* We ignore the quality when comparing the sorts: it has an impact
        on squashing in the kernel but cannot cause a universe error. *)
@@ -283,12 +283,12 @@ let include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort =
     | None, Some _ -> evd
     | Some uctor, Some uind ->
       let mk u = ESorts.make (Sorts.sort_of_univ u) in
-      Evd.set_leq_sort env evd (mk uctor) (mk uind)
+      Evd.set_leq_sort evd (mk uctor) (mk uind)
   else
     match ESorts.kind evd ctor_sort with
     | SProp | Prop -> evd
     | Set | Type _ | QSort _ ->
-      Evd.set_leq_sort env evd ctor_sort inductive_sort
+      Evd.set_leq_sort evd ctor_sort inductive_sort
 
 type default_dep_elim = DeclareInd.default_dep_elim = DefaultElim | PropButDepElim
 
@@ -306,7 +306,7 @@ let inductive_levels env evd ~poly ~indnames ~arities_explicit arities ctors =
   let evd = List.fold_left (fun evd (raw_arity,(_,s),ctors) ->
       if less_than_2 ctors || is_impredicative_sort evd s then evd
       else (* >=2 constructors is like having a bool argument *)
-        include_constructor_argument env evd ~poly ~ctor_sort:ESorts.set ~inductive_sort:s)
+        include_constructor_argument evd ~poly ~ctor_sort:ESorts.set ~inductive_sort:s)
       evd inds
   in
   (* If indices_matter, the index telescope acts like an extra
@@ -353,7 +353,7 @@ let inductive_levels env evd ~poly ~indnames ~arities_explicit arities ctors =
       if is_impredicative_sort evd s then evd
       else List.fold_left
           (List.fold_left (fun evd ctor_sort ->
-               include_constructor_argument env evd ~poly ~ctor_sort ~inductive_sort:s))
+               include_constructor_argument evd ~poly ~ctor_sort ~inductive_sort:s))
           evd (Option.List.cons indices ctors))
       evd inds
   in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -235,12 +235,12 @@ let def_class_levels ~def ~env_ar_params sigma aritysorts ctors =
   in
   let ctor_sort = Retyping.get_sort_of env_ar_params sigma ctor in
   let is_prop_ctor = EConstr.ESorts.is_prop sigma ctor_sort in
-  let sigma = Evd.set_leq_sort env_ar_params sigma ctor_sort s in
+  let sigma = Evd.set_leq_sort sigma ctor_sort s in
   if Option.cata (Evd.is_flexible_level sigma) false (is_sort_variable sigma s)
   && is_prop_ctor
   then (* We assume that the level in aritysort is not constrained
           and clear it, if it is flexible *)
-    let sigma = Evd.set_eq_sort env_ar_params sigma EConstr.ESorts.set s in
+    let sigma = Evd.set_eq_sort sigma EConstr.ESorts.set s in
     sigma, EConstr.ESorts.prop, projname, ctor
   else
     sigma, s, projname, ctor


### PR DESCRIPTION
It was only used to get type_in_type, but it's better to get it from the ustate IMO.

Overlays:
- https://github.com/MetaCoq/metacoq/pull/1136
- https://github.com/unicoq/unicoq/pull/97
- https://github.com/mattam82/Coq-Equations/pull/630