### PR TITLE
basic-overlay stdlib repo is stdlib not stdlib-test

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -419,7 +419,7 @@ project verdi_raft "https://github.com/uwplse/verdi-raft" "master"
 ########################################################################
 # Stdlib
 ########################################################################
-project stdlib "https://github.com/coq/stdlib-test" "master"
+project stdlib "https://github.com/coq/stdlib" "master"
 # TODO replace temporary test repo by actual one
 # Contact TODO on github
 


### PR DESCRIPTION
Github redirects stdlib-test to stdlib but having the right one in the file is nicer

