### PR TITLE
[zify] Protect clear_body with a try

### DIFF
--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1524,7 +1524,7 @@ let interp_pscript s =
     Tacticals.tclTHEN
       (Tactics.letin_tac None (Names.Name id) c None
          {Locus.onhyps = None; Locus.concl_occs = Locus.AllOccurrences})
-      (Tactics.clear_body [id])
+      (Tacticals.tclTRY (Tactics.clear_body [id]))
   | Pose (id, c) -> Tactics.pose_proof (Names.Name id) c
 
 let rec interp_pscripts l =


### PR DESCRIPTION
zify is not careful enough about dependent hypotheses.
The fix consists is protecting a `clear_body` with a `try`.


Fixes #19924
