### PR TITLE
Do not use the delta_resolver type for safe environment paramresolver.

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -477,11 +477,7 @@ let replace_mp_in_kn mpfrom mpto kn =
     if mp==mp'' then kn
     else KerName.make mp'' l
 
-let rec mp_in_mp mp mp1 =
-  match mp1 with
-    | _ when ModPath.equal mp1 mp -> true
-    | MPdot (mp2,_l) -> mp_in_mp mp mp2
-    | _ -> false
+let mp_in_mp = ModPath.subpath
 
 let subset_prefixed_by mp resolver =
   let mp_prefix mkey mequ rslv =

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -314,6 +314,12 @@ module ModPath = struct
     | MPdot (mp1, l1), MPdot (mp2, l2) -> String.equal l1 l2 && equal mp1 mp2
     | (MPfile _ | MPbound _ | MPdot _), _ -> false
 
+  let rec subpath mp mp' =
+    if equal mp mp' then true
+    else match mp' with
+    | MPdot (mp', _) -> subpath mp mp'
+    | _ -> false
+
   open Hashset.Combine
 
   let rec hash = function

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -256,6 +256,9 @@ sig
   val equal : t -> t -> bool
   val hash : t -> int
 
+  val subpath : t -> t -> bool
+  (* [subpath p q] is true when q = p.l1. ... . ln, where n is potentially 0 *)
+
   val is_bound : t -> bool
 
   val dummy : t

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -259,8 +259,7 @@ val typing : safe_environment -> Constr.constr -> judgment
 
 val exists_objlabel : Label.t -> safe_environment -> bool
 
-val delta_of_senv :
-  safe_environment -> Mod_subst.delta_resolver * Mod_subst.delta_resolver
+val delta_of_senv : safe_environment -> Mod_subst.delta_resolver
 
 val constant_of_delta_kn_senv : safe_environment -> KerName.t -> Constant.t
 val mind_of_delta_kn_senv : safe_environment -> KerName.t -> MutInd.t

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -944,7 +944,7 @@ let check_subtypes_mt mp sub_mtb_l =
   check_sub mp mtb sub_mtb_l
 
 let current_modresolver () =
-  fst @@ Safe_typing.delta_of_senv @@ Global.safe_env ()
+  Safe_typing.delta_of_senv @@ Global.safe_env ()
 
 let current_struct () =
   let struc = Safe_typing.structure_body_of_safe_env @@ Global.safe_env () in


### PR DESCRIPTION
This usage is the only one subtly breaking an implicit invariant of the delta resolver, namely that all entries share a common non-trivial modpath root. Instead, this datatype morally contains a set of disjoint delta-resolvers for each library and module parameter root loaded in the environment.

We reflect this using an ad-hoc datatype with the corresponding API and runtime invariant checks.