### PR TITLE
chore: Update CODEOWNERS to address #19962

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,4 +285,4 @@
 
 /.ocamlinit  @coq/build-maintainers
 *dune*       @coq/build-maintainers
-*.opam       @coq/build-maintainers
+*.opam       @coq/build-maintainers @erikmd


### PR DESCRIPTION
Fixes #19962 :
> when there's a refactoring that impacts the `*.opam` files for Coq (either those stored in the Coq repo itself, or [this one in coq/opam](https://github.com/coq/opam/blob/master/core-dev/packages/coq-stdlib/coq-stdlib.dev/opam)) and I am not aware of this change, this is a bit annoying since it breaks Docker-Coq / Docker-Rocq without notice, and it's more difficult to react quickly after-the-fact when the PR is merged in rocq master, and thereby, end users cannot benefit from an up-to-date dev image for some time!

Cc @proux01 @Zimmi48 
If you think this solution does not follows c32e1c54c87231b6411d3002766972e18438fc4a's guideline,
another solution would be to add me in the coq/build-maintainers team ?