### PR TITLE
Fix domain substitution of delta-resolvers.

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -512,7 +512,7 @@ let subst_mp_delta subst mp mkey =
 let gen_subst_delta_resolver dom subst resolver =
   let mp_apply_subst mkey mequ rslv =
     let mkey' = if dom then subst_mp subst mkey else mkey in
-    let rslv',mequ' = subst_mp_delta subst mequ mkey in
+    let rslv',mequ' = subst_mp_delta subst mequ mkey' in
     Deltamap.join rslv' (Deltamap.add_mp mkey' mequ' rslv)
   in
   let kn_apply_subst kkey hint rslv =

--- a/test-suite/bugs/bug_20079.v
+++ b/test-suite/bugs/bug_20079.v
@@ -1,0 +1,21 @@
+Module Type T.
+End T.
+
+Module FOO (ARG: T).
+ Module INNER := ARG.
+End FOO.
+
+Module Type Typ.
+  Parameter t : Type.
+End Typ.
+
+Module Update (E:Typ).
+Include E.
+End Update.
+
+(** This module generates a non-trivial domain substitution of the
+    δ-resolver associated to FOO. *)
+Module Make (X: Typ).
+ Module MyX := Update X.
+ Module BAR := FOO MyX.
+End Make.


### PR DESCRIPTION
The function subst_dom_codom_delta_resolver was generating nonsensical data when applying a substitution with non-trivial delta-resolvers in its bindings.

Basically, assuming some substitution `σ` it is enough to look at the domain-codomain substitution of a singleton delta-resolver `δ := [mp₀ ↦ mp₁]` to understand the issue. Assume `mp₀ ↦ (mp₀', δ₀)` and `mp₁ ↦ (mp₁', δ₁)` are both in `σ`. We expect

```
subst_dom_codom_delta_resolver σ δ = [mp₀' ↦ mp₁'] ⊕ ε
```

where `ε` is the delta-resolver associating to subpaths of `mp₀'` the corresponding value through `σ` in `δ₁`. That is, if `[mp₀.p ↦ v] ∈ δ₁` we expect `[mp₀'.p ↦ σ(v)] ∈ ε`.

Unfortunately the current implementation generates an incorrect binding as it adds instead `[mp₀.p ↦ σ(v)]` to `ε`. I discovered this while trying to enforce static invariants on the delta-resolver type.

There are no files in the test-suite that trigger this behaviour, but the stdlib does have a few instances of the issue. In the current code this means that the delta-equivalence is incomplete as we silently lose these additional equations. Maybe it is even unsound if we fiddle a bit with bound modules, but I do not want to try to find an exploit. In any case I added a minimized example to the test-suite so as to keep track of this behaviour.