### PR TITLE
Fix composition of module substitution.

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -45,6 +45,52 @@ module Deltamap = struct
   let fold fmp fkn (mm,km) i =
     MPmap.fold fmp mm (KNmap.fold fkn km i)
   let join map1 map2 = fold add_mp add_kn map1 map2
+
+  (** keep only data that is relevant for names with a modpath ⊇ root *)
+  let reroot root (mm, km) =
+    (* filter the modpaths *)
+    let fold_mp mp data (glb, accu) =
+      if ModPath.subpath root mp then
+        (* root ⊆ mp, keep it *)
+        glb, MPmap.add mp data accu
+      else if ModPath.subpath mp root then
+        (* This is a subpath of the root. It may be relevant due to find_prefix,
+           but only when 1. root is not in mm, and 2. this is the most precise
+           path in mm above root, as find_prefix will always return this one
+           without considering the less precise ones. *)
+        let glb = match glb with
+        | None -> Some mp
+        | Some glb -> if ModPath.subpath glb mp then Some mp else Some glb
+        in
+        glb, accu
+      else
+        (* path that is incomparable, skip it *)
+        glb, accu
+    in
+    let glb, mm' = MPmap.fold fold_mp mm (None, MPmap.empty) in
+    let mm' = match glb with
+    | None -> mm'
+    | Some glb ->
+      if MPmap.mem root mm then mm'
+      else
+        (* Add root to the resolver and map it to what find_prefix would have
+           returned on root *)
+        let rec diff accu mp =
+          if ModPath.equal mp glb then accu
+          else match mp with
+          | MPdot (mp, l) -> diff (l :: accu) mp
+          | MPbound _ | MPfile _ -> assert false
+        in
+        let diff = diff [] root in
+        let data = MPmap.get glb mm in
+        let data' = List.fold_left (fun accu l -> MPdot (accu, l)) data diff in
+        MPmap.add root data' mm'
+    in
+    (* filter the kernames *)
+    let filter_kn kn _ = ModPath.subpath root (KerName.modpath kn) in
+    let km' = KNmap.filter filter_kn km in
+    (mm', km')
+
 end
 
 (* Invariant: in the [delta_hint] map, an [Equiv] should only
@@ -574,6 +620,8 @@ let join subst1 subst2 =
         add_delta_resolver
           (subst_dom_codom_delta_resolver subst2 resolve) resolve'
       in
+      (* remove data from resolve' whose path is incompatible with mp' *)
+      let resolve' = Deltamap.reroot mp' resolve' in
       mp', resolve'
     in
     let prefixed_subst = substitution_prefixed_by mpk mp' subst2 in


### PR DESCRIPTION
This is a subtle problem that does not cause unsoundness. Rather, it makes the composition of module substitution wasteful in its representation.

Basically, for any module substitution σ, if (mp, δ) ∈ σ where mp : modpath and δ : delta_resolver, then morally the only relevant data in δ are renamings of the form (mp₀ ↦ mp₁) where mp ⊆ mp₀ and (kn₀ ↦ kn₁) where mp ⊆ modpath(kn₀).

I say morally, as this is not literally true: there is the corner case where mp' ∈ δ with mp' ⊆ mp but mp ∉ δ, as find_prefix will expand any path mp' ⊆ mp ⊆ p using the data attached to mp'. This means that there is an implicit form of η-expansion contained in the delta resolver, as we could replace the binding (mp', p) in δ with (mp, p ++ mp \ mp') without changing the observable behaviour.

In any case, paths that are incomparable with mp are complete garbage that will never be accessed.

It turns out that all calls to substitution extension respected the invariant that their delta resolvers contained no garbage, except Mod_subst.join. We fix this function by performing a cleanup pass before adding the resolver.
