### PR TITLE
Fix some calls to Mod_subst.add_delta_resolver.

### DIFF
--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -330,7 +330,7 @@ and strengthen_and_subst_struct struc subst mp_from mp_to alias incl reso =
         if is_functor (mod_type mb') then
           add_mp_delta_resolver mp_to' mp_to' reso', item'
         else
-          add_delta_resolver reso' (mod_delta mb'), item'
+          add_delta_resolver (mod_delta mb') reso', item'
     | (l,SFBmodtype mty) ->
         let mp_from' = MPdot (mp_from,l) in
         let mp_to' = MPdot(mp_to,l) in


### PR DESCRIPTION
As revealed by the implementation, this function expects that its first argument is a delta resolver for a more precise path than its second argument. Intuitively, this means that the first argument lives in a (not necessarily strict) submodule of the first argument.

Some calls to the kernel were breaking this invariant. There may be a way to trigger nasty unsoundness issues out of this, although in all cases the resolvers looked like they were orthogonal and thus the operation was probably commutative.

For atomicity I have split this PR in three, so now it depends some other PRs.

Depends on:
- https://github.com/coq/coq/pull/20115
- https://github.com/coq/coq/pull/20116