### PR TITLE
Typecheck pseudo sort poly inductives in kernel using above prop qvar

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -327,7 +327,7 @@ let v_template_arity =
   v_tuple "template_arity" [|v_sort|]
 
 let v_template_universes =
-  v_tuple "template_universes" [|v_list v_bool;v_context_set|]
+  v_tuple "template_universes" [|v_list v_bool;v_context_set; v_bool|]
 
 let v_primitive =
   v_enum "primitive" 63 (* Number of constructors of the CPrimitives.t type *)

--- a/dev/ci/user-overlays/20102-SkySkimmer-kernel-template-qvar.sh
+++ b/dev/ci/user-overlays/20102-SkySkimmer-kernel-template-qvar.sh
@@ -1,0 +1,5 @@
+overlay paramcoq https://github.com/SkySkimmer/paramcoq cominductive-lbound 20102 kernel-template-qvar
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp cominductive-lbound 20102 kernel-template-qvar
+
+overlay metacoq https://github.com/SkySkimmer/metacoq kernel-template-qvar 20102

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -25,6 +25,8 @@ open Constr
     In truly universe polymorphic mode, we always use RegularArity.
 *)
 
+type template_pseudo_sort_poly = TemplatePseudoSortPoly | TemplateUnivOnly
+
 type template_arity = {
   template_level : Sorts.t;
 }
@@ -32,6 +34,7 @@ type template_arity = {
 type template_universes = {
   template_param_arguments : bool list;
   template_context : Univ.ContextSet.t;
+  template_pseudo_sort_poly : template_pseudo_sort_poly;
 }
 
 type ('a, 'b) declaration_arity =

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -53,7 +53,9 @@ let hcons_template_arity ar =
 
 let hcons_template_universe ar =
   { template_param_arguments = ar.template_param_arguments;
-    template_context = Univ.hcons_universe_context_set ar.template_context }
+    template_context = Univ.hcons_universe_context_set ar.template_context;
+    template_pseudo_sort_poly = ar.template_pseudo_sort_poly;
+  }
 
 let universes_context = function
   | Monomorphic -> UVars.AbstractContext.empty

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -183,10 +183,10 @@ let cook_inductive info mib =
   in
   let mind_template = match mib.mind_template with
   | None -> None
-  | Some {template_param_arguments=levels; template_context} ->
+  | Some {template_param_arguments=levels; template_context; template_pseudo_sort_poly} ->
       let sec_levels = List.make (Context.Rel.nhyps (rel_context_of_cooking_cache cache)) false in
       let levels = List.rev_append sec_levels levels in
-      Some {template_param_arguments=levels; template_context}
+      Some {template_param_arguments=levels; template_context; template_pseudo_sort_poly}
   in
   {
     mind_packets;

--- a/kernel/entries.mli
+++ b/kernel/entries.mli
@@ -23,7 +23,10 @@ type universes_entry =
 type inductive_universes_entry =
   | Monomorphic_ind_entry
   | Polymorphic_ind_entry of UVars.UContext.t
-  | Template_ind_entry of Univ.ContextSet.t
+  | Template_ind_entry of {
+      univs : Univ.ContextSet.t;
+      pseudo_sort_poly : Declarations.template_pseudo_sort_poly;
+    }
 
 type variance_entry = UVars.Variance.t option array
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -1043,3 +1043,13 @@ struct
   let hash _env c = GlobRef.CanOrd.hash c
   let canonize _env c = GlobRef.canonize c
 end
+
+module Internal = struct
+  let for_checking_pseudo_sort_poly env =
+    let q = Sorts.QVar.make_var 0 in
+    assert (not (Sorts.QVar.Set.mem q env.env_qualities));
+    let env = map_universes UGraph.Internal.for_checking_pseudo_sort_poly env in
+    { env with env_qualities = Sorts.QVar.Set.add q env.env_qualities }
+
+  let is_above_prop env q = UGraph.Internal.is_above_prop env.env_universes q
+end

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -463,3 +463,11 @@ val no_link_info : link_info
 
 (** Primitives *)
 val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
+
+module Internal : sig
+  (** Makes qvar 0 bound and treated as above prop.
+      Do not use outside kernel inductive typechecking. *)
+  val for_checking_pseudo_sort_poly : env -> env
+
+  val is_above_prop : env -> Sorts.QVar.t -> bool
+end

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -272,17 +272,26 @@ let check_record data =
         else None)
     data
 
-(* For a level to be template polymorphic, it must be introduced
-   by the definition (so have no constraint except lbound <= l)
-   and not to be constrained from below, so any universe l' <= l
-   can be used as an instance of l. All bounds from above, i.e.
-   l <=/< r will be valid for any l' <= l. *)
-let unbounded_from_below u cstrs =
-  Univ.Constraints.for_all (fun (l, d, r) ->
-      match d with
-      | Eq | Lt -> not (Univ.Level.equal l u) && not (Univ.Level.equal r u)
-      | Le -> not (Univ.Level.equal r u))
-    cstrs
+(* Template univs must be unbounded from below for subject reduction
+   (with partially applied template poly, cf RFC 90).
+
+   We also forbid strict bounds from above because they lead
+   to problems when instantiated with algebraic universes
+   (template_u < v can become w+1 < v which we cannot yet handle). *)
+let check_unbounded_from_below (univs,csts) =
+  Univ.Constraints.iter (fun (l,d,r) ->
+      let bad = match d with
+        | Eq | Lt ->
+          if Level.Set.mem l univs then Some l
+          else if Level.Set.mem r univs then Some r
+          else None
+        | Le -> if Level.Set.mem r univs then Some r else None
+      in
+      bad |> Option.iter (fun bad ->
+          CErrors.user_err Pp.(str "Universe level " ++ Level.raw_pr bad ++
+                               str " cannot be template because it appears in constraint " ++
+                               Level.raw_pr l ++ pr_constraint_type d ++ Level.raw_pr r)))
+    csts
 
 let get_arity c =
   let decls, c = Term.decompose_prod_decls c in
@@ -294,92 +303,107 @@ let get_arity c =
     end
   | _ -> None
 
-let get_template univs ~env_params ~env_ar_par ~params entries data =
-  match univs with
-  | Polymorphic_ind_entry _ | Monomorphic_ind_entry -> None
-  | Template_ind_entry {univs=ctx; pseudo_sort_poly} ->
-    let entry, sort = match entries, data with
-      | [entry], [(_, _, info)] -> entry, info.ind_univ
-      | _ -> CErrors.user_err Pp.(str "Template-polymorphism not allowed with mutual inductives.")
-    in
-    (* Compute potential template parameters *)
-    let map decl = match decl with
-    | LocalAssum (_, t) ->
-      let s = match get_arity t with
-      | Some (_, l) -> if Level.Set.mem l (fst ctx) then Some l else None
-      | None -> None
-      in
-      Some s
-    | LocalDef _ -> None
-    in
-    let template_params = List.map_filter map params in
-    let fold accu u = match u with
-    | None -> accu
-    | Some u ->
-      if Level.Set.mem u accu then
-        CErrors.user_err Pp.(str "Non-linear template level " ++ Level.raw_pr u)
-      else Level.Set.add u accu
-    in
-    let plevels = List.fold_left fold Level.Set.empty template_params in
-    (* We must ensure that template levels can be substituted by an arbitrary
-       algebraic universe. A reasonable approximation is to restrict their
-       appearance to the sort of arities from parameters.
+let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
+| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> None
+| Template_ind_entry {univs=(template_univs, _ as template_context); pseudo_sort_poly} ->
+  let params = mie.mind_entry_params in
+  let ind =
+    match mie.mind_entry_inds with
+    | [ind] -> ind
+    | _ -> CErrors.user_err Pp.(str "Template-polymorphism not allowed with mutual inductives.")
+  in
+  let () = check_unbounded_from_below template_context in
+  (* Template univs must only appear in the conclusion of the
+     inductive and linearly in the conclusion of parameters.
+     This makes them Irrelevant for conversion and also makes them easy to substitute.
+     The inductive and binding parameter types must be syntactically arities. *)
+  let check_not_appearing c =
+    let us = Vars.universes_of_constr c in
+    let appearing = Level.Set.inter us template_univs in
+    if not (Level.Set.is_empty appearing) then
+      CErrors.user_err
+        Pp.(str "Template " ++
+            str (CString.plural (Level.Set.cardinal appearing) "universe") ++
+            spc() ++ Level.Set.pr Level.raw_pr appearing ++ spc() ++
+            str "appear in illegal positions.")
+  in
+  let check_not_appearing_rel_ctx ctx =
+    List.iter (Context.Rel.Declaration.iter_constr check_not_appearing) ctx
+  in
 
-       Furthermore, to prevent the generation of algebraic levels with increments
-       strictly larger than 1, we must also forbid the return sort to contain
-       a positive increment on a template level, see #19230.
+  (** params *)
+  (* for each non-letin param, find whether it binds a template univ *)
+  let template_params =
+    CList.filter_map (fun param ->
+        match param with
+        | LocalDef (_,b,t) ->
+          check_not_appearing b;
+          check_not_appearing t;
+          None
+        | LocalAssum (_,t) ->
+          match get_arity t with
+          | None ->
+            check_not_appearing t;
+            Some None
+          | Some (decls, l) ->
+            let () = check_not_appearing_rel_ctx decls in
+            if Level.Set.mem l template_univs then Some (Some l) else Some None)
+      params
+  in
+  let bound_in_params =
+    List.fold_left (fun bound_in_params -> function
+        | None -> bound_in_params
+        | Some l ->
+          if Level.Set.mem l bound_in_params then
+            CErrors.user_err Pp.(str "Non-linear template level " ++ Level.raw_pr l)
+          else Level.Set.add l bound_in_params)
+      Level.Set.empty
+      template_params
+  in
+  let unbound_in_params = Level.Set.diff template_univs bound_in_params in
+  let () = if not (Level.Set.is_empty unbound_in_params) then
+      CErrors.user_err
+        Pp.(str "Template " ++
+            str (CString.plural (Level.Set.cardinal unbound_in_params) "universe") ++
+            spc() ++ Level.Set.pr Level.raw_pr unbound_in_params ++ spc() ++
+            str "are not bound by parameters.")
 
-       TODO: when algebraic universes land, remove this check. *)
-    let plevels =
-      let fold plevels c = Level.Set.diff plevels (Vars.universes_of_constr c) in
-      let fold_params plevels = function
-      | LocalDef (_, b, t) -> fold (fold plevels t) b
-      | LocalAssum (_, t) ->
-        match get_arity t with
-        | None -> fold plevels t
-        | Some (decls, _) -> fold plevels (it_mkProd_or_LetIn mkProp decls)
-      in
-      let plevels = List.fold_left fold_params plevels params in
-      let plevels =
-        let (decls, s) = Term.decompose_prod_decls entry.mind_entry_arity in
-        let () = assert (isSort s) in
-        fold plevels (it_mkProd_or_LetIn mkProp decls)
-      in
-      let plevels = List.fold_left fold plevels entry.mind_entry_lc in
-      plevels
+  in
+
+  (** arity *)
+  let () =
+    (* don't use get_arity, we allow constant template poly (eg eq) *)
+    let (decls, s) = Term.decompose_prod_decls ind.mind_entry_arity in
+    let () = if not (isSort s) then
+        CErrors.user_err Pp.(str "Template polymorphic inductive's type must be a syntactic arity.")
     in
-    let plevels = match sort with
-    | Type u ->
-      let fold accu (l, n) = if Int.equal n 0 then accu else Level.Set.remove l accu in
-      List.fold_left fold plevels (Universe.repr u)
-    | Prop | SProp | Set -> plevels
+    check_not_appearing_rel_ctx decls;
+    match destSort s with
+    | SProp | Prop | Set -> ()
     | QSort _ -> assert false
-    in
-    let map = function
-    | None -> None
-    | Some l -> if Level.Set.mem l plevels then Some l else None
-    in
-    let params = List.map map template_params in
-    let unbound = Level.Set.diff (fst ctx) plevels in
-    let plevels =
-      if not (Level.Set.is_empty unbound) then
-        CErrors.user_err Pp.(strbrk "The following template universes are not \
-          bound by parameters: " ++ pr_sequence Level.raw_pr (Level.Set.elements unbound))
-      else Level.Set.elements plevels
-    in
-    let check_bound l =
-      if not (unbounded_from_below l (snd ctx)) then
-        CErrors.user_err Pp.(strbrk "Universe level " ++ Level.raw_pr l ++ strbrk " has a lower bound")
-    in
-    let () = List.iter check_bound plevels in
-    (* We reuse the same code as the one for variance inference. *)
-    let init_variance = Array.map_of_list (fun l -> l, Some Variance.Irrelevant) plevels in
-    let _variance = InferCumulativity.infer_inductive ~env_params ~env_ar_par init_variance
-        ~arities:[entry.mind_entry_arity]
-        ~ctors:[entry.mind_entry_lc]
-    in
-    let params = List.rev_map Option.has_some params in
-    Some { template_param_arguments = params; template_context = ctx; template_pseudo_sort_poly = pseudo_sort_poly }
+    | Type u ->
+      (* forbid template poly with an increment on a template univ in the conclusion
+         otherwise repeatedly applying it can generate universes with +2
+         which we cannot yet handle. *)
+      let has_increment =
+        Universe.exists (fun (u,n) ->
+            if Level.Set.mem u template_univs then
+              not (Int.equal n 0)
+            else false) u
+      in
+      if has_increment then
+        CErrors.user_err
+          Pp.(str "Template polymorphism with conclusion strictly larger than a bound universe not supported.")
+  in
+
+  (** ctors *)
+  let () = List.iter check_not_appearing ind.mind_entry_lc in
+
+  Some {
+    template_param_arguments = List.rev_map Option.has_some template_params;
+    template_context;
+    template_pseudo_sort_poly = pseudo_sort_poly;
+  }
 
 let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info) =
   if not (List.is_empty univ_info.missing)
@@ -426,6 +450,8 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   assert (List.is_empty (Environ.rel_context env));
 
   (* universes *)
+  let template = get_template mie in
+
   let env_univs =
     match mie.mind_entry_universes with
     | Template_ind_entry {univs=ctx; pseudo_sort_poly} ->
@@ -503,8 +529,6 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
         in
         Some variances
   in
-
-  let template = get_template mie.mind_entry_universes ~env_params ~env_ar_par ~params mie.mind_entry_inds data in
 
   (* Abstract universes *)
   let usubst, univs = match mie.mind_entry_universes with

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -118,10 +118,16 @@ let no_sort_variable () =
 
 type template_univ =
   | TemplateProp
+  | TemplateAboveProp of Sorts.QVar.t * Universe.t
   | TemplateUniv of Universe.t
 
 let max_template_universe u v = match u, v with
   | TemplateProp, x | x, TemplateProp -> x
+  | TemplateAboveProp (q1,u), TemplateAboveProp (q2,v) ->
+    if Sorts.QVar.equal q1 q2 then TemplateAboveProp (q1, Universe.sup u v)
+    else TemplateUniv (Universe.sup u v)
+  | TemplateAboveProp (_, u), TemplateUniv v
+  | TemplateUniv u, TemplateAboveProp (_,v)
   | TemplateUniv u, TemplateUniv v -> TemplateUniv (Universe.sup u v)
 
 (* cons_subst add the mapping [u |-> su] in subst if [u] is not *)
@@ -191,32 +197,34 @@ let subst_univs_sort (subs, pseudo_sort_poly) = function
   let u = Universe.repr u in
   let supern u n = iterate Universe.super n u in
   let map (u, n) =
-    if Level.is_set u then Some (Universe.type0, n)
+    if Level.is_set u then TemplateUniv (supern Universe.type0 n)
     else match Level.Map.find u subs, pseudo_sort_poly with
     | TemplateProp, TemplatePseudoSortPoly ->
       if Int.equal n 0 then
         (* This is an instantiation of a template universe by Prop, ignore it *)
-        None
+        TemplateProp
       else
         (* Prop + S n actually means Set + S n *)
-        Some (Universe.type0, n)
+        TemplateUniv (supern Universe.type0 n)
+    | TemplateAboveProp (q, u), TemplatePseudoSortPoly ->
+      TemplateAboveProp (q, supern u n)
     | TemplateProp, TemplateUnivOnly ->
       (* exploit Prop <= Set *)
-      Some (Universe.type0, n)
-    | TemplateUniv v, _ -> Some (v,n)
+      TemplateUniv (supern Universe.type0 n)
+    | TemplateAboveProp (_, u), TemplateUnivOnly ->
+      TemplateUniv (supern u n)
+    | TemplateUniv v, _ -> TemplateUniv (supern v n)
     | exception Not_found ->
       (* Either an unbound template universe due to missing arguments, or a
          global one appearing in the inductive arity. *)
-      Some (Universe.make u, n)
+      TemplateUniv (supern (Universe.make u) n)
   in
-  let u = List.filter_map map u in
-  match u with
-  | [] ->
-    (* No constraints, fall in Prop *)
+  let u = List.map map u in
+  match List.fold_left max_template_universe TemplateProp u with
+  | TemplateProp ->
     Sorts.prop
-  | (u,n) :: rest ->
-    let fold accu (u, n) = Universe.sup accu (supern u n) in
-    Sorts.sort_of_univ (List.fold_left fold (supern u n) rest)
+  | TemplateUniv u -> Sorts.sort_of_univ u
+  | TemplateAboveProp (q,u) -> Sorts.qsort q u
 
 let get_arity c =
   let decls, c = Term.decompose_prod_decls c in
@@ -247,10 +255,11 @@ let instantiate_template_constraints subst templ =
     (* v is not a local universe by the unbounded from below property *)
     let u = subst_univs_sort (subst, templ.template_pseudo_sort_poly) (Sorts.sort_of_univ (Universe.make u)) in
     match u with
-    | Sorts.QSort _ | Sorts.SProp -> assert false
+    | Sorts.SProp -> assert false
     | Sorts.Prop -> accu
     | Sorts.Set -> Constraints.add (Univ.Level.set, cst, v) accu
-    | Sorts.Type u ->
+    | Sorts.(Type u | QSort (_, u)) ->
+      (* if qsort, it is above prop *)
       let fold accu (u, n) = match n, cst with
       | 0, _ -> Constraints.add (u, cst, v) accu
       | 1, Le -> Constraints.add (u, Lt, v) accu

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -48,6 +48,7 @@ val instantiate_inductive_constraints :
 
 type template_univ =
   | TemplateProp
+  | TemplateAboveProp of Sorts.QVar.t * Universe.t
   | TemplateUniv of Universe.t
 
 type param_univs = (expected:Univ.Level.t -> template_univ) list

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -58,7 +58,7 @@ val instantiate_template_constraints
   -> Univ.Constraints.t
 
 val instantiate_template_universes : mind_specif -> param_univs ->
-  Constraints.t * rel_context * template_univ Univ.Level.Map.t
+  Constraints.t * rel_context * (template_univ Univ.Level.Map.t * template_pseudo_sort_poly)
 
 val constrained_type_of_inductive : mind_specif puniverses -> types constrained
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -124,3 +124,11 @@ val explain_universe_inconsistency : (Sorts.QVar.t -> Pp.t) -> (Level.t -> Pp.t)
 
 (** {6 Debugging} *)
 val check_universes_invariants : t -> unit
+
+module Internal : sig
+  (** Makes qvar 0 bound and treated as above prop.
+      Do not use outside kernel inductive typechecking. *)
+  val for_checking_pseudo_sort_poly : t -> t
+
+  val is_above_prop : t -> Sorts.QVar.t -> bool
+end

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -20,7 +20,7 @@ Expands to: Inductive Corelib.Init.Datatypes.option
 Declared in library Corelib.Init.Datatypes, line 202, characters 10-16
 option : Type@{option.u0} -> Type@{max(Set,option.u0)}
 
-option is template universe polymorphic on option.u0
+option is template universe polymorphic on option.u0 (cannot be instantiated to Prop)
 Arguments option A%type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
 Declared in library Corelib.Init.Datatypes, line 202, characters 10-16

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -256,7 +256,7 @@ Universe inconsistency. Cannot enforce a < a because a = a.
 JMeq :
 forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
 
-JMeq is template universe polymorphic on JMeq.u0
+JMeq is template universe polymorphic on JMeq.u0 (cannot be instantiated to Prop)
 Arguments JMeq [A]%type_scope x [B]%type_scope _
 Expands to: Inductive UnivBinders.PartialTemplate.JMeq
 Declared in library UnivBinders, line 219, characters 10-14

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -846,7 +846,7 @@ let interp_structure_core (entry:RecordEntry.t) ~projections_kind ~indlocs data 
     | Monomorphic_ind_entry ->
       (UState.Monomorphic_entry entry.global_univs, entry.ubinders)
     | Template_ind_entry ctx ->
-      (UState.Monomorphic_entry (Univ.ContextSet.union entry.global_univs ctx), entry.ubinders)
+      (UState.Monomorphic_entry (Univ.ContextSet.union entry.global_univs ctx.univs), entry.ubinders)
     | Polymorphic_ind_entry uctx ->
       (UState.Polymorphic_entry uctx, UnivNames.empty_binders)
   in


### PR DESCRIPTION
Extracted from https://github.com/coq/coq/pull/19985
If the higher layers use sort polymorphism to infer template info they will send more general types to the kernel (typically `Inductive foo T := bar (_:nat -> T).` will be inferred template) so the kernel needs to be modified, but the kernel change does not depend on the higher layer change AFAICT so we can make incremental progress here.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/893
- https://github.com/MetaCoq/metacoq/pull/1137
- https://github.com/coq-community/paramcoq/pull/133