### PR TITLE
[v9.0] Bump stdlib commit after version switcher update.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -419,8 +419,7 @@ project verdi_raft 'https://github.com/uwplse/verdi-raft' 'a3375e867326a82225e72
 ########################################################################
 # Stdlib
 ########################################################################
-project stdlib 'https://github.com/coq/stdlib' '155be26dc10a8b6ddb3cfbdd4c144c077c583b5f'
-# TODO replace temporary test repo by actual one
+project stdlib 'https://github.com/coq/stdlib' '732498358e2258595ae0ab174297238a21f8d177'
 # Contact TODO on github
 
 ########################################################################


### PR DESCRIPTION
BTW, @proux01: it's a bit problematic that the stdlib doc is deployed through a pipeline in the Coq/Rocq repo, as it means in particular that if there are more frequent Stdlib releases than Rocq releases (which was one of the points of the split), then the stable Stdlib documentation won't be updated to account for that...

Since the stdlib doc is already built as part of the stdlib CI, wouldn't it be possible to push to the coq/doc repo directly from the stdlib CI, instead of going through the Coq/Rocq CI?