### PR TITLE
Allow error messages from number/string notation parsers

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/20107-number-nota.rst
+++ b/doc/changelog/08-vernac-commands-and-options/20107-number-nota.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :cmd:`Number Notation` and :cmd:`String Notation` understand parsers which may produce error messages
+  (`#20107 <https://github.com/coq/coq/pull/20107>`_,
+  fixes `#20042 <https://github.com/coq/coq/issues/20042>`_,
+  by Gaëtan Gilbert).

--- a/doc/changelog/11-standard-library/20107-number-nota.rst
+++ b/doc/changelog/11-standard-library/20107-number-nota.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  type `result` in `Corelib.Datatypes`, equivalent to `sum`
+  but with a name fitting possibly-failing computations
+  (`#20107 <https://github.com/coq/coq/pull/20107>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -2026,34 +2026,28 @@ Number notations
          parsing and printing functions, respectively.  The parsing function
          :n:`@qualid__parse` should have one of the following types:
 
-            * :n:`Number.int -> @qualid__type`
-            * :n:`Number.int -> option @qualid__type`
-            * :n:`Number.uint -> @qualid__type`
-            * :n:`Number.uint -> option @qualid__type`
-            * :n:`Z -> @qualid__type`
-            * :n:`Z -> option @qualid__type`
-            * :n:`PrimInt63.pos_neg_int63 -> @qualid__type`
-            * :n:`PrimInt63.pos_neg_int63 -> option @qualid__type`
-            * :n:`PrimFloat.float -> @qualid__type`
-            * :n:`PrimFloat.float -> option @qualid__type`
-            * :n:`Number.number -> @qualid__type`
-            * :n:`Number.number -> option @qualid__type`
+            * :n:`Number.int -> @qualid__type'`
+            * :n:`Number.uint -> @qualid__type'`
+            * :n:`Z -> @qualid__type'`
+            * :n:`PrimInt63.pos_neg_int63 -> @qualid__type'`
+            * :n:`PrimFloat.float -> @qualid__type'`
+            * :n:`Number.number -> @qualid__type'`
+
+         where :n:`@qualid__type'` is one of
+
+            * :n:`@qualid__type`
+            * :n:`option @qualid__type`
+            * :n:`result @qualid__type _`
 
          And the printing function :n:`@qualid__print` should have one of the
          following types:
 
-            * :n:`@qualid__type -> Number.int`
-            * :n:`@qualid__type -> option Number.int`
-            * :n:`@qualid__type -> Number.uint`
-            * :n:`@qualid__type -> option Number.uint`
-            * :n:`@qualid__type -> Z`
-            * :n:`@qualid__type -> option Z`
-            * :n:`@qualid__type -> PrimInt63.pos_neg_int63`
-            * :n:`@qualid__type -> option PrimInt63.pos_neg_int63`
-            * :n:`@qualid__type -> PrimFloat.float`
-            * :n:`@qualid__type -> option PrimFloat.float`
-            * :n:`@qualid__type -> Number.number`
-            * :n:`@qualid__type -> option Number.number`
+            * :n:`@qualid__type' -> Number.int`
+            * :n:`@qualid__type' -> Number.uint`
+            * :n:`@qualid__type' -> Z`
+            * :n:`@qualid__type' -> PrimInt63.pos_neg_int63`
+            * :n:`@qualid__type' -> PrimFloat.float`
+            * :n:`@qualid__type' -> Number.number`
 
          When parsing, the application of the parsing function
          :n:`@qualid__parse` to the number will be fully reduced, and universes
@@ -2162,10 +2156,13 @@ Number notations
    .. exn:: Cannot interpret this number as a value of type @type
 
      The number notation registered for :token:`type` does not support
-     the given number.  This error is given when the interpretation
-     function returns :g:`None`, or if the interpretation is registered
-     only for integers or non-negative integers, and the given number
-     has a fractional or exponent part or is negative.
+     the given number. This error is given when the interpretation
+     function returns :g:`None` (when :n:`@qualid__type'` is :n:`option
+     @qualid__type`) or :g:`Error e` (when :n:`@qualid__type'` is
+     :n:`result @qualid__type _`, in which case `e` will be printed and
+     appended to the error message), or if the interpretation is
+     registered only for integers or non-negative integers, and the
+     given number has a fractional or exponent part or is negative.
 
    .. exn:: overflow in int63 literal @bigint
 
@@ -2219,22 +2216,22 @@ String notations
          parsing and printing functions, respectively.  The parsing function
          :n:`@qualid__parse` should have one of the following types:
 
-            * :n:`Byte.byte -> @qualid__type`
-            * :n:`Byte.byte -> option @qualid__type`
+            * :n:`Byte.byte -> @qualid__type'`
             * :n:`list Byte.byte -> @qualid__type`
-            * :n:`list Byte.byte -> option @qualid__type`
             * :n:`PrimString.string -> @qualid__type`
-            * :n:`PrimString.string -> option @qualid__type`
+
+         where :n:`@qualid__type'` is one of
+
+            * :n:`@qualid__type`
+            * :n:`option @qualid__type`
+            * :n:`result @qualid__type _`
 
          The printing function :n:`@qualid__print` should have one of the
          following types:
 
-            * :n:`@qualid__type -> Byte.byte`
-            * :n:`@qualid__type -> option Byte.byte`
+            * :n:`@qualid__type' -> Byte.byte`
             * :n:`@qualid__type -> list Byte.byte`
-            * :n:`@qualid__type -> option (list Byte.byte)`
             * :n:`@qualid__type -> PrimString.string`
-            * :n:`@qualid__type -> option PrimString.string`
 
          When parsing, the application of the parsing function
          :n:`@qualid__parse` to the string will be fully reduced, and universes
@@ -2252,7 +2249,7 @@ String notations
 
      The string notation registered for :token:`type` does not support
      the given string.  This error is given when the interpretation
-     function returns :g:`None`.
+     function returns :g:`None` or :g:`Error e`.
 
    .. exn:: @qualid__parse should go from Byte.byte, (list Byte.byte), or PrimString.string to @type or (option @type).
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -156,7 +156,7 @@ type string_target_kind =
   | Byte
   | PString
 
-type option_kind = Option | Direct
+type option_kind = Direct | Option | Error
 type 'target conversion_kind = 'target * option_kind
 
 (** A postprocessing translation [to_post] can be done after execution

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -93,8 +93,8 @@ let locate_number () =
       hexadecimal = unsafe_ref_ind q_hex;
       number = unsafe_ref_ind q_num;
     } in
-    Some (int_ty, gref q_int, gref q_uint, gref q_dint, gref q_duint,
-          num_ty, gref q_num, gref q_dec)
+    Some (int_ty, gref q_int, gref q_uint,
+          num_ty, gref q_num)
 
 let locate_int63 () =
   let pos_neg_int63n = "num.int63.pos_neg_int63" in
@@ -460,12 +460,12 @@ let vernac_number_notation local ty f g opts scope =
   (* Check the type of f *)
   let to_kind =
     match num_ty with
-    | Some (int_ty, cint, _, _, _, _, _, _) when has_type env sigma f (arrow cint cty) -> Int int_ty, Direct
-    | Some (int_ty, cint, _, _, _, _, _, _) when has_type env sigma f (arrow cint (opt cty)) -> Int int_ty, Option
-    | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma f (arrow cuint cty) -> UInt int_ty, Direct
-    | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma f (arrow cuint (opt cty)) -> UInt int_ty, Option
-    | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma f (arrow cnum cty) -> Number num_ty, Direct
-    | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma f (arrow cnum (opt cty)) -> Number num_ty, Option
+    | Some (int_ty, cint, _, _, _) when has_type env sigma f (arrow cint cty) -> Int int_ty, Direct
+    | Some (int_ty, cint, _, _, _) when has_type env sigma f (arrow cint (opt cty)) -> Int int_ty, Option
+    | Some (int_ty, _, cuint, _, _) when has_type env sigma f (arrow cuint cty) -> UInt int_ty, Direct
+    | Some (int_ty, _, cuint, _, _) when has_type env sigma f (arrow cuint (opt cty)) -> UInt int_ty, Option
+    | Some (_, _, _, num_ty, cnum) when has_type env sigma f (arrow cnum cty) -> Number num_ty, Direct
+    | Some (_, _, _, num_ty, cnum) when has_type env sigma f (arrow cnum (opt cty)) -> Number num_ty, Option
     | _ ->
     match z_pos_ty with
     | Some (z_pos_ty, cZ) when has_type env sigma f (arrow cZ cty) -> Z z_pos_ty, Direct
@@ -484,12 +484,12 @@ let vernac_number_notation local ty f g opts scope =
   let cty = match tyc_params with TargetPrim (c, _, _) -> gref c | TargetInd _ -> cty in
   let of_kind =
     match num_ty with
-    | Some (int_ty, cint, _, _, _, _, _, _) when has_type env sigma g (arrow cty cint) -> Int int_ty, Direct
-    | Some (int_ty, cint, _, _, _, _, _, _) when has_type env sigma g (arrow cty (opt cint)) -> Int int_ty, Option
-    | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma g (arrow cty cuint) -> UInt int_ty, Direct
-    | Some (int_ty, _, cuint, _, _, _, _, _) when has_type env sigma g (arrow cty (opt cuint)) -> UInt int_ty, Option
-    | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma g (arrow cty cnum) -> Number num_ty, Direct
-    | Some (_, _, _, _, _, num_ty, cnum, _) when has_type env sigma g (arrow cty (opt cnum)) -> Number num_ty, Option
+    | Some (int_ty, cint, _, _, _) when has_type env sigma g (arrow cty cint) -> Int int_ty, Direct
+    | Some (int_ty, cint, _, _, _) when has_type env sigma g (arrow cty (opt cint)) -> Int int_ty, Option
+    | Some (int_ty, _, cuint, _, _) when has_type env sigma g (arrow cty cuint) -> UInt int_ty, Direct
+    | Some (int_ty, _, cuint, _, _) when has_type env sigma g (arrow cty (opt cuint)) -> UInt int_ty, Option
+    | Some (_, _, _, num_ty, cnum) when has_type env sigma g (arrow cty cnum) -> Number num_ty, Direct
+    | Some (_, _, _, num_ty, cnum) when has_type env sigma g (arrow cty (opt cnum)) -> Number num_ty, Option
     | _ ->
     match z_pos_ty with
     | Some (z_pos_ty, cZ) when has_type env sigma g (arrow cty cZ) -> Z z_pos_ty, Direct

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -63,7 +63,7 @@ comparison : Set
 
 comparison is not universe polymorphic
 Expands to: Inductive Corelib.Init.Datatypes.comparison
-Declared in library Corelib.Init.Datatypes, line 351, characters 10-20
+Declared in library Corelib.Init.Datatypes, line 360, characters 10-20
 Inductive comparison : Set :=
     Eq : comparison | Lt : comparison | Gt : comparison.
 bar : foo

--- a/test-suite/output/StringNotationErrors.out
+++ b/test-suite/output/StringNotationErrors.out
@@ -1,0 +1,16 @@
+"hello"
+     : smallstring
+File "./output/StringNotationErrors.v", line 21, characters 13-30:
+The command has indeed failed with message:
+Cannot interpret this string as a value of type smallstring
+("not a small string: too long string"%pstring)
+"too long string"
+     : smallstring
+"hello"
+     : smallstring
+File "./output/StringNotationErrors.v", line 45, characters 13-30:
+The command has indeed failed with message:
+Cannot interpret this string as a value of type smallstring
+(NotSmallString "too long string")
+SmallString "too long string"
+     : smallstring

--- a/test-suite/output/StringNotationErrors.v
+++ b/test-suite/output/StringNotationErrors.v
@@ -1,0 +1,49 @@
+Require Import PrimInt63 PrimString.
+
+Inductive smallstring := SmallString (_:string).
+
+Declare Scope smallstring_scope.
+Open Scope smallstring_scope.
+
+Module V1.
+
+  Definition of_smallstring '(SmallString v) := v.
+
+
+  Definition to_smallstring v :=
+    if PrimInt63.leb (length v) 10 then Ok (SmallString v)
+    else Error (cat "not a small string: " v).
+
+  String Notation smallstring to_smallstring of_smallstring : smallstring_scope.
+
+  Check "hello".
+
+  Fail Check "too long string".
+
+  (* printing function doesn't check so we print something that doesn't parse *)
+  Check SmallString "too long string".
+
+End V1.
+
+Module V2.
+  Inductive smallstring_error := NotSmallString (_:string).
+
+  Definition to_smallstring v :=
+    if PrimInt63.leb (length v) 10 then Ok (SmallString v)
+    else Error (NotSmallString v).
+
+  Definition of_smallstring '(SmallString v) :=
+    match to_smallstring v with
+    | Ok _ => Ok v
+    | Error e => Error e
+    end.
+
+  String Notation smallstring to_smallstring of_smallstring : smallstring_scope.
+
+  Check "hello".
+
+  Fail Check "too long string".
+
+  (* printing function produces an error message but its content is ignored *)
+  Check SmallString "too long string".
+End V2.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -232,6 +232,15 @@ Register sum as core.sum.type.
 Register inl as core.sum.inl.
 Register inr as core.sum.inr.
 
+Inductive result (A E : Type) :=
+| Ok (_:A)
+| Error (_:E).
+
+Arguments Ok {_ _} _, [_] _ _.
+Arguments Error {_ _} _, _ [_] _.
+
+Register result as core.result.type.
+
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 


### PR DESCRIPTION

Close #20042

Not entirely sure if it makes sense to allow error messages in the
printing function as they will be ignored, but it was more uniform to
do it.
