### PR TITLE
Fix composition of delta resolvers in "with Module".

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -46,6 +46,13 @@ module Deltamap = struct
     MPmap.fold fmp mm (KNmap.fold fkn km i)
   let join map1 map2 = fold add_mp add_kn map1 map2
 
+  (** if mp0 ⊆ root, we can see a resolver on root as a resolver on mp *)
+  let upcast mp0 (mm, km) =
+    let check mp = assert (ModPath.subpath mp0 mp) in
+    let () = MPmap.iter (fun mp _ -> check mp) mm in
+    let () = KNmap.iter (fun kn _ -> check (KerName.modpath kn)) km in
+    (mm, km)
+
   (** keep only data that is relevant for names with a modpath ⊇ root *)
   let reroot root (mm, km) =
     (* filter the modpaths *)
@@ -99,6 +106,8 @@ end
 type delta_resolver = Deltamap.t
 
 let empty_delta_resolver = Deltamap.empty
+
+let upcast_delta_resolver = Deltamap.upcast
 
 module Umap :
   sig

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -32,6 +32,10 @@ val add_inline_delta_resolver :
 
 val add_delta_resolver : delta_resolver -> delta_resolver -> delta_resolver
 
+(** Assuming mp ⊆ root(delta), [upcast_delta_resolver mp delta] allows seeing
+    [delta] as a resolver with root = mp. *)
+val upcast_delta_resolver : ModPath.t -> delta_resolver -> delta_resolver
+
 (** Effect of a [delta_resolver] on a module path, on a kernel name *)
 
 val mp_of_delta : delta_resolver -> ModPath.t -> ModPath.t

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -185,7 +185,7 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
       let new_mb = strengthen_and_subst_module_body new_mp new_mb mp' false in
       (** TODO: check this is fine when new_mb is a functor *)
       let new_mb' = strengthen_module_body ~src:new_mp (mod_type new_mb) (mod_delta new_mb) new_mb in
-      let new_reso = add_delta_resolver reso (mod_delta new_mb) in
+      let new_reso = add_delta_resolver reso (upcast_delta_resolver mp (mod_delta new_mb)) in
       (* we propagate the new equality in the rest of the signature
          with the identity substitution accompanied by the new resolver*)
       let id_subst = map_mp mp' mp' (mod_delta new_mb) in
@@ -205,7 +205,10 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
           check_with_mod (cst, ustate) env' struc (idl,new_mp) mp' (mod_delta old)
         in
         let new_mb = replace_module_body struc' reso' old in
-        let new_reso = add_delta_resolver reso reso' in
+        (* XXX we are adding bits of [mod_delta old] twice below, all bindings
+           [mp₀ ↦ mp₁] where mp₁ ≠ mp.idl should already be part of reso and
+           will be left untouched in reso' by check_with_mod *)
+        let new_reso = add_delta_resolver reso (upcast_delta_resolver mp reso') in
         let id_subst = map_mp mp' mp' reso' in
         let new_after = subst_structure id_subst mp after in
         before@(lab,SFBmodule new_mb)::new_after, new_reso, cst

--- a/test-suite/bugs/bug_20115.v
+++ b/test-suite/bugs/bug_20115.v
@@ -1,0 +1,33 @@
+Module Type PARAM.
+Parameter T : Type.
+End PARAM.
+
+Module Type NESTED.
+  Declare Module KI: PARAM.
+End NESTED.
+
+Module Type BUNDLE.
+  Declare Module KI: PARAM.
+  Declare Module K0: NESTED with Module KI := KI.
+End BUNDLE.
+
+Declare Module MyKI : PARAM.
+Declare Module MyKO : BUNDLE with Module KI := MyKI.
+
+(** Check that the delta-resolver contains the correct equivalence
+
+    MyKO.K0.KI.T ↦ MyKI.T *)
+
+Goal MyKI.T.
+Proof.
+match goal with
+[ |- MyKO.K0.KI.T ] => idtac
+end.
+Abort.
+
+Goal MyKO.K0.KI.T.
+Proof.
+match goal with
+[ |- MyKI.T ] => idtac
+end.
+Abort.


### PR DESCRIPTION
The previous code was breaking the implicit invariant that the left argument as expected to live in a subpath of the right argument. This was behaving as expected though, because there was also an implicit lifting operation of the resolver at the same time. In the current implementation, lifting is just the identity, but this will change.

This commit makes the lifting explicit without changing any observable behaviour.