### PR TITLE
Stronger invariants in delta resolvers.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -220,7 +220,7 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
     let mtb = Modops.module_type_of_module (lookup_module mp env) in
     let state = (Environ.universes env, Conversion.checked_universes) in
     let _ : UGraph.t = Subtyping.check_subtypes state env mp mtb (MPbound farg_id) farg_b in
-    let subst = Mod_subst.map_mbid farg_id mp Mod_subst.empty_delta_resolver in
+    let subst = Mod_subst.map_mbid farg_id mp (Mod_subst.empty_delta_resolver mp) in
     Modops.subst_signature subst mp_mse fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -286,10 +286,8 @@ let v_resolver =
     [|v_mp; v_map v_mp v_mp;
       v_hmap v_kn v_delta_hint|]
 
-let v_mp_resolver = v_tuple "" [|v_mp;v_resolver|]
-
 let v_subst =
-  v_annot_c ("substitution", v_map v_mp v_mp_resolver)
+  v_annot_c ("substitution", v_map v_mp v_resolver)
 
 (** kernel/lazyconstr *)
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -283,7 +283,7 @@ let v_delta_hint =
 
 let v_resolver =
   v_tuple "delta_resolver"
-    [|v_map v_mp v_mp;
+    [|v_mp; v_map v_mp v_mp;
       v_hmap v_kn v_delta_hint|]
 
 let v_mp_resolver = v_tuple "" [|v_mp;v_resolver|]

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -315,7 +315,7 @@ and subst_module_body : type a. _ -> _ -> _ -> _ -> a generic_module_body -> a g
   let subst =
     if ModPath.equal mp mp' then subst
     else if is_mod && not (is_functor ty) then subst
-    else add_mp mp mp' empty_delta_resolver subst
+    else add_mp mp mp' (empty_delta_resolver mp') subst
   in
   let ty' = subst_signature subst do_delta mp ty in
   let me' = subst_impl subst mp me in

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -15,21 +15,31 @@ open Constr
 
 (** {6 Delta resolver} *)
 
-(** A delta_resolver maps name (constant, inductive, module_path)
-   to canonical name  *)
+(** A delta resolver is a renaming of kernames and modpaths.
+    Objects on which the resolver acts non-trivially must share a common modpath
+    prefix called the root of the resolver. *)
 type delta_resolver
 
-val empty_delta_resolver : delta_resolver
+(** Given a root, build a resolver. *)
+val empty_delta_resolver : ModPath.t -> delta_resolver
 
+val has_root_delta_resolver : ModPath.t -> delta_resolver -> bool
+
+(** [add_mp_delta_resolver mp v reso] assumes that root(reso) ⊆ mp. *)
 val add_mp_delta_resolver :
   ModPath.t -> ModPath.t -> delta_resolver -> delta_resolver
 
+(** [add_kn_delta_resolver kn v reso] assumes that root(reso) ⊆ modpath(kn). *)
 val add_kn_delta_resolver :
   KerName.t -> KerName.t -> delta_resolver -> delta_resolver
 
+(** [add_inline_delta_resolver kn v reso] assumes that root(reso) ⊆ modpath(kn). *)
 val add_inline_delta_resolver :
   KerName.t -> (int * constr UVars.univ_abstracted option) -> delta_resolver -> delta_resolver
 
+(** [add_delta_resolver reso1 reso2] merges two renamings, assuming that
+    root(reso2) ⊆ root(reso1). Note that this is asymmetrical. The root of the
+    result is root(reso2). *)
 val add_delta_resolver : delta_resolver -> delta_resolver -> delta_resolver
 
 (** Assuming mp ⊆ root(delta), [upcast_delta_resolver mp delta] allows seeing
@@ -45,16 +55,9 @@ val kn_of_delta : delta_resolver -> KerName.t -> KerName.t
 
 val constant_of_delta_kn : delta_resolver -> KerName.t -> Constant.t
 
-(** Same, but a 2nd resolver is tried if the 1st one had no effect *)
-
-val constant_of_deltas_kn :
-  delta_resolver -> delta_resolver -> KerName.t -> Constant.t
-
 (** Same for inductive names *)
 
 val mind_of_delta_kn : delta_resolver -> KerName.t -> MutInd.t
-val mind_of_deltas_kn :
-  delta_resolver -> delta_resolver -> KerName.t -> MutInd.t
 
 (** Extract the set of inlined constant in the resolver *)
 val inline_of_delta : int option -> delta_resolver -> (int * KerName.t) list

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -43,9 +43,9 @@ let split_struc k m struc =
     | h::tail -> split (h::rev_before) tail
   in split [] struc
 
-let discr_resolver mtb = match mod_type mtb with
+let discr_resolver mp mtb = match mod_type mtb with
   | NoFunctor _ -> mod_delta mtb
-  | MoreFunctor _ -> empty_delta_resolver
+  | MoreFunctor _ -> empty_delta_resolver mp
 
 let rec rebuild_mp mp l =
   match l with
@@ -245,7 +245,7 @@ let translate_apply ustate env inl mp (sign,alg,reso,cst,vm) mp1 mkalg =
   let farg_id, farg_b, fbody_b = destr_functor sign in
   let mtb = module_type_of_module (lookup_module mp1 env) in
   let cst = Subtyping.check_subtypes (cst, ustate) env mp1 mtb (MPbound farg_id) farg_b in
-  let mp_delta = discr_resolver mtb in
+  let mp_delta = discr_resolver mp1 mtb in
   let mp_delta = inline_delta_resolver env inl mp1 farg_id farg_b mp_delta in
   let subst = map_mbid farg_id mp1 mp_delta in
   let body = subst_signature subst mp fbody_b in

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -21,7 +21,7 @@ compiler *)
 let rec translate_mod mp env mod_expr acc =
   match mod_expr with
   | NoFunctor struc ->
-      let env' = add_structure mp struc empty_delta_resolver env in
+      let env' = add_structure mp struc (empty_delta_resolver mp) env in
       List.fold_left (translate_field mp env') acc struc
   | MoreFunctor _ -> acc
 
@@ -65,7 +65,7 @@ let dump_library mp env mod_expr =
   debug_native_compiler (fun () -> Pp.str "Compiling library...");
   match mod_expr with
   | NoFunctor struc ->
-      let env = add_structure mp struc empty_delta_resolver env in
+      let env = add_structure mp struc (empty_delta_resolver mp) env in
       let t0 = Sys.time () in
       clear_global_tbl ();
       clear_symbols ();

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -81,7 +81,7 @@ module NamedDecl = Context.Named.Declaration
       module parameters [params] and earlier environment [oldsenv]
     * SIG (params,oldsenv) : same for a local module type
   - [modresolver] : delta_resolver concerning the module content, that needs to
-    be marshalled on disk
+    be marshalled on disk. Its root must be [modpath].
   - [paramresolver] : delta_resolver in scope but not part of the library per
     se, that is from functor parameters and required libraries
   - [revstruct] : current module content, most recent declarations first
@@ -249,7 +249,7 @@ let empty_environment =
   { env = Environ.empty_env;
     modpath = ModPath.dummy;
     modvariant = NONE;
-    modresolver = Mod_subst.empty_delta_resolver;
+    modresolver = Mod_subst.empty_delta_resolver ModPath.dummy;
     paramresolver = ParamResolver.empty DirPath.dummy;
     revstruct = [];
     modlabels = Label.Set.empty;
@@ -1220,7 +1220,7 @@ let start_mod_modtype ~istype l senv =
     (* carried over fields *)
     env = senv.env;
     future_cst = senv.future_cst;
-    modresolver = Mod_subst.empty_delta_resolver;
+    modresolver = Mod_subst.empty_delta_resolver mp;
     paramresolver = ParamResolver.add_delta_resolver senv.modpath senv.modresolver senv.paramresolver;
     univ = senv.univ;
     required = senv.required;
@@ -1436,7 +1436,7 @@ let start_library dir senv =
     modvariant = LIBRARY;
     required = senv.required;
 
-    modresolver = Mod_subst.empty_delta_resolver;
+    modresolver = Mod_subst.empty_delta_resolver mp;
     paramresolver = ParamResolver.empty dir;
     revstruct = [];
     modlabels = Label.Set.empty;

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -180,7 +180,7 @@ let no_delta = Mod_subst.empty_delta_resolver
 
 let flatten_modtype env mp me_alg struc_opt =
   match struc_opt with
-  | Some me -> me, no_delta
+  | Some me -> me, no_delta mp
   | None ->
      let mtb = expand_modtype env mp me_alg in
      mod_type mtb, mod_delta mtb
@@ -427,7 +427,7 @@ let mono_environment ~opaque_access refs mpl =
   let l = List.rev (environment_until None) in
   List.rev_map
     (fun (mp,struc) ->
-      mp, extract_structure opaque_access env mp no_delta ~all:(Visit.needed_mp_all mp) struc)
+      mp, extract_structure opaque_access env mp (no_delta mp) ~all:(Visit.needed_mp_all mp) struc)
     l
 
 (**************************************)
@@ -696,7 +696,7 @@ let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
   let l = List.rev (environment_until (Some dir_m)) in
   let select l (mp,struc) =
     if Visit.needed_mp mp
-    then (mp, extract_structure opaque_access env mp no_delta ~all:true struc) :: l
+    then (mp, extract_structure opaque_access env mp (no_delta mp) ~all:true struc) :: l
     else l
   in
   let struc = List.fold_left select [] l in

--- a/test-suite/bugs/bug_20124_1.v
+++ b/test-suite/bugs/bug_20124_1.v
@@ -1,0 +1,23 @@
+Module Type MiniOrderedType.
+  Parameter Inline t : Type.
+End MiniOrderedType.
+
+Module Type L_Struct.
+  Declare Module FOrd : MiniOrderedType.
+End L_Struct.
+
+Module Type ST_Struct.
+  Declare Module L : L_Struct.
+End ST_Struct.
+
+Module CP_beta_eta (L_ : L_Struct).
+  Module L := L_.
+End CP_beta_eta.
+
+Module Make (ST : ST_Struct) (CP : ST_Struct with Module L := ST.L).
+
+End Make.
+
+Declare Module ST : ST_Struct.
+Module CP := CP_beta_eta ST.L.
+Module SN := Make ST CP.

--- a/test-suite/bugs/bug_20124_2.v
+++ b/test-suite/bugs/bug_20124_2.v
@@ -1,0 +1,20 @@
+Module Type Empty.
+End Empty.
+
+Module Type Param.
+  Parameter T : Type.
+End Param.
+
+Module M0. End M0.
+
+Module FUNC0 (ARG0 : Empty) : Param.
+  Definition T : Type := unit.
+End FUNC0.
+
+Module FUNC (ARG : Empty).
+  Module K := FUNC0(M0).
+End FUNC.
+
+Module ANS := FUNC(M0).
+
+Print Assumptions ANS.K.T.

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -308,7 +308,7 @@ let print_struct is_impl extent env mp struc =
   prlist_with_sep spc (print_body is_impl extent env mp) struc
 
 let print_structure is_type extent env mp locals struc =
-  let env' = Modops.add_structure mp struc Mod_subst.empty_delta_resolver env in
+  let env' = Modops.add_structure mp struc (Mod_subst.empty_delta_resolver mp) env in
   nametab_register_module_body mp struc;
   let kwd = if is_type then "Sig" else "Struct" in
   hv 2 (keyword kwd ++ spc () ++ print_struct false extent env' mp struc ++


### PR DESCRIPTION
An implicit invariant of this data structure was that all paths contained in a resolver would have a common prefix corresponding to the path of the ambient module. We make this path explicit in the resolver and adapt the substitution API accordingly.