### PR TITLE
Rename PDF refman, and other occurrences of Coq RefMan.

### DIFF
--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -1,8 +1,8 @@
-The Coq Reference Manual is a collective work from the Coq Development
-Team whose members are listed in the file CREDITS of the Coq source
-package. All related documents (the LaTeX and BibTeX sources, the
+The Rocq Reference Manual is a collective work from the Rocq Development
+Team whose members are listed on https://rocq-prover.org/governance.
+All related documents (the LaTeX and BibTeX sources, the
 embedded png files, and the PostScript, PDF and html outputs) are
-copyright (c) 1999-2019, Inria, CNRS and contributors, with the
+copyright Inria, CNRS and contributors, with the
 exception of the Ubuntu font file UbuntuMono-B.ttf, which is Copyright
 2010,2011 Canonical Ltd and licensed under the Ubuntu font license,
 version 1.0
@@ -17,10 +17,9 @@ the Open Publication License, v1.0 or later (the latest version is
 presently available at http://www.opencontent.org/openpub/).  Options A
 and B are *not* elected.
 
-The Coq Standard Library is a collective work from the Coq Development
-Team whose members are listed in the file CREDITS of the Coq source
-package. All related documents (the Coq vernacular source files and
-the PostScript, PDF and html outputs) are copyright (c) 1999-2019,
+The Rocq Core Library is a collective work from the Rocq Development
+Team. All related documents (the Rocq vernacular source files and
+the PostScript, PDF and html outputs) are copyright
 Inria, CNRS and contributors. The material connected to the Standard
 Library is distributed under the terms of the Lesser General Public
 License version 2.1 or later.

--- a/doc/common/styles/html/simple/styles.hva
+++ b/doc/common/styles/html/simple/styles.hva
@@ -15,7 +15,7 @@
 <div id="container">
 
 <div id="header">
-<h1>Coq Reference Manual</h1>
+<h1>The Rocq Prover Reference Manual</h1>
 </div>
 
 <div id="content">

--- a/doc/dune
+++ b/doc/dune
@@ -58,6 +58,7 @@
   (source_tree sphinx)
   (source_tree tools/coqrst)
   ../config/coq_config.py
+  ../ide/rocqide/coq.png
   unreleased.rst
   (env_var SPHINXWARNOPT)
   (env_var COQRST_EXTRA))

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -199,7 +199,7 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-PDF_URL = "https://github.com/coq/coq/releases/download/V{version}/coq-{version}-reference-manual.pdf"
+PDF_URL = "https://github.com/coq/coq/releases/download/V{version}/rocq-{version}-reference-manual.pdf"
 html_theme_options = {
     'collapse_navigation': False
 }
@@ -375,11 +375,11 @@ latex_additional_files = [
     "_static/coqnotations.sty"
 ]
 
-latex_documents = [('index', 'CoqRefMan.tex', 'The Coq Reference Manual', author, 'manual')]
+latex_documents = [('index', f'rocq-{version}-reference-manual.tex', 'The Rocq Prover Reference Manual', author, 'manual')]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-# latex_logo = "../../ide/coq.png"
+latex_logo = "../../ide/rocqide/coq.png"
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/man/coq_makefile.1
+++ b/man/coq_makefile.1
@@ -30,6 +30,6 @@ Will give you a description of the whole list of options of
 .BR coqdep (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqc.1
+++ b/man/coqc.1
@@ -61,6 +61,6 @@ Print the compiled file on the standard output.
 .BR coqdep (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqchk.1
+++ b/man/coqchk.1
@@ -104,6 +104,6 @@ Print list of options.
 .BR coqdep (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqdoc.1
+++ b/man/coqdoc.1
@@ -221,5 +221,6 @@ Specify the HTML character set, to be inserted in the HTML header.
 .SH SEE ALSO
 .
 .I
-The Coq Reference Manual
-from http://coq.inria.fr/
+The Rocq Prover Reference Manual.
+.PP
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqnative.1
+++ b/man/coqnative.1
@@ -79,6 +79,6 @@ Print list of options.
 .BR coqdep (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -165,6 +165,6 @@ Don't load opaque proofs in memory.
 .BR coqdep (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org

--- a/man/coqtop.byte.1
+++ b/man/coqtop.byte.1
@@ -28,6 +28,6 @@ and
 .BR coqc (1)
 .PP
 .I
-The Coq Reference Manual.
+The Rocq Prover Reference Manual.
 .PP
-The Coq web site: http://coq.inria.fr
+The Rocq Prover website: https://rocq-prover.org


### PR DESCRIPTION
There are still other occurrences of "Coq" in the old man pages that I didn't touch.

With this change, the produced PDF refman will directly have the correct name and won't have to be renamed anymore by the release manager.

Also, now the Rocq logo is included on the front page of the PDF refman.