### PR TITLE
coq_makefile: Ensure `STDTIME` works when `TIMED` is empty

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -77,7 +77,6 @@ TIMED?=
 TIMECMD?=
 # Use command time on linux, gtime on Mac OS
 TIMEFMT?="$(if $(findstring undefined, $(flavor 1)),$@,$(1)) (real: %e, user: %U, sys: %S, mem: %M ko)"
-ifneq (,$(TIMED))
 ifeq (0,$(shell command time -f "" true >/dev/null 2>/dev/null; echo $$?))
 STDTIME?=command time -f $(TIMEFMT)
 else
@@ -86,9 +85,6 @@ STDTIME?=gtime -f $(TIMEFMT)
 else
 STDTIME?=command time
 endif
-endif
-else
-STDTIME?=command time -f $(TIMEFMT)
 endif
 
 COQBIN?=


### PR DESCRIPTION
The only use of `STDTIME` is https://github.com/coq/coq/blob/c22a07452968a5f7e22720b3b3adaf2710eb27dd/tools/CoqMakefile.in#L224, where we ignore `STDTIME` if `TIMED` is empty.  So AFAICT, there's no reason to set `STDTIME` to `command time -f $(TIMEFMT)` when `TIMED` is empty.
