### PR TITLE
Introduce a notion of change function in the tactic API.

### DIFF
--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -152,8 +152,10 @@ let  mkCaseEq a  : unit Proofview.tactic =
             let env = Proofview.Goal.env gl in
             (* FIXME: this looks really wrong. Does anybody really use
                this tactic? *)
-            let (_, c) = Tacred.pattern_occs [Locus.OnlyOccurrences [1], a] env (Evd.from_env env) concl in
-            change_concl c
+            let ans = Tacred.pattern_occs [Locus.OnlyOccurrences [1], a] env (Evd.from_env env) concl in
+            match ans with
+            | NoChange -> Proofview.tclUNIT ()
+            | Changed (_, c) -> change_concl c
           end;
           simplest_case a]
   end

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1854,8 +1854,8 @@ and interp_atomic ist tac : unit Proofview.tactic =
           in
           let ist = { ist with lfun = lfun' } in
             if is_onhyps && is_onconcl
-            then interp_type ist env sigma c
-            else interp_constr ist env sigma c
+            then Changed (interp_type ist env sigma c)
+            else Changed (interp_constr ist env sigma c)
         in
         Tactics.change ~check None c_interp (interp_clause ist (pf_env gl) (project gl) cl)
       end
@@ -1876,7 +1876,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           let env = ensure_freshness env in
           let ist = { ist with lfun = lfun' } in
             try
-              interp_constr ist env sigma c
+              Changed (interp_constr ist env sigma c)
             with e when to_catch e (* Hack *) ->
               user_err  (strbrk "Failed to get enough information from the left-hand side to type the right-hand side.")
         in

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -171,7 +171,7 @@ let change pat c cl =
   Proofview.Goal.enter begin fun gl ->
   let c subst env sigma =
     let subst = Array.map_of_list snd (Id.Map.bindings subst) in
-    delayed_of_tactic (Tac2ffi.app_fun1 c (array constr) constr subst) env sigma
+    Tacred.Changed (delayed_of_tactic (Tac2ffi.app_fun1 c (array constr) constr subst) env sigma)
   in
   let cl = mk_clause cl in
   Tactics.change ~check:true pat c cl

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -28,6 +28,9 @@ val subst_evaluable_reference :
 type reduction_tactic_error =
     InvalidAbstraction of env * evar_map * constr * (env * Type_errors.type_error)
 
+type 'a change = NoChange | Changed of 'a
+type change_function = env -> evar_map -> constr -> (evar_map * constr) change
+
 exception ReductionTacticError of reduction_tactic_error
 
 (** {6 Reduction functions associated to tactics. } *)
@@ -75,7 +78,7 @@ val unfoldn :
 val fold_commands : constr list ->  reduction_function
 
 (** Pattern *)
-val pattern_occs : (occurrences * constr) list -> e_reduction_function
+val pattern_occs : (occurrences * constr) list -> change_function
 
 (** Rem: Lazy strategies are defined in Reduction *)
 
@@ -118,7 +121,7 @@ val contextually : bool -> occurrences * constr_pattern ->
   (patvar_map -> reduction_function) -> reduction_function
 
 val e_contextually : bool -> occurrences * constr_pattern ->
-  (patvar_map -> e_reduction_function) -> e_reduction_function
+  (patvar_map -> change_function) -> change_function
 
 (** Errors if the inductive is not allowed for pattern-matching. **)
 val check_privacy : env -> inductive -> unit

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -251,6 +251,10 @@ let red_product_exn env sigma c = match red_product env sigma c with
   | None -> user_err Pp.(str "No head constant to reduce.")
   | Some c -> c
 
+let pattern_occs occs env sigma c = match pattern_occs occs env sigma c with
+| NoChange -> sigma, c
+| Changed (sigma, c) -> sigma, c
+
 let reduction_of_red_expr_val = function
   | Red -> (e_red red_product_exn, DEFAULTcast)
   | Hnf -> (e_red hnf_constr,DEFAULTcast)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -149,7 +149,7 @@ val exact_proof      : Constrexpr.constr_expr -> unit Proofview.tactic
 type tactic_reduction = Reductionops.reduction_function
 type e_tactic_reduction = Reductionops.e_reduction_function
 
-type change_arg = patvar_map -> env -> evar_map -> evar_map * constr
+type change_arg = patvar_map -> env -> evar_map -> (evar_map * constr) Tacred.change
 
 val make_change_arg   : constr -> change_arg
 val reduct_in_hyp     : check:bool -> reorder:bool -> tactic_reduction -> hyp_location -> unit Proofview.tactic


### PR DESCRIPTION
This allows implementing several fast paths in change-like functions. Notably, all callers of Tacred.e_contextually are now aware that this function may very well be the identity.

I observed some slowdowns caused by this lack of fast-paths in logrel-coq.