### PR TITLE
Add coq-lean4-import to the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1150,6 +1150,9 @@ plugin:ci-lean_importer:
 
 plugin:ci-lean4_importer:
   extends: .ci-template
+  needs:
+  - build:base
+  - library:ci-stdlib
 
 plugin:ci-ltac2_compiler:
   extends: .ci-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1148,6 +1148,9 @@ plugin:ci-fiat_parsers:
 plugin:ci-lean_importer:
   extends: .ci-template
 
+plugin:ci-lean4_importer:
+  extends: .ci-template
+
 plugin:ci-ltac2_compiler:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -80,6 +80,7 @@ CI_TARGETS= \
     ci-json \
     ci-kami \
     ci-lean_importer \
+    ci-lean4_importer \
     ci-ltac2_compiler \
     ci-mathcomp_test \
     ci-metacoq \

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -156,6 +156,8 @@ ci-cross_crypto: ci-stdlib
 
 ci-mtac2: ci-unicoq ci-stdlib
 
+ci-lean4_importer: ci-stdlib
+
 ci-coqutil: ci-stdlib
 ci-kami: ci-stdlib
 ci-rewriter: ci-stdlib

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -501,8 +501,13 @@ project jasmin "https://github.com/jasmin-lang/jasmin" "main"
 ########################################################################
 # Lean Importer
 ########################################################################
+# Lean3 version
 project lean_importer "https://github.com/SkySkimmer/coq-lean-import" "master"
 # Contact @SkySkimmer on github
+
+# Lean4 version
+project lean4_importer "https://github.com/JasonGross/coq-lean-import" "lean4-rebased"
+# Contact @JasonGross or @SkySkimmer on github
 
 ########################################################################
 # SMTCoq

--- a/dev/ci/ci-lean4_importer.sh
+++ b/dev/ci/ci-lean4_importer.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download lean4_importer
+
+if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
+
+export COQEXTRAFLAGS='-native-compiler no'
+
+( cd "${CI_BUILD_DIR}/lean4_importer"
+  make .merlin
+  make
+  make test
+)


### PR DESCRIPTION
I've started depending on this in one of my projects, and would like to know when some change to Coq breaks it.  (An alternative possibility is to upstream the shift from Lean 3 to Lean 4, cc @SkySkimmer )