### PR TITLE
Changes for 9.0, with porting instructions and renaming advice

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,16 +21,22 @@ Yves Bertot <yves.bertot@inria.fr>                 bertot <bertot@85f007b7-540e-
 Yves Bertot <yves.bertot@inria.fr>                 Yves Bertot <bertot@inria.fr>
 Yves Bertot <yves.bertot@inria.fr>                 Yves Bertot <Yves.Bertot@inria.fr>
 Yves Bertot <yves.bertot@inria.fr>                 Yves Bertot <bertot@nardis.inria.fr>
+Yves Bertot <yves.bertot@inria.fr>                 yves.bertot@inria.fr < >
+Yves Bertot <yves.bertot@inria.fr>                 ybertot
 Frédéric Besson <frederic.besson@inria.fr>         Frederic Besson <frederic.besson@inria.fr>
 Frédéric Besson <frederic.besson@inria.fr>         fbesson <fbesson@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Frédéric Besson <frederic.besson@inria.fr>         BESSON Frederic <frederic.besson@inria.fr>
 Frédéric Besson <frederic.besson@inria.fr>         fajb <fajb@users.noreply.github.com>
 Siddharth Bhat <siddu.druid@gmail.com>             Siddharth <siddu.druid@gmail.com>
 Lasse Blaauwbroek <lasse@blaauwbroek.eu>           Lasse Blaauwbroek <lasse@lasse-work.localdomain>
+Lasse Blaauwbroek <lasse@blaauwbroek.eu>           LasseBlaauwbroek
 Martin Bodin <martin.bodin@ens-lyon.org>           Martin Bodin <mbodin@ic.ac.uk>
 Martin Bodin <martin.bodin@ens-lyon.org>           Martin Bodin <martin.bodin@inria.fr>
+Mathis Bouverot <mathis.bouverot@ens.psl.eu>       MathisBD <mathis.bouverot@ens.psl.eu> 
 Ana Borges <ana.agvb@gmail.com>                    Ana <ana.agvb@gmail.com>
+@drenched-moth < >                                   drenched-moth <85354652+drenched-moth@users.noreply.github.com>
 Ana Borges <ana.agvb@gmail.com>                    ana-borges <ana-borges@users.noreply.github.com>
+Felix Loyau-Kahn <felix.loyau-kahn@etu.u-paris.fr>         felixL-K <felix.loyau-kahn@etu.u-paris.fr>
 Simon Boulier <simon.boulier@ens-rennes.fr>        SimonBoulier <simon.boulier@ens-rennes.fr>
 Simon Boulier <simon.boulier@ens-rennes.fr>        SimonBoulier <SimonBoulier@users.noreply.github.com>
 Pierre Boutillier <pierre.boutillier@ens-lyon.org> pboutill <pboutill@85f007b7-540e-0410-9357-904b9bb8a0f7>
@@ -40,6 +46,7 @@ Michele Caci <michele.caci@gmail.com>              mcaci <michele.caci@gmail.com
 Ali Caglayan <alizter@gmail.com>                   Alizter <Alizter@users.noreply.github.com>
 Arthur Charguéraud <arthur@chargueraud.org>        charguer <arthur@chargueraud.org>
 chluebi <42419603+chluebi@users.noreply.github.com>  chluebi <42419603+chluebi@users.noreply.github.com>
+Tej Chajed <tchajed@mit.edu>                       tchajed
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xclerc@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xavier.clerc@inria.fr>
 Cyril Cohen <cyril.cohen@crans.org>                Cyril Cohen <cohen@crans.org>
@@ -60,6 +67,7 @@ Olivier Desmettre <desmettr@gforge>                desmettr <desmettr@85f007b7-5
 Christian Doczkal <christian.doczkal@inria.fr>     Christian Doczkal <christian.doczkal@ens-lyon.fr>
 Damien Doligez <doligez@gforge>                    doligez <doligez@85f007b7-540e-0410-9357-904b9bb8a0f7>
 İsmail Dönmez <ismail-s@users.noreply.github.com>  Ismail <ismail-s@users.noreply.github.com>
+Louise Dubois de Prisque < >                       louiseddp                        
 formalize.eth <formalize@protonmail.com>           ilya <ilya@localhost.localdomain>
 Andres Erbsen <andreser@mit.edu>                   Andres Erbsen <andres@kevix.co>
 Andres Erbsen <andreser@mit.edu>                   andres-erbsen <andres-erbsen@users.noreply.github.com>
@@ -94,6 +102,7 @@ Jason Gross <jgross@mit.edu>                       Jason Gross <jasongross9@gmai
 Jason Gross <jgross@mit.edu>                       JasonGross <JasonGross@users.noreply.github.com>
 Vincent Gross <vgross@gforge>                      vgross <vgross@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Samuel Gruetter <samuel.gruetter@epfl.ch>          Samuel Gruetter <saemi472@gmail.com>
+Samuel Gruetter <samuel.gruetter@epfl.ch>          samuelgruetter
 Huang Guan-Shieng <huang@gforge>                   huang <huang@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Armaël Guéneau <armael.gueneau@ens-lyon.org>       Armael <armael@isomorphis.me>
 Armaël Guéneau <armael.gueneau@ens-lyon.org>       Armaël Guéneau <armael.gueneau@ens-lyon.fr>
@@ -105,23 +114,26 @@ Jasper Hugunin <jasper@hugunin.net>                Jasper Hugunin <jasperh@cs.wa
 Jasper Hugunin <jasper@hugunin.net>                Jasper Hugunin <jasper@hashplex.com>
 Tom Hutchinson <thutchin@gforge>                   thutchin <thutchin@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Bodo Igler <bodo.igler@hs-rm.de>                   igler <bodo.igler@hs-rm.de>
-
 Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org> Jacques-Henri Jourdan <jacques-henri.jourdan@inria.fr>
 Pierre Jouvelot <pierre.jouvelot@mines-paristech.fr> jouvelot <pierre.jouvelot@mines-paristech.fr>
+Ralf Jung < >                                      RalfJung
 Jan-Oliver Kaiser <janno@mpi-sws.org>              Janno <Janno@users.noreply.github.com>
 Jan-Oliver Kaiser <janno@mpi-sws.org>              Jan-Oliver Kaiser <janno@bedrocksystems.com>
 Cezary Kaliszyk <cek@gforge>                       cek <cek@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Wojciech Karpiel <w.karpiel@o2.pl>                 WojciechKarpiel <w.karpiel@o2.pl>
 Wojciech Karpiel <w.karpiel@o2.pl>                 Wojciech Karpiel <w.karpiel@avsystem.com>
+Chantal Keller < >                                 ckeller
 Florent Kirchner <fkirchne@gforge>                 fkirchne <fkirchne@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Florent Kirchner <fkirchne@gforge>                 kirchner <kirchner@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Johannes Kloos <jkloos@mpi-sws.org>                jkloos <jkloos@mpi-sws.org>
 Matej Košík <matej.kosik@inria.fr>                 Matej Kosik <m4tej.kosik@gmail.com>
 Matej Košík <matej.kosik@inria.fr>                 Matej Kosik <matej.kosik@inria.fr>
 Matej Košík <matej.kosik@inria.fr>                 Matej Košík <mail@matej-kosik.net>
+Evgenii Kosogorov <284661@niuitmo.ru>              doctor-kaliy
 Ethan A. Kuefner <ek@conjectu.red>                 e kuefner <ek@conjectu.red>
 Ambroise Lafont <chaster_killer@hotmail.fr>        amblaf <you@example.com>
 Ambroise Lafont <chaster_killer@hotmail.fr>        Ambroise <chaster_killer@hotmail.fr>
+Thomas Lamiaux < >                                 thomas-lamiaux
 Vincent Laporte <Vincent.Laporte@inria.fr>         Vincent Laporte <Vincent.Laporte@gmail.com>
 Vincent Laporte <Vincent.Laporte@inria.fr>         Vincent Laporte <Vincent.Laporte@fondation-inria.fr>
 Marc Lasson <marc.lasson@gmail.com>                mlasson <marc.lasson@gmail.com>
@@ -130,6 +142,7 @@ Olivier Laurent <olivier.laurent@ens-lyon.fr>      Olivier Laurent <30601497+ola
 William Lawvere <mundungus.corleone@gmail.com>     william-lawvere <mundungus.corleone@gmail.com>
 Larry Darryl Lee Jr. <llee454@gmail.com>           llee454@gmail.com <llee454@gmail.com>
 Larry Darryl Lee Jr. <llee454@gmail.com>           Larry D. Lee Jr <llee454@gmail.com>
+Rodolphe Lepigre <rodolphe@bedrocksystems.com>     rlepigre
 Xavier Leroy <xavier.leroy@college-de-france.fr>   Xavier Leroy <xavier.leroy@inria.fr>
 Pierre Letouzey <pierre.letouzey@inria.fr>         letouzey <letouzey@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre Letouzey <pierre.letouzey@inria.fr>         letouzey <pierre.letouzey@inria.fr>
@@ -143,6 +156,7 @@ Gregory Malecha <gmalecha@eecs.harvard.edu>        Gregory Malecha <gmalecha@cs.
 Gregory Malecha <gmalecha@eecs.harvard.edu>        Gregory Malecha <gmalecha@gmail.com>
 Lionel Elie Mamane <lmamane@gforge>                lmamane <lmamane@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Claude Marché <marche@gforge>                      marche <marche@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Tomaz Gomes Mascarenhas <tomgm1502@gmail.com>      tomaz1502 <tomgm1502@gmail.com>
 Micaela Mayero <mayero@gforge>                     mayero <mayero@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Guillaume Melquiond <guillaume.melquiond@inria.fr> gmelquio <gmelquio@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Guillaume Melquiond <guillaume.melquiond@inria.fr> Guillaume Melquiond <guillaume.melquiond@gmail.com>
@@ -154,14 +168,17 @@ Erik Martin-Dorel <erik.martin-dorel@irit.fr>      erikmd <erikmd@users.noreply.
 Julien Narboux <jnarboux@gforge>                   jnarboux <jnarboux@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Julien Narboux <jnarboux@gforge>                   narboux <narboux@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Jean-Marc Notin <notin@gforge>                     notin,no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty <notin,no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Charles Norton <arthur@chargueraud.org>            CharlesCNorton <135471798+CharlesCNorton@users.noreply.github.com>
 Jean-Marc Notin <notin@gforge>                     notin <notin@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Russell O'Connor <roconnor@blockstream.io>         roconnor <roconnor@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Russell O'Connor <roconnor@blockstream.io>         roconnor-blockstream <roconnor@blockstream.com>
 Sotaro Okada <soukouki0@yahoo.co.jp>               soukouki <soukouki0@yahoo.co.jp>
 Carl Patenaude-Poulin <carlpaten@protonmail.com>   Carl Patenaude Poulin <carl.patenaudepoulin@mail.mcgill.ca>
+Karl Palmskog < >                                  palmskog
 Christine Paulin <cpaulin@gforge>                  cpaulin <cpaulin@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Christine Paulin <cpaulin@gforge>                  mohring <mohring@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> ppedrot <ppedrot@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> ppedrot
 Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>
 Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> ppedrot <ppedrot@users.noreply.github.com>
 Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> <Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr>
@@ -191,6 +208,7 @@ Claudio Sacerdoti Coen <sacerdot@gforge>           sacerdot <sacerdot@85f007b7-5
 Kazuhiko Sakaguchi <pi8027@gmail.com>              Kazuhiko Sakaguchi <sakaguchi@coins.tsukuba.ac.jp>
 Kazuhiko Sakaguchi <pi8027@gmail.com>              Kazuhiko Sakaguchi <sakaguchi@peano-system.jp>
 Kazuhiko Sakaguchi <pi8027@gmail.com>              pi8027 <pi8027@users.noreply.github.com>
+Marcello Seri <mseri@users.noreply.github.com>
 Vincent Siles <vsiles@gforge>                      vsiles <vsiles@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Kartik Singhal <kartiksinghal@gmail.com>           Kartik Singhal <ks@cs.uchicago.edu>
 Michael Soegtrop <michael.soegtrop@intel.com>      Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
@@ -207,7 +225,7 @@ Naveen Srinivasan <172697+naveensrinivasan@users.noreply.github.com> naveen <172
 Paul Steckler <steck@stecksoft.com>                Paul Steckler <psteck@mit.edu>
 Frank Steffahn <fdsteffahn@gmail.com>              staffehn <fdsteffahn@gmail.com>
 Sergei Stepanenko <kaptch@gmail.com>               Kaptch <kaptch@gmail.com>
-
+Nicolas Tabareau <nicolas.tabareau@inria.fr>       nicolas tabareau <nicolas.tabareau@gmail.com>
 Enrico Tassi <Enrico.Tassi@inria.fr>               gareuselesinge <gareuselesinge@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Enrico Tassi <Enrico.Tassi@inria.fr>               <Enrico.Tassi@inria.fr>
 Enrico Tassi <Enrico.Tassi@inria.fr>               Enrico Tassi <enrico.tassi@inria.fr>
@@ -215,6 +233,8 @@ Enrico Tassi <Enrico.Tassi@inria.fr>               Enrico Tassi <gares@fettunta.
 Enrico Tassi <Enrico.Tassi@inria.fr>               Enrico <gares@fettunta.org>
 Enrico Tassi <Enrico.Tassi@inria.fr>               gares <gares@users.noreply.github.com>
 Enrico Tassi <Enrico.Tassi@inria.fr>               gares <gares@fettunta.org>
+Romain Tetley <romain.tetley@inria.fr>             rtetley
+Guillaume Munch-Maccagnoni <guillaume.munch-maccagnoni@inria.fr>  gadmm
 Hendrik Tews <Hendrik.Tews@kernkonzept.com>        Hendrik Tews <tews@elite.askra.de>
 Laurent Théry <laurent.thery@inria.fr>             thery <thery@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Laurent Théry <laurent.thery@inria.fr>             thery <thery@sophia.inria.fr>
@@ -231,6 +251,7 @@ Benjamin Werner <werner@gforge>                    werner <werner@85f007b7-540e-
 Li-yao Xia <lysxia@gmail.com>                      Lysxia <lysxia@gmail.com>
 Li-yao Xia <lysxia@gmail.com>                      Xia Li-yao <lysxia@gmail.com>
 Li-yao Xia <lysxia@gmail.com>                      Xia Li-yao <Lysxia@users.noreply.github.com>
+Remzi Yang <13716567376yh@gmail.com>               remzi <13716567376yh@gmail.com>
 Wang Zhuyang <hawnzug@gmail.com>                   hawnzug <hawnzug@gmail.com>
 Beta Ziliani <beta@mpi-sws.org>                    Beta Ziliani <bziliani@famaf.unc.edu.ar>
 Beta Ziliani <beta@mpi-sws.org>                    beta <beta@mpi-sws.org>

--- a/dev/tools/list-contributors.sh
+++ b/dev/tools/list-contributors.sh
@@ -21,9 +21,21 @@ cat assignees.tmp | $SED -z "s/\n/, /g"
 echo
 rm assignees.tmp
 
-git shortlog -s -n --merges --group=trailer:reviewed-by --group=trailer:ack-by $1 | cut -f2 | sort -k 2 | grep -v -e "coqbot" -e "^$" > reviewers.tmp
-
+git shortlog -s -n --merges --group=trailer:reviewed-by --group=trailer:ack-by $1 | cut -f2 > reviewers-pseudos.tmp
+rm -f reviewers-names.tmp
+for i in `cat reviewers-pseudos.tmp`
+do
+  res=`grep $i .mailmap`
+  if [[ $? == 1 ]]
+  then
+    echo $i" not found"
+    break
+  fi
+  echo $res | tail -n1 | cut -d'<' -f1 >> reviewers-names.tmp
+done
+cat reviewers-names.tmp | sort -k 2 > reviewers.tmp
+rm reviewers-pseudos.tmp reviewers-names.tmp
 cat reviewers.tmp | wc -l | xargs echo "Reviewers:"
-cat reviewers.tmp | $SED -z "s/\n/, /g"
+cat reviewers.tmp | $SED -z "s/ \n/, /g"
 echo
 rm reviewers.tmp

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -11,8 +11,197 @@ Recent changes
 Version 9.0
 -----------
 
+.. contents::
+   :local:
+   :depth: 1
+
 Summary of changes
 ~~~~~~~~~~~~~~~~~~
+
+The Rocq Prover version 9.0 is the first Rocq Prover release after the renaming
+from The Coq Proof Assistant. The Rocq Prover 9.0 command line interface is
+backwards compatible with Coq 8.20, providing compatibility shims so that
+developments depending on Coq can be easily ported, see `Porting to The Rocq
+Prover`_  for details. The 9.0 version is based on a new single binary `rocq`
+that dispatches commands to previously separate binaries, a split and renaming
+of the standard library to `Stdlib` and improvements to the handling of
+template-polymorphism, bringing it closer to a complete subsumption by sort
+polymorphism.
+
+We highlight some of the most impactful changes here:
+
+  - "The Rocq Prover" is the new official name of the project. We leave to users the
+    choice of renaming their projects to reflect this change, see `Renaming Advice`_.
+    The Rocq Prover comes with a new visual identity and website, see `The Rocq Prover Website`_.
+
+  - A single `rocq` binary dispatches commands for compilation, read-eval-print-loop,
+    documentation building, dependency computation, etc. See :ref:`therocqcommands`.
+    It corresponds to the `rocq-runtime` `opam package <https://ocaml.org/p/rocq-runtime>`_.
+    This is a bare-bones package that does not provide any Gallina code.
+
+  - The `Coq` standard library has been :ref:`split <90stdlib>` into two libraries:
+
+    - A `Corelib` library (the `rocq-core` opam package). This is an
+      extended prelude, which is
+      enough to run `rocq` tactics and contains the `Ltac2` library and bindings
+      for primitive types (integers, floats, arrays and strings).
+    - An `Stdlib` library (the `rocq-stdlib` opam package). The `Stdlib` is
+      now maintained out of the main `rocq` repository. We welcome maintainers and
+      contributors to the `new repository <https://github.com/rocq-prover/stdlib>`_.
+      A specific call for contributions will be
+      sent soon.
+
+Notable breaking changes:
+
+  - The legacy loading mode for plugins has been :ref:`removed <LegacyLoadingRemoval>`.
+
+See the `Changes in 9.0.0`_ section below for the detailed list of changes,
+including potentially breaking changes marked with **Changed**.
+Rocq's `reference manual for 9.0 <https://rocq-prover.org/doc/v9.0/refman>`_,
+documentation of the 9.0 `core <https://rocq-prover.org/doc/v9.0/corelib>`_ and
+`standard <https://rocq-prover.org/doc/v9.0/stdlib>`_ libraries,
+`reference manual of the 9.0 standard library <https://rocq-prover.org/doc/v9.0/refman-stdlib>`_
+and `developer documentation of the 9.0 ML API <https://rocq-prover.org/doc/v9.0/api>`_
+are also available.
+
+Théo Zimmermann with help from Jason Gross maintained
+`coqbot <https://github.com/coq/bot>`_ used to run Coq's CI and other
+pull request management tasks.
+
+Jason Gross maintained the `bug minimizer <https://github.com/JasonGross/coq-tools>`_
+and its `automatic use through coqbot <https://github.com/coq/coq/wiki/Coqbot-minimize-feature>`_.
+
+Ali Caglayan, Emilio Jesús Gallego Arias, Rudi Grinberg and Rodolphe Lepigre maintained the
+`Dune build system for OCaml and Coq/Rocq <https://github.com/ocaml/dune/>`_
+used to build Rocq itself and many Rocq projects.
+
+The `opam repository <https://github.com/coq/opam>`_ for Rocq packages has been maintained by
+Guillaume Claret, Guillaume Melquiond, Karl Palmskog, Matthieu Sozeau
+and Enrico Tassi with contributions from many users. The up-to-data list
+of packages is `available on the Rocq website <https://rocq-prover.org/packages>`_.
+
+Erik Martin-Dorel and Jaime Arias maintained the
+`Rocq Docker images <https://hub.docker.com/r/rocq/rocq-prover>`_.
+Erik Martin-Dorel maintained the `docker-keeper <https://gitlab.com/erikmd/docker-keeper>`_ compiler
+used to build and keep those images up to date (note that the tool is not Rocq specific).
+Erik Martin-Dorel and Théo Zimmermann maintained the
+`docker-coq-action <https://github.com/coq-community/docker-coq-action>`_
+container action (which is applicable to any opam project hosted on GitHub).
+
+Cyril Cohen, Vincent Laporte, Pierre Roux and Théo Zimmermann
+maintained the `Nix toolbox <https://github.com/coq-community/coq-nix-toolbox>`_.
+The docker-coq-action and the Nix toolbox are used by many Rocq projects for continuous integration.
+
+Rocq 9.0 was made possible thanks to the following 27 reviewers:
+Yves Bertot, Ali Caglayan, Tej Chajed, Andres Erbsen, Jim Fehrle,
+Emilio Jesús Gallego Arias, Gaëtan Gilbert, Jason Gross, Samuel Gruetter,
+Hugo Herbelin, Thomas Lamiaux, Olivier Laurent, Rodolphe Lepigre,
+Erik Martin-Dorel, Guillaume Melquiond, Guillaume Munch-Maccagnoni,
+Karl Palmskog, Pierre-Marie Pédrot, Pierre Rousselin, Pierre Roux,
+Marcello Seri, Michael Soegtrop, Matthieu Sozeau, Enrico Tassi,
+Romain Tetley, Oliver Turner and Théo Zimmermann.
+
+See the `Rocq Team <https://rocq-prover.org/governance>`_ page for
+more details on Rocq's development teams.
+
+The 48 contributors to the 9.0 version are:
+Jean Abou Samra, Tanaka Akira, David Allsopp, Frédéric Besson, Mathis Bouverot, Sylvain Chiron,
+Cyril Cohen, Lucas Donati, Andrej Dudenhefner, Arya Elfren, Andres Erbsen, Siegmentation Fault,
+Jim Fehrle, Gaëtan Gilbert, Tomaz Gomes Mascarenhas, Jason Gross, Hugo Herbelin, Florent Hivert,
+Daniil Iaitskov, Emilio Jesús Gallego Arias, Jan-Oliver Kaiser, Rodolphe Lepigre, Yann Leray,
+Felix Loyau-Kahn, Erik Martin-Dorel, Guillaume Melquiond, Guillaume Munch-Maccagnoni,
+Aleksandar Nanevski, Charles Norton, Karl Palmskog, Pierre-Marie Pédrot, Pierre Rousselin,
+Pierre Roux, Kazuhiko Sakaguchi, Gabriel Scherer, Marcello Seri, Benny Smit, Michael Soegtrop,
+Matthieu Sozeau, Nicolas Tabareau, Enrico Tassi, Oliver Turner, Quentin Vermande, Daneel Yaitskov,
+Remzi Yang, Tan Yee Jian and Théo Zimmermann.
+
+The Coq/Rocq community at large helped improve this new version via
+the GitHub issue and pull request system, the coq-club@inria.fr mailing list,
+the `Discourse forum <https://coq.discourse.group/>`_ and the
+`Coq Zulip chat <https://coq.zulipchat.com>`_.
+
+Version 9.0's development spanned 7 months from the release of Coq 8.20.0.
+Pierre-Marie Pédrot and Matthieu Sozeau are the release managers of Rocq 9.0.
+This release is the result of 491 merged PRs, closing 68 issues.
+
+| Nantes, March 2025
+| Pierre-Marie Pédrot and Matthieu Sozeau for the Rocq development team
+
+Porting to The Rocq Prover
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Rocq Prover version 9.0 includes compatibility shims that make it possible
+to invoke it through legacy Coq commands: `coq-tex`, `coq_makefile`, `coqchk`, `coqdoc`, `coqpp`, `coqtop`,
+`coqwc`, `coqc`, `coqdep`, `coqnative`, `coqtimelog2html`, `coqtop.byte`, `coqworkmgr`.
+When using `opam`, this compatibility layer is provided by the packages `coq-core`,
+`coq-stdlib` and `coq`. In this setting, nothing needs to be changed to the build systems
+of existing projects to compile with `Rocq 9.0` (aliased as `Coq 9.0`).
+
+You should expect warnings that the standard library previously under namespace
+`Coq` has been renamed to `Stdlib`. See `this entry
+<https://rocq-prover.org/doc/v9.0/refman-stdlib/changes.html#changed>`_ from
+the Standard Library's changelog for the suggested workflow to port theories.
+
+There are important changes to consider for building plugins and libraries:
+
+- To be future-proof, projects based on `coq_makefile` can be ported to not rely
+  on the compatibility layer anymore. To do so, one must replace uses of
+  `coq_makefile` with :ref:`rocq makefile <rocq_makefile>`, which will directly
+  call the new `rocq` binary without relying on the compatibility shims.
+
+- If using `dune` to :ref:`build <building_dune>` a Rocq project, you will still
+  need the compatibility shim for `coq-core` so that `dune`'s Coq language extension
+  functions correctly.
+
+Regarding packaging:
+
+- Opam packages that depend on the compatibility shims should remain named as `coq-*`, whereas
+  ported packages should be named `rocq-*`, with the `coq` dependency being replaced by
+  a `rocq-core` and `rocq-stdlib` dependency (unless your package does not depend on the stdlib),
+  but **not** `rocq-prover` which is only a user-oriented metapackage.
+- Similarly, Nix packages that use the compatibility shims can be kept in
+  `coqPackages` (and can keep depending on `coq`), whereas ported packages can
+  be added in `rocqPackages`, depending on `rocq-core`.
+
+In both cases, when a `rocq` port is done, a `coq` metapackage can be kept,
+simply depending on the new `rocq` package and `coq`.
+
+Renaming Advice
+~~~~~~~~~~~~~~~
+
+We have applied the `renaming <https://rocq-prover.org/about#Name>`_ from the
+Coq Proof Assistant to The Rocq Prover in this version, and officialy supported
+projects in the `Rocq organization <https://github.com/rocq-prover>`_ will be
+renamed in the future. The Rocq Development Team's official position on renaming of
+projects *it does not officially maintain* is to let their authors do as they wish.
+We just note that the new identity is quite compatible with existing
+Rooster references. However, we encourage existing and forthcoming projects to
+adopt the new logo, its colors and fonts, see the `ìdentity guidelines
+<https://rocq-prover.org/logo>`_ for more information.
+
+The Rocq Prover Website
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Rocq Prover comes with a new `website <https://rocq-prover.org>`_ which was
+developped by Matthieu Sozeau, Nicolas Tabareau and Théo Zimmermann in
+collaboration with Bastien Sozeau of the `Noir Blanc Rouge
+<https://noirblancrouge.com/>`_ type foundry. The new website is a fork of the
+`OCaml.org <https://ocaml.org>`_ website developed by `Tarides
+<https://tarides.com/>`_. The Rocq development team is thankful for their help
+and for open-sourcing their website. It includes full support for the `Rocq
+package archive <https://github.com/coq/opam>`_, a responsive design and easy
+contributions through markdown files. The new identity, customized fonts and
+logo were designed by Bastien Sozeau, consulting for the Rocq development team.
+The logo is released under the UNLICENSE open-source `license <https://github.com/coq/rocq-prover.org/LICENSE>`_
+and customized 3rd-party fonts are released under open-source `licences <https://github.com/coq/rocq-prover.org/LICENSE-3RD-PARTY>`_.
+
+The website is deployed automatically using a
+custom `deployer <https://deploy.rocq-prover.org>`_ developed by Matthieu
+Sozeau. The deployer keeps the website up-to-date with the github repositories
+of the `website <https://github.com/coq/rocq-prover.org>`__ and `documentation
+<https://github.com/coq/doc>`_. Its code is accessible on `github
+<https://github.com/coq/deploy-rocq-prover.org>`_.
+
 
 Changes in 9.0.0
 ~~~~~~~~~~~~~~~~
@@ -297,6 +486,9 @@ Commands and options
   :cmd:`Create HintDb` no longer erases pre-existing hint databases
   (`#19808 <https://github.com/coq/coq/pull/19808>`_,
   by Gaëtan Gilbert).
+
+.. _LegacyLoadingRemoval:
+
 - **Removed:**
   "legacy" (non-findlib) loading mode for plugins in :cmd:`Declare ML Module`
   (`#18385 <https://github.com/coq/coq/pull/18385>`_,
@@ -442,6 +634,8 @@ RocqIDE
 
 Standard library
 ^^^^^^^^^^^^^^^^
+
+.. _90stdlib:
 
 - **Changed:**
   Stdlib moved to its own repository, look for


### PR DESCRIPTION
Release notes for 9.0. I added two specific paragraphs about porting to Rocq Prover and Renaming Advice, that might fit better somewhere else, but let's finalize them here and move them at the end. TODOs:

- [x] Contributor list
- [x] Maintainer list
- [x] Issues and PRs count
- [x] Link checks once V9.0 is on rocq-prover.org/doc

Enjoy! I'll be on holidays starting February 1st, so please @ppedrot or someone else feel free (or rather, obliged) to take charge of integrating changes while I'm away. 