### PR TITLE
Fix whitespace in rocq usage command

### DIFF
--- a/topbin/rocq.ml
+++ b/topbin/rocq.ml
@@ -74,10 +74,10 @@ let print_usage fmt () =
       subcommands
   in
   Printf.fprintf fmt "Usage: rocq [-debug-shim] {-v|--version|--print-version|--help|SUBCOMMAND} [ARGUMENTS...]\n\
-\n\
 \n  -v, --version: print human readable version info\
 \n  --print-version: print machine readable version info\
-Supported subcommands:\n\
+\n\n\
+Supported subcommands:\n\n\
 %s\n\
 \n\
 Use \"rocq subcommand --help\" to get more information about a given subcommand.\n" (String.concat "\n" subcommands)


### PR DESCRIPTION
Fix whitespace in the usage display of `rocq`.
Before:
```
Usage: rocq [-debug-shim] {-v|--version|--print-version|--help|SUBCOMMAND} [ARGUMENTS...]


  -v, --version: print human readable version info
  --print-version: print machine readable version infoSupported subcommands:
    compile             Compile a Rocq source file
    c                   Alias for compile
    repl                Interactive read-eval-print loop
```

After:
```
Usage: rocq [-debug-shim] {-v|--version|--print-version|--help|SUBCOMMAND} [ARGUMENTS...]

  -v, --version: print human readable version info
  --print-version: print machine readable version info

Supported subcommands:

    compile             Compile a Rocq source file
    c                   Alias for compile
    repl                Interactive read-eval-print loop
```
