### PR TITLE
Stop relying on a global visit state in extraction.

### DIFF
--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -49,66 +49,69 @@ let environment_until dir_opt =
   a structure recording the needed dependencies for the current extraction *)
 
 module type VISIT = sig
-  (* Reset the dependencies by emptying the visit lists *)
-  val reset : unit -> unit
+  type t
+  (* Environment of visited data *)
+  val make : unit -> t
 
   (* Add the module_path and all its prefixes to the mp visit list.
      We'll keep all fields of these modules. *)
-  val add_mp_all : ModPath.t -> unit
+  val add_mp_all : t -> ModPath.t -> unit
 
   (* Add reference / ... in the visit lists.
      These functions silently add the mp of their arg in the mp list *)
-  val add_ref : GlobRef.t -> unit
-  val add_kn : KerName.t -> unit
-  val add_decl_deps : ml_decl -> unit
-  val add_spec_deps : ml_spec -> unit
+  val add_ref : t -> GlobRef.t -> unit
+  val add_kn : t -> KerName.t -> unit
+  val add_decl_deps : t -> ml_decl -> unit
+  val add_spec_deps : t -> ml_spec -> unit
 
   (* Test functions:
      is a particular object a needed dependency for the current extraction ? *)
-  val needed_ind : MutInd.t -> bool
-  val needed_cst : Constant.t -> bool
-  val needed_mp : ModPath.t -> bool
-  val needed_mp_all : ModPath.t -> bool
+  val needed_ind : t -> MutInd.t -> bool
+  val needed_cst : t -> Constant.t -> bool
+  val needed_mp : t -> ModPath.t -> bool
+  val needed_mp_all : t -> ModPath.t -> bool
 end
 
 module Visit : VISIT = struct
-  type must_visit =
+  type t =
       { mutable kn : KNset.t;
         mutable mp : MPset.t;
         mutable mp_all : MPset.t }
   (* the imperative internal visit lists *)
-  let v = { kn = KNset.empty; mp = MPset.empty; mp_all = MPset.empty }
+  let make () = {
+    kn = KNset.empty;
+    mp = MPset.empty;
+    mp_all = MPset.empty;
+  }
   (* the accessor functions *)
-  let reset () =
-    v.kn <- KNset.empty;
-    v.mp <- MPset.empty;
-    v.mp_all <- MPset.empty
-  let needed_ind i = KNset.mem (MutInd.user i) v.kn
-  let needed_cst c = KNset.mem (Constant.user c) v.kn
-  let needed_mp mp = MPset.mem mp v.mp || MPset.mem mp v.mp_all
-  let needed_mp_all mp = MPset.mem mp v.mp_all
-  let add_mp mp =
+  let needed_ind v i = KNset.mem (MutInd.user i) v.kn
+  let needed_cst v c = KNset.mem (Constant.user c) v.kn
+  let needed_mp v mp = MPset.mem mp v.mp || MPset.mem mp v.mp_all
+  let needed_mp_all v mp = MPset.mem mp v.mp_all
+  let add_mp v mp =
     check_loaded_modfile mp; v.mp <- MPset.union (prefixes_mp mp) v.mp
-  let add_mp_all mp =
+  let add_mp_all v mp =
     check_loaded_modfile mp;
     v.mp <- MPset.union (prefixes_mp mp) v.mp;
     v.mp_all <- MPset.add mp v.mp_all
-  let add_kn kn = v.kn <- KNset.add kn v.kn; add_mp (KerName.modpath kn)
-  let add_ref = let open GlobRef in function
-    | ConstRef c -> add_kn (Constant.user c)
-    | IndRef (ind,_) | ConstructRef ((ind,_),_) -> add_kn (MutInd.user ind)
+  let add_kn v kn = v.kn <- KNset.add kn v.kn; add_mp v (KerName.modpath kn)
+  let add_ref v = let open GlobRef in function
+    | ConstRef c -> add_kn v (Constant.user c)
+    | IndRef (ind,_) | ConstructRef ((ind,_),_) -> add_kn v (MutInd.user ind)
     | VarRef _ -> assert false
-  let add_decl_deps = decl_iter_references add_ref add_ref add_ref
-  let add_spec_deps = spec_iter_references add_ref add_ref add_ref
+  let add_decl_deps v decl =
+    decl_iter_references (fun kn -> add_ref v kn) (fun r -> add_ref v r) (fun r -> add_ref v r) decl
+  let add_spec_deps v spec =
+    spec_iter_references (fun r -> add_ref v r) (fun r -> add_ref v r) (fun r -> add_ref v r) spec
 end
 
-let add_field_label mp = function
-  | (lab, (SFBconst _|SFBmind _ | SFBrules _)) -> Visit.add_kn (KerName.make mp lab)
-  | (lab, (SFBmodule _|SFBmodtype _)) -> Visit.add_mp_all (MPdot (mp,lab))
+let add_field_label venv mp = function
+  | (lab, (SFBconst _|SFBmind _ | SFBrules _)) -> Visit.add_kn venv (KerName.make mp lab)
+  | (lab, (SFBmodule _|SFBmodtype _)) -> Visit.add_mp_all venv (MPdot (mp,lab))
 
-let rec add_labels mp = function
-  | MoreFunctor (_,_,m) -> add_labels mp m
-  | NoFunctor sign -> List.iter (add_field_label mp) sign
+let rec add_labels venv mp = function
+  | MoreFunctor (_,_,m) -> add_labels venv mp m
+  | NoFunctor sign -> List.iter (fun f -> add_field_label venv mp f) sign
 
 exception Impossible
 
@@ -204,32 +207,32 @@ let make_mind resolver mp l =
 (* From a [structure_body] (i.e. a list of [structure_field_body])
    to specifications. *)
 
-let rec extract_structure_spec env mp reso = function
+let rec extract_structure_spec venv env mp reso = function
   | [] -> []
   | (l,SFBconst cb) :: msig ->
       let c = make_cst reso mp l in
       let s = extract_constant_spec env c cb in
-      let specs = extract_structure_spec env mp reso msig in
+      let specs = extract_structure_spec venv env mp reso msig in
       if logical_spec s then specs
-      else begin Visit.add_spec_deps s; (l,Spec s) :: specs end
+      else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
   | (l,SFBmind _) :: msig ->
       let mind = make_mind reso mp l in
       let s = Sind (mind, extract_inductive env mind) in
-      let specs = extract_structure_spec env mp reso msig in
+      let specs = extract_structure_spec venv env mp reso msig in
       if logical_spec s then specs
-      else begin Visit.add_spec_deps s; (l,Spec s) :: specs end
+      else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
   | (l, SFBrules _) :: msig ->
-      let specs = extract_structure_spec env mp reso msig in
+      let specs = extract_structure_spec venv env mp reso msig in
       specs
   | (l,SFBmodule mb) :: msig ->
-      let specs = extract_structure_spec env mp reso msig in
+      let specs = extract_structure_spec venv env mp reso msig in
       let mp = MPdot (mp, l) in
-      let spec = extract_mbody_spec env mp mb in
+      let spec = extract_mbody_spec venv env mp mb in
       (l,Smodule spec) :: specs
   | (l,SFBmodtype mtb) :: msig ->
-      let specs = extract_structure_spec env mp reso msig in
+      let specs = extract_structure_spec venv env mp reso msig in
       let mp = MPdot (mp, l) in
-      let spec = extract_mbody_spec env mp mtb in
+      let spec = extract_mbody_spec venv env mp mtb in
       (l,Smodtype spec) :: specs
 
 (* From [module_expression] to specifications *)
@@ -238,28 +241,30 @@ let rec extract_structure_spec env mp reso = function
    [extract_mexpression_spec] should come from a [mod_type_alg] field.
    This way, any encountered [MEident] should be a true module type. *)
 
-and extract_mexpr_spec env mp1 (me_struct_o,me_alg) = match me_alg with
-  | MEident mp -> Visit.add_mp_all mp; MTident mp
+and extract_mexpr_spec venv env mp1 (me_struct_o,me_alg) = match me_alg with
+  | MEident mp ->
+    let () = Visit.add_mp_all venv mp in
+    MTident mp
   | MEwith(me',WithDef(idl,(c,ctx)))->
       let me_struct,delta = flatten_modtype env mp1 me' me_struct_o in
       let env' = env_for_mtb_with_def env mp1 me_struct delta idl in
-      let mt = extract_mexpr_spec env mp1 (None,me') in
+      let mt = extract_mexpr_spec venv env mp1 (None,me') in
       let sg = Evd.from_env env in
       (match extract_with_type env' sg (EConstr.of_constr c) with
        (* cb may contain some kn *)
          | None -> mt
          | Some (vl,typ) ->
-            type_iter_references Visit.add_ref typ;
+            let () = type_iter_references (fun r -> Visit.add_ref venv r) typ in
             MTwith(mt,ML_With_type(idl,vl,typ)))
   | MEwith(me',WithMod(idl,mp))->
-      Visit.add_mp_all mp;
-      MTwith(extract_mexpr_spec env mp1 (None,me'), ML_With_module(idl,mp))
+      let () = Visit.add_mp_all venv mp in
+      MTwith (extract_mexpr_spec venv env mp1 (None, me'), ML_With_module(idl, mp))
   | MEapply _ ->
      (* No higher-order module type in OCaml : we use the expanded version *)
      let me_struct,delta = flatten_modtype env mp1 me_alg me_struct_o in
-     extract_msignature_spec env mp1 delta me_struct
+     extract_msignature_spec venv env mp1 delta me_struct
 
-and extract_mexpression_spec env mp1 (me_struct,me_alg) = match me_alg with
+and extract_mexpression_spec venv env mp1 (me_struct,me_alg) = match me_alg with
   | MEMoreFunctor me_alg' ->
       let mbid, mtb, me_struct' = match me_struct with
       | MoreFunctor (mbid, mtb, me') -> (mbid, mtb, me')
@@ -267,24 +272,24 @@ and extract_mexpression_spec env mp1 (me_struct,me_alg) = match me_alg with
       in
       let mp = MPbound mbid in
       let env' = Modops.add_module_parameter mbid mtb env in
-      MTfunsig (mbid, extract_mbody_spec env mp mtb,
-                extract_mexpression_spec env' mp1 (me_struct',me_alg'))
-  | MENoFunctor m -> extract_mexpr_spec env mp1 (Some me_struct,m)
+      MTfunsig (mbid, extract_mbody_spec venv env mp mtb,
+                extract_mexpression_spec venv env' mp1 (me_struct', me_alg'))
+  | MENoFunctor m -> extract_mexpr_spec venv env mp1 (Some me_struct, m)
 
-and extract_msignature_spec env mp1 reso = function
+and extract_msignature_spec venv env mp1 reso = function
   | NoFunctor struc ->
       let env' = Modops.add_structure mp1 struc reso env in
-      MTsig (mp1, extract_structure_spec env' mp1 reso struc)
+      MTsig (mp1, extract_structure_spec venv env' mp1 reso struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp = MPbound mbid in
       let env' = Modops.add_module_parameter mbid mtb env in
-      MTfunsig (mbid, extract_mbody_spec env mp mtb,
-                extract_msignature_spec env' mp1 reso me)
+      MTfunsig (mbid, extract_mbody_spec venv env mp mtb,
+                extract_msignature_spec venv env' mp1 reso me)
 
-and extract_mbody_spec : 'a. _ -> _ -> 'a generic_module_body -> _ =
-  fun env mp mb -> match mod_type_alg mb with
-  | Some ty -> extract_mexpression_spec env mp (mod_type mb, ty)
-  | None -> extract_msignature_spec env mp (mod_delta mb) (mod_type mb)
+and extract_mbody_spec : 'a. _ -> _ -> _ -> 'a generic_module_body -> _ =
+  fun venv env mp mb -> match mod_type_alg mb with
+  | Some ty -> extract_mexpression_spec venv env mp (mod_type mb, ty)
+  | None -> extract_msignature_spec venv env mp (mod_delta mb) (mod_type mb)
 
 (* From a [structure_body] (i.e. a list of [structure_field_body])
    to implementations.
@@ -293,78 +298,84 @@ and extract_mbody_spec : 'a. _ -> _ -> 'a generic_module_body -> _ =
    important: last to first ensures correct dependencies.
 *)
 
-let rec extract_structure access env mp reso ~all = function
+let rec extract_structure access venv env mp reso ~all = function
   | [] -> []
   | (l,SFBconst cb) :: struc ->
       (try
          let sg = Evd.from_env env in
          let vl,recd,struc = factor_fix env sg l cb struc in
          let vc = Array.map (make_cst reso mp) vl in
-         let ms = extract_structure access env mp reso ~all struc in
-         let b = Array.exists Visit.needed_cst vc in
+         let ms = extract_structure access venv env mp reso ~all struc in
+         let b = Array.exists (Visit.needed_cst venv) vc in
          if all || b then
            let d = extract_fixpoint env sg vc recd in
            if (not b) && (logical_decl d) then ms
-           else begin Visit.add_decl_deps d; (l,SEdecl d) :: ms end
+           else
+            let () = Visit.add_decl_deps venv d in
+            (l, SEdecl d) :: ms
          else ms
        with Impossible ->
-         let ms = extract_structure access env mp reso ~all struc in
+         let ms = extract_structure access venv env mp reso ~all struc in
          let c = make_cst reso mp l in
-         let b = Visit.needed_cst c in
+         let b = Visit.needed_cst venv c in
          if all || b then
            let d = extract_constant access env c cb in
            if (not b) && (logical_decl d) then ms
-           else begin Visit.add_decl_deps d; (l,SEdecl d) :: ms end
+           else
+            let () = Visit.add_decl_deps venv d in
+            (l, SEdecl d) :: ms
          else ms)
   | (l,SFBmind mib) :: struc ->
-      let ms = extract_structure access env mp reso ~all struc in
+      let ms = extract_structure access venv env mp reso ~all struc in
       let mind = make_mind reso mp l in
-      let b = Visit.needed_ind mind in
+      let b = Visit.needed_ind venv mind in
       if all || b then
         let d = Dind (mind, extract_inductive env mind) in
         if (not b) && (logical_decl d) then ms
-        else begin Visit.add_decl_deps d; (l,SEdecl d) :: ms end
+        else
+          let () = Visit.add_decl_deps venv d in
+          (l, SEdecl d) :: ms
       else ms
   | (l, SFBrules rrb) :: struc ->
-      let b = List.exists (fun (cst, _) -> Visit.needed_cst cst) rrb.rewrules_rules in
-      let ms = extract_structure access env mp reso ~all struc in
+      let b = List.exists (fun (cst, _) -> Visit.needed_cst venv cst) rrb.rewrules_rules in
+      let ms = extract_structure access venv env mp reso ~all struc in
       if all || b then begin
         List.iter (fun (cst, _) -> Table.add_symbol_rule (ConstRef cst) l) rrb.rewrules_rules;
         ms
       end else ms
   | (l,SFBmodule mb) :: struc ->
-      let ms = extract_structure access env mp reso ~all struc in
+      let ms = extract_structure access venv env mp reso ~all struc in
       let mp = MPdot (mp,l) in
-      let all' = all || Visit.needed_mp_all mp in
-      if all' || Visit.needed_mp mp then
-        (l,SEmodule (extract_module access env mp ~all:all' mb)) :: ms
+      let all' = all || Visit.needed_mp_all venv mp in
+      if all' || Visit.needed_mp venv mp then
+        (l, SEmodule (extract_module access venv env mp ~all:all' mb)) :: ms
       else ms
   | (l,SFBmodtype mtb) :: struc ->
-      let ms = extract_structure access env mp reso ~all struc in
+      let ms = extract_structure access venv env mp reso ~all struc in
       let mp = MPdot (mp,l) in
-      if all || Visit.needed_mp mp then
-        (l,SEmodtype (extract_mbody_spec env mp mtb)) :: ms
+      if all || Visit.needed_mp venv mp then
+        (l, SEmodtype (extract_mbody_spec venv env mp mtb)) :: ms
       else ms
 
 (* From [module_expr] and [module_expression] to implementations *)
 
-and extract_mexpr access env mp = function
+and extract_mexpr access venv env mp = function
   | MEwith _ -> assert false (* no 'with' syntax for modules *)
   | me when lang () != Ocaml || Table.is_extrcompute () ->
       (* In Haskell/Scheme, we expand everything.
          For now, we also extract everything, dead code will be removed later
          (see [Modutil.optimize_struct]. *)
       let sign, delta = expand_mexpr env mp me in
-      extract_msignature access env mp delta ~all:true sign
+      extract_msignature access venv env mp delta ~all:true sign
   | MEident mp ->
       if is_modfile mp && not (modular ()) then error_MPfile_as_mod mp false;
-      Visit.add_mp_all mp; Miniml.MEident mp
+      Visit.add_mp_all venv mp; Miniml.MEident mp
   | MEapply (me, arg) ->
-      Miniml.MEapply (extract_mexpr access env mp me,
-                      extract_mexpr access env mp (MEident arg))
+      Miniml.MEapply (extract_mexpr access venv env mp me,
+                      extract_mexpr access venv env mp (MEident arg))
 
-and extract_mexpression access env mp mty = function
-  | MENoFunctor me -> extract_mexpr access env mp me
+and extract_mexpression access venv env mp mty = function
+  | MENoFunctor me -> extract_mexpr access venv env mp me
   | MEMoreFunctor me ->
       let (mbid, mtb, mty) = match mty with
       | MoreFunctor (mbid, mtb, mty) -> (mbid, mtb, mty)
@@ -374,22 +385,22 @@ and extract_mexpression access env mp mty = function
       let env' = Modops.add_module_parameter mbid mtb env in
       Miniml.MEfunctor
         (mbid,
-         extract_mbody_spec env mp1 mtb,
-         extract_mexpression access env' mp mty me)
+         extract_mbody_spec venv env mp1 mtb,
+         extract_mexpression access venv env' mp mty me)
 
-and extract_msignature access env mp reso ~all = function
+and extract_msignature access venv env mp reso ~all = function
   | NoFunctor struc ->
       let env' = Modops.add_structure mp struc reso env in
-      Miniml.MEstruct (mp,extract_structure access env' mp reso ~all struc)
+      Miniml.MEstruct (mp,extract_structure access venv env' mp reso ~all struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp1 = MPbound mbid in
       let env' = Modops.add_module_parameter mbid mtb env in
       Miniml.MEfunctor
         (mbid,
-         extract_mbody_spec env mp1 mtb,
-         extract_msignature access env' mp reso ~all me)
+         extract_mbody_spec venv env mp1 mtb,
+         extract_msignature access venv env' mp reso ~all me)
 
-and extract_module access env mp ~all mb =
+and extract_module access venv env mp ~all mb =
   (* A module has an empty [mod_expr] when :
      - it is a module variable (for instance X inside a Module F [X:SIG])
      - it is a module assumption (Declare Module).
@@ -398,14 +409,14 @@ and extract_module access env mp ~all mb =
      moment we don't support this situation. *)
   let impl = match Mod_declarations.mod_expr mb with
     | Abstract -> error_no_module_expr mp
-    | Algebraic me -> extract_mexpression access env mp (mod_type mb) me
+    | Algebraic me -> extract_mexpression access venv env mp (mod_type mb) me
     | Struct sign ->
       (* This module has a signature, otherwise it would be FullStruct.
          We extract just the elements required by this signature. *)
-      let () = add_labels mp (mod_type mb) in
+      let () = add_labels venv mp (mod_type mb) in
       let sign = Modops.annotate_struct_body sign (mod_type mb) in
-      extract_msignature access env mp (mod_delta mb) ~all:false sign
-    | FullStruct -> extract_msignature access env mp (mod_delta mb) ~all (mod_type mb)
+      extract_msignature access venv env mp (mod_delta mb) ~all:false sign
+    | FullStruct -> extract_msignature access venv env mp (mod_delta mb) ~all (mod_type mb)
   in
   (* Slight optimization: for modules without explicit signatures
      ([FullStruct] case), we build the type out of the extracted
@@ -414,20 +425,20 @@ and extract_module access env mp ~all mb =
     | FullStruct ->
       assert (Option.is_empty @@ mod_type_alg mb);
       mtyp_of_mexpr impl
-    | _ -> extract_mbody_spec env mp mb
+    | _ -> extract_mbody_spec venv env mp mb
   in
   { ml_mod_expr = impl;
     ml_mod_type = typ }
 
 let mono_environment ~opaque_access refs mpl =
-  Visit.reset ();
-  List.iter Visit.add_ref refs;
-  List.iter Visit.add_mp_all mpl;
+  let venv = Visit.make () in
+  let () = List.iter (fun r -> Visit.add_ref venv r) refs in
+  let () = List.iter (fun mp -> Visit.add_mp_all venv mp) mpl in
   let env = Global.env () in
   let l = List.rev (environment_until None) in
   List.rev_map
     (fun (mp,struc) ->
-      mp, extract_structure opaque_access env mp (no_delta mp) ~all:(Visit.needed_mp_all mp) struc)
+      mp, extract_structure opaque_access venv env mp (no_delta mp) ~all:(Visit.needed_mp_all venv mp) struc)
     l
 
 (**************************************)
@@ -589,7 +600,7 @@ let print_structure_to_file (fn,si,mo) dry struc =
 
 
 let reset () =
-  Visit.reset (); reset_tables (); reset_renaming_tables Everything
+  reset_tables (); reset_renaming_tables Everything
 
 let init ?(compute=false) ?(inner=false) modular library =
   if not inner then check_inside_section ();
@@ -691,12 +702,13 @@ let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
     let q = qualid_of_ident m in
     try Nametab.full_name_module q with Not_found -> error_unknown_module ?loc q
   in
-  Visit.add_mp_all (MPfile dir_m);
+  let venv = Visit.make () in
+  let () = Visit.add_mp_all venv (MPfile dir_m) in
   let env = Global.env () in
   let l = List.rev (environment_until (Some dir_m)) in
   let select l (mp,struc) =
-    if Visit.needed_mp mp
-    then (mp, extract_structure opaque_access env mp (no_delta mp) ~all:true struc) :: l
+    if Visit.needed_mp venv mp
+    then (mp, extract_structure opaque_access venv env mp (no_delta mp) ~all:true struc) :: l
     else l
   in
   let struc = List.fold_left select [] l in


### PR DESCRIPTION
This is looking for desynchronization trouble, memory leaks, and I am not even mentioning thread safety.