### PR TITLE
Generate Sort poly eliminator

### DIFF
--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1116,12 +1116,14 @@ Generation of induction principles with ``Scheme``
       | SProp
       | Set
       | Type
+      | Poly
 
    Generates :term:`induction principles <induction principle>` with given
-   :n:`scheme_type`\s and :n:`scheme_sort`\s for an inductive type. In the case
-   where the inductive definition is a mutual inductive definition, the
-   :n:`with` clause is used to generate a mutually recursive inductive scheme
-   for each clause of the mutual inductive type.
+   :n:`scheme_type`\s and :n:`sort_family`\s for an inductive type. For sort
+   polymorphic inductives, :n:`Poly` generates a sort polymorphic induction
+   principle.  In the case where the inductive definition is a mutual inductive
+   definition, the :n:`with` clause is used to generate a mutually recursive
+   inductive scheme for each clause of the mutual inductive type.
 
    :n:`@ident`
       The name of the scheme. If not provided, the name will be determined

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1118,12 +1118,13 @@ Generation of induction principles with ``Scheme``
       | Type
       | Poly
 
-   Generates :term:`induction principles <induction principle>` with given
-   :n:`scheme_type`\s and :n:`sort_family`\s for an inductive type. For sort
-   polymorphic inductives, :n:`Poly` generates a sort polymorphic induction
-   principle.  In the case where the inductive definition is a mutual inductive
-   definition, the :n:`with` clause is used to generate a mutually recursive
-   inductive scheme for each clause of the mutual inductive type.
+   Generates :term:`induction principles <induction principle>` with
+   given :n:`scheme_type`\s and :n:`sort_family`\s for an inductive
+   type. :n:`Poly` generates a sort polymorphic induction principle.
+   In the case where the inductive definition is a mutual inductive
+   definition, the :n:`with` clause is used to generate a mutually
+   recursive inductive scheme for each clause of the mutual inductive
+   type.
 
    :n:`@ident`
       The name of the scheme. If not provided, the name will be determined

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -36,6 +36,7 @@ sort_family: [
 | "Prop"
 | "SProp"
 | "Type"
+| "Poly"
 ]
 
 universe_increment: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -598,6 +598,7 @@ sort_family: [
 | "SProp"
 | "Set"
 | "Type"
+| "Poly"
 ]
 
 hint_info: [

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1096,9 +1096,9 @@ let new_quality_variable ?loc ?name evd =
   let uctx, q = UState.new_sort_variable ?loc ?name evd.universes in
   {evd with universes = uctx}, q
 
-let new_sort_variable ?loc rigid sigma =
-  let (sigma, u) = new_univ_variable ?loc rigid sigma in
-  let uctx, q = UState.new_sort_variable sigma.universes in
+let new_sort_variable ?loc ?qname ?uname rigid sigma =
+  let (sigma, u) = new_univ_variable ?name:uname ?loc rigid sigma in
+  let uctx, q = UState.new_sort_variable ?name:qname sigma.universes in
   ({ sigma with universes = uctx }, Sorts.qsort q u)
 
 let add_forgotten_univ d u =

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -550,7 +550,7 @@ val universe_binders : evar_map -> UnivNames.universe_binders
 val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t
 val new_quality_variable : ?loc:Loc.t -> ?name:Id.t -> evar_map -> evar_map * Sorts.QVar.t
 val new_univ_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Universe.t
-val new_sort_variable : ?loc:Loc.t -> rigid -> evar_map -> evar_map * esorts
+val new_sort_variable : ?loc:Loc.t -> ?qname:Id.t -> ?uname:Id.t -> rigid -> evar_map -> evar_map * esorts
 
 val add_forgotten_univ : evar_map -> Univ.Level.t -> evar_map
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -549,6 +549,7 @@ val universe_binders : evar_map -> UnivNames.universe_binders
 
 val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t
 val new_quality_variable : ?loc:Loc.t -> ?name:Id.t -> evar_map -> evar_map * Sorts.QVar.t
+val new_univ_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Universe.t
 val new_sort_variable : ?loc:Loc.t -> rigid -> evar_map -> evar_map * esorts
 
 val add_forgotten_univ : evar_map -> Univ.Level.t -> evar_map

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1130,7 +1130,7 @@ let add_universe ?loc name strict uctx u =
   { uctx with names; local; initial_universes; universes }
 
 let new_sort_variable ?loc ?name uctx =
-  let q = UnivGen.new_sort_global () in
+  let q = UnivGen.fresh_sort_quality () in
   (* don't need to check_fresh as it's guaranteed new *)
   let sort_variables = QState.add ~check_fresh:false ~named:(Option.has_some name)
       q uctx.sort_variables

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -66,13 +66,13 @@ let new_sort_id =
   let cnt = ref 0 in
   fun () -> incr cnt; !cnt
 
-let new_sort_global () =
+let fresh_sort_quality () =
   let s = if Flags.async_proofs_is_worker() then !Flags.async_proofs_worker_id else "" in
   Sorts.QVar.make_unif s (new_sort_id ())
 
 let fresh_instance auctx : _ in_sort_context_set =
   let qlen, ulen = AbstractContext.size auctx in
-  let qinst = Array.init qlen (fun _ -> Sorts.Quality.QVar (new_sort_global())) in
+  let qinst = Array.init qlen (fun _ -> Sorts.Quality.QVar (fresh_sort_quality())) in
   let uinst = Array.init ulen (fun _ -> fresh_level()) in
   let qctx = Array.fold_left (fun qctx q -> match q with
       | Sorts.Quality.QVar q -> Sorts.QVar.Set.add q qctx
@@ -162,7 +162,7 @@ let fresh_universe_context_set_instance ctx =
 let fresh_sort_context_instance ((qs,us),csts) =
   let usubst, (us, csts) = fresh_universe_context_set_instance (us,csts) in
   let qsubst, qs = QVar.Set.fold (fun q (qsubst,qs) ->
-      let q' = new_sort_global () in
+      let q' = fresh_sort_quality () in
       QVar.Map.add q (Sorts.Quality.QVar q') qsubst, QVar.Set.add q' qs)
       qs
       (QVar.Map.empty, QVar.Set.empty)

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -138,9 +138,13 @@ let fresh_sort_in_family = function
   | InSProp -> Sorts.sprop, empty_sort_context
   | InProp -> Sorts.prop, empty_sort_context
   | InSet -> Sorts.set, empty_sort_context
-  | InType | InQSort (* Treat as Type *) ->
+  | InType (* Treat as Type *) ->
     let u = fresh_level () in
       sort_of_univ (Univ.Universe.make u), ((QVar.Set.empty,Level.Set.singleton u),Constraints.empty)
+  | InQSort ->
+    let q = fresh_sort_quality () in
+    let u = fresh_level () in
+      qsort q (Univ.Universe.make u), ((QVar.Set.singleton q,Level.Set.singleton u),Constraints.empty)
 
 let new_global_univ () =
   let u = fresh_level () in

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -26,7 +26,7 @@ exception UniverseLengthMismatch of univ_length_mismatch
 (** Side-effecting functions creating new universe levels. *)
 
 val new_univ_global : unit -> UGlobal.t
-val new_sort_global : unit -> Sorts.QVar.t
+val fresh_sort_quality : unit -> Sorts.QVar.t
 val fresh_level : unit -> Level.t
 
 val new_global_univ : unit -> Universe.t in_universe_context_set

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -147,7 +147,8 @@ GRAMMAR EXTEND Gram
     [ [ "Set"  -> { Sorts.InSet }
       | "Prop" -> { Sorts.InProp }
       | "SProp" -> { Sorts.InSProp }
-      | "Type" -> { Sorts.InType } ] ]
+      | "Type" -> { Sorts.InType }
+      | IDENT "Poly" -> { Sorts.InQSort } ] ]
   ;
   universe_increment:
     [ [ "+"; n = natural -> { n }

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -702,7 +702,8 @@ let elimination_suffix = function
   | InSProp -> "_sind"
   | InProp -> "_ind"
   | InSet  -> "_rec"
-  | InType | InQSort -> "_rect"
+  | InType -> "_rect"
+  | InQSort -> "_elim"
 
 let case_suffix = "_case"
 

--- a/tactics/elimschemes.mli
+++ b/tactics/elimschemes.mli
@@ -18,5 +18,7 @@ val elim_scheme : dep:bool -> to_kind:Sorts.family -> individual scheme_kind
 
 val case_dep : individual scheme_kind
 val case_nodep : individual scheme_kind
+val case_poly_dep : individual scheme_kind
+val case_poly_nodep : individual scheme_kind
 val casep_dep : individual scheme_kind
 val casep_nodep : individual scheme_kind

--- a/test-suite/bugs/bug_19203.v
+++ b/test-suite/bugs/bug_19203.v
@@ -11,7 +11,7 @@ Definition nand@{q| |} (a b : bool@{q|}) : bool@{q|} :=
 Inductive seq@{q|u|} {A : Type@{q|u}} (a : A) : A -> Type@{q|u} := | srefl : seq a a.
 Arguments srefl {_ _}.
 
-Definition seq_elim@{q|u v|} :=
+Definition seq_elim_nodep@{q|u v|} :=
   fun (A : Type@{q|u}) (x : A) (P : A -> Type@{q|v}) (f : P x) (a : A) (e : seq x a) =>
   match e in (seq _ a0) return (P a0) with
   | srefl => f
@@ -19,7 +19,7 @@ Definition seq_elim@{q|u v|} :=
 
 Register seq as core.eq.type.
 Register srefl as core.eq.refl.
-Register seq_elim as core.eq.rect.
+Register seq_elim_nodep as core.eq.rect.
 
 Lemma foo@{q| |} (f : bool@{q|} -> bool@{q|}) (x : bool@{q|}) : seq (f true) (f true).
 Proof.

--- a/test-suite/bugs/bug_19215.v
+++ b/test-suite/bugs/bug_19215.v
@@ -32,11 +32,6 @@ where "x = y :> A" := (@eq A x y) : type_scope.
 Arguments eq {A} x _.
 Arguments eq_refl {A x} , [A] x.
 
-Polymorphic Definition eq_elim@{s s' | u v w |} [A:Type@{s|u}] [x:A]
-  (P : forall a : A, x = a :> A -> Type@{s'|w}) :
-  P x (eq_refl@{s s'|u v} x) -> forall [a : A] (e : x = a :> A), P a e :=
-  fun t _ e => match e with eq_refl => t end.
-
 Polymorphic Definition eq_ind@{s | u|} [A] [x] P := @eq_elim@{s Prop|u Set Set} A x (fun a _ => P a).
 
 Polymorphic Definition eq_singleton@{s s' | u v|} [A:Type@{s|u}] [x:A]

--- a/test-suite/output/SchemeNames.out
+++ b/test-suite/output/SchemeNames.out
@@ -1,23 +1,31 @@
-File "./output/SchemeNames.v", line 14, characters 2-47:
+File "./output/SchemeNames.v", line 15, characters 2-47:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Prop" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Prop"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 15, characters 2-46:
+File "./output/SchemeNames.v", line 16, characters 2-46:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Set" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Set"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 16, characters 2-47:
+File "./output/SchemeNames.v", line 17, characters 2-47:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
-the return type has sort "Type" while it should be SProp.
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{SchemeNames.23}" while it should be SProp.
 Elimination of an inductive object of sort SProp
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.23}"
+because strict proofs can be eliminated only to build strict proofs.
+File "./output/SchemeNames.v", line 18, characters 2-47:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{α3 | SchemeNames.24}"
+while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type@{α3 | SchemeNames.24}"
 because strict proofs can be eliminated only to build strict proofs.
 fooSProp_inds :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
@@ -26,26 +34,34 @@ fooSProp_inds is not universe polymorphic
 Arguments fooSProp_inds P%function_scope f f0 f1
 fooSProp_inds is transparent
 Expands to: Constant SchemeNames.fooSProp_inds
-File "./output/SchemeNames.v", line 23, characters 2-48:
+File "./output/SchemeNames.v", line 25, characters 2-48:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Prop" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Prop"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 24, characters 2-47:
+File "./output/SchemeNames.v", line 26, characters 2-47:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Set" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Set"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 25, characters 2-48:
+File "./output/SchemeNames.v", line 27, characters 2-48:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
-the return type has sort "Type" while it should be SProp.
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{SchemeNames.25}" while it should be SProp.
 Elimination of an inductive object of sort SProp
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.25}"
+because strict proofs can be eliminated only to build strict proofs.
+File "./output/SchemeNames.v", line 28, characters 2-48:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{α4 | SchemeNames.26}"
+while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type@{α4 | SchemeNames.26}"
 because strict proofs can be eliminated only to build strict proofs.
 fooSProp_inds_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
@@ -53,26 +69,34 @@ fooSProp_inds_nodep is not universe polymorphic
 Arguments fooSProp_inds_nodep P%type_scope f f0 f1
 fooSProp_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_inds_nodep
-File "./output/SchemeNames.v", line 32, characters 2-49:
+File "./output/SchemeNames.v", line 35, characters 2-49:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Prop" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Prop"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 33, characters 2-48:
+File "./output/SchemeNames.v", line 36, characters 2-48:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Set" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Set"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 34, characters 2-49:
+File "./output/SchemeNames.v", line 37, characters 2-49:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
-the return type has sort "Type" while it should be SProp.
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{SchemeNames.27}" while it should be SProp.
 Elimination of an inductive object of sort SProp
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.27}"
+because strict proofs can be eliminated only to build strict proofs.
+File "./output/SchemeNames.v", line 38, characters 2-49:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{α5 | SchemeNames.28}"
+while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type@{α5 | SchemeNames.28}"
 because strict proofs can be eliminated only to build strict proofs.
 fooSProp_cases :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
@@ -81,26 +105,34 @@ fooSProp_cases is not universe polymorphic
 Arguments fooSProp_cases P%function_scope f f0 f1
 fooSProp_cases is transparent
 Expands to: Constant SchemeNames.fooSProp_cases
-File "./output/SchemeNames.v", line 41, characters 2-42:
+File "./output/SchemeNames.v", line 45, characters 2-42:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Prop" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Prop"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 42, characters 2-41:
+File "./output/SchemeNames.v", line 46, characters 2-41:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
+Incorrect elimination in the inductive type "fooSProp@{}":
 the return type has sort "Set" while it should be SProp.
 Elimination of an inductive object of sort SProp
 is not allowed on a predicate in sort "Set"
 because strict proofs can be eliminated only to build strict proofs.
-File "./output/SchemeNames.v", line 43, characters 2-42:
+File "./output/SchemeNames.v", line 47, characters 2-42:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooSProp":
-the return type has sort "Type" while it should be SProp.
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{SchemeNames.29}" while it should be SProp.
 Elimination of an inductive object of sort SProp
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.29}"
+because strict proofs can be eliminated only to build strict proofs.
+File "./output/SchemeNames.v", line 48, characters 2-42:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooSProp@{}":
+the return type has sort "Type@{α6 | SchemeNames.30}"
+while it should be SProp.
+Elimination of an inductive object of sort SProp
+is not allowed on a predicate in sort "Type@{α6 | SchemeNames.30}"
 because strict proofs can be eliminated only to build strict proofs.
 fooSProp_cases_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
@@ -108,23 +140,32 @@ fooSProp_cases_nodep is not universe polymorphic
 Arguments fooSProp_cases_nodep P%type_scope f f0 f1
 fooSProp_cases_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_cases_nodep
-File "./output/SchemeNames.v", line 49, characters 2-36:
+File "./output/SchemeNames.v", line 54, characters 2-36:
 The command has indeed failed with message:
 Cannot extract computational content from proposition 
 "fooSProp".
-File "./output/SchemeNames.v", line 61, characters 2-45:
+File "./output/SchemeNames.v", line 66, characters 2-45:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
+Incorrect elimination in the inductive type "fooProp@{}":
 the return type has sort "Set" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Set"
 because proofs can be eliminated only to build proofs.
-File "./output/SchemeNames.v", line 62, characters 2-46:
+File "./output/SchemeNames.v", line 67, characters 2-46:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
-the return type has sort "Type" while it should be SProp or Prop.
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{SchemeNames.33}"
+while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.33}"
+because proofs can be eliminated only to build proofs.
+File "./output/SchemeNames.v", line 68, characters 2-46:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{α9 | SchemeNames.34}"
+while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type@{α9 | SchemeNames.34}"
 because proofs can be eliminated only to build proofs.
 fooProp_inds_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
@@ -140,19 +181,28 @@ fooProp_ind_dep is not universe polymorphic
 Arguments fooProp_ind_dep P%function_scope f f0 f1
 fooProp_ind_dep is transparent
 Expands to: Constant SchemeNames.fooProp_ind_dep
-File "./output/SchemeNames.v", line 71, characters 2-46:
+File "./output/SchemeNames.v", line 77, characters 2-46:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
+Incorrect elimination in the inductive type "fooProp@{}":
 the return type has sort "Set" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Set"
 because proofs can be eliminated only to build proofs.
-File "./output/SchemeNames.v", line 72, characters 2-47:
+File "./output/SchemeNames.v", line 78, characters 2-47:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
-the return type has sort "Type" while it should be SProp or Prop.
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{SchemeNames.35}"
+while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.35}"
+because proofs can be eliminated only to build proofs.
+File "./output/SchemeNames.v", line 79, characters 2-47:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{α10 | SchemeNames.36}"
+while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type@{α10 | SchemeNames.36}"
 because proofs can be eliminated only to build proofs.
 fooProp_inds : forall P : SProp, P -> P -> fooProp -> P
 
@@ -166,19 +216,28 @@ fooProp_ind is not universe polymorphic
 Arguments fooProp_ind P%type_scope f f0 f1
 fooProp_ind is transparent
 Expands to: Constant SchemeNames.fooProp_ind
-File "./output/SchemeNames.v", line 81, characters 2-47:
+File "./output/SchemeNames.v", line 88, characters 2-47:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
+Incorrect elimination in the inductive type "fooProp@{}":
 the return type has sort "Set" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Set"
 because proofs can be eliminated only to build proofs.
-File "./output/SchemeNames.v", line 82, characters 2-48:
+File "./output/SchemeNames.v", line 89, characters 2-48:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
-the return type has sort "Type" while it should be SProp or Prop.
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{SchemeNames.37}"
+while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.37}"
+because proofs can be eliminated only to build proofs.
+File "./output/SchemeNames.v", line 90, characters 2-48:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{α11 | SchemeNames.38}"
+while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type@{α11 | SchemeNames.38}"
 because proofs can be eliminated only to build proofs.
 fooProp_cases_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
@@ -194,19 +253,28 @@ fooProp_case_dep is not universe polymorphic
 Arguments fooProp_case_dep P%function_scope f f0 f1
 fooProp_case_dep is transparent
 Expands to: Constant SchemeNames.fooProp_case_dep
-File "./output/SchemeNames.v", line 91, characters 2-40:
+File "./output/SchemeNames.v", line 99, characters 2-40:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
+Incorrect elimination in the inductive type "fooProp@{}":
 the return type has sort "Set" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Set"
 because proofs can be eliminated only to build proofs.
-File "./output/SchemeNames.v", line 92, characters 2-41:
+File "./output/SchemeNames.v", line 100, characters 2-41:
 The command has indeed failed with message:
-Incorrect elimination in the inductive type "fooProp":
-the return type has sort "Type" while it should be SProp or Prop.
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{SchemeNames.39}"
+while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
-is not allowed on a predicate in sort "Type"
+is not allowed on a predicate in sort "Type@{SchemeNames.39}"
+because proofs can be eliminated only to build proofs.
+File "./output/SchemeNames.v", line 101, characters 2-41:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooProp@{}":
+the return type has sort "Type@{α12 | SchemeNames.40}"
+while it should be SProp or Prop.
+Elimination of an inductive object of sort Prop
+is not allowed on a predicate in sort "Type@{α12 | SchemeNames.40}"
 because proofs can be eliminated only to build proofs.
 fooProp_cases : forall P : SProp, P -> P -> fooProp -> P
 
@@ -220,7 +288,7 @@ fooProp_case is not universe polymorphic
 Arguments fooProp_case P%type_scope f f0 f1
 fooProp_case is transparent
 Expands to: Constant SchemeNames.fooProp_case
-File "./output/SchemeNames.v", line 99, characters 2-35:
+File "./output/SchemeNames.v", line 108, characters 2-35:
 The command has indeed failed with message:
 Cannot extract computational content from proposition 
 "fooProp".
@@ -246,12 +314,21 @@ Arguments fooSet_rec P%function_scope f f0 f1
 fooSet_rec is transparent
 Expands to: Constant SchemeNames.fooSet_rec
 fooSet_rect :
-forall P : fooSet -> Type, P aS -> P bS -> forall f1 : fooSet, P f1
+forall P : fooSet -> Type@{fooSet_rect.u0},
+P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_rect is not universe polymorphic
 Arguments fooSet_rect P%function_scope f f0 f1
 fooSet_rect is transparent
 Expands to: Constant SchemeNames.fooSet_rect
+fooSet_elim@{q | u} :
+forall P : fooSet -> Type@{q | u}, P aS -> P bS -> forall f1 : fooSet, P f1
+(* q | u |=  *)
+
+fooSet_elim is universe polymorphic
+Arguments fooSet_elim P%function_scope f f0 f1
+fooSet_elim is transparent
+Expands to: Constant SchemeNames.fooSet_elim
 fooSet_inds_nodep : forall P : SProp, P -> P -> fooSet -> P
 
 fooSet_inds_nodep is not universe polymorphic
@@ -270,12 +347,21 @@ fooSet_rec_nodep is not universe polymorphic
 Arguments fooSet_rec_nodep P%type_scope f f0 f1
 fooSet_rec_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_rec_nodep
-fooSet_rect_nodep : forall P : Type, P -> P -> fooSet -> P
+fooSet_rect_nodep :
+forall P : Type@{fooSet_rect_nodep.u0}, P -> P -> fooSet -> P
 
 fooSet_rect_nodep is not universe polymorphic
 Arguments fooSet_rect_nodep P%type_scope f f0 f1
 fooSet_rect_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_rect_nodep
+fooSet_elim_nodep@{q | u} :
+forall P : Type@{q | u}, P -> P -> fooSet -> P
+(* q | u |=  *)
+
+fooSet_elim_nodep is universe polymorphic
+Arguments fooSet_elim_nodep P%type_scope f f0 f1
+fooSet_elim_nodep is transparent
+Expands to: Constant SchemeNames.fooSet_elim_nodep
 fooSet_cases :
 forall P : fooSet -> SProp, P aS -> P bS -> forall f1 : fooSet, P f1
 
@@ -298,12 +384,22 @@ Arguments fooSet'_case P%function_scope f f0 f1
 fooSet'_case is transparent
 Expands to: Constant SchemeNames.fooSet'_case
 fooSet'_caset :
-forall P : fooSet' -> Type, P aS' -> P bS' -> forall f1 : fooSet', P f1
+forall P : fooSet' -> Type@{fooSet'_caset.u0},
+P aS' -> P bS' -> forall f1 : fooSet', P f1
 
 fooSet'_caset is not universe polymorphic
 Arguments fooSet'_caset P%function_scope f f0 f1
 fooSet'_caset is transparent
 Expands to: Constant SchemeNames.fooSet'_caset
+fooSet'_casep@{q | u} :
+forall P : fooSet' -> Type@{q | u},
+P aS' -> P bS' -> forall f1 : fooSet', P f1
+(* q | u |=  *)
+
+fooSet'_casep is universe polymorphic
+Arguments fooSet'_casep P%function_scope f f0 f1
+fooSet'_casep is transparent
+Expands to: Constant SchemeNames.fooSet'_casep
 fooSet_cases_nodep : forall P : SProp, P -> P -> fooSet -> P
 
 fooSet_cases_nodep is not universe polymorphic
@@ -322,26 +418,35 @@ fooSet'_case_nodep is not universe polymorphic
 Arguments fooSet'_case_nodep P%type_scope f f0 f1
 fooSet'_case_nodep is transparent
 Expands to: Constant SchemeNames.fooSet'_case_nodep
-fooSet'_caset_nodep : forall P : Type, P -> P -> fooSet' -> P
+fooSet'_caset_nodep :
+forall P : Type@{fooSet'_caset_nodep.u0}, P -> P -> fooSet' -> P
 
 fooSet'_caset_nodep is not universe polymorphic
 Arguments fooSet'_caset_nodep P%type_scope f f0 f1
 fooSet'_caset_nodep is transparent
 Expands to: Constant SchemeNames.fooSet'_caset_nodep
+fooSet'_casep_nodep@{q | u} :
+forall P : Type@{q | u}, P -> P -> fooSet' -> P
+(* q | u |=  *)
+
+fooSet'_casep_nodep is universe polymorphic
+Arguments fooSet'_casep_nodep P%type_scope f f0 f1
+fooSet'_casep_nodep is transparent
+Expands to: Constant SchemeNames.fooSet'_casep_nodep
 fooSet_beq : fooSet -> fooSet -> bool
 
 fooSet_beq is not universe polymorphic
 Arguments fooSet_beq X Y
 fooSet_beq is transparent
 Expands to: Constant SchemeNames.fooSet_beq
-Declared in library SchemeNames, line 160, characters 2-29
+Declared in library SchemeNames, line 177, characters 2-29
 fooSet_eq_dec : forall x y : fooSet, {x = y} + {x <> y}
 
 fooSet_eq_dec is not universe polymorphic
 Arguments fooSet_eq_dec x y
 fooSet_eq_dec is transparent
 Expands to: Constant SchemeNames.fooSet_eq_dec
-Declared in library SchemeNames, line 160, characters 2-29
+Declared in library SchemeNames, line 177, characters 2-29
 internal_fooSet_dec_bl :
 forall x : fooSet,
 (fun x0 : fooSet => forall y : fooSet, fooSet_beq x0 y = true -> x0 = y) x
@@ -350,7 +455,7 @@ internal_fooSet_dec_bl is not universe polymorphic
 Arguments internal_fooSet_dec_bl x y _
 internal_fooSet_dec_bl is transparent
 Expands to: Constant SchemeNames.internal_fooSet_dec_bl
-Declared in library SchemeNames, line 160, characters 2-29
+Declared in library SchemeNames, line 177, characters 2-29
 internal_fooSet_dec_lb :
 forall x : fooSet,
 (fun x0 : fooSet => forall y : fooSet, x0 = y -> fooSet_beq x0 y = true) x
@@ -359,7 +464,7 @@ internal_fooSet_dec_lb is not universe polymorphic
 Arguments internal_fooSet_dec_lb x y _
 internal_fooSet_dec_lb is transparent
 Expands to: Constant SchemeNames.internal_fooSet_dec_lb
-Declared in library SchemeNames, line 160, characters 2-29
+Declared in library SchemeNames, line 177, characters 2-29
 fooType_inds :
 forall P : fooType -> SProp, P aT -> P bT -> forall f1 : fooType, P f1
 
@@ -382,12 +487,21 @@ Arguments fooType_rec P%function_scope f f0 f1
 fooType_rec is transparent
 Expands to: Constant SchemeNames.fooType_rec
 fooType_rect :
-forall P : fooType -> Type, P aT -> P bT -> forall f1 : fooType, P f1
+forall P : fooType -> Type@{fooType_rect.u0},
+P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_rect is not universe polymorphic
 Arguments fooType_rect P%function_scope f f0 f1
 fooType_rect is transparent
 Expands to: Constant SchemeNames.fooType_rect
+fooType_elim@{q | u} :
+forall P : fooType -> Type@{q | u}, P aT -> P bT -> forall f1 : fooType, P f1
+(* q | u |=  *)
+
+fooType_elim is universe polymorphic
+Arguments fooType_elim P%function_scope f f0 f1
+fooType_elim is transparent
+Expands to: Constant SchemeNames.fooType_elim
 fooType_inds_nodep : forall P : SProp, P -> P -> fooType -> P
 
 fooType_inds_nodep is not universe polymorphic
@@ -406,12 +520,21 @@ fooType_rec_nodep is not universe polymorphic
 Arguments fooType_rec_nodep P%type_scope f f0 f1
 fooType_rec_nodep is transparent
 Expands to: Constant SchemeNames.fooType_rec_nodep
-fooType_rect_nodep : forall P : Type, P -> P -> fooType -> P
+fooType_rect_nodep :
+forall P : Type@{fooType_rect_nodep.u0}, P -> P -> fooType -> P
 
 fooType_rect_nodep is not universe polymorphic
 Arguments fooType_rect_nodep P%type_scope f f0 f1
 fooType_rect_nodep is transparent
 Expands to: Constant SchemeNames.fooType_rect_nodep
+fooType_elim_nodep@{q | u} :
+forall P : Type@{q | u}, P -> P -> fooType -> P
+(* q | u |=  *)
+
+fooType_elim_nodep is universe polymorphic
+Arguments fooType_elim_nodep P%type_scope f f0 f1
+fooType_elim_nodep is transparent
+Expands to: Constant SchemeNames.fooType_elim_nodep
 fooType_cases :
 forall P : fooType -> SProp, P aT -> P bT -> forall f1 : fooType, P f1
 
@@ -434,12 +557,22 @@ Arguments fooType'_case P%function_scope f f0 f1
 fooType'_case is transparent
 Expands to: Constant SchemeNames.fooType'_case
 fooType'_caset :
-forall P : fooType' -> Type, P aT' -> P bT' -> forall f1 : fooType', P f1
+forall P : fooType' -> Type@{fooType'_caset.u0},
+P aT' -> P bT' -> forall f1 : fooType', P f1
 
 fooType'_caset is not universe polymorphic
 Arguments fooType'_caset P%function_scope f f0 f1
 fooType'_caset is transparent
 Expands to: Constant SchemeNames.fooType'_caset
+fooType'_casep@{q | u} :
+forall P : fooType' -> Type@{q | u},
+P aT' -> P bT' -> forall f1 : fooType', P f1
+(* q | u |=  *)
+
+fooType'_casep is universe polymorphic
+Arguments fooType'_casep P%function_scope f f0 f1
+fooType'_casep is transparent
+Expands to: Constant SchemeNames.fooType'_casep
 fooType_cases_nodep : forall P : SProp, P -> P -> fooType -> P
 
 fooType_cases_nodep is not universe polymorphic
@@ -458,26 +591,35 @@ fooType'_case_nodep is not universe polymorphic
 Arguments fooType'_case_nodep P%type_scope f f0 f1
 fooType'_case_nodep is transparent
 Expands to: Constant SchemeNames.fooType'_case_nodep
-fooType'_caset_nodep : forall P : Type, P -> P -> fooType' -> P
+fooType'_caset_nodep :
+forall P : Type@{fooType'_caset_nodep.u0}, P -> P -> fooType' -> P
 
 fooType'_caset_nodep is not universe polymorphic
 Arguments fooType'_caset_nodep P%type_scope f f0 f1
 fooType'_caset_nodep is transparent
 Expands to: Constant SchemeNames.fooType'_caset_nodep
+fooType'_casep_nodep@{q | u} :
+forall P : Type@{q | u}, P -> P -> fooType' -> P
+(* q | u |=  *)
+
+fooType'_casep_nodep is universe polymorphic
+Arguments fooType'_casep_nodep P%type_scope f f0 f1
+fooType'_casep_nodep is transparent
+Expands to: Constant SchemeNames.fooType'_casep_nodep
 fooType_beq : fooType -> fooType -> bool
 
 fooType_beq is not universe polymorphic
 Arguments fooType_beq X Y
 fooType_beq is transparent
 Expands to: Constant SchemeNames.fooType_beq
-Declared in library SchemeNames, line 226, characters 2-30
+Declared in library SchemeNames, line 251, characters 2-30
 fooType_eq_dec : forall x y : fooType, {x = y} + {x <> y}
 
 fooType_eq_dec is not universe polymorphic
 Arguments fooType_eq_dec x y
 fooType_eq_dec is transparent
 Expands to: Constant SchemeNames.fooType_eq_dec
-Declared in library SchemeNames, line 226, characters 2-30
+Declared in library SchemeNames, line 251, characters 2-30
 internal_fooType_dec_bl :
 forall x : fooType,
 (fun x0 : fooType => forall y : fooType, fooType_beq x0 y = true -> x0 = y) x
@@ -486,7 +628,7 @@ internal_fooType_dec_bl is not universe polymorphic
 Arguments internal_fooType_dec_bl x y _
 internal_fooType_dec_bl is transparent
 Expands to: Constant SchemeNames.internal_fooType_dec_bl
-Declared in library SchemeNames, line 226, characters 2-30
+Declared in library SchemeNames, line 251, characters 2-30
 internal_fooType_dec_lb :
 forall x : fooType,
 (fun x0 : fooType => forall y : fooType, x0 = y -> fooType_beq x0 y = true) x
@@ -495,22 +637,184 @@ internal_fooType_dec_lb is not universe polymorphic
 Arguments internal_fooType_dec_lb x y _
 internal_fooType_dec_lb is transparent
 Expands to: Constant SchemeNames.internal_fooType_dec_lb
-Declared in library SchemeNames, line 226, characters 2-30
+Declared in library SchemeNames, line 251, characters 2-30
+File "./output/SchemeNames.v", line 266, characters 2-47:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooPoly@{α34 | SchemeNames.96}":
+the return type has sort "SProp" while it should be in sort quality α34.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 267, characters 2-46:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooPoly@{α35 | SchemeNames.97}":
+the return type has sort "Prop" while it should be in sort quality α35.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 268, characters 2-45:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooPoly@{α36 | SchemeNames.98}":
+the return type has sort "Set" while it should be in sort quality α36.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 269, characters 2-46:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type "fooPoly@{α37 | SchemeNames.99}":
+the return type has sort "Type@{SchemeNames.100}"
+while it should be in sort quality α37.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+fooPoly_elim@{α | u u0} :
+forall P : fooPoly@{α | u} -> Type@{α | u0},
+P aPo@{α | u} -> P bPo@{α | u} -> forall f1 : fooPoly@{α | u}, P f1
+(* α | u u0 |=  *)
+
+fooPoly_elim is universe polymorphic
+Arguments fooPoly_elim P%function_scope f f0 f1
+fooPoly_elim is transparent
+Expands to: Constant SchemeNames.fooPoly_elim
+File "./output/SchemeNames.v", line 276, characters 2-48:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type
+"fooPoly@{α39 | SchemeNames.103}":
+the return type has sort "SProp" while it should be in sort quality α39.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 277, characters 2-47:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type
+"fooPoly@{α40 | SchemeNames.104}":
+the return type has sort "Prop" while it should be in sort quality α40.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 278, characters 2-46:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type
+"fooPoly@{α41 | SchemeNames.105}":
+the return type has sort "Set" while it should be in sort quality α41.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+File "./output/SchemeNames.v", line 279, characters 2-47:
+The command has indeed failed with message:
+Incorrect elimination in the inductive type
+"fooPoly@{α42 | SchemeNames.106}":
+the return type has sort "Type@{SchemeNames.107}"
+while it should be in sort quality α42.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+fooPoly_elim_nodep@{α | u u0} :
+forall P : Type@{α | u0}, P -> P -> fooPoly@{α | u} -> P
+(* α | u u0 |=  *)
+
+fooPoly_elim_nodep is universe polymorphic
+Arguments fooPoly_elim_nodep P%type_scope f f0 f1
+fooPoly_elim_nodep is transparent
+Expands to: Constant SchemeNames.fooPoly_elim_nodep
+File "./output/SchemeNames.v", line 292, characters 2-48:
+The command has indeed failed with message:
+Incorrect elimination of "f1" in the inductive type
+"fooPoly@{α48 | SchemeNames.114}":
+the return type has sort "Prop" while it should be in sort quality α48.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+fooPoly_cases@{u} :
+forall P : fooPoly@{SProp | u} -> SProp,
+P aPo@{SProp | u} ->
+P bPo@{SProp | u} -> forall f1 : fooPoly@{SProp | u}, P f1
+(* u |=  *)
+
+fooPoly_cases is universe polymorphic
+Arguments fooPoly_cases P%function_scope f f0 f1
+fooPoly_cases is transparent
+Expands to: Constant SchemeNames.fooPoly_cases
+fooPoly_case not a defined object.
+fooPoly'_case@{u} :
+forall P : fooPoly'@{Type | u} -> Set,
+P aPo'@{Type | u} ->
+P bPo'@{Type | u} -> forall f1 : fooPoly'@{Type | u}, P f1
+(* u |=  *)
+
+fooPoly'_case is universe polymorphic
+Arguments fooPoly'_case P%function_scope f f0 f1
+fooPoly'_case is transparent
+Expands to: Constant SchemeNames.fooPoly'_case
+fooPoly'_caset@{u u0} :
+forall P : fooPoly'@{Type | u} -> Type@{u0},
+P aPo'@{Type | u} ->
+P bPo'@{Type | u} -> forall f1 : fooPoly'@{Type | u}, P f1
+(* u u0 |=  *)
+
+fooPoly'_caset is universe polymorphic
+Arguments fooPoly'_caset P%function_scope f f0 f1
+fooPoly'_caset is transparent
+Expands to: Constant SchemeNames.fooPoly'_caset
+fooPoly'_casep@{α | u u0} :
+forall P : fooPoly'@{α | u} -> Type@{α | u0},
+P aPo'@{α | u} -> P bPo'@{α | u} -> forall f1 : fooPoly'@{α | u}, P f1
+(* α | u u0 |=  *)
+
+fooPoly'_casep is universe polymorphic
+Arguments fooPoly'_casep P%function_scope f f0 f1
+fooPoly'_casep is transparent
+Expands to: Constant SchemeNames.fooPoly'_casep
+File "./output/SchemeNames.v", line 306, characters 2-41:
+The command has indeed failed with message:
+Incorrect elimination of "f1" in the inductive type
+"fooPoly@{α53 | SchemeNames.121}":
+the return type has sort "Prop" while it should be in sort quality α53.
+Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
+is only allowed on a predicate in the same sort quality.
+fooPoly_cases_nodep@{u} :
+forall P : SProp, P -> P -> fooPoly@{SProp | u} -> P
+(* u |=  *)
+
+fooPoly_cases_nodep is universe polymorphic
+Arguments fooPoly_cases_nodep P%type_scope f f0 f1
+fooPoly_cases_nodep is transparent
+Expands to: Constant SchemeNames.fooPoly_cases_nodep
+fooPoly_case_nodep not a defined object.
+fooPoly'_case_nodep@{u} :
+forall P : Set, P -> P -> fooPoly'@{Type | u} -> P
+(* u |=  *)
+
+fooPoly'_case_nodep is universe polymorphic
+Arguments fooPoly'_case_nodep P%type_scope f f0 f1
+fooPoly'_case_nodep is transparent
+Expands to: Constant SchemeNames.fooPoly'_case_nodep
+fooPoly'_caset_nodep@{u u0} :
+forall P : Type@{u0}, P -> P -> fooPoly'@{Type | u} -> P
+(* u u0 |=  *)
+
+fooPoly'_caset_nodep is universe polymorphic
+Arguments fooPoly'_caset_nodep P%type_scope f f0 f1
+fooPoly'_caset_nodep is transparent
+Expands to: Constant SchemeNames.fooPoly'_caset_nodep
+fooPoly'_casep_nodep@{α | u u0} :
+forall P : Type@{α | u0}, P -> P -> fooPoly'@{α | u} -> P
+(* α | u u0 |=  *)
+
+fooPoly'_casep_nodep is universe polymorphic
+Arguments fooPoly'_casep_nodep P%type_scope f f0 f1
+fooPoly'_casep_nodep is transparent
+Expands to: Constant SchemeNames.fooPoly'_casep_nodep
+File "./output/SchemeNames.v", line 319, characters 2-35:
+The command has indeed failed with message:
+Cannot extract computational content from proposition 
+"fooPoly".
 F_rect :
-forall (f : Type) (P : F f -> Type),
+forall (f : Type@{F.u0}) (P : F f -> Type@{F_rect.u0}),
 (forall f0 : f, P (C f f0)) -> forall f1 : F f, P f1
 
 F_rect is not universe polymorphic
 Arguments F_rect f%type_scope (P f0)%function_scope f1
 F_rect is transparent
 Expands to: Constant SchemeNames.F_rect
-Declared in library SchemeNames, line 235, characters 0-30
+Declared in library SchemeNames, line 324, characters 0-30
 PP_rect :
-forall (P : Type) (P0 : PP P -> Type),
+forall (P : Type@{PP.u0}) (P0 : PP P -> Type@{PP_rect.u0}),
 (forall p : P, P0 (D P p)) -> forall p : PP P, P0 p
 
 PP_rect is not universe polymorphic
 Arguments PP_rect P%type_scope (P0 f)%function_scope p
 PP_rect is transparent
 Expands to: Constant SchemeNames.PP_rect
-Declared in library SchemeNames, line 238, characters 0-32
+Declared in library SchemeNames, line 327, characters 0-32

--- a/test-suite/output/SchemeNames.v
+++ b/test-suite/output/SchemeNames.v
@@ -1,4 +1,5 @@
 Unset Elimination Schemes.
+Set Printing Universes.
 
 (** In this file we test the generation and naming of elimination schemes. *)
 
@@ -14,6 +15,7 @@ Unset Elimination Schemes.
   Fail Scheme Induction for fooSProp Sort Prop.
   Fail Scheme Induction for fooSProp Sort Set.
   Fail Scheme Induction for fooSProp Sort Type.
+  Fail Scheme Induction for fooSProp Sort Poly.
 
   About fooSProp_inds.
 
@@ -23,6 +25,7 @@ Unset Elimination Schemes.
   Fail Scheme Minimality for fooSProp Sort Prop.
   Fail Scheme Minimality for fooSProp Sort Set.
   Fail Scheme Minimality for fooSProp Sort Type.
+  Fail Scheme Minimality for fooSProp Sort Poly.
 
   About fooSProp_inds_nodep.
 
@@ -32,6 +35,7 @@ Unset Elimination Schemes.
   Fail Scheme Elimination for fooSProp Sort Prop.
   Fail Scheme Elimination for fooSProp Sort Set.
   Fail Scheme Elimination for fooSProp Sort Type.
+  Fail Scheme Elimination for fooSProp Sort Poly.
 
   About fooSProp_cases.
 
@@ -41,6 +45,7 @@ Unset Elimination Schemes.
   Fail Scheme Case for fooSProp Sort Prop.
   Fail Scheme Case for fooSProp Sort Set.
   Fail Scheme Case for fooSProp Sort Type.
+  Fail Scheme Case for fooSProp Sort Poly.
 
   About fooSProp_cases_nodep.
 
@@ -60,6 +65,7 @@ Unset Elimination Schemes.
        Scheme Induction for fooProp Sort Prop.  (* fooProp_ind_dep *)
   Fail Scheme Induction for fooProp Sort Set.
   Fail Scheme Induction for fooProp Sort Type.
+  Fail Scheme Induction for fooProp Sort Poly.
 
   About fooProp_inds_dep.
   About fooProp_ind_dep.
@@ -70,6 +76,7 @@ Unset Elimination Schemes.
        Scheme Minimality for fooProp Sort Prop.  (* fooProp_ind *)
   Fail Scheme Minimality for fooProp Sort Set.
   Fail Scheme Minimality for fooProp Sort Type.
+  Fail Scheme Minimality for fooProp Sort Poly.
 
   About fooProp_inds.
   About fooProp_ind.
@@ -80,6 +87,7 @@ Unset Elimination Schemes.
        Scheme Elimination for fooProp Sort Prop.  (* fooProp_case_dep *)
   Fail Scheme Elimination for fooProp Sort Set.
   Fail Scheme Elimination for fooProp Sort Type.
+  Fail Scheme Elimination for fooProp Sort Poly.
 
   About fooProp_cases_dep.
   About fooProp_case_dep.
@@ -90,6 +98,7 @@ Unset Elimination Schemes.
        Scheme Case for fooProp Sort Prop.  (* fooProp_case *)
   Fail Scheme Case for fooProp Sort Set.
   Fail Scheme Case for fooProp Sort Type.
+  Fail Scheme Case for fooProp Sort Poly.
 
   About fooProp_cases.
   About fooProp_case.
@@ -110,11 +119,13 @@ Unset Elimination Schemes.
   Scheme Induction for fooSet Sort Prop.  (* fooSet_ind *)
   Scheme Induction for fooSet Sort Set.   (* fooSet_rec *)
   Scheme Induction for fooSet Sort Type.  (* fooSet_rect *)
+  Scheme Induction for fooSet Sort Poly.  (* fooSet_elim *)
 
   About fooSet_inds.
   About fooSet_ind.
   About fooSet_rec.
   About fooSet_rect.
+  About fooSet_elim.
 
   (** ** Try Minimality into all Sorts *)
 
@@ -122,11 +133,13 @@ Unset Elimination Schemes.
   Scheme Minimality for fooSet Sort Prop.  (* fooSet_ind_nodep *)
   Scheme Minimality for fooSet Sort Set.   (* fooSet_rec_nodep *)
   Scheme Minimality for fooSet Sort Type.  (* fooSet_rect_nodep *)
+  Scheme Minimality for fooSet Sort Poly.  (* fooSet_elim_nodep *)
 
   About fooSet_inds_nodep.
   About fooSet_ind_nodep.
   About fooSet_rec_nodep.
   About fooSet_rect_nodep.
+  About fooSet_elim_nodep.
 
   (** **  Try Elimination into all Sorts *)
 
@@ -137,11 +150,13 @@ Unset Elimination Schemes.
   Scheme Elimination for fooSet Sort Prop.  (* fooSet_case *)
   Scheme Elimination for fooSet' Sort Set.  (* fooSet'_case *)
   Scheme Elimination for fooSet' Sort Type. (* fooSet'_caset *)
+  Scheme Elimination for fooSet' Sort Poly. (* fooSet'_casep *)
 
   About fooSet_cases.
   About fooSet_case.
   About fooSet'_case.
   About fooSet'_caset.
+  About fooSet'_casep.
 
    (** ** Try Case into all Sorts *)
 
@@ -149,11 +164,13 @@ Unset Elimination Schemes.
   Scheme Case for fooSet Sort Prop.  (* fooSet_case_nodep *)
   Scheme Case for fooSet' Sort Set.  (* fooSet'_case_nodep *)
   Scheme Case for fooSet' Sort Type. (* fooSet'_caset_nodep *)
+  Scheme Case for fooSet' Sort Poly. (* fooSet'_casep_nodep *)
 
   About fooSet_cases_nodep.
   About fooSet_case_nodep.
   About fooSet'_case_nodep.
   About fooSet'_caset_nodep.
+  About fooSet'_casep_nodep.
 
   (** ** Scheme Equality *)
 
@@ -168,7 +185,7 @@ Unset Elimination Schemes.
 
   (** Here is an inductive Type. *)
 
-  Inductive fooType : Type := aT | bT.
+  Inductive fooType@{u} : Type@{u} := aT | bT.
 
   (** ** Try Induction into all Sorts *)
 
@@ -176,11 +193,13 @@ Unset Elimination Schemes.
   Scheme Induction for fooType Sort Prop.  (* fooType_ind *)
   Scheme Induction for fooType Sort Set.   (* fooType_rec *)
   Scheme Induction for fooType Sort Type.  (* fooType_rect *)
+  Scheme Induction for fooType Sort Poly.  (* fooType_elim *)
 
   About fooType_inds.
   About fooType_ind.
   About fooType_rec.
   About fooType_rect.
+  About fooType_elim.
 
   (** ** Try Minimality into all Sorts *)
 
@@ -188,26 +207,30 @@ Unset Elimination Schemes.
   Scheme Minimality for fooType Sort Prop.  (* fooType_ind_nodep *)
   Scheme Minimality for fooType Sort Set.   (* fooType_rec_nodep *)
   Scheme Minimality for fooType Sort Type.  (* fooType_rect_nodep *)
+  Scheme Minimality for fooType Sort Poly.  (* fooType_elim_nodep *)
 
   About fooType_inds_nodep.
   About fooType_ind_nodep.
   About fooType_rec_nodep.
   About fooType_rect_nodep.
+  About fooType_elim_nodep.
 
   (** ** Try Elimination into all Sorts *)
 
   (** Unforunately there is some overlap with names so we need to create a fresh inductive. *)
-  Inductive fooType' : Type := aT' | bT'.
+  Inductive fooType'@{u} : Type@{u} := aT' | bT'.
 
   Scheme Elimination for fooType Sort SProp. (* fooType_cases *)
   Scheme Elimination for fooType Sort Prop.  (* fooType_case *)
   Scheme Elimination for fooType' Sort Set.  (* fooType'_case *)
   Scheme Elimination for fooType' Sort Type. (* fooType'_caset *)
+  Scheme Elimination for fooType' Sort Poly. (* fooType'_casep *)
 
   About fooType_cases.
   About fooType_case.
   About fooType'_case.
   About fooType'_caset.
+  About fooType'_casep.
 
   (** ** Try Case into all Sorts *)
 
@@ -215,11 +238,13 @@ Unset Elimination Schemes.
   Scheme Case for fooType Sort Prop.  (* fooType_case_nodep *)
   Scheme Case for fooType' Sort Set.  (* fooType'_case_nodep *)
   Scheme Case for fooType' Sort Type. (* fooType'_caset_nodep *)
+  Scheme Case for fooType' Sort Poly. (* fooType'_casep_nodep *)
 
   About fooType_cases_nodep.
   About fooType_case_nodep.
   About fooType'_case_nodep.
   About fooType'_caset_nodep.
+  About fooType'_casep_nodep.
 
   (** ** Scheme Equality *)
 
@@ -229,6 +254,70 @@ Unset Elimination Schemes.
   About fooType_eq_dec.
   About internal_fooType_dec_bl.
   About internal_fooType_dec_lb.
+
+(** * Schemes for inductive sort poly *)
+
+  (** Here is an inductive Type. *)
+
+  Polymorphic Inductive fooPoly@{q|u|} : Type@{q|u} := aPo | bPo.
+
+  (** ** Try Induction into all Sorts *)
+
+  Fail Scheme Induction for fooPoly Sort SProp.
+  Fail Scheme Induction for fooPoly Sort Prop.
+  Fail Scheme Induction for fooPoly Sort Set.
+  Fail Scheme Induction for fooPoly Sort Type.
+  Scheme Induction for fooPoly Sort Poly.  (* fooPoly_elim *)
+
+  About fooPoly_elim.
+
+  (** ** Try Minimality into all Sorts *)
+
+  Fail Scheme Minimality for fooPoly Sort SProp.
+  Fail Scheme Minimality for fooPoly Sort Prop.
+  Fail Scheme Minimality for fooPoly Sort Set.
+  Fail Scheme Minimality for fooPoly Sort Type.
+  Scheme Minimality for fooPoly Sort Poly.  (* fooPoly_elim_nodep *)
+
+  About fooPoly_elim_nodep.
+
+  (** ** Try Elimination into all Sorts *)
+
+  (** Unforunately there is some overlap with names so we need to create a fresh inductive. *)
+  Polymorphic Inductive fooPoly'@{q|u|} : Type@{q|u} := aPo' | bPo'.
+
+  (* XXX why is the quality of the inductive getting unified with the
+     target sort except in the Prop case? *)
+  Scheme Elimination for fooPoly Sort SProp. (* fooPoly_cases *)
+  Fail Scheme Elimination for fooPoly Sort Prop.
+  Scheme Elimination for fooPoly' Sort Set.  (* fooPoly'_case *)
+  Scheme Elimination for fooPoly' Sort Type. (* fooPoly'_caset *)
+  Scheme Elimination for fooPoly' Sort Poly. (* fooPoly'_casep *)
+
+  About fooPoly_cases.
+  About fooPoly_case.
+  About fooPoly'_case.
+  About fooPoly'_caset.
+  About fooPoly'_casep.
+
+  (** ** Try Case into all Sorts *)
+
+  Scheme Case for fooPoly Sort SProp. (* fooPoly_cases_nodep *)
+  Fail Scheme Case for fooPoly Sort Prop.  (* fooPoly_case_nodep *)
+  Scheme Case for fooPoly' Sort Set.  (* fooPoly'_case_nodep *)
+  Scheme Case for fooPoly' Sort Type. (* fooPoly'_caset_nodep *)
+  Scheme Case for fooPoly' Sort Poly. (* fooPoly'_casep_nodep *)
+
+  About fooPoly_cases_nodep.
+  About fooPoly_case_nodep.
+  About fooPoly'_case_nodep.
+  About fooPoly'_caset_nodep.
+  About fooPoly'_casep_nodep.
+
+  (** ** Scheme Equality *)
+
+  Fail Scheme Equality for fooPoly.
+  (* XXX error message claims fooPoly is a proposition *)
 
 Set Elimination Schemes.
 

--- a/test-suite/output/sort_poly_elim_error.out
+++ b/test-suite/output/sort_poly_elim_error.out
@@ -1,7 +1,7 @@
 File "./output/sort_poly_elim_error.v", line 8, characters 0-108:
 The command has indeed failed with message:
 Incorrect elimination of "p" in the inductive type
-"sum@{Prop | sort_poly_elim_error.23 sort_poly_elim_error.24}":
+"sum@{Prop | sort_poly_elim_error.26 sort_poly_elim_error.27}":
 the return type has sort "Type" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Type"

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -343,23 +343,24 @@ let sch_isrec = function
 let scheme_suffix_gen {sch_type; sch_sort} sort =
   (* The _ind/_rec_/case suffix *)
   let ind_suffix = match sch_isrec sch_type, sch_sort with
-    | true  , InSProp
-    | true  , InProp  -> "_ind"
-    | true  , _       -> "_rec"
-    | false , _       -> "_case" in
-  (* SProp and Type have an auxillary ending to the _ind suffix *)
-  let aux_suffix = match sch_sort with
-    | InSProp -> "s"
-    | InType  -> "t"
-    | _       -> "" in
+    | true  , InSProp -> "_inds"
+    | true  , InProp -> "_ind"
+    | true  , InSet -> "_rec"
+    | true  , InType -> "_rect"
+    | true  , InQSort -> "_elim"
+    | false , (InProp | InSet | InQSort) -> "_case"
+    | false , InSProp -> "_cases"
+    | false , InType -> "_caset"
+  in
   (* Some schemes are deliminated with _dep or no_dep *)
   let dep_suffix = match sch_isdep sch_type , sort with
     | true  , InProp  -> "_dep"
     | false , InSet
     | false , InType
+    | false , InQSort
     | false , InSProp -> "_nodep"
     | _ , _           -> "" in
-  ind_suffix ^ aux_suffix ^ dep_suffix
+  ind_suffix ^ dep_suffix
 
 let smart_ind qid =
   let ind = Smartlocate.smart_global_inductive qid in


### PR DESCRIPTION
This PR adds generation of a sort polymorphic eliminator using the `Scheme` command, with `Poly` as a new possible `sort_family`.

- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [X] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.