### PR TITLE
 Keep qvar in template poly entry and declarations

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -322,7 +322,12 @@ let v_oracle =
   |]
 
 let v_template_universes =
-  v_tuple "template_universes" [|v_list v_bool;v_context_set; v_bool|]
+  v_tuple "template_universes" [|
+    v_list (v_opt v_sort);
+    v_sort;
+    v_abs_context;
+    v_instance;
+  |]
 
 let v_primitive =
   v_enum "primitive" 63 (* Number of constructors of the CPrimitives.t type *)

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -321,9 +321,6 @@ let v_oracle =
     v_pred v_proj_repr;
   |]
 
-let v_template_arity =
-  v_tuple "template_arity" [|v_sort|]
-
 let v_template_universes =
   v_tuple "template_universes" [|v_list v_bool;v_context_set; v_bool|]
 
@@ -417,18 +414,13 @@ let v_wfp =
       [|v_int;v_array v_wfp|] (* Rtree.Rec *)
     |]))
 
-let v_mono_ind_arity =
-  v_tuple "monomorphic_inductive_arity" [|v_constr;v_sort|]
-
-let v_ind_arity = v_sum "inductive_arity" 0
-  [|[|v_mono_ind_arity|];[|v_template_arity|]|]
-
 let v_squash_info = v_sum "squash_info" 1 [|[|v_set v_quality|]|]
 
 let v_one_ind = v_tuple "one_inductive_body"
   [|v_id;
     v_rctxt;
-    v_ind_arity;
+    v_sort;
+    v_constr;
     v_array v_id;
     v_array v_constr;
     v_int;

--- a/dev/ci/user-overlays/20178-SkySkimmer-template-entry-qvar.sh
+++ b/dev/ci/user-overlays/20178-SkySkimmer-template-entry-qvar.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi template-entry-qvar 20178
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations template-entry-qvar 20178

--- a/dev/ci/user-overlays/20178-SkySkimmer-template-entry-qvar.sh
+++ b/dev/ci/user-overlays/20178-SkySkimmer-template-entry-qvar.sh
@@ -1,3 +1,9 @@
 overlay elpi https://github.com/SkySkimmer/coq-elpi template-entry-qvar 20178
 
 overlay equations https://github.com/SkySkimmer/Coq-Equations template-entry-qvar 20178
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp template-entry-qvar 20178
+
+overlay metacoq https://github.com/SkySkimmer/metacoq template-entry-qvar 20178
+
+overlay paramcoq https://github.com/SkySkimmer/paramcoq template-entry-qvar 20178

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1207,8 +1207,8 @@ let nf_univ_variables evd =
   let uctx = UState.normalize_variables evd.universes in
   {evd with universes = uctx}
 
-let collapse_sort_variables evd =
-  let universes = UState.collapse_sort_variables evd.universes in
+let collapse_sort_variables ?except evd =
+  let universes = UState.collapse_sort_variables ?except evd.universes in
   { evd with universes }
 
 let minimize_universes ?(collapse_sort_variables=true) evd =
@@ -1720,6 +1720,7 @@ module MiniEConstr = struct
     let univ_value l =
       UnivFlex.normalize_univ_variable lsubst l
     in
+    let relevance_value r = UState.nf_relevance sigma.universes r in
     let qvar_value q = UState.nf_qvar sigma.universes q in
     let next s = { s with evc_lift = s.evc_lift + 1 } in
     let find clos id = match Id.Map.find_opt id clos.evc_map with
@@ -1792,7 +1793,7 @@ module MiniEConstr = struct
         self nclos c
       end
     | _ ->
-      UnivSubst.map_universes_opt_subst_with_binders next self qvar_value univ_value clos c
+      UnivSubst.map_universes_opt_subst_with_binders next self relevance_value qvar_value univ_value clos c
     in
     let clos = {
       evc_lift = 0;

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -612,7 +612,7 @@ val with_sort_context_set : ?loc:Loc.t -> rigid -> evar_map -> 'a UnivGen.in_sor
 
 val nf_univ_variables : evar_map -> evar_map
 
-val collapse_sort_variables : evar_map -> evar_map
+val collapse_sort_variables : ?except:Sorts.QVar.Set.t -> evar_map -> evar_map
 
 val fix_undefined_variables : evar_map -> evar_map
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -93,6 +93,8 @@ val univ_entry : poly:bool -> t -> named_universes_entry
 val universe_binders : t -> UnivNames.universe_binders
 (** Return local names of universes. *)
 
+val compute_instance_binders : t -> UVars.Instance.t -> UVars.bound_names
+
 val nf_qvar : t -> QVar.t -> Quality.t
 (** Returns the normal form of the sort variable. *)
 
@@ -226,7 +228,7 @@ val minimize : t -> t
 
 val collapse_above_prop_sort_variables : to_prop:bool -> t -> t
 
-val collapse_sort_variables : t -> t
+val collapse_sort_variables : ?except:QVar.Set.t -> t -> t
 
 type ('a, 'b, 'c) gen_universe_decl = {
   univdecl_qualities : 'a;
@@ -257,6 +259,8 @@ val check_univ_decl_rev : t -> universe_decl -> t * UVars.UContext.t
 val check_uctx_impl : fail:(Pp.t -> unit) -> t -> t -> unit
 
 val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
+
+val check_template_univ_decl : t -> template_qvars:QVar.Set.t -> universe_decl -> Univ.ContextSet.t
 
 (** {5 TODO: Document me} *)
 

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -162,8 +162,7 @@ let subst_univs_fn_puniverses f (c, u as cu) =
   let u' = Instance.subst_fn f u in
     if u' == u then cu else (c, u')
 
-let map_universes_opt_subst_with_binders next aux fqual funiv k c =
-  let frel = Sorts.relevance_subst_fn fqual in
+let map_universes_opt_subst_with_binders next aux frel fqual funiv k c =
   let flevel = fqual, level_subst_of funiv in
   let aux_rec ((nas, tys, bds) as rc) =
     let nas' = Array.Smart.map (Context.map_annot_relevance frel) nas in
@@ -244,7 +243,7 @@ let map_universes_opt_subst_with_binders next aux fqual funiv k c =
     else mkProj (p, r', v')
   | _ -> Constr.map_with_binders next aux k c
 
-let nf_evars_and_universes_opt_subst fevar fqual funiv c =
+let nf_evars_and_universes_opt_subst fevar frel fqual funiv c =
   let rec self () c = match Constr.kind c with
   | Evar (evk, args) ->
     let args' = SList.Smart.map (self ()) args in
@@ -252,7 +251,7 @@ let nf_evars_and_universes_opt_subst fevar fqual funiv c =
     | None -> if args == args' then c else mkEvar (evk, args')
     | Some c -> self () c
     end
-  | _ -> map_universes_opt_subst_with_binders ignore self fqual funiv () c
+  | _ -> map_universes_opt_subst_with_binders ignore self frel fqual funiv () c
   in
   self () c
 

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -30,12 +30,14 @@ val subst_univs_constraints : universe_subst_fn -> Constraints.t -> Constraints.
 val map_universes_opt_subst_with_binders
   : ('a -> 'a)
   -> ('a -> constr -> constr)
+  -> (Sorts.relevance -> Sorts.relevance)
   -> quality_subst_fn
   -> universe_subst_fn
   -> 'a -> constr -> constr
 
 val nf_evars_and_universes_opt_subst
   : (existential -> constr option)
+  -> (Sorts.relevance -> Sorts.relevance)
   -> quality_subst_fn
   -> universe_subst_fn
   -> constr -> constr

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -17,20 +17,28 @@ open Constr
 
 (** {6 Representation of constants (Definition/Axiom) } *)
 
-(** Non-universe polymorphic mode polymorphism (Coq 8.2+): inductives
-    and constants hiding inductives are implicitly polymorphic when
-    applied to parameters, on the universes appearing in the whnf of
-    their parameters and their conclusion, in a template style.
+(** Template polymorphism: provides universe polymorphism and sort
+    polymorphism (restricted to above prop qualities), with implicit instances
+    and inferring the universes from the types of parameters instead.
 
-    In truly universe polymorphic mode, we always use RegularArity.
+    The data other than [mind_template] in the inductive bodies is
+    instantiated to the default universes (e.g. [mind_user_arity],
+    [mind_sort], the constructor data, etc).
 *)
 
-type template_pseudo_sort_poly = TemplatePseudoSortPoly | TemplateUnivOnly
-
 type template_universes = {
-  template_param_arguments : bool list;
-  template_context : Univ.ContextSet.t;
-  template_pseudo_sort_poly : template_pseudo_sort_poly;
+  (** For each LocalAssum parameter (in regular order, not rel_context order),
+      tell whether it binds a quality or a universe level
+      (read from the sort, NB it is possible to bind a qvar next to a constant universe)
+      (the binders are DeBruijn levels as with universe polymorphism,
+      but may be instantiated with algebraics) *)
+  template_param_arguments : Sorts.t option list;
+  (** Inductive sort with abstracted universes. *)
+  template_concl : Sorts.t;
+  template_context : UVars.AbstractContext.t;
+  (** Template_defaults qualities are all QType.
+      Also the universes are all levels so we can use Instance. *)
+  template_defaults : UVars.Instance.t;
 }
 
 (** Inlining level of parameters at functor applications.

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -27,10 +27,6 @@ open Constr
 
 type template_pseudo_sort_poly = TemplatePseudoSortPoly | TemplateUnivOnly
 
-type template_arity = {
-  template_level : Sorts.t;
-}
-
 type template_universes = {
   template_param_arguments : bool list;
   template_context : Univ.ContextSet.t;
@@ -158,15 +154,6 @@ type record_info =
 | FakeRecord
 | PrimRecord of (Id.t * Label.t array * Sorts.relevance array * types array) array
 
-type regular_inductive_arity = {
-  mind_user_arity : types;
-  mind_sort : Sorts.t;
-}
-
-type inductive_arity =
-  | RegularArity of regular_inductive_arity
-  | TemplateArity of template_arity
-
 type squash_info =
   | AlwaysSquashed
   | SometimesSquashed of Sorts.Quality.Set.t
@@ -191,7 +178,12 @@ type one_inductive_body = {
      a list in reverse order
      [[realdecl_i{r_i};...;realdecl_i1;paramdecl_m;...;paramdecl_1]]. *)
 
-    mind_arity : inductive_arity; (** Arity sort and original user arity *)
+    mind_sort : Sorts.t; (** Arity sort *)
+
+    mind_user_arity : types;
+    (** Original user arity, convertible to [mkArity (mind_arity_ctxt, mind_sort)].
+        As such it contains the parameters.
+        (not necessarily a syntactic arity, eg [relation A] instead of [A -> A -> Prop]) *)
 
     mind_consnames : Id.t array; (** Names of the constructors: [cij] *)
 
@@ -235,6 +227,7 @@ type one_inductive_body = {
     mind_recargs : wf_paths; (** Signature of recursive arguments in the constructors *)
 
     mind_relevance : Sorts.relevance;
+    (* XXX this is redundant with mind_sort, is it actually worth keeping? *)
 
 (** {8 Datas for bytecode compilation } *)
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -34,9 +34,10 @@ let safe_flags oracle = {
 (** {6 Arities } *)
 
 let hcons_template_universe ar =
-  { template_param_arguments = ar.template_param_arguments;
-    template_context = Univ.hcons_universe_context_set ar.template_context;
-    template_pseudo_sort_poly = ar.template_pseudo_sort_poly;
+  { template_param_arguments = List.Smart.map (Option.Smart.map Sorts.hcons) ar.template_param_arguments;
+    template_concl = Sorts.hcons ar.template_concl;
+    template_context = UVars.hcons_abstract_universe_context ar.template_context;
+    template_defaults = UVars.Instance.hcons ar.template_defaults;
   }
 
 let universes_context = function

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -178,10 +178,10 @@ let cook_inductive info mib =
   in
   let mind_template = match mib.mind_template with
   | None -> None
-  | Some {template_param_arguments=levels; template_context; template_pseudo_sort_poly} ->
-      let sec_levels = List.make (Context.Rel.nhyps (rel_context_of_cooking_cache cache)) false in
+  | Some {template_param_arguments=levels; template_context; template_concl; template_defaults;} ->
+      let sec_levels = List.make (Context.Rel.nhyps (rel_context_of_cooking_cache cache)) None in
       let levels = List.rev_append sec_levels levels in
-      Some {template_param_arguments=levels; template_context; template_pseudo_sort_poly}
+      Some {template_param_arguments=levels; template_context; template_concl; template_defaults}
   in
   {
     mind_packets;

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -112,14 +112,8 @@ let cook_projection cache ~params t =
   t
 
 let cook_one_ind cache ~ntypes mip =
-  let mind_arity = match mip.mind_arity with
-    | RegularArity {mind_user_arity=arity;mind_sort=sort} ->
-      let arity = abstract_as_type cache arity in
-      let sort = abstract_as_sort cache sort in
-      RegularArity {mind_user_arity=arity; mind_sort=sort}
-    | TemplateArity {template_level} ->
-      TemplateArity {template_level}
-  in
+  let mind_user_arity = abstract_as_type cache mip.mind_user_arity in
+  let mind_sort = abstract_as_sort cache mip.mind_sort in
   let mind_arity_ctxt = cook_rel_context cache mip.mind_arity_ctxt in
   let mind_user_lc = Array.map (cook_lc cache ~ntypes) mip.mind_user_lc in
   let mind_nf_lc = Array.map (fun (ctx,t) ->
@@ -130,7 +124,8 @@ let cook_one_ind cache ~ntypes mip =
   in
   { mind_typename = mip.mind_typename;
     mind_arity_ctxt;
-    mind_arity;
+    mind_user_arity;
+    mind_sort;
     mind_consnames = mip.mind_consnames;
     mind_user_lc;
     mind_nrealargs = mip.mind_nrealargs;

--- a/kernel/entries.mli
+++ b/kernel/entries.mli
@@ -24,8 +24,9 @@ type inductive_universes_entry =
   | Monomorphic_ind_entry
   | Polymorphic_ind_entry of UVars.UContext.t
   | Template_ind_entry of {
-      univs : Univ.ContextSet.t;
-      pseudo_sort_poly : Declarations.template_pseudo_sort_poly;
+      uctx : UVars.UContext.t;
+      (* The quality part of default_univs must be all qtype *)
+      default_univs : UVars.Instance.t;
     }
 
 type variance_entry = UVars.Variance.t option array

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -761,10 +761,10 @@ let polymorphic_pind (ind,u) env =
 let type_in_type_ind (mind,_i) env =
   not (lookup_mind mind env).mind_typing_flags.check_universes
 
-let template_polymorphic_ind (mind,i) env =
-  match (lookup_mind mind env).mind_packets.(i).mind_arity with
-  | TemplateArity _ -> true
-  | RegularArity _ -> false
+let template_polymorphic_ind (mind,_) env =
+  match (lookup_mind mind env).mind_template with
+  | Some _ -> true
+  | None -> false
 
 let template_polymorphic_pind (ind,u) env =
   if not (UVars.Instance.is_empty u) then false

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -1056,11 +1056,11 @@ struct
 end
 
 module Internal = struct
-  let for_checking_pseudo_sort_poly env =
-    let q = Sorts.QVar.make_var 0 in
-    assert (not (Sorts.QVar.Set.mem q env.env_qualities));
-    let env = map_universes UGraph.Internal.for_checking_pseudo_sort_poly env in
-    { env with env_qualities = Sorts.QVar.Set.add q env.env_qualities }
+  let push_template_context uctx env =
+    let env = push_context ~strict:false uctx env in
+    let qvars, _ = UVars.UContext.to_context_set uctx in
+    let env = map_universes (UGraph.Internal.add_template_qvars qvars) env in
+    env
 
   let is_above_prop env q = UGraph.Internal.is_above_prop env.env_universes q
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -446,9 +446,9 @@ val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
 val retroknowledge : env -> Retroknowledge.retroknowledge
 
 module Internal : sig
-  (** Makes qvar 0 bound and treated as above prop.
+  (** Makes the qvars treated as above prop.
       Do not use outside kernel inductive typechecking. *)
-  val for_checking_pseudo_sort_poly : env -> env
+  val push_template_context : UContext.t -> env -> env
 
   val is_above_prop : env -> Sorts.QVar.t -> bool
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -303,19 +303,41 @@ let check_unbounded_from_below (univs,csts) =
                                Level.raw_pr l ++ pr_constraint_type d ++ Level.raw_pr r)))
     csts
 
-let get_arity c =
+let get_template_binding_arity c =
   let decls, c = Term.decompose_prod_decls c in
   match kind c with
   | Sort (Type u) ->
     begin match Universe.level u with
-    | Some l -> Some (decls, l)
+    | Some l -> Some (decls, None, l)
     | None -> None
+    end
+  | Sort (QSort (q, u)) ->
+    begin match Universe.level u with
+    | Some l -> Some (decls, Some q, l)
+    | None -> assert false (* currently quality must always be bound next to a universe *)
     end
   | _ -> None
 
+let check_no_increment ~template_univs u =
+  (* forbid template poly with an increment on a template univ in the conclusion
+     otherwise repeatedly applying it can generate universes with +2
+     which we cannot yet handle. *)
+  let has_increment =
+    Universe.exists (fun (u,n) ->
+        if Level.Set.mem u template_univs then
+          not (Int.equal n 0)
+        else false) u
+  in
+  if has_increment then
+    CErrors.user_err
+      Pp.(str "Template polymorphism with conclusion strictly larger than a bound universe not supported.")
+
 let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
-| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> mie, None
-| Template_ind_entry {univs=(template_univs, _ as template_context); pseudo_sort_poly} ->
+| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> mie, None, None
+| Template_ind_entry {uctx; default_univs} ->
+  let template_qvars, (template_univs, _ as template_context) =
+    UVars.UContext.to_context_set uctx
+  in
   let params = mie.mind_entry_params in
   let ind =
     match mie.mind_entry_inds with
@@ -328,9 +350,16 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
      This makes them Irrelevant for conversion and also makes them easy to substitute.
      The inductive and binding parameter types must be syntactically arities. *)
   let check_not_appearing c =
-    let us = Vars.universes_of_constr c in
+    let qs, us = Vars.sort_and_universes_of_constr c in
+    let qappearing = Sorts.QVar.Set.inter qs template_qvars in
     let appearing = Level.Set.inter us template_univs in
-    if not (Level.Set.is_empty appearing) then
+    if not (Sorts.QVar.Set.is_empty qappearing) then
+      CErrors.user_err
+        Pp.(str "Template " ++
+            str (if Int.equal 1 (Sorts.QVar.Set.cardinal qappearing) then "quality" else "qualities") ++
+            spc() ++ prlist_with_sep spc Sorts.QVar.raw_pr (Sorts.QVar.Set.elements qappearing) ++ spc() ++
+            str "appear in illegal positions.")
+    else if not (Level.Set.is_empty appearing) then
       CErrors.user_err
         Pp.(str "Template " ++
             str (CString.plural (Level.Set.cardinal appearing) "universe") ++
@@ -351,37 +380,54 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
           check_not_appearing t;
           None
         | LocalAssum (_,t) ->
-          match get_arity t with
+          match get_template_binding_arity t with
           | None ->
             check_not_appearing t;
             Some None
-          | Some (decls, l) ->
+          | Some (decls, qopt, l) ->
             let () = check_not_appearing_rel_ctx decls in
-            if Level.Set.mem l template_univs then Some (Some l) else Some None)
+            if Level.Set.mem l template_univs then Some (Some (qopt, l))
+            else begin
+              let () = if Option.has_some qopt then
+                  CErrors.user_err Pp.(str "Template quality bound next to non template level.")
+              in
+              Some None
+            end)
       params
   in
-  let bound_in_params =
-    List.fold_left (fun bound_in_params -> function
+  let qbound, ubound =
+    List.fold_left (fun (qbound, ubound as bound_in_params) -> function
         | Some None | None -> bound_in_params
-        | Some (Some l) ->
-          if Level.Set.mem l bound_in_params then
+        | Some (Some (qopt,l)) ->
+          if Level.Set.mem l ubound then
             CErrors.user_err Pp.(str "Non-linear template level " ++ Level.raw_pr l)
-          else Level.Set.add l bound_in_params)
-      Level.Set.empty
+          else
+            let qbound = Option.fold_right Sorts.QVar.Set.add qopt qbound in
+            qbound, Level.Set.add l ubound)
+      (Sorts.QVar.Set.empty,Level.Set.empty)
       template_params
   in
-  let unbound_in_params = Level.Set.diff template_univs bound_in_params in
-  let () = if not (Level.Set.is_empty unbound_in_params) then
+  let q_unbound = Sorts.QVar.Set.diff template_qvars qbound in
+  let () = if not (Sorts.QVar.Set.is_empty q_unbound) then
       CErrors.user_err
         Pp.(str "Template " ++
-            str (CString.plural (Level.Set.cardinal unbound_in_params) "universe") ++
-            spc() ++ Level.Set.pr Level.raw_pr unbound_in_params ++ spc() ++
-            str "are not bound by parameters.")
+            str (if Int.equal 1 (Sorts.QVar.Set.cardinal q_unbound) then "quality" else "qualities") ++ spc() ++
+            prlist_with_sep spc Sorts.QVar.raw_pr (Sorts.QVar.Set.elements q_unbound) ++ spc() ++
+            str "not bound by parameters.")
+
+  in
+  let u_unbound = Level.Set.diff template_univs ubound in
+  let () = if not (Level.Set.is_empty u_unbound) then
+      CErrors.user_err
+        Pp.(str "Template " ++
+            str (CString.plural (Level.Set.cardinal u_unbound) "universe") ++
+            spc() ++ Level.Set.pr Level.raw_pr u_unbound ++ spc() ++
+            str "not bound by parameters.")
 
   in
 
   (** arity *)
-  let arity_for_pseudo_poly =
+  let pseudo_sort_poly =
     (* don't use get_arity, we allow constant template poly (eg eq) *)
     let (decls, s) = Term.decompose_prod_decls ind.mind_entry_arity in
     let () = if not (isSort s) then
@@ -389,63 +435,75 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
     in
     check_not_appearing_rel_ctx decls;
     match destSort s with
-    | SProp | Prop | Set -> None
-    | QSort _ -> assert false
+    | SProp | Prop | Set -> TemplateUnivOnly
+    | QSort (_, u) ->
+      (* typechecking will fail with "unbound qvar" if the quality isn't in template_qvars *)
+      check_no_increment ~template_univs u;
+      (* the inductive's occurrences will be typechecked as though the
+         conclusion qvar was bound next to each conclusion univ.
+         Since we take the max of the given qualities this is an over-approximation
+         (ie we check "foo (A:Type@{q | u}) (B:Type@{v}) : Type@{q | max(u,v)}"
+         then treat it as "foo (A:Type@{q | u}) (B:Type@{q | v}) : Type@{q | max(u,v)}"
+         which is less general since q is forced above prop)
+      *)
+      TemplatePseudoSortPoly
     | Type u ->
-      (* forbid template poly with an increment on a template univ in the conclusion
-         otherwise repeatedly applying it can generate universes with +2
-         which we cannot yet handle. *)
-      let has_increment =
-        Universe.exists (fun (u,n) ->
-            if Level.Set.mem u template_univs then
-              not (Int.equal n 0)
-            else false) u
-      in
-      if has_increment then
-        CErrors.user_err
-          Pp.(str "Template polymorphism with conclusion strictly larger than a bound universe not supported.")
-      else Some (decls, u)
+      check_no_increment ~template_univs u;
+      TemplateUnivOnly
   in
 
   (** ctors *)
   let () = List.iter check_not_appearing ind.mind_entry_lc in
 
-  (* for typechecking pseudo sort poly, replace Type@{u} with Type@{Var 0 | u}
-     in the conclusion and for the bound univs which appear in the conclusion
-     XXX it would be nicer to have the higher layers send us qvars instead *)
-  let mie = match pseudo_sort_poly, arity_for_pseudo_poly with
-    | TemplateUnivOnly, _ -> mie
-    | TemplatePseudoSortPoly, None ->
-      CErrors.user_err Pp.(str "Invalid pseudo sort poly template inductive.")
-    | TemplatePseudoSortPoly, Some (indices, concl) ->
-      let concl_bound_univs = Level.Set.inter template_univs (Universe.levels concl) in
-      let bound_qvar = Sorts.QVar.make_var 0 in
-      let params = List.map (fun param ->
-          match param with
-          | LocalDef _ -> param (* letin *)
-          | LocalAssum (na, t) ->
-            match get_arity t with
-            | None -> param
-            | Some (decls, l) ->
-              if Level.Set.mem l concl_bound_univs then
-                let l = Universe.make l in
-                LocalAssum (na, it_mkProd_or_LetIn (mkSort (Sorts.qsort bound_qvar l)) decls)
-              else param)
-          params
-      in
-      let arity = it_mkProd_or_LetIn (mkSort (Sorts.qsort bound_qvar concl)) indices in
-      { mie with
-        mind_entry_params = params;
-        mind_entry_inds =
-          [{ind with
-            mind_entry_arity = arity;
-           }];
-      }
-  in
-
   let template_assums = CList.filter_map (fun x -> x) template_params in
 
-  mie, Some {
+  (* Substitution from the template binders to the default univs (and qtype for the qvars) *)
+  let template_usubst : UVars.sort_level_subst =
+    let bind_instance = UVars.UContext.instance uctx in
+    let () = if not UVars.(eq_sizes (Instance.length bind_instance) (Instance.length default_univs))
+      then CErrors.anomaly Pp.(str "Inorrect default template universes declaration.")
+    in
+    let bind_qs, bind_us = UVars.Instance.to_array bind_instance in
+    let default_qs, default_us = UVars.Instance.to_array default_univs in
+    let qsubst = Array.fold_left2 (fun qsubst bind_q default_q ->
+        let open Sorts.Quality in
+        match bind_q, default_q with
+        | QConstant _, _ -> assert false
+        | QVar bind_q, QConstant QType ->
+          Sorts.QVar.Map.add bind_q default_q qsubst
+        | QVar _, _ -> CErrors.anomaly Pp.(str "Default template quality must be QType."))
+        Sorts.QVar.Map.empty
+        bind_qs default_qs
+    in
+    let usubst = Array.fold_left2 (fun usubst bind_u default_u ->
+        assert (not @@ Level.is_set bind_u);
+        Level.Map.add bind_u default_u usubst)
+        Level.Map.empty
+        bind_us default_us
+    in
+    qsubst, usubst
+  in
+
+  let template_context =
+    let univs =
+      Level.Set.fold (fun u acc ->
+          let u = Univ.subst_univs_level_level (snd template_usubst) u in
+          Level.Set.add u acc)
+        template_univs
+        Level.Set.empty
+    in
+    let csts =
+      Constraints.fold (fun (u,d,v) acc ->
+          let u = Univ.subst_univs_level_level (snd template_usubst) u in
+          let () = assert (not @@ Level.Map.mem v (snd template_usubst)) in
+          Constraints.add (u, d, v) acc)
+        (snd template_context)
+        Constraints.empty
+    in
+    univs, csts
+  in
+
+  mie, Some template_usubst, Some {
     template_param_arguments = List.rev_map Option.has_some template_assums;
     template_context;
     template_pseudo_sort_poly = pseudo_sort_poly;
@@ -496,16 +554,12 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   assert (List.is_empty (Environ.rel_context env));
 
   (* universes *)
-  let mie, template = get_template mie in
+  let mie, template_usubst, template = get_template mie in
 
   let env_univs =
     match mie.mind_entry_universes with
-    | Template_ind_entry {univs=ctx; pseudo_sort_poly} ->
-      let env =  Environ.push_context_set ~strict:false ctx env in
-      begin match pseudo_sort_poly with
-      | TemplatePseudoSortPoly -> Environ.Internal.for_checking_pseudo_sort_poly env
-      | TemplateUnivOnly -> env
-      end
+    | Template_ind_entry {uctx; default_univs=_} ->
+      Environ.Internal.push_template_context uctx env
     | Monomorphic_ind_entry -> env
     | Polymorphic_ind_entry ctx -> push_context ctx env
   in
@@ -577,18 +631,10 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   (* Abstract universes *)
   let usubst, univs = match mie.mind_entry_universes with
   | Monomorphic_ind_entry ->
-      UVars.empty_sort_subst, Monomorphic
-  | Template_ind_entry info -> begin match info.pseudo_sort_poly with
-      | TemplateUnivOnly -> UVars.empty_sort_subst, Monomorphic
-      | TemplatePseudoSortPoly ->
-        (* replace Type@{Var 0 | u} back to Type@{u}
-           XXX it would be nicer to keep the qvar in the declared structure *)
-        let qsubst =
-          Sorts.QVar.Map.singleton (Sorts.QVar.make_var 0) Sorts.Quality.(QConstant QType)
-        in
-        let usubst = Univ.empty_level_subst in
-        (qsubst, usubst), Monomorphic
-    end
+    UVars.empty_sort_subst, Monomorphic
+  | Template_ind_entry _ ->
+    let usubst = Option.get template_usubst in
+    usubst, Monomorphic
   | Polymorphic_ind_entry uctx ->
     let (inst, auctx) = UVars.abstract_universes uctx in
     let inst = UVars.make_instance_subst inst in

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -20,6 +20,8 @@ open Entries
 open Type_errors
 open Context.Rel.Declaration
 
+type inductive_arity = { user_arity : Constr.types; sort : Sorts.t }
+
 (** Check name unicity.
     Redundant with safe_typing's add_field checks -> to remove?. *)
 
@@ -523,12 +525,7 @@ let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info) =
   in
   let ind_univ = UVars.subst_sort_level_sort usubst univ_info.ind_univ in
 
-  let arity =
-    if univ_info.ind_template then
-      TemplateArity { template_level = ind_univ; }
-    else
-      RegularArity {mind_user_arity = arity; mind_sort = ind_univ}
-  in
+  let arity = {user_arity = arity; sort = ind_univ} in
 
   let squashed = Option.map (function
       | AlwaysSquashed -> AlwaysSquashed

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -23,6 +23,7 @@ module NotPrimRecordReason : sig
 
 end
 
+type inductive_arity = { user_arity : Constr.types; sort : Sorts.t }
 
 (** Type checking for some inductive entry.
     Returns:

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -146,7 +146,7 @@ let remember_subst u subst =
     Univ.Level.Map.add u (max_template_universe su (Univ.Level.Map.find u subst)) subst
   with Not_found -> subst
 
-type param_univs = (expected:Univ.Level.t -> template_univ) list
+type param_univs = (default:Sorts.t -> template_univ) list
 
 let get_arity c =
   let decls, c = Term.decompose_prod_decls c in
@@ -170,7 +170,7 @@ let make_subst =
     | LocalAssum (_,t)::sign, true::exp, a::args ->
         (* We recover the level of the argument *)
         let _, u = get_arity t in
-        let s = a ~expected:u in
+        let s = a ~default:(Sorts.sort_of_univ (Universe.make u)) in
         make (cons_subst u s subst) (sign, exp, args)
     | LocalAssum (_na,t) :: sign, true::exp, [] ->
         (* No more argument here: we add the remaining universes to the *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -226,16 +226,6 @@ let subst_univs_sort (subs, pseudo_sort_poly) = function
   | TemplateUniv u -> Sorts.sort_of_univ u
   | TemplateAboveProp (q,u) -> Sorts.qsort q u
 
-let get_arity c =
-  let decls, c = Term.decompose_prod_decls c in
-  match kind c with
-  | Sort (Sorts.Type u) ->
-    begin match Universe.level u with
-    | Some l -> (decls, l)
-    | None -> assert false
-    end
-  | _ -> assert false
-
 let rec subst_univs_ctx accu subs ctx params = match ctx, params with
 | [], [] -> accu
 | (LocalDef _ as decl) :: ctx, params ->

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -53,13 +53,15 @@ type template_univ =
 
 type param_univs = (default:Sorts.t -> template_univ) list
 
+type template_subst = Sorts.Quality.t Int.Map.t * Universe.t Int.Map.t
+
 val instantiate_template_constraints
-  : template_univ Univ.Level.Map.t
+  : template_subst
   -> Declarations.template_universes
   -> Univ.Constraints.t
 
 val instantiate_template_universes : mind_specif -> param_univs ->
-  Constraints.t * rel_context * (template_univ Univ.Level.Map.t * template_pseudo_sort_poly)
+  Constraints.t * rel_context * template_subst
 
 val constrained_type_of_inductive : mind_specif puniverses -> types constrained
 
@@ -165,3 +167,11 @@ val check_fix : ?evars:evar_handler -> env -> fixpoint -> unit
 val check_cofix : ?evars:evar_handler -> env -> cofixpoint -> unit
 
 val abstract_mind_lc : int -> int -> MutInd.t -> (rel_context * constr) array -> constr array
+
+module Template : sig
+  val bind_kind : Sorts.t -> int option * int option
+  val template_subst_sort : template_subst -> Sorts.t -> Sorts.t
+
+  (** Qualities must be above_prop  *)
+  val max_template_quality : Sorts.Quality.t -> Sorts.Quality.t -> Sorts.Quality.t
+end

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -51,7 +51,7 @@ type template_univ =
   | TemplateAboveProp of Sorts.QVar.t * Universe.t
   | TemplateUniv of Universe.t
 
-type param_univs = (expected:Univ.Level.t -> template_univ) list
+type param_univs = (default:Sorts.t -> template_univ) list
 
 val instantiate_template_constraints
   : template_univ Univ.Level.Map.t

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -621,7 +621,7 @@ let push_section_context uctx senv =
   let sections = Section.push_local_universe_context uctx sections in
   let senv = { senv with sections=Some sections } in
   let qualities, ctx = UVars.UContext.to_context_set uctx in
-  assert (Sorts.Quality.Set.is_empty qualities);
+  assert (Sorts.QVar.Set.is_empty qualities);
   (* push_context checks freshness *)
   { senv with
     env = Environ.push_context ~strict:false uctx senv.env;

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1148,7 +1148,11 @@ let add_mind l mie senv =
      point. *)
   let senv = match mib.mind_template with
   | None -> senv
-  | Some { template_context = ctx; _ } -> push_context_set ~strict:true ctx senv
+  | Some { template_context = ctx; template_defaults = u; _ } ->
+    let qs, levels = UVars.Instance.levels u in
+    assert (Sorts.Quality.Set.for_all (fun q -> Sorts.Quality.equal Sorts.Quality.qtype q) qs);
+    let csts = UVars.AbstractContext.instantiate u ctx in
+    push_context_set ~strict:true (levels,csts) senv
   in
   (kn, why_not_prim_record), add_checked_mind kn mib senv
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -396,11 +396,11 @@ let check_cast env c ct k expected_type =
    dynamic constraints of the form u<=v are enforced *)
 
 let make_param_univs env indu spec args argtys =
-  Array.to_list @@ Array.mapi (fun i argt ~expected ->
+  Array.to_list @@ Array.mapi (fun i argt ~default ->
       match (snd (Reduction.dest_arity env argt)) with
       | SProp | exception Reduction.NotArity ->
         Type_errors.error_cant_apply_bad_type env
-          (i+1, mkType (Universe.make expected), argt)
+          (i+1, mkSort default, argt)
           (make_judge (mkIndU indu) (Inductive.type_of_inductive (spec, snd indu)))
           (make_judgev args argtys)
       | Prop -> TemplateProp

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -28,7 +28,8 @@ module G = AcyclicGraph.Make(struct
 type t = {
   graph: G.t;
   type_in_type : bool;
-  checking_pseudo_sort_poly : bool;
+  (* above_prop only for checking template poly! *)
+  above_prop_qvars : Sorts.QVar.Set.t;
 }
 
 (* Universe inconsistency: error raised when trying to enforce a relation
@@ -79,7 +80,7 @@ let check_eq_level g u v =
 let empty_universes = {
   graph=G.empty;
   type_in_type=false;
-  checking_pseudo_sort_poly=false;
+  above_prop_qvars=Sorts.QVar.Set.empty;
 }
 
 let initial_universes =
@@ -229,10 +230,7 @@ let check_eq_sort ugraph s1 s2 = match s1, s2 with
 | (QSort _, (Type _ | Set)) | ((Type _ | Set), QSort _) -> false
 
 let is_above_prop ugraph q =
-  ugraph.checking_pseudo_sort_poly
-  && match Sorts.QVar.var_index q with
-  | Some 0 -> true
-  | _ -> false
+  Sorts.QVar.Set.mem q ugraph.above_prop_qvars
 
 let check_leq_sort ugraph s1 s2 = match s1, s2 with
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> true
@@ -309,7 +307,9 @@ let explain_universe_inconsistency default_prq default_prl (printers, (o,u,v,p) 
 
 module Internal = struct
 
-  let for_checking_pseudo_sort_poly g = {g with checking_pseudo_sort_poly=true}
+  let add_template_qvars qvars g =
+    assert (Sorts.QVar.Set.is_empty g.above_prop_qvars);
+    {g with above_prop_qvars=qvars}
 
   let is_above_prop = is_above_prop
 end

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -120,9 +120,9 @@ val explain_universe_inconsistency : (Sorts.QVar.t -> Pp.t) -> (Level.t -> Pp.t)
 val check_universes_invariants : t -> unit
 
 module Internal : sig
-  (** Makes qvar 0 bound and treated as above prop.
+  (** Makes the qvars treated as above prop.
       Do not use outside kernel inductive typechecking. *)
-  val for_checking_pseudo_sort_poly : t -> t
+  val add_template_qvars : Sorts.QVar.Set.t -> t -> t
 
   val is_above_prop : t -> Sorts.QVar.t -> bool
 end

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -344,8 +344,15 @@ struct
     (f inst, (inst, csts))
 
   let to_context_set (_, (inst, csts)) =
-    let qctx, levels = Instance.levels inst in
-    qctx, (levels, csts)
+    let qs, us = Instance.to_array inst in
+    let us = Array.fold_left (fun acc x -> Level.Set.add x acc) Level.Set.empty us in
+    let qs = Array.fold_left (fun acc -> function
+        | Sorts.Quality.QVar x -> Sorts.QVar.Set.add x acc
+        | Sorts.Quality.QConstant _ -> assert false)
+        Sorts.QVar.Set.empty
+        qs
+    in
+    qs, (us, csts)
 
 end
 

--- a/kernel/uVars.mli
+++ b/kernel/uVars.mli
@@ -139,7 +139,7 @@ sig
   val of_context_set : (Instance.t -> bound_names) -> QVar.Set.t -> ContextSet.t -> t
   (** Build a vector of universe levels assuming a function generating names *)
 
-  val to_context_set : t -> Quality.Set.t * ContextSet.t
+  val to_context_set : t -> QVar.Set.t * ContextSet.t
   (** Discard the names and order of the universes *)
 
 end

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -349,6 +349,7 @@ struct
   module Set = CSet.Make(Self)
 
   let make l = tip (Expr.make l)
+  let maken l n = tip (l, n)
   let tip x = tip x
 
   let pr f l = match l with

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -116,6 +116,9 @@ sig
   val make : Level.t -> t
   (** Create a universe representing the given level. *)
 
+  val maken : Level.t -> int -> t
+  (** Composition of [make] and iterated [super]. *)
+
   val pr : (Level.t -> Pp.t) -> t -> Pp.t
   (** Pretty-printing *)
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -182,11 +182,11 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
     | _ -> EConstr.map !evdref (refresh_term_evars ~onevars ~top:false) t
   and refresh_polymorphic_positions args pos =
     let rec aux i = function
-      | true :: ls ->
+      | Some _ :: ls ->
         if i < Array.length args then
           ignore(refresh_term_evars ~onevars:true ~top:false args.(i));
         aux (succ i) ls
-      | false :: ls ->
+      | None :: ls ->
         if i < Array.length args then
           ignore(refresh_term_evars ~onevars:false ~top:false args.(i));
         aux (succ i) ls

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -624,18 +624,12 @@ let declare_prop_but_default_dependent_elim i =
 let is_prop_but_default_dependent_elim i = Indset_env.mem i !prop_but_default_dependent_elim
 
 let pseudo_sort_family_for_elim ind mip =
-  let s = match mip.mind_arity with
-    | RegularArity a -> a.mind_sort
-    | TemplateArity a -> a.template_level
-  in
+  let s = mip.mind_sort in
   if Sorts.is_prop s && is_prop_but_default_dependent_elim ind then InType
   else Sorts.family s
 
 let is_in_prop mip =
-  let s = match mip.mind_arity with
-    | RegularArity a -> a.mind_sort
-    | TemplateArity a -> a.template_level
-  in
+  let s = mip.mind_sort in
   Sorts.is_prop s
 
 let default_case_analysis_dependence env ind =

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -720,56 +720,6 @@ let arity_of_case_predicate env (ind,params) dep k =
   let concl = if dep then mkArrow mind r (mkSort k) else mkSort k in
   it_mkProd_or_LetIn concl arsign
 
-(***********************************************)
-(* Inferring the sort of parameters of a polymorphic inductive type
-   knowing the sort of the conclusion *)
-
-let univ_level_mem l s = match s with
-| Prop | Set | SProp -> false
-| Type u -> Univ.univ_level_mem l u
-| QSort (_, u) -> assert false (* template cannot contain sort variables *)
-
-(* Compute the inductive argument types: replace the sorts
-   that appear in the type of the inductive by the sort of the
-   conclusion, and the other ones by fresh universes. *)
-let rec instantiate_universes env evdref scl is = function
-  | (LocalDef _ as d)::sign, exp ->
-    EConstr.of_rel_decl d :: instantiate_universes env evdref scl is (sign, exp)
-  | d::sign, false::exp ->
-    EConstr.of_rel_decl d :: instantiate_universes env evdref scl is (sign, exp)
-  | (LocalAssum (na,ty))::sign, true::exp ->
-      let ctx,s = Reduction.dest_arity env ty in
-      let l = match s with Type u -> Option.get @@ Univ.Universe.level u | _ -> assert false in
-      let u = Univ.Universe.make l in
-      let s =
-        (* Does the sort of parameter [u] appear in (or equal)
-           the sort of inductive [is] ? *)
-        if univ_level_mem l is then
-          scl (* constrained sort: replace by scl *)
-        else
-          (* unconstrained sort: replace by fresh universe *)
-          let evm, s = Evd.new_sort_variable Evd.univ_flexible !evdref in
-          let evm = Evd.set_leq_sort evm s (EConstr.ESorts.make (Sorts.sort_of_univ u)) in
-            evdref := evm; s
-      in
-      let ctx = EConstr.of_rel_context ctx in
-      let na = EConstr.of_binder_annot na in
-      (LocalAssum (na, mkArity (ctx, s))) :: instantiate_universes env evdref scl is (sign, exp)
-  | sign, [] -> EConstr.of_rel_context sign (* Uniform parameters are exhausted *)
-  | [], _ -> assert false
-
-let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
-  match mib.mind_template with
-  | None -> sigma, subst_instance_constr u (EConstr.of_constr mip.mind_user_arity)
-  | Some templ ->
-    let _,scl = splay_arity env sigma conclty in
-    let ctx = List.rev mip.mind_arity_ctxt in
-    let evdref = ref sigma in
-    let ctx =
-      instantiate_universes
-        env evdref scl mip.mind_sort (ctx,templ.template_param_arguments) in
-    !evdref, mkArity (List.rev ctx, scl)
-
 let type_of_projection_constant env (p,u) =
   let _, pty = lookup_projection p env in
   EConstr.Vars.subst_instance_constr u (EConstr.of_constr pty)

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -231,11 +231,6 @@ val compute_projections : Environ.env -> inductive -> (constr * types) array
     projection and its type. *)
 
 (********************)
-
-val type_of_inductive_knowing_conclusion :
-  env -> evar_map -> mind_specif puniverses -> EConstr.types -> evar_map * EConstr.types
-
-(********************)
 val control_only_guard : env -> Evd.evar_map -> EConstr.types -> unit
 
 val error_not_allowed_dependent_analysis : Environ.env -> bool -> Names.inductive -> Pp.t

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -47,9 +47,6 @@ val get_judgment_of : env -> evar_map -> constr -> unsafe_judgment
 val type_of_global_reference_knowing_parameters : env -> evar_map -> constr ->
   constr array -> types
 
-val type_of_global_reference_knowing_conclusion :
-  env -> evar_map -> constr -> types -> evar_map * types
-
 val sorts_of_context : env -> evar_map -> rel_context -> ESorts.t list
 
 val expand_projection : env -> evar_map -> Names.Projection.t -> constr -> constr list -> constr

--- a/pretyping/templateArity.ml
+++ b/pretyping/templateArity.ml
@@ -30,10 +30,7 @@ let get_template_arity env ind ~ctoropt =
   in
   let can_be_prop, type_after_params = match ctoropt with
     | None ->
-      let s = match mip.mind_arity with
-        | RegularArity _ -> assert false
-        | TemplateArity { template_level = s } -> s
-      in
+      let s = mip.mind_sort in
       let ctx = List.rev @@ List.skipn (List.length mib.mind_params_ctxt) @@
         List.rev mip.mind_arity_ctxt
       in

--- a/pretyping/templateArity.ml
+++ b/pretyping/templateArity.ml
@@ -12,15 +12,17 @@ open Util
 open Names
 open EConstr
 
+type template_binder = {
+  bind_sort : Sorts.t;
+  default : Sorts.t;
+}
+
 type template_arity =
   | NonTemplateArg of Name.t binder_annot * types * template_arity
-  | TemplateArg of Name.t binder_annot * rel_context * Univ.Level.t * template_arity
+  | TemplateArg of Name.t binder_annot * rel_context * template_binder * template_arity
   | DefParam of Name.t binder_annot * constr * types * template_arity
   | CtorType of Declarations.template_universes * types
   | IndType of Declarations.template_universes * rel_context * Sorts.t
-
-(* be Prop if all these levels are Prop *)
-type template_can_be_prop = { template_can_be_prop : Univ.Level.Set.t option }
 
 let get_template_arity env ind ~ctoropt =
   let mib, mip = Inductive.lookup_mind_specif env ind in
@@ -28,42 +30,17 @@ let get_template_arity env ind ~ctoropt =
     | None -> assert false
     | Some t -> t
   in
-  let can_be_prop, type_after_params = match ctoropt with
+  let type_after_params = match ctoropt with
     | None ->
-      let s = mip.mind_sort in
       let ctx = List.rev @@ List.skipn (List.length mib.mind_params_ctxt) @@
         List.rev mip.mind_arity_ctxt
       in
-      let template_can_be_prop = match template.template_pseudo_sort_poly with
-        | TemplateUnivOnly -> None
-        | TemplatePseudoSortPoly ->
-          (* we still need to check which levels are used in the conclusion *)
-          match s with
-          | SProp | Prop | Set -> None
-          | QSort _ -> assert false
-          | Type u ->
-            (* if all template levels are instantiated to Prop, do we get Prop?
-               XXX skip this check and trust that only actually pseudo sort poly inductives
-               are declared pseudo sort poly? *)
-            let template_levels = Univ.ContextSet.levels template.template_context in
-            if List.exists (fun (u,n) -> n > 0 || not (Univ.Level.Set.mem u template_levels))
-                (Univ.Universe.repr u)
-            then None
-            else
-              (* don't use the qvar for non used univs
-                 eg with "Ind (A:Type@{u}) (B:Type@{v}) : Type@{u}"
-                 "Ind True nat" should be Prop *)
-              let used_template_levels =
-                Univ.Level.Set.inter template_levels (Univ.Universe.levels u)
-              in
-              Some used_template_levels
-      in
-      { template_can_be_prop }, IndType (template, EConstr.of_rel_context ctx, s)
+      IndType (template, EConstr.of_rel_context ctx, template.template_concl)
     | Some ctor ->
       let ctyp = mip.mind_user_lc.(ctor-1) in
       let _, ctyp = Term.decompose_prod_n_decls (List.length mib.mind_params_ctxt) ctyp in
       (* don't bother with Prop for constructors *)
-      { template_can_be_prop = None}, CtorType (template, EConstr.of_constr ctyp)
+      CtorType (template, EConstr.of_constr ctyp)
   in
   let rec aux is_template (params:Constr.rel_context) = match is_template, params with
     | _, LocalDef (na,v,t) :: params ->
@@ -71,20 +48,15 @@ let get_template_arity env ind ~ctoropt =
       DefParam (EConstr.of_binder_annot na, EConstr.of_constr v, EConstr.of_constr t, codom)
     | [], [] -> type_after_params
     | _ :: _, [] | [], LocalAssum _ :: _ -> assert false
-    | false :: is_template, LocalAssum (na,t) :: params ->
+    | None :: is_template, LocalAssum (na,t) :: params ->
       let codom = aux is_template params in
       NonTemplateArg (EConstr.of_binder_annot na, EConstr.of_constr t, codom)
-    | true :: is_template, LocalAssum (na,t) :: params ->
-      let ctx, c = Term.decompose_prod_decls t in
-      let u = match Constr.kind c with
-        | Sort (Type u) -> begin match Univ.Universe.level u with
-            | Some u -> u
-            | None -> assert false
-          end
-        | _ -> assert false
-      in
+    | Some bind_sort :: is_template, LocalAssum (na,t) :: params ->
+      let ctx, _ = Term.decompose_prod_decls t in
       let codom = aux is_template params in
-      TemplateArg (EConstr.of_binder_annot na, EConstr.of_rel_context ctx, u, codom)
+      let default = UVars.subst_instance_sort template.template_defaults bind_sort in
+      let binder = { bind_sort; default } in
+      TemplateArg (EConstr.of_binder_annot na, EConstr.of_rel_context ctx, binder, codom)
   in
   let res = aux template.template_param_arguments (List.rev mib.mind_params_ctxt) in
-  can_be_prop, res
+  res

--- a/pretyping/templateArity.mli
+++ b/pretyping/templateArity.mli
@@ -11,22 +11,24 @@
 open Names
 open EConstr
 
+type template_binder = {
+  bind_sort : Sorts.t;
+  default : Sorts.t;
+}
+
 (** NB: the types and rel_contexts may mention previous args
    eg "sigT : forall A, (A -> Type) -> Type" is
    "TemplateArg ([], u, TemplateArg ([_:Rel 1], v, IndType (_, [], Type@{max(u,v)})))"
    note the "Rel 1" *)
 type template_arity =
   | NonTemplateArg of Name.t binder_annot * types * template_arity
-  | TemplateArg of Name.t binder_annot * rel_context * Univ.Level.t * template_arity
+  | TemplateArg of Name.t binder_annot * rel_context * template_binder * template_arity
   | DefParam of Name.t binder_annot * constr * types * template_arity
   | CtorType of Declarations.template_universes * types
   | IndType of Declarations.template_universes * rel_context * Sorts.t
-
-(** be Prop if all these levels are Prop *)
-type template_can_be_prop = { template_can_be_prop : Univ.Level.Set.t option }
 
 val get_template_arity
   : Environ.env
   -> Names.inductive
   -> ctoropt:int option
-  -> template_can_be_prop * template_arity
+  -> template_arity

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -35,7 +35,8 @@ let fresh_template_context env0 sigma ind (mib, mip as spec) args =
   | [] -> sigma, List.rev sorts
   | LocalAssum (na, t) as decl :: ctx ->
     let sigma, decl, s =
-      if templ.(i) then
+      match templ.(i) with
+      | Some _ ->
         let decls, s0 = Reductionops.dest_arity env sigma t in
         let sigma, s =
           if i < Array.length args then match Reductionops.sort_of_arity env sigma args.(i).uj_type with
@@ -58,7 +59,7 @@ let fresh_template_context env0 sigma ind (mib, mip as spec) args =
         | Sorts.Type u | Sorts.QSort (_, u) -> TemplateUniv u
         in
         sigma, LocalAssum (na, t), s
-      else
+      | None ->
         sigma, decl, (fun ~default -> assert false)
     in
     freshen (i + 1) (push_rel decl env) sigma (decl :: accu) (s :: sorts) ctx

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -44,13 +44,13 @@ let fresh_template_context env0 sigma ind (mib, mip as spec) args =
           else sigma, s0
         in
         let t = EConstr.it_mkProd_or_LetIn (mkSort s) decls in
-        let s ~expected = match ESorts.kind sigma s with
+        let s ~default = match ESorts.kind sigma s with
         | Sorts.SProp ->
           let indty = EConstr.of_constr @@
             Inductive.type_of_inductive (spec, UVars.Instance.empty)
           in
           error_cant_apply_bad_type env0 sigma
-            (i+1, mkType (Univ.Universe.make expected), args.(i).uj_type)
+            (i+1, mkSort (ESorts.make default), args.(i).uj_type)
             (make_judge (mkIndU (ind, EInstance.empty)) indty)
             args
         | Sorts.Prop -> TemplateProp
@@ -59,7 +59,7 @@ let fresh_template_context env0 sigma ind (mib, mip as spec) args =
         in
         sigma, LocalAssum (na, t), s
       else
-        sigma, decl, (fun ~expected -> assert false)
+        sigma, decl, (fun ~default -> assert false)
     in
     freshen (i + 1) (push_rel decl env) sigma (decl :: accu) (s :: sorts) ctx
   | LocalDef (na, b, t) as decl :: ctx ->

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -124,7 +124,8 @@ let get_type_of_with_metas ~metas env sigma c =
 
 let refresh_template_constraints ~metas env sigma ind c =
   let (mib, _) as spec = Inductive.lookup_mind_specif env ind in
-  let (_, cstrs0) = (Option.get mib.mind_template).template_context in
+  let ctx = (Option.get mib.mind_template).template_context in
+  let cstrs0 = UVars.UContext.constraints @@ UVars.AbstractContext.repr ctx in
   if Univ.Constraints.is_empty cstrs0 then sigma
   else
     let _, allargs = decompose_app sigma c in
@@ -235,8 +236,8 @@ let clenv_environments env sigma template bound t =
           let na' = if dep then na.binder_name else Anonymous in
           let sigma, t1, templ, tmpl = match templ with
           | [] -> sigma, t1, templ, None
-          | false :: templ -> sigma, t1, templ, None
-          | true :: templ ->
+          | None :: templ -> sigma, t1, templ, None
+          | Some _ :: templ ->
             let decls, _ = Reductionops.dest_arity env sigma t1 in
             let sigma, s = Evd.new_univ_level_variable Evd.univ_flexible_alg sigma in
             let t1 = EConstr.it_mkProd_or_LetIn (EConstr.mkType (Univ.Universe.make s)) decls in

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -49,7 +49,7 @@ End No.
 
 Module ExplicitTemplate.
   #[universes(template)]
-  Inductive identity@{i} (A : Type@{i}) (a : A) : A -> Type@{i} := id_refl : identity A a a.
+  Inductive identity@{i} (A : Type@{i}) (a : A) : A -> Type@{i} := id_refl (_:A) : identity A a a.
 
   (* There used to be a weird interaction of template polymorphism and inductive
      types which fall in Prop due to kernel sort inference. This inductive is
@@ -59,7 +59,24 @@ Module ExplicitTemplate.
      from the kernel. Now the universe annotation is respected by the kernel. *)
   Fail Check (identity Type nat nat : Prop).
   Check (identity True I I : Prop).
+  Check identity nat 0 0 : Set.
+  Fail Check identity Type nat nat : Set.
+  Check identity Type nat nat : Type.
 End ExplicitTemplate.
+
+Module ExplicitTemplate2.
+  #[universes(template)]
+  Inductive identity@{i} (A : Type@{i}) (a : A) : A -> Type@{i} := id_refl : identity A a a.
+  (* we generate fresh qualities for A and the conclusion, and they end up unrelated
+     therefore the conclusion quality has no binders,
+     we can't make it a template poly quality and instead collapse to Type *)
+
+  Fail Check (identity Type nat nat : Prop).
+  Fail Check (identity True I I : Prop).
+  Check identity nat 0 0 : Set.
+  Fail Check identity Type nat nat : Set.
+  Check identity Type nat nat : Type.
+End ExplicitTemplate2.
 
 Polymorphic Definition f@{i} : Type@{i} := nat.
 Polymorphic Definition baz@{i} : Type@{i} -> Type@{i} := fun x => x.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -142,8 +142,9 @@ let get_inductive_deps ~noprop env kn =
             List.fold_left (aux env) accu a
           else
             let _,mip = Inductive.lookup_mind_specif env ind in
-            (* Types in SProp have trivial equality and are skipped *)
-            if match mip.mind_arity with RegularArity {mind_sort = SProp} -> true | _ -> false then
+            (* Types in SProp have trivial equality and are skipped
+               XXX should be substituting polymorphic universes *)
+            if Sorts.is_sprop mip.mind_sort then
               List.fold_left (aux env) accu a
             else
               List.fold_left (aux env) (kn' :: accu) a

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -53,7 +53,7 @@ type t = {
   mie : Entries.mutual_inductive_entry;
   default_dep_elim : DeclareInd.default_dep_elim list;
   nuparams : int option;
-  univ_binders : UnivNames.universe_binders;
+  univ_binders : UState.named_universes_entry;
   implicits : DeclareInd.one_inductive_impls list;
   uctx : Univ.ContextSet.t;
   where_notations : Metasyntax.notation_interpretation_decl list;
@@ -93,7 +93,12 @@ val interp_mutual_inductive_constr
   -> env_ar:Environ.env
   (** Environment with the inductives in the rel_context *)
   -> private_ind:bool
-  -> DeclareInd.default_dep_elim list * Entries.mutual_inductive_entry * UnivNames.universe_binders * Univ.ContextSet.t
+  -> DeclareInd.default_dep_elim list
+     * Entries.mutual_inductive_entry
+     * (* for global universe names, used by DeclareInd *)
+     UState.named_universes_entry
+     * (* global universes to declare before the inductive (ie without the template univs) *)
+     Univ.ContextSet.t
 
 (************************************************************************)
 (** Internal API, exported for Record                                   *)

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -230,9 +230,7 @@ let declare_mutual_inductive_with_eliminations ?typing_flags ?(indlocs=[]) ?defa
             | DefaultElim ->
               default_prop_dep_elim () &&
               let _, mip = Global.lookup_inductive ind in
-              match mip.mind_arity with
-              | RegularArity ar -> Sorts.is_prop ar.mind_sort
-              | TemplateArity ar -> Sorts.is_prop ar.template_level
+              Sorts.is_prop mip.mind_sort
           in
           if prop_but_default_dep_elim then
             Indrec.declare_prop_but_default_dependent_elim ind)

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -25,7 +25,7 @@ val declare_mutual_inductive_with_eliminations
   -> ?indlocs:indlocs
   -> ?default_dep_elim:default_dep_elim list
   -> Entries.mutual_inductive_entry (* Inductive types declaration *)
-  -> UState.named_universes_entry
+  -> UState.named_universes_entry (* Global universes, including the template default instance *)
   -> one_inductive_impls list (* Implicit arguments *)
   -> Names.MutInd.t
 

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -255,10 +255,7 @@ let print_squash env ref udecl = match ref with
       let inst = if fst @@ UVars.AbstractContext.size univs = 0 then mt()
         else Printer.pr_universe_instance sigma (UVars.make_abstract_instance univs)
       in
-      let inds = match mip.mind_arity with
-        | TemplateArity a -> a.template_level
-        | RegularArity a -> a.mind_sort
-      in
+      let inds = mip.mind_sort in
       let target = match inds with
           | SProp -> str "SProp"
           | Prop -> str "SProp or Prop"

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -885,7 +885,7 @@ let declare_structure (decl:Record_decl.t) =
       ~indlocs:decl.indlocs
       ~default_dep_elim
   in
-  let map i (ind_entry, { RecordEntry.inhabitant_id; implfs }, { Data.is_coercion; proj_flags; }) =
+  let map i ({ RecordEntry.inhabitant_id; implfs }, { Data.is_coercion; proj_flags; }) =
     let rsp = (kn, i) in (* This is ind path of idstruc *)
     let cstr = (rsp, 1) in
     let kind = decl.projections_kind in
@@ -899,7 +899,7 @@ let declare_structure (decl:Record_decl.t) =
     let () = declare_structure_entry struc in
     GlobRef.IndRef rsp
   in
-  let data = List.combine3 decl.entry.mie.mind_entry_inds decl.entry.ind_infos decl.records in
+  let data = List.combine decl.entry.ind_infos decl.records in
   let inds = List.mapi map data in
   Declared.Record kn, inds
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -207,7 +207,7 @@ module RecordEntry = struct
 
   type t = {
     global_univs : Univ.ContextSet.t;
-    ubinders : UnivNames.universe_binders;
+    ubinders : UState.named_universes_entry;
     mie : Entries.mutual_inductive_entry;
     ind_infos : one_ind_info list;
     param_impls : Impargs.manual_implicits;
@@ -709,7 +709,6 @@ module Record_decl = struct
   type t = {
     entry : RecordEntry.t;
     records : Data.t list;
-    globnames : UState.named_universes_entry;
     projections_kind : Decls.definition_object_kind;
     indlocs : DeclareInd.indlocs;
   }
@@ -842,17 +841,8 @@ let pre_process_structure udecl kind ~flags ~primitive_proj (records : Ast.t lis
   entry, projections_kind, decl_data, indlocs
 
 let interp_structure_core (entry:RecordEntry.t) ~projections_kind ~indlocs data =
-  let globnames = match entry.mie.mind_entry_universes with
-    | Monomorphic_ind_entry ->
-      (UState.Monomorphic_entry entry.global_univs, entry.ubinders)
-    | Template_ind_entry ctx ->
-      (UState.Monomorphic_entry (Univ.ContextSet.union entry.global_univs ctx.univs), entry.ubinders)
-    | Polymorphic_ind_entry uctx ->
-      (UState.Polymorphic_entry uctx, UnivNames.empty_binders)
-  in
   let open Record_decl in
   { entry;
-    globnames;
     projections_kind;
     records = data;
     indlocs;
@@ -880,7 +870,7 @@ let declare_structure (decl:Record_decl.t) =
   let default_dep_elim = List.map (fun x -> x.RecordEntry.default_dep_elim) decl.entry.ind_infos in
   let kn =
     DeclareInd.declare_mutual_inductive_with_eliminations decl.entry.mie
-      decl.globnames
+      decl.entry.ubinders
       impls
       ~indlocs:decl.indlocs
       ~default_dep_elim

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -60,7 +60,7 @@ module RecordEntry : sig
 
   type t = {
     global_univs : Univ.ContextSet.t;
-    ubinders : UnivNames.universe_binders;
+    ubinders : UState.named_universes_entry;
     mie : Entries.mutual_inductive_entry;
     ind_infos : one_ind_info list;
     param_impls : Impargs.manual_implicits;
@@ -73,7 +73,6 @@ module Record_decl : sig
   type t = {
     entry : RecordEntry.t;
     records : Data.t list;
-    globnames : UState.named_universes_entry;
     projections_kind : Decls.definition_object_kind;
     indlocs : DeclareInd.indlocs;
   }


### PR DESCRIPTION
This slightly changes behaviour for inductives which don't really need
template, eg `Inductive foo (A:Type@{i}) : Type@{i} := .` is now not
pseudo sort poly because the parameter and conclusion qualities end up
unrelated, so the conclusion quality has no binders and must be
collapsed to Type.

There is currently no way to explicitly specify it, as
`Inductive foo@{q|i|} ...` won't work because the named `q` can't be
made above prop (and we need it above prop for evar normalization to
substitute it away in relevances).

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/637
- https://github.com/LPCIC/coq-elpi/pull/766
- https://github.com/ejgallego/coq-lsp/pull/902
- https://github.com/MetaCoq/metacoq/pull/1145
- https://github.com/coq-community/paramcoq/pull/134