### PR TITLE
Rename and tweak Modops.add_module_type.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -227,7 +227,7 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
 let rec check_mexpression env opac sign mbtyp mp_mse res = match sign with
   | MEMoreFunctor body ->
     let arg_id, mtb, mbtyp = Modops.destr_functor mbtyp in
-    let env' = Modops.add_module_type (MPbound arg_id) mtb env in
+    let env' = Modops.add_module_parameter arg_id mtb env in
     let body, delta = check_mexpression env' opac body mbtyp mp_mse res in
     MoreFunctor(arg_id,mtb,body), delta
   | MENoFunctor me -> check_mexpr env opac me mp_mse res
@@ -254,7 +254,6 @@ let rec check_module env opac mp mb opacify =
   | Some (sign,delta) ->
     let mtb1 = mk_mtb sign delta
     and mtb2 = mk_mtb (mod_type mb) delta_mb in
-    let env = Modops.add_module_type mp mtb1 env in
     let state = (Environ.universes env, Conversion.checked_universes) in
     let _ : UGraph.t = Subtyping.check_subtypes state env mp mtb1 mp mtb2 in
     ()
@@ -290,7 +289,7 @@ and check_structure_field env opac mp lab res opacify = function
 and check_signature env opac sign mp_mse res opacify = match sign with
   | MoreFunctor (arg_id, mtb, body) ->
       let () = check_module_type env (MPbound arg_id) mtb in
-      let env' = Modops.add_module_type (MPbound arg_id) mtb env in
+      let env' = Modops.add_module_parameter arg_id mtb env in
       let opac = check_signature env' opac body mp_mse res Cset.empty in
       opac
   | NoFunctor struc ->

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -302,7 +302,7 @@ let rec translate_mse_funct (cst, ustate) (vm, vmstate) env ~is_mod mp inl mse =
   | (mbid, ty, ty_inl) :: params ->
     let mp_id = MPbound mbid in
     let mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp_id ty_inl ([],ty) in
-    let env' = add_module_type mp_id mtb env in
+    let env' = add_module_parameter mbid mtb env in
     let sign,alg,reso,cst,vm = translate_mse_funct (cst, ustate) (vm, vmstate) env' ~is_mod mp inl mse params in
     let alg' = MEMoreFunctor alg in
     MoreFunctor (mbid, mtb, sign), alg',reso, cst, vm

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -203,8 +203,8 @@ let add_structure mp sign resolver env =
 let add_module mp mb env =
   add_module mp mb no_link_info env
 
-let add_module_type mp mtb env =
-  add_module mp (module_body_of_type mtb) env
+let add_module_parameter mbid mtb env =
+  add_module (MPbound mbid) (module_body_of_type mtb) env
 
 (** {6 Strengthening a signature for subtyping } *)
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -55,8 +55,8 @@ val add_module : ModPath.t -> module_body -> env -> env
 the native compiler. The linking information is updated. *)
 val add_linked_module : ModPath.t -> module_body -> link_info -> env -> env
 
-(** same, for a module type *)
-val add_module_type : ModPath.t -> module_type_body -> env -> env
+(** add an abstract module parameter to the environment *)
+val add_module_parameter : MBId.t -> module_type_body -> env -> env
 
 val add_retroknowledge : Retroknowledge.action list -> env -> env
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1186,9 +1186,6 @@ let full_add_module mp mb senv =
   let linkinfo = Nativecode.link_info_of_dirpath dp in
   { senv with env = Modops.add_linked_module mp mb linkinfo senv.env }
 
-let full_add_module_type mp mt senv =
-  { senv with env = Modops.add_module_type mp mt senv.env }
-
 (** Insertion of modules *)
 
 let add_module l me inl senv =
@@ -1249,7 +1246,7 @@ let add_module_parameter mbid mte inl senv =
   let vmstate = vm_state senv in
   let mtb, _, vmtab = Mod_typing.translate_modtype state vmstate senv.env mp inl ([],mte) in
   let senv = set_vm_library vmtab senv in
-  let senv = full_add_module_type mp mtb senv in
+  let senv = { senv with env = Modops.add_module_parameter mbid mtb senv.env } in
   let new_variant = match senv.modvariant with
     | STRUCT (params,oldenv) -> STRUCT ((mbid,mtb) :: params, oldenv)
     | SIG (params,oldenv) -> SIG ((mbid,mtb) :: params, oldenv)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -295,7 +295,7 @@ and check_signatures (cst, ustate) trace env mp1 sig1 mp2 sig2 subst1 subst2 res
             in
             let mp1' = MPdot (mp1, l) in
             let mp2' = MPdot (mp2, l) in
-            let env = add_module_type mp2' mtb2 (add_module_type mp1' mtb1 env) in
+            let env = add_module mp2' (module_body_of_type mtb2) (add_module mp1' (module_body_of_type mtb1) env) in
             check_modtypes (cst, ustate) (Submodule l :: trace) env mp1' mtb1 mp2' mtb2 subst1 subst2 true
   in
     List.fold_left check_one_body cst sig2
@@ -329,7 +329,7 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 equiv
         let mparg1 = MPbound arg_id1 in
         let mparg2 = MPbound arg_id2 in
         let subst1 = join (map_mbid arg_id1 mparg2 (mod_delta arg_t2)) subst1 in
-        let env = add_module_type mparg2 arg_t2 env in
+        let env = add_module_parameter arg_id2 arg_t2 env in
         let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 arg_t2 mparg1 arg_t1 subst2 subst1 equiv in
         (* contravariant *)
         let env =
@@ -344,7 +344,7 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 equiv
     check_structure cst ~nargs:0 env (mod_type mtb1) (mod_type mtb2) equiv subst1 subst2
 
 let check_subtypes state env mp_sup sup mp_super super =
-  let env = add_module_type mp_sup sup env in
+  let env = add_module mp_sup (module_body_of_type sup) env in
   check_modtypes state [] env
     mp_sup (strengthen sup mp_sup) mp_super super empty_subst
     (map_mp mp_super mp_sup (mod_delta sup)) false

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -266,7 +266,7 @@ and extract_mexpression_spec env mp1 (me_struct,me_alg) = match me_alg with
       | _ -> assert false
       in
       let mp = MPbound mbid in
-      let env' = Modops.add_module_type mp mtb env in
+      let env' = Modops.add_module_parameter mbid mtb env in
       MTfunsig (mbid, extract_mbody_spec env mp mtb,
                 extract_mexpression_spec env' mp1 (me_struct',me_alg'))
   | MENoFunctor m -> extract_mexpr_spec env mp1 (Some me_struct,m)
@@ -277,7 +277,7 @@ and extract_msignature_spec env mp1 reso = function
       MTsig (mp1, extract_structure_spec env' mp1 reso struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp = MPbound mbid in
-      let env' = Modops.add_module_type mp mtb env in
+      let env' = Modops.add_module_parameter mbid mtb env in
       MTfunsig (mbid, extract_mbody_spec env mp mtb,
                 extract_msignature_spec env' mp1 reso me)
 
@@ -371,7 +371,7 @@ and extract_mexpression access env mp mty = function
       | NoFunctor _ -> assert false
       in
       let mp1 = MPbound mbid in
-      let env' = Modops.add_module_type mp1 mtb	env in
+      let env' = Modops.add_module_parameter mbid mtb env in
       Miniml.MEfunctor
         (mbid,
          extract_mbody_spec env mp1 mtb,
@@ -383,7 +383,7 @@ and extract_msignature access env mp reso ~all = function
       Miniml.MEstruct (mp,extract_structure access env' mp reso ~all struc)
   | MoreFunctor (mbid, mtb, me) ->
       let mp1 = MPbound mbid in
-      let env' = Modops.add_module_type mp1 mtb	env in
+      let env' = Modops.add_module_parameter mbid mtb env in
       Miniml.MEfunctor
         (mbid,
          extract_mbody_spec env mp1 mtb,

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -362,7 +362,7 @@ let rec print_functor fty fatom is_type extent env mp used locals = function
       let () = used := Id.Set.add id !used in
       let mp1 = MPbound mbid in
       let pr_mtb1 = fty extent env mp1 used locals mtb1 in
-      let env' = Modops.add_module_type mp1 mtb1 env in
+      let env' = Modops.add_module_parameter mbid mtb1 env in
       let locals' = (mbid, get_new_id locals (MBId.to_id mbid))::locals in
       let kwd = if is_type then "Funsig" else "Functor" in
       hov 2


### PR DESCRIPTION
Despite the name and the comment in the mli file, rather than adding a module type, this function is actually used to add an abstract module parameter to the environment.

This revealed that in module checking we added the module twice, since subtyping was already adding the argument to the environment.