### PR TITLE
Add Ltac2.Option.{is_some,is_none,compare,join,iter}

### DIFF
--- a/doc/changelog/06-Ltac2-language/20184-ltac2-option-is-some-none.rst
+++ b/doc/changelog/06-Ltac2-language/20184-ltac2-option-is-some-none.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``Ltac2.Option.is_some``, ``Ltac2.Option.is_none``, ``Ltac2.Option.compare``,
+  ``Ltac2.Option.join``, ``Ltac2.Option.iter``
+  (`#20184 <https://github.com/coq/coq/pull/20184>`_,
+  by Jason Gross).

--- a/user-contrib/Ltac2/Option.v
+++ b/user-contrib/Ltac2/Option.v
@@ -25,6 +25,12 @@ Ltac2 map (f : 'a -> 'b) (ov : 'a option) :=
   | None => None
   end.
 
+Ltac2 iter (f : 'a -> unit) (ov : 'a option) :=
+  match ov with
+  | Some v => f v
+  | None => ()
+  end.
+
 Ltac2 default (def : 'a) (ov : 'a option) :=
   match ov with
   | Some v => v
@@ -55,6 +61,12 @@ Ltac2 bind (x : 'a option) (f : 'a -> 'b option) :=
   | None => None
   end.
 
+Ltac2 join (x : 'a option option) :=
+  match x with
+  | Some x => x
+  | None => None
+  end.
+
 Ltac2 ret (x : 'a) := Some x.
 
 Ltac2 lift (f : 'a -> 'b) (x : 'a option) := map f x.
@@ -70,3 +82,24 @@ Ltac2 equal (eq : 'a -> 'b -> bool) (a : 'a option) (b : 'b option) : bool
                  | _ => false
                  end
      end.
+
+Ltac2 compare (cmp : 'a -> 'b -> int) (a : 'a option) (b : 'b option) :=
+  match a, b with
+  | Some a, Some b => cmp a b
+  | None, None => 0
+  | None, Some _ => -1
+  | Some _, None => 1
+  end.
+
+
+Ltac2 is_some (a : 'a option) :=
+  match a with
+  | Some _ => true
+  | None => false
+  end.
+
+Ltac2 is_none (a : 'a option) :=
+  match a with
+  | Some _ => false
+  | None => true
+  end.


### PR DESCRIPTION
These are the missing functions from https://ocaml.org/manual/5.2/api/Option.html

- [ ] Added / updated **test-suite**.
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
