### PR TITLE
`Ltac2.Control` {throw,assert} functions take formats

### DIFF
--- a/doc/changelog/06-Ltac2-language/20186-ltac2-better-error-messages.rst
+++ b/doc/changelog/06-Ltac2-language/20186-ltac2-better-error-messages.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  ``Ltac2.Control.throw_invalid_argument``,
+  ``Ltac2.Control.throw_out_of_bounds``,
+  ``Ltac2.Control.assert_valid_argument``, ``Ltac2.Control.assert_bounds``, and
+  ``Ltac2.Control.backtrack_tactic_failure`` now take printf formats.  The old
+  behavior can be captured for non-literal strings with, e.g.,
+  `Control.backtrack_tactic_failure "%s" msg`.
+  (`#20186 <https://github.com/coq/coq/pull/20186>`_,
+  by Jason Gross).

--- a/test-suite/ltac2/printf.v
+++ b/test-suite/ltac2/printf.v
@@ -46,3 +46,16 @@ Fail Ltac2 Eval print_if true "%a" (fun _ => Control.throw Assertion_failure) ()
 
 (* ikfprintf doesn't run the closure *)
 Ltac2 Eval print_if false "%a" (fun _ => Control.throw Assertion_failure) ().
+
+(* Check printf formatting for control failures *)
+
+Ltac2 Eval match Control.case (fun () => Control.backtrack_tactic_failure "%s" "foo") with
+  | Control.Val _ => Control.throw Assertion_failure
+  | Control.Err (Control.Tactic_failure (Some msg)) => Control.assert_true (String.equal "foo" (Message.to_string msg))
+  | Control.Err _ => Control.throw Assertion_failure
+  end.
+
+Ltac2 check_parsing_throw_invalid_argument () := Control.throw_invalid_argument "%s" "foo".
+Ltac2 check_parsing_throw_out_of_bounds () := Control.throw_out_of_bounds "%s" "foo".
+Ltac2 Eval ignore (Control.assert_valid_argument "%s" "foo" true).
+Ltac2 Eval ignore (Control.assert_bounds "%s" "foo" true).

--- a/user-contrib/Ltac2/Control.v
+++ b/user-contrib/Ltac2/Control.v
@@ -99,23 +99,35 @@ Ltac2 @ external check_interrupt : unit -> unit := "rocq-runtime.plugins.ltac2" 
 
 (** Assertions throwing exceptions and short form throws *)
 
-Ltac2 throw_invalid_argument (msg : string) :=
-  Control.throw (Invalid_argument (Some (Message.of_string msg))).
+Ltac2 throw_invalid_argument fmt :=
+  Message.Format.kfprintf (fun msg => Control.throw (Invalid_argument (Some msg))) fmt.
 
-Ltac2 throw_out_of_bounds (msg : string) :=
-  Control.throw (Out_of_bounds (Some (Message.of_string msg))).
+Ltac2 Notation "throw_invalid_argument" fmt(format) := throw_invalid_argument fmt.
 
-Ltac2 assert_valid_argument (msg : string) (test : bool) :=
-  match test with
-  | true => ()
-  | false => throw_invalid_argument msg
-  end.
+Ltac2 throw_out_of_bounds fmt :=
+  Message.Format.kfprintf (fun msg => Control.throw (Out_of_bounds (Some msg))) fmt.
 
-Ltac2 assert_bounds (msg : string) (test : bool) :=
-  match test with
-  | true => ()
-  | false => throw_out_of_bounds msg
-  end.
+Ltac2 Notation "throw_out_of_bounds" fmt(format) := throw_out_of_bounds fmt.
+
+Ltac2 assert_valid_argument fmt :=
+  Message.Format.kfprintf (fun msg (test : bool) =>
+    match test with
+    | true => ()
+    | false => throw_invalid_argument "%a" (fun () x => x) msg
+    end)
+    fmt.
+
+Ltac2 Notation "assert_valid_argument" fmt(format) := assert_valid_argument fmt.
+
+Ltac2 assert_bounds fmt :=
+  Message.Format.kfprintf (fun msg (test : bool) =>
+    match test with
+    | true => ()
+    | false => throw_out_of_bounds "%a" (fun () x => x) msg
+    end)
+    fmt.
+
+Ltac2 Notation "assert_bounds" fmt(format) := assert_bounds fmt.
 
 Ltac2 assert_true b :=
   if b then () else throw Assertion_failure.
@@ -125,8 +137,10 @@ Ltac2 assert_false b :=
 
 (** Short form backtracks *)
 
-Ltac2 backtrack_tactic_failure (msg : string) :=
-  Control.zero (Tactic_failure (Some (Message.of_string msg))).
+Ltac2 backtrack_tactic_failure fmt :=
+  Message.Format.kfprintf (fun msg => Control.zero (Tactic_failure (Some msg))) fmt.
+
+Ltac2 Notation "backtrack_tactic_failure" fmt(format) := backtrack_tactic_failure fmt.
 
 (** Backtraces. *)
 


### PR DESCRIPTION
This makes it easier to write failure messages like `Control.backtrack_tactic_failure "Expected equality %t = %t" a b`.  The old behavior can be captured for non-literal strings with, e.g., `Control.backtrack_tactic_failure "%s" msg`.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.
- [ ] Opened **overlay** pull requests.
