### PR TITLE
[CI] Fix stdlib-doc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ variables:
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
-  BASE_CACHEKEY: "old_ubuntu_lts-V2024-10-11-f72b1aa7c6"
+  BASE_CACHEKEY: "old_ubuntu_lts-V2025-02-03-12b21803e1"
   EDGE_CACHEKEY: "edge_ubuntu-V2025-01-14-7a5eeda540"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"

--- a/dev/ci/docker/old_ubuntu_lts/Dockerfile
+++ b/dev/ci/docker/old_ubuntu_lts/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         # Dependencies of stdlib and sphinx doc
         texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk \
         python3-pip python3-setuptools python3-pexpect python3-bs4 fonts-freefont-otf \
+        # Dependency of stdlib-doc
+        graphviz \
         # Dependencies of source-doc and coq-makefile
         texlive-science tipa \
         # Dependencies of HB (test suite)


### PR DESCRIPTION
Putting 9.0 milestone in case we want to bump the stdlib pin on the v9.0 branch (not unlikely)