### PR TITLE
Handle queries in rocqshim when possible

### DIFF
--- a/boot/env.ml
+++ b/boot/env.ml
@@ -169,14 +169,21 @@ let print_config ?(prefix_var_name="") env f =
      | Coq_config.NativeOff -> "no"
      | Coq_config.NativeOn {ondemand=true} -> "ondemand")
 
-let print_query ~usage : Usage.query -> unit = function
+let print_query usage : Usage.query -> unit = function
   | PrintVersion -> Usage.version ()
   | PrintMachineReadableVersion -> Usage.machine_readable_version ()
   | PrintWhere ->
     let env = init () in
     let coqlib = coqlib env |> Path.to_string in
     print_endline coqlib
-  | PrintHelp -> Usage.print_usage stderr usage
+  | PrintHelp -> begin match usage with
+      | Some usage -> Usage.print_usage stderr usage
+      | None -> assert false
+    end
   | PrintConfig ->
     let env = init() in
     print_config env stdout
+
+let query_needs_env : Usage.query -> bool = function
+  | PrintVersion | PrintMachineReadableVersion | PrintHelp -> false
+  | PrintWhere | PrintConfig -> true

--- a/boot/env.mli
+++ b/boot/env.mli
@@ -102,6 +102,7 @@ val corelib : t -> Path.t
 (** coq/lib directory, not sure if to keep this *)
 val coqlib : t -> Path.t
 
+(** [camlfind ()] is the path to the ocamlfind binary. *)
 val ocamlfind : unit -> string
 
 val print_config : ?prefix_var_name:string -> t -> out_channel -> unit

--- a/boot/env.mli
+++ b/boot/env.mli
@@ -108,8 +108,12 @@ val docdir : unit -> string
 
 val print_config : ?prefix_var_name:string -> t -> out_channel -> unit
 
-(** Needs a Rocq environment for Where and Config. *)
-val print_query : usage:Usage.specific_usage -> Usage.query -> unit
+(** Needs a Rocq environment for Where and Config.
+    If the [usage] argument is [None], the query must not be PrintHelp. *)
+val print_query : Usage.specific_usage option -> Usage.query -> unit
+
+(** Where and Config need to be able to find coqlib (i.e. -boot won't work) *)
+val query_needs_env : Usage.query -> bool
 
 (** Internal, should be set automatically by passing cmdline args to
    init; note that this will set both [coqlib] and [corelib] for now. *)

--- a/boot/env.mli
+++ b/boot/env.mli
@@ -102,6 +102,15 @@ val corelib : t -> Path.t
 (** coq/lib directory, not sure if to keep this *)
 val coqlib : t -> Path.t
 
+val ocamlfind : unit -> string
+
+val docdir : unit -> string
+
+val print_config : ?prefix_var_name:string -> t -> out_channel -> unit
+
+(** Needs a Rocq environment for Where and Config. *)
+val print_query : usage:Usage.specific_usage -> Usage.query -> unit
+
 (** Internal, should be set automatically by passing cmdline args to
    init; note that this will set both [coqlib] and [corelib] for now. *)
 val set_coqlib : string -> unit

--- a/boot/env.mli
+++ b/boot/env.mli
@@ -104,8 +104,6 @@ val coqlib : t -> Path.t
 
 val ocamlfind : unit -> string
 
-val docdir : unit -> string
-
 val print_config : ?prefix_var_name:string -> t -> out_channel -> unit
 
 (** Needs a Rocq environment for Where and Config.

--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -116,3 +116,8 @@ type specific_usage = {
 let print_usage co { executable_name; extra_args; extra_options } =
   print_usage_common co ("Usage: " ^ executable_name ^ " <options> " ^ extra_args ^ "\n\n");
   output_string co extra_options
+
+type query =
+  | PrintWhere | PrintConfig
+  | PrintVersion | PrintMachineReadableVersion
+  | PrintHelp

--- a/boot/usage.mli
+++ b/boot/usage.mli
@@ -26,3 +26,9 @@ type specific_usage = {
        given executable. } *)
 
 val print_usage : out_channel -> specific_usage -> unit
+
+(** NB: Where and Config need to be able to find coqlib (i.e. -boot won't work) *)
+type query =
+  | PrintWhere | PrintConfig
+  | PrintVersion | PrintMachineReadableVersion
+  | PrintHelp

--- a/boot/usage.mli
+++ b/boot/usage.mli
@@ -27,7 +27,6 @@ type specific_usage = {
 
 val print_usage : out_channel -> specific_usage -> unit
 
-(** NB: Where and Config need to be able to find coqlib (i.e. -boot won't work) *)
 type query =
   | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion

--- a/boot/util.ml
+++ b/boot/util.ml
@@ -61,12 +61,10 @@ let getenv_rocq_gen ~rocq ~coq =
 let getenv_rocq name =
   getenv_rocq_gen ~rocq:("ROCQ"^name) ~coq:("COQ"^name)
 
-(** Add a local installation suffix (unless the suffix is itself
-    absolute in which case the prefix does not matter) *)
 let use_suffix prefix suffix =
-  if String.length suffix > 0 && suffix.[0] = '/'
-  then suffix
-  else Filename.concat prefix suffix
+  if Filename.is_relative suffix
+  then Filename.concat prefix suffix
+  else suffix
 
 let canonical_path_name p =
   let current = Sys.getcwd () in
@@ -78,20 +76,3 @@ let canonical_path_name p =
   with Sys_error _ ->
     (* We give up to find a canonical name and just simplify it... *)
     Filename.concat current p
-
-let coqbin =
-  canonical_path_name (Filename.dirname Sys.executable_name)
-
-(** The following only makes sense when executables are running from
-    source tree (e.g. during build or in local mode). *)
-let coqroot =
-  Filename.dirname coqbin
-
-(** [check_file_else ~dir ~file oth] checks if [file] exists in
-    the installation directory [dir] given relatively to [coqroot],
-    which maybe has been relocated.
-    If the check fails, then [oth ()] is evaluated.
-    Using file system equality seems well enough for this heuristic *)
-let check_file_else ~dir ~file oth =
-  let path = use_suffix coqroot dir in
-  if Sys.file_exists (Filename.concat path file) then path else oth ()

--- a/boot/util.ml
+++ b/boot/util.ml
@@ -60,19 +60,3 @@ let getenv_rocq_gen ~rocq ~coq =
 
 let getenv_rocq name =
   getenv_rocq_gen ~rocq:("ROCQ"^name) ~coq:("COQ"^name)
-
-let use_suffix prefix suffix =
-  if Filename.is_relative suffix
-  then Filename.concat prefix suffix
-  else suffix
-
-let canonical_path_name p =
-  let current = Sys.getcwd () in
-  try
-    Sys.chdir p;
-    let p' = Sys.getcwd () in
-    Sys.chdir current;
-    p'
-  with Sys_error _ ->
-    (* We give up to find a canonical name and just simplify it... *)
-    Filename.concat current p

--- a/boot/util.mli
+++ b/boot/util.mli
@@ -21,11 +21,3 @@ val getenv_rocq_gen : rocq:string -> coq:string -> string option
     it is deprecated, otherwise [None]. *)
 
 val set_warn_deprecated_coq_var : (rocq:string -> coq:string -> unit) -> unit
-
-val canonical_path_name : string -> string
-(** If the path does not exist, returns it prefixed with cwd. *)
-
-val use_suffix : string -> string -> string
-(** [use_suffix prefix suffix] adds a local installation suffix (unless
-    the suffix is itself absolute in which case the prefix does not
-    matter) *)

--- a/boot/util.mli
+++ b/boot/util.mli
@@ -22,5 +22,10 @@ val getenv_rocq_gen : rocq:string -> coq:string -> string option
 
 val set_warn_deprecated_coq_var : (rocq:string -> coq:string -> unit) -> unit
 
-val check_file_else :
-  dir:string -> file:string -> (unit -> string) -> string
+val canonical_path_name : string -> string
+(** If the path does not exist, returns it prefixed with cwd. *)
+
+val use_suffix : string -> string -> string
+(** [use_suffix prefix suffix] adds a local installation suffix (unless
+    the suffix is itself absolute in which case the prefix does not
+    matter) *)

--- a/dev/ci/user-overlays/20190-SkySkimmer-rocq-queries.sh
+++ b/dev/ci/user-overlays/20190-SkySkimmer-rocq-queries.sh
@@ -1,0 +1,1 @@
+overlay ltac2_compiler https://github.com/SkySkimmer/coq-ltac2-compiler rocq-queries 20190

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -143,10 +143,11 @@ let call_compiler ?profile:(profile=false) ml_filename =
        ::"-rectypes"
        ::"-w"::"a"
        ::include_dirs) @
-      ["-impl"; ml_filename] in
-  debug_native_compiler (fun () -> Pp.str (Envars.ocamlfind () ^ " " ^ (String.concat " " args)));
+    ["-impl"; ml_filename] in
+  let ocamlfind = Boot.Env.ocamlfind () in
+  debug_native_compiler (fun () -> Pp.str (ocamlfind ^ " " ^ (String.concat " " args)));
   try
-    let res = CUnix.sys_command (Envars.ocamlfind ()) args in
+    let res = CUnix.sys_command ocamlfind args in
     match res with
     | Unix.WEXITED 0 -> link_filename
     | Unix.WEXITED _n | Unix.WSIGNALED _n | Unix.WSTOPPED _n ->

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -100,8 +100,6 @@ let _ =
 let use_suffix prefix suffix =
   if String.length suffix > 0 && suffix.[0] = '/' then suffix else prefix / suffix
 
-let docdir = Boot.Env.docdir
-
 let datadir () =
   (* This assumes implicitly that the suffix is non-trivial *)
   let path = use_suffix coqroot Coq_config.datadirsuffix in

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -173,3 +173,14 @@ let print_config ?(prefix_var_name="") f =
      | Coq_config.NativeOn {ondemand=false} -> "yes"
      | Coq_config.NativeOff -> "no"
      | Coq_config.NativeOn {ondemand=true} -> "ondemand")
+
+let print_query ~usage : Boot.Usage.query -> unit = function
+  | PrintVersion -> Boot.Usage.version ()
+  | PrintMachineReadableVersion -> Boot.Usage.machine_readable_version ()
+  | PrintWhere ->
+    let env = Boot.Env.init () in
+    let coqlib = Boot.Env.coqlib env |> Boot.Path.to_string in
+    print_endline coqlib
+  | PrintHelp -> Boot.Usage.print_usage stderr usage
+  | PrintConfig ->
+    print_config stdout

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -121,10 +121,6 @@ let coqpath =
   let () = if coqpath <> "" then warn_deprecated_coq_var ~rocq:"ROCQPATH" ~coq:"COQPATH" () in
   make_search_path rocqpath @ make_search_path coqpath
 
-(** {2 Caml paths} *)
-
-let ocamlfind = Boot.Env.ocamlfind
-
 (** {1 XDG utilities} *)
 
 let xdg_data_home warn =

--- a/lib/envars.mli
+++ b/lib/envars.mli
@@ -66,8 +66,3 @@ val xdg_config_home : (string -> unit) -> string
 val xdg_data_home   : (string -> unit) -> string
 val xdg_data_dirs   : (string -> unit) -> string list
 val xdg_dirs : warn : (string -> unit) -> string list
-
-(** {6 Prints the configuration information } *)
-val print_config : ?prefix_var_name:string -> out_channel -> unit
-
-val print_query : usage:Boot.Usage.specific_usage -> Boot.Usage.query -> unit

--- a/lib/envars.mli
+++ b/lib/envars.mli
@@ -31,9 +31,6 @@ val expand_path_macros : warn:(string -> unit) -> string -> string
     USERPROFILE). If all of them fail, [warn] is called. *)
 val home : warn:(string -> unit) -> string
 
-(** [docdir] is the path to the installed documentation. *)
-val docdir : unit -> string
-
 (** [datadir] is the path to the installed data directory. *)
 val datadir : unit -> string
 

--- a/lib/envars.mli
+++ b/lib/envars.mli
@@ -51,9 +51,6 @@ val coqroot : string
     the order it gets added to the search path. *)
 val coqpath : string list
 
-(** [camlfind ()] is the path to the ocamlfind binary. *)
-val ocamlfind : unit -> string
-
 (** Rocq tries to honor the XDG Base Directory Specification to access
     the user's configuration files.
 

--- a/lib/envars.mli
+++ b/lib/envars.mli
@@ -69,3 +69,5 @@ val xdg_dirs : warn : (string -> unit) -> string list
 
 (** {6 Prints the configuration information } *)
 val print_config : ?prefix_var_name:string -> out_channel -> unit
+
+val print_query : usage:Boot.Usage.specific_usage -> Boot.Usage.query -> unit

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -759,7 +759,7 @@ let compile f =
                ; "-c"; f^"i"
                ; f
                ] in
-    let res = CUnix.sys_command (Envars.ocamlfind ()) args in
+    let res = CUnix.sys_command (Boot.Env.ocamlfind ()) args in
     match res with
     | Unix.WEXITED 0 -> ()
     | Unix.WEXITED n | Unix.WSIGNALED n | Unix.WSTOPPED n ->

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -90,13 +90,8 @@ type coqargs_pre = {
   injections  : injection_command list;
 }
 
-type coqargs_query = Boot.Usage.query =
-  | PrintWhere | PrintConfig
-  | PrintVersion | PrintMachineReadableVersion
-  | PrintHelp
-
 type coqargs_main =
-  | Queries of coqargs_query list
+  | Queries of Boot.Usage.query list
   | Run
 
 type coqargs_post = {

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -90,7 +90,7 @@ type coqargs_pre = {
   injections  : injection_command list;
 }
 
-type coqargs_query =
+type coqargs_query = Boot.Usage.query =
   | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
   | PrintHelp

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -85,13 +85,8 @@ type coqargs_pre = {
   injections  : injection_command list;
 }
 
-type coqargs_query =
-  | PrintWhere | PrintConfig
-  | PrintVersion | PrintMachineReadableVersion
-  | PrintHelp
-
 type coqargs_main =
-  | Queries of coqargs_query list
+  | Queries of Boot.Usage.query list
   | Run
 
 type coqargs_post = {

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -175,7 +175,7 @@ let init_runtime ~usage opts =
   init_load_paths opts;
 
   match opts.Coqargs.main with
-  | Coqargs.Queries q -> List.iter (Envars.print_query ~usage) q; exit 0
+  | Coqargs.Queries q -> List.iter (Boot.Env.print_query ~usage) q; exit 0
   | Coqargs.Run -> ()
 
 let init_document opts =

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -175,7 +175,7 @@ let init_runtime ~usage opts =
   init_load_paths opts;
 
   match opts.Coqargs.main with
-  | Coqargs.Queries q -> List.iter (Boot.Env.print_query ~usage) q; exit 0
+  | Coqargs.Queries q -> List.iter (Boot.Env.print_query (Some usage)) q; exit 0
   | Coqargs.Run -> ()
 
 let init_document opts =

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -85,17 +85,6 @@ let init_coqlib opts = match opts.Coqargs.config.Coqargs.coqlib with
   | Some s ->
     Boot.Env.set_coqlib s
 
-let print_query ~usage = let open Coqargs in function
-  | PrintVersion -> Boot.Usage.version ()
-  | PrintMachineReadableVersion -> Boot.Usage.machine_readable_version ()
-  | PrintWhere ->
-    let env = Boot.Env.init () in
-    let coqlib = Boot.Env.coqlib env |> Boot.Path.to_string in
-    print_endline coqlib
-  | PrintHelp -> Boot.Usage.print_usage stderr usage
-  | PrintConfig ->
-    Envars.print_config stdout
-
 let dirpath_of_file f =
   let ldir0 =
     try
@@ -186,7 +175,7 @@ let init_runtime ~usage opts =
   init_load_paths opts;
 
   match opts.Coqargs.main with
-  | Coqargs.Queries q -> List.iter (print_query ~usage) q; exit 0
+  | Coqargs.Queries q -> List.iter (Envars.print_query ~usage) q; exit 0
   | Coqargs.Run -> ()
 
 let init_document opts =

--- a/sysinit/dune
+++ b/sysinit/dune
@@ -5,7 +5,7 @@
  (modules coqargs)
  (wrapped false)
  ; don't depend on rocq-runtime.lib -> impossible to imperatively set random flags
- (libraries rocq-runtime.config rocq-runtime.clib))
+ (libraries rocq-runtime.config rocq-runtime.boot rocq-runtime.clib))
 
 (deprecated_library_name
  (old_public_name coq-core.coqargs)

--- a/tools/rocqmakefile.ml
+++ b/tools/rocqmakefile.ml
@@ -224,8 +224,8 @@ let windrive s =
 
 let generate_conf_coq_config oc =
   section oc "Rocq configuration.";
-  Envars.print_config ~prefix_var_name:"COQMF_" oc;
   let env = Boot.Env.init () in
+  Boot.Env.print_config ~prefix_var_name:"COQMF_" env oc;
   let coqlib = Boot.Env.(coqlib env |> Path.to_string) in
   (* XXX: FIXME, why does this variable needs the root lib *)
   fprintf oc "COQMF_WINDRIVE=%s\n" (windrive coqlib)

--- a/topbin/rocq.ml
+++ b/topbin/rocq.ml
@@ -108,16 +108,16 @@ let () =
   let opts, args = Rocqshim.parse_opts args in
   match args with
   (* help prints *)
-  | "-v" :: _ | "--version" :: _ -> Boot.Usage.version ()
-  | ("-print-version"|"--print-version") :: _ -> Boot.Usage.machine_readable_version ()
   | ("-h" | "-H" | "-help" | "--help") :: _ ->
     Printf.printf "%a%!" print_usage ();
     exit 0
 
   | cmd :: args ->
     begin match List.find_opt (fun (cmd',_,_) -> String.equal cmd cmd') subcommands with
-    | None -> fatal_error "Unknown subcommand %s\n%a%!" cmd print_usage ()
     | Some (_,_,cmd) -> run_subcommand opts args cmd
+    | None ->
+      if Rocqshim.try_run_queries opts (cmd::args) then ()
+      else fatal_error "Unknown subcommand %s\n%a%!" cmd print_usage ()
     end
 
   | [] -> error_usage ()

--- a/topbin/rocqshim.mli
+++ b/topbin/rocqshim.mli
@@ -24,6 +24,10 @@ val parse_opts : string list -> opts * string list
 (** Initialize environment and search paths. *)
 val init : opts -> string list -> unit
 
+(** Returns whether there are queries in the argument list, and if there are print their output.
+    Does not handle PrintHelp queries. *)
+val try_run_queries : opts -> string list -> bool
+
 (** On windows [Unix.execv] creates a new process and exits this one.
     This confuses dune into thinking we are done,
     so instead we create_process and wait for it. *)


### PR DESCRIPTION
This allows us to handle queries before trying to find Prelude.vo,
except for -where and -config which need to initialize the Rocq
environment, and -help which is different based on the subcommand and
so needs to find the subcommand exe.

As such #20128 is not fixed for -help (but is fixed for -v).

We will need to move the specific_usage data somewhere more accessible
to the shim to be able to fix -help.

Overlays:
- https://github.com/SkySkimmer/coq-ltac2-compiler/pull/26
