### PR TITLE
Stop relying on canonicalizing maps in the section mechanism.

### DIFF
--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -68,7 +68,7 @@ type abstr_inst_info = {
     Using the notations above, a expand_info is a map [c ↦ a1..an]
     over all generalized global declarations of the section *)
 
-type 'a entry_map = 'a Cmap.t * 'a Mindmap.t
+type 'a entry_map = 'a Cmap_env.t * 'a Mindmap_env.t
 type expand_info = abstr_inst_info entry_map
 
 (** The collection of instantiations to be done on generalized
@@ -86,7 +86,7 @@ type cooking_info = {
 }
 
 let empty_cooking_info = {
-  expand_info = (Cmap.empty, Mindmap.empty);
+  expand_info = (Cmap_env.empty, Mindmap_env.empty);
   abstr_info = {
       abstr_ctx = [];
       abstr_auctx = AbstractContext.empty;
@@ -154,9 +154,9 @@ let share cache top_abst_subst r (cstl,knl) =
   with Not_found ->
   let {abstr_uinst;abstr_rev_inst} =
     match r with
-    | IndRef (kn,_i) -> Mindmap.find kn knl
-    | ConstructRef ((kn,_i),_j) -> Mindmap.find kn knl
-    | ConstRef cst -> Cmap.find cst cstl
+    | IndRef (kn,_i) -> Mindmap_env.find kn knl
+    | ConstructRef ((kn,_i),_j) -> Mindmap_env.find kn knl
+    | ConstRef cst -> Cmap_env.find cst cstl
   in
   let inst = (abstr_uinst, discharge_inst top_abst_subst abstr_rev_inst, List.length abstr_rev_inst) in
   RefTable.add cache r inst;
@@ -179,7 +179,7 @@ let discharge_proj (_,_,abstr_inst_length) p =
   Projection.map_npars map p
 
 let is_empty_modlist (cm, mm) =
-  Cmap.is_empty cm && Mindmap.is_empty mm
+  Cmap_env.is_empty cm && Mindmap_env.is_empty mm
 
 let expand_constr cache modlist top_abst_subst c =
   let share_univs = share_univs cache top_abst_subst in
@@ -316,7 +316,7 @@ let make_cooking_info ~recursive expand_info hyps uctx =
   | None -> info
   | Some ind ->
     let (cmap, imap) = info.expand_info in
-    { info with expand_info = (cmap, Mindmap.add ind abstr_inst_info imap) }
+    { info with expand_info = (cmap, Mindmap_env.add ind abstr_inst_info imap) }
   in
   info, abstr_inst_info
 

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -25,7 +25,7 @@ open Constr
 
 type abstr_inst_info
 
-type 'a entry_map = 'a Cmap.t * 'a Mindmap.t
+type 'a entry_map = 'a Cmap_env.t * 'a Mindmap_env.t
 type expand_info = abstr_inst_info entry_map
 
 (** The collection of instantiations to be done on generalized

--- a/kernel/section.ml
+++ b/kernel/section.ml
@@ -52,8 +52,8 @@ let all_poly_univs sec = sec.all_poly_univs
 let map_custom f sec = {sec with custom = f sec.custom}
 
 let add_emap e v (cmap, imap) = match e with
-| SecDefinition con -> (Cmap.add con v cmap, imap)
-| SecInductive ind -> (cmap, Mindmap.add ind v imap)
+| SecDefinition con -> (Cmap_env.add con v cmap, imap)
+| SecInductive ind -> (cmap, Mindmap_env.add ind v imap)
 
 let push_local_universe_context ctx sec =
   if UContext.is_empty ctx then sec
@@ -87,8 +87,8 @@ let open_section ~custom prev =
     all_poly_univs = Option.cata (fun sec -> sec.all_poly_univs) Instance.empty prev;
     has_poly_univs = Option.cata has_poly_univs false prev;
     entries = [];
-    expand_info_map = (Cmap.empty, Mindmap.empty);
-    cooking_info_map = (Cmap.empty, Mindmap.empty);
+    expand_info_map = (Cmap_env.empty, Mindmap_env.empty);
+    cooking_info_map = (Cmap_env.empty, Mindmap_env.empty);
     custom = custom;
   }
 
@@ -130,8 +130,8 @@ let push_global env ~poly e sec =
     let expand_info_map = add_emap e abstr_inst_info sec.expand_info_map in
     { sec with entries = e :: sec.entries; expand_info_map; cooking_info_map }
 
-let segment_of_constant con sec = Cmap.find con (fst sec.cooking_info_map)
-let segment_of_inductive con sec = Mindmap.find con (snd sec.cooking_info_map)
+let segment_of_constant con sec = Cmap_env.find con (fst sec.cooking_info_map)
+let segment_of_inductive con sec = Mindmap_env.find con (snd sec.cooking_info_map)
 
 let is_in_section _env gr sec =
   let open GlobRef in
@@ -140,6 +140,6 @@ let is_in_section _env gr sec =
     let vars = sec.context in
     List.exists (fun decl -> Id.equal id (NamedDecl.get_id decl)) vars
   | ConstRef con ->
-    Cmap.mem con (fst sec.expand_info_map)
+    Cmap_env.mem con (fst sec.expand_info_map)
   | IndRef (ind, _) | ConstructRef ((ind, _), _) ->
-    Mindmap.mem ind (snd sec.expand_info_map)
+    Mindmap_env.mem ind (snd sec.expand_info_map)


### PR DESCRIPTION
There is no point in computing the canonical names, since sections can never introduce modules and thus aliasing. All section-local constants are in particular expected to be canonical.