### PR TITLE
Abstract the datatype of maps of hint modes.

### DIFF
--- a/dev/ci/user-overlays/20201-ppedrot-hint-opaque-modes.sh
+++ b/dev/ci/user-overlays/20201-ppedrot-hint-opaque-modes.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/ppedrot/coq-elpi hint-opaque-modes 20201

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -466,7 +466,7 @@ module Search = struct
 
   (** Local hints *)
   let autogoal_cache = Summary.ref ~name:"autogoal_cache"
-      (DirPath.empty, true, Context.Named.empty, GlobRef.Map.empty,
+      (DirPath.empty, true, Context.Named.empty, Hints.Modes.empty,
        Hint_db.empty TransparentState.full true)
 
   let make_autogoal_hints only_classes (modes,st as mst) gl =
@@ -1090,7 +1090,7 @@ let typeclasses_eauto ?(only_classes=false)
   in
   let st = match dbs with x :: _ -> Hint_db.transparent_state x | _ -> st in
   let modes = List.map Hint_db.modes dbs in
-  let modes = List.fold_left (GlobRef.Map.union (fun _ m1 m2 -> Some (m1@m2))) GlobRef.Map.empty modes in
+  let modes = List.fold_left Modes.union Modes.empty modes in
   let depth = match depth with None -> get_typeclasses_depth () | Some l -> Some l in
   Proofview.tclIGNORE
     (Search.eauto_tac (modes,st) ~only_classes ?strategy

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -86,7 +86,7 @@ val deactivate_solver : name:CString.Map.key -> unit
 
 module Search : sig
   val eauto_tac :
-    Hints.hint_mode array list GlobRef.Map.t * TransparentState.t
+    Hints.Modes.t * TransparentState.t
     (** The transparent_state and modes used when working with local hypotheses  *)
     -> ?unique:bool
     (** Should we force a unique solution *)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -183,6 +183,13 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
+module Modes =
+struct
+  type t = hint_mode array list GlobRef.Map.t
+  let empty = GlobRef.Map.empty
+  let union m1 m2 = GlobRef.Map.union (fun _ m1 m2 -> Some (m1@m2)) m1 m2
+end
+
 type 'a hints_transparency_target =
   | HintsVariables
   | HintsConstants
@@ -623,6 +630,7 @@ val cut : t -> hints_path
 val unfolds : t -> Id.Set.t * Cset.t * PRset.t
 val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
 val modes : t -> hint_mode array list GlobRef.Map.t
+val find_mode : env -> GlobRef.t -> t -> hint_mode array list
 val fold : (GlobRef.t option -> hint_mode array list -> full_hint list -> 'a -> 'a) ->
   t -> 'a -> 'a
 end =
@@ -829,6 +837,8 @@ struct
     { db with hintdb_map = GlobRef.Map.union f db.hintdb_map mode_entries }
 
   let modes db = GlobRef.Map.map (fun se -> se.sentry_mode) db.hintdb_map
+
+  let find_mode _env gr db = (GlobRef.Map.find gr db.hintdb_map).sentry_mode
 
   let use_dn db = db.use_dn
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -110,6 +110,13 @@ type 'a with_mode =
   | ModeMatch of mode_match * 'a
   | ModeMismatch
 
+module Modes :
+sig
+  type t
+  val empty : t
+  val union : t -> t -> t
+end
+
 module Hint_db :
   sig
     type t
@@ -150,8 +157,9 @@ module Hint_db :
 
     val unfolds : t -> Id.Set.t * Cset.t * PRset.t
 
-    val add_modes : hint_mode array list GlobRef.Map.t -> t -> t
-    val modes : t -> hint_mode array list GlobRef.Map.t
+    val add_modes : Modes.t -> t -> t
+    val modes : t -> Modes.t
+    val find_mode : env -> GlobRef.t -> t -> hint_mode array list
   end
 
 type hint_db = Hint_db.t


### PR DESCRIPTION
This is the only datatype in the API that exposes a use to the canonical-name-based GlobRef.Map.t type.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/768