### PR TITLE
Fix rocq dep issue with empty string arguments

### DIFF
--- a/test-suite/coq-makefile/coqdep-attribute/b.v
+++ b/test-suite/coq-makefile/coqdep-attribute/b.v
@@ -1,1 +1,2 @@
 #[warnings="-all"] From Test Require a.
+#[warnings=""] Comments "".

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -100,7 +100,7 @@ and skip_attribute = parse
       { comment lexbuf; skip_attribute lexbuf }
   | "]"
       { () }
-  | '"' [^ '"']+ '"'
+  | '"' [^ '"']* '"'
       { skip_attribute lexbuf }
   | _
       { skip_attribute lexbuf }


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20209


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
