### PR TITLE
Tac2ffi stop exposing the raw tags

### DIFF
--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -61,6 +61,10 @@ val of_constr : EConstr.t -> valexpr
 val to_constr : valexpr -> EConstr.t
 val constr : EConstr.t repr
 
+val of_matching_context : Constr_matching.context -> valexpr
+val to_matching_context : valexpr -> Constr_matching.context
+val matching_context : Constr_matching.context repr
+
 val of_preterm : Ltac_pretype.closed_glob_constr -> valexpr
 val to_preterm : valexpr -> Ltac_pretype.closed_glob_constr
 val preterm : Ltac_pretype.closed_glob_constr repr
@@ -69,6 +73,8 @@ val of_cast : Constr.cast_kind -> valexpr
 val to_cast : valexpr -> Constr.cast_kind
 val cast : Constr.cast_kind repr
 
+(** Toplevel representation of OCaml exceptions. Invariant: no [LtacError]
+    should be used with [err]. *)
 val of_err : Exninfo.iexn -> valexpr
 val to_err : valexpr -> Exninfo.iexn
 val err : Exninfo.iexn repr
@@ -120,13 +126,61 @@ val of_evar : Evar.t -> valexpr
 val to_evar : valexpr -> Evar.t
 val evar : Evar.t repr
 
+val of_sort : ESorts.t -> valexpr
+val to_sort : valexpr -> ESorts.t
+val sort : ESorts.t repr
+
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
 val pp : Pp.t repr
 
+val of_transparent_state : TransparentState.t -> valexpr
+val to_transparent_state : valexpr -> TransparentState.t
+val transparent_state : TransparentState.t repr
+
+val of_pretype_flags : Pretyping.inference_flags -> valexpr
+val to_pretype_flags : valexpr -> Pretyping.inference_flags
+val pretype_flags : Pretyping.inference_flags repr
+
+val of_expected_type : Pretyping.typing_constraint -> valexpr
+val to_expected_type : valexpr -> Pretyping.typing_constraint
+val expected_type : Pretyping.typing_constraint repr
+
+type ind_data = (Names.Ind.t * Declarations.mutual_inductive_body)
+
+val of_ind_data : ind_data -> valexpr
+val to_ind_data : valexpr -> ind_data
+val ind_data : ind_data repr
+
+val of_inductive : inductive -> valexpr
+val to_inductive : valexpr -> inductive
+val inductive : inductive repr
+
 val of_constant : Constant.t -> valexpr
 val to_constant : valexpr -> Constant.t
 val constant : Constant.t repr
+
+val of_constructor : constructor -> valexpr
+val to_constructor : valexpr -> constructor
+val constructor : constructor repr
+
+val of_projection : Projection.t -> valexpr
+val to_projection : valexpr -> Projection.t
+val projection : Projection.t repr
+
+val of_qvar : Sorts.QVar.t -> valexpr
+val to_qvar : valexpr -> Sorts.QVar.t
+val qvar : Sorts.QVar.t repr
+
+val of_case : Constr.case_info -> valexpr
+val to_case : valexpr -> Constr.case_info
+val case : Constr.case_info repr
+
+type binder = (Name.t EConstr.binder_annot * types)
+
+val of_binder : binder -> valexpr
+val to_binder : valexpr -> binder
+val binder : binder repr
 
 val of_instance : EConstr.EInstance.t -> valexpr
 val to_instance : valexpr -> EConstr.EInstance.t
@@ -143,6 +197,10 @@ val repr_ext : 'a Val.tag -> 'a repr
 val of_open : KerName.t * valexpr array -> valexpr
 val to_open : valexpr -> KerName.t * valexpr array
 val open_ : (KerName.t * valexpr array) repr
+
+val of_free : Id.Set.t -> valexpr
+val to_free : valexpr -> Id.Set.t
+val free : Id.Set.t repr
 
 val of_uint63 : Uint63.t -> valexpr
 val to_uint63 : valexpr -> Uint63.t
@@ -164,39 +222,6 @@ val to_fun1 : 'a repr -> 'b repr -> valexpr -> ('a, 'b) fun1
 val fun1 : 'a repr -> 'b repr -> ('a, 'b) fun1 repr
 
 val valexpr : valexpr repr
-
-(** {5 Dynamic tags} *)
-
-val val_constr : EConstr.t Val.tag
-val val_ident : Id.t Val.tag
-val val_pattern : Pattern.constr_pattern Val.tag
-val val_preterm : Ltac_pretype.closed_glob_constr Val.tag
-val val_matching_context : Constr_matching.context Val.tag
-val val_evar : Evar.t Val.tag
-val val_pp : Pp.t Val.tag
-val val_sort : ESorts.t Val.tag
-val val_cast : Constr.cast_kind Val.tag
-val val_inductive : inductive Val.tag
-val val_constant : Constant.t Val.tag
-val val_constructor : constructor Val.tag
-val val_projection : Projection.t Val.tag
-val val_qvar : Sorts.QVar.t Val.tag
-val val_case : Constr.case_info Val.tag
-val val_binder : (Name.t EConstr.binder_annot * types) Val.tag
-val val_free : Id.Set.t Val.tag
-val val_uint63 : Uint63.t Val.tag
-val val_float : Float64.t Val.tag
-val val_ltac1 : Geninterp.Val.t Val.tag
-val val_pretype_flags : Pretyping.inference_flags Val.tag
-val val_expected_type : Pretyping.typing_constraint Val.tag
-
-val val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag
-val val_transparent_state : TransparentState.t Val.tag
-
-val val_exninfo : Exninfo.info Tac2dyn.Val.tag
-val val_exn : Exninfo.iexn Tac2dyn.Val.tag
-(** Toplevel representation of OCaml exceptions. Invariant: no [LtacError]
-    should be put into a value with tag [val_exn]. *)
 
 (** Exception *)
 

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -892,7 +892,7 @@ let () = register_init "message" begin fun _ _ pp ->
 end
 
 let () = register_init "err" begin fun _ _ e ->
-  let e = to_ext val_exn e in
+  let e = to_err e in
   hov 2 (str "err:(" ++ CErrors.iprint_no_report e ++ str ")")
 end
 

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -599,8 +599,6 @@ let () =
 
 (** Tactics for [Ltac2/TransparentState.v]. *)
 
-let transparent_state = Tac2ffi.repr_ext Tac2ffi.val_transparent_state
-
 let () =
   define "current_transparent_state"
     (unit @-> tac transparent_state)

--- a/plugins/ltac2_ltac1/tac2core_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2core_ltac1.ml
@@ -30,8 +30,7 @@ let return x = Proofview.tclUNIT x
 
 (** Ltac1 in Ltac2 *)
 
-let ltac1 = Tac2ffi.repr_ext Tac2ffi.val_ltac1
-let of_ltac1 v = Tac2ffi.of_ext Tac2ffi.val_ltac1 v
+let ltac1 = Tac2quote_ltac1.ltac1
 
 let () =
   define "ltac1_ref" (list ident @-> ret ltac1) @@ fun ids ->
@@ -60,7 +59,7 @@ let () =
   let open Tacexpr in
   let open Locus in
   let k ret =
-    Proofview.tclIGNORE (Tac2val.apply k [Tac2ffi.of_ext val_ltac1 ret])
+    Proofview.tclIGNORE (Tac2val.apply k [Tac2ffi.repr_of ltac1 ret])
   in
   let fold arg (i, vars, lfun) =
     let id = Id.of_string ("x" ^ string_of_int i) in
@@ -142,7 +141,7 @@ let () =
   let interp _ (ids, tac) =
     let clos args =
       let add lfun id v =
-        let v = Tac2ffi.to_ext val_ltac1 v in
+        let v = Tac2ffi.repr_to ltac1 v in
         Id.Map.add id v lfun
       in
       let lfun = List.fold_left2 add Id.Map.empty ids args in
@@ -201,7 +200,7 @@ let () =
   let interp _ (ids, tac) =
     let clos args =
       let add lfun id v =
-        let v = Tac2ffi.to_ext val_ltac1 v in
+        let v = Tac2ffi.repr_to ltac1 v in
         Id.Map.add id v lfun
       in
       let lfun = List.fold_left2 add Id.Map.empty ids args in
@@ -209,7 +208,7 @@ let () =
       let lfun = Tac2interp.set_env ist lfun in
       let ist = Ltac_plugin.Tacinterp.default_ist () in
       let ist = { ist with Geninterp.lfun = lfun } in
-      return (Tac2ffi.of_ext val_ltac1 (Tacinterp.Value.of_closure ist tac))
+      return (Tac2ffi.repr_of ltac1 (Tacinterp.Value.of_closure ist tac))
     in
     let len = List.length ids in
     if Int.equal len 0 then
@@ -348,8 +347,8 @@ let () =
     let tac = cast_typ typ_ltac2 @@ Id.Map.get tac_id ist.Tacinterp.lfun in
     let arg = Id.Map.get arg_id ist.Tacinterp.lfun in
     let tac = Tac2ffi.to_closure tac in
-    Tac2val.apply tac [of_ltac1 arg] >>= fun ans ->
-    let ans = Tac2ffi.to_ext val_ltac1 ans in
+    Tac2val.apply tac [Tac2ffi.repr_of ltac1 arg] >>= fun ans ->
+    let ans = Tac2ffi.repr_to ltac1 ans in
     Ftactic.return ans
   in
   let () = Geninterp.register_interp0 wit_ltac2_val interp_fun in
@@ -374,7 +373,7 @@ let ltac2_eval =
       being the arguments it should be fed with *)
     let tac = cast_typ typ_ltac2 tac in
     let tac = Tac2ffi.to_closure tac in
-    let args = List.map (fun arg -> Tac2ffi.of_ext val_ltac1 arg) args in
+    let args = List.map (fun arg -> Tac2ffi.repr_of ltac1 arg) args in
     Proofview.tclIGNORE (Tac2val.apply tac args)
   in
   let () = Tacenv.register_ml_tactic ml_name [|eval_fun|] in

--- a/plugins/ltac2_ltac1/tac2quote_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2quote_ltac1.ml
@@ -2,3 +2,7 @@ open Ltac2_plugin.Tac2dyn
 
 let wit_ltac1 = Arg.create "ltac1"
 let wit_ltac1val = Arg.create "ltac1val"
+
+let val_ltac1 : Geninterp.Val.t Val.tag = Val.create "ltac1"
+
+let ltac1 = Ltac2_plugin.Tac2ffi.repr_ext val_ltac1

--- a/plugins/ltac2_ltac1/tac2quote_ltac1.mli
+++ b/plugins/ltac2_ltac1/tac2quote_ltac1.mli
@@ -16,3 +16,5 @@ val wit_ltac1 : (Id.t CAst.t list * Ltac_plugin.Tacexpr.raw_tactic_expr, Id.t li
 
 val wit_ltac1val : (Id.t CAst.t list * Ltac_plugin.Tacexpr.raw_tactic_expr, Id.t list * Ltac_plugin.Tacexpr.glob_tactic_expr) Arg.tag
 (** Ltac1 AST quotation, seen as a value-returning expression, with type Ltac1.t. *)
+
+val ltac1 : Geninterp.Val.t Ltac2_plugin.Tac2ffi.repr

--- a/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2stdlib_ltac1.ml
@@ -24,8 +24,6 @@ let pname ?(plugin=ltac2_ltac1_plugin) s = { mltac_plugin = plugin; mltac_tactic
 
 let define ?plugin s = define (pname ?plugin s)
 
-let ltac1 = Tac2ffi.repr_ext Tac2ffi.val_ltac1
-
 let val_tag wit = match val_tag wit with
 | Base t -> t
 | _ -> assert false
@@ -41,7 +39,7 @@ let in_gen wit v = Val.Dyn (val_tag wit, v)
 let out_gen wit v = prj (val_tag wit) v
 
 let () =
-  define "ltac1_of_intro_pattern" (Tac2stdlib.intro_pattern @-> ret ltac1) @@ fun v ->
+  define "ltac1_of_intro_pattern" (Tac2stdlib.intro_pattern @-> ret Tac2quote_ltac1.ltac1) @@ fun v ->
   let v = Tac2tactics.mk_intro_pattern v in
   in_gen (topwit Ltac_plugin.Tacarg.wit_simple_intropattern) v
 
@@ -80,7 +78,7 @@ and to_or_and_intro_pattern : Tactypes.delayed_open_constr Tactypes.or_and_intro
 and to_intro_patterns v = List.map to_intro_pattern v
 
 let () =
-  define "ltac1_to_intro_pattern" (ltac1 @-> ret (option Tac2stdlib.intro_pattern)) @@ fun v ->
+  define "ltac1_to_intro_pattern" (Tac2quote_ltac1.ltac1 @-> ret (option Tac2stdlib.intro_pattern)) @@ fun v ->
   (* should we be using Taccoerce.coerce_to_intro_pattern instead?
      semantics are different: it also handles wit_hyp and Var constr *)
   match out_gen (topwit Ltac_plugin.Tacarg.wit_simple_intropattern) v with


### PR DESCRIPTION
Having the raw tag could be used to test if a value is a given tag (without the hack of catching the assertion failure from to_foo), but all uses went through of/to_ext so this extra power is not needed.
