### PR TITLE
Let binder (x:T|P) not depend on the implicit status of sig.

### DIFF
--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -38,12 +38,11 @@ variable can be introduced at the same time. It is also possible to give
 the type of the variable as follows:
 :n:`(@ident : @type := @term)`.
 
-`(x : T | P)` is syntactic sugar for `(x : Stdlib.Init.Specif.sig (fun x : T => P))`,
+`(x : T | P)` is syntactic sugar for `(x : @Stdlib.Init.Specif.sig _ (fun x : T => P))`,
 which would more typically be written `(x : {x : T | P})`.
 Since `(x : T | P)` uses `sig` directly,
 changing the notation `{x : T | P}`
-will not change the meaning of `(x : T | P)`, while
-changing the implicit arguments of `sig` will break `(x : T | P)`).
+will not change the meaning of `(x : T | P)`.
 
 Lists of :n:`@binder`\s are allowed. In the case of :g:`fun` and :g:`forall`,
 it is intended that at least one binder of the list is an assumption otherwise

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -107,7 +107,7 @@ let force_quality ?loc = function
 
 (* XXX use registered ref? but currently constrexpr doesn't have a node for registered refs
    and we can't do [Rocqlib.lib_ref] at parsing time, it's only available in the interp phase. *)
-let sigref loc = mkRefC (Libnames.qualid_of_string ~loc "Corelib.Init.Specif.sig")
+let sigref loc = Libnames.qualid_of_string ~loc "Corelib.Init.Specif.sig"
 
 }
 
@@ -465,8 +465,9 @@ GRAMMAR EXTEND Gram
           | _ -> [CLocalDef (id,None,c,None)] }
       | "("; id = name; ":"; t = lconstr; ":="; c = lconstr; ")" ->
         { [CLocalDef (id,None,c,Some t)] }
-      | "("; id=name; ":"; t=lconstr; "|"; c=lconstr; ")" ->
-        { let typ = mkAppC (sigref loc, [mkLambdaC ([id], default_binder_kind, t, c)]) in
+      | "("; id=name; ":"; t=lconstr; "|"; c=lconstr; ")" -> {
+        let lambda = mkLambdaC ([id], default_binder_kind, t, c) in
+        let typ = CAst.make ~loc @@ CAppExpl ((sigref loc,None), [CAst.make @@ CHole None; lambda]) in
           [CLocalAssum ([id], None, default_binder_kind, typ)] }
       | "{"; id = name; "}" ->
         { [CLocalAssum ([id], None, Default MaxImplicit, CAst.make ~loc @@ CHole (None))] }


### PR DESCRIPTION
Rebase of #19670 + fixing https://github.com/coq/coq/pull/19670#discussion_r1820732640