### PR TITLE
Warning when generating a constraint involving a template universe

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -15,6 +15,29 @@ open Univ
 open Sorts
 open UVars
 
+let template_default_univs = Summary.ref ~name:"template default univs" Univ.Level.Set.empty
+
+let cache_template_default_univs us =
+  template_default_univs := Univ.Level.Set.union !template_default_univs us
+
+let template_default_univs_obj =
+  Libobject.declare_object {
+    (Libobject.default_object "template default univs") with
+    cache_function = cache_template_default_univs;
+    load_function = (fun _ us -> cache_template_default_univs us);
+    discharge_function = (fun x -> Some x);
+    classify_function = (fun _ -> Escape);
+  }
+
+let add_template_default_univs kn =
+  match (Global.lookup_mind kn).mind_template with
+  | None -> ()
+  | Some template ->
+    let _, us = UVars.Instance.levels template.template_defaults in
+    Lib.add_leaf (template_default_univs_obj us)
+
+let template_default_univs () = !template_default_univs
+
 module UnivFlex = UnivFlex
 
 type universes_entry =
@@ -521,6 +544,26 @@ let get_constraint = function
 | Conversion.CONV -> Eq
 | Conversion.CUMUL -> Le
 
+let warn_template =
+  CWarnings.create_warning ~from:[CWarnings.CoreCategories.fragile] ~default:Disabled ~name:"bad-template-constraint" ()
+
+let do_warn_template = CWarnings.create_in warn_template
+    Pp.(fun (uctx,csts) ->
+        str "Adding constraints involving global template univs:" ++ spc() ++
+        Constraints.pr (pr_uctx_level uctx) csts )
+
+let warn_template uctx csts =
+  match CWarnings.warning_status warn_template with
+  | Disabled -> ()
+  | Enabled | AsError ->
+  let is_template u = Level.Set.mem u (template_default_univs()) in
+  let csts = Constraints.filter (fun (u,_,v as cst) ->
+      not (Level.is_set u) && not (Level.is_set v) &&
+      (is_template u || is_template v) &&
+      not (UGraph.check_constraint uctx.universes cst)) csts in
+  if not @@ Constraints.is_empty csts then
+    do_warn_template (uctx,csts)
+
 let unify_quality univs c s1 s2 l =
   let fail () = if UGraph.type_in_type univs then l.local_sorts
     else sort_inconsistency (get_constraint c) s1 s2
@@ -718,6 +761,7 @@ let process_universe_constraints uctx cstrs =
   } in
   let local = UnivProblem.Set.fold unify_universes cstrs local in
   let extra = { UnivMinim.above_prop = local.local_above_prop; UnivMinim.weak_constraints = local.local_weak } in
+  let () = warn_template uctx local.local_cst in
   !vars, extra, local.local_cst, local.local_sorts
 
 let add_universe_constraints uctx cstrs =

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -293,3 +293,5 @@ val reboot : Environ.env -> t -> t
     DO NOT USE OUTSIDE OF DEDICATED AREA. *)
 
 end
+
+val add_template_default_univs : MutInd.t -> unit

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -132,6 +132,7 @@ let declare_mind ?typing_flags ~indlocs mie =
       List.iter (fun {CAst.v} -> Declare.check_exists v) cons) names;
   let mind, why_not_prim_record = Global.add_mind ?typing_flags id mie in
   let () = Lib.add_leaf (inInductive (id, { ind_names = names })) in
+  let () = UState.add_template_default_univs mind in
   if is_unsafe_typing_flags() then feedback_axiom ();
   Impargs.declare_mib_implicits mind;
   declare_inductive_argument_scopes mind mie;


### PR DESCRIPTION

The goal is to be able to detect bugs like https://github.com/coq/coq/issues/20224 so we don't want to just check that all templates are fully applied. Instead we keep around a set of template universes and warn when adding a constraint involving them.

It is off by default as currently it is not very useful. The problem is that the eliminators are monomorphic and share the template global universes, so every time we do eg `induction` on something in a template inductive we get a constraint involving the template universe.
