### PR TITLE
Delay getenv calls

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -123,7 +123,7 @@ let init_load_path () =
   List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:CheckLibrary.default_root_prefix)
     (xdg_dirs ~warn:(fun x -> Feedback.msg_warning (str x)));
   (* then directories in ROCQPATH *)
-  List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:CheckLibrary.default_root_prefix) rocqpath;
+  List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:CheckLibrary.default_root_prefix) (rocqpath());
   (* then current directory *)
   add_path ~unix_path:"." ~rocq_root:CheckLibrary.default_root_prefix
 

--- a/dev/ci/user-overlays/20230-SkySkimmer-delay-coq-env.sh
+++ b/dev/ci/user-overlays/20230-SkySkimmer-delay-coq-env.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp delay-coq-env 20230

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -110,7 +110,7 @@ let configdir () =
   let path = use_suffix coqroot Coq_config.configdirsuffix in
   if Sys.file_exists path then path else Coq_config.configdir
 
-let coqpath =
+let coqpath () =
   let make_search_path path =
     let paths = path_to_list path in
     let valid_paths = List.filter Sys.file_exists paths in

--- a/lib/envars.mli
+++ b/lib/envars.mli
@@ -49,7 +49,7 @@ val coqroot : string
 (** [coqpath] is the standard path to coq.
     Notice that coqpath is stored in reverse order, since that is
     the order it gets added to the search path. *)
-val coqpath : string list
+val coqpath : unit -> string list
 
 (** Rocq tries to honor the XDG Base Directory Specification to access
     the user's configuration files.

--- a/sysinit/coqloadpath.ml
+++ b/sysinit/coqloadpath.ml
@@ -48,7 +48,7 @@ let init_load_path ~coqenv =
   let contrib_vo = build_userlib_path ~unix_path:user_contrib in
 
   let misc_vo =
-    List.map (fun s -> build_userlib_path ~unix_path:s) (xdg_dirs @ rocqpath) in
+    List.map (fun s -> build_userlib_path ~unix_path:s) (xdg_dirs @ (rocqpath())) in
 
   let ml_loadpath = meta_dir in
   let vo_loadpath =

--- a/tools/coqdep/lib/rocqdep_main.ml
+++ b/tools/coqdep/lib/rocqdep_main.ml
@@ -46,7 +46,7 @@ let coqdep args =
       Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) user_contrib [];
     let add_dir s = Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s [] in
     List.iter add_dir (Envars.xdg_dirs ~warn:warn_home_dir);
-    List.iter add_dir Envars.coqpath
+    List.iter add_dir (Envars.coqpath())
   end;
   if args.Args.sort then
     sort st

--- a/topbin/rocqnative.ml
+++ b/topbin/rocqnative.ml
@@ -246,7 +246,7 @@ let init_load_path_std () =
   List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:Loadpath.default_root_prefix)
     (xdg_dirs ~warn:(fun x -> Feedback.msg_warning (str x)));
   (* then directories in ROCQPATH *)
-  List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:Loadpath.default_root_prefix) rocqpath
+  List.iter (fun s -> add_rec_path ~unix_path:s ~rocq_root:Loadpath.default_root_prefix) (rocqpath())
 
 let init_load_path ~boot ~vo_path =
   if not boot then init_load_path_std ();


### PR DESCRIPTION
This delays the getenv until feedback is ready to handle warnings.

Fix #20229

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/915