### PR TITLE
refman-pdf deeper table of contents

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -358,6 +358,9 @@ latex_elements = {
 
                  % Silence 'LaTeX Warning: Command \nobreakspace invalid in math mode'
                  \everymath{\def\nobreakspace{\ }}
+
+                 % deeper table of contents than default
+                 \setcounter{tocdepth}{4}
                  """
 }
 


### PR DESCRIPTION
https://documentation.help/Sphinx/toctree.html#id3
>The maxdepth option does not apply to the LaTeX writer, where the whole table of contents will always be presented at the begin of the document, and its depth is controlled by the tocdepth counter, which you can reset in your latex_preamble config value using e.g. \setcounter{tocdepth}{2}.

Default seems to be 1 counted after the chapter name, eg Proofs > Basic proof writing 2 gives eg Proofs > Basic proof writing > Proof mode

https://coq.inria.fr/doc/V8.20.0/refman/ seems like unlimited depth, eg
- (chapter + 4) Proofs > Basic proof writing > Proof mode > Entering and exiting proof mode > Proof using options
- (chapter + 5) Appendix > History and recent changes > Recent changes > Version 8.20 > Changes in 8.20.0 > Kernel
- (chapter + 6) Proofs > Creating new tactics > Ltac2 > Meta-programming > Term Antiquotations > Semantics > Static semantics

Note that the PDF contains the metadata at AFAICT full depth, cf left panel: ![Image](https://github.com/user-attachments/assets/a79eb2e1-772b-461e-85d0-175884e379f7) with depths 6+ being put at the same level as depth 5 ie `\subparagraph`.

Due to the above point tocdepth=5 means full depth, producing 21 pages of TOC. (example PDF:
[rocq-9.1+alpha-reference-manual.pdf](https://github.com/user-attachments/files/18768796/rocq-9.1%2Balpha-reference-manual.pdf))

This seems heavy to me considering there is also the sidebar TOC. Also latex stops putting section numbers after depth chapter + 2 (eg "2 Specification language > 2.1 Core language > 2.1.1 Basic notions and conventions > Syntax and lexical conventions") so when there's over a page below that depth (eg ssreflect) it's easy to feel lost.

Meanwhile the individual version changelogs are at depth chapter + 3 (Appendix > History and recent changes > Recent changes > Version 8.20).

Based on this I picked tocdepth 3. See results in CI artifacts.

Close #20157
