### PR TITLE
Stop using deprecated typing.io in python code

### DIFF
--- a/doc/tools/coqrst/notations/TacticNotationsLexer.py
+++ b/doc/tools/coqrst/notations/TacticNotationsLexer.py
@@ -1,7 +1,7 @@
 # Generated from TacticNotations.g by ANTLR 4.7.2
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
+from typing import TextIO
 import sys
 
 

--- a/doc/tools/coqrst/notations/TacticNotationsParser.py
+++ b/doc/tools/coqrst/notations/TacticNotationsParser.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
+from typing import TextIO
 import sys
 
 def serializedATN():


### PR DESCRIPTION
Deprecated since python 3.8 (2019 october),
removed in python 3.13 (2024 october)
https://github.com/python/cpython/issues/92871
