### PR TITLE
Print/About print arguments with DelimOnlyTmpScope

### DIFF
--- a/dev/ci/user-overlays/20235-SkySkimmer-print-args-delim-tmp.sh
+++ b/dev/ci/user-overlays/20235-SkySkimmer-print-args-delim-tmp.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/SkySkimmer/stdlib print-args-delim-tmp 20235

--- a/test-suite/output/Arguments.out
+++ b/test-suite/output/Arguments.out
@@ -1,7 +1,7 @@
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
-Arguments Nat.sub (n m)%nat_scope : simpl nomatch
+Arguments Nat.sub (n m)%_nat_scope : simpl nomatch
 The reduction tactics unfold Nat.sub but avoid exposing match constructs
 Nat.sub is transparent
 Expands to: Constant Corelib.Init.Nat.sub
@@ -9,7 +9,7 @@ Declared in library Corelib.Init.Nat, line 71, characters 0-120
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
-Arguments Nat.sub n%nat_scope / m%nat_scope : simpl nomatch
+Arguments Nat.sub n%_nat_scope / m%_nat_scope : simpl nomatch
 The reduction tactics unfold Nat.sub when applied to 1 argument
   but avoid exposing match constructs
 Nat.sub is transparent
@@ -18,7 +18,7 @@ Declared in library Corelib.Init.Nat, line 71, characters 0-120
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
-Arguments Nat.sub !n%nat_scope / m%nat_scope : simpl nomatch
+Arguments Nat.sub !n%_nat_scope / m%_nat_scope : simpl nomatch
 The reduction tactics unfold Nat.sub
   when the 1st argument evaluates to a constructor and
   when applied to 1 argument but avoid exposing match constructs
@@ -28,7 +28,7 @@ Declared in library Corelib.Init.Nat, line 71, characters 0-120
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
-Arguments Nat.sub (!n !m)%nat_scope /
+Arguments Nat.sub (!n !m)%_nat_scope /
 The reduction tactics unfold Nat.sub when the 1st and
   2nd arguments evaluate to a constructor and when applied to 2 arguments
 Nat.sub is transparent
@@ -37,7 +37,7 @@ Declared in library Corelib.Init.Nat, line 71, characters 0-120
 Nat.sub : nat -> nat -> nat
 
 Nat.sub is not universe polymorphic
-Arguments Nat.sub (!n !m)%nat_scope
+Arguments Nat.sub (!n !m)%_nat_scope
 The reduction tactics unfold Nat.sub when the 1st and
   2nd arguments evaluate to a constructor
 Nat.sub is transparent
@@ -48,7 +48,7 @@ forall {D1 C1 : Type},
 (D1 -> C1) -> forall [D2 C2 : Type], (D2 -> C2) -> D1 * D2 -> C1 * C2
 
 pf is not universe polymorphic
-Arguments pf {D1}%foo_scope {C1}%type_scope f [D2 C2] g x : simpl never
+Arguments pf {D1}%_foo_scope {C1}%_type_scope f [D2 C2] g x : simpl never
 The reduction tactics never unfold pf
 pf is transparent
 Expands to: Constant Arguments.pf
@@ -56,7 +56,7 @@ Declared in library Arguments, line 12, characters 11-13
 fcomp : forall {A B C : Type}, (B -> C) -> (A -> B) -> A -> C
 
 fcomp is not universe polymorphic
-Arguments fcomp {A B C}%type_scope f g x /
+Arguments fcomp {A B C}%_type_scope f g x /
 The reduction tactics unfold fcomp when applied to 6 arguments
 fcomp is transparent
 Expands to: Constant Arguments.fcomp
@@ -64,7 +64,7 @@ Declared in library Arguments, line 19, characters 11-16
 volatile : nat -> nat
 
 volatile is not universe polymorphic
-Arguments volatile / x%nat_scope
+Arguments volatile / x%_nat_scope
 The reduction tactics always unfold volatile
 volatile is transparent
 Expands to: Constant Arguments.volatile
@@ -72,7 +72,7 @@ Declared in library Arguments, line 22, characters 11-19
 f : T1 -> T2 -> nat -> unit -> nat -> nat
 
 f is not universe polymorphic
-Arguments f x y n%nat_scope v m%nat_scope
+Arguments f x y n%_nat_scope v m%_nat_scope
 f uses section variables T1 T2.
 f is transparent
 Expands to: Constant Arguments.S1.S2.f
@@ -80,7 +80,7 @@ Declared in library Arguments, line 30, characters 0-147
 f : T1 -> T2 -> nat -> unit -> nat -> nat
 
 f is not universe polymorphic
-Arguments f x y !n%nat_scope !v !m%nat_scope
+Arguments f x y !n%_nat_scope !v !m%_nat_scope
 f uses section variables T1 T2.
 The reduction tactics unfold f when the 3rd, 4th and
   5th arguments evaluate to a constructor
@@ -90,7 +90,7 @@ Declared in library Arguments, line 30, characters 0-147
 f : forall [T2 : Type], T1 -> T2 -> nat -> unit -> nat -> nat
 
 f is not universe polymorphic
-Arguments f [T2]%type_scope x y !n%nat_scope !v !m%nat_scope
+Arguments f [T2]%_type_scope x y !n%_nat_scope !v !m%_nat_scope
 f uses section variable T1.
 The reduction tactics unfold f when the 4th, 5th and
   6th arguments evaluate to a constructor
@@ -100,7 +100,7 @@ Declared in library Arguments, line 30, characters 0-147
 f : forall [T1 T2 : Type], T1 -> T2 -> nat -> unit -> nat -> nat
 
 f is not universe polymorphic
-Arguments f [T1 T2]%type_scope x y !n%nat_scope !v !m%nat_scope
+Arguments f [T1 T2]%_type_scope x y !n%_nat_scope !v !m%_nat_scope
 The reduction tactics unfold f when the 5th, 6th and
   7th arguments evaluate to a constructor
 f is transparent
@@ -132,7 +132,7 @@ Extra arguments: _, _.
 volatilematch : nat -> nat
 
 volatilematch is not universe polymorphic
-Arguments volatilematch / n%nat_scope : simpl nomatch
+Arguments volatilematch / n%_nat_scope : simpl nomatch
 The reduction tactics always unfold volatilematch
   but avoid exposing match constructs
 volatilematch is transparent
@@ -146,4 +146,4 @@ forall xxxxxxxxxxxxxx' xxxxxxxxxxxxxx'' : nat,
 nat -> xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx' + xxxxxxxxxxxxxx'' = 0 ]
 
 Arguments f xxxxxxxxxxxxxx
-  (xxxxxxxxxxxxxx' xxxxxxxxxxxxxx'' xxxxxxxxxxxxxx''')%nat_scope
+  (xxxxxxxxxxxxxx' xxxxxxxxxxxxxx'' xxxxxxxxxxxxxx''')%_nat_scope

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -1,31 +1,31 @@
 a : bool -> bool
 
 a is not universe polymorphic
-Arguments a _%bool_scope
+Arguments a _%_bool_scope
 Expands to: Variable a
 b : bool -> bool
 
 b is not universe polymorphic
-Arguments b _%bool_scope
+Arguments b _%_bool_scope
 Expands to: Variable b
 negb'' : bool -> bool
 
 negb'' is not universe polymorphic
-Arguments negb'' b%bool_scope
+Arguments negb'' b%_bool_scope
 negb'' is transparent
 Expands to: Constant ArgumentsScope.A.B.negb''
 Declared in library ArgumentsScope, line 9, characters 11-17
 negb' : bool -> bool
 
 negb' is not universe polymorphic
-Arguments negb' b%bool_scope
+Arguments negb' b%_bool_scope
 negb' is transparent
 Expands to: Constant ArgumentsScope.A.negb'
 Declared in library ArgumentsScope, line 6, characters 11-16
 negb : bool -> bool
 
 negb is not universe polymorphic
-Arguments negb b%bool_scope
+Arguments negb b%_bool_scope
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
 Declared in library Corelib.Init.Datatypes, line 84, characters 11-15
@@ -86,7 +86,7 @@ Declared in library ArgumentsScope, line 9, characters 11-17
 f : bool -> bool
 
 f is not universe polymorphic
-Arguments f x%A_scope%B_scope
+Arguments f x%_A_scope%_B_scope
 f is transparent
 Expands to: Constant ArgumentsScope.f
 Declared in library ArgumentsScope, line 41, characters 11-12
@@ -97,7 +97,7 @@ f true
 f : bool -> bool
 
 f is not universe polymorphic
-Arguments f x%B_scope%A_scope
+Arguments f x%_B_scope%_A_scope
 f is transparent
 Expands to: Constant ArgumentsScope.f
 Declared in library ArgumentsScope, line 41, characters 11-12
@@ -108,28 +108,28 @@ f false
 g : bool -> bool
 
 g is not universe polymorphic
-Arguments g x%A_scope%B_scope
+Arguments g x%_A_scope%_B_scope
 g is transparent
 Expands to: Constant ArgumentsScope.g
 Declared in library ArgumentsScope, line 64, characters 11-12
 g' : nat -> nat
 
 g' is not universe polymorphic
-Arguments g' x%B_scope%A_scope
+Arguments g' x%_B_scope%_A_scope
 g' is transparent
 Expands to: Constant ArgumentsScope.g'
 Declared in library ArgumentsScope, line 71, characters 11-13
 g'' : unit -> unit
 
 g'' is not universe polymorphic
-Arguments g'' x%B_scope
+Arguments g'' x%_B_scope
 g'' is transparent
 Expands to: Constant ArgumentsScope.g''
 Declared in library ArgumentsScope, line 78, characters 11-14
 f : A -> B -> A
 
 f is not universe polymorphic
-Arguments f _%X _%Y
+Arguments f _%_X _%_Y
 f is transparent
 Expands to: Constant ArgumentsScope.SectionTest1.S.f
 Declared in library ArgumentsScope, line 91, characters 15-16
@@ -142,7 +142,7 @@ Declared in library ArgumentsScope, line 91, characters 15-16
 N.f : A -> A
 
 N.f is not universe polymorphic
-Arguments N.f _%X
+Arguments N.f _%_X
 Expands to: Constant ArgumentsScope.SectionTest2.N.f
 g : A -> A
 

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -14,25 +14,25 @@ where
 ?y : [ |- nat]
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
 
-Arguments eq {A}%type_scope x _
-Arguments eq_refl {B}%type_scope {y}, [_] _
+Arguments eq {A}%_type_scope x _
+Arguments eq_refl {B}%_type_scope {y}, [_] _
   (where some original arguments have been renamed)
 eq_refl : forall {B : Type} {y : B}, y = y
 
 eq_refl is template universe polymorphic
-Arguments eq_refl {B}%type_scope {y}, [_] _
+Arguments eq_refl {B}%_type_scope {y}, [_] _
   (where some original arguments have been renamed)
 Expands to: Constructor Corelib.Init.Logic.eq_refl
 Declared in library Corelib.Init.Logic, line 379, characters 4-11
 Inductive myEq (B : Type) (x : A) : A -> Prop :=  myrefl : B -> myEq B x x.
 
-Arguments myEq B%type_scope x _
-Arguments myrefl {C}%type_scope x _
+Arguments myEq B%_type_scope x _
+Arguments myrefl {C}%_type_scope x _
   (where some original arguments have been renamed)
 myrefl : forall {C : Type} (x : A), C -> myEq C x x
 
 myrefl is template universe polymorphic
-Arguments myrefl {C}%type_scope x _
+Arguments myrefl {C}%_type_scope x _
   (where some original arguments have been renamed)
 myrefl uses section variable A.
 Expands to: Constructor Arguments_renaming.Test1.myrefl
@@ -45,12 +45,12 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   end
      : forall {T : Type}, T -> nat -> nat -> nat
 
-Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
+Arguments myplus {Z}%_type_scope !t (!n m)%_nat_scope
   (where some original arguments have been renamed)
 myplus : forall {Z : Type}, Z -> nat -> nat -> nat
 
 myplus is not universe polymorphic
-Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
+Arguments myplus {Z}%_type_scope !t (!n m)%_nat_scope
   (where some original arguments have been renamed)
 The reduction tactics unfold myplus when the 2nd and
   3rd arguments evaluate to a constructor
@@ -62,13 +62,13 @@ Declared in library Arguments_renaming, line 31, characters 0-108
 Inductive myEq (A B : Type) (x : A) : A -> Prop :=
     myrefl : B -> myEq A B x x.
 
-Arguments myEq (A B)%type_scope x _
-Arguments myrefl A%type_scope {C}%type_scope x _
+Arguments myEq (A B)%_type_scope x _
+Arguments myrefl A%_type_scope {C}%_type_scope x _
   (where some original arguments have been renamed)
 myrefl : forall (A : Type) {C : Type} (x : A), C -> myEq A C x x
 
 myrefl is template universe polymorphic
-Arguments myrefl A%type_scope {C}%type_scope x _
+Arguments myrefl A%_type_scope {C}%_type_scope x _
   (where some original arguments have been renamed)
 Expands to: Constructor Arguments_renaming.myrefl
 Declared in library Arguments_renaming, line 25, characters 40-46
@@ -82,12 +82,12 @@ fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
   end
      : forall {T : Type}, T -> nat -> nat -> nat
 
-Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
+Arguments myplus {Z}%_type_scope !t (!n m)%_nat_scope
   (where some original arguments have been renamed)
 myplus : forall {Z : Type}, Z -> nat -> nat -> nat
 
 myplus is not universe polymorphic
-Arguments myplus {Z}%type_scope !t (!n m)%nat_scope
+Arguments myplus {Z}%_type_scope !t (!n m)%_nat_scope
   (where some original arguments have been renamed)
 The reduction tactics unfold myplus when the 2nd and
   3rd arguments evaluate to a constructor

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -7,7 +7,7 @@ fix F (t : t) : P t :=
      : forall P : t -> Type,
        (let x := t in forall x0 : x, P x0 -> P (k x0)) -> forall t : t, P t
 
-Arguments t_rect (P f)%function_scope t
+Arguments t_rect (P f)%_function_scope t
      = fun d : TT => match d with
                      | {| f3 := b |} => b
                      end
@@ -26,7 +26,7 @@ match eq_nat_dec x y with
 end
      : forall (x y : nat) (P : nat -> Type), P x -> P y -> P y
 
-Arguments proj (x y)%nat_scope P%function_scope def prf
+Arguments proj (x y)%_nat_scope P%_function_scope def prf
 foo =
 fix foo (A : Type) (l : list A) {struct l} : option A :=
   match l with
@@ -36,14 +36,14 @@ fix foo (A : Type) (l : list A) {struct l} : option A :=
   end
      : forall A : Type, list A -> option A
 
-Arguments foo A%type_scope l%list_scope
+Arguments foo A%_type_scope l%_list_scope
 uncast =
 fun (A : Type) (x : I A) => match x with
                             | x0 <: _ => x0
                             end
      : forall A : Type, I A -> A
 
-Arguments uncast A%type_scope x
+Arguments uncast A%_type_scope x
 foo' = if A 0 then true else false
      : bool
 f =
@@ -90,7 +90,7 @@ lem2 =
 fun dd : bool => if dd as aa return (aa = aa) then eq_refl else eq_refl
      : forall k : bool, k = k
 
-Arguments lem2 k%bool_scope
+Arguments lem2 k%_bool_scope
 lem3 =
 fun dd : nat * nat => let (bb, cc) as aa return (aa = aa) := dd in eq_refl
      : forall k : nat * nat, k = k

--- a/test-suite/output/DebugRelevances.out
+++ b/test-suite/output/DebugRelevances.out
@@ -2,27 +2,27 @@ foo@{u} =
 fun (A : (* Relevant *) Type) (a : (* Relevant *) A) => a
      : forall A : (* Relevant *) Type, A -> A
 
-Arguments foo A%type_scope a
+Arguments foo A%_type_scope a
 foo'@{} =
 fun (A : (* Relevant *) Prop) (a : (* Relevant *) A) => a
      : forall A : (* Relevant *) Prop, A -> A
 
-Arguments foo' A%type_scope a
+Arguments foo' A%_type_scope a
 bar@{} =
 fun (A : (* Relevant *) SProp) (a : (* Irrelevant *) A) => a
      : forall A : (* Relevant *) SProp, A -> A
 
-Arguments bar A%type_scope a
+Arguments bar A%_type_scope a
 baz@{s | u} =
 fun (A : (* Relevant *) Type) (a : (* s *) A) => a
      : forall A : (* Relevant *) Type, A -> A
 
-Arguments baz A%type_scope a
+Arguments baz A%_type_scope a
 boz@{s s' | u} =
 fun (A B : (* Relevant *) Type) (a : (* s *) hide) (_ : (* s' *) hide) => a
      : forall A B : (* Relevant *) Type, hide -> hide -> hide
 
-Arguments boz (A B)%type_scope a b
+Arguments boz (A B)%_type_scope a b
 1 goal
   
   f := fun (A : (* Relevant *) Type) (_ : (* α8 *) A) => A

--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -5,7 +5,7 @@ ex_intro (P:=fun _ : nat => True) (x:=0) I
 d2 = fun x : nat => d1 (y:=x)
      : forall [x x0 : nat], x0 = x -> x0 = x
 
-Arguments d2 [x x]%nat_scope h
+Arguments d2 [x x]%_nat_scope h
 map id (1 :: nil)
      : list nat
 map id' (1 :: nil)

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -8,20 +8,20 @@ l : list' A
 Unable to unify "list' (A * A)%type" with "list' A".
 Inductive foo (A : Type) (x : A) (y : A := x) : Prop :=  Foo : foo A x.
 
-Arguments foo A%type_scope x
-Arguments Foo A%type_scope x
+Arguments foo A%_type_scope x
+Arguments Foo A%_type_scope x
 myprod unit bool
      : Set
 option : Type -> Type
 
 option is template universe polymorphic
-Arguments option A%type_scope
+Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
 Declared in library Corelib.Init.Datatypes, line 202, characters 10-16
 option : Type@{option.u0} -> Type@{max(Set,option.u0)}
 
 option is template universe polymorphic on option.u0 (cannot be instantiated to Prop)
-Arguments option A%type_scope
+Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
 Declared in library Corelib.Init.Datatypes, line 202, characters 10-16
 File "./output/Inductive.v", line 27, characters 4-13:
@@ -38,7 +38,7 @@ or : Prop -> Prop -> Prop
 
 or is not universe polymorphic
 or may only be eliminated to produce values whose type is SProp or Prop.
-Arguments or (A B)%type_scope
+Arguments or (A B)%_type_scope
 Expands to: Inductive Corelib.Init.Logic.or
 Declared in library Corelib.Init.Logic, line 89, characters 10-12
 sunit : SProp
@@ -68,7 +68,7 @@ ssig@{q1 q2 q3 | a b} may only be eliminated to produce values whose type is in 
   are equal to the instantiation of q3, or to qualities smaller
   (SProp <= Prop <= Type, and all variables <= Type)
   than the instantiation of q3.
-Arguments ssig A%type_scope B%function_scope
+Arguments ssig A%_type_scope B%_function_scope
 Expands to: Inductive Inductive.ssig
 Declared in library Inductive, line 48, characters 22-26
 BoxP@{q | a} : Type@{q | a} -> Prop
@@ -77,6 +77,6 @@ BoxP@{q | a} : Type@{q | a} -> Prop
 BoxP is universe polymorphic
 BoxP@{q | a} may only be eliminated to produce values whose type is SProp or Prop,
   unless instantiated such that the quality q is SProp or Prop.
-Arguments BoxP A%type_scope
+Arguments BoxP A%_type_scope
 Expands to: Inductive Inductive.BoxP
 Declared in library Inductive, line 56, characters 22-26

--- a/test-suite/output/InductiveMainName.out
+++ b/test-suite/output/InductiveMainName.out
@@ -22,5 +22,5 @@ Expands to: Constant InductiveMainName.bar''
 Record foo''' : Set := Build_foo''' { bar''' : nat } as id.
 
 foo''' has primitive projections with eta conversion.
-Arguments Build_foo''' bar'''%nat_scope
+Arguments Build_foo''' bar'''%_nat_scope
 Arguments bar''' id

--- a/test-suite/output/InitSyntax.out
+++ b/test-suite/output/InitSyntax.out
@@ -1,8 +1,8 @@
 Inductive sig2 (A : Type) (P Q : A -> Prop) : Type :=
     exist2 : forall x : A, P x -> Q x -> {x : A | P x & Q x}.
 
-Arguments sig2 [A]%type_scope (P Q)%type_scope
-Arguments exist2 [A]%type_scope (P Q)%function_scope x _ _
+Arguments sig2 [A]%_type_scope (P Q)%_type_scope
+Arguments exist2 [A]%_type_scope (P Q)%_function_scope x _ _
 exists x : nat, x = x
      : Prop
 fun b : bool => if b then b else b

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -231,7 +231,7 @@ fun l : list nat => match l with
                     end
      : list nat -> list nat
 
-Arguments foo l%list_scope
+Arguments foo l%_list_scope
 Notation "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
   : type_scope (default interpretation)
 Notation "'exists' ! x .. y , p" :=

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -23,7 +23,7 @@ swap =
 fun (A B : Type) '(x, y) => (y, x)
      : forall {A B : Type}, A * B -> B * A
 
-Arguments swap {A B}%type_scope pat
+Arguments swap {A B}%_type_scope pat
 fun (A B : Type) '(x, y) => swap (x, y) = (y, x)
      : forall A B : Type, A * B -> Prop
 forall (A B : Type) '(x, y), swap (x, y) = (y, x)
@@ -50,6 +50,6 @@ fun (pat : nat) '(x, y) => x + y = pat
 f = fun x : nat => x + x
      : nat -> nat
 
-Arguments f x%nat_scope
+Arguments f x%_nat_scope
 fun x : nat => x + x
      : nat -> nat

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -1,25 +1,25 @@
 existT : forall [A : Type] (P : A -> Type) (x : A), P x -> {x : A & P x}
 
 existT is template universe polymorphic
-Arguments existT [A]%type_scope P%function_scope x _
+Arguments existT [A]%_type_scope P%_function_scope x _
 Expands to: Constructor Corelib.Init.Specif.existT
 Declared in library Corelib.Init.Specif, line 45, characters 4-10
 Inductive sigT (A : Type) (P : A -> Type) : Type :=
     existT : forall x : A, P x -> {x : A & P x}.
 
-Arguments sigT [A]%type_scope P%type_scope
-Arguments existT [A]%type_scope P%function_scope x _
+Arguments sigT [A]%_type_scope P%_type_scope
+Arguments existT [A]%_type_scope P%_function_scope x _
 existT : forall [A : Type] (P : A -> Type) (x : A), P x -> {x : A & P x}
 
 Argument A is implicit
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
 
-Arguments eq {A}%type_scope x _
-Arguments eq_refl {A}%type_scope {x}, [_] _
+Arguments eq {A}%_type_scope x _
+Arguments eq_refl {A}%_type_scope {x}, [_] _
 eq_refl : forall {A : Type} {x : A}, x = x
 
 eq_refl is template universe polymorphic
-Arguments eq_refl {A}%type_scope {x}, [_] _
+Arguments eq_refl {A}%_type_scope {x}, [_] _
 Expands to: Constructor Corelib.Init.Logic.eq_refl
 Declared in library Corelib.Init.Logic, line 379, characters 4-11
 eq_refl : forall {A : Type} {x : A}, x = x
@@ -36,11 +36,11 @@ fix add (n m : nat) {struct n} : nat :=
   end
      : nat -> nat -> nat
 
-Arguments Nat.add (n m)%nat_scope
+Arguments Nat.add (n m)%_nat_scope
 Nat.add : nat -> nat -> nat
 
 Nat.add is not universe polymorphic
-Arguments Nat.add (n m)%nat_scope
+Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
 Declared in library Corelib.Init.Nat, line 47, characters 0-113
@@ -49,16 +49,16 @@ Nat.add : nat -> nat -> nat
 plus_n_O : forall n : nat, n = n + 0
 
 plus_n_O is not universe polymorphic
-Arguments plus_n_O n%nat_scope
+Arguments plus_n_O n%_nat_scope
 plus_n_O is opaque
 Expands to: Constant Corelib.Init.Peano.plus_n_O
 Declared in library Corelib.Init.Peano, line 99, characters 6-14
 Inductive le (n : nat) : nat -> Prop :=
     le_n : n <= n | le_S : forall m : nat, n <= m -> n <= S m.
 
-Arguments le (n _)%nat_scope
-Arguments le_n n%nat_scope
-Arguments le_S {n}%nat_scope [m]%nat_scope _
+Arguments le (n _)%_nat_scope
+Arguments le_n n%_nat_scope
+Arguments le_S {n}%_nat_scope [m]%_nat_scope _
 comparison : Set
 
 comparison is not universe polymorphic
@@ -88,14 +88,14 @@ Declared in library Corelib.Init.Logic, line 757, characters 0-41
 eq_sym : forall [A : Type] [x y : A], x = y -> y = x
 
 eq_sym is not universe polymorphic
-Arguments eq_sym [A]%type_scope [x y] _
+Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym is transparent
 Expands to: Constant Corelib.Init.Logic.eq_sym
 Declared in library Corelib.Init.Logic, line 419, characters 12-18
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
 
-Arguments eq {A}%type_scope x _
-Arguments eq_refl {A}%type_scope {x}, {_} _
+Arguments eq {A}%_type_scope x _
+Arguments eq_refl {A}%_type_scope {x}, {_} _
 n:nat
 
 Hypothesis of the goal context.
@@ -111,14 +111,14 @@ Hypothesis of the goal context.
 Alias.eq : forall {A : Type}, A -> A -> Prop
 
 Alias.eq is template universe polymorphic
-Arguments Alias.eq {A}%type_scope x _
+Arguments Alias.eq {A}%_type_scope x _
 Expands to: Inductive PrintInfos.Alias.eq (syntactically equal to
             Corelib.Init.Logic.eq)
 Declared in library Corelib.Init.Logic, line 378, characters 10-12
 Alias.eq_refl : forall {A : Type} {x : A}, x = x
 
 Alias.eq_refl is template universe polymorphic
-Arguments Alias.eq_refl {A}%type_scope {x}, [_] _
+Arguments Alias.eq_refl {A}%_type_scope {x}, [_] _
 Expands to: Constructor PrintInfos.Alias.eq_refl (syntactically equal to
             Corelib.Init.Logic.eq_refl)
 Declared in library Corelib.Init.Logic, line 379, characters 4-11
@@ -126,7 +126,7 @@ Alias.eq_ind :
 forall [A : Type] (x : A) (P : A -> Prop), P x -> forall y : A, x = y -> P y
 
 Alias.eq_ind is not universe polymorphic
-Arguments Alias.eq_ind [A]%type_scope x P%function_scope f y e
+Arguments Alias.eq_ind [A]%_type_scope x P%_function_scope f y e
   (where some original arguments have been renamed)
 Alias.eq_ind is transparent
 Expands to: Constant PrintInfos.Alias.eq_ind (syntactically equal to
@@ -136,13 +136,13 @@ fst : forall A B : Type, prod A B -> A
 
 fst is not universe polymorphic
 fst is a projection of prod
-Arguments fst (A B)%type_scope p
+Arguments fst (A B)%_type_scope p
 fst is transparent
 Expands to: Constant PrintInfos.AboutProj.fst
 fst : forall A B : Type, prod A B -> A
 
 fst is not universe polymorphic
 fst is a primitive projection of prod
-Arguments fst (A B)%type_scope p
+Arguments fst (A B)%_type_scope p
 fst is transparent
 Expands to: Constant PrintInfos.AboutPrimProj.fst

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -9,7 +9,7 @@ end
        P a (reflT@{u} a) -> forall (a0 : A) (e : eqT@{u} a a0), P a0 e
 (* u u0 |=  *)
 
-Arguments eqT_rect A%type_scope a P%function_scope f a0 e
+Arguments eqT_rect A%_type_scope a P%_function_scope f a0 e
 seq_rect =
 fun (A : Type@{seq.u0}) (a : A)
   (P : forall a0 : A, seq a a0 -> Type@{seq_rect.u0}) 
@@ -21,7 +21,7 @@ end
          (P : forall a0 : A, seq a a0 -> Type@{seq_rect.u0}),
        P a (srefl a) -> forall (a0 : A) (s : seq a a0), P a0 s
 
-Arguments seq_rect A%type_scope a P%function_scope f a0 s
+Arguments seq_rect A%_type_scope a P%_function_scope f a0 s
 eq_sym =
 fun (A : Type) (x y : A) (H : @eq A x y) =>
 match H in (@eq _ _ a) return (@eq A a x) with
@@ -29,7 +29,7 @@ match H in (@eq _ _ a) return (@eq A a x) with
 end
      : forall [A : Type] [x y : A] (_ : @eq A x y), @eq A y x
 
-Arguments eq_sym [A]%type_scope [x y] _
+Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym =
 fun (A : Type) (x y : A) (H : x = y) =>
 match H in (_ = a) return (a = x) with
@@ -37,7 +37,7 @@ match H in (_ = a) return (a = x) with
 end
      : forall [A : Type] [x y : A], x = y -> y = x
 
-Arguments eq_sym [A]%type_scope [x y] _
+Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym =
 fun (A : Type) (x y : A) (H : x = y) =>
 match H in (_ = a) return (a = x) with
@@ -45,4 +45,4 @@ match H in (_ = a) return (a = x) with
 end
      : forall [A : Type] [x y : A], x = y -> y = x
 
-Arguments eq_sym [A]%type_scope [x y] _
+Arguments eq_sym [A]%_type_scope [x y] _

--- a/test-suite/output/PrintSecDeps.out
+++ b/test-suite/output/PrintSecDeps.out
@@ -14,7 +14,7 @@ Declared in library PrintSecDeps, line 10, characters 13-16
 bla : forall A : Type, A -> Prop
 
 bla is not universe polymorphic
-Arguments bla A%type_scope x
+Arguments bla A%_type_scope x
 bla is transparent
 Expands to: Constant PrintSecDeps.bla
 Declared in library PrintSecDeps, line 6, characters 13-16

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -32,7 +32,7 @@ nat_ind (fun n0 : nat => ((n0 * m) + n0) = (n0 * (S m)))
   n
      : forall n m : nat, ((n * m) + n) = (n * (S m))
 
-Arguments mult_n_Sm (n m)%nat_scope
+Arguments mult_n_Sm (n m)%_nat_scope
 1 :: (2 :: [3; 4])
      : list nat
 {0 = 1} + {2 <= (4 + 5)}

--- a/test-suite/output/Projections.out
+++ b/test-suite/output/Projections.out
@@ -8,13 +8,13 @@ let B := A in fun (C : Type) (u : U A C) => (A, B, C, c _ _ u)
        forall C : Type, U A C -> Type * Type * Type * (B * A * C)
 
 a is a projection of U
-Arguments a (A C)%type_scope u
+Arguments a (A C)%_type_scope u
 Record U (A : Type) (B : Type := A) (C : Type) : Type := Build_U
   { c : (B * A * C)%type;  a := (A, B, C, c);  b : a = a }.
 
 U has primitive projections with eta conversion.
-Arguments U (A C)%type_scope
-Arguments Build_U (A C)%type_scope c b
-Arguments c (A C)%type_scope u
-Arguments a (A C)%type_scope u
-Arguments b (A C)%type_scope u
+Arguments U (A C)%_type_scope
+Arguments Build_U (A C)%_type_scope c b
+Arguments c (A C)%_type_scope u
+Arguments a (A C)%_type_scope u
+Arguments b (A C)%_type_scope u

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -6,7 +6,7 @@ Replace File "./output/Qf_stdlib.v", line 16, characters 6-22 with Corelib.Init.
 Nat.add : nat -> nat -> nat
 
 Nat.add is not universe polymorphic
-Arguments Nat.add (n m)%nat_scope
+Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
 Declared in library Corelib.Init.Nat, line 47, characters 0-113

--- a/test-suite/output/RecordProjParameter.out
+++ b/test-suite/output/RecordProjParameter.out
@@ -2,7 +2,7 @@ t1 : Atype -> forall a : Type, a
 
 t1 is not universe polymorphic
 t1 is a projection of Atype
-Arguments t1 a0 a%type_scope
+Arguments t1 a0 a%_type_scope
 t1 is transparent
 Expands to: Constant RecordProjParameter.t1
 t3 : forall a0 : Atype, t2 a0
@@ -16,7 +16,7 @@ u1 : Btype -> forall b b0 : Type, b * b0
 
 u1 is not universe polymorphic
 u1 is a projection of Btype
-Arguments u1 b1 (b b0)%type_scope
+Arguments u1 b1 (b b0)%_type_scope
 u1 is transparent
 Expands to: Constant RecordProjParameter.u1
 u3 : forall b1 : Btype, u2 b1
@@ -30,7 +30,7 @@ v1 : Ctype -> forall c0 : Type, c0
 
 v1 is not universe polymorphic
 v1 is a projection of Ctype
-Arguments v1 c c0%type_scope
+Arguments v1 c c0%_type_scope
 v1 is transparent
 Expands to: Constant RecordProjParameter.v1
 v3 : forall c : Ctype, v2 c

--- a/test-suite/output/SchemeNames.out
+++ b/test-suite/output/SchemeNames.out
@@ -23,7 +23,7 @@ fooSProp_inds :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
 
 fooSProp_inds is not universe polymorphic
-Arguments fooSProp_inds P%function_scope f f0 f1
+Arguments fooSProp_inds P%_function_scope f f0 f1
 fooSProp_inds is transparent
 Expands to: Constant SchemeNames.fooSProp_inds
 File "./output/SchemeNames.v", line 23, characters 2-48:
@@ -50,7 +50,7 @@ because strict proofs can be eliminated only to build strict proofs.
 fooSProp_inds_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
 fooSProp_inds_nodep is not universe polymorphic
-Arguments fooSProp_inds_nodep P%type_scope f f0 f1
+Arguments fooSProp_inds_nodep P%_type_scope f f0 f1
 fooSProp_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_inds_nodep
 File "./output/SchemeNames.v", line 32, characters 2-49:
@@ -78,7 +78,7 @@ fooSProp_cases :
 forall P : fooSProp -> SProp, P aSP -> P bSP -> forall f1 : fooSProp, P f1
 
 fooSProp_cases is not universe polymorphic
-Arguments fooSProp_cases P%function_scope f f0 f1
+Arguments fooSProp_cases P%_function_scope f f0 f1
 fooSProp_cases is transparent
 Expands to: Constant SchemeNames.fooSProp_cases
 File "./output/SchemeNames.v", line 41, characters 2-42:
@@ -105,7 +105,7 @@ because strict proofs can be eliminated only to build strict proofs.
 fooSProp_cases_nodep : forall P : SProp, P -> P -> fooSProp -> P
 
 fooSProp_cases_nodep is not universe polymorphic
-Arguments fooSProp_cases_nodep P%type_scope f f0 f1
+Arguments fooSProp_cases_nodep P%_type_scope f f0 f1
 fooSProp_cases_nodep is transparent
 Expands to: Constant SchemeNames.fooSProp_cases_nodep
 File "./output/SchemeNames.v", line 49, characters 2-36:
@@ -130,14 +130,14 @@ fooProp_inds_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
 
 fooProp_inds_dep is not universe polymorphic
-Arguments fooProp_inds_dep P%function_scope f f0 f1
+Arguments fooProp_inds_dep P%_function_scope f f0 f1
 fooProp_inds_dep is transparent
 Expands to: Constant SchemeNames.fooProp_inds_dep
 fooProp_ind_dep :
 forall P : fooProp -> Prop, P aP -> P bP -> forall f1 : fooProp, P f1
 
 fooProp_ind_dep is not universe polymorphic
-Arguments fooProp_ind_dep P%function_scope f f0 f1
+Arguments fooProp_ind_dep P%_function_scope f f0 f1
 fooProp_ind_dep is transparent
 Expands to: Constant SchemeNames.fooProp_ind_dep
 File "./output/SchemeNames.v", line 71, characters 2-46:
@@ -157,13 +157,13 @@ because proofs can be eliminated only to build proofs.
 fooProp_inds : forall P : SProp, P -> P -> fooProp -> P
 
 fooProp_inds is not universe polymorphic
-Arguments fooProp_inds P%type_scope f f0 f1
+Arguments fooProp_inds P%_type_scope f f0 f1
 fooProp_inds is transparent
 Expands to: Constant SchemeNames.fooProp_inds
 fooProp_ind : forall P : Prop, P -> P -> fooProp -> P
 
 fooProp_ind is not universe polymorphic
-Arguments fooProp_ind P%type_scope f f0 f1
+Arguments fooProp_ind P%_type_scope f f0 f1
 fooProp_ind is transparent
 Expands to: Constant SchemeNames.fooProp_ind
 File "./output/SchemeNames.v", line 81, characters 2-47:
@@ -184,14 +184,14 @@ fooProp_cases_dep :
 forall P : fooProp -> SProp, P aP -> P bP -> forall f1 : fooProp, P f1
 
 fooProp_cases_dep is not universe polymorphic
-Arguments fooProp_cases_dep P%function_scope f f0 f1
+Arguments fooProp_cases_dep P%_function_scope f f0 f1
 fooProp_cases_dep is transparent
 Expands to: Constant SchemeNames.fooProp_cases_dep
 fooProp_case_dep :
 forall P : fooProp -> Prop, P aP -> P bP -> forall f1 : fooProp, P f1
 
 fooProp_case_dep is not universe polymorphic
-Arguments fooProp_case_dep P%function_scope f f0 f1
+Arguments fooProp_case_dep P%_function_scope f f0 f1
 fooProp_case_dep is transparent
 Expands to: Constant SchemeNames.fooProp_case_dep
 File "./output/SchemeNames.v", line 91, characters 2-40:
@@ -211,13 +211,13 @@ because proofs can be eliminated only to build proofs.
 fooProp_cases : forall P : SProp, P -> P -> fooProp -> P
 
 fooProp_cases is not universe polymorphic
-Arguments fooProp_cases P%type_scope f f0 f1
+Arguments fooProp_cases P%_type_scope f f0 f1
 fooProp_cases is transparent
 Expands to: Constant SchemeNames.fooProp_cases
 fooProp_case : forall P : Prop, P -> P -> fooProp -> P
 
 fooProp_case is not universe polymorphic
-Arguments fooProp_case P%type_scope f f0 f1
+Arguments fooProp_case P%_type_scope f f0 f1
 fooProp_case is transparent
 Expands to: Constant SchemeNames.fooProp_case
 File "./output/SchemeNames.v", line 99, characters 2-35:
@@ -228,104 +228,104 @@ fooSet_inds :
 forall P : fooSet -> SProp, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_inds is not universe polymorphic
-Arguments fooSet_inds P%function_scope f f0 f1
+Arguments fooSet_inds P%_function_scope f f0 f1
 fooSet_inds is transparent
 Expands to: Constant SchemeNames.fooSet_inds
 fooSet_ind :
 forall P : fooSet -> Prop, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_ind is not universe polymorphic
-Arguments fooSet_ind P%function_scope f f0 f1
+Arguments fooSet_ind P%_function_scope f f0 f1
 fooSet_ind is transparent
 Expands to: Constant SchemeNames.fooSet_ind
 fooSet_rec :
 forall P : fooSet -> Set, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_rec is not universe polymorphic
-Arguments fooSet_rec P%function_scope f f0 f1
+Arguments fooSet_rec P%_function_scope f f0 f1
 fooSet_rec is transparent
 Expands to: Constant SchemeNames.fooSet_rec
 fooSet_rect :
 forall P : fooSet -> Type, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_rect is not universe polymorphic
-Arguments fooSet_rect P%function_scope f f0 f1
+Arguments fooSet_rect P%_function_scope f f0 f1
 fooSet_rect is transparent
 Expands to: Constant SchemeNames.fooSet_rect
 fooSet_inds_nodep : forall P : SProp, P -> P -> fooSet -> P
 
 fooSet_inds_nodep is not universe polymorphic
-Arguments fooSet_inds_nodep P%type_scope f f0 f1
+Arguments fooSet_inds_nodep P%_type_scope f f0 f1
 fooSet_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_inds_nodep
 fooSet_ind_nodep : forall P : Prop, P -> P -> fooSet -> P
 
 fooSet_ind_nodep is not universe polymorphic
-Arguments fooSet_ind_nodep P%type_scope f f0 f1
+Arguments fooSet_ind_nodep P%_type_scope f f0 f1
 fooSet_ind_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_ind_nodep
 fooSet_rec_nodep : forall P : Set, P -> P -> fooSet -> P
 
 fooSet_rec_nodep is not universe polymorphic
-Arguments fooSet_rec_nodep P%type_scope f f0 f1
+Arguments fooSet_rec_nodep P%_type_scope f f0 f1
 fooSet_rec_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_rec_nodep
 fooSet_rect_nodep : forall P : Type, P -> P -> fooSet -> P
 
 fooSet_rect_nodep is not universe polymorphic
-Arguments fooSet_rect_nodep P%type_scope f f0 f1
+Arguments fooSet_rect_nodep P%_type_scope f f0 f1
 fooSet_rect_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_rect_nodep
 fooSet_cases :
 forall P : fooSet -> SProp, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_cases is not universe polymorphic
-Arguments fooSet_cases P%function_scope f f0 f1
+Arguments fooSet_cases P%_function_scope f f0 f1
 fooSet_cases is transparent
 Expands to: Constant SchemeNames.fooSet_cases
 fooSet_case :
 forall P : fooSet -> Prop, P aS -> P bS -> forall f1 : fooSet, P f1
 
 fooSet_case is not universe polymorphic
-Arguments fooSet_case P%function_scope f f0 f1
+Arguments fooSet_case P%_function_scope f f0 f1
 fooSet_case is transparent
 Expands to: Constant SchemeNames.fooSet_case
 fooSet'_case :
 forall P : fooSet' -> Set, P aS' -> P bS' -> forall f1 : fooSet', P f1
 
 fooSet'_case is not universe polymorphic
-Arguments fooSet'_case P%function_scope f f0 f1
+Arguments fooSet'_case P%_function_scope f f0 f1
 fooSet'_case is transparent
 Expands to: Constant SchemeNames.fooSet'_case
 fooSet'_caset :
 forall P : fooSet' -> Type, P aS' -> P bS' -> forall f1 : fooSet', P f1
 
 fooSet'_caset is not universe polymorphic
-Arguments fooSet'_caset P%function_scope f f0 f1
+Arguments fooSet'_caset P%_function_scope f f0 f1
 fooSet'_caset is transparent
 Expands to: Constant SchemeNames.fooSet'_caset
 fooSet_cases_nodep : forall P : SProp, P -> P -> fooSet -> P
 
 fooSet_cases_nodep is not universe polymorphic
-Arguments fooSet_cases_nodep P%type_scope f f0 f1
+Arguments fooSet_cases_nodep P%_type_scope f f0 f1
 fooSet_cases_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_cases_nodep
 fooSet_case_nodep : forall P : Prop, P -> P -> fooSet -> P
 
 fooSet_case_nodep is not universe polymorphic
-Arguments fooSet_case_nodep P%type_scope f f0 f1
+Arguments fooSet_case_nodep P%_type_scope f f0 f1
 fooSet_case_nodep is transparent
 Expands to: Constant SchemeNames.fooSet_case_nodep
 fooSet'_case_nodep : forall P : Set, P -> P -> fooSet' -> P
 
 fooSet'_case_nodep is not universe polymorphic
-Arguments fooSet'_case_nodep P%type_scope f f0 f1
+Arguments fooSet'_case_nodep P%_type_scope f f0 f1
 fooSet'_case_nodep is transparent
 Expands to: Constant SchemeNames.fooSet'_case_nodep
 fooSet'_caset_nodep : forall P : Type, P -> P -> fooSet' -> P
 
 fooSet'_caset_nodep is not universe polymorphic
-Arguments fooSet'_caset_nodep P%type_scope f f0 f1
+Arguments fooSet'_caset_nodep P%_type_scope f f0 f1
 fooSet'_caset_nodep is transparent
 Expands to: Constant SchemeNames.fooSet'_caset_nodep
 fooSet_beq : fooSet -> fooSet -> bool
@@ -364,104 +364,104 @@ fooType_inds :
 forall P : fooType -> SProp, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_inds is not universe polymorphic
-Arguments fooType_inds P%function_scope f f0 f1
+Arguments fooType_inds P%_function_scope f f0 f1
 fooType_inds is transparent
 Expands to: Constant SchemeNames.fooType_inds
 fooType_ind :
 forall P : fooType -> Prop, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_ind is not universe polymorphic
-Arguments fooType_ind P%function_scope f f0 f1
+Arguments fooType_ind P%_function_scope f f0 f1
 fooType_ind is transparent
 Expands to: Constant SchemeNames.fooType_ind
 fooType_rec :
 forall P : fooType -> Set, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_rec is not universe polymorphic
-Arguments fooType_rec P%function_scope f f0 f1
+Arguments fooType_rec P%_function_scope f f0 f1
 fooType_rec is transparent
 Expands to: Constant SchemeNames.fooType_rec
 fooType_rect :
 forall P : fooType -> Type, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_rect is not universe polymorphic
-Arguments fooType_rect P%function_scope f f0 f1
+Arguments fooType_rect P%_function_scope f f0 f1
 fooType_rect is transparent
 Expands to: Constant SchemeNames.fooType_rect
 fooType_inds_nodep : forall P : SProp, P -> P -> fooType -> P
 
 fooType_inds_nodep is not universe polymorphic
-Arguments fooType_inds_nodep P%type_scope f f0 f1
+Arguments fooType_inds_nodep P%_type_scope f f0 f1
 fooType_inds_nodep is transparent
 Expands to: Constant SchemeNames.fooType_inds_nodep
 fooType_ind_nodep : forall P : Prop, P -> P -> fooType -> P
 
 fooType_ind_nodep is not universe polymorphic
-Arguments fooType_ind_nodep P%type_scope f f0 f1
+Arguments fooType_ind_nodep P%_type_scope f f0 f1
 fooType_ind_nodep is transparent
 Expands to: Constant SchemeNames.fooType_ind_nodep
 fooType_rec_nodep : forall P : Set, P -> P -> fooType -> P
 
 fooType_rec_nodep is not universe polymorphic
-Arguments fooType_rec_nodep P%type_scope f f0 f1
+Arguments fooType_rec_nodep P%_type_scope f f0 f1
 fooType_rec_nodep is transparent
 Expands to: Constant SchemeNames.fooType_rec_nodep
 fooType_rect_nodep : forall P : Type, P -> P -> fooType -> P
 
 fooType_rect_nodep is not universe polymorphic
-Arguments fooType_rect_nodep P%type_scope f f0 f1
+Arguments fooType_rect_nodep P%_type_scope f f0 f1
 fooType_rect_nodep is transparent
 Expands to: Constant SchemeNames.fooType_rect_nodep
 fooType_cases :
 forall P : fooType -> SProp, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_cases is not universe polymorphic
-Arguments fooType_cases P%function_scope f f0 f1
+Arguments fooType_cases P%_function_scope f f0 f1
 fooType_cases is transparent
 Expands to: Constant SchemeNames.fooType_cases
 fooType_case :
 forall P : fooType -> Prop, P aT -> P bT -> forall f1 : fooType, P f1
 
 fooType_case is not universe polymorphic
-Arguments fooType_case P%function_scope f f0 f1
+Arguments fooType_case P%_function_scope f f0 f1
 fooType_case is transparent
 Expands to: Constant SchemeNames.fooType_case
 fooType'_case :
 forall P : fooType' -> Set, P aT' -> P bT' -> forall f1 : fooType', P f1
 
 fooType'_case is not universe polymorphic
-Arguments fooType'_case P%function_scope f f0 f1
+Arguments fooType'_case P%_function_scope f f0 f1
 fooType'_case is transparent
 Expands to: Constant SchemeNames.fooType'_case
 fooType'_caset :
 forall P : fooType' -> Type, P aT' -> P bT' -> forall f1 : fooType', P f1
 
 fooType'_caset is not universe polymorphic
-Arguments fooType'_caset P%function_scope f f0 f1
+Arguments fooType'_caset P%_function_scope f f0 f1
 fooType'_caset is transparent
 Expands to: Constant SchemeNames.fooType'_caset
 fooType_cases_nodep : forall P : SProp, P -> P -> fooType -> P
 
 fooType_cases_nodep is not universe polymorphic
-Arguments fooType_cases_nodep P%type_scope f f0 f1
+Arguments fooType_cases_nodep P%_type_scope f f0 f1
 fooType_cases_nodep is transparent
 Expands to: Constant SchemeNames.fooType_cases_nodep
 fooType_case_nodep : forall P : Prop, P -> P -> fooType -> P
 
 fooType_case_nodep is not universe polymorphic
-Arguments fooType_case_nodep P%type_scope f f0 f1
+Arguments fooType_case_nodep P%_type_scope f f0 f1
 fooType_case_nodep is transparent
 Expands to: Constant SchemeNames.fooType_case_nodep
 fooType'_case_nodep : forall P : Set, P -> P -> fooType' -> P
 
 fooType'_case_nodep is not universe polymorphic
-Arguments fooType'_case_nodep P%type_scope f f0 f1
+Arguments fooType'_case_nodep P%_type_scope f f0 f1
 fooType'_case_nodep is transparent
 Expands to: Constant SchemeNames.fooType'_case_nodep
 fooType'_caset_nodep : forall P : Type, P -> P -> fooType' -> P
 
 fooType'_caset_nodep is not universe polymorphic
-Arguments fooType'_caset_nodep P%type_scope f f0 f1
+Arguments fooType'_caset_nodep P%_type_scope f f0 f1
 fooType'_caset_nodep is transparent
 Expands to: Constant SchemeNames.fooType'_caset_nodep
 fooType_beq : fooType -> fooType -> bool
@@ -501,7 +501,7 @@ forall (f : Type) (P : F f -> Type),
 (forall f0 : f, P (C f f0)) -> forall f1 : F f, P f1
 
 F_rect is not universe polymorphic
-Arguments F_rect f%type_scope (P f0)%function_scope f1
+Arguments F_rect f%_type_scope (P f0)%_function_scope f1
 F_rect is transparent
 Expands to: Constant SchemeNames.F_rect
 Declared in library SchemeNames, line 235, characters 0-30
@@ -510,7 +510,7 @@ forall (P : Type) (P0 : PP P -> Type),
 (forall p : P, P0 (D P p)) -> forall p : PP P, P0 p
 
 PP_rect is not universe polymorphic
-Arguments PP_rect P%type_scope (P0 f)%function_scope p
+Arguments PP_rect P%_type_scope (P0 f)%_function_scope p
 PP_rect is transparent
 Expands to: Constant SchemeNames.PP_rect
 Declared in library SchemeNames, line 238, characters 0-32

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -5,42 +5,42 @@ Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
 (* uu |=  *)
 
 PWrap has primitive projections with eta conversion.
-Arguments PWrap A%type_scope
-Arguments pwrap A%type_scope punwrap
-Arguments punwrap A%type_scope p
+Arguments PWrap A%_type_scope
+Arguments pwrap A%_type_scope punwrap
+Arguments punwrap A%_type_scope p
 Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
   { punwrap : A }.
 (* uu |=  *)
 
 PWrap has primitive projections with eta conversion.
-Arguments PWrap A%type_scope
-Arguments pwrap A%type_scope punwrap
-Arguments punwrap A%type_scope p
+Arguments PWrap A%_type_scope
+Arguments pwrap A%_type_scope punwrap
+Arguments punwrap A%_type_scope p
 Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
   { runwrap : A }.
 (* uu |=  *)
 
-Arguments RWrap A%type_scope
-Arguments rwrap A%type_scope runwrap
-Arguments runwrap A%type_scope r
+Arguments RWrap A%_type_scope
+Arguments rwrap A%_type_scope runwrap
+Arguments runwrap A%_type_scope r
 runwrap@{uu} =
 fun (A : Type@{uu}) (r : RWrap@{uu} A) => let (runwrap) := r in runwrap
      : forall A : Type@{uu}, RWrap@{uu} A -> A
 (* uu |=  *)
 
 runwrap is a projection of RWrap
-Arguments runwrap A%type_scope r
+Arguments runwrap A%_type_scope r
 Wrap@{uu} = fun A : Type@{uu} => A
      : Type@{uu} -> Type@{uu}
 (* uu |=  *)
 
-Arguments Wrap A%type_scope
+Arguments Wrap A%_type_scope
 wrap@{uu} =
 fun (A : Type@{uu}) (Wrap : Wrap@{uu} A) => Wrap
      : forall {A : Type@{uu}}, Wrap@{uu} A -> A
 (* uu |=  *)
 
-Arguments wrap {A}%type_scope {Wrap}
+Arguments wrap {A}%_type_scope {Wrap}
 bar@{uu} = nat
      : Wrap@{uu} Set
 (* uu |= Set < uu *)
@@ -99,15 +99,15 @@ Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
 (* E |=  *)
 
 PWrap has primitive projections with eta conversion.
-Arguments PWrap A%type_scope
-Arguments pwrap A%type_scope punwrap
-Arguments punwrap A%type_scope p
+Arguments PWrap A%_type_scope
+Arguments pwrap A%_type_scope punwrap
+Arguments punwrap A%_type_scope p
 punwrap@{K} : forall A : Type@{K}, PWrap@{K} A -> A
 (* K |=  *)
 
 punwrap is universe polymorphic
 punwrap is a primitive projection of PWrap
-Arguments punwrap A%type_scope p
+Arguments punwrap A%_type_scope p
 punwrap is transparent
 Expands to: Constant UnivBinders.punwrap
 File "./output/UnivBinders.v", line 104, characters 0-19:
@@ -129,7 +129,7 @@ Inductive insecind@{k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{k}.
 (* k |=  *)
 
-Arguments inseccstr _%type_scope
+Arguments inseccstr _%_type_scope
 insec@{uu v} = Type@{uu} -> Type@{v}
      : Type@{max(uu+1,v+1)}
 (* uu v |=  *)
@@ -137,7 +137,7 @@ Inductive insecind@{uu k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{uu k}.
 (* uu k |=  *)
 
-Arguments inseccstr _%type_scope
+Arguments inseccstr _%_type_scope
 insec2@{u} = Prop
      : Type@{Set+1}
 (* u |=  *)
@@ -158,38 +158,38 @@ axfoo@{i u u0} : Type@{u} -> Type@{i}
 (* i u u0 |=  *)
 
 axfoo is universe polymorphic
-Arguments axfoo _%type_scope
+Arguments axfoo _%_type_scope
 Expands to: Constant UnivBinders.axfoo
 axbar@{i u u0} : Type@{u0} -> Type@{i}
 (* i u u0 |=  *)
 
 axbar is universe polymorphic
-Arguments axbar _%type_scope
+Arguments axbar _%_type_scope
 Expands to: Constant UnivBinders.axbar
 axfoo' : Type@{axfoo'.u0} -> Type@{axfoo'.i}
 
 axfoo' is not universe polymorphic
-Arguments axfoo' _%type_scope
+Arguments axfoo' _%_type_scope
 Expands to: Constant UnivBinders.axfoo'
 axbar' : Type@{axfoo'.u1} -> Type@{axfoo'.i}
 
 axbar' is not universe polymorphic
-Arguments axbar' _%type_scope
+Arguments axbar' _%_type_scope
 Expands to: Constant UnivBinders.axbar'
 *** [ axfoo@{i u u0} : Type@{u} -> Type@{i} ]
 (* i u u0 |=  *)
 
-Arguments axfoo _%type_scope
+Arguments axfoo _%_type_scope
 *** [ axbar@{i u u0} : Type@{u0} -> Type@{i} ]
 (* i u u0 |=  *)
 
-Arguments axbar _%type_scope
+Arguments axbar _%_type_scope
 *** [ axfoo' : Type@{axfoo'.u0} -> Type@{axfoo'.i} ]
 
-Arguments axfoo' _%type_scope
+Arguments axfoo' _%_type_scope
 *** [ axbar' : Type@{axfoo'.u1} -> Type@{axfoo'.i} ]
 
-Arguments axbar' _%type_scope
+Arguments axbar' _%_type_scope
 File "./output/UnivBinders.v", line 158, characters 19-26:
 The command has indeed failed with message:
 When declaring multiple assumptions in one command, only the first name is
@@ -212,44 +212,44 @@ Inductive MutualR1@{u} (A : Type@{u}) : Prop :=
     Build_MutualR2 : MutualR1@{u} A -> MutualR2@{u} A.
 (* u |=  *)
 
-Arguments MutualR1 A%type_scope
-Arguments Build_MutualR1 A%type_scope p1
-Arguments p1 A%type_scope m
-Arguments MutualR2 A%type_scope
-Arguments Build_MutualR2 A%type_scope p2
-Arguments p2 A%type_scope m
+Arguments MutualR1 A%_type_scope
+Arguments Build_MutualR1 A%_type_scope p1
+Arguments p1 A%_type_scope m
+Arguments MutualR2 A%_type_scope
+Arguments Build_MutualR2 A%_type_scope p2
+Arguments p2 A%_type_scope m
 Inductive MutualI1@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1 : MutualI2@{u u0} A -> MutualI1@{u u0} A
   with MutualI2@{u u0} (A : Type@{u}) : Type@{u0} :=
     C2 : MutualI1@{u u0} A -> MutualI2@{u u0} A.
 (* u u0 |=  *)
 
-Arguments MutualI1 A%type_scope
-Arguments C1 A%type_scope p1
-Arguments MutualI2 A%type_scope
-Arguments C2 A%type_scope p2
+Arguments MutualI1 A%_type_scope
+Arguments C1 A%_type_scope p1
+Arguments MutualI2 A%_type_scope
+Arguments C2 A%_type_scope p2
 CoInductive MutualR1'@{u} (A : Type@{u}) : Prop :=
     Build_MutualR1' : MutualR2'@{u} A -> MutualR1'@{u} A
   with MutualR2'@{u} (A : Type@{u}) : Prop :=
     Build_MutualR2' : MutualR1'@{u} A -> MutualR2'@{u} A.
 (* u |=  *)
 
-Arguments MutualR1' A%type_scope
-Arguments Build_MutualR1' A%type_scope p1'
-Arguments p1' A%type_scope m
-Arguments MutualR2' A%type_scope
-Arguments Build_MutualR2' A%type_scope p2'
-Arguments p2' A%type_scope m
+Arguments MutualR1' A%_type_scope
+Arguments Build_MutualR1' A%_type_scope p1'
+Arguments p1' A%_type_scope m
+Arguments MutualR2' A%_type_scope
+Arguments Build_MutualR2' A%_type_scope p2'
+Arguments p2' A%_type_scope m
 CoInductive MutualI1'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1' : MutualI2'@{u u0} A -> MutualI1'@{u u0} A
   with MutualI2'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C2' : MutualI1'@{u u0} A -> MutualI2'@{u u0} A.
 (* u u0 |=  *)
 
-Arguments MutualI1' A%type_scope
-Arguments C1' A%type_scope p1
-Arguments MutualI2' A%type_scope
-Arguments C2' A%type_scope p2
+Arguments MutualI1' A%_type_scope
+Arguments C1' A%_type_scope p1
+Arguments MutualI2' A%_type_scope
+Arguments C2' A%_type_scope p2
 File "./output/UnivBinders.v", line 209, characters 0-33:
 The command has indeed failed with message:
 Universe inconsistency. Cannot enforce a < a because a = a.
@@ -257,7 +257,7 @@ JMeq :
 forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
 
 JMeq is template universe polymorphic on JMeq.u0 (cannot be instantiated to Prop)
-Arguments JMeq [A]%type_scope x [B]%type_scope _
+Arguments JMeq [A]%_type_scope x [B]%_type_scope _
 Expands to: Inductive UnivBinders.PartialTemplate.JMeq
 Declared in library UnivBinders, line 219, characters 10-14
 File "./output/UnivBinders.v", line 234, characters 2-38:

--- a/test-suite/output/Utf8Impargs.out
+++ b/test-suite/output/Utf8Impargs.out
@@ -1,7 +1,7 @@
 id : ∀ {A : Type}, A -> A
 
 id is not universe polymorphic
-Arguments id {A}%type_scope a
+Arguments id {A}%_type_scope a
 id is transparent
 Expands to: Constant Utf8Impargs.id
 Declared in library Utf8Impargs, line 6, characters 11-13

--- a/test-suite/output/bug_14815.out
+++ b/test-suite/output/bug_14815.out
@@ -13,4 +13,4 @@ for
 f
      : nat -> nat
 
-Arguments f n%nat_scope
+Arguments f n%_nat_scope

--- a/test-suite/output/bug_15020.out
+++ b/test-suite/output/bug_15020.out
@@ -3,7 +3,7 @@ forall {A : Type} {x : A} (P : A -> Type),
 P x -> forall {y : A}, x = y -> P y
 
 eq_rect is not universe polymorphic
-Arguments eq_rect {A}%type_scope {x} P%function_scope f {y} e
+Arguments eq_rect {A}%_type_scope {x} P%_function_scope f {y} e
   (where some original arguments have been renamed)
 eq_rect is transparent
 Expands to: Constant Corelib.Init.Logic.eq_rect

--- a/test-suite/output/bug_15221.out
+++ b/test-suite/output/bug_15221.out
@@ -4,4 +4,4 @@ fun x y : nat => let/c f := foo x y in
                  f = b
      : nat -> nat -> Prop
 
-Arguments chain (x y)%nat_scope
+Arguments chain (x y)%_nat_scope

--- a/test-suite/output/bug_3810.out
+++ b/test-suite/output/bug_3810.out
@@ -1,5 +1,5 @@
 test : Foo -> nat -> forall {A : Type}, A
 
 test is not universe polymorphic
-Arguments test H n%nat_scope {A}%type_scope
+Arguments test H n%_nat_scope {A}%_type_scope
 Expands to: Constant bug_3810.test

--- a/test-suite/output/wish_18097.out
+++ b/test-suite/output/wish_18097.out
@@ -8,7 +8,7 @@ fix pow (n m : nat) {struct m} : nat :=
   end
      : nat -> nat -> nat
 
-Arguments Nat.pow (n m)%nat_scope
+Arguments Nat.pow (n m)%_nat_scope
 Notation pow := Nat.pow
 Expands to: Notation wish_18097.pow
 Declared in library wish_18097, line 1, characters 0-24
@@ -16,7 +16,7 @@ Declared in library wish_18097, line 1, characters 0-24
 Nat.pow : nat -> nat -> nat
 
 Nat.pow is not universe polymorphic
-Arguments Nat.pow (n m)%nat_scope
+Arguments Nat.pow (n m)%_nat_scope
 Nat.pow is transparent
 Expands to: Constant Corelib.Init.Nat.pow
 Declared in library Corelib.Init.Nat, line 143, characters 0-117

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -377,7 +377,7 @@ let rec main_implicits i renames recargs scopes impls =
       | [], (None::_ | []) -> (Anonymous, Glob_term.Explicit)
     in
     let notation_scope = match scopes with
-      | scope :: _ -> List.map (fun s -> CAst.make (Constrexpr.DelimUnboundedScope, s)) scope
+      | scope :: _ -> List.map (fun s -> CAst.make (Constrexpr.DelimOnlyTmpScope, s)) scope
       | [] -> []
     in
     let status = {Vernacexpr.implicit_status; name; recarg_like; notation_scope} in


### PR DESCRIPTION
Currently this is the only possible scope for arguments, but in the future `Arguments foo x%scope` will change meaning to DelimUnboundedScope.

Fix #20082

Overlays:
- https://github.com/coq/stdlib/pull/108