### PR TITLE
Rely on explicit printing of pairs of terms in some module errors

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -158,7 +158,7 @@ let dirpath_of_global = let open GlobRef in function
 let qualid_of_global ?loc env r =
   Libnames.make_qualid ?loc (dirpath_of_global r) (id_of_global env r)
 
-let safe_gen f env sigma c =
+let safe_extern_wrapper f env sigma c =
   let orig_extern_ref = Constrextern.get_extern_reference () in
   let extern_ref ?loc vars r =
     try orig_extern_ref vars r
@@ -169,10 +169,14 @@ let safe_gen f env sigma c =
   try
     let p = f env sigma c in
     Constrextern.set_extern_reference orig_extern_ref;
-    p
+    Some p
   with e when CErrors.noncritical e ->
     Constrextern.set_extern_reference orig_extern_ref;
-    str "??"
+    None
+
+let safe_gen f env sigma c = match safe_extern_wrapper f env sigma c with
+| None -> str "??"
+| Some v -> v
 
 let safe_pr_lconstr_env = safe_gen pr_lconstr_env
 let safe_pr_constr_env = safe_gen pr_constr_env

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -60,6 +60,7 @@ val pr_constr_n_env        : ?inctx:bool -> ?scope:scope_name -> env -> evar_map
 
 val safe_pr_constr_env  : env -> evar_map -> constr -> Pp.t
 val safe_pr_lconstr_env : env -> evar_map -> constr -> Pp.t
+val safe_extern_wrapper : (env -> evar_map -> 'a -> 'b) -> env -> evar_map -> 'a -> 'b option
 
 val pr_econstr_env      : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> EConstr.t -> Pp.t
 val pr_leconstr_env     : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> EConstr.t -> Pp.t

--- a/test-suite/output/bug_20242.out
+++ b/test-suite/output/bug_20242.out
@@ -1,0 +1,9 @@
+File "./output/bug_20242.v", line 5, characters 49-60:
+The command has indeed failed with message:
+Signature components for field B do not match: expected type
+"foo@{Type | A.A.u0} bug_20242.B.A" but found type
+"foo@{SProp | bug_20242.26} bug_20242.B.A".
+Error: The module B needs to be closed.
+
+
+coqc exited with code 1

--- a/test-suite/output/bug_20242.v
+++ b/test-suite/output/bug_20242.v
@@ -1,0 +1,5 @@
+Polymorphic Record foo@{s|u|} (x : Type@{s|u}) := {}.
+Inductive sEmpty : SProp := .
+Module Type A. Axiom A : Type. Axiom B : foo A. End A.
+Unset Universe Checking.
+Module B <: A. Axiom A : SProp. Axiom B : foo A. Fail End B.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1147,10 +1147,11 @@ let explain_not_match_error = function
   | NotConvertibleBodyField ->
     str "the body of definitions differs"
   | NotConvertibleTypeField (env, typ1, typ2) ->
+    let typ1, typ2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr typ1) (EConstr.of_constr typ2) in
     str "expected type" ++ spc ()  ++
-    quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) typ2) ++ spc () ++
+    typ2 ++ spc () ++
     str "but found type" ++ spc () ++
-    quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) typ1)
+    typ1
   | NotSameConstructorNamesField ->
     str "constructor names differ"
   | NotSameInductiveNameInBlockField ->
@@ -1186,10 +1187,11 @@ let explain_not_match_error = function
       UnivNames.pr_level_with_global_universes
       incon
   | IncompatiblePolymorphism (env, t1, t2) ->
+    let t1, t2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr t1) (EConstr.of_constr t2) in
     str "conversion of polymorphic values generates additional constraints: " ++
-      quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t1) ++ spc () ++
+      quote t1 ++ spc () ++
       str "compared to " ++ spc () ++
-      quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t2)
+      quote t2
   | IncompatibleConstraints { got; expect } ->
     let open UVars in
     let pr_auctx auctx =


### PR DESCRIPTION
We rely on the approximation mechanism to test whether two terms are displayed alike to the user to disambiguate some module errors. I had to wrap the expansion mechanism to ensure we do not try to print references missing from the environment to make this work properly. 

Fixes #20242.