### PR TITLE
`Unset Universe Checking` unifies all sorts

### DIFF
--- a/doc/changelog/01-kernel/20247-unset-universe-checking-qsort.rst
+++ b/doc/changelog/01-kernel/20247-unset-universe-checking-qsort.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  ``Unset`` :flag:`Universe Checking` now allows unification of differing
+  :n:`@sort`\s
+  (`#20247 <https://github.com/coq/coq/pull/20247>`_,
+  fixes `#20241 <https://github.com/coq/coq/issues/20241>`_,
+  by Jason Gross).

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -968,6 +968,8 @@ let check_convert_instances ~flex:_ u u' univs =
 
 (* general conversion and inference functions *)
 let check_inductive_instances cv_pb variance u1 u2 univs =
+  if UGraph.type_in_type univs then Result.Ok univs
+  else
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
   if Sorts.QConstraints.trivial qcsts && (UGraph.check_constraints ucsts univs) then Result.Ok univs
   else Result.Error None

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1702,7 +1702,9 @@ let infer_cmp_universes _env pb s0 s1 univs =
   | CONV -> infer_eq univs s0 s1
 
 let infer_convert_instances ~flex u u' (univs,cstrs as cuniv) =
-  if flex then
+  if UGraph.type_in_type univs then
+    Result.Ok cuniv
+  else if flex then
     if UGraph.check_eq_instances univs u u' then Result.Ok cuniv
     else Result.Error None
   else
@@ -1713,6 +1715,9 @@ let infer_convert_instances ~flex u u' (univs,cstrs as cuniv) =
       Result.Error None
 
 let infer_inductive_instances cv_pb variance u1 u2 (univs,csts) =
+  if UGraph.type_in_type univs
+  then Result.Ok (univs, csts)
+  else
   let qcsts, csts' = get_cumulativity_constraints cv_pb variance u1 u2 in
   if Sorts.QConstraints.trivial qcsts then
     match UGraph.merge_constraints csts' univs with

--- a/test-suite/bugs/bug_20241.v
+++ b/test-suite/bugs/bug_20241.v
@@ -1,0 +1,44 @@
+Set Debug "all".
+Set Universe Polymorphism.
+Set Allow StrictProp.
+Set Polymorphic Inductive Cumulativity.
+Set Primitive Projections.
+Record Iso@{s s'|u u'|} (a : Type@{s|u}) (b : Type@{s'|u'}) := { fwd : a -> b ; bwd : b -> a }.
+Inductive sEmpty : SProp := .
+Definition iso_sEmpty : Iso sEmpty sEmpty := {| fwd := fun x => x ; bwd := fun x => x |}.
+#[local] Unset Universe Polymorphism.
+Module Type Foo.
+  Parameter bar : Type.
+  Parameter baz : Iso bar bar.
+End Foo.
+Unset Universe Checking.
+Module M <: Foo.
+  Definition bar : Type := sEmpty.
+  Definition baz : Iso bar bar.
+  Proof. exact (iso_sEmpty : Iso@{SProp SProp|_ _} bar bar). Defined.
+  (* The term "iso_sEmpty : Iso bar bar" has type
+"Iso@{SProp SProp | IsomorphismChecker.Original.39
+IsomorphismChecker.Original.40} bar bar"
+while it is expected to have type
+"Iso@{Type Type | bar.u0 bar.u0} bar bar". *)
+Definition baz_default : Iso bar bar.
+Proof. lazy. exact (iso_sEmpty : Iso@{SProp SProp|_ _} bar bar). Defined.
+Definition baz_vm : Iso bar bar.
+Proof. vm_compute. exact (iso_sEmpty : Iso@{SProp SProp|_ _} bar bar). Defined.
+Definition baz_native : Iso bar bar.
+Proof. native_compute. exact (iso_sEmpty : Iso@{SProp SProp|_ _} bar bar). Defined.
+End M.
+
+
+Set Allow StrictProp.
+Set Universe Checking.
+Polymorphic Record foo@{s|u|} (x : Type@{s|u}) := {}.
+Module Type A. Axiom A : Type. Axiom B : foo A. End A.
+Unset Universe Checking.
+Set Printing Universes.
+Module B <: A. Axiom A : SProp. Axiom B : foo A. End B.
+(* Signature components for field B do not match: expected type
+"foo@{Type | A.A.u0} IsomorphismChecker.bug_interface_04.B.A"
+but found type
+"foo@{SProp | IsomorphismChecker.bug_interface_04.72}
+IsomorphismChecker.bug_interface_04.B.A". *)


### PR DESCRIPTION
`Unset Universe Checking` should disable all error messages resulting from mismatched universes or sorts.  It is expected that it will break subject reduction, etc.

Fix #20241

I am not sure that I caught all the cases; if there's a better abstraction boundary to maintain about where to check for whether universe checking is set, please let me know.

- [x] Added / updated **test-suite**.

- [x] Added **changelog**.
- [ ] Opened **overlay** pull requests.

