### PR TITLE
coqdev.el stop using the shim

### DIFF
--- a/dev/tools/coqdev.el
+++ b/dev/tools/coqdev.el
@@ -51,7 +51,7 @@
   "Setup `compile-command' for Rocq development."
   (let ((dir (coqdev-default-directory)))
     (when dir (setq-local compile-command (concat "cd " (shell-quote-argument dir) "
-dune build @check # rocq-runtime.install dev/shim/rocq")))))
+dune build @check # rocq-runtime.install")))))
 (add-hook 'hack-local-variables-hook #'coqdev-setup-compile-command)
 
 (defvar camldebug-command-name) ; from camldebug.el (caml package)
@@ -89,9 +89,7 @@ Specifically `camldebug-command-name' and `ocamldebug-command-name'."
 Note that this function is executed before _Coqproject is read if it exists."
   (let ((dir (coqdev-default-directory)))
     (when dir
-      (if (string-prefix-p (concat dir "_build_ci") default-directory)
-          (setq-local coq-prog-name (concat dir "_build/install/default/bin/coqtop"))
-        (setq-local coq-prog-name (concat dir "_build/default/dev/shim/coqtop"))))))
+      (setq-local coq-prog-name (concat dir "_build/install/default/bin/coqtop")))))
 (add-hook 'hack-local-variables-hook #'coqdev-setup-proofgeneral)
 
 (defvar coqdev-ocamldebug-command "dune exec -- dev/dune-dbg -emacs coqc /tmp/foo.v"


### PR DESCRIPTION
It was useful when `make world` took a long time but AFAICT not anymore.
