### PR TITLE
Fix bench false positive detection of failed dependency

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -541,7 +541,7 @@ $coq_opam_package (unknown package)"
         for dep in $(opam install --show-actions "$coq_opam_package" | grep -o '∗\s*install\s*[^ ]*' | sed 's/∗\s*install\s*//g'); do
             # show-actions will print transitive deps
             # so we don't need to look at the skipped_packages
-            if echo "$failed_packages" | grep -q "$dep"; then
+            if echo "$failed_packages" | grep -q "^$dep "; then
                 skipped_packages="$skipped_packages
 $coq_opam_package (dependency $dep failed)"
                 continue 3


### PR DESCRIPTION
eg if `coq-hott` failed in NEW, the next `coq-foo` package would want to install `coq` in OLD and `echo coq-hott | grep -q coq` would incorrectly detect `coq` as having failed, so `coq-foo` would be skipped.
