### PR TITLE
Print rigid qualities in sorts even if print universes is off

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1230,6 +1230,8 @@ let universe_of_name evd s = UState.universe_of_name evd.universes s
 
 let quality_of_name evd s = UState.quality_of_name evd.universes s
 
+let is_rigid_qvar evd q = UState.is_rigid_qvar evd.universes q
+
 let universe_binders evd = UState.universe_binders evd.universes
 
 let universes evd = UState.ugraph evd.universes

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -541,6 +541,8 @@ val restrict_universe_context : evar_map -> Univ.Level.Set.t -> evar_map
 val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 val quality_of_name : evar_map -> Id.t -> Sorts.QVar.t
 
+val is_rigid_qvar : evar_map -> Sorts.QVar.t -> bool
+
 val is_relevance_irrelevant : evar_map -> erelevance -> bool
 (** Whether the relevance is irrelevant modulo qstate *)
 (* XXX move to ERelevance *)

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -41,6 +41,7 @@ module QState : sig
   val union : fail:(t -> Quality.t -> Quality.t -> t) -> t -> t -> t
   val add : check_fresh:bool -> rigid:bool -> elt -> t -> t
   val repr : elt -> t -> Quality.t
+  val is_rigid : t -> QVar.t -> bool
   val unify_quality : fail:(unit -> t) -> Conversion.conv_pb -> Quality.t -> Quality.t -> t -> t
   val is_above_prop : elt -> t -> bool
   val undefined : t -> QVar.Set.t
@@ -77,6 +78,8 @@ let rec repr q m = match QMap.find q m.qmap with
   QVar q
 
 let is_above_prop q m = QSet.mem q m.above
+
+let is_rigid m q = QSet.mem q m.rigid
 
 let set q qv m =
   let q = repr q m in
@@ -263,6 +266,8 @@ let id_of_level uctx l =
 let id_of_qvar uctx l =
   try (QVar.Map.find l (fst (snd uctx.names))).uname
   with Not_found -> None
+
+let is_rigid_qvar uctx q = QState.is_rigid uctx.sort_variables q
 
 let qualid_of_qvar_names (bind, (qrev,_)) l =
   try Some (Libnames.qualid_of_ident (Option.get (QVar.Map.find l qrev).uname))

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -39,14 +39,14 @@ module QState : sig
   type elt = QVar.t
   val empty : t
   val union : fail:(t -> Quality.t -> Quality.t -> t) -> t -> t -> t
-  val add : check_fresh:bool -> named:bool -> elt -> t -> t
+  val add : check_fresh:bool -> rigid:bool -> elt -> t -> t
   val repr : elt -> t -> Quality.t
   val unify_quality : fail:(unit -> t) -> Conversion.conv_pb -> Quality.t -> Quality.t -> t -> t
   val is_above_prop : elt -> t -> bool
   val undefined : t -> QVar.Set.t
   val collapse_above_prop : to_prop:bool -> t -> t
   val collapse : ?except:QVar.Set.t -> t -> t
-  val pr : (QVar.t -> Pp.t) -> t -> Pp.t
+  val pr : (QVar.t -> Libnames.qualid option) -> t -> Pp.t
   val of_set : QVar.Set.t -> t
 end =
 struct
@@ -55,8 +55,8 @@ module QSet = QVar.Set
 module QMap = QVar.Map
 
 type t = {
-  named : QSet.t;
-  (** Named variables, may not be set to another *)
+  rigid : QSet.t;
+  (** Rigid variables, may not be set to another *)
   qmap : Quality.t option QMap.t;
   (* TODO: use a persistent union-find structure *)
   above : QSet.t;
@@ -66,7 +66,7 @@ type t = {
 
 type elt = QVar.t
 
-let empty = { named = QSet.empty; qmap = QMap.empty; above = QSet.empty }
+let empty = { rigid = QSet.empty; qmap = QMap.empty; above = QSet.empty }
 
 let rec repr q m = match QMap.find q m.qmap with
 | None -> QVar q
@@ -86,24 +86,24 @@ let set q qv m =
   | q, QVar qv ->
     if QVar.equal q qv then Some m
     else
-    if QSet.mem q m.named then None
+    if QSet.mem q m.rigid then None
     else
       let above =
         if QSet.mem q m.above then QSet.add qv (QSet.remove q m.above)
         else m.above
       in
-      Some { named = m.named; qmap = QMap.add q (Some (QVar qv)) m.qmap; above }
+      Some { rigid = m.rigid; qmap = QMap.add q (Some (QVar qv)) m.qmap; above }
   | q, (QConstant qc as qv) ->
     if qc == QSProp && QSet.mem q m.above then None
-    else if QSet.mem q m.named then None
+    else if QSet.mem q m.rigid then None
     else
-      Some { named = m.named; qmap = QMap.add q (Some qv) m.qmap; above = QSet.remove q m.above }
+      Some { rigid = m.rigid; qmap = QMap.add q (Some qv) m.qmap; above = QSet.remove q m.above }
 
 let set_above_prop q m =
   let q = repr q m in
   let q = match q with QVar q -> q | QConstant _ -> assert false in
-  if QSet.mem q m.named then None
-  else Some { named = m.named; qmap = m.qmap; above = QSet.add q m.above }
+  if QSet.mem q m.rigid then None
+  else Some { rigid = m.rigid; qmap = m.qmap; above = QSet.add q m.above }
 
 let unify_quality ~fail c q1 q2 local = match q1, q2 with
 | QConstant QType, QConstant QType
@@ -157,21 +157,21 @@ let union ~fail s1 s2 =
   | exception Not_found -> false
   in
   let above = QSet.filter filter @@ QSet.union s1.above s2.above in
-  let s = { named = QSet.union s1.named s2.named; qmap; above } in
+  let s = { rigid = QSet.union s1.rigid s2.rigid; qmap; above } in
   List.fold_left (fun s (q1,q2) ->
       let q1 = nf_quality s q1 and q2 = nf_quality s q2 in
       unify_quality ~fail:(fun () -> fail s q1 q2) CONV q1 q2 s)
     s
     extra
 
-let add ~check_fresh ~named q m =
+let add ~check_fresh ~rigid q m =
   if check_fresh then assert (not (QMap.mem q m.qmap));
-  { named = if named then QSet.add q m.named else m.named;
+  { rigid = if rigid then QSet.add q m.rigid else m.rigid;
     qmap = QMap.add q None m.qmap;
     above = m.above }
 
 let of_set qs =
-  { named = QSet.empty; qmap = QMap.bind (fun _ -> None) qs; above = QSet.empty }
+  { rigid = QSet.empty; qmap = QMap.bind (fun _ -> None) qs; above = QSet.empty }
 
 (* XXX what about [above]? *)
 let undefined m =
@@ -186,28 +186,37 @@ let collapse_above_prop ~to_prop m =
       else Some (QConstant QType)
   | Some _ -> v
   in
-  { named = m.named; qmap = QMap.mapi map m.qmap; above = QSet.empty }
+  { rigid = m.rigid; qmap = QMap.mapi map m.qmap; above = QSet.empty }
 
 let collapse ?(except=QSet.empty) m =
   let map q v = match v with
-  | None -> if QSet.mem q m.named || QSet.mem q except then None else Some (QConstant QType)
+  | None -> if QSet.mem q m.rigid || QSet.mem q except then None else Some (QConstant QType)
   | Some _ -> v
   in
-  { named = m.named; qmap = QMap.mapi map m.qmap; above = QSet.empty }
+  { rigid = m.rigid; qmap = QMap.mapi map m.qmap; above = QSet.empty }
 
-let pr prqvar { qmap; above; named } =
+let pr prqvar_opt { qmap; above; rigid } =
   let open Pp in
+  let prqvar q = match prqvar_opt q with
+    | None -> QVar.raw_pr q
+    | Some qid -> Libnames.pr_qualid qid
+  in
   let prbody u = function
   | None ->
     if QSet.mem u above then str " >= Prop"
-    else if QSet.mem u named then
-      str " (internal name " ++ QVar.raw_pr u ++ str ")"
+    else if QSet.mem u rigid then
+      str " (rigid)"
     else mt ()
   | Some q ->
     let q = Quality.pr prqvar q in
     str " := " ++ q
   in
-  h (prlist_with_sep fnl (fun (u, v) -> prqvar u ++ prbody u v) (QMap.bindings qmap))
+  let prqvar_name q =
+    match prqvar_opt q with
+    | None -> mt()
+    | Some qid -> str " (named " ++ Libnames.pr_qualid qid ++ str ")"
+  in
+  h (prlist_with_sep fnl (fun (u, v) -> QVar.raw_pr u ++ prbody u v ++ prqvar_name u) (QMap.bindings qmap))
 
 end
 
@@ -1049,7 +1058,7 @@ let merge ?loc ~sideff rigid uctx uctx' =
 
 let merge_sort_variables ?loc ~sideff uctx qvars =
   let sort_variables =
-    QVar.Set.fold (fun qv qstate -> QState.add ~check_fresh:(not sideff) ~named:false qv qstate)
+    QVar.Set.fold (fun qv qstate -> QState.add ~check_fresh:(not sideff) ~rigid:false qv qstate)
       qvars
       uctx.sort_variables
   in
@@ -1158,7 +1167,7 @@ let add_universe ?loc name strict uctx u =
 let new_sort_variable ?loc ?name uctx =
   let q = UnivGen.new_sort_global () in
   (* don't need to check_fresh as it's guaranteed new *)
-  let sort_variables = QState.add ~check_fresh:false ~named:(Option.has_some name)
+  let sort_variables = QState.add ~check_fresh:false ~rigid:(Option.has_some name)
       q uctx.sort_variables
   in
   let names = match name with
@@ -1297,7 +1306,7 @@ let pr_weak prl {minim_extra={UnivMinim.weak_constraints=weak; above_prop}} =
     ++ if UPairSet.is_empty weak || Level.Set.is_empty above_prop then mt() else cut () ++
     prlist_with_sep cut (fun u -> h (str "Prop <= " ++ prl u)) (Level.Set.elements above_prop))
 
-let pr_sort_opt_subst uctx = QState.pr (pr_uctx_qvar uctx) uctx.sort_variables
+let pr_sort_opt_subst uctx = QState.pr (qualid_of_qvar_names uctx.names) uctx.sort_variables
 
 let pr ctx =
   let open Pp in

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -277,6 +277,8 @@ val id_of_level : t -> Univ.Level.t -> Id.t option
 
 val id_of_qvar : t -> Sorts.QVar.t -> Id.t option
 
+val is_rigid_qvar : t -> Sorts.QVar.t -> bool
+
 val pr_weak : (Univ.Level.t -> Pp.t) -> t -> Pp.t
 
 val pr : t -> Pp.t

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -901,8 +901,8 @@ let extern_glob_sort uvars (q, l) =
 
 (** wrapper to handle print_universes: don't forget small univs *)
 let extern_glob_sort uvars (s:glob_sort) =
-  let really_extern = !print_universes || match s with
-    | None, UNamed [s, 0] -> begin match s with
+  let really_extern = !print_universes || Option.has_some (fst s) || match snd s with
+    | UNamed [s, 0] -> begin match s with
         | GSet | GProp | GSProp -> true
         | GUniv _ | GLocalUniv _ | GRawUniv _ -> false
       end

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -394,8 +394,13 @@ let detype_sort sigma = function
        else glob_Type_sort)
   | QSort (q, u) ->
     if !print_universes then
-      let q = if print_sort_quality () then Some (detype_qvar sigma q) else None in
+      let q = if print_sort_quality () || Evd.is_rigid_qvar sigma q then
+          Some (detype_qvar sigma q)
+        else None
+      in
       q, detype_universe sigma u
+    else if Evd.is_rigid_qvar sigma q then
+      Some (detype_qvar sigma q), UAnonymous {rigid=UState.univ_flexible}
     else glob_Type_sort
 
 let detype_relevance_info sigma na =

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -198,8 +198,7 @@ let pr_univ l =
   | UNamed [x] -> pr_univ_expr x
   | UNamed l -> str"max(" ++ prlist_with_sep (fun () -> str",") pr_univ_expr l ++ str")"
   | UAnonymous {rigid=UnivRigid} -> tag_type (str "Type")
-  | UAnonymous {rigid=UnivFlexible b} ->
-    tag_type (str "Type")
+  | UAnonymous {rigid=UnivFlexible _} -> tag_type (str "_")
 
 let pr_qvar_expr = function
   | CQAnon _ -> tag_type (str "_")

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -203,7 +203,7 @@ let pr_univ l =
 let pr_qvar_expr = function
   | CQAnon _ -> tag_type (str "_")
   | CQVar qid -> tag_type (pr_qualid qid)
-  | CRawQVar q -> (* TODO names *) tag_type (Sorts.QVar.raw_pr q)
+  | CRawQVar q -> tag_type (Sorts.QVar.raw_pr q)
 
 let pr_relevance = function
   | CRelevant -> str "Relevant"

--- a/test-suite/output/SortQuality.out
+++ b/test-suite/output/SortQuality.out
@@ -1,1 +1,14 @@
+Type
 Type@{α1 | SortQuality.21}
+Type@{α1 | SortQuality.21}
+Type
+A
+     : Type@{s | _}
+A
+     : Type@{s | u}
+(* {u} |=  *)
+A
+     : Type@{s | u}
+(* {u} |=  *)
+A
+     : Type@{s | _}

--- a/test-suite/output/SortQuality.v
+++ b/test-suite/output/SortQuality.v
@@ -1,10 +1,32 @@
-Set Printing Universes.
-Set Printing Sort Qualities.
+Ltac show H :=
+  let T := type of H in
+  let s := type of T in
+  idtac s.
 
-Goal True.
-Proof.
-refine (let H := _ in _).
-let T := type of H in
-let s := type of T in
-idtac s.
-Abort.
+Module M1.
+  Goal True.
+  Proof.
+  refine (let H := _ in _).
+  show H.
+  Set Printing Universes.
+  show H.
+  Set Printing Sort Qualities.
+  show H.
+  Unset Printing Universes.
+  show H.
+  Abort.
+End M1.
+
+Module M2.
+  Set Universe Polymorphism.
+  Lemma foo@{s|u|} (A : Type@{s|u}) : True.
+  Proof.
+  Check A.
+  Set Printing Universes.
+  Check A.
+  Set Printing Sort Qualities.
+  Check A.
+  Unset Printing Universes.
+  Check A.
+  Abort.
+End M2.


### PR DESCRIPTION
I think if we write
~~~coq
  Lemma foo@{s|u|} (A : Type@{s|u}) : True.
~~~
we want to see `A : Type@{s | _}` not `A : Type`.