### PR TITLE
Fix retyping with missing meta handler while printing

### DIFF
--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -140,7 +140,7 @@ let type_of_constant env sigma (c,u) =
   EConstr.of_constr (rename_type ty (GlobRef.ConstRef c))
 
 let safe_meta_type metas n = match metas with
-| None -> assert false (* missing meta handler *)
+| None -> None
 | Some f -> f n
 
 exception SingletonInductiveBecomesProp of inductive

--- a/test-suite/bugs/bug_20251.v
+++ b/test-suite/bugs/bug_20251.v
@@ -1,0 +1,12 @@
+Set Primitive Projections.
+Set Printing Primitive Projection Parameters.
+
+Record R (A:Type) := mk { p : A }.
+Arguments p {_} _.
+
+Axiom xbar : forall A,forall x: R A,  p x = p x.
+
+Goal 0 = 0.
+  Set Debug "tactic-unification".
+  Fail apply xbar.
+Abort.


### PR DESCRIPTION
IMO it makes no sense to assert false in the missing handler case, but return None in the missing meta in handler case. We return None in both cases now. It will then be turned into retype_error BadMeta.

Fix #20251
