### PR TITLE
Approximate box depth in constrextern

### DIFF
--- a/dev/ci/user-overlays/20275-SkySkimmer-constrextern-max-depth.sh
+++ b/dev/ci/user-overlays/20275-SkySkimmer-constrextern-max-depth.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/SkySkimmer/stdlib constrextern-max-depth 20275

--- a/doc/changelog/08-vernac-commands-and-options/20275-constrextern-max-depth.rst
+++ b/doc/changelog/08-vernac-commands-and-options/20275-constrextern-max-depth.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :opt:`Printing Depth` completely skips subterms beyond the given depth.
+  In general the formatter depth is higher than the term depth, so there is no visible change,
+  but some notations print subterms without increasing the formatting depth in which case
+  you may need to increase the printing depth to avoid `...`
+  (`#20275 <https://github.com/coq/coq/pull/20275>`_,
+  by Gaëtan Gilbert).

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -89,3 +89,5 @@ val with_meta_as_hole : ('a -> 'b) -> 'a -> 'b
 
 (** Probably shouldn't be used *)
 val empty_extern_env : extern_env
+
+val set_max_depth : int option -> unit

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -81,7 +81,9 @@ let default_margin = Format.pp_get_margin !std_ft ()
 
 let get_depth_boxes () = Some (Format.pp_get_max_boxes !std_ft ())
 let set_depth_boxes v =
-  Format.pp_set_max_boxes !std_ft (match v with None -> default | Some v -> v)
+  let v = (match v with None -> default | Some v -> v) in
+  Constrextern.set_max_depth (Some v);
+  Format.pp_set_max_boxes !std_ft v
 
 let get_margin0 () = Format.pp_get_margin !std_ft ()
 


### PR DESCRIPTION
On
~~~coq
Require Import PrimInt63.

Ltac mk_term n x :=
  let ty := type of x in
  let rec go n :=
    lazymatch n with
    | 0%int63 => constr:(@nil ty)
    | _ => let n := eval lazy in (PrimInt63.sub n 1%int63) in
          let res := go n in
          uconstr:(@cons ty x res)
    end
  in
  let r := go n in exact r.

Definition d100 := ltac:(mk_term 100%int63 tt).
Definition d1000 := ltac:(mk_term 1000%int63 tt).
Definition d10000 := ltac:(mk_term 10000%int63 tt).

Set Printing Depth 10. Set Printing All.

Time Instructions Print d100.
Time Instructions Print d1000.
Time Instructions Print d10000.
~~~
we used to get respectively
- "1.4M instructions, 0s"
- "14M instructions, 0.001s"
- "150M instructions, 0.02s"

Now we get 240k instructions and 0s for all.

Motivation: https://coq.zulipchat.com/#narrow/channel/237656-Coq-devs-.26-plugin-devs/topic/Printing.20performance

Overlays:
- https://github.com/coq/stdlib/pull/117