### PR TITLE
timelog2html add option to produce machine readable data for render_line_results

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -679,11 +679,12 @@ $skipped_packages"
         if [ "$old_data" ] && [ "$new_data" ]; then
           mkdir -p "$working_dir/html/$coq_opam_package/$(dirname "$vo")/"
           $timelog2html \
+            "-o" "$working_dir/html/$coq_opam_package/${vo%%o}.html" \
+            "-raw-o" "$working_dir/html/$coq_opam_package/${vo%%o}.rocq-timediff" \
             "$new_base_path/${vo%%o}" \
             "$old_data" \
             "$new_data" \
-            > "$working_dir/html/$coq_opam_package/${vo%%o}.html" ||
-            echo "Failed (code $?): timelog2html for $vo on $old_data $new_data"
+            || echo "Failed (code $?): timelog2html for $vo on $old_data $new_data"
         fi
     done
 done

--- a/dev/bench/htmloutput.mli
+++ b/dev/bench/htmloutput.mli
@@ -14,3 +14,6 @@ val output : out_channel -> vname:string ->
 
 val max_data_count : int
 (** Max length supported for the inner [measure array]. *)
+
+val raw_output : out_channel -> min_diff:Q.t ->
+  (BenchUtil.source_loc * BenchUtil.measure array) array -> unit

--- a/dev/bench/render_line_results.ml
+++ b/dev/bench/render_line_results.ml
@@ -1,6 +1,6 @@
 
-(** Recursively list .html files' relative directories in given directory *)
-let list_html_files dir =
+(** Recursively list .rocq-timediff files' relative directories in given directory *)
+let list_timediff_files dir =
   let rec loop result = function
     | f :: fs when Sys.is_directory f ->
         Sys.readdir f
@@ -9,7 +9,7 @@ let list_html_files dir =
         |> CList.append fs
         |> loop result
     | f :: fs ->
-      if Filename.check_suffix f ".html" then
+      if Filename.check_suffix f ".rocq-timediff" then
         loop (f::result) fs
       else
         loop result fs
@@ -20,11 +20,11 @@ let list_html_files dir =
   |> loop []
 
 type one_data = {
-  time1 : float;
-  time2 : float;
-  diff : float;
-  pdiff : float;
-  lnum : int;
+  time1 : string;
+  time2 : string;
+  diff : string;
+  pdiff : string;
+  lnum : string;
   file : string;
 }
 
@@ -33,41 +33,17 @@ exception UnableToParse
 (** Read all the lines of a file into a list *)
 let read_timing_lines file =
   let ic = open_in file in
+  let html_file =  (Filename.chop_extension file) ^ ".html" in
   (* We tail recursively read lines in the file discarding the uninteresting ones *)
   let rec read_lines_aux acc =
     match input_line ic with
-    | line ->
-        if Str.string_match (Str.regexp "Line:.*") line 0 then
-          (* We know this line is ["Line:"] *)
-          let lnum = match Str.split (Str.regexp " ") line with
-            | _ :: ln :: _ -> int_of_string ln
-            | _ -> raise @@ UnableToParse
-          in
-          (* Second line is empty *)
-          let _ = input_line ic in
-          (* Time1 - we have floats written with s so with split that too *)
-          let time1 = match Str.split (Str.regexp "[ s]") (input_line ic) with
-            | _ :: time1_str :: _ -> float_of_string time1_str
-            | _ -> raise @@ UnableToParse
-          in
-          (* Time2 *)
-          let time2 = match Str.split (Str.regexp "[ s]") (input_line ic) with
-            | _ :: time2_str :: _ -> float_of_string time2_str
-            | _ -> raise @@ UnableToParse
-          in
-          (* Difference *)
-          let diff = time2 -. time1 in
-          (* Percentage diff *)
-          let pdiff = if time1 <> 0.0 then (diff *. 100.0) /. time1 else Float.infinity in
-          (* We accumulate the timing data in a tuple if the difference is non-zero *)
-          (* We also check that timed values are not too small (tolerence is trial and error) *)
-          if Float.abs diff <= 1e-4 then
-            acc |> read_lines_aux
-          else
-            {time1; time2; diff; pdiff; lnum; file} :: acc |> read_lines_aux
-        else
-          read_lines_aux acc
     | exception End_of_file -> acc
+    | "" -> read_lines_aux acc
+    | line ->
+      match String.split_on_char ' ' line with
+      | [time1; time2; diff; pdiff; lnum] ->
+        {time1; time2; diff; pdiff; lnum; file=html_file} :: acc |> read_lines_aux
+      | _ -> raise UnableToParse
   in
   let lines =
     try Some (read_lines_aux [])
@@ -93,17 +69,12 @@ let html_str ?html lnum s = match html with
   | None -> Table.raw_str s
   | Some html ->
     let size = String.length s in
-    let s = Printf.sprintf "<a href=\"%s%s#L%d\">%s</a>" html.link_prefix s lnum s in
+    let s = Printf.sprintf "<a href=\"%s%s#L%s\">%s</a>" html.link_prefix s lnum s in
     { Table.str = s; size }
 
 let list_timing_data ?html {time1; time2; diff; pdiff; lnum; file} =
-  let str_time1 = Printf.sprintf "%.4f" time1 in
-  let str_time2 = Printf.sprintf "%.4f" time2 in
-  let str_diff  = Printf.sprintf "%.4f" diff in
-  let str_pdiff = Printf.sprintf "%3.2f%%" pdiff in
-  let str_line_num = string_of_int lnum in
   List.append
-    (List.map Table.raw_str [ str_time1; str_time2; str_diff; str_pdiff; str_line_num])
+    (List.map Table.raw_str [ time1; time2; diff; pdiff; lnum])
     [ html_str ?html lnum file ]
 
 let render_table ?(reverse=false) title num table =
@@ -123,10 +94,10 @@ let main () =
   let () = Printexc.record_backtrace true in
   let data =
     Unix.getcwd ()
-    |> list_html_files
+    |> list_timediff_files
     |> CList.filter_map read_timing_lines
     |> CList.flatten
-    |> CList.sort (fun x y -> Float.compare x.diff y.diff)
+    |> CList.sort (fun x y -> Float.compare (float_of_string x.diff) (float_of_string y.diff))
   in
   let table =
     data

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -10,13 +10,16 @@
 
 let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
 
-let usage () = die "Usage: rocq timelog2html VFILE DATAFILES\n\n%a\n%s\n"
+let usage () = die "Usage: rocq timelog2html [options] VFILE DATAFILES\n\n%a\n%s\n"
     (fun fmt len -> Printf.fprintf fmt "(1 to %d data files are supported.)" len)
     Htmloutput.max_data_count
     "Data files may be JSON profile files (as produced by rocq c -profile) with extension .json or .json.gz,\
-\nor timing files (as produced by rocq c -time-file)"
+     \nor timing files (as produced by rocq c -time-file).\
+     \n\
+     \nOptions:\
+     \n  -o FILE: output to FILE (default is - meaning stdout)"
 
-let parse_args = function
+let parse_files = function
   | [] | [_] -> usage ()
   | vfile :: data_files ->
     let data_files = Array.of_list data_files in
@@ -24,6 +27,24 @@ let parse_args = function
       then usage ()
     in
     vfile, data_files
+
+type output = Stdout | File of string
+
+let with_output out f =
+  match out with
+  | Stdout -> f stdout
+  | File fname ->
+    let ch = open_out fname in
+    Fun.protect ~finally:(fun () -> close_out ch) (fun () -> f ch)
+
+let parse_output = function
+  | "-" -> Stdout
+  | f -> File f
+
+let parse_args = function
+  | "-o" :: f :: args -> parse_output f, parse_files args
+  | ["-o"] -> usage()
+  | args -> Stdout, parse_files args
 
 let file_data data_file =
   if List.exists (fun suf -> CString.is_suffix suf data_file) [".json"; ".json.gz"] then
@@ -34,7 +55,7 @@ let file_data data_file =
     data_file, CArray.of_list data
 
 let main args =
-  let vfile, data_files = parse_args args in
+  let out, (vfile, data_files) = parse_args args in
 
   let source = BenchUtil.read_whole_file vfile in
 
@@ -48,5 +69,5 @@ let main args =
 
   let vname = Filename.basename vfile in
 
-  let () = Htmloutput.output stdout ~vname ~data_files all_data in
+  let () = with_output out (fun ch -> Htmloutput.output ch ~vname ~data_files all_data) in
   ()

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -8,16 +8,20 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr fmt
+let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr (fmt^^"\n%!")
 
-let usage () = die "Usage: rocq timelog2html [options] VFILE DATAFILES\n\n%a\n%s\n"
-    (fun fmt len -> Printf.fprintf fmt "(1 to %d data files are supported.)" len)
+let usage () = die "Usage: rocq timelog2html [options] VFILE DATAFILES\n\n%a\n%s"
+    (fun fmt len -> Printf.fprintf fmt "1 to %d data files are supported." len)
     Htmloutput.max_data_count
-    "Data files may be JSON profile files (as produced by rocq c -profile) with extension .json or .json.gz,\
+    "Data files may be .json or .json.gz profile files (as produced by rocq c -profile),\
      \nor timing files (as produced by rocq c -time-file).\
      \n\
      \nOptions:\
-     \n  -o FILE: output to FILE (default is - meaning stdout)"
+     \n  -o FILE: output to FILE (default is - meaning stdout)\
+     \n  -raw-o FILE: output machine readable data to FILE (default off, - means stdout)\
+     \n               (only supported with 2 data files)\
+     \n  -min-diff DIFF: in -raw-o, only output lines with time diff greater than DIFF\
+     \n                  (DIFF in OCaml float format, default 1e-4)"
 
 let parse_files = function
   | [] | [_] -> usage ()
@@ -30,7 +34,19 @@ let parse_files = function
 
 type output = Stdout | File of string
 
-let with_output out f =
+type opts = {
+  output : output;
+  raw_output : output option;
+  min_diff : Q.t;
+}
+
+let defaults = {
+  output = Stdout;
+  raw_output = None;
+  min_diff = Q.(one / of_int 10_000);
+}
+
+let with_output f out =
   match out with
   | Stdout -> f stdout
   | File fname ->
@@ -41,10 +57,16 @@ let parse_output = function
   | "-" -> Stdout
   | f -> File f
 
-let parse_args = function
-  | "-o" :: f :: args -> parse_output f, parse_files args
-  | ["-o"] -> usage()
-  | args -> Stdout, parse_files args
+let parse_min_diff d =
+  try Q.of_float @@ float_of_string d
+  with Failure _ -> usage ()
+
+let rec parse_args opts = function
+  | "-o" :: f :: args -> parse_args { opts with output = parse_output f } args
+  | "-raw-o" :: f :: args -> parse_args { opts with raw_output = Some (parse_output f) } args
+  | "-min-diff" :: d :: args -> parse_args { opts with min_diff = parse_min_diff d } args
+  | ["-o"|"-raw-o"|"-min-diff"] -> usage()
+  | args -> opts, parse_files args
 
 let file_data data_file =
   if List.exists (fun suf -> CString.is_suffix suf data_file) [".json"; ".json.gz"] then
@@ -55,7 +77,7 @@ let file_data data_file =
     data_file, CArray.of_list data
 
 let main args =
-  let out, (vfile, data_files) = parse_args args in
+  let opts, (vfile, data_files) = parse_args defaults args in
 
   let source = BenchUtil.read_whole_file vfile in
 
@@ -69,5 +91,10 @@ let main args =
 
   let vname = Filename.basename vfile in
 
-  let () = with_output out (fun ch -> Htmloutput.output ch ~vname ~data_files all_data) in
+  let () = opts.raw_output |> Option.iter @@ with_output @@ fun ch ->
+    Htmloutput.raw_output ch ~min_diff:opts.min_diff all_data
+  in
+  let () =  opts.output |> with_output @@ fun ch ->
+    Htmloutput.output ch ~vname ~data_files all_data
+  in
   ()


### PR DESCRIPTION
Much nicer than parsing `title` strings in the html IMO.

Depends:
- https://github.com/coq/coq/pull/20266 (mostly because it would conflict in bench.sh)