### PR TITLE
Cache the set of metas appearing in firstorder atoms

### DIFF
--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -42,6 +42,7 @@ type atom
 val hole_atom : atom
 val repr_atom : Env.t -> atom -> EConstr.t
 val compare_atom : atom -> atom -> int
+val meta_in_atom : metavariable -> atom -> bool
 
 type atoms = { positive:atom list; negative:atom list }
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -59,8 +59,8 @@ let do_sequent env sigma setref triv id seq i dom atoms=
   let phref=ref triv in
   let do_atoms a1 a2 =
     let do_pair t1 t2 =
-      match unif_atoms (Sequent.state seq) env sigma i dom t1 t2 with
-          None->()
+      match unif_atoms ~check:(not !phref) (Sequent.state seq) env sigma i dom t1 t2 with
+        | None-> ()
         | Some (Phantom _) ->phref:=true
         | Some c ->flag:=false;setref:=IS.add (c,id) !setref in
       List.iter (fun t->List.iter (do_pair t) a2.negative) a1.positive;

--- a/plugins/firstorder/unify.ml
+++ b/plugins/firstorder/unify.ml
@@ -141,8 +141,10 @@ let mk_rel_inst evd t=
   in
   let nt=renum_rec 0 t in (!new_rel - 1,nt)
 
-let unif_atoms state env evd i dom t1 t2 =
+let unif_atoms ~check state env evd i dom t1 t2 =
   try
+    (* Fast path: the meta is definitely not in any of these atoms *)
+    let () = if not check && not (Formula.meta_in_atom i t1) && not (Formula.meta_in_atom i t2) then raise UFAIL in
     let t1 = Formula.repr_atom state t1 in
     let t=Int.List.assoc i (unif env evd t1 (Formula.repr_atom state t2)) in
       if isMeta evd t then Some (Phantom dom)

--- a/plugins/firstorder/unify.mli
+++ b/plugins/firstorder/unify.mli
@@ -23,6 +23,6 @@ type instance=
     Real of Item.t * int (* terme * valeur heuristique *)
   | Phantom of constr        (* domaine de quantification *)
 
-val unif_atoms : Formula.Env.t -> Environ.env -> Evd.evar_map -> metavariable -> constr -> Formula.atom -> Formula.atom -> instance option
+val unif_atoms : check:bool -> Formula.Env.t -> Environ.env -> Evd.evar_map -> metavariable -> constr -> Formula.atom -> Formula.atom -> instance option
 
 val more_general : Environ.env -> Evd.evar_map -> Item.t -> Item.t -> bool

--- a/test-suite/bugs/bug_20281.v
+++ b/test-suite/bugs/bug_20281.v
@@ -1,0 +1,7 @@
+Axiom Q : Prop.
+
+Goal forall (A : Type) (P : A -> Prop) (X : A) (H : forall b : A, and Q (P b)), Q.
+Proof.
+intros.
+solve [firstorder].
+Qed.


### PR DESCRIPTION
We use this set to quickly compute whether a firstorder unification is actually useful.