### PR TITLE
Avoid printing extra parens in Pputil.pr_*_generic

### DIFF
--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -118,10 +118,6 @@ val pr_clauses : (* default: *) bool option ->
   ('a -> Pp.t) -> 'a Locus.clause_expr -> Pp.t
   (* Some true = default is concl; Some false = default is all; None = no default *)
 
-val pr_raw_generic : env -> Evd.evar_map -> rlevel generic_argument -> Pp.t
-
-val pr_glb_generic : env -> Evd.evar_map -> glevel generic_argument -> Pp.t
-
 val pr_raw_extend: env -> Evd.evar_map -> int ->
   ml_tactic_entry -> raw_tactic_arg list -> Pp.t
 

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -60,52 +60,54 @@ let pr_or_by_notation f = let open Constrexpr in CAst.with_val (function
 
 let hov_if_not_empty n p = if Pp.ismt p then p else hov n p
 
-let rec pr_raw_generic env sigma (GenArg (Rawwit wit, x)) =
+let rec pr_raw_generic env sigma ?level (GenArg (Rawwit wit, x)) =
   match wit with
     | ListArg wit ->
-      let map x = pr_raw_generic env sigma (in_gen (rawwit wit) x) in
+      let map x = pr_raw_generic env sigma ?level (in_gen (rawwit wit) x) in
       let ans = pr_sequence map x in
       hov_if_not_empty 0 ans
     | OptArg wit ->
       let ans = match x with
         | None -> mt ()
-        | Some x -> pr_raw_generic env sigma (in_gen (rawwit wit) x)
+        | Some x -> pr_raw_generic env sigma ?level (in_gen (rawwit wit) x)
       in
       hov_if_not_empty 0 ans
     | PairArg (wit1, wit2) ->
       let p, q = x in
       let p = in_gen (rawwit wit1) p in
       let q = in_gen (rawwit wit2) q in
-      hov_if_not_empty 0 (pr_sequence (pr_raw_generic env sigma) [p; q])
+      hov_if_not_empty 0 (pr_sequence (pr_raw_generic env sigma ?level) [p; q])
     | ExtraArg s ->
        let open Genprint in
        match generic_raw_print (in_gen (rawwit wit) x) with
        | PrinterBasic pp -> pp env sigma
-       | PrinterNeedsLevel { default_ensure_surrounded; printer } ->
-         printer env sigma default_ensure_surrounded
+       | PrinterNeedsLevel { default_already_surrounded; printer } ->
+         let level = Option.default default_already_surrounded level in
+         printer env sigma level
 
 
-let rec pr_glb_generic env sigma (GenArg (Glbwit wit, x)) =
+let rec pr_glb_generic env sigma ?level (GenArg (Glbwit wit, x)) =
   match wit with
     | ListArg wit ->
-      let map x = pr_glb_generic env sigma (in_gen (glbwit wit) x) in
+      let map x = pr_glb_generic env sigma ?level (in_gen (glbwit wit) x) in
       let ans = pr_sequence map x in
       hov_if_not_empty 0 ans
     | OptArg wit ->
       let ans = match x with
         | None -> mt ()
-        | Some x -> pr_glb_generic env sigma (in_gen (glbwit wit) x)
+        | Some x -> pr_glb_generic env sigma ?level (in_gen (glbwit wit) x)
       in
       hov_if_not_empty 0 ans
     | PairArg (wit1, wit2) ->
       let p, q = x in
       let p = in_gen (glbwit wit1) p in
       let q = in_gen (glbwit wit2) q in
-      let ans = pr_sequence (pr_glb_generic env sigma) [p; q] in
+      let ans = pr_sequence (pr_glb_generic env sigma ?level) [p; q] in
       hov_if_not_empty 0 ans
     | ExtraArg s ->
        let open Genprint in
        match generic_glb_print (in_gen (glbwit wit) x) with
        | PrinterBasic pp -> pp env sigma
-       | PrinterNeedsLevel { default_ensure_surrounded; printer } ->
-         printer env sigma default_ensure_surrounded
+       | PrinterNeedsLevel { default_already_surrounded; printer } ->
+         let level = Option.default default_already_surrounded level in
+         printer env sigma level

--- a/printing/pputils.mli
+++ b/printing/pputils.mli
@@ -20,8 +20,10 @@ val pr_lname : lname -> Pp.t
 val pr_or_var : ('a -> Pp.t) -> 'a Locus.or_var -> Pp.t
 val pr_or_by_notation : ('a -> Pp.t) -> 'a Constrexpr.or_by_notation -> Pp.t
 
-val pr_raw_generic : Environ.env -> Evd.evar_map -> rlevel generic_argument -> Pp.t
-val pr_glb_generic : Environ.env -> Evd.evar_map -> glevel generic_argument -> Pp.t
+val pr_raw_generic : Environ.env -> Evd.evar_map -> ?level:Constrexpr.entry_relative_level ->
+  rlevel generic_argument -> Pp.t
+val pr_glb_generic : Environ.env -> Evd.evar_map -> ?level:Constrexpr.entry_relative_level ->
+  glevel generic_argument -> Pp.t
 
 (* The comments interface is imperative due to the printer not
    threading it, this could be solved using a better data

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1655,7 +1655,7 @@ let pr_hint env sigma h = match h.obj with
   | Unfold_nth c ->
     str"unfold " ++  pr_evaluable_reference c
   | Extern (_, tac) ->
-    str "(*external*) " ++ Pputils.pr_glb_generic env sigma tac
+    str "(*external*) " ++ Pputils.pr_glb_generic env sigma ~level:(LevelLe 0) tac
 
 let pr_id_hint env sigma (id, v) =
   let pr_pat p = match p.pat with

--- a/test-suite/misc/comment-lexing/test.v.beautified
+++ b/test-suite/misc/comment-lexing/test.v.beautified
@@ -22,7 +22,7 @@ intro c0rou.
 (** Le raisonnement sous-jacent est :
       soit c0rou une preuve arbitraire (inconnue) de [c0 = Rouge],
       on peut s'en servir pour démontrer coul_suiv [c0 = Vert]. *)
-(rewrite c0rou).
-(cbn[coul_suiv]).
+rewrite c0rou.
+cbn[coul_suiv].
 reflexivity.
 Qed.

--- a/test-suite/output-coqtop/bug_16462.out
+++ b/test-suite/output-coqtop/bug_16462.out
@@ -21,8 +21,8 @@ Tactic failure (level 1).
 In nested Ltac calls to "baz", "f" (bound to fun f x y => idtac v; f x), 
 "f" (bound to
 fun _ => let v' := v in
-         constr:((fun _ => ltac:((idtac v'; fail 1))))) and
-"(fun _ => ltac:((idtac v'; fail 1)))" (with x:=I, v':=Unnamed_thm_subproof,
+         constr:((fun _ => ltac:(idtac v'; fail 1)))) and
+"(fun _ => ltac:(idtac v'; fail 1))" (with x:=I, v':=Unnamed_thm_subproof,
 v:=Unnamed_thm_subproof, H:=H), last term evaluation failed.
 
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -44,7 +44,7 @@ let pr_constr_pattern_expr = pr_in_global_env pr_constr_pattern_expr
 
 (* In principle this may use the env/sigma, in practice not sure if it
    does except through pr_constr_expr in beautify mode. *)
-let pr_gen = pr_in_global_env Pputils.pr_raw_generic
+let pr_gen = pr_in_global_env (Pputils.pr_raw_generic ?level:None)
 
 (* No direct Global.env or pr_in_global_env use after this *)
 


### PR DESCRIPTION
Note that we don't regress on #16596.

We also preserve the parentheses in Print HintDb for hint externs (see auto_order output test for an example).

Is there ever a case where ensure_surrounded doesn't mean LevelLe 0?
