### PR TITLE
Specif notations use %_type for the second component

### DIFF
--- a/doc/changelog/03-notations/20294-specif-type.rst
+++ b/doc/changelog/03-notations/20294-specif-type.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The `Specif` notations (`exists x : A, P`, `{ x : A | P }`, `{ x : A & P }`, etc)
+  locally open `type_scope` for the second component (`P`).
+  This makes eg `{ x & type_1 * type_2 }` work even when `nat_scope` is opened instead of interpreting `*` as peano multiplication
+  (`#20294 <https://github.com/coq/coq/pull/20294>`_,
+  by Gaëtan Gilbert).

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -59,26 +59,26 @@ Arguments sig2 (A P Q)%_type.
 Arguments sigT (A P)%_type.
 Arguments sigT2 (A P Q)%_type.
 
-Notation "{ x | P }" := (sig (fun x => P)) : type_scope.
-Notation "{ x | P & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
-Notation "{ x : A | P }" := (sig (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x | P }" := (sig (fun x => P%_type)) : type_scope.
+Notation "{ x | P & Q }" := (sig2 (fun x => P%_type) (fun x => Q%_type)) : type_scope.
+Notation "{ x : A | P }" := (sig (A:=A) (fun x => P%_type)) : type_scope.
+Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P%_type) (fun x => Q%_type)) :
   type_scope.
-Notation "{ x & P }" := (sigT (fun x => P)) : type_scope.
-Notation "{ x & P & Q }" := (sigT2 (fun x => P) (fun x => Q)) : type_scope.
-Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x & P }" := (sigT (fun x => P%_type)) : type_scope.
+Notation "{ x & P & Q }" := (sigT2 (fun x => P%_type) (fun x => Q%_type)) : type_scope.
+Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P%_type)) : type_scope.
+Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P%_type) (fun x => Q)) :
   type_scope.
 
-Notation "{ ' pat | P }" := (sig (fun pat => P)) : type_scope.
-Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P) (fun pat => Q)) : type_scope.
-Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat | P }" := (sig (fun pat => P%_type)) : type_scope.
+Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P%_type) (fun pat => Q%_type)) : type_scope.
+Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P%_type)) : type_scope.
+Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P%_type) (fun pat => Q%_type)) :
   type_scope.
-Notation "{ ' pat & P }" := (sigT (fun pat => P)) : type_scope.
-Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P) (fun pat => Q)) : type_scope.
-Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat & P }" := (sigT (fun pat => P%_type)) : type_scope.
+Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P%_type) (fun pat => Q%_type)) : type_scope.
+Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P%_type)) : type_scope.
+Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P%_type) (fun pat => Q%_type)) :
   type_scope.
 
 Add Printing Let sig.


### PR DESCRIPTION
sigT is `sigT {A}%_type P%_function` so the `sigT (fun x => P)` in the notation does not automatically associate type_scope to P.

With this change, for instance

~~~
Check { x & (x >= 1) * (x >= 2) }.
~~~

works even though the prelude opens nat_scope (by exporting Peano).
