### PR TITLE
Improve ci-elpi(_test) scripts

### DIFF
--- a/dev/ci/scripts/ci-elpi.sh
+++ b/dev/ci/scripts/ci-elpi.sh
@@ -10,7 +10,6 @@ git_download elpi
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/elpi"
-  touch dune-workspace
   make dune-files
   dune build --root  . --only-packages=rocq-elpi @install
   dune install --root . rocq-elpi --prefix="$CI_INSTALL_DIR"

--- a/dev/ci/scripts/ci-elpi_test.sh
+++ b/dev/ci/scripts/ci-elpi_test.sh
@@ -8,7 +8,5 @@ ci_dir="$(dirname "$0")"
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/elpi"
-  export DUNE_build_FLAGS="--release"
-  make -j1 all-tests
-  make -j1 all-examples
+  dune build --root  . --only-packages=rocq-elpi-tests,rocq-elpi-tests-stdlib @all
 )


### PR DESCRIPTION
The dune-workspace in ci-elpi was because we didn't use --root, so not needed now.

In tests we just `build --only-packages=(test packages)`.
