### PR TITLE
Stop abusing the atom mechanism in firstorder reification

### DIFF
--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -42,7 +42,6 @@ val empty : t
 val add : flags -> Environ.env -> Evd.evar_map -> EConstr.t -> t -> t * uid
 val find : uid -> t -> EConstr.t
 val repr : uid -> int
-val hole : uid
 end =
 struct
 
@@ -57,12 +56,10 @@ type t = {
 type uid = int
 
 let empty = {
-  max_uid = 1; (* uid 0 is reserved for Meta 1 *)
-  repr = CM.singleton (Constr.mkMeta 1) 0;
-  data = Int.Map.singleton 0 (Constr.mkMeta 1);
+  max_uid = 0;
+  repr = CM.empty;
+  data = Int.Map.empty;
 }
-
-let hole = 0
 
 (* This is nonsense, but backwards compatibility mandates it *)
 let add flags env sigma c e =
@@ -159,8 +156,6 @@ let fresh_atom ~flags state env sigma metas atm =
   let st, uid = Env.add flags env sigma atm !state in
   let () = state := st in
   { atom = uid; vars }
-
-let hole_atom = { atom = Env.hole; vars = Int.Set.singleton 1 }
 
 let kind_of_formula ~flags env sigma term =
   let cciterm = special_whd ~flags env sigma term in
@@ -300,9 +295,12 @@ type _ pattern =
 | LeftPattern : left_pattern -> [ `Hyp ] pattern
 | RightPattern : right_pattern -> [ `Goal ] pattern
 
+type uid = unit ref
+let eq_uid (r1 : uid) r2 = r1 == r2
+
 type 'a t = {
   id : 'a identifier;
-  constr : atom;
+  uid : uid;
   pat : 'a pattern;
   atoms : atoms;
 }
@@ -356,8 +354,8 @@ let build_formula (type a) ~flags state env sigma (side : a side) (nam : a ident
                               | Forall(_,_)->LLforall a) in
                 LeftPattern pat
       in
-      let typ = fresh_atom ~flags state env sigma [] typ in
-      !state, Left { id = nam; constr = typ; pat = pattern; atoms = atoms}
+      let uid = ref () in
+      !state, Left { id = nam; uid; pat = pattern; atoms = atoms}
     with Is_atom a ->
       let state = ref state in
       let a = fresh_atom ~flags state env sigma [] a in

--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -287,7 +287,7 @@ type left_pattern=
   | Lor of pinductive
   | Lforall of metavariable*constr*bool
   | Lexists of pinductive
-  | LA of atom*left_arrow_pattern
+  | LA of left_arrow_pattern
 
 type _ identifier =
 | GoalId : [ `Goal ] identifier
@@ -346,9 +346,7 @@ let build_formula (type a) ~flags state env sigma (side : a side) (nam : a ident
                   | Forall (d,_) ->
                       Lforall(m,d,trivial)
                   | Arrow (a,b) ->
-                    let nfa = fresh_atom ~flags state env sigma [] a in
-                        LA (nfa,
-                            match kind_of_formula ~flags env sigma a with
+                        LA (match kind_of_formula ~flags env sigma a with
                                 False(i,l)-> LLfalse(i,l)
                               | Atom t->     LLatom
                               | And(i,l,_)-> LLand(i,l)

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -39,7 +39,6 @@ end
 
 type atom
 
-val hole_atom : atom
 val repr_atom : Env.t -> atom -> EConstr.t
 val compare_atom : atom -> atom -> int
 val meta_in_atom : metavariable -> atom -> bool
@@ -82,13 +81,16 @@ type _ identifier = private
 val goal_id : [ `Goal ] identifier
 val formula_id : Environ.env -> GlobRef.t -> [ `Hyp ] identifier
 
+type uid
+val eq_uid : uid -> uid -> bool
+
 type _ pattern =
 | LeftPattern : left_pattern -> [ `Hyp ] pattern
 | RightPattern : right_pattern -> [ `Goal ] pattern
 
 type 'a t = private {
         id: 'a identifier;
-        constr: atom;
+        uid: uid;
         pat: 'a pattern;
         atoms: atoms}
 

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -73,7 +73,7 @@ type left_pattern=
   | Lor of pinductive
   | Lforall of metavariable*constr*bool
   | Lexists of pinductive
-  | LA of atom*left_arrow_pattern
+  | LA of left_arrow_pattern
 
 type _ identifier = private
 | GoalId : [ `Goal ] identifier

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -85,7 +85,7 @@ let ground_tac ~flags solver startseq =
                       | Lexists ind ->
                           left_exists_tac ~flags ind backtrack (get_id hd)
                             continue (re_add seq1)
-                      | LA (typ,lap)->
+                      | LA lap ->
                           let la_tac=
                             begin
                               match lap with
@@ -106,7 +106,7 @@ let ground_tac ~flags solver startseq =
                                     (ll_arrow_tac ~flags a b c backtrack
                                        (get_id hd) continue (re_add seq1))
                             end in
-                            ll_atom_tac ~flags typ la_tac (get_id hd) continue (re_add seq1)
+                            ll_atom_tac ~flags la_tac (get_id hd) continue (re_add seq1)
                   end
             with Heap.EmptyHeap->solver
       end

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -30,7 +30,7 @@ let ground_tac ~flags solver startseq =
   Proofview.Goal.enter begin fun gl ->
   let rec toptac skipped seq =
     Proofview.Goal.enter begin fun gl ->
-    tclORELSE (axiom_tac seq)
+    tclORELSE (axiom_tac ~flags seq)
       begin
         try
           let (hd, seq1) = take_formula (pf_env gl) (project gl) seq

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -65,7 +65,7 @@ let do_sequent env sigma setref triv id seq i dom atoms=
         | Some c ->flag:=false;setref:=IS.add (c,id) !setref in
       List.iter (fun t->List.iter (do_pair t) a2.negative) a1.positive;
       List.iter (fun t->List.iter (do_pair t) a2.positive) a1.negative in
-    Sequent.iter_redexes (function AnyFormula lf->do_atoms atoms lf.atoms) seq;
+    Sequent.iter_redexes (function lf -> do_atoms atoms lf) seq;
     do_atoms atoms (Sequent.make_simple_atoms seq);
     !flag && !phref
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -85,6 +85,8 @@ let give_instances env sigma lf seq=
 
 let rec collect_quantified env sigma seq =
   try
+    (* This works because the only caller of this function ensures that at this
+       point we only have formulae with priority lower than forall / exists. *)
     let hd, seq1 = take_formula env sigma seq in
     let AnyFormula hd0 = hd in
       (match hd0.pat with

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -93,7 +93,7 @@ let axiom_tac ~flags seq =
     | None -> tclFAIL (Pp.str "No axiom link")
   end
 
-let ll_atom_tac ~flags a backtrack id continue seq =
+let ll_atom_tac ~flags backtrack id continue seq =
   let open EConstr in
   let tac =
     Proofview.Goal.enter begin fun gl ->

--- a/plugins/firstorder/rules.mli
+++ b/plugins/firstorder/rules.mli
@@ -26,7 +26,7 @@ val clear_global: GlobRef.t -> tactic
 
 val axiom_tac : flags:Formula.flags -> Sequent.t -> tactic
 
-val ll_atom_tac : flags:Formula.flags -> Formula.atom -> lseqtac with_backtracking
+val ll_atom_tac : flags:Formula.flags -> lseqtac with_backtracking
 
 val and_tac : flags:Formula.flags -> seqtac with_backtracking
 

--- a/plugins/firstorder/rules.mli
+++ b/plugins/firstorder/rules.mli
@@ -24,7 +24,7 @@ val wrap : flags:Formula.flags -> int -> bool -> seqtac
 
 val clear_global: GlobRef.t -> tactic
 
-val axiom_tac : Sequent.t -> tactic
+val axiom_tac : flags:Formula.flags -> Sequent.t -> tactic
 
 val ll_atom_tac : flags:Formula.flags -> Formula.atom -> lseqtac with_backtracking
 

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -37,7 +37,7 @@ let priority : type a. a pattern -> int = (* pure heuristics, <=0 for non revers
           | Lor _                  ->  40
           | Lforall (_,_,_)        -> -30
           | Lexists _              ->  60
-          | LA(_,lap) ->
+          | LA lap ->
               match lap with
                   LLatom           ->   0
                 | LLfalse (_,_)    -> 100

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -128,7 +128,7 @@ type t=
 
 let has_fuel seq = seq.depth > 0
 
-let iter_redexes f seq = HP.iter f seq.redexes
+let iter_redexes f seq = HP.iter (fun (AnyFormula p) -> f p.atoms) seq.redexes
 
 let deepen seq={seq with depth=seq.depth-1}
 

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -20,7 +20,7 @@ val has_fuel : t -> bool
 
 val make_simple_atoms : t -> atoms
 
-val iter_redexes : (Formula.any_formula -> unit) -> t -> unit
+val iter_redexes : (atoms -> unit) -> t -> unit
 
 val deepen: t -> t
 

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -34,6 +34,8 @@ val add_formula : flags:flags -> hint:bool -> Environ.env -> Evd.evar_map -> Glo
 
 val re_add_formula_list : Evd.evar_map -> Formula.any_formula list -> t -> t
 
+val mem_hyp : Id.t -> t -> bool
+
 val find_left : Evd.evar_map -> atom -> t -> GlobRef.t
 
 val find_goal : Evd.evar_map -> t -> GlobRef.t

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -36,10 +36,6 @@ val re_add_formula_list : Evd.evar_map -> Formula.any_formula list -> t -> t
 
 val mem_hyp : Id.t -> t -> bool
 
-val find_left : Evd.evar_map -> atom -> t -> GlobRef.t
-
-val find_goal : Evd.evar_map -> t -> GlobRef.t
-
 val take_formula : Environ.env -> Evd.evar_map -> t -> Formula.any_formula * t
 
 val empty_seq : int -> t

--- a/test-suite/bugs/bug_20301.v
+++ b/test-suite/bugs/bug_20301.v
@@ -1,0 +1,26 @@
+Set Universe Polymorphism.
+
+Axiom Ty : Set.
+Axiom Exp : Ty -> Set.
+
+Axiom halts@{u} : forall {τ : Ty} (_ : Exp τ), Type@{u}.
+
+Axiom step_preserves_halting@{u|} :
+  forall {τ : Ty} (e e' : Exp τ), (halts@{u} e) -> (halts@{u} e').
+
+Axiom SN@{u} : forall {τ : Ty} (_ : Exp τ), Type@{u}.
+
+Lemma foo@{u} : forall
+  (τ1 τ2 : Ty)
+  (e e' e'' : Exp τ2)
+  (X : @halts@{u} τ2 e)
+  (Y : forall (x : Exp τ1) (_ : @SN@{u} τ1 x), @SN@{u} τ2 e'')
+  (IHτ : forall (_ : @SN@{u} τ2 e''), False),
+  prod (forall (x : Exp τ1) (_ : @SN@{u} τ1 x), False) (@halts@{u} τ2 e').
+Proof.
+intros.
+pose proof (step_preserves_halting e e') as H2.
+split.
++ refine (fun x H => IHτ (Y x H)).
++ solve[firstorder].
+Qed.


### PR DESCRIPTION
The firstorder tactic implements a reification mechanism where blobesque formulas are turned into atoms, basically some kind of unique identifier. Each identifier is associated to an equivalence class of terms that have the same strong normal form, which is a very costly process.

Some of these atoms were actually not related to the reification mechanism and only allocated for technical and historical reasons, namely finding arguments for hypotheses of the form `forall x : A, B` and `A -> B` for arbitrary type `A`. Instead of hacking our way around via atom equality, we now try to find these arguments through conversion. This should be essentially backwards compatible, except for two potential discrepancies:
- The new algorithm is now able to handle η-conversion, as deep normalization does not quotient η-conversion away
- The new algorithm may pick hypotheses in a slightly different order. The old one was following the order of insertion of atoms while the new one follows the order of the context. This probably doesn't matter since (obviously) no sane person relies on the exact proof term generated by firstorder.

The new code is both faster and slower in theory, but hopefully faster on actual examples. It's now linear in the number of hypotheses, but it saves potentially very costly strong normalization (including full δ!) of the type of hypotheses. We could try to be even more clever about the first point since firstorder only cares about the context it introduced itself whereas in this PR we blindly crawl the whole goal context, but I doubt it matters in practice.