### PR TITLE
Canonicalize projections in the dnet

### DIFF
--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -99,7 +99,9 @@ let constr_val_discr env sigma ts t =
     match EConstr.kind sigma t with
     | App (f,l) -> decomp (Array.fold_right (fun a l -> a::l) l stack) f
     | Proj (p,_,c) when evaluable_projection p env ts -> Everything
-    | Proj (p,_,c) -> Label(ProjLabel (Projection.repr p, 0), c :: stack)
+    | Proj (p,_,c) ->
+      let p = Environ.QProjection.canonize env p in
+      Label(ProjLabel (Projection.repr p, 0), c :: stack)
     | Cast (c,_,_) -> decomp stack c
     | Const (c,_) when evaluable_constant c env ts -> Everything
     | Const (c,_) ->
@@ -136,7 +138,9 @@ let constr_pat_discr env ts p =
     match p with
     | PApp (f,args) -> decomp (Array.to_list args @ stack) f
     | PProj (p,c) when evaluable_projection p env ts -> None
-    | PProj (p,c) -> Some (ProjLabel (Projection.repr p, 0), c :: stack)
+    | PProj (p,c) ->
+      let p = Environ.QProjection.canonize env p in
+      Some (ProjLabel (Projection.repr p, 0), c :: stack)
     | PRef ((IndRef _) as ref)
     | PRef ((ConstructRef _ ) as ref) ->
       let ref = Environ.QGlobRef.canonize env ref in
@@ -167,7 +171,9 @@ let constr_pat_discr_syntactic env p =
   let rec decomp stack p =
     match eta_reduce_pat p with
     | PApp (f,args) -> decomp (Array.to_list args @ stack) f
-    | PProj (p,c) -> Some (ProjLabel (Names.Projection.repr p, 0), c :: stack)
+    | PProj (p,c) ->
+      let p = Environ.QProjection.canonize env p in
+      Some (ProjLabel (Names.Projection.repr p, 0), c :: stack)
     | PRef ((IndRef _) as ref)
     | PRef ((ConstructRef _ ) as ref) ->
       let ref = Environ.QGlobRef.canonize env ref in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

We needed this change in our own custom pattern translation code. I think the problem only comes up with `Include` but I am not entirely sure.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
