### PR TITLE
Ltac2 expose f_equal directly instead of through ltac1

### DIFF
--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -626,3 +626,6 @@ let () =
   define "simple_congruence"
   (option int @-> option (list constr) @-> tac unit)
   Tac2tactics.simple_congruence
+
+let () = define "f_equal" (unit @-> tac unit) @@ fun () ->
+    Tac2tactics.f_equal

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -461,3 +461,5 @@ let contradiction c =
 let congruence n l = Cc_core_plugin.Cctac.congruence_tac n (Option.default [] l)
 
 let simple_congruence n l = Cc_core_plugin.Cctac.simple_congruence_tac n (Option.default [] l)
+
+let f_equal = Cc_core_plugin.Cctac.f_equal

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -136,3 +136,5 @@ val mk_intro_pattern : intro_pattern -> Tactypes.intro_pattern
 val congruence : int option -> constr list option -> unit Proofview.tactic
 
 val simple_congruence : int option -> constr list option -> unit Proofview.tactic
+
+val f_equal : unit Proofview.tactic

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -615,8 +615,9 @@ Ltac2 Notation "congruence" n(opt(tactic(0))) l(opt(seq("with", list1(constr))))
 
 Ltac2 Notation "simple" "congruence" n(opt(tactic(0))) l(opt(seq("with", list1(constr)))) := Std.simple_congruence n l.
 
-Ltac2 f_equal0 () := ltac1:(f_equal).
-Ltac2 Notation f_equal := f_equal0 ().
+#[deprecated(since="9.1", note="Use Std.f_equal instead.")]
+Ltac2 f_equal0 := Std.f_equal.
+Ltac2 Notation f_equal := Std.f_equal ().
 
 (** now *)
 

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -272,5 +272,9 @@ Ltac2 @ external unify : constr -> constr -> unit := "rocq-runtime.plugins.ltac2
 
 Ltac2 @ external congruence : int option -> constr list option -> unit :=
   "rocq-runtime.plugins.ltac2" "congruence".
+
 Ltac2 @ external simple_congruence : int option -> constr list option -> unit :=
   "rocq-runtime.plugins.ltac2" "simple_congruence".
+
+Ltac2 @external f_equal : unit -> unit :=
+  "rocq-runtime.plugins.ltac2" "f_equal".


### PR DESCRIPTION
We already have the other congruence plugin tactics.
