### PR TITLE
[v9.0] Bump stdlib after theme fixes.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -419,7 +419,7 @@ project verdi_raft 'https://github.com/uwplse/verdi-raft' 'a3375e867326a82225e72
 ########################################################################
 # Stdlib
 ########################################################################
-project stdlib 'https://github.com/coq/stdlib' '732498358e2258595ae0ab174297238a21f8d177'
+project stdlib 'https://github.com/coq/stdlib' '2b50da773d975b742f731fe4d0bed033a8d30844'
 # Contact TODO on github
 
 ########################################################################


### PR DESCRIPTION
Should properly fix #19976 (until we decouple the deployment of the doc of the stdlib from the one of Rocq).