### PR TITLE
Share code for delayed marshal between vmlibrary and library

### DIFF
--- a/kernel/vmlibrary.ml
+++ b/kernel/vmlibrary.ml
@@ -11,69 +11,6 @@
 open Names
 open Vmemitcodes
 
-exception Faulty of string
-
-(* TODO: share with Library *)
-
-module Delayed :
-sig
-
-type 'a t
-val make : file:string -> ObjFile.in_handle -> segment:'a ObjFile.id -> 'a t
-val return : 'a -> 'a t
-val eval : 'a t -> 'a
-
-end =
-struct
-
-type 'a delayed = {
-  del_file : string;
-  del_off : int64;
-  del_digest : Digest.t;
-}
-
-type 'a node = ToFetch of 'a delayed | Fetched of 'a
-
-type 'a t = 'a node ref
-
-let in_delayed f ch ~segment =
-  let seg = ObjFile.get_segment ch ~segment in
-  let digest = seg.ObjFile.hash in
-  { del_file = f; del_digest = digest; del_off = seg.ObjFile.pos; }
-
-let make ~file ch ~segment =
-  let del = in_delayed file ch ~segment in
-  ref (ToFetch del)
-
-(** Fetching a table of opaque terms at position [pos] in file [f],
-    expecting to find first a copy of [digest]. *)
-
-let fetch_delayed del =
-  let { del_digest = digest; del_file = f; del_off = pos; } = del in
-  let ch = open_in_bin f in
-  let obj, digest' =
-    try
-      let () = LargeFile.seek_in ch pos in
-      let obj = System.marshal_in f ch in
-      let digest' = Digest.input ch in
-      obj, digest'
-    with e -> close_in ch; raise e
-  in
-  close_in ch;
-  if not (String.equal digest digest') then raise (Faulty f);
-  obj
-
-let eval r = match !r with
-| Fetched v -> v
-| ToFetch del ->
-  let v = fetch_delayed del in
-  let () = r := Fetched v in
-  v
-
-let return v = ref (Fetched v)
-
-end
-
 module VmTable =
 struct
 
@@ -110,14 +47,14 @@ type compiled_library = {
   lib_data : to_patch array;
 }
 
-type on_disk = DirPath.t * compiled_library Delayed.t
+type on_disk = DirPath.t * compiled_library ObjFile.Delayed.t
 
 let inject lib =
-  (lib.lib_dp, Delayed.return lib)
+  (lib.lib_dp, ObjFile.Delayed.return lib)
 
 type t = {
   local : VmTable.t;
-  foreign : compiled_library Delayed.t DPmap.t;
+  foreign : compiled_library ObjFile.Delayed.t DPmap.t;
 }
 
 type index = VmTable.index
@@ -141,7 +78,7 @@ let add code lib =
 let vm_segment : compiled_library ObjFile.id = ObjFile.make_id "vmlibrary"
 
 let load dp ~file ch =
-  (dp, Delayed.make ~file ~segment:vm_segment ch : on_disk)
+  (dp, ObjFile.Delayed.make ~file ~what:None ~whatfor:(DirPath.to_string dp) ~segment:vm_segment ch : on_disk)
 
 let link (dp, m) libs =
   let () = assert (not @@ DPmap.mem dp libs.foreign) in
@@ -158,7 +95,7 @@ let resolve (dp, i) libs =
     | exception Not_found -> missing_index dp i
   else match DPmap.find dp libs.foreign with
   | tab ->
-    let tab = Delayed.eval tab in
+    let tab = ObjFile.Delayed.eval ~verbose:false tab in
     tab.lib_data.(i)
   | exception Not_found ->
     CErrors.anomaly Pp.(str "Missing VM table for library " ++

--- a/lib/objFile.mli
+++ b/lib/objFile.mli
@@ -40,3 +40,24 @@ val marshal_out_binary : out_handle -> segment:'a id -> out_channel * (unit -> u
     [Stdlib.output_*] APIs should be used on [oc]. [stop ()] must be invoked in
     order to signal that all data was written to [oc] (which should not be used
     afterwards). Only after calling [stop] the other API can be used on [oh]. *)
+
+module Delayed : sig
+  type 'a t
+  (** Serialized objects loaded on-the-fly *)
+
+  val make : file:string -> what:string option -> whatfor:string -> in_handle -> segment:'a id -> 'a t
+  (** [whatfor] is expected to be the dirpath of the file.
+      If [what] is [Some str] we print "Fetching str ..." when forced. *)
+
+  val return : 'a -> 'a t
+
+  val eval : verbose:bool -> 'a t -> 'a
+  (** Fetches the value. If the digest changed since the [in_delayed]
+      call, raises an error.
+
+      With [verbose:true], if the value has not been previously
+      fetched, print a message to msg_info.
+
+      Calling [eval] multiple times on a given ['a t] value only does
+      the work once (like Lazy.force). *)
+end


### PR DESCRIPTION
The code for printing "fetching opaques from disk ..." is also shared, but not actually used by vmlibrary (we pass verbose:false). We could change behaviour to start printing a message when vm data gets fetched, but that seems like it could get verbose.
