### PR TITLE
Enforce that cached include objects are properly expanded.

### DIFF
--- a/dev/ci/user-overlays/20362-ppedrot-declaremode-cache-include.sh
+++ b/dev/ci/user-overlays/20362-ppedrot-declaremode-cache-include.sh
@@ -1,0 +1,1 @@
+overlay coq_lsp https://github.com/ppedrot/coq-lsp declaremode-cache-include 20362

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -40,15 +40,15 @@ let module_kind is_type =
 
 type classified_objects = {
   substobjs : Libobject.t list;
-  keepobjs : Libobject.t list;
-  escapeobjs : Libobject.t list;
+  keepobjs : Libobject.keep_objects;
+  escapeobjs : Libobject.escape_objects;
   anticipateobjs : Libobject.t list;
 }
 
 let empty_classified = {
   substobjs = [];
-  keepobjs = [];
-  escapeobjs = [];
+  keepobjs = { keep_objects = [] };
+  escapeobjs = { escape_objects = [] };
   anticipateobjs = [];
 }
 
@@ -67,9 +67,9 @@ let classify_segment seg =
       | Substitute ->
         clean {acc with substobjs = o :: acc.substobjs} stk
       | Keep ->
-        clean {acc with keepobjs = o :: acc.keepobjs} stk
+        clean {acc with keepobjs = { keep_objects = o :: acc.keepobjs.keep_objects } } stk
       | Escape ->
-        clean {acc with escapeobjs = o :: acc.escapeobjs} stk
+        clean {acc with escapeobjs = { escape_objects = o :: acc.escapeobjs.escape_objects } } stk
       | Anticipate ->
         clean {acc with anticipateobjs = o :: acc.anticipateobjs} stk
       end

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -97,8 +97,8 @@ type discharged_item =
 
 type classified_objects = {
   substobjs : Libobject.t list;
-  keepobjs : Libobject.t list;
-  escapeobjs : Libobject.t list;
+  keepobjs : Libobject.keep_objects;
+  escapeobjs : Libobject.escape_objects;
   anticipateobjs : Libobject.t list;
 }
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -123,20 +123,26 @@ module ExportObj = struct
   type t = { mpl : (open_filter * Names.ModPath.t) list } [@@unboxed]
 end
 
-type algebraic_objects =
-  | Objs of t list
-  | Ref of Names.ModPath.t * Mod_subst.substitution
+type ('subs, 'alg, 'keep, 'escape) object_view =
+| ModuleObject of Names.Id.t * 'subs
+| ModuleTypeObject of Names.Id.t * 'subs
+| IncludeObject of 'alg
+| KeepObject of Names.Id.t * 'keep
+| EscapeObject of Names.Id.t * 'escape
+| ExportObject of ExportObj.t
+| AtomicObject of obj
 
-and t =
-  | ModuleObject of Names.Id.t * substitutive_objects
-  | ModuleTypeObject of Names.Id.t * substitutive_objects
-  | IncludeObject of algebraic_objects
-  | KeepObject of Names.Id.t * t list
-  | EscapeObject of Names.Id.t * t list
-  | ExportObject of ExportObj.t
-  | AtomicObject of obj
+type t = (substitutive_objects, algebraic_objects, keep_objects, escape_objects) object_view
+
+and algebraic_objects =
+| Objs of t list
+| Ref of Names.ModPath.t * Mod_subst.substitution
 
 and substitutive_objects = Names.MBId.t list * algebraic_objects
+
+and keep_objects = { keep_objects : t list }
+
+and escape_objects = { escape_objects : t list }
 
 type 'a stored_decl = O : ('a, Nametab.object_prefix * 'a, 'd) object_declaration -> 'a stored_decl
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -156,24 +156,30 @@ module ExportObj : sig
   type t = { mpl : (open_filter * Names.ModPath.t) list } [@@unboxed]
 end
 
-type algebraic_objects =
-  | Objs of t list
-  | Ref of ModPath.t * Mod_subst.substitution
+type ('subs, 'alg, 'keep, 'escape) object_view =
+| ModuleObject of Id.t * 'subs
+| ModuleTypeObject of Id.t * 'subs
+| IncludeObject of 'alg
+| KeepObject of Id.t * 'keep
+| EscapeObject of Id.t * 'escape
+| ExportObject of ExportObj.t
+| AtomicObject of obj
 
 (* there are some extra invariants we could try to enforce by typing:
    - substitutive_objects do not contain KeepObject and EscapeObject
    - KeepObject only contains itself and atoms
    - EscapeObject only contains itself and atoms *)
-and t =
-  | ModuleObject of Id.t * substitutive_objects
-  | ModuleTypeObject of Id.t * substitutive_objects
-  | IncludeObject of algebraic_objects
-  | KeepObject of Id.t * t list
-  | EscapeObject of Id.t * t list
-  | ExportObject of ExportObj.t
-  | AtomicObject of obj
+type t = (substitutive_objects, algebraic_objects, keep_objects, escape_objects) object_view
 
-and substitutive_objects = MBId.t list * algebraic_objects
+and algebraic_objects =
+| Objs of t list
+| Ref of Names.ModPath.t * Mod_subst.substitution
+
+and substitutive_objects = Names.MBId.t list * algebraic_objects
+
+and keep_objects = { keep_objects : t list }
+
+and escape_objects = { escape_objects : t list }
 
 (** Object declaration and names: if you need the current prefix
    (typically to interact with the nametab), you need to have it


### PR DESCRIPTION
This patch fixes an inefficiency of the implementation of Include     objects. Namely, each time an Include has to be imported, its content is recomputed on the fly by performing substitution of the included module. We could force that all such objects are always expanded, but this would defeat the purpose of the indirection, which is to keep a compact representation of included modules in object files.

Rather, we generalize the type of objects so as to have two distinct representations, one for the object file and one for the Rocq process. This allows enforcing that the module cache used by Declaremods only keeps substituted objects by typing, while maintaining the indirect form for object files. This patch may augment memory consumption to some extent since we now cache a larger object, but it is likely that most of this memory was already retained because all objects contained in the included modules were added to the summary.

On the example from #20343, i.e. require-importing 1000 times the Reals file from the stdlib, this reduces the total process time from ~17s to ~10s on my machine.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/928