### PR TITLE
Tweaks around memory consumption of Nametab

### DIFF
--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -209,7 +209,8 @@ struct
               | current -> push_path (Relative (uname, o)) current
           else tree.path
         in
-        mktree this map
+        if this == tree.path && map == tree.map then tree
+        else mktree this map
     | [] ->
         match tree.path with
           | Absolute (uname',o') :: _ ->
@@ -224,7 +225,10 @@ struct
                 (* But ours is also absolute! This is an error! *)
                 CErrors.user_err Pp.(str @@ "Cannot mask the absolute name \""
                                    ^ U.to_string uname' ^ "\"!")
-          | current -> mktree (push_path (Absolute (uname, o)) current) tree.map
+          | current ->
+            let this = push_path (Absolute (uname, o)) current in
+            if this == tree.path then tree
+            else mktree this tree.map
 
 let rec push_exactly uname o level tree = function
 | [] ->
@@ -239,7 +243,8 @@ let rec push_exactly uname o level tree = function
             warn_masking_absolute n; tree.path
         | current -> push_path (Relative (uname, o)) current
     in
-    mktree this tree.map
+    if this == tree.path then tree
+    else mktree this tree.map
   else (* not right level *)
     let modify _ mc = push_exactly uname o (level-1) mc path in
     let map =
@@ -248,8 +253,8 @@ let rec push_exactly uname o level tree = function
         let ptab = modify () empty_tree in
         ModIdmap.add modid ptab tree.map
     in
-    mktree tree.path map
-
+    if map == tree.map then tree
+    else mktree tree.path map
 
 let push visibility uname o tab =
   let id,dir = U.repr uname in


### PR DESCRIPTION
First commit tries to dampen the fact that the current implementation of nametabs causes memory leaks. Instead of duplicating the same data when pushing it in a nametab several times in a row, we check that the head value is not equal to the one being added. This does not solve the issue that the Nametab structure is fundamentally leaky when overwriting bindings, but in practice it seems to mitigate it well enough.

Second commit tries to preserve more sharing when adding bindings.

The memory leak issue was discovered in #20343. We could probably fix it for real by changing the representation, but there is a risk of adding an overhead for the additional checks and / or a fringe change in semantics when removing bindings. (The latter feature is only used by abbreviations that, for some reason, can be toggled on and off. We could find another way to implement that, though, especially given that the remove code looks quite fishy.)

Atop of #20362, this PR further reduces the time for the example from #20343 from ~10s to ~7s on my machine.