### PR TITLE
Use full_path for absolute paths more consistently

### DIFF
--- a/dev/ci/user-overlays/20371-SkySkimmer-dirpath-full-path.sh
+++ b/dev/ci/user-overlays/20371-SkySkimmer-dirpath-full-path.sh
@@ -1,0 +1,11 @@
+overlay coq_dpdgraph https://github.com/SkySkimmer/coq-dpdgraph dirpath-full-path 20371
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp dirpath-full-path 20371
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer dirpath-full-path 20371
+
+overlay quickchick https://github.com/SkySkimmer/QuickChick dirpath-full-path 20371
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician dirpath-full-path 20371
+
+overlay vscoq https://github.com/SkySkimmer/vscoq dirpath-full-path 20371

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -312,7 +312,7 @@ let status force =
   ignore (Stm.finish ~doc:(get_doc ()) : Vernacstate.t);
   if force then Stm.join ~doc:(get_doc ());
   let path =
-    let l = Names.DirPath.repr (Lib.cwd ()) in
+    let l = Names.DirPath.repr (Libnames.dirpath_of_path @@ Lib.cwd ()) in
     List.rev_map Names.Id.to_string l
   in
   let proof =

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -185,20 +185,20 @@ let rec dirpath_of_modpath = function
   | MPbound mbid -> let (_,id,_) = MBId.repr mbid in DirPath.make [id]
   | MPdot (t, l) -> Libnames.add_dirpath_suffix (dirpath_of_modpath t) (Label.to_id l)
 
-let path_of_global = function
-  | GlobRef.VarRef id -> Libnames.make_path DirPath.empty id
+let qualid_of_global = function
+  | GlobRef.VarRef id -> Libnames.qualid_of_ident id
   (* We rely on the tacite invariant that the label of a constant is used to build its internal name *)
-  | GlobRef.ConstRef cst -> Libnames.make_path (dirpath_of_modpath (Constant.modpath cst)) (Label.to_id (Constant.label cst))
+  | GlobRef.ConstRef cst -> Libnames.make_qualid (dirpath_of_modpath (Constant.modpath cst)) (Label.to_id (Constant.label cst))
   (* We rely on the tacite invariant that an inductive block inherits the name of its first type *)
-  | GlobRef.IndRef (ind,1) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Label.to_id (MutInd.label ind))
+  | GlobRef.IndRef (ind,1) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Label.to_id (MutInd.label ind))
   (* These are hacks *)
-  | GlobRef.IndRef (ind,n) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
-  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
-  | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_path (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.IndRef (ind,n) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
+  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
 
 let default_extern_reference ?loc vars r =
   try Nametab.shortest_qualid_of_global ?loc vars r
-  with Not_found when GlobRef.is_bound r -> qualid_of_path (path_of_global r)
+  with Not_found when GlobRef.is_bound r -> qualid_of_global r
 
 let my_extern_reference = ref default_extern_reference
 

--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -69,7 +69,7 @@ type variable_data = {
 let vartab =
   Summary.ref (Id.Map.empty : (variable_data*DirPath.t) Id.Map.t) ~name:"VARIABLE"
 
-let secpath () = drop_dirpath_prefix (Lib.library_dp()) (Lib.cwd())
+let secpath () = Lib.current_dirpath true
 let add_variable_data id o = vartab := Id.Map.add id (o,secpath()) !vartab
 
 let variable_opacity id = let {opaque},_ = Id.Map.find id !vartab in opaque

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -146,7 +146,7 @@ let type_of_global_ref gr =
     | ConstructRef _ -> "constr"
 
 let remove_sections dir =
-  let cwd = Lib.cwd_except_section () in
+  let cwd = Libnames.dirpath_of_path @@ Lib.cwd_except_section () in
   if Libnames.is_dirpath_prefix_of cwd dir then
     (* Not yet (fully) discharged *)
     cwd

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -355,10 +355,7 @@ module type LibActions = sig
 
   type summary
   val stage : Summary.Stage.t
-  val check_section_fresh : DirPath.t -> Id.t -> unit
   val open_section : Id.t -> unit
-
-  val push_section_name : DirPath.t -> unit
 
   val close_section : summary -> unit
 
@@ -476,9 +473,6 @@ module InterpActions : LibActions with type summary = Summary.Interp.frozen = st
 
   let stage = Summary.Stage.Interp
 
-  let check_section_fresh _ _ = ()
-
-  let push_section_name _ = ()
   let close_section fs = Global.close_section fs
 
   let add_entry node =

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -18,9 +18,6 @@ type export = (export_flag * Libobject.open_filter) option (* None for a Module 
 let make_oname Libobject.{ obj_dir; obj_mp } id =
   Names.(Libnames.make_path obj_dir id, KerName.make obj_mp (Label.of_id id))
 
-let oname_prefix (sp, kn) =
-  { Libobject.obj_dir = Libnames.dirpath sp; obj_mp = KerName.modpath kn }
-
 type 'summary node =
   | CompilingLibrary of Libobject.object_prefix
   | OpenedModule of is_type * export * Libobject.object_prefix * 'summary

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -355,7 +355,6 @@ module type LibActions = sig
 
   type summary
   val stage : Summary.Stage.t
-  val check_mod_fresh : is_type:bool -> Nametab.object_prefix -> Id.t -> unit
   val check_section_fresh : DirPath.t -> Id.t -> unit
   val open_section : Id.t -> unit
 
@@ -389,14 +388,6 @@ module SynterpActions : LibActions with type summary = Summary.Synterp.frozen = 
   type summary = Summary.Synterp.frozen
   let stage = Summary.Stage.Synterp
 
-  let check_mod_fresh ~is_type prefix id =
-    let exists =
-      if is_type then Nametab.exists_cci (Libnames.make_path prefix.Nametab.obj_dir id)
-      else Nametab.exists_module prefix.Nametab.obj_dir
-    in
-    if exists then
-      CErrors.user_err Pp.(Id.print id ++ str " already exists.")
-
   let check_section_fresh obj_dir id =
     if Nametab.exists_dir obj_dir then
       CErrors.user_err Pp.(Id.print id ++ str " already exists.")
@@ -422,7 +413,6 @@ module SynterpActions : LibActions with type summary = Summary.Synterp.frozen = 
   let start_mod ~is_type export id mp fs =
     let dir = Libnames.add_dirpath_suffix !synterp_state.path_prefix.Nametab.obj_dir id in
     let prefix = Nametab.{ obj_dir = dir; obj_mp = mp; } in
-    check_mod_fresh ~is_type prefix id;
     assert (not (sections_are_opened()));
     add_entry (OpenedModule (is_type,export,prefix,fs));
     synterp_state := { !synterp_state with path_prefix = prefix } ;
@@ -486,7 +476,6 @@ module InterpActions : LibActions with type summary = Summary.Interp.frozen = st
 
   let stage = Summary.Stage.Interp
 
-  let check_mod_fresh ~is_type prefix id = ()
   let check_section_fresh _ _ = ()
 
   let push_section_name _ = ()

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -61,15 +61,15 @@ val contents : unit -> Summary.Interp.frozen library_segment
     - cwd = A.B.M.S
     - cwd_except_section = A.B.M
     - current_dirpath true = M.S
-    - current_dirpath false = S
+    - current_dirpath false = M
     - current_mp = MPdot(MPfile A.B, M)
 
     make_path (resp make_path_except_section) uses cwd (resp cwd_except_section)
     make_kn uses current_mp
 *)
 val prefix : unit -> Libobject.object_prefix
-val cwd : unit -> DirPath.t
-val cwd_except_section : unit -> DirPath.t
+val cwd : unit -> Libnames.full_path
+val cwd_except_section : unit -> Libnames.full_path
 val current_dirpath : bool -> DirPath.t (* false = except sections *)
 val make_path : Id.t -> Libnames.full_path
 val make_path_except_section : Id.t -> Libnames.full_path

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -22,7 +22,6 @@ type export = (export_flag * Libobject.open_filter) option (* None for a Module 
 
 val make_oname : Libobject.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name
-val oname_prefix : Libobject.object_name -> Libobject.object_prefix
 
 type 'summary node =
   | CompilingLibrary of Libobject.object_prefix

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -20,19 +20,19 @@ type is_type = bool (* Module Type or just Module *)
 type export_flag = Export | Import
 type export = (export_flag * Libobject.open_filter) option (* None for a Module Type *)
 
-val make_oname : Nametab.object_prefix -> Names.Id.t -> Libobject.object_name
+val make_oname : Libobject.object_prefix -> Names.Id.t -> Libobject.object_name
 val make_foname : Names.Id.t -> Libobject.object_name
-val oname_prefix : Libobject.object_name -> Nametab.object_prefix
+val oname_prefix : Libobject.object_name -> Libobject.object_prefix
 
 type 'summary node =
-  | CompilingLibrary of Nametab.object_prefix
-  | OpenedModule of is_type * export * Nametab.object_prefix * 'summary
-  | OpenedSection of Nametab.object_prefix * 'summary
+  | CompilingLibrary of Libobject.object_prefix
+  | OpenedModule of is_type * export * Libobject.object_prefix * 'summary
+  | OpenedSection of Libobject.object_prefix * 'summary
 
 (** Extract the [object_prefix] component. Note that it is the prefix
    of the objects *inside* this node, eg in [Module M.] we have
    [OpenedModule] with prefix containing [M]. *)
-val node_prefix : 'summary node -> Nametab.object_prefix
+val node_prefix : 'summary node -> Libobject.object_prefix
 
 type 'summary library_segment = ('summary node * Libobject.t list) list
 
@@ -68,7 +68,7 @@ val contents : unit -> Summary.Interp.frozen library_segment
     make_path (resp make_path_except_section) uses cwd (resp cwd_except_section)
     make_kn uses current_mp
 *)
-val prefix : unit -> Nametab.object_prefix
+val prefix : unit -> Libobject.object_prefix
 val cwd : unit -> DirPath.t
 val cwd_except_section : unit -> DirPath.t
 val current_dirpath : bool -> DirPath.t (* false = except sections *)
@@ -125,19 +125,19 @@ module type StagedLibS = sig
 
   val start_module :
     export -> Id.t -> ModPath.t ->
-    summary -> Nametab.object_prefix
+    summary -> Libobject.object_prefix
 
   val start_modtype :
     Id.t -> ModPath.t ->
-    summary -> Nametab.object_prefix
+    summary -> Libobject.object_prefix
 
   val end_module :
     unit ->
-    Nametab.object_prefix * summary * classified_objects
+    Libobject.object_prefix * summary * classified_objects
 
   val end_modtype :
     unit ->
-    Nametab.object_prefix * summary * classified_objects
+    Libobject.object_prefix * summary * classified_objects
 
   type frozen
 

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -72,16 +72,37 @@ let dirpath_of_string s =
   in
   DirPath.make path
 
-(*s Section paths are absolute names *)
+(** Absolute paths *)
 
 type full_path = {
-  dirpath : DirPath.t ;
-  basename : Id.t }
+  dirpath : DirPath.t;
+  basename : Id.t;
+}
 
 let dirpath sp = sp.dirpath
 let basename sp = sp.basename
 
+let dirpath_of_path { dirpath; basename } =
+  add_dirpath_suffix dirpath basename
+
 let make_path pa id = { dirpath = pa; basename = id }
+
+let make_path0 dp =
+  let dp, id = split_dirpath dp in
+  make_path dp id
+
+let dummy_full_path = make_path0 DirPath.dummy
+
+let add_path_suffix { dirpath = pa0; basename = id0 } id =
+  { dirpath = add_dirpath_suffix pa0 id0; basename = id }
+
+let path_pop_n_suffixes n ({ dirpath = dp; } as path) =
+  if n = 0 then path
+  else
+    let dp = pop_dirpath_n (n-1) dp in
+    make_path0 dp
+
+let path_pop_suffix p = path_pop_n_suffixes 1 p
 
 let repr_path { dirpath = pa; basename = id } = (pa,id)
 

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -85,6 +85,8 @@ let basename sp = sp.basename
 let dirpath_of_path { dirpath; basename } =
   add_dirpath_suffix dirpath basename
 
+let is_path_prefix_of p dp = is_dirpath_prefix_of (dirpath_of_path p) dp
+
 let make_path pa id = { dirpath = pa; basename = id }
 
 let make_path0 dp =
@@ -95,6 +97,12 @@ let dummy_full_path = make_path0 DirPath.dummy
 
 let add_path_suffix { dirpath = pa0; basename = id0 } id =
   { dirpath = add_dirpath_suffix pa0 id0; basename = id }
+
+let append_path ({ dirpath = dp; basename = id0 } as p) dp' =
+  if DirPath.is_empty dp' then p
+  else
+    let dp', id = split_dirpath dp' in
+    { dirpath = append_dirpath (add_dirpath_suffix dp id0) dp'; basename = id }
 
 let path_pop_n_suffixes n ({ dirpath = dp; } as path) =
   if n = 0 then path

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -35,10 +35,6 @@ let is_dirpath_suffix_of dir1 dir2 =
   let dir2 = DirPath.repr dir2 in
   List.prefix_of Id.equal dir1 dir2
 
-let chop_dirpath n d =
-  let d1,d2 = List.chop n (List.rev (DirPath.repr d)) in
-  DirPath.make (List.rev d1), DirPath.make (List.rev d2)
-
 let drop_dirpath_prefix d1 d2 =
   let d =
     List.drop_prefix Id.equal
@@ -47,8 +43,6 @@ let drop_dirpath_prefix d1 d2 =
   DirPath.make (List.rev d)
 
 let append_dirpath d1 d2 = DirPath.make (DirPath.repr d2 @ DirPath.repr d1)
-
-let add_dirpath_prefix id d = DirPath.make (DirPath.repr d @ [id])
 
 let add_dirpath_suffix p id = DirPath.make (id :: DirPath.repr p)
 
@@ -86,8 +80,6 @@ type full_path = {
 
 let dirpath sp = sp.dirpath
 let basename sp = sp.basename
-
-let full_path_is_ident sp = DirPath.is_empty (dirpath sp)
 
 let make_path pa id = { dirpath = pa; basename = id }
 
@@ -155,8 +147,7 @@ let qualid_of_dirpath ?loc dir =
 
 let qualid_of_lident lid = qualid_of_ident ?loc:lid.CAst.loc lid.CAst.v
 
-let qualid_is_ident qid =
-  full_path_is_ident qid.CAst.v
+let qualid_is_ident qid = DirPath.is_empty (dirpath qid.CAst.v)
 
 let qualid_basename qid =
   qid.CAst.v.basename

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -41,6 +41,8 @@ val make_path : DirPath.t -> Id.t -> full_path
 
 val add_path_suffix : full_path -> Id.t -> full_path
 
+val append_path : full_path -> DirPath.t -> full_path
+
 (** Destructors of [full_path] *)
 val repr_path : full_path -> DirPath.t * Id.t
 
@@ -57,6 +59,8 @@ val basename : full_path -> Id.t
 
 (** The full path as a [DirPath.t]. *)
 val dirpath_of_path : full_path -> DirPath.t
+
+val is_path_prefix_of : full_path -> DirPath.t -> bool
 
 (** Parsing and printing of section path as ["root.module.id"] *)
 val path_of_string : string -> full_path

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -39,10 +39,24 @@ val eq_full_path : full_path -> full_path -> bool
 (** Constructors of [full_path] *)
 val make_path : DirPath.t -> Id.t -> full_path
 
+val add_path_suffix : full_path -> Id.t -> full_path
+
 (** Destructors of [full_path] *)
 val repr_path : full_path -> DirPath.t * Id.t
-val dirpath : full_path -> DirPath.t
+
+(** [path_pop_n_suffixes n p] removes the last [n] elements of [p].
+    Raises [Failure] if [p] is not long enough. *)
+val path_pop_n_suffixes : int -> full_path -> full_path
+
+(** [path_pop_suffix p] is [path_pop_n_suffixes 1 p]. *)
+val path_pop_suffix : full_path -> full_path
+
+(** The prefix of the path *)
+val dirpath : full_path -> DirPath.t [@@deprecated "Compose [dirpath_of_path] and [pop_dirpath]"]
 val basename : full_path -> Id.t
+
+(** The full path as a [DirPath.t]. *)
+val dirpath_of_path : full_path -> DirPath.t
 
 (** Parsing and printing of section path as ["root.module.id"] *)
 val path_of_string : string -> full_path
@@ -94,3 +108,6 @@ val rocq_init_string : string (* "Corelib" *)
 (** This is the default root prefix for developments which doesn't
    mention a root *)
 val default_root_prefix : DirPath.t
+
+(** For uninitialized data, cf [DirPath.dummy] *)
+val dummy_full_path : full_path

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -23,9 +23,7 @@ val pop_dirpath_n : int -> DirPath.t -> DirPath.t
 val split_dirpath : DirPath.t -> DirPath.t * Id.t
 
 val add_dirpath_suffix : DirPath.t -> Id.t -> DirPath.t
-val add_dirpath_prefix : Id.t -> DirPath.t -> DirPath.t
 
-val chop_dirpath : int -> DirPath.t -> DirPath.t * DirPath.t
 val append_dirpath : DirPath.t -> DirPath.t -> DirPath.t
 
 val drop_dirpath_prefix : DirPath.t -> DirPath.t -> DirPath.t
@@ -45,7 +43,6 @@ val make_path : DirPath.t -> Id.t -> full_path
 val repr_path : full_path -> DirPath.t * Id.t
 val dirpath : full_path -> DirPath.t
 val basename : full_path -> Id.t
-val full_path_is_ident : full_path -> bool
 
 (** Parsing and printing of section path as ["root.module.id"] *)
 val path_of_string : string -> full_path

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -145,12 +145,12 @@ and keep_objects = { keep_objects : t list }
 and escape_objects = { escape_objects : t list }
 
 type object_prefix = {
-  obj_dir : Names.DirPath.t;
+  obj_path : Libnames.full_path;
   obj_mp  : Names.ModPath.t;
 }
 
 let eq_object_prefix op1 op2 =
-  Names.DirPath.equal op1.obj_dir op2.obj_dir &&
+  Libnames.eq_full_path op1.obj_path op2.obj_path &&
   Names.ModPath.equal op1.obj_mp  op2.obj_mp
 
 type 'a stored_decl = O : ('a, object_prefix * 'a, 'd) object_declaration -> 'a stored_decl
@@ -165,8 +165,8 @@ let declare_object_gen odecl =
   let () = cache_tab := DynMap.add tag (O odecl) !cache_tab in
   tag
 
-let make_oname { obj_dir; obj_mp } id =
-  Libnames.make_path obj_dir id, Names.KerName.make obj_mp (Names.Label.of_id id)
+let make_oname { obj_path; obj_mp } id =
+  Libnames.add_path_suffix obj_path id, Names.KerName.make obj_mp (Names.Label.of_id id)
 
 let declare_named_object_full odecl =
   let odecl =

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -144,7 +144,16 @@ and keep_objects = { keep_objects : t list }
 
 and escape_objects = { escape_objects : t list }
 
-type 'a stored_decl = O : ('a, Nametab.object_prefix * 'a, 'd) object_declaration -> 'a stored_decl
+type object_prefix = {
+  obj_dir : Names.DirPath.t;
+  obj_mp  : Names.ModPath.t;
+}
+
+let eq_object_prefix op1 op2 =
+  Names.DirPath.equal op1.obj_dir op2.obj_dir &&
+  Names.ModPath.equal op1.obj_mp  op2.obj_mp
+
+type 'a stored_decl = O : ('a, object_prefix * 'a, 'd) object_declaration -> 'a stored_decl
 
 module DynMap = Dyn.Map (struct type 'a t = 'a stored_decl end)
 
@@ -156,7 +165,7 @@ let declare_object_gen odecl =
   let () = cache_tab := DynMap.add tag (O odecl) !cache_tab in
   tag
 
-let make_oname Nametab.{ obj_dir; obj_mp } id =
+let make_oname { obj_dir; obj_mp } id =
   Libnames.make_path obj_dir id, Names.KerName.make obj_mp (Names.Label.of_id id)
 
 let declare_named_object_full odecl =

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -206,20 +206,20 @@ val declare_named_object :
   ('a, object_name * 'a, _) object_declaration -> (Id.t -> 'a -> obj)
 
 (** Object prefix morally contains the "prefix" naming of an object to
-   be stored by [library], where [obj_dir] is the "absolute" path and
+   be stored by [library], where [obj_path] is the "absolute" path and
    [obj_mp] is the current "module" prefix.
 
     Thus, for an object living inside [Module A. Section B.] the
    prefix would be:
 
-    [ { obj_dir = "A.B"; obj_mp = "A"; } ]
+    [ { obj_path = "A.B"; obj_mp = "A"; } ]
 
-    Note that [obj_dir] is a "path" that is to say,
+    Note that [obj_path] is a "path" that is to say,
    as opposed to [obj_mp] which is a single module name.
 
  *)
 type object_prefix = {
-  obj_dir : DirPath.t;
+  obj_path : Libnames.full_path;
   obj_mp  : ModPath.t;
 }
 

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Nametab
 open Mod_subst
 
 (** [Libobject] declares persistent objects, given with methods:
@@ -205,6 +204,26 @@ val declare_named_object_full :
 
 val declare_named_object :
   ('a, object_name * 'a, _) object_declaration -> (Id.t -> 'a -> obj)
+
+(** Object prefix morally contains the "prefix" naming of an object to
+   be stored by [library], where [obj_dir] is the "absolute" path and
+   [obj_mp] is the current "module" prefix.
+
+    Thus, for an object living inside [Module A. Section B.] the
+   prefix would be:
+
+    [ { obj_dir = "A.B"; obj_mp = "A"; } ]
+
+    Note that [obj_dir] is a "path" that is to say,
+   as opposed to [obj_mp] which is a single module name.
+
+ *)
+type object_prefix = {
+  obj_dir : DirPath.t;
+  obj_mp  : ModPath.t;
+}
+
+val eq_object_prefix : object_prefix -> object_prefix -> bool
 
 val declare_named_object_gen :
   ('a, object_prefix * 'a, _) object_declaration -> ('a -> obj)

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -17,12 +17,12 @@ module GlobDirRef = struct
   type t =
     | DirOpenModule of ModPath.t
     | DirOpenModtype of ModPath.t
-    | DirOpenSection of DirPath.t
+    | DirOpenSection of full_path
 
   let equal r1 r2 = match r1, r2 with
     | DirOpenModule op1, DirOpenModule op2 -> ModPath.equal op1 op2
     | DirOpenModtype op1, DirOpenModtype op2 -> ModPath.equal op1 op2
-    | DirOpenSection op1, DirOpenSection op2 -> DirPath.equal op1 op2
+    | DirOpenSection op1, DirOpenSection op2 -> eq_full_path op1 op2
     | (DirOpenModule _ | DirOpenModtype _ | DirOpenSection _), _ -> false
 
 end
@@ -419,16 +419,8 @@ module MPTab = Make(FullPath)(MPEqual)
 type ccitab = ExtRefTab.t
 let the_ccitab = Summary.ref ~name:"ccitab" (ExtRefTab.empty : ccitab)
 
-module DirPath' =
-struct
-  include DirPath
-  let repr dir = match DirPath.repr dir with
-    | [] -> CErrors.anomaly (Pp.str "Empty dirpath.")
-    | id :: l -> (id, l)
-end
-
-module MPDTab = Make(DirPath')(MPEqual)
-module DirTab = Make(DirPath')(GlobDirRef)
+module MPDTab = Make(FullPath)(MPEqual)
+module DirTab = Make(FullPath)(GlobDirRef)
 
 module UnivTab = Make(FullPath)(Univ.UGlobal)
 type univtab = UnivTab.t
@@ -443,7 +435,7 @@ let the_globrevtab =
 
 let the_globwarntab = Summary.ref ~name:"globwarntag" ExtRefMap.empty
 
-type mprevtab = DirPath.t MPmap.t
+type mprevtab = full_path MPmap.t
 
 type mptrevtab = full_path MPmap.t
 
@@ -555,7 +547,7 @@ let basename_of_global ref =
 let path_of_abbreviation kn =
   ExtRefMap.find (Abbrev kn) !the_globrevtab
 
-let dirpath_of_module mp =
+let path_of_module mp =
   MPmap.find mp Modules.(!nametab.modrevtab)
 
 let path_of_modtype mp =

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -12,15 +12,6 @@ open Names
 open Libnames
 open Globnames
 
-type object_prefix = {
-  obj_dir : DirPath.t;
-  obj_mp  : ModPath.t;
-}
-
-let eq_op op1 op2 =
-  DirPath.equal op1.obj_dir op2.obj_dir &&
-  ModPath.equal op1.obj_mp  op2.obj_mp
-
 (* to this type are mapped DirPath.t's in the nametab *)
 module GlobDirRef = struct
   type t =

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -61,7 +61,7 @@ module GlobDirRef : sig
   type t =
     | DirOpenModule of ModPath.t
     | DirOpenModtype of ModPath.t
-    | DirOpenSection of DirPath.t
+    | DirOpenSection of full_path
   val equal : t -> t -> bool
 end
 
@@ -86,8 +86,8 @@ val map_visibility : (int -> int) -> visibility -> visibility
 
 val push : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
-val push_module : visibility -> DirPath.t -> ModPath.t -> unit
-val push_dir : visibility -> DirPath.t -> GlobDirRef.t -> unit
+val push_module : visibility -> full_path -> ModPath.t -> unit
+val push_dir : visibility -> full_path -> GlobDirRef.t -> unit
 val push_abbreviation : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> Globnames.abbreviation -> unit
 
 val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
@@ -110,7 +110,7 @@ val locate_abbreviation : qualid -> Globnames.abbreviation
 val locate_modtype : qualid -> ModPath.t
 val locate_dir : qualid -> GlobDirRef.t
 val locate_module : qualid -> ModPath.t
-val locate_section : qualid -> DirPath.t
+val locate_section : qualid -> full_path
 val locate_universe : qualid -> Univ.UGlobal.t
 
 val locate_extended_nowarn : qualid -> Globnames.extended_global_reference
@@ -150,8 +150,8 @@ val extended_global_of_path : full_path -> Globnames.extended_global_reference
 
 val exists_cci : full_path -> bool
 val exists_modtype : full_path -> bool
-val exists_module : DirPath.t -> bool
-val exists_dir : DirPath.t -> bool
+val exists_module : full_path -> bool
+val exists_dir : full_path -> bool
 val exists_universe : full_path -> bool
 
 (** {6 These functions declare (resp. return) the source location of the object if known } *)
@@ -162,7 +162,7 @@ val cci_src_loc : Globnames.extended_global_reference -> Loc.t option
 (** {6 These functions locate qualids into full user names } *)
 
 val full_name_modtype : qualid -> full_path
-val full_name_module : qualid -> DirPath.t
+val full_name_module : qualid -> full_path
 
 (** {6 Reverse lookup }
   Finding user names corresponding to the given
@@ -173,7 +173,7 @@ val full_name_module : qualid -> DirPath.t
 
 val path_of_abbreviation : Globnames.abbreviation -> full_path
 val path_of_global : GlobRef.t -> full_path
-val dirpath_of_module : ModPath.t -> DirPath.t
+val path_of_module : ModPath.t -> full_path
 val path_of_modtype : ModPath.t -> full_path
 
 (** A universe_id might not be registered with a corresponding user name.

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -56,26 +56,6 @@ open Libnames
 
 *)
 
-(** Object prefix morally contains the "prefix" naming of an object to
-   be stored by [library], where [obj_dir] is the "absolute" path and
-   [obj_mp] is the current "module" prefix.
-
-    Thus, for an object living inside [Module A. Section B.] the
-   prefix would be:
-
-    [ { obj_dir = "A.B"; obj_mp = "A"; } ]
-
-    Note that [obj_dir] is a "path" that is to say,
-   as opposed to [obj_mp] which is a single module name.
-
- *)
-type object_prefix = {
-  obj_dir : DirPath.t;
-  obj_mp  : ModPath.t;
-}
-
-val eq_op : object_prefix -> object_prefix -> bool
-
 (** to this type are mapped [DirPath.t]'s in the nametab *)
 module GlobDirRef : sig
   type t =

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -699,9 +699,11 @@ let simple_extraction ~opaque_access r =
 let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
   init true true;
   let dir_m =
+    (* XXX WTF is going on here? *)
     let q = qualid_of_ident m in
     try Nametab.full_name_module q with Not_found -> error_unknown_module ?loc q
   in
+  let dir_m = dirpath_of_path dir_m in
   let venv = Visit.make () in
   let () = Visit.add_mp_all venv (MPfile dir_m) in
   let env = Global.env () in

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -297,8 +297,8 @@ let safe_pr_long_global r =
     | _ -> assert false
 
 let pr_long_mp mp =
-  let lid = DirPath.repr (Nametab.dirpath_of_module mp) in
-  str (String.concat "." (List.rev_map Id.to_string lid))
+  let sp = Nametab.path_of_module mp in
+  Libnames.pr_path sp
 
 let pr_long_global ref = pr_path (Nametab.path_of_global ref)
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1696,10 +1696,9 @@ let register_mes interactive_proof fname rec_impls wf_mes_expr wf_rel_expr_opt
     | None ->
       let ltof =
         let make_dir l = DirPath.make (List.rev_map Id.of_string l) in
-        Libnames.qualid_of_path
-          (Libnames.make_path
-             (make_dir ["Arith"; "Wf_nat"])
-             (Id.of_string "ltof"))
+        Libnames.make_qualid
+          (make_dir ["Arith"; "Wf_nat"])
+          (Id.of_string "ltof")
       in
       let fun_from_mes =
         let applied_mes =

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -28,7 +28,7 @@ let classes_dirpath =
   Names.DirPath.make (List.map Id.of_string ["Classes";"Corelib"])
 
 let init_setoid () =
-  if is_dirpath_prefix_of classes_dirpath (Lib.cwd ()) then ()
+  if is_dirpath_prefix_of classes_dirpath (Libnames.dirpath_of_path @@ Lib.cwd ()) then ()
   else Rocqlib.check_required_library ["Corelib";"Setoids";"Setoid"]
 
 type rewrite_attributes = {

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -201,16 +201,16 @@ let load_replace i (prefix, {repl_local; repl_tac; repl_expr=t}) =
   match repl_local with
   | Local | Export -> ()
   | SuperGlobal ->
-    replace repl_tac prefix.Nametab.obj_mp t
+    replace repl_tac prefix.obj_mp t
 
 let open_replace i (prefix, {repl_local; repl_tac; repl_expr=t}) =
   match repl_local with
   | Local | SuperGlobal -> ()
   | Export ->
-    replace repl_tac prefix.Nametab.obj_mp t
+    replace repl_tac prefix.obj_mp t
 
 let cache_replace (prefix, {repl_local; repl_tac; repl_expr=t}) =
-  replace repl_tac prefix.Nametab.obj_mp t
+  replace repl_tac prefix.obj_mp t
 
 let subst_replace (subst, {repl_local; repl_tac; repl_expr}) =
   { repl_local;

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -234,7 +234,7 @@ type typext = {
 
 let push_typext vis prefix def =
   let iter data =
-    let spc = Libnames.make_path prefix.obj_dir data.edata_name in
+    let spc = Libnames.add_path_suffix prefix.obj_path data.edata_name in
     let knc = KerName.make prefix.obj_mp (Label.of_id data.edata_name) in
     Tac2env.push_constructor vis spc knc
   in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -466,7 +466,7 @@ module Search = struct
 
   (** Local hints *)
   let autogoal_cache = Summary.ref ~name:"autogoal_cache"
-      (DirPath.empty, true, Context.Named.empty, Hints.Modes.empty,
+      (Libnames.dummy_full_path, true, Context.Named.empty, Hints.Modes.empty,
        Hint_db.empty TransparentState.full true)
 
   let make_autogoal_hints only_classes (modes,st as mst) gl =
@@ -476,7 +476,7 @@ module Search = struct
     let (dir, onlyc, sign', cached_modes, cached_hints) = !autogoal_cache in
     let cwd = Lib.cwd () in
     let eq c1 c2 = EConstr.eq_constr sigma c1 c2 in
-    if DirPath.equal cwd dir &&
+    if Libnames.eq_full_path cwd dir &&
          (onlyc == only_classes) &&
            Context.Named.equal (ERelevance.equal sigma) eq sign sign' &&
              cached_modes == modes

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -589,7 +589,7 @@ let classes_dirpath =
   DirPath.make (List.map Id.of_string ["Classes";"Corelib"])
 
 let init_setoid () =
-  if is_dirpath_prefix_of classes_dirpath (Lib.cwd ()) then ()
+  if is_dirpath_prefix_of classes_dirpath (Libnames.dirpath_of_path @@ Lib.cwd ()) then ()
   else check_required_library ["Corelib";"Setoids";"Setoid"]
 
 let check_setoid cl =

--- a/vernac/comSearch.mli
+++ b/vernac/comSearch.mli
@@ -18,7 +18,7 @@ val interp_search_request :
   bool * Vernacexpr.search_request ->
   bool * Search.glob_search_request
 
-val interp_search_restriction : Libnames.qualid list search_restriction -> Names.DirPath.t list search_restriction
+val interp_search_restriction : Libnames.qualid list search_restriction -> Libnames.full_path list search_restriction
 
 val interp_search : Environ.env -> Evd.evar_map ->
   searchable -> Libnames.qualid list search_restriction -> unit

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -49,14 +49,14 @@ let do_univ_name ~check i dp src (id,univ) =
 
 let cache_univ_names (prefix, (src, univs)) =
   let depth = Lib.sections_depth () in
-  let dp = Libnames.pop_dirpath_n depth prefix.Nametab.obj_dir in
+  let dp = Libnames.pop_dirpath_n depth prefix.Libobject.obj_dir in
   List.iter (do_univ_name ~check:true (Nametab.Until 1) dp src) univs
 
 let load_univ_names i (prefix, (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Nametab.obj_dir src) univs
+  List.iter (do_univ_name ~check:false (Nametab.Until i) prefix.Libobject.obj_dir src) univs
 
 let open_univ_names i (prefix, (src, univs)) =
-  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Nametab.obj_dir src) univs
+  List.iter (do_univ_name ~check:false (Nametab.Exactly i) prefix.Libobject.obj_dir src) univs
 
 let discharge_univ_names = function
   | BoundUniv, _ -> None

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -172,7 +172,7 @@ val append_end_library_hook : (unit -> unit) -> unit
     (together with their section path). Ignores synterp objects. *)
 
 val iter_all_interp_segments :
-  (Nametab.object_prefix -> Libobject.t -> unit) -> unit
+  (Libobject.object_prefix -> Libobject.t -> unit) -> unit
 
 
 val debug_print_modtab : unit -> Pp.t

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -671,14 +671,14 @@ let print_abbreviation access env sigma kn =
 
 (** Unused outside? *)
 
-let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.Nametab.obj_dir))
+let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.obj_dir))
 
 let print_library_node = function
   | Lib.OpenedSection (prefix, _) ->
     str " >>>>>>> Section " ++ pr_prefix_name prefix
   | Lib.OpenedModule (_,_,prefix,_) ->
     str " >>>>>>> Module " ++ pr_prefix_name prefix
-  | Lib.CompilingLibrary { Nametab.obj_dir; _ } ->
+  | Lib.CompilingLibrary { obj_dir; _ } ->
     str " >>>>>>> Library " ++ DirPath.print obj_dir
 
 (** Printing part of command [Check] *)
@@ -756,7 +756,7 @@ let print_context env sigma ~with_values =
     | (node, leaves) :: rest ->
       if is_done n then mt()
       else
-        let mp = (Lib.node_prefix node).Nametab.obj_mp in
+        let mp = (Lib.node_prefix node).obj_mp in
         let n, pleaves = print_leaves env sigma ~with_values mp n leaves in
         if is_done n then pleaves
         else prec n rest ++ pleaves
@@ -830,7 +830,7 @@ let print_full_pure_leaf access env sigma mp = function
 let print_full_pure_context access env sigma =
   let rec prec = function
     | (node,leaves)::rest ->
-      let mp = (Lib.node_prefix node).Nametab.obj_mp in
+      let mp = (Lib.node_prefix node).obj_mp in
       let pp = Pp.prlist (print_full_pure_leaf access env sigma mp) leaves in
       prec rest ++ pp
   | [] -> mt ()
@@ -851,7 +851,7 @@ let read_sec_context qid =
     with Not_found ->
       user_err ?loc:qid.loc (str "Unknown section.") in
   let rec get_cxt in_cxt = function
-    | (Lib.OpenedSection ({Nametab.obj_dir;_},_), _ as hd)::rest ->
+    | (Lib.OpenedSection ({obj_dir;_},_), _ as hd)::rest ->
         if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
     | [] -> []
     | hd::rest -> get_cxt (hd::in_cxt) rest

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -671,15 +671,15 @@ let print_abbreviation access env sigma kn =
 
 (** Unused outside? *)
 
-let pr_prefix_name prefix = Id.print (snd (split_dirpath prefix.obj_dir))
+let pr_prefix_name prefix = Id.print (basename prefix.obj_path)
 
 let print_library_node = function
   | Lib.OpenedSection (prefix, _) ->
     str " >>>>>>> Section " ++ pr_prefix_name prefix
   | Lib.OpenedModule (_,_,prefix,_) ->
     str " >>>>>>> Module " ++ pr_prefix_name prefix
-  | Lib.CompilingLibrary { obj_dir; _ } ->
-    str " >>>>>>> Library " ++ DirPath.print obj_dir
+  | Lib.CompilingLibrary { obj_path; _ } ->
+    str " >>>>>>> Library " ++ pr_path obj_path
 
 (** Printing part of command [Check] *)
 
@@ -851,8 +851,8 @@ let read_sec_context qid =
     with Not_found ->
       user_err ?loc:qid.loc (str "Unknown section.") in
   let rec get_cxt in_cxt = function
-    | (Lib.OpenedSection ({obj_dir;_},_), _ as hd)::rest ->
-        if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
+    | (Lib.OpenedSection ({obj_path;_},_), _ as hd)::rest ->
+        if eq_full_path dir obj_path then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
     | [] -> []
     | hd::rest -> get_cxt (hd::in_cxt) rest
   in
@@ -955,11 +955,11 @@ let pr_located_qualid env = function
         let open GlobDirRef in match dir with
         | DirOpenModule mp -> "Open Module", ModPath.print mp
         | DirOpenModtype mp -> "Open Module Type", ModPath.print mp
-        | DirOpenSection dir -> "Open Section", DirPath.print dir
+        | DirOpenSection dir -> "Open Section", pr_path dir
       in
       str s ++ spc () ++ mp
   | Module mp ->
-    str "Module" ++ spc () ++ DirPath.print (Nametab.dirpath_of_module mp)
+    str "Module" ++ spc () ++ pr_path (Nametab.path_of_module mp)
   | ModuleType mp ->
       str "Module Type" ++ spc () ++ pr_path (Nametab.path_of_modtype mp)
   | Other (obj, info) -> info.name obj

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -61,7 +61,7 @@ let keyword s = tag_keyword (str s)
 
 let get_new_id locals id =
   let rec get_id l id =
-    let dir = DirPath.make [id] in
+    let dir = Libnames.make_path DirPath.empty id in
       if not (Nametab.exists_module dir || Nametab.exists_dir dir) then
         id
       else
@@ -199,7 +199,7 @@ let print_kn locals kn =
 
 let nametab_register_dir obj_mp =
   let id = mk_fake_top () in
-  let obj_dir = DirPath.make [id] in
+  let obj_dir = Libnames.make_path DirPath.empty id in
   Nametab.(push_module (Until 1) obj_dir obj_mp)
 
 (** Nota: the [global_reference] we register in the nametab below
@@ -257,7 +257,7 @@ let nametab_register_modparam used mbid mtb =
     with e when CErrors.noncritical e ->
       (* Otherwise, we try to play with the nametab ourselves *)
       let mp = MPbound mbid in
-      let check id = Id.Set.mem id used || Nametab.exists_module (DirPath.make [id]) in
+      let check id = Id.Set.mem id used || Nametab.exists_module (Libnames.make_path DirPath.empty id) in
       let id = Namegen.next_ident_away_from id check in
       let dir = DirPath.make [id] in
       nametab_register_dir mp;

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -83,7 +83,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
     | AtomicObject o ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
-          let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
+          let kn = KerName.make prefix.obj_mp (Label.of_id id) in
           let cst = Global.constant_of_delta_kn kn in
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
@@ -91,7 +91,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
           fn gr (Some kind) env sigma typ
         end @@
         DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-          let kn = KerName.make prefix.Nametab.obj_mp (Label.of_id id) in
+          let kn = KerName.make prefix.obj_mp (Label.of_id id) in
           let mind = Global.mind_of_delta_kn kn in
           let mib = Global.lookup_mind mind in
           let iter_packet i mip =

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -201,7 +201,7 @@ let blacklist_filter : filter_function = fun ref kind env sigma typ ->
 
 let module_filter : _ -> filter_function = fun mods ref kind env sigma typ ->
   let sp = Nametab.path_of_global ref in
-  let sl = dirpath sp in
+  let sl = pop_dirpath @@ dirpath_of_path sp in
   match mods with
   | SearchOutside mods ->
     let is_outside md = not (is_dirpath_prefix_of md sl) in
@@ -321,7 +321,7 @@ let interface_search env sigma =
   in
   let filter_function ref kind env sigma constr =
     let id = Names.Id.to_string (Nametab.basename_of_global ref) in
-    let path = Libnames.dirpath (Nametab.path_of_global ref) in
+    let path = pop_dirpath @@ dirpath_of_path (Nametab.path_of_global ref) in
     let toggle x b = if x then b else not b in
     let match_name (regexp, flag) =
       toggle (Str.string_match regexp id 0) flag

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -36,7 +36,7 @@ type display_function =
 val blacklist_filter : filter_function
 (** Check whether a reference is blacklisted. *)
 
-val module_filter : DirPath.t list search_restriction -> filter_function
+val module_filter : Libnames.full_path list search_restriction -> filter_function
 (** Check whether a reference pertains or not to a set of modules *)
 
 val search_filter : glob_search_item -> filter_function
@@ -47,12 +47,12 @@ val search_filter : glob_search_item -> filter_function
 goal and the global environment for things matching [pattern] and
 satisfying module exclude/include clauses of [modinout]. *)
 
-val search_rewrite : env -> Evd.evar_map -> constr_pattern -> DirPath.t list search_restriction
+val search_rewrite : env -> Evd.evar_map -> constr_pattern -> Libnames.full_path list search_restriction
                   -> display_function -> unit
-val search_pattern : env -> Evd.evar_map -> constr_pattern -> DirPath.t list search_restriction
+val search_pattern : env -> Evd.evar_map -> constr_pattern -> Libnames.full_path list search_restriction
                   -> display_function -> unit
 val search         : env -> Evd.evar_map -> (bool * glob_search_request) list
-                  -> DirPath.t list search_restriction -> display_function -> unit
+                  -> Libnames.full_path list search_restriction -> display_function -> unit
 
 type search_constraint =
   | Name_Pattern of Str.regexp
@@ -61,7 +61,7 @@ type search_constraint =
   (** Whether the object type satisfies a pattern *)
   | SubType_Pattern of Pattern.constr_pattern
   (** Whether some subtype of object type satisfies a pattern *)
-  | In_Module of Names.DirPath.t
+  | In_Module of Libnames.full_path
   (** Whether the object pertains to a module *)
   | Include_Blacklist
   (** Bypass the Search blacklist *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1368,12 +1368,12 @@ let add_subnames_of ?loc len n ns full_n ref =
       ns Sorts.all_families
 
 let interp_names m ns =
-  let dp_m = Nametab.dirpath_of_module m in
+  let dp_m = Nametab.path_of_module m in
   let ns =
     List.fold_left (fun ns (n,etc) ->
         let len, full_n =
           let dp_n,n = repr_qualid n in
-          List.length (DirPath.repr dp_n), make_path (append_dirpath dp_m dp_n) n
+          List.length (DirPath.repr dp_n), add_path_suffix (append_path dp_m dp_n) n
         in
         let ref = try importable_extended_global_of_path ?loc:n.loc full_n
           with Not_found ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1351,7 +1351,7 @@ let add_subnames_of ?loc len n ns full_n ref =
     CErrors.user_err ?loc Pp.(str "Only inductive types can be used with Import (...).")
   | Globnames.TrueGlobal (IndRef (mind,i)) ->
     let open Declarations in
-    let dp = Libnames.dirpath full_n in
+    let path_prefix = path_pop_suffix full_n in
     let mib = Global.lookup_mind mind in
     let mip = mib.mind_packets.(i) in
     let ns = add1 (IndRef (mind,i)) ns in
@@ -1361,7 +1361,7 @@ let add_subnames_of ?loc len n ns full_n ref =
     List.fold_left (fun ns f ->
         let s = Indrec.elimination_suffix f in
         let n_elim = Id.of_string (Id.to_string mip.mind_typename ^ s) in
-        match importable_extended_global_of_path ?loc (Libnames.make_path dp n_elim) with
+        match importable_extended_global_of_path ?loc (Libnames.add_path_suffix path_prefix n_elim) with
         | exception Not_found -> ns
         | None -> ns
         | Some ref -> (len, ref) :: ns)


### PR DESCRIPTION
In particular, the module and section nametabs use full_path instead
of dirpath, and the libobject object_prefix contains a full_path
instead of a dirpath.

Note that the comment on `Lib.current_dirpath false` was apparently
incorrect (or maybe this changed semantics at some point?)

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/932
- https://github.com/QuickChick/QuickChick/pull/402
- https://github.com/lukaszcz/coqhammer/pull/190
- https://github.com/coq-tactician/coq-tactician/pull/96
- https://github.com/coq/vscoq/pull/1068
- https://github.com/coq-community/coq-dpdgraph/pull/143