### PR TITLE
Remove the ability to declare arbitrary terms as hints.

### DIFF
--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1579,8 +1579,6 @@ let add_hints ~locality dbnames h =
 
 let hint_globref gr = IsGlobRef gr
 
-let hint_constr (c, diff) = IsConstr (c, diff)
-
 let warn_non_reference_hint_using =
   CWarnings.create ~name:"non-reference-hint-using" ~category:CWarnings.CoreCategories.deprecated
     Pp.(fun (env, sigma, c) -> str "Use of the non-reference term " ++ pr_leconstr_env env sigma c ++ str " in \"using\" clauses is deprecated")

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -200,9 +200,6 @@ val add_hints : locality:hint_locality -> hint_db_name list -> hints_entry -> un
 
 val hint_globref : GlobRef.t -> hint_term
 
-val hint_constr : constr * UnivGen.sort_context_set option -> hint_term
-[@@ocaml.deprecated "(8.13) Declare a hint constant instead"]
-
 (** A constr which is Hint'ed will be:
    - (1) used as an Exact, if it does not start with a product
    - (2) used as an Apply, if its HNF starts with a product, and


### PR DESCRIPTION
This feature was deprecated since 8.12 and its default was set to error in 8.20. This removal is long overdue. The implementation still uses internally potentially arbitrary terms due to the using clause but even this feature is deprecated.
