### PR TITLE
Handle registered refs in constrexpr and parse `libref:(qualid)`  as a registered ref

### DIFF
--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -285,7 +285,9 @@ rest of the Rocq Prover manual: :term:`terms <term>` and :term:`types
         | [| {*; @term } %| @term {? : @type } |] {? @univ_annot }
         | @term_ltac
         | ( @term )
-        qualid_annotated ::= @qualid {? @univ_annot }
+        global ::= @qualid
+        | libref : ( @qualid )
+        qualid_annotated ::= @global {? @univ_annot }
 
      .. note::
 

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -273,8 +273,8 @@ Accessing fields (projections)
    .. insertprodn term_projection term_projection
 
    .. prodn::
-      term_projection ::= @term0 .( @qualid {? @univ_annot } {* @arg } )
-      | @term0 .( @ @qualid {? @univ_annot } {* @term1 } )
+      term_projection ::= @term0 .( @global {? @univ_annot } {* @arg } )
+      | @term0 .( @ @global {? @univ_annot } {* @term1 } )
 
    The value of a field can be accessed using *projection form* (:n:`@term_projection`,
    shown here) or with *application form* (see :n:`@term_application`) using the

--- a/doc/sphinx/language/core/variants.rst
+++ b/doc/sphinx/language/core/variants.rst
@@ -142,11 +142,11 @@ to apply specific treatments accordingly.
    | @pattern10
    pattern10 ::= @pattern1 as @name
    | @pattern1 {* @pattern1 }
-   | @ @qualid {* @pattern1 }
+   | @ @global {* @pattern1 }
    pattern1 ::= @pattern0 % @scope_key
    | @pattern0 %_ @scope_key
    | @pattern0
-   pattern0 ::= @qualid
+   pattern0 ::= @global
    | %{%| {* @qualid := @pattern } %|%}
    | _
    | ( {+| @pattern } )

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -421,7 +421,7 @@ Creating Hints
 
    The `Hint` commands are:
 
-   .. cmd:: Hint Resolve {+ {| @qualid | @one_term } } {? @hint_info } {? : {+ @ident } }
+   .. cmd:: Hint Resolve {+ {| @global | @one_term } } {? @hint_info } {? : {+ @ident } }
             Hint Resolve {| -> | <- } {+ @qualid } {? @natural } {? : {+ @ident } }
       :name: Hint Resolve; _
 
@@ -470,7 +470,7 @@ Creating Hints
          The head symbol of the type of :n:`@qualid` is a bound variable
          such that this tactic cannot be associated with a constant.
 
-   .. cmd:: Hint Immediate {+ {| @qualid | @one_term } } {? : {+ @ident } }
+   .. cmd:: Hint Immediate {+ {| @global | @one_term } } {? : {+ @ident } }
 
       For each specified :n:`@qualid`, adds the tactic :tacn:`simple apply` :n:`@qualid;`
       :tacn:`solve` :n:`[` :tacn:`trivial` :n:`]` to the hint list

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -24,9 +24,9 @@ lglob: [
 ]
 
 hint: [
-| REPLACE "Resolve" "->" LIST1 global OPT natural
-| WITH "Resolve" [ "->" | "<-" ] LIST1 global OPT natural
-| DELETE "Resolve" "<-" LIST1 global OPT natural
+| REPLACE "Resolve" "->" LIST1 reference OPT natural
+| WITH "Resolve" [ "->" | "<-" ] LIST1 reference OPT natural
+| DELETE "Resolve" "<-" LIST1 reference OPT natural
 | REPLACE "Variables" "Transparent"
 | WITH [ "Constants" | "Projections" | "Variables" ] [ "Transparent" | "Opaque" ]
 | DELETE "Variables" "Opaque"
@@ -34,9 +34,9 @@ hint: [
 | DELETE "Constants" "Opaque"
 | DELETE "Projections" "Transparent"
 | DELETE "Projections" "Opaque"
-| REPLACE "Transparent" LIST1 global
-| WITH [ "Transparent" | "Opaque" ] LIST1 global
-| DELETE "Opaque" LIST1 global
+| REPLACE "Transparent" LIST1 reference
+| WITH [ "Transparent" | "Opaque" ] LIST1 reference
+| DELETE "Opaque" LIST1 reference
 
 | REPLACE "Extern" natural OPT Constr.constr_pattern "=>" generic_tactic
 | WITH "Extern" natural OPT constr_pattern "=>" generic_tactic
@@ -113,7 +113,6 @@ RENAME: [
   (* map missing names for rhs *)
 | Constr.constr term
 | Constr.term0 term0
-| Constr.global global
 | Constr.lconstr lconstr
 | Constr.cpattern cpattern
 | G_vernac.section_subset_expr section_var_expr
@@ -387,7 +386,7 @@ term1: [
 ]
 
 term0: [
-| DELETE reference univ_annot
+| DELETE global univ_annot
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO number_or_string NUMBER
@@ -700,9 +699,9 @@ strategy_flag: [
 ]
 
 filtered_import: [
-| REPLACE global "(" LIST1 one_import_filter_name SEP "," ")"
-| WITH global OPT [ "(" LIST1 one_import_filter_name SEP "," ")" ]
-| DELETE global
+| REPLACE reference "(" LIST1 one_import_filter_name SEP "," ")"
+| WITH reference OPT [ "(" LIST1 one_import_filter_name SEP "," ")" ]
+| DELETE reference
 ]
 
 is_module_expr: [
@@ -726,18 +725,18 @@ gallina_ext: [
    Note that smart_global is "qualid | by_notation" and that
    ident_decl is "ident OPT univ_decl"; move
  *)
-| REPLACE "Canonical" OPT "Structure" global OPT [ OPT univ_decl def_body ]
+| REPLACE "Canonical" OPT "Structure" reference OPT [ OPT univ_decl def_body ]
 | WITH "Canonical" OPT "Structure" ident_decl def_body
 | REPLACE "Canonical" OPT "Structure" by_notation
 | WITH "Canonical" OPT "Structure" smart_global
 
-| DELETE "Coercion" global ":" coercion_class ">->" coercion_class
+| DELETE "Coercion" reference ":" coercion_class ">->" coercion_class
 | REPLACE "Coercion" by_notation ":" coercion_class ">->" coercion_class
 | WITH "Coercion" smart_global OPT [ ":" coercion_class ">->" coercion_class ]
 
 (* semantically restricted per https://github.com/coq/coq/pull/12936#discussion_r492705820 *)
-(* global OPT univ_decl is just ident_decl, the first OPT is moved to the rule above *)
-| REPLACE "Coercion" global OPT [ OPT univ_decl def_body ]
+(* reference OPT univ_decl is just ident_decl, the first OPT is moved to the rule above *)
+| REPLACE "Coercion" reference OPT [ OPT univ_decl def_body ]
 | WITH "Coercion" ident_decl def_body
 
 | REPLACE "Include" "Type" module_type_inl LIST0 ext_module_type
@@ -754,10 +753,10 @@ gallina_ext: [
 | WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
 
 | DELETE "Require" export_token LIST1 filtered_import
-| REPLACE "From" global "Require" export_token LIST1 filtered_import
+| REPLACE "From" reference "Require" export_token LIST1 filtered_import
 | WITH OPT [ "From" dirpath ] "Require" export_token LIST1 filtered_import
 
-| REPLACE "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
+| REPLACE "From" reference "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 | WITH "From" dirpath "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 ]
 
@@ -1665,10 +1664,10 @@ locatable: [
 ]
 
 ne_in_or_out_modules: [
-| REPLACE "inside" LIST1 global
-| WITH [ "inside" | "in" | "outside" ] LIST1 global
-| DELETE "in" LIST1 global
-| DELETE "outside" LIST1 global
+| REPLACE "inside" LIST1 reference
+| WITH [ "inside" | "in" | "outside" ] LIST1 reference
+| DELETE "in" LIST1 reference
+| DELETE "outside" LIST1 reference
 ]
 
 search_queries: [
@@ -1917,9 +1916,9 @@ simple_tactic: [
 ]
 
 tacdef_body: [
-| REPLACE global LIST1 input_fun ltac_def_kind ltac_expr5
-| WITH global LIST0 input_fun ltac_def_kind ltac_expr5
-| DELETE global ltac_def_kind ltac_expr5
+| REPLACE reference LIST1 input_fun ltac_def_kind ltac_expr5
+| WITH reference LIST0 input_fun ltac_def_kind ltac_expr5
+| DELETE reference ltac_def_kind ltac_expr5
 ]
 
 tac2def_typ: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2277,7 +2277,6 @@ SPLICE: [
 | ne_string
 | lstring
 | fullyqualid
-| global
 | reference
 | bar_cbrace
 | lconstr

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -11,6 +11,7 @@ Prim.name: [
 
 global: [
 | Prim.reference
+| "libref" ":" "(" Prim.reference ")"
 ]
 
 constr_pattern: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -44,7 +44,7 @@ universe_increment: [
 ]
 
 universe_name: [
-| global
+| Prim.reference
 | "Set"
 | "Prop"
 ]
@@ -116,7 +116,7 @@ term1: [
 term0: [
 | atomic_constr
 | term_match
-| reference univ_annot
+| global univ_annot
 | NUMBER
 | string
 | "(" term200 ")"
@@ -142,7 +142,7 @@ fields_def: [
 ]
 
 field_def: [
-| global binders ":=" lconstr
+| reference binders ":=" lconstr
 ]
 
 binder_constr: [
@@ -194,7 +194,7 @@ univ_level_or_quality: [
 | "Prop"
 | "Type"
 | "_"
-| global
+| reference
 ]
 
 fix_decls: [
@@ -244,7 +244,7 @@ eqn: [
 ]
 
 record_pattern: [
-| global ":=" pattern200
+| reference ":=" pattern200
 ]
 
 record_patterns: [
@@ -273,7 +273,7 @@ pattern90: [
 pattern10: [
 | pattern1 "as" name
 | pattern1 LIST1 pattern1
-| "@" Prim.reference LIST0 pattern1
+| "@" global LIST0 pattern1
 | pattern1
 ]
 
@@ -284,7 +284,7 @@ pattern1: [
 ]
 
 pattern0: [
-| Prim.reference
+| global
 | "{|" record_patterns bar_cbrace
 | "_"
 | "(" pattern200 ")"
@@ -528,7 +528,7 @@ command: [
 | "Guarded"
 | "Validate" "Proof"
 | "Create" "HintDb" IDENT; [ "discriminated" | ]
-| "Remove" "Hints" LIST1 global opt_hintbases
+| "Remove" "Hints" LIST1 reference opt_hintbases
 | "Hint" hint opt_hintbases
 | "Comments" LIST0 comment
 | "Attributes" attribute_list
@@ -543,8 +543,8 @@ command: [
 | "Type" lconstr
 | "Print" printable
 | "Print" smart_global OPT univ_name_list
-| "Print" "Module" "Type" global
-| "Print" "Module" global
+| "Print" "Module" "Type" reference
+| "Print" "Module" reference
 | "Print" "Namespace" dirpath
 | "Inspect" natural
 | "Set" setting_name option_setting
@@ -583,30 +583,30 @@ command: [
 | "Preterm"
 | "Derive" open_binders "SuchThat" constr "As" identref      (* derive plugin *)
 | "Derive" open_binders "in" constr "as" identref      (* derive plugin *)
-| "Extraction" global      (* extraction plugin *)
-| "Recursive" "Extraction" LIST1 global      (* extraction plugin *)
-| "Extraction" string LIST1 global      (* extraction plugin *)
-| "Extraction" "TestCompile" LIST1 global      (* extraction plugin *)
-| "Separate" "Extraction" LIST1 global      (* extraction plugin *)
+| "Extraction" reference      (* extraction plugin *)
+| "Recursive" "Extraction" LIST1 reference      (* extraction plugin *)
+| "Extraction" string LIST1 reference      (* extraction plugin *)
+| "Extraction" "TestCompile" LIST1 reference      (* extraction plugin *)
+| "Separate" "Extraction" LIST1 reference      (* extraction plugin *)
 | "Extraction" "Library" identref      (* extraction plugin *)
 | "Recursive" "Extraction" "Library" identref      (* extraction plugin *)
 | "Extraction" "Language" language      (* extraction plugin *)
-| "Extraction" "Inline" LIST1 global      (* extraction plugin *)
-| "Extraction" "NoInline" LIST1 global      (* extraction plugin *)
+| "Extraction" "Inline" LIST1 reference      (* extraction plugin *)
+| "Extraction" "NoInline" LIST1 reference      (* extraction plugin *)
 | "Print" "Extraction" "Inline"      (* extraction plugin *)
 | "Reset" "Extraction" "Inline"      (* extraction plugin *)
-| "Extraction" "Implicit" global "[" LIST0 int_or_id "]"      (* extraction plugin *)
+| "Extraction" "Implicit" reference "[" LIST0 int_or_id "]"      (* extraction plugin *)
 | "Extraction" "Blacklist" LIST1 preident      (* extraction plugin *)
 | "Print" "Extraction" "Blacklist"      (* extraction plugin *)
 | "Reset" "Extraction" "Blacklist"      (* extraction plugin *)
-| "Extract" "Callback" OPT string global      (* extraction plugin *)
+| "Extract" "Callback" OPT string reference      (* extraction plugin *)
 | "Print" "Extraction" "Callback"      (* extraction plugin *)
 | "Reset" "Extraction" "Callback"      (* extraction plugin *)
 | "Print" "Extraction" "Foreign"      (* extraction plugin *)
-| "Extract" "Constant" global LIST0 string "=>" mlname      (* extraction plugin *)
-| "Extract" "Foreign" "Constant" global "=>" string      (* extraction plugin *)
-| "Extract" "Inlined" "Constant" global "=>" mlname      (* extraction plugin *)
-| "Extract" "Inductive" global "=>" mlname "[" LIST0 mlname "]" OPT string      (* extraction plugin *)
+| "Extract" "Constant" reference LIST0 string "=>" mlname      (* extraction plugin *)
+| "Extract" "Foreign" "Constant" reference "=>" string      (* extraction plugin *)
+| "Extract" "Inlined" "Constant" reference "=>" mlname      (* extraction plugin *)
+| "Extract" "Inductive" reference "=>" mlname "[" LIST0 mlname "]" OPT string      (* extraction plugin *)
 | "Show" "Extraction"      (* extraction plugin *)
 | "Set" "Firstorder" "Solver" generic_tactic
 | "Print" "Firstorder" "Solver"
@@ -711,8 +711,8 @@ reference_or_constr: [
 
 hint: [
 | "Resolve" LIST1 reference_or_constr hint_info
-| "Resolve" "->" LIST1 global OPT natural
-| "Resolve" "<-" LIST1 global OPT natural
+| "Resolve" "->" LIST1 reference OPT natural
+| "Resolve" "<-" LIST1 reference OPT natural
 | "Immediate" LIST1 reference_or_constr
 | "Variables" "Transparent"
 | "Variables" "Opaque"
@@ -720,11 +720,11 @@ hint: [
 | "Constants" "Opaque"
 | "Projections" "Transparent"
 | "Projections" "Opaque"
-| "Transparent" LIST1 global
-| "Opaque" LIST1 global
-| "Mode" global mode
-| "Unfold" LIST1 global
-| "Constructors" LIST1 global
+| "Transparent" LIST1 reference
+| "Opaque" LIST1 reference
+| "Mode" reference mode
+| "Unfold" LIST1 reference
+| "Constructors" LIST1 reference
 | "Extern" natural OPT Constr.constr_pattern "=>" generic_tactic
 ]
 
@@ -889,9 +889,9 @@ gallina: [
 | "Scheme" "Equality" "for" smart_global
 | "Scheme" "Boolean" "Equality" "for" smart_global
 | "Combined" "Scheme" identref "from" LIST1 identref SEP ","
-| "Register" global "as" qualid
-| "Register" "Scheme" global "as" qualid "for" global
-| "Register" "Inline" global
+| "Register" reference "as" qualid
+| "Register" "Scheme" reference "as" qualid "for" reference
+| "Register" "Inline" reference
 | "Primitive" ident_decl OPT [ ":" lconstr ] ":=" register_token
 | "Universe" LIST1 identref
 | "Universes" LIST1 identref
@@ -1139,9 +1139,9 @@ gallina_ext: [
 | "Section" identref
 | "End" identref
 | "Collection" identref ":=" section_subset_expr
-| "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
+| "From" reference "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 | "Require" export_token LIST1 filtered_import
-| "From" global "Require" export_token LIST1 filtered_import
+| "From" reference "Require" export_token LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ext_module_type
@@ -1149,17 +1149,17 @@ gallina_ext: [
 | "Transparent" OPT "!" LIST1 smart_global
 | "Opaque" OPT "!" LIST1 smart_global
 | "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]
-| "Canonical" OPT "Structure" global OPT [ OPT univ_decl def_body ]
+| "Canonical" OPT "Structure" reference OPT [ OPT univ_decl def_body ]
 | "Canonical" OPT "Structure" by_notation
-| "Coercion" global OPT [ OPT univ_decl def_body ]
+| "Coercion" reference OPT [ OPT univ_decl def_body ]
 | "Identity" "Coercion" identref ":" coercion_class ">->" coercion_class
-| "Coercion" global ":" coercion_class ">->" coercion_class
+| "Coercion" reference ":" coercion_class ">->" coercion_class
 | "Coercion" by_notation ":" coercion_class ">->" coercion_class
 | "Context" LIST1 binder
 | "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
-| "Existing" "Instance" global hint_info
-| "Existing" "Instances" LIST1 global OPT [ "|" natural ]
-| "Existing" "Class" global
+| "Existing" "Instance" reference hint_info
+| "Existing" "Instances" LIST1 reference OPT [ "|" natural ]
+| "Existing" "Class" reference
 | "Arguments" smart_global LIST0 arg_specs OPT [ "," LIST1 [ LIST0 implicits_alt ] SEP "," ] OPT [ ":" LIST1 args_modifier SEP "," ]
 | "Implicit" "Type" reserv_list
 | "Implicit" "Types" reserv_list
@@ -1173,12 +1173,12 @@ import_categories: [
 ]
 
 filtered_import: [
-| global
-| global "(" LIST1 one_import_filter_name SEP "," ")"
+| reference
+| reference "(" LIST1 one_import_filter_name SEP "," ")"
 ]
 
 one_import_filter_name: [
-| global OPT [ "(" ".." ")" ]
+| reference OPT [ "(" ".." ")" ]
 ]
 
 export_token: [
@@ -1388,7 +1388,7 @@ query_command: [
 printable: [
 | "Term" smart_global OPT univ_name_list
 | "All"
-| "Section" global
+| "Section" reference
 | "Grammar" LIST0 IDENT
 | "Custom" "Grammar" IDENT
 | "Keywords"
@@ -1447,8 +1447,8 @@ locatable: [
 | smart_global
 | "Term" smart_global
 | "File" ne_string
-| "Library" global
-| "Module" global
+| "Library" reference
+| "Module" reference
 ]
 
 option_setting: [
@@ -1458,7 +1458,7 @@ option_setting: [
 ]
 
 table_value: [
-| global
+| reference
 | STRING
 ]
 
@@ -1467,9 +1467,9 @@ setting_name: [
 ]
 
 ne_in_or_out_modules: [
-| "inside" LIST1 global
-| "in" LIST1 global
-| "outside" LIST1 global
+| "inside" LIST1 reference
+| "in" LIST1 reference
+| "outside" LIST1 reference
 ]
 
 in_or_out_modules: [
@@ -1561,7 +1561,7 @@ enable_enable_disable: [
 
 enable_notation_rule: [
 | ne_string
-| global LIST0 ident
+| reference LIST0 ident
 |
 ]
 
@@ -2102,7 +2102,7 @@ hints_path: [
 | "emp"
 | "eps"
 | hints_path "|" hints_path
-| LIST1 global
+| LIST1 reference
 | "_"
 | hints_path hints_path
 ]
@@ -2295,8 +2295,8 @@ ltac_def_kind: [
 ]
 
 tacdef_body: [
-| Constr.global LIST1 input_fun ltac_def_kind ltac_expr5
-| Constr.global ltac_def_kind ltac_expr5
+| Prim.reference LIST1 input_fun ltac_def_kind ltac_expr5
+| Prim.reference ltac_def_kind ltac_expr5
 ]
 
 tactic: [
@@ -2612,12 +2612,12 @@ ring_mod: [
 | "abstract"      (* ring plugin *)
 | "morphism" constr      (* ring plugin *)
 | "constants" "[" tactic "]"      (* ring plugin *)
-| "closed" "[" LIST1 global "]"      (* ring plugin *)
+| "closed" "[" LIST1 reference "]"      (* ring plugin *)
 | "preprocess" "[" tactic "]"      (* ring plugin *)
 | "postprocess" "[" tactic "]"      (* ring plugin *)
 | "setoid" constr constr      (* ring plugin *)
 | "sign" constr      (* ring plugin *)
-| "power" constr "[" LIST1 global "]"      (* ring plugin *)
+| "power" constr "[" LIST1 reference "]"      (* ring plugin *)
 | "power_tac" constr "[" tactic "]"      (* ring plugin *)
 | "div" constr      (* ring plugin *)
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -46,8 +46,13 @@ term0: [
 | "(" term ")"
 ]
 
+global: [
+| qualid
+| "libref" ":" "(" qualid ")"
+]
+
 qualid_annotated: [
-| qualid OPT univ_annot
+| global OPT univ_annot
 ]
 
 term_ltac: [
@@ -55,8 +60,8 @@ term_ltac: [
 ]
 
 term_projection: [
-| term0 ".(" qualid OPT univ_annot LIST0 arg ")"
-| term0 ".(" "@" qualid OPT univ_annot LIST0 ( term1 ) ")"
+| term0 ".(" global OPT univ_annot LIST0 arg ")"
+| term0 ".(" "@" global OPT univ_annot LIST0 ( term1 ) ")"
 ]
 
 term_scope: [
@@ -443,7 +448,7 @@ pattern: [
 pattern10: [
 | pattern1 "as" name
 | pattern1 LIST0 pattern1
-| "@" qualid LIST0 pattern1
+| "@" global LIST0 pattern1
 ]
 
 pattern1: [
@@ -453,7 +458,7 @@ pattern1: [
 ]
 
 pattern0: [
-| qualid
+| global
 | "{|" LIST0 ( qualid ":=" pattern ) "|}"
 | "_"
 | "(" LIST1 pattern SEP "|" ")"
@@ -996,9 +1001,9 @@ command: [
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
 | "Ltac2" "Check" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Globalize" ltac2_expr      (* ltac2 plugin *)
-| "Hint" "Resolve" LIST1 [ qualid | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
+| "Hint" "Resolve" LIST1 [ global | one_term ] OPT hint_info OPT ( ":" LIST1 ident )
 | "Hint" "Resolve" [ "->" | "<-" ] LIST1 qualid OPT natural OPT ( ":" LIST1 ident )
-| "Hint" "Immediate" LIST1 [ qualid | one_term ] OPT ( ":" LIST1 ident )
+| "Hint" "Immediate" LIST1 [ global | one_term ] OPT ( ":" LIST1 ident )
 | "Hint" [ "Constants" | "Projections" | "Variables" ] [ "Transparent" | "Opaque" ] OPT ( ":" LIST1 ident )
 | "Hint" [ "Transparent" | "Opaque" ] LIST1 qualid OPT ( ":" LIST1 ident )
 | "Hint" "Mode" qualid LIST1 [ "+" | "!" | "-" ] OPT ( ":" LIST1 ident )

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -352,7 +352,7 @@ let pattern_of_string ?env s =
 
 let dirpath_of_string_list s =
   let path = String.concat "." s in
-  let qid = Procq.parse_string Procq.Constr.global path in
+  let qid = Procq.parse_string Procq.Prim.reference path in
   let id =
     try Nametab.full_name_module qid
     with Not_found ->

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -11,6 +11,10 @@
 open Names
 open Libnames
 
+type reference_expr_kind = CQualidRef | CLibRef
+
+type reference_expr = reference_expr_kind * qualid
+
 (** {6 Concrete syntax for terms } *)
 
 (** Universes *)
@@ -112,10 +116,10 @@ type prim_token =
 (** [constr_expr] is the abstract syntax tree produced by the parser *)
 type cases_pattern_expr_r =
   | CPatAlias of cases_pattern_expr * lname
-  | CPatCstr  of qualid
+  | CPatCstr  of reference_expr
     * cases_pattern_expr list option * cases_pattern_expr list
   (** [CPatCstr (_, c, Some l1, l2)] represents [(@ c l1) l2] *)
-  | CPatAtom of qualid option
+  | CPatAtom of reference_expr option
   | CPatOr   of cases_pattern_expr list
   | CPatNotation of notation_with_optional_scope option * notation * cases_pattern_notation_substitution
     * cases_pattern_expr list (** CPatNotation (_, n, l1 ,l2) represents
@@ -135,15 +139,15 @@ and cases_pattern_notation_substitution =
     kinded_cases_pattern_expr list (* for cases_pattern subterms parsed as binders *)
 
 and constr_expr_r =
-  | CRef     of qualid * instance_expr option
+  | CRef     of reference_expr * instance_expr option
   | CFix     of lident * fix_expr list
   | CCoFix   of lident * cofix_expr list
   | CProdN   of local_binder_expr list * constr_expr
   | CLambdaN of local_binder_expr list * constr_expr
   | CLetIn   of lname * constr_expr * constr_expr option * constr_expr
-  | CAppExpl of (qualid * instance_expr option) * constr_expr list
+  | CAppExpl of (reference_expr * instance_expr option) * constr_expr list
   | CApp     of constr_expr * (constr_expr * explicitation CAst.t option) list
-  | CProj    of explicit_flag * (qualid * instance_expr option)
+  | CProj    of explicit_flag * (reference_expr * instance_expr option)
               * (constr_expr * explicitation CAst.t option) list * constr_expr
   | CRecord  of (qualid * constr_expr) list
 

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -12,6 +12,19 @@ open Names
 open Libnames
 open Constrexpr
 
+val reference_expr_kind_eq : reference_expr_kind -> reference_expr_kind -> bool
+val reference_expr_eq : reference_expr -> reference_expr -> bool
+
+val ref_expr_of_ident : ?loc:Loc.t -> Id.t -> reference_expr
+
+val ref_expr_is_ident : reference_expr -> bool
+(** Is a CQualidRef of an ident *)
+
+val ref_expr_basename : reference_expr -> Id.t
+(** Assertion failure unless it's a CQualidRef (basename of CLibRef is nonsense) *)
+
+val pr_ref_expr : reference_expr -> Pp.t
+
 (** Constrexpr_ops: utilities on [constr_expr] *)
 
 val expr_Type_sort : sort_expr

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -158,6 +158,7 @@ val intern_name_alias :
 
 (** Expands abbreviations; raise an error if not existing *)
 val interp_reference : ltac_sign -> qualid -> glob_constr
+val interp_reference_expr : ltac_sign -> reference_expr -> glob_constr
 
 (** Interpret binders *)
 

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -20,6 +20,7 @@ open Libnames
 open Globnames
 open Abbreviation
 open Notation_term
+open Constrexpr
 
 let global_of_extended_global_head = function
   | TrueGlobal ref -> ref
@@ -89,6 +90,10 @@ let global_with_alias ?head qid =
   with Not_found as exn ->
     let _, info = Exninfo.capture exn in
     Nametab.error_global_not_found ~info qid
+
+let ref_expr_with_alias ?head = function
+  | CQualidRef, qid -> global_with_alias ?head qid
+  | CLibRef, qid -> Rocqlib.lib_ref_qualid qid
 
 let smart_global ?(head = false) = let open Constrexpr in CAst.with_loc_val (fun ?loc -> function
   | AN r ->

--- a/interp/smartlocate.mli
+++ b/interp/smartlocate.mli
@@ -11,6 +11,7 @@
 open Names
 open Libnames
 open Globnames
+open Constrexpr
 
 (** [locate_global_with_alias] locates global reference possibly following
    a notation if this notation has a role of aliasing; raise [Not_found]
@@ -28,6 +29,8 @@ val global_of_extended_global : extended_global_reference -> GlobRef.t option
     or a [UserError] if bound to a syntactic def that does not denote
     a reference. *)
 val global_with_alias : ?head:bool -> qualid -> GlobRef.t
+
+val ref_expr_with_alias : ?head:bool -> reference_expr -> GlobRef.t
 
 (** The same for constants *)
 val global_constant_with_alias : qualid -> Constant.t

--- a/library/rocqlib.ml
+++ b/library/rocqlib.ml
@@ -43,11 +43,15 @@ let () = CErrors.register_handler (function
     | NotFoundRef s -> Some Pp.(str "not found in table: " ++ str s)
     | _ -> None)
 
-let lib_ref s =
+let lib_ref ?loc s =
   try CString.Map.find s !table
-  with Not_found -> raise (NotFoundRef s)
+  with Not_found -> Loc.raise ?loc (NotFoundRef s)
+
+let lib_ref_qualid qid = lib_ref ?loc:qid.CAst.loc (Libnames.string_of_qualid qid)
 
 let lib_ref_opt s = CString.Map.find_opt s !table
+
+let lib_ref_opt_qualid qid = lib_ref_opt (Libnames.string_of_qualid qid)
 
 let add_ref s c =
   table := CString.Map.add s c !table

--- a/library/rocqlib.mli
+++ b/library/rocqlib.mli
@@ -35,10 +35,14 @@ exception NotFoundRef of string
 
 (** Retrieves the reference bound to the given name (by a previous call to {!register_ref}).
     Raises [NotFoundRef] if no reference is bound to this name. *)
-val lib_ref : string -> GlobRef.t
+val lib_ref : ?loc:Loc.t -> string -> GlobRef.t
+
+val lib_ref_qualid : Libnames.qualid -> GlobRef.t
 
 (** As [lib_ref] but returns [None] instead of raising. *)
 val lib_ref_opt : string -> GlobRef.t option
+
+val lib_ref_opt_qualid : Libnames.qualid -> GlobRef.t option
 
 (** Checks whether a name refers to a registered constant.
     For any name [n], if [has_ref n] returns [true], [lib_ref n] will succeed. *)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -36,7 +36,7 @@ let binders_of_names l =
 
 let pat_of_name CAst.{loc;v} = match v with
 | Anonymous -> CAst.make ?loc @@ CPatAtom None
-| Name id -> CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident id))
+| Name id -> CAst.make ?loc @@ CPatAtom (Some (CQualidRef,qualid_of_ident id))
 
 (* Hack to parse "(x:=t)" as an explicit argument without conflicts with the *)
 (* admissible notation "(x t)" *)
@@ -107,7 +107,7 @@ let force_quality ?loc = function
 
 (* XXX use registered ref? but currently constrexpr doesn't have a node for registered refs
    and we can't do [Rocqlib.lib_ref] at parsing time, it's only available in the interp phase. *)
-let sigref loc = Libnames.qualid_of_string ~loc "Corelib.Init.Specif.sig"
+let sigref loc = CQualidRef, Libnames.qualid_of_string ~loc "Corelib.Init.Specif.sig"
 
 }
 
@@ -125,7 +125,7 @@ GRAMMAR EXTEND Gram
     [ [ "_" -> { CAst.make ~loc Anonymous } ] ]
   ;
   global:
-    [ [ r = Prim.reference -> { r } ] ]
+    [ [ r = Prim.reference -> { CQualidRef, r } ] ]
   ;
   constr_pattern:
     [ [ c = constr -> { c } ] ]
@@ -154,7 +154,7 @@ GRAMMAR EXTEND Gram
       | -> { 0 } ] ]
   ;
   universe_name:
-    [ [ id = global -> { CType id }
+    [ [ id = Prim.reference -> { CType id }
       | "Set"  -> { CSet }
       | "Prop" -> { CProp } ] ]
   ;
@@ -191,12 +191,12 @@ GRAMMAR EXTEND Gram
       | "@"; f = global; i = univ_annot; args = LIST0 NEXT -> { CAst.make ~loc @@ CAppExpl((f,i),args) }
       | "@"; lid = pattern_ident; args = LIST1 identref ->
         { let { CAst.loc = locid; v = id } = lid in
-          let args = List.map (fun x -> CAst.make @@ CRef (qualid_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
+          let args = List.map (fun x -> CAst.make @@ CRef (ref_expr_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
           CAst.make ~loc @@ CApp(CAst.make ?loc:locid @@ CPatVar id,args) }
       | c = binder_constr -> { c } ]
     | "9"
       [ ".."; c = term LEVEL "0"; ".." ->
-        { CAst.make ~loc @@ CAppExpl ((qualid_of_ident ~loc ldots_var, None),[c]) } ]
+        { CAst.make ~loc @@ CAppExpl ((ref_expr_of_ident ~loc ldots_var, None),[c]) } ]
     | "8" [ ]
     | "1" LEFTA
       [ c = term; ".("; f = global; i = univ_annot; args = LIST0 arg; ")" ->
@@ -211,7 +211,7 @@ GRAMMAR EXTEND Gram
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }
-      | id = reference; i = univ_annot ->
+      | id = global; i = univ_annot ->
         { CAst.make ~loc @@ CRef (id, i) }
       | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
@@ -245,7 +245,7 @@ GRAMMAR EXTEND Gram
       | -> { [] } ] ]
   ;
   field_def:
-    [ [ id = global; bl = binders; ":="; c = lconstr ->
+    [ [ id = reference; bl = binders; ":="; c = lconstr ->
         { (id, mkLambdaCN ~loc bl c) } ] ]
   ;
   binder_constr:
@@ -328,7 +328,7 @@ GRAMMAR EXTEND Gram
       | "Prop" -> { Prop }
       | "Type" -> { Type }
       | "_" -> { Anon loc }
-      | id = global -> { Global id } ] ]
+      | id = reference -> { Global id } ] ]
   ;
   fix_decls:
     [ [ dcl = fix_decl -> { let (id,_,_,_,_,_) = dcl.CAst.v in (id,[dcl.CAst.v]) }
@@ -381,7 +381,7 @@ GRAMMAR EXTEND Gram
         "=>"; rhs = lconstr -> { (CAst.make ~loc (pll,rhs)) } ] ]
   ;
   record_pattern:
-    [ [ id = global; ":="; pat = pattern LEVEL "200" -> { (id, pat) } ] ]
+    [ [ id = reference; ":="; pat = pattern LEVEL "200" -> { (id, pat) } ] ]
   ;
   record_patterns:
     [ [ p = record_pattern; ";"; ps = record_patterns -> { p :: ps }
@@ -399,7 +399,7 @@ GRAMMAR EXTEND Gram
       [ p = pattern; "as"; na = name ->
         { CAst.make ~loc @@ CPatAlias (p, na) }
       | p = pattern; lp = LIST1 NEXT -> { mkAppPattern ~loc p lp }
-      | "@"; r = Prim.reference; lp = LIST0 NEXT ->
+      | "@"; r = global; lp = LIST0 NEXT ->
         { CAst.make ~loc @@ CPatCstr (r, Some lp, []) } ]
     | "1" LEFTA
       [ c = pattern; "%"; key = IDENT ->
@@ -407,7 +407,7 @@ GRAMMAR EXTEND Gram
       | c = pattern; "%_"; key = IDENT ->
         { CAst.make ~loc @@ CPatDelimiters (DelimOnlyTmpScope,key,c) } ]
     | "0"
-      [ r = Prim.reference                -> { CAst.make ~loc @@ CPatAtom (Some r) }
+      [ r = global -> { CAst.make ~loc @@ CPatAtom (Some r) }
       | "{|"; pat = record_patterns; bar_cbrace -> { CAst.make ~loc @@ CPatRecord pat }
       | "_" -> { CAst.make ~loc @@ CPatAtom None }
       | "("; p = pattern LEVEL "200"; ")" ->

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -125,7 +125,9 @@ GRAMMAR EXTEND Gram
     [ [ "_" -> { CAst.make ~loc Anonymous } ] ]
   ;
   global:
-    [ [ r = Prim.reference -> { CQualidRef, r } ] ]
+    [ [ r = Prim.reference -> { CQualidRef, r }
+      | IDENT "libref"; ":"; "("; r = Prim.reference; ")" -> { CLibRef, r }
+      ] ]
   ;
   constr_pattern:
     [ [ c = constr -> { c } ] ]

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -11,7 +11,6 @@
 open Names
 open Genarg
 open Constrexpr
-open Libnames
 
 (** The parser of Rocq *)
 
@@ -182,7 +181,7 @@ module Constr :
     val binder_constr : constr_expr Entry.t
     val term : constr_expr Entry.t
     val ident : Id.t Entry.t
-    val global : qualid Entry.t
+    val global : reference_expr Entry.t
     val universe_name : sort_name_expr Entry.t
     val sort : sort_expr Entry.t
     val sort_quality_or_set : UnivGen.QualityOrSet.t Entry.t

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -72,21 +72,21 @@ END
 
 VERNAC COMMAND EXTEND Extraction CLASSIFIED AS QUERY STATE opaque_access
 (* Extraction in the Rocq toplevel *)
-| [ "Extraction" global(x) ] -> { simple_extraction x }
-| [ "Recursive" "Extraction" ne_global_list(l) ] -> { full_extraction None l }
+| [ "Extraction" reference(x) ] -> { simple_extraction x }
+| [ "Recursive" "Extraction" ne_reference_list(l) ] -> { full_extraction None l }
 
 (* Monolithic extraction to a file *)
-| [ "Extraction" string(f) ne_global_list(l) ]
+| [ "Extraction" string(f) ne_reference_list(l) ]
   -> { full_extraction (Some f) l }
 
 (* Extraction to a temporary file and OCaml compilation *)
-| [ "Extraction" "TestCompile" ne_global_list(l) ]
+| [ "Extraction" "TestCompile" ne_reference_list(l) ]
   -> { extract_and_compile l }
 END
 
 VERNAC COMMAND EXTEND SeparateExtraction CLASSIFIED AS QUERY STATE opaque_access
 (* Same, with content split in several files *)
-| [ "Separate" "Extraction" ne_global_list(l) ]
+| [ "Separate" "Extraction" ne_reference_list(l) ]
   -> { separate_extraction l }
 END
 
@@ -109,12 +109,12 @@ END
 
 VERNAC COMMAND EXTEND ExtractionInline CLASSIFIED AS SIDEFF
 (* Custom inlining directives *)
-| [ "Extraction" "Inline" ne_global_list(l) ]
+| [ "Extraction" "Inline" ne_reference_list(l) ]
   -> { extraction_inline true l }
 END
 
 VERNAC COMMAND EXTEND ExtractionNoInline CLASSIFIED AS SIDEFF
-| [ "Extraction" "NoInline" ne_global_list(l) ]
+| [ "Extraction" "NoInline" ne_reference_list(l) ]
   -> { extraction_inline false l }
 END
 
@@ -130,7 +130,7 @@ END
 
 VERNAC COMMAND EXTEND ExtractionImplicit CLASSIFIED AS SIDEFF
 (* Custom implicit arguments of some csts/inds/constructors *)
-| [ "Extraction" "Implicit" global(r) "[" int_or_id_list(l) "]" ]
+| [ "Extraction" "Implicit" reference(r) "[" int_or_id_list(l) "]" ]
   -> { extraction_implicit r l }
 END
 
@@ -154,7 +154,7 @@ END
 
 (* Defining a Rocq object as ML callback for FFI call target from C *)
 VERNAC COMMAND EXTEND ExtractionCallback CLASSIFIED AS SIDEFF
-| [ "Extract" "Callback" string_opt(o) global(x) ]
+| [ "Extract" "Callback" string_opt(o) reference(x) ]
   -> { extract_callback o x }
 END
 
@@ -183,23 +183,23 @@ END
 
 (* Overriding of a Rocq object by an ML one *)
 VERNAC COMMAND EXTEND ExtractionConstant CLASSIFIED AS SIDEFF
-| [ "Extract" "Constant" global(x) string_list(idl) "=>" mlname(y) ]
+| [ "Extract" "Constant" reference(x) string_list(idl) "=>" mlname(y) ]
   -> { extract_constant_inline false x idl y }
 END
 
 (* Overriding of a Rocq object by an ML one that will be a FFI call to C *)
 VERNAC COMMAND EXTEND ExtractionForeignConstant CLASSIFIED AS SIDEFF
-| [ "Extract" "Foreign" "Constant" global(x) "=>" string(y) ]
+| [ "Extract" "Foreign" "Constant" reference(x) "=>" string(y) ]
   -> { extract_constant_foreign x y }
 END
 
 VERNAC COMMAND EXTEND ExtractionInlinedConstant CLASSIFIED AS SIDEFF
-| [ "Extract" "Inlined" "Constant" global(x) "=>" mlname(y) ]
+| [ "Extract" "Inlined" "Constant" reference(x) "=>" mlname(y) ]
   -> { extract_constant_inline true x [] y }
 END
 
 VERNAC COMMAND EXTEND ExtractionInductive CLASSIFIED AS SIDEFF
-| [ "Extract" "Inductive" global(x) "=>"
+| [ "Extract" "Inductive" reference(x) "=>"
     mlname(id) "[" mlname_list(idl) "]" string_opt(o) ]
   -> { extract_inductive x id idl o }
 END

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1639,7 +1639,7 @@ let register_wf interactive_proof ?(is_mes = false) fname rec_impls wf_rel_expr
     let f_app_args =
       CAst.make
       @@ Constrexpr.CAppExpl
-           ( (Libnames.qualid_of_ident fname, None)
+           ( (Constrexpr_ops.ref_expr_of_ident fname, None)
            , List.map
                (function
                  | {CAst.v = Anonymous} -> assert false
@@ -1918,11 +1918,11 @@ let rec chop_n_arrow n t =
     | _ -> CErrors.anomaly (Pp.str "Not enough products.")
 
 let rec add_args id new_args =
-  let open Libnames in
   let open Constrexpr in
+  let open Constrexpr_ops in
   CAst.map (function
     | CRef (qid, _) as b ->
-      if qualid_is_ident qid && Id.equal (qualid_basename qid) id then
+      if ref_expr_is_ident qid && Id.equal (ref_expr_basename qid) id then
         CAppExpl ((qid, None), new_args)
       else b
     | CFix _ | CCoFix _ -> CErrors.anomaly ~label:"add_args " (Pp.str "todo.")
@@ -1963,7 +1963,7 @@ let rec add_args id new_args =
         , Option.map (add_args id new_args) t
         , add_args id new_args b2 )
     | CAppExpl ((qid, us), exprl) ->
-      if qualid_is_ident qid && Id.equal (qualid_basename qid) id then
+      if ref_expr_is_ident qid && Id.equal (ref_expr_basename qid) id then
         CAppExpl
           ((qid, us), new_args @ List.map (add_args id new_args) exprl)
       else CAppExpl ((qid, us), List.map (add_args id new_args) exprl)
@@ -2075,7 +2075,7 @@ let make_graph (f_ref : GlobRef.t) =
                            (fun {CAst.loc; v = n} ->
                              CAst.make ?loc
                              @@ CRef
-                                  ( Libnames.qualid_of_ident ?loc
+                                  ( Constrexpr_ops.ref_expr_of_ident ?loc
                                     @@ Nameops.Name.get_id n
                                   , None ))
                            nal

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -59,11 +59,11 @@ end
 
 (* By default the strategy for "rewrite_db" is top-down *)
 
-let mkappc s l = CAst.make @@ CAppExpl ((qualid_of_ident (Id.of_string s),None),l)
+let mkappc s l = CAst.make @@ CAppExpl ((Constrexpr_ops.ref_expr_of_ident (Id.of_string s),None),l)
 
 let declare_an_instance {CAst.v=n; loc} s args =
   (((CAst.make ?loc @@ Name n),None),
-   CAst.make @@ CAppExpl ((qualid_of_string s,None), args))
+   CAst.make @@ CAppExpl (((CQualidRef,qualid_of_string s),None), args))
 
 let declare_instance a aeq n s = declare_an_instance n s [a;aeq]
 
@@ -236,7 +236,7 @@ let add_morphism atts ~tactic binders m s n =
   let instance_name = (CAst.make ?loc:instance_id.loc @@ Name instance_id.v),None in
   let instance_t =
     CAst.make @@ CAppExpl
-      ((Libnames.qualid_of_string "Corelib.Classes.Morphisms.Proper",None),
+      (((CQualidRef,Libnames.qualid_of_string "Corelib.Classes.Morphisms.Proper"),None),
        [cHole; s; m])
   in
   let _id, lemma = Classes.new_instance_interactive

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -13,7 +13,6 @@
 open Pp
 open Stdarg
 open Procq.Prim
-open Procq.Constr
 open Pltac
 open Hints
 
@@ -173,7 +172,7 @@ PRINTED BY { pr_pre_hints_path }
 | [ "emp" ] -> { Hints.PathEmpty }
 | [ "eps" ] -> { Hints.PathEpsilon }
 | [ hints_path(p) "|" hints_path(q) ] -> { Hints.PathOr (p, q) }
-| [ ne_global_list(g) ] -> { Hints.PathAtom (Hints.PathHints g) }
+| [ ne_reference_list(g) ] -> { Hints.PathAtom (Hints.PathHints g) }
 | [ "_" ] -> { Hints.PathAtom Hints.PathAny }
 | [ hints_path(p) hints_path(q) ] -> { Hints.PathSeq (p, q) }
 END

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -167,7 +167,7 @@ GRAMMAR EXTEND Gram
   (* Tactic arguments to the right of an application *)
   tactic_arg:
     [ [ a = tactic_value -> { a }
-      | c = Constr.constr -> { (match c with { CAst.v = CRef (r,None) } -> Reference r | c -> ConstrMayEval (ConstrTerm c)) }
+      | c = Constr.constr -> { (match c with { CAst.v = CRef ((CQualidRef,r),None) } -> Reference r | c -> ConstrMayEval (ConstrTerm c)) }
       (* Unambiguous entries: tolerated w/o "ltac:" modifier *)
       | "()" -> { TacGeneric (None, genarg_of_unit ()) } ] ]
   ;
@@ -266,13 +266,13 @@ GRAMMAR EXTEND Gram
 
   (* Definitions for tactics *)
   tacdef_body:
-    [ [ name = Constr.global; it=LIST1 input_fun;
+    [ [ name = Prim.reference; it=LIST1 input_fun;
         redef = ltac_def_kind; body = ltac_expr ->
         { if redef then Tacexpr.TacticRedefinition (name, CAst.make ~loc (TacFun (it, body)))
           else
             let id = reference_to_id name in
             Tacexpr.TacticDefinition (id, CAst.make ~loc (TacFun (it, body))) }
-      | name = Constr.global; redef = ltac_def_kind;
+      | name = Prim.reference; redef = ltac_def_kind;
         body = ltac_expr ->
         { if redef then Tacexpr.TacticRedefinition (name, body)
           else

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -20,7 +20,6 @@ open Namegen
 open Tacexpr
 open Genredexpr
 open Constrexpr
-open Libnames
 open Tok
 open Tactypes
 open Tactics
@@ -147,7 +146,7 @@ let mkTacCase with_evar = function
   (* Reinterpret ident as notations for variables in the context *)
   (* because we don't know if they are quantified or not *)
   | [(clear,ElimOnIdent id),(None,None),None],None ->
-      TacCase (with_evar,(clear,(CAst.make @@ CRef (qualid_of_ident ?loc:id.CAst.loc id.CAst.v,None),NoBindings)))
+      TacCase (with_evar,(clear,(CAst.make @@ CRef (Constrexpr_ops.ref_expr_of_ident ?loc:id.CAst.loc id.CAst.v,None),NoBindings)))
   | ic ->
       if List.exists (function ((_, ElimOnAnonHyp _),_,_) -> true | _ -> false) (fst ic)
       then

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1006,7 +1006,9 @@ let interp_destruction_arg ist gl arg =
         if Tactics.is_quantified_hypothesis id gl then
           keep,ElimOnIdent (CAst.make ?loc id)
         else
-          let c = (DAst.make ?loc @@ GVar id,Some (CAst.make @@ CRef (qualid_of_ident ?loc id,None))) in
+          let c = (DAst.make ?loc @@ GVar id,
+                   Some (CAst.make @@ CRef (Constrexpr_ops.ref_expr_of_ident ?loc id,None)))
+          in
           let f env sigma =
             let (sigma,c) = interp_open_constr ist env sigma c in
             (sigma, (c,NoBindings))

--- a/plugins/ring/g_ring.mlg
+++ b/plugins/ring/g_ring.mlg
@@ -18,6 +18,7 @@ open Ring
 open Stdarg
 open Tacarg
 open Procq.Constr
+open Procq.Prim
 open Pltac
 
 }
@@ -58,12 +59,12 @@ VERNAC ARGUMENT EXTEND ring_mod
   | [ "abstract" ] -> { Ring_kind Abstract }
   | [ "morphism" constr(morph) ] -> { Ring_kind(Morphism morph) }
   | [ "constants" "[" tactic(cst_tac) "]" ] -> { Const_tac(CstTac cst_tac) }
-  | [ "closed" "[" ne_global_list(l) "]" ] -> { Const_tac(Closed l) }
+  | [ "closed" "[" ne_reference_list(l) "]" ] -> { Const_tac(Closed l) }
   | [ "preprocess" "[" tactic(pre) "]" ] -> { Pre_tac pre }
   | [ "postprocess" "[" tactic(post) "]" ] -> { Post_tac post }
   | [ "setoid" constr(sth) constr(ext) ] -> { Setoid(sth,ext) }
   | [ "sign" constr(sign_spec) ] -> { Sign_spec sign_spec }
-  | [ "power" constr(pow_spec) "[" ne_global_list(l) "]" ] ->
+  | [ "power" constr(pow_spec) "[" ne_reference_list(l) "]" ] ->
            { Pow_spec (Closed l, pow_spec) }
   | [ "power_tac" constr(pow_spec) "[" tactic(cst_tac) "]" ] ->
            { Pow_spec (CstTac cst_tac, pow_spec) }

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -21,7 +21,6 @@ open Locusops
 
 open Ltac_plugin
 open Proofview.Notations
-open Libnames
 open Ssrmatching_plugin
 open Ssrmatching
 open Ssrast
@@ -714,7 +713,7 @@ open Util
 (** Constructors for constr_expr *)
 let mkCProp loc = CAst.make ?loc @@ CSort Constrexpr_ops.expr_Prop_sort
 let mkCType loc = CAst.make ?loc @@ CSort Constrexpr_ops.expr_Type_sort
-let mkCVar ?loc id = CAst.make ?loc @@ CRef (qualid_of_ident ?loc id, None)
+let mkCVar ?loc id = CAst.make ?loc @@ CRef (Constrexpr_ops.ref_expr_of_ident ?loc id, None)
 let rec mkCHoles ?loc n =
   if n <= 0 then [] else (CAst.make ?loc @@ CHole (None)) :: mkCHoles ?loc (n - 1)
 let mkCHole loc = CAst.make ?loc @@ CHole (None)

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -19,7 +19,6 @@ open Procq
 open Ltac_plugin
 open Stdarg
 open Tacarg
-open Libnames
 open Util
 open Locus
 open Tacexpr
@@ -1328,8 +1327,8 @@ END
 {
 
 let bvar_lname = let open CAst in function
-  | { v = CRef (qid, _) } when qualid_is_ident qid ->
-    CAst.make ?loc:qid.CAst.loc @@ Name (qualid_basename qid)
+  | { v = CRef (qid, _) } when ref_expr_is_ident qid ->
+    CAst.make ?loc:(snd qid).CAst.loc @@ Name (ref_expr_basename qid)
   | { loc = loc } -> CAst.make ?loc Anonymous
 
 let pr_ssrbinder env sigma prc _ _ (_, c) = prc env sigma c
@@ -1432,8 +1431,8 @@ END
 let pr_ssrfixfwd _ _ _ (id, fwd) = str " fix " ++ pr_id id ++ pr_fwd fwd
 
 let bvar_locid = function
-  | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
-    CAst.make ?loc:qid.CAst.loc (qualid_basename qid)
+  | { CAst.v = CRef (qid, _) } when ref_expr_is_ident qid ->
+    CAst.make ?loc:(snd qid).CAst.loc (ref_expr_basename qid)
   | _ -> CErrors.user_err (Pp.str "Missing identifier after \"(co)fix\"")
 
 }

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -165,7 +165,7 @@ let declare_one_prenex_implicit locality f =
 }
 
 VERNAC COMMAND EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
-  | #[ locality = Attributes.locality; ] [ "Prenex" "Implicits" ne_global_list(fl) ]
+  | #[ locality = Attributes.locality; ] [ "Prenex" "Implicits" ne_reference_list(fl) ]
   -> {
          let locality = Locality.make_section_locality locality in
          List.iter (declare_one_prenex_implicit locality) fl;

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -17,7 +17,6 @@ open Genarg
 open Context
 module CoqConstr = Constr
 open CoqConstr
-open Libnames
 open Tactics
 open Termops
 open Glob_term
@@ -117,10 +116,10 @@ let add_genarg tag pr =
   wit
 
 (** Constructors for constr_expr *)
-let isCVar   = function { CAst.v = CRef (qid,_) } -> qualid_is_ident qid | _ -> false
+let isCVar   = function { CAst.v = CRef (qid,_) } -> ref_expr_is_ident qid | _ -> false
 let destCVar = function
-  | { CAst.v = CRef (qid,_) } when qualid_is_ident qid ->
-    qualid_basename qid
+  | { CAst.v = CRef (qid,_) } when ref_expr_is_ident qid ->
+    ref_expr_basename qid
   | _ ->
     CErrors.anomaly (str"not a CRef.")
 let isGLambda c = match DAst.get c with GLambda (Name _, _, _, _, _) -> true | _ -> false
@@ -1012,10 +1011,10 @@ let wit_rpatternty = add_genarg "rpatternty" (fun env sigma -> pr_pattern pr_cpa
 let id_of_cpattern {pattern = (c1, c2); _} =
   let open CAst in
   match DAst.get c1, c2 with
-  | _, Some { v = CRef (qid, _) } when qualid_is_ident qid ->
-    Some (qualid_basename qid)
-  | _, Some { v = CAppExpl ((qid, _), []) } when qualid_is_ident qid ->
-    Some (qualid_basename qid)
+  | _, Some { v = CRef (qid, _) } when ref_expr_is_ident qid ->
+    Some (ref_expr_basename qid)
+  | _, Some { v = CAppExpl ((qid, _), []) } when ref_expr_is_ident qid ->
+    Some (ref_expr_basename qid)
   | GRef (GlobRef.VarRef x, _), None -> Some x
   | _ -> None
 let id_of_Cterm t = match id_of_cpattern t with

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -419,7 +419,8 @@ let locate_global_inductive_or_int63_or_float env allow_params qid =
     else TargetInd (Smartlocate.global_inductive_with_alias qid, [])
 
 let intern_cref env sigma r =
-  Constrintern.intern_constr env sigma (CAst.make @@ Constrexpr.CAppExpl ((r,None),[]))
+  Constrintern.intern_constr env sigma
+    (CAst.make @@ Constrexpr.CAppExpl (((CQualidRef,r),None),[]))
 
 let vernac_number_notation local ty f g opts scope =
   let rec parse_opts = function

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -255,8 +255,8 @@ let pr_universe_instance l =
   pr_opt_no_spc (pr_univ_annot pr_inside_universe_instance) l
 
 let pr_reference qid =
-  if qualid_is_ident qid then tag_var (pr_id @@ qualid_basename qid)
-  else pr_qualid qid
+  if ref_expr_is_ident qid then tag_var (pr_id @@ ref_expr_basename qid)
+  else Constrexpr_ops.pr_ref_expr qid
 
 let pr_cref ref us =
   pr_reference ref ++ pr_universe_instance us
@@ -324,7 +324,7 @@ let pr_record left right pr = function
       str right)
 
 let pr_record_body left right pr l =
-  let pr_defined_field (id, c) = hov 2 (pr_reference id ++ str" :=" ++ pr c) in
+  let pr_defined_field (id, c) = hov 2 (pr_reference (CQualidRef,id) ++ str" :=" ++ pr c) in
   pr_record left right pr_defined_field l
 
 let las = lapp
@@ -704,7 +704,7 @@ let pr pr sep lev_after inherited a =
     return (fun lev_after -> pr_proj (pr mt) pr_app c (CAst.make (CRef (f,us))) l) lproj
   | CAppExpl ((qid,us),[t])
   | CApp ({v = CRef(qid,us)},[t,None])
-    when qualid_is_ident qid && Id.equal (qualid_basename qid) Notation_ops.ldots_var ->
+    when ref_expr_is_ident qid && Id.equal (ref_expr_basename qid) Notation_ops.ldots_var ->
     return (fun lev_after ->
         hov 0 (str ".." ++ pr spc no_after (LevelLe latom) t ++ spc () ++ str ".."))
       larg

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -16,6 +16,8 @@ open Libnames
 open Constrexpr
 open Names
 
+val pr_reference : reference_expr -> Pp.t
+
 val pr_tight_coma : unit -> Pp.t
 
 val pr_with_comments : ?loc:Loc.t -> Pp.t -> Pp.t

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -474,8 +474,9 @@ module Intern = struct
     in
     let p = match p with
       | Inl r -> interp_ref r
-      | Inr { v = CAppExpl((r,None),[]) } ->
+      | Inr { v = CAppExpl(((CQualidRef,r),None),[]) } ->
         (* We interpret similarly @ref and ref *)
+        (* XXX CLibRef? *)
         interp_ref (make @@ AN r)
       | Inr c ->
         Inr (ist.intern_pattern c)

--- a/tactics/stdarg.ml
+++ b/tactics/stdarg.ml
@@ -76,7 +76,6 @@ let wit_integer = wit_int
 let wit_natural = wit_nat
 let wit_preident = wit_pre_ident
 let wit_reference = wit_ref
-let wit_global = wit_ref
 let wit_clause = wit_clause_dft_concl
 
 let wit_generic_tactic = Gentactic.wit_generic_tactic

--- a/tactics/stdarg.mli
+++ b/tactics/stdarg.mli
@@ -71,5 +71,4 @@ val wit_natural : int uniform_genarg_type
 val wit_integer : int uniform_genarg_type
 val wit_preident : string uniform_genarg_type
 val wit_reference : (qualid, GlobRef.t located or_var, GlobRef.t) genarg_type
-val wit_global : (qualid, GlobRef.t located or_var, GlobRef.t) genarg_type
 val wit_clause :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) genarg_type

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -140,7 +140,7 @@ Entry term is
   | NUMBER
   | atomic_constr
   | term_match
-  | reference; univ_annot
+  | global; univ_annot
   | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -65,7 +65,7 @@ Entry term is
   | NUMBER
   | atomic_constr
   | term_match
-  | reference; univ_annot
+  | global; univ_annot
   | string
   | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
     test_array_closing; "|"; "]"; univ_annot ] ]

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -14,7 +14,7 @@ open Names
 open Vernacexpr
 
 let smart_global r =
-  let gr = Smartlocate.smart_global r in
+  let gr = Smartlocate.(smart_global r) in
   Dumpglob.add_glob ?loc:r.loc gr;
   gr
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -268,8 +268,9 @@ let build_wellfounded env sigma poly udecl {CAst.v=recname; loc} ctx body ccl im
 (*********************************)
 (* Interpretation of Co/Fixpoint *)
 
+(* XXX use CLibRef *)
 let make_qref s = Libnames.qualid_of_string s
-let lt_ref = make_qref "Init.Peano.lt"
+let lt_ref = CQualidRef, make_qref "Init.Peano.lt"
 
 let position_of_argument ctx binders na =
   let exception Found of int in
@@ -316,7 +317,7 @@ let find_rec_annot ~program_mode ~function_mode env sigma Vernacexpr.{fname={CAs
         let r = match na, rfel with
           | Some id, None ->
             let loc = id.CAst.loc in
-            CAst.make ?loc @@ CRef (Libnames.qualid_of_ident ?loc id.CAst.v,None)
+            CAst.make ?loc @@ CRef (Constrexpr_ops.ref_expr_of_ident ?loc id.CAst.v,None)
           | Some _, Some _ -> CErrors.user_err ?loc Pp.(str"Measure takes three arguments only in Function.")
           | None, rfel -> default_order rfel in
         Some (r, mes), [] (* useless: will use Fix_sub *)

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -102,7 +102,7 @@ let interp_hints ~poly h =
     let open Vernacexpr in
     match rectify_hint_constr c with
     | HintsReference c ->
-      let gr = Smartlocate.global_with_alias c in
+      let gr = Smartlocate.ref_expr_with_alias c in
       (hint_globref gr)
     | HintsConstr c ->
       let () = warn_deprecated_hint_constr () in

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -255,7 +255,7 @@ type prod_info = production_level * production_position
 type (_, _) entry =
 | TTIdent : ('self, lident) entry
 | TTName : ('self, lname) entry
-| TTGlobal : ('r, qualid) entry
+| TTGlobal : ('r, reference_expr) entry
 | TTBigint : ('r, string) entry
 | TTBinder : bool -> ('self, kinded_cases_pattern_expr) entry
 | TTConstr : notation_entry * prod_info * 'r target -> ('r, 'r) entry
@@ -411,11 +411,11 @@ let rec interp_entry forpat e = match e with
   let TTAny e = interp_entry forpat e in TTAny (TTClosedBinderListOther (e, tkl))
 
 let cases_pattern_expr_of_id { CAst.loc; v = id } =
-  CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
+  CAst.make ?loc @@ CPatAtom (Some (CQualidRef,qualid_of_ident ?loc id))
 
 let cases_pattern_expr_of_name { CAst.loc; v = na } = CAst.make ?loc @@ match na with
   | Anonymous -> CPatAtom None
-  | Name id   -> CPatAtom (Some (qualid_of_ident ?loc id))
+  | Name id   -> CPatAtom (Some (CQualidRef,qualid_of_ident ?loc id))
 
 type 'r env = {
   constrs : 'r list;

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -104,7 +104,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Create"; IDENT "HintDb" ;
           id = IDENT ; b = [ IDENT "discriminated" -> { true } | -> { false } ] ->
             { VernacSynPure (VernacCreateHintDb (id, b)) }
-      | IDENT "Remove"; IDENT "Hints"; ids = LIST1 global; dbnames = opt_hintbases ->
+      | IDENT "Remove"; IDENT "Hints"; ids = LIST1 reference; dbnames = opt_hintbases ->
           { VernacSynPure (VernacRemoveHints (dbnames, ids)) }
       | IDENT "Hint"; h = hint; dbnames = opt_hintbases ->
           { VernacSynPure (VernacHints (dbnames, h)) }
@@ -116,9 +116,9 @@ GRAMMAR EXTEND Gram
   hint:
     [ [ IDENT "Resolve"; lc = LIST1 reference_or_constr; info = hint_info ->
           { HintsResolve (List.map (fun x -> (info, true, x)) lc) }
-      | IDENT "Resolve"; "->"; lc = LIST1 global; n = OPT natural ->
+      | IDENT "Resolve"; "->"; lc = LIST1 reference; n = OPT natural ->
           { HintsResolveIFF (true, lc, n) }
-      | IDENT "Resolve"; "<-"; lc = LIST1 global; n = OPT natural ->
+      | IDENT "Resolve"; "<-"; lc = LIST1 reference; n = OPT natural ->
           { HintsResolveIFF (false, lc, n) }
       | IDENT "Immediate"; lc = LIST1 reference_or_constr -> { HintsImmediate lc }
       | IDENT "Variables"; IDENT "Transparent" -> { HintsTransparency (HintsVariables, true) }
@@ -127,11 +127,11 @@ GRAMMAR EXTEND Gram
       | IDENT "Constants"; IDENT "Opaque" -> { HintsTransparency (HintsConstants, false) }
       | IDENT "Projections"; IDENT "Transparent" -> { HintsTransparency (HintsProjections, true) }
       | IDENT "Projections"; IDENT "Opaque" -> { HintsTransparency (HintsProjections, false) }
-      | IDENT "Transparent"; lc = LIST1 global -> { HintsTransparency (HintsReferences lc, true) }
-      | IDENT "Opaque"; lc = LIST1 global -> { HintsTransparency (HintsReferences lc, false) }
-      | IDENT "Mode"; l = global; m = mode -> { HintsMode (l, m) }
-      | IDENT "Unfold"; lqid = LIST1 global -> { HintsUnfold lqid }
-      | IDENT "Constructors"; lc = LIST1 global -> { HintsConstructors lc }
+      | IDENT "Transparent"; lc = LIST1 reference -> { HintsTransparency (HintsReferences lc, true) }
+      | IDENT "Opaque"; lc = LIST1 reference -> { HintsTransparency (HintsReferences lc, false) }
+      | IDENT "Mode"; l = reference; m = mode -> { HintsMode (l, m) }
+      | IDENT "Unfold"; lqid = LIST1 reference -> { HintsUnfold lqid }
+      | IDENT "Constructors"; lc = LIST1 reference -> { HintsConstructors lc }
       | IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";
         tac = generic_tactic ->
         { Vernacexpr.HintsExtern (n,c, tac) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -283,11 +283,11 @@ GRAMMAR EXTEND Gram
           { VernacSchemeEquality (SchemeBooleanEquality,id) }
       | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
               l = LIST1 identref SEP "," -> { VernacCombinedScheme (id, l) }
-      | IDENT "Register"; g = global; "as"; quid = qualid ->
+      | IDENT "Register"; g = reference; "as"; quid = qualid ->
           { VernacRegister(g, RegisterCoqlib quid) }
-      | IDENT "Register"; IDENT "Scheme"; g = global; "as"; qid = qualid; IDENT "for"; g' = global ->
+      | IDENT "Register"; IDENT "Scheme"; g = reference; "as"; qid = qualid; IDENT "for"; g' = reference ->
         { VernacRegister(g, RegisterScheme {inductive = g'; scheme_kind = qid}) }
-      | IDENT "Register"; IDENT "Inline"; g = global ->
+      | IDENT "Register"; IDENT "Inline"; g = reference ->
           { VernacRegister(g, RegisterInline) }
       | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
           { VernacPrimitive(id, r, typopt) }
@@ -673,7 +673,7 @@ GRAMMAR EXTEND Gram
           { VernacSynPure (VernacNameSectionHypSet (id, expr)) }
 
       (* Requiring an external file *)
-      | IDENT "From" ; ns = global ;
+      | IDENT "From" ; ns = reference ;
         IDENT "Extra"; IDENT "Dependency"; f = ne_string ;
         id = OPT [ "as"; id = IDENT -> { id } ] ->
           { VernacSynterp (VernacExtraDependency (ns, f, Option.map Id.of_string id)) }
@@ -681,7 +681,7 @@ GRAMMAR EXTEND Gram
       (* Requiring an already compiled module *)
       | IDENT "Require"; export = export_token; qidl = LIST1 filtered_import ->
           { VernacSynterp (VernacRequire (None, export, qidl)) }
-      | IDENT "From" ; ns = global ; IDENT "Require"; export = export_token
+      | IDENT "From" ; ns = reference ; IDENT "Require"; export = export_token
         ; qidl = LIST1 filtered_import ->
         { VernacSynterp (VernacRequire (Some ns, export, qidl)) }
       | IDENT "Import"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
@@ -701,11 +701,11 @@ GRAMMAR EXTEND Gram
   ] ]
   ;
   filtered_import:
-    [ [ m = global -> { (m, ImportAll) }
-      | m = global; "("; ns = LIST1 one_import_filter_name SEP ","; ")" -> { (m, ImportNames ns) } ] ]
+    [ [ m = reference -> { (m, ImportAll) }
+      | m = reference; "("; ns = LIST1 one_import_filter_name SEP ","; ")" -> { (m, ImportNames ns) } ] ]
   ;
   one_import_filter_name:
-    [ [ n = global; etc = OPT [ "("; ".."; ")" -> { () } ] -> { n, Option.has_some etc } ] ]
+    [ [ n = reference; etc = OPT [ "("; ".."; ")" -> { () } ] -> { n, Option.has_some etc } ] ]
   ;
   export_token:
     [ [ IDENT "Import"; cats = OPT import_categories -> { Some (Import,cats) }
@@ -825,7 +825,7 @@ GRAMMAR EXTEND Gram
           LIST1 [ v=strategy_level; "["; q=LIST1 smart_global; "]" -> { (v,q) } ] ->
             { VernacSynPure (VernacSetStrategy l) }
       (* Canonical structure *)
-      | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; qid = global; ud = OPT [ u = OPT univ_decl; d = def_body -> { (u,d) } ] ->
+      | IDENT "Canonical"; OPT [ IDENT "Structure" -> {()} ]; qid = reference; ud = OPT [ u = OPT univ_decl; d = def_body -> { (u,d) } ] ->
           { match ud with
            | None ->
              VernacSynPure (VernacCanonical CAst.(make ?loc:qid.CAst.loc @@ AN qid))
@@ -836,14 +836,14 @@ GRAMMAR EXTEND Gram
           { VernacSynPure (VernacCanonical CAst.(make ~loc @@ ByNotation ntn)) }
 
       (* Coercions *)
-      | IDENT "Coercion"; qid = global; ud = OPT [ u = OPT univ_decl; d = def_body -> { u, d } ] ->
+      | IDENT "Coercion"; qid = reference; ud = OPT [ u = OPT univ_decl; d = def_body -> { u, d } ] ->
           { match ud with Some (u, d) -> let s = coerce_reference_to_id qid in
           VernacSynPure (VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d))
           | None -> VernacSynPure (VernacCoercion (CAst.make ~loc @@ AN qid, None)) }
       | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
          s = coercion_class; ">->"; t = coercion_class ->
            { VernacSynPure (VernacIdentityCoercion (f, s, t)) }
-      | IDENT "Coercion"; qid = global; ":"; s = coercion_class; ">->";
+      | IDENT "Coercion"; qid = reference; ":"; s = coercion_class; ">->";
          t = coercion_class ->
           { VernacSynPure (VernacCoercion (CAst.make ~loc @@ AN qid, Some(s, t))) }
       | IDENT "Coercion"; ntn = by_notation; ":"; s = coercion_class; ">->";
@@ -860,17 +860,17 @@ GRAMMAR EXTEND Gram
              ":="; c = lconstr -> { Some (false,c) } | -> { None } ] ->
            { VernacSynPure (VernacInstance (fst namesup,snd namesup,t,props,info)) }
 
-      | IDENT "Existing"; IDENT "Instance"; id = global;
+      | IDENT "Existing"; IDENT "Instance"; id = reference;
           info = hint_info ->
           { VernacSynPure (VernacExistingInstance [id, info]) }
 
-      | IDENT "Existing"; IDENT "Instances"; ids = LIST1 global;
+      | IDENT "Existing"; IDENT "Instances"; ids = LIST1 reference;
         pri = OPT [ "|"; i = natural -> { i } ] ->
          { let info = { Typeclasses.hint_priority = pri; hint_pattern = None } in
          let insts = List.map (fun i -> (i, info)) ids in
           VernacSynPure (VernacExistingInstance insts) }
 
-      | IDENT "Existing"; IDENT "Class"; is = global -> { VernacSynPure (VernacExistingClass is) }
+      | IDENT "Existing"; IDENT "Class"; is = reference -> { VernacSynPure (VernacExistingClass is) }
 
       (* Arguments *)
       | IDENT "Arguments"; qid = smart_global;
@@ -1069,9 +1069,9 @@ GRAMMAR EXTEND Gram
       (* Printing (careful factorization of entries) *)
       | IDENT "Print"; p = printable -> { VernacSynPure (VernacPrint p) }
       | IDENT "Print"; qid = smart_global; l = OPT univ_name_list -> { VernacSynPure (VernacPrint (PrintName (qid,l))) }
-      | IDENT "Print"; IDENT "Module"; "Type"; qid = global ->
+      | IDENT "Print"; IDENT "Module"; "Type"; qid = reference ->
           { VernacSynPure (VernacPrint (PrintModuleType qid)) }
-      | IDENT "Print"; IDENT "Module"; qid = global ->
+      | IDENT "Print"; IDENT "Module"; qid = reference ->
           { VernacSynPure (VernacPrint (PrintModule qid)) }
       | IDENT "Print"; IDENT "Namespace" ; ns = dirpath ->
           { VernacSynPure (VernacPrint (PrintNamespace ns)) }
@@ -1126,7 +1126,7 @@ GRAMMAR EXTEND Gram
   printable:
     [ [ IDENT "Term"; qid = smart_global; l = OPT univ_name_list -> { PrintName (qid,l) }
       | IDENT "All" -> { PrintFullContext }
-      | IDENT "Section"; s = global -> { PrintSectionContext s }
+      | IDENT "Section"; s = reference -> { PrintSectionContext s }
       | IDENT "Grammar"; ents = LIST0 IDENT ->
           (* This should be in "syntax" section but is here for factorization*)
           { PrintGrammar ents }
@@ -1200,8 +1200,8 @@ GRAMMAR EXTEND Gram
     [ [ qid = smart_global -> { LocateAny qid }
       | IDENT "Term"; qid = smart_global -> { LocateTerm qid }
       | IDENT "File"; f = ne_string -> { LocateFile f }
-      | IDENT "Library"; qid = global -> { LocateLibrary qid }
-      | IDENT "Module"; qid = global -> { LocateModule qid } ] ]
+      | IDENT "Library"; qid = reference -> { LocateLibrary qid }
+      | IDENT "Module"; qid = reference -> { LocateModule qid } ] ]
   ;
   option_setting:
     [ [ -> { OptionSetTrue }
@@ -1209,16 +1209,16 @@ GRAMMAR EXTEND Gram
       | s  = STRING    -> { OptionSetString s } ] ]
   ;
   table_value:
-    [ [ id = global   -> { Goptions.QualidRefValue id }
+    [ [ id = reference   -> { Goptions.QualidRefValue id }
       | s  = STRING   -> { Goptions.StringRefValue s } ] ]
   ;
   setting_name:
     [ [ fl = LIST1 [ x = IDENT -> { x } ] -> { fl } ]]
   ;
   ne_in_or_out_modules:
-    [ [ IDENT "inside"; l = LIST1 global -> { SearchInside l }
-      | "in"; l = LIST1 global -> { SearchInside l }
-      | IDENT "outside"; l = LIST1 global -> { SearchOutside l } ] ]
+    [ [ IDENT "inside"; l = LIST1 reference -> { SearchInside l }
+      | "in"; l = LIST1 reference -> { SearchInside l }
+      | IDENT "outside"; l = LIST1 reference -> { SearchOutside l } ] ]
   ;
   in_or_out_modules:
     [ [ m = ne_in_or_out_modules -> { m }
@@ -1368,7 +1368,7 @@ GRAMMAR EXTEND Gram
   ;
   enable_notation_rule:
     [ [ s = ne_string -> { Some (Inl s) }
-      | qid = global; idl = LIST0 ident -> { Some (Inr (idl,qid)) }
+      | qid = reference; idl = LIST0 ident -> { Some (Inr (idl,qid)) }
       | -> { None } ] ]
   ;
   enable_notation_interpretation:

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -23,7 +23,6 @@ open Ppextend
 open Extend
 open Libobject
 open Constrintern
-open Libnames
 open Notation
 open Nameops
 
@@ -285,7 +284,7 @@ let adjust_infix_notation df notation_symbols c =
   let vars = names_of_constr_expr c in
   let x, y, notation_symbols = adjust_symbols vars notation_symbols in
   let df = Id.to_string x ^ " " ^ df ^ " " ^ Id.to_string y in
-  let inject_var x = CAst.make @@ CRef (qualid_of_ident x,None) in
+  let inject_var x = CAst.make @@ CRef (ref_expr_of_ident x,None) in
   let metas = [inject_var x; inject_var y] in
   let c = mkAppC (c,metas) in
   df, notation_symbols, c

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -295,7 +295,7 @@ let pr_opt_hintbases l = match l with
   | _ as z -> str":" ++ spc() ++ prlist_with_sep sep str z
 
 let pr_reference_or_constr pr_c = function
-  | HintsReference r -> pr_qualid r
+  | HintsReference r -> pr_reference r
   | HintsConstr c -> pr_c c
 
 let pr_hint_mode = let open Hints in function

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -360,7 +360,7 @@ type discharge = DoDischarge | NoDischarge
 type hint_info_expr = Constrexpr.constr_pattern_expr Typeclasses.hint_info_gen
 
 type reference_or_constr =
-  | HintsReference of Libnames.qualid
+  | HintsReference of reference_expr
   | HintsConstr of Constrexpr.constr_expr
 
 type hints_expr =


### PR DESCRIPTION
Attempt to upstream this elpi feature https://github.com/LPCIC/coq-elpi/blob/a8ce1db39daaba427c57e0a88dd5cb066e3e418a/src/rocq_elpi_vernacular_syntax.mlg#L105-L109 in a more principled way.