### PR TITLE
Compile Ltac2 with -noinit

### DIFF
--- a/doc/changelog/06-Ltac2-language/20387-ltac2-noinit.rst
+++ b/doc/changelog/06-Ltac2-language/20387-ltac2-noinit.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Ltac2 does not depend on the prelude (i.e.  it is compiled with `-noinit`).
+  It still depends on `Corelib.Init.Ltac` due to the interoperation with Ltac1
+  (`#20387 <https://github.com/rocq-prover/rocq/pull/20387>`_,
+  by Gaëtan Gilbert).

--- a/dune
+++ b/dune
@@ -59,7 +59,7 @@
   %{workspace_root}/_build/install/%{context_name}/lib/rocq-runtime/META)
  (action
   (with-stdout-to %{targets}
-   (run tools/dune_rule_gen/gen_rules.exe Ltac2 user-contrib/Ltac2 %{env:COQ_DUNE_EXTRA_OPT=}))))
+   (run tools/dune_rule_gen/gen_rules.exe Ltac2 user-contrib/Ltac2 -noinit %{env:COQ_DUNE_EXTRA_OPT=}))))
 
 (rule
  (targets theories_dune_split)
@@ -79,7 +79,7 @@
   (source_tree user-contrib))
  (action
   (with-stdout-to %{targets}
-   (run tools/dune_rule_gen/gen_rules.exe Ltac2 user-contrib/Ltac2 -split %{env:COQ_DUNE_EXTRA_OPT=}))))
+   (run tools/dune_rule_gen/gen_rules.exe Ltac2 user-contrib/Ltac2 -noinit -split %{env:COQ_DUNE_EXTRA_OPT=}))))
 
 ; Use summary.log as the target
 (alias

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -329,6 +329,9 @@ let () =
     (bool @-> list induction_clause @-> option constr_with_bindings @-> tac unit)
     (Tac2tactics.induction_destruct true)
 
+let () = define "tac_exfalso" (unit @-> tac unit) @@ fun () ->
+  Tactics.exfalso
+
 let () =
   define "tac_red" (clause @-> tac unit) (Tac2tactics.reduce Red)
 

--- a/test-suite/ltac2/noinit.v
+++ b/test-suite/ltac2/noinit.v
@@ -1,0 +1,19 @@
+(* -*- coq-prog-args: ("-noinit"); -*- *)
+
+Require Import Ltac2.Ltac2.
+
+Fail Check Corelib.Init.Logic.True.
+
+Require Import Corelib.Init.Logic.
+
+Check Corelib.Init.Logic.True.
+
+Goal True.
+  Fail now ().
+Abort.
+
+Require Corelib.Init.Tactics.
+
+Goal True.
+  now ().
+Qed.

--- a/theories/Init/Ltac.v
+++ b/theories/Init/Ltac.v
@@ -11,3 +11,6 @@
 Declare ML Module "rocq-runtime.plugins.ltac".
 
 #[export] Set Default Proof Mode "Classic".
+
+(** Forward declaration for ltac2. *)
+Ltac easy_forward_decl := fail "Cannot use easy: Corelib.Init.Tactics not loaded".

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -178,6 +178,8 @@ Ltac easy :=
   solve [ do_atom | use_hyps; do_ccl ] ||
   fail "Cannot solve this goal".
 
+Ltac Ltac.easy_forward_decl ::= easy.
+
 Tactic Notation "now" tactic(t) := t; easy.
 
 (** Slightly more than [easy]*)

--- a/tools/dune_rule_gen/coq_rules.mli
+++ b/tools/dune_rule_gen/coq_rules.mli
@@ -30,9 +30,12 @@ module Boot_type : sig
     (** Standard library *)
     | NoInit
     (** Standalone library (without Coq's core lib, for example the prelude) *)
-    | Regular of Theory.t
-    (** Regular library, qualified with -Q, path controls where the
-        Coq init is *)
+    | Regular of { corelib : Theory.t; noinit : bool }
+    (** Regular library, qualified with -Q, [corelib] controls where
+        the Corelib is.
+
+        [noinit = true] only means there is no implicit dep on the
+        prelude, it may still depend on Corelib (unlike [NoInit]). *)
 
 end
 

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Require Corelib.Init.Ltac.
+
 (* EJGA: Seems that Rocq's findlib loader is not loading this correctly? *)
 Declare ML Module "rocq-runtime.plugins.ltac2".
 Declare ML Module "rocq-runtime.plugins.ltac2_ltac1".

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Require Import Corelib.Init.Ltac.
 Require Import Ltac2.Init.
 Require Ltac2.Control Ltac2.Fresh Ltac2.Option Ltac2.Pattern Ltac2.Array Ltac2.Int Ltac2.Std Ltac2.Constr.
 
@@ -633,7 +634,7 @@ Ltac2 Notation f_equal := Std.f_equal ().
 
 (** now *)
 
-Ltac2 now0 t := t (); ltac1:(easy).
+Ltac2 now0 t := t (); ltac1:(easy_forward_decl).
 Ltac2 Notation "now" t(thunk(self)) : 6 := now0 t.
 
 (** profiling *)

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -358,10 +358,7 @@ Ltac2 Notation "inversion_clear"
   ids(opt(seq("in", list1(ident)))) :=
   Std.inversion Std.FullInversionClear arg pat ids.
 
-Ltac2 exfalso0 () := Control.enter (fun () =>
-  unshelve (let f := '(_ :> False) in induction $f)).
-
-Ltac2 Notation exfalso := exfalso0 ().
+Ltac2 Notation exfalso := Std.exfalso ().
 
 Ltac2 Notation "red" cl(opt(clause)) :=
   Std.red (default_on_concl cl).

--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -155,6 +155,8 @@ Ltac2 @ external destruct : evar_flag -> induction_clause list ->
 Ltac2 @ external induction : evar_flag -> induction_clause list ->
   constr_with_bindings option -> unit := "rocq-runtime.plugins.ltac2" "tac_induction".
 
+Ltac2 @external exfalso : unit -> unit := "rocq-runtime.plugins.ltac2" "tac_exfalso".
+
 Ltac2 @ external red : clause -> unit := "rocq-runtime.plugins.ltac2" "tac_red".
 Ltac2 @ external hnf : clause -> unit := "rocq-runtime.plugins.ltac2" "tac_hnf".
 Ltac2 @ external simpl : red_flags -> (pattern * occurrences) option -> clause -> unit := "rocq-runtime.plugins.ltac2" "tac_simpl".

--- a/user-contrib/Ltac2/dune.disabled
+++ b/user-contrib/Ltac2/dune.disabled
@@ -3,6 +3,8 @@
  (package rocq-core)
  (synopsis "Ltac2 tactic language")
  (flags -w -deprecated-native-compiler-option)
+ (stdlib no)
+ (theories Corelib)
  (plugins
    rocq-runtime.plugins.ltac2_ltac1
    rocq-runtime.plugins.ltac2))


### PR DESCRIPTION
This does not entirely remove the dependency on corelib as we still need ltac1.

We also add a forward declaration for `easy` in Init.Ltac as it is used in Ltac2.Notations.

cf #20385

Overlays:
- https://github.com/UniMath/UniMath/pull/2010

Depends:
- https://github.com/coq/coq/pull/20391