### PR TITLE
Ltac1: importing a definition does not undo its mutations

### DIFF
--- a/dev/ci/user-overlays/20391-SkySkimmer-ltac1-no-unredef.sh
+++ b/dev/ci/user-overlays/20391-SkySkimmer-ltac1-no-unredef.sh
@@ -1,0 +1,1 @@
+overlay metacoq https://github.com/SkySkimmer/metacoq ltac1-no-unredef 20391

--- a/doc/changelog/05-Ltac-language/20391-ltac1-no-unredef.rst
+++ b/doc/changelog/05-Ltac-language/20391-ltac1-no-unredef.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :cmd:`Ltac` redefinitions (`Ltac foo ::= ...`) are not undone by
+  importing the module containing the original definition.
+  To get the previous behaviour, add `Ltac foo ::= orig_def.`
+  after the original definition `Ltac foo := orig_def.`
+  (`#20391 <https://github.com/coq/coq/pull/20391>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -168,7 +168,7 @@ let open_md i (prefix, {local; id; for_ml=b; expr=t; depr}) =
   (* todo: generate a warning when non-unique, record choices for non-unique mappings *)
   let sp, kn = Lib.make_oname prefix id in
   let () = if not local then push_tactic (Nametab.Exactly i) sp kn in
-  add ~depr kn b t
+  ()
 
 let cache_md (prefix, {local; id; for_ml=b; expr=t; depr}) =
   let sp, kn = Lib.make_oname prefix id in


### PR DESCRIPTION
cf #10556

The previous behaviour can be gotten by doing eg

~~~coq
(* auxiliary definition to avoid repeating it, if it's a simple expression it can also be inlined *) Ltac original_def := ...

Ltac the_def := original_def.

#[export] Ltac the_def ::= original_def.
~~~

instead of `Ltac the_def := ...`.

Overlays:
- https://github.com/MetaRocq/metarocq/pull/1159