### PR TITLE
Fix order of implicit -I $rocq-runtime/.. vs explicit -I in coqdep

### DIFF
--- a/doc/changelog/09-cli-tools/20393-coqdep-implicit-i.rst
+++ b/doc/changelog/09-cli-tools/20393-coqdep-implicit-i.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  `rocq dep` implicitly adds `-I $rocq-runtime/..` after the explicit `-I` instead of before
+  (where `$rocq-runtime` is the expected location of the rocq-runtime package).
+  This means that if a local plugin (whose META is in an explicit `-I` path) is installed next to rocq-runtime,
+  `rocq dep` will emit a dependency on the local version instead of the installed version
+  (`#20393 <https://github.com/coq/coq/pull/20393>`_,
+  by Gaëtan Gilbert).

--- a/test-suite/coq-makefile/findlib-local/Loader.v
+++ b/test-suite/coq-makefile/findlib-local/Loader.v
@@ -1,0 +1,1 @@
+Declare ML Module "rocq-runtime.plugins.ltac".

--- a/test-suite/coq-makefile/findlib-local/Loader.v.d.expected
+++ b/test-suite/coq-makefile/findlib-local/Loader.v.d.expected
@@ -1,0 +1,2 @@
+Loader.vo Loader.glob Loader.v.beautified Loader.required_vo: Loader.v ltac/fake.cma ltac/fake.cmxs @ROCQWORKER@ META.rocq-runtime
+Loader.vo Loader.glob Loader.v.beautified Loader.required_vo: Loader.v ltac/fake.cma ltac/fake.cmxs @ROCQWORKER@ META.rocq-runtime

--- a/test-suite/coq-makefile/findlib-local/META.rocq-runtime
+++ b/test-suite/coq-makefile/findlib-local/META.rocq-runtime
@@ -1,0 +1,12 @@
+directory = "."
+package "plugins" (
+package "ltac" (
+directory = "ltac"
+version = "dev"
+requires = ""
+archive(byte) = "fake.cma"
+archive(native) = "fake.cmxa"
+plugin(byte) = "fake.cma"
+plugin(native) = "fake.cmxs"
+)
+)

--- a/test-suite/coq-makefile/findlib-local/_CoqProject
+++ b/test-suite/coq-makefile/findlib-local/_CoqProject
@@ -1,0 +1,3 @@
+Loader.v
+-I .
+META.rocq-runtime

--- a/test-suite/coq-makefile/findlib-local/run.sh
+++ b/test-suite/coq-makefile/findlib-local/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+. ../template/path-init.sh
+
+rm -rf _test
+mkdir _test
+find . -maxdepth 1 -not -name . -not -name _test -exec cp -r '{}' -t _test ';'
+
+cd _test
+
+coqdep -f _CoqProject Loader.v -worker @ROCQWORKER@ > Loader.v.d.real
+
+diff -u Loader.v.d.expected Loader.v.d.real

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -345,7 +345,7 @@ let init ~make_separator_hack args =
     if args.Args.boot then ml_path
     else
       let env = Boot.Env.init () in
-      Boot.Env.Path.(to_string @@ relative (Boot.Env.corelib env) "..") :: ml_path
+       ml_path @ Boot.Env.Path.[to_string @@ relative (Boot.Env.corelib env) ".."]
   in
   findlib_init ml_path;
   List.iter (add_include loadpath) args.Args.vo_path;


### PR DESCRIPTION
Typically the previous order meant that when developping a plugin, if a version was installed next to rocq coqdep would emit the dependency on it instead of the local files.
