### PR TITLE
Port native_compute to OCaml 5.

### DIFF
--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -106,14 +106,3 @@ value rocq_tcode_array(value tcodes) {
   }
   CAMLreturn(res);
 }
-
-CAMLprim value rocq_obj_set_tag (value arg, value new_tag)
-{
-#if OCAML_VERSION >= 50000
-// Placeholder used by native_compute
-  abort();
-#else
-  Tag_val (arg) = Int_val (new_tag);
-#endif
-  return Val_unit;
-}

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1823,8 +1823,8 @@ let pp_mllam fmt l =
       let prefix = annot.asw_prefix in
       let accu = string_of_accu_construct prefix ind in
       Format.fprintf fmt
-        "@[begin if Obj.tag (Obj.repr (%a)) = Obj.closure_tag then@\n%a@\nelse match Obj.magic (%a) with@\n| %s _ -> assert false@\n@\n%aend@]"
-        pp_mllam c pp_mllam accu_br pp_mllam c accu (pp_branches prefix ind) br
+        "@[begin if Obj.is_block (Obj.repr (%a)) && Char.code (String.unsafe_get (Obj.magic (%a)) (-8)) = Obj.closure_tag then@\n%a@\nelse match Obj.magic (%a) with@\n| %s _ -> assert false@\n@\n%aend@]"
+        pp_mllam c pp_mllam c pp_mllam accu_br pp_mllam c accu (pp_branches prefix ind) br
     | MLconstruct(prefix,ind,tag,args) ->
         Format.fprintf fmt "@[(Obj.magic (%s%a) : Nativevalues.t)@]"
           (string_of_construct prefix ~constant:false ind tag) pp_cargs args
@@ -1855,8 +1855,8 @@ let pp_mllam fmt l =
       end;
     | MLisaccu (_, _, c) ->
         Format.fprintf fmt
-          "@[begin Obj.tag (Obj.repr (%a)) = Obj.closure_tag end@]"
-        pp_mllam c
+          "@[begin Obj.is_block (Obj.repr (%a)) && Char.code (String.unsafe_get (Obj.magic (%a)) (-8)) = Obj.closure_tag end@]"
+        pp_mllam c pp_mllam c
 
   and pp_letrec fmt defs =
     let len = Array.length defs in

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1823,9 +1823,8 @@ let pp_mllam fmt l =
       let prefix = annot.asw_prefix in
       let accu = string_of_accu_construct prefix ind in
       Format.fprintf fmt
-        "@[begin match Obj.magic (%a) with@\n| %s _ ->@\n  %a@\n%aend@]"
-        pp_mllam c accu pp_mllam accu_br (pp_branches prefix ind) br
-
+        "@[begin if Obj.tag (Obj.repr (%a)) = Obj.closure_tag then@\n%a@\nelse match Obj.magic (%a) with@\n| %s _ -> assert false@\n@\n%aend@]"
+        pp_mllam c pp_mllam accu_br pp_mllam c accu (pp_branches prefix ind) br
     | MLconstruct(prefix,ind,tag,args) ->
         Format.fprintf fmt "@[(Obj.magic (%s%a) : Nativevalues.t)@]"
           (string_of_construct prefix ~constant:false ind tag) pp_cargs args
@@ -1854,11 +1853,10 @@ let pp_mllam fmt l =
         pp_mllam fmt arr.(len-1);
         Format.fprintf fmt "))@]"
       end;
-    | MLisaccu (prefix, ind, c) ->
-        let accu = string_of_accu_construct prefix ind in
+    | MLisaccu (_, _, c) ->
         Format.fprintf fmt
-          "@[begin match Obj.magic (%a) with@\n| %s _ ->@\n  true@\n| _ ->@\n  false@\nend@]"
-        pp_mllam c accu
+          "@[begin Obj.tag (Obj.repr (%a)) = Obj.closure_tag end@]"
+        pp_mllam c
 
   and pp_letrec fmt defs =
     let len = Array.length defs in

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -101,10 +101,7 @@ let caml_version_nums { CamlConf.caml_version; _ } =
   generic_version_nums ~name:"the OCaml compiler" caml_version
 
 let check_caml_version prefs caml_version caml_version_nums =
-  if caml_version_nums >= [5;0;0] && prefs.nativecompiler <> NativeNo then
-    let () = cprintf prefs "Your version of OCaml is %s." caml_version in
-    die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0"
-  else if caml_version_nums >= [4;9;0] then
+  if caml_version_nums >= [4;9;0] then
     cprintf prefs "You have OCaml %s. Good!" caml_version
   else
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in


### PR DESCRIPTION
This pull request is not meant to be applied, since it is way too fragile as it is. It only exists because @gasche needed to experiment with `native_compute` on OCaml 5, so I might as well make it public.

The first commit is the actual port. It changes accumulators so that they no longer have tag 0 but tag 247 (as any closure should under OCaml 5). This makes `native_compute` 160% slower, compared to OCaml 4 with tag-0 accumulators.

The second commit is a 64-bit, little-endian hack to test what the actual cost of `Obj.tag` is. The slowdown is reduced to just 10%. In other words, 60% of the execution time of `native_compute` is actually wasted inside `Obj.tag` alone. Indeed, as surprising as it might be, `Obj.tag` is not a builtin construct but a dumb C function.

(@gasche The timing difference for the hack is because there was an occurrence of `Obj.tag` that I mistakenly thought had negligible impact. Now that I have hopefully removed all the impactful instances of `Obj.tag`, the performances of OCaml 5 are almost on par with OCaml 4.)