### PR TITLE
Do not perform strong βι-reduction when trying to find coercions.

### DIFF
--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -220,7 +220,8 @@ let class_of env sigma t =
       let { cl_param = n1 } = class_info cl in
       (t, n1, cl, u, args)
     with Not_found ->
-      let t = Tacred.hnf_constr env sigma t in
+      let t = Tacred.hnf_constr0 env sigma t in
+      let t = Reductionops.clos_whd_flags RedFlags.betaiota env sigma t in
       let (cl, u, args) = find_class_type env sigma t in
       let { cl_param = n1 } = class_info cl in
       (t, n1, cl, u, args)
@@ -265,7 +266,8 @@ let apply_on_class_of env sigma t cont =
     cont cl
   with Not_found ->
     (* Is it worth to be more incremental on the delta steps? *)
-    let t = Tacred.hnf_constr env sigma t in
+    let t = Tacred.hnf_constr0 env sigma t in
+    let t = Reductionops.clos_whd_flags RedFlags.betaiota env sigma t in
     let (cl, u, args) = find_class_type env sigma t in
     let { cl_param = n1 } = class_info cl in
     if not (Int.equal (List.length args) n1) then raise Not_found;


### PR DESCRIPTION
The find_class_type function only cares about the weak head, so instead of strongly normalizing a potentially huge type like crazy, we just head reduce it.