### PR TITLE
Explicitly pass the safe env to Namegen.next_global_ident_away.

### DIFF
--- a/dev/ci/user-overlays/20423-ppedrot-namegen-no-global.sh
+++ b/dev/ci/user-overlays/20423-ppedrot-namegen-no-global.sh
@@ -1,0 +1,5 @@
+overlay equations https://github.com/ppedrot/Coq-Equations namegen-no-global 20423
+
+overlay lean_importer https://github.com/ppedrot/rocq-lean-import namegen-no-global 20423
+
+overlay rewriter https://github.com/ppedrot/rewriter namegen-no-global 20423

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -419,9 +419,9 @@ let next_name_away_in_goal (type a) (gen : a Generator.t) env na (avoid : a) =
    used globally, one looks for a name of same base with lower subscript
    beyond the current subscript *)
 
-let next_global_ident_away id avoid =
+let next_global_ident_away senv id avoid =
   let id = if Id.Set.mem id avoid then restart_subscript id else id in
-  let bad id = Id.Set.mem id avoid || Global.exists_objlabel (Label.of_id id) in
+  let bad id = Id.Set.mem id avoid || Safe_typing.exists_objlabel (Label.of_id id) senv in
   next_ident_away_from id bad
 
 (* 4- Looks for next fresh name outside a list; if name already used,

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -92,7 +92,7 @@ val next_ident_away_in_goal : Environ.env -> Id.t -> Id.Set.t -> Id.t
 
 (** Avoid clashing with a name already used in current module
    but tolerate overwriting section variables, as in goals *)
-val next_global_ident_away : Id.t -> Id.Set.t -> Id.t
+val next_global_ident_away : Safe_typing.safe_environment -> Id.t -> Id.Set.t -> Id.t
 
 (** Default is [default_non_dependent_ident] *)
 val next_name_away  : Name.t -> Id.Set.t -> Id.t

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -93,7 +93,7 @@ let pf_get_new_ids idl g =
   let ids = Id.Set.of_list ids in
   List.fold_right
     (fun id acc ->
-      next_global_ident_away id (Id.Set.union (Id.Set.of_list acc) ids) :: acc)
+      next_global_ident_away (Global.safe_env ()) id (Id.Set.union (Id.Set.of_list acc) ids) :: acc)
     idl []
 
 let next_ident_away_in_goal ids avoid =
@@ -1400,7 +1400,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
       with e when CErrors.noncritical e ->
         anomaly (Pp.str "open_new_goal with an unnamed theorem.") )
   in
-  let na = next_global_ident_away name Id.Set.empty in
+  let na = next_global_ident_away (Global.safe_env ()) name Id.Set.empty in
   if Termops.occur_existential sigma gls_type then
     CErrors.user_err Pp.(str "\"abstract\" cannot handle existentials");
   let hook _ =

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -190,7 +190,7 @@ let decl_constant name univs c =
        (DefinitionEntry (definition_entry ~opaque:true ~types ~univs c)))
 
 let decl_constant na suff univs c =
-  let na = Namegen.next_global_ident_away (Nameops.add_suffix na suff) Id.Set.empty in
+  let na = Namegen.next_global_ident_away (Global.safe_env ()) (Nameops.add_suffix na suff) Id.Set.empty in
   decl_constant na univs c
 
 (* Calling a global tactic *)

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -65,7 +65,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
            else (Context.Named.add d s1,s2))
         goal_sign (Context.Named.empty, Environ.empty_named_context_val)
     in
-    let name = Namegen.next_global_ident_away name (pf_ids_set_of_hyps gl) in
+    let name = Namegen.next_global_ident_away (Global.safe_env ()) name (pf_ids_set_of_hyps gl) in
     let concl = match goal_type with
       | None ->  Proofview.Goal.concl gl
       | Some ty -> ty

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -69,7 +69,7 @@ let hid = Id.of_string "H"
 let xid = Id.of_string "X"
 let default_id_of_sort = function InSProp | InProp | InSet -> hid | InType | InQSort -> xid
 let fresh env id avoid =
-  let freshid = next_global_ident_away id avoid in
+  let freshid = next_global_ident_away (Global.safe_env ()) id avoid in
   freshid, Id.Set.add freshid avoid
 let with_context_set ctx (b, ctx') =
   (b, UnivGen.sort_context_union ctx ctx')

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -576,7 +576,7 @@ let new_instance_common ~program_mode env instid ctx cl =
       | Name id -> id
       | Anonymous ->
         let i = Nameops.add_suffix (id_of_class env k.clu_impl) "_instance_0" in
-        Namegen.next_global_ident_away i (Termops.vars_of_env env))
+        Namegen.next_global_ident_away (Global.safe_env ()) i (Termops.vars_of_env env))
   in
   let env' = push_rel_context ctx env in
   id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -750,7 +750,7 @@ let declare_variable ~name ~kind ~typing_flags d =
       in
       let se = if opaque then
           let cname = Id.of_string (Id.to_string name ^ "_subproof") in
-          let cname = Namegen.next_global_ident_away cname Id.Set.empty in
+          let cname = Namegen.next_global_ident_away (Global.safe_env ()) cname Id.Set.empty in
           let de = {
             proof_entry_body = DeferredOpaque { body = Future.from_val ((body, Univ.ContextSet.empty), Evd.empty_side_effects); feedback_id };
             proof_entry_secctx = None; (* de.proof_entry_secctx is NOT respected *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -820,7 +820,7 @@ let vernac_definition_hook ~canonical_instance ~local ~poly ~reversible = let op
 let default_thm_id = Id.of_string "Unnamed_thm"
 
 let fresh_name_for_anonymous_theorem () =
-  Namegen.next_global_ident_away default_thm_id Id.Set.empty
+  Namegen.next_global_ident_away (Global.safe_env ()) default_thm_id Id.Set.empty
 
 let vernac_definition_name lid local =
   let lid =


### PR DESCRIPTION
This function was the only one in namegen to directly access the global environment. Given that there are not that many callers and they are all in the upper layers, we pass the environment used to check for freshness functionally.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/644
- https://github.com/rocq-community/rocq-lean-import/pull/33
- https://github.com/mit-plv/rewriter/pull/172