### PR TITLE
Fix comment in Ltac1.v to avoid coqdoc mangling it

### DIFF
--- a/user-contrib/Ltac2/Ltac1.v
+++ b/user-contrib/Ltac2/Ltac1.v
@@ -64,4 +64,4 @@ Ltac2 @ external to_intro_pattern : t -> intro_pattern option := "rocq-runtime.p
 
 Ltac2 @ external tag_name : t -> string :=  "rocq-runtime.plugins.ltac2_ltac1" "ltac1_tag_name".
 (** Name of the ltac1 value class the argument belongs to. Should be
-    used only for error printing, typically "expected a constr but got a $tag_name". *)
+    used only for error printing, typically "expected a constr but got a tag_name". *)


### PR DESCRIPTION
On https://rocq-prover.org/doc/master/corelib/Ltac2.Ltac1.html it shows

~~~
Name of the ltac1 value class the argument belongs to. Should be used only for error printing, typically "expected a constr but got a 
~~~
