### PR TITLE
Enable use of (open_)lconstr from Ltac2.

### DIFF
--- a/doc/changelog/06-Ltac2-language/20430-lconstr_in_ltac.rst
+++ b/doc/changelog/06-Ltac2-language/20430-lconstr_in_ltac.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Enable use of (open\_)lconstr inside Ltac2 Notation command
+  (`#20430 <https://github.com/coq/coq/pull/20430>`_,
+  by Pim Otte).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -577,8 +577,11 @@ The current implementation recognizes the following built-in quotations:
 - ``ident``, which parses identifiers (type ``Init.ident``).
 - ``constr``, which parses Rocq terms and produces an-evar free term at runtime
   (type ``Init.constr``).
+- ``lconstr``, which is equivalent to ``constr`` but at precedence level 200.
 - ``open_constr``, which parses Rocq terms and produces a term potentially with
   holes at runtime (type ``Init.constr`` as well).
+- ``open_lconstr``, which is equivalent to ``open_constr`` but at precedence
+  level 200.
 - ``preterm``, which parses Rocq terms and produces a value which must
   be typechecked with ``Constr.pretype`` (type ``Init.preterm``).
 - ``pat``, which parses Rocq patterns and produces a pattern used for term

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -2056,35 +2056,56 @@ let () = add_scope "thunk" begin function
 | arg -> scope_fail "thunk" arg
 end
 
-let () = add_scope "constr" (fun arg ->
+let () = add_scope "constr" begin function arg ->
+  let delimiters = List.map (function
+      | SexprRec (_, { v = Some s }, []) -> s
+      | _ -> scope_fail "constr" arg)
+      arg
+  in
+  let act e = Tac2quote.of_constr ~delimiters e in
+  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+end
+
+  let () = add_scope "lconstr" begin function arg ->
     let delimiters = List.map (function
         | SexprRec (_, { v = Some s }, []) -> s
-        | _ -> scope_fail "constr" arg)
+        | _ -> scope_fail "lconstr" arg)
         arg
     in
     let act e = Tac2quote.of_constr ~delimiters e in
-    Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
-  )
+    Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
+  end
 
-let () = add_scope "open_constr" (fun arg ->
-    let delimiters = List.map (function
-        | SexprRec (_, { v = Some s }, []) -> s
-        | _ -> scope_fail "open_constr" arg)
-        arg
-    in
-    let act e = Tac2quote.of_open_constr ~delimiters e in
-    Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
-  )
+let () = add_scope "open_constr" begin function arg ->
+  let delimiters = List.map (function
+      | SexprRec (_, { v = Some s }, []) -> s
+      | _ -> scope_fail "open_constr" arg)
+      arg
+  in
+  let act e = Tac2quote.of_open_constr ~delimiters e in
+  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+end
 
-let () = add_scope "preterm" (fun arg ->
-    let delimiters = List.map (function
-        | SexprRec (_, { v = Some s }, []) -> s
-        | _ -> scope_fail "preterm" arg)
-        arg
-    in
-    let act e = Tac2quote.of_preterm ~delimiters e in
-    Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
-  )
+let () = add_scope "open_lconstr" begin function arg ->
+  let delimiters = List.map (function
+      | SexprRec (_, { v = Some s }, []) -> s
+      | _ -> scope_fail "open_lconstr" arg)
+      arg
+  in
+  let act e = Tac2quote.of_open_constr ~delimiters e in
+  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
+end
+
+
+let () = add_scope "preterm" begin function arg ->
+  let delimiters = List.map (function
+      | SexprRec (_, { v = Some s }, []) -> s
+      | _ -> scope_fail "preterm" arg)
+      arg
+  in
+  let act e = Tac2quote.of_preterm ~delimiters e in
+  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+end
 
 let add_expr_scope name entry f =
   add_scope name begin function

--- a/test-suite/ltac2/lconstr.v
+++ b/test-suite/ltac2/lconstr.v
@@ -1,0 +1,17 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Notation "Assume" _(lconstr) := constructor.
+
+Goal forall n : nat, True.
+Proof.
+  intros n.
+  Assume n < 10.
+Abort.
+
+Ltac2 Notation "Assume_open" _(open_lconstr) := constructor.
+
+Goal forall n : nat, True.
+Proof.
+  intros n.
+  Assume_open n < 10.
+Abort.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

Per discussion on [zulip](https://rocq-prover.zulipchat.com/#narrow/channel/278935-Ltac2/topic/lconstr.20in.20Ltac2.20Notations/with/506693388). This is useful to Waterproof, where we build on Ltac2 and want to be able to allow students to use less parentheses.

I've conservatively removed checkboxes that I think don't apply, I'm not sure about some of the others. (For example: I couldn't really find a place where this API is tested.)

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
