### PR TITLE
Use GlobEnv in the Coercion API.

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -416,7 +416,7 @@ let coerce_row ~program_mode typing_fun env sigma pats (tomatch,(na,indopt)) =
   let loc = loc_of_glob_constr tomatch in
   let sigma, tycon, realnames = find_tomatch_tycon !!env sigma loc indopt in
   let sigma, j = typing_fun tycon env sigma tomatch in
-  let sigma, j = Coercion.inh_coerce_to_base ?loc:(loc_of_glob_constr tomatch) ~program_mode !!env sigma j in
+  let sigma, j = Coercion.inh_coerce_to_base ?loc:(loc_of_glob_constr tomatch) ~program_mode env sigma j in
   let typ = nf_evar sigma j.uj_type in
   let env = make_return_predicate_ltac_lvar env sigma na tomatch j.uj_val in
   let sigma, t =
@@ -471,7 +471,7 @@ let adjust_tomatch_to_pattern ~program_mode sigma pb ((current,typ),deps,dep) =
                   raise (PretypeError (!!(pb.env), sigma, CannotUnify (indt, typ, Some e)))
                 | sigma -> sigma, current
               else
-                let sigma, j, _trace = Coercion.inh_conv_coerce_to ?loc ~program_mode ~resolve_tc:true !!(pb.env) sigma (make_judge current typ) indt in
+                let sigma, j, _trace = Coercion.inh_conv_coerce_to ?loc ~program_mode ~resolve_tc:true pb.env sigma (make_judge current typ) indt in
                 sigma, j.uj_val
             in
             sigma, (current, try_find_ind !!(pb.env) sigma indt names))
@@ -2879,7 +2879,7 @@ let compile_cases ?loc ~program_mode style (typing_fun, sigma) tycon env (predop
     let used, sigma, j = compile ~program_mode sigma pb in
 
     (* We coerce to the tycon (if an elim predicate was provided) *)
-    let sigma, j = inh_conv_coerce_to_tycon ?loc ~program_mode !!env sigma j tycon in
+    let sigma, j = inh_conv_coerce_to_tycon ?loc ~program_mode env sigma j tycon in
     used, sigma, j
   in
 

--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -26,13 +26,13 @@ val reapply_coercions : evar_map -> coercion_trace -> EConstr.t -> EConstr.t
     inserts a coercion into [j], if needed, in such a way it gets as
     type a sort; it fails if no coercion is applicable *)
 val inh_coerce_to_sort : ?loc:Loc.t -> ?use_coercions:bool ->
-  env -> evar_map -> unsafe_judgment -> evar_map * unsafe_type_judgment
+  GlobEnv.t -> evar_map -> unsafe_judgment -> evar_map * unsafe_type_judgment
 
 (** [inh_coerce_to_base env isevars j] coerces [j] to its base type; i.e. it
     inserts a coercion into [j], if needed, in such a way it gets as
     type its base type (the notion depends on the coercion system) *)
 val inh_coerce_to_base : ?loc:Loc.t -> program_mode:bool ->
-  env -> evar_map -> unsafe_judgment -> evar_map * unsafe_judgment
+  GlobEnv.t -> evar_map -> unsafe_judgment -> evar_map * unsafe_judgment
 
 (** [remove_subset env sigma t] applies program mode transformations
    to [t], recursively transforming [{x : A | P}] into [A] *)
@@ -45,11 +45,11 @@ val remove_subset : env -> evar_map -> types -> types
     resort before failing) *)
 
 val inh_conv_coerce_to : ?loc:Loc.t -> program_mode:bool -> resolve_tc:bool ->
-  ?use_coercions:bool -> ?patvars_abstract:bool -> env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  ?use_coercions:bool -> ?patvars_abstract:bool -> GlobEnv.t -> evar_map -> ?flags:Evarconv.unify_flags ->
   unsafe_judgment -> types -> evar_map * unsafe_judgment * coercion_trace option
 
 val inh_conv_coerce_rigid_to : ?loc:Loc.t -> program_mode:bool -> resolve_tc:bool ->
-  ?use_coercions:bool -> ?patvars_abstract:bool -> env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  ?use_coercions:bool -> ?patvars_abstract:bool -> GlobEnv.t -> evar_map -> ?flags:Evarconv.unify_flags ->
   unsafe_judgment -> types -> evar_map * unsafe_judgment * coercion_trace option
 
 (** [inh_pattern_coerce_to loc env isevars pat ind1 ind2] coerces the Cases
@@ -96,4 +96,4 @@ val reapply_coercions_body : evar_map -> coercion_trace -> delayed_app_body -> d
     resolve_tc=false disables resolving type classes (as the last
     resort before failing) *)
 val inh_app_fun : program_mode:bool -> resolve_tc:bool -> ?use_coercions:bool ->
-  env -> evar_map -> ?flags:Evarconv.unify_flags -> delayed_app_body -> types -> evar_map * delayed_app_body * types * coercion_trace
+  GlobEnv.t -> evar_map -> ?flags:Evarconv.unify_flags -> delayed_app_body -> types -> evar_map * delayed_app_body * types * coercion_trace

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -504,7 +504,7 @@ let adjust_evar_source sigma na c =
 let inh_conv_coerce_to_tycon ?loc ~flags:{ program_mode; resolve_tc; use_coercions; patvars_abstract } env sigma j = function
   | None -> sigma, j, Some Coercion.empty_coercion_trace
   | Some t ->
-    Coercion.inh_conv_coerce_to ?loc ~program_mode ~resolve_tc ~use_coercions ~patvars_abstract !!env sigma j t
+    Coercion.inh_conv_coerce_to ?loc ~program_mode ~resolve_tc ~use_coercions ~patvars_abstract env sigma j t
 
 let check_instance subst = function
   | [] -> ()
@@ -1150,7 +1150,7 @@ struct
           sigma, body, na, c1, subs, c2, Coercion.empty_coercion_trace
         | _ ->
           let typ = Vars.esubst Vars.lift_substituend subs typ in
-          let sigma, body, typ, trace = Coercion.inh_app_fun ~program_mode:flags.program_mode ~resolve_tc:flags.resolve_tc ~use_coercions:flags.use_coercions !!env sigma body typ in
+          let sigma, body, typ, trace = Coercion.inh_app_fun ~program_mode:flags.program_mode ~resolve_tc:flags.resolve_tc ~use_coercions:flags.use_coercions env sigma body typ in
           let resty = whd_all !!env sigma typ in
           let na, c1, c2 = match EConstr.kind sigma resty with
           | Prod (na, c1, c2) -> (na, c1, c2)
@@ -1572,7 +1572,7 @@ let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.
       let loc = loc_of_glob_constr c in
       let sigma, tj =
         let use_coercions = flags.use_coercions in
-        Coercion.inh_coerce_to_sort ?loc ~use_coercions !!env sigma j in
+        Coercion.inh_coerce_to_sort ?loc ~use_coercions env sigma j in
       match valcon with
       | None -> sigma, tj
       | Some v ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1757,7 +1757,9 @@ let is_mimick_head sigma ts f =
 
 let try_to_coerce ~metas env evd c cty tycon =
   let j = make_judge c cty in
-  let (evd',j',_trace) = Coercion.inh_conv_coerce_rigid_to ~program_mode:false ~resolve_tc:true env evd j tycon in
+  let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+  let genv = GlobEnv.make ~hypnaming env evd Glob_ops.empty_lvar in
+  let (evd',j',_trace) = Coercion.inh_conv_coerce_rigid_to ~program_mode:false ~resolve_tc:true genv evd j tycon in
   let evd' = Evarconv.solve_unif_constraints_with_heuristics env evd' in
   let metas = Meta.map_metas_fvalue (fun c -> nf_evar evd' c) metas in
   (evd', metas, j'.uj_val)

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -32,7 +32,9 @@ let absurd c =
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let j = Retyping.get_judgment_of env sigma c in
-    let sigma, j = Coercion.inh_coerce_to_sort env sigma j in
+    let hypnaming = Evarutil.RenameExistingBut (Evarutil.VarSet.variables (Global.env ())) in
+    let genv = GlobEnv.make ~hypnaming env sigma Glob_ops.empty_lvar in
+    let sigma, j = Coercion.inh_coerce_to_sort genv sigma j in
     let t = nf_betaiota env sigma j.Environ.utj_val in
     let r = ESorts.relevance_of_sort j.Environ.utj_type in
     Proofview.Unsafe.tclEVARS sigma <*>

--- a/tactics/eClause.ml
+++ b/tactics/eClause.ml
@@ -140,7 +140,9 @@ let define_with_type sigma env ev c =
   let t = Retyping.get_type_of env sigma ev in
   let ty = Retyping.get_type_of env sigma c in
   let j = Environ.make_judge c ty in
-  let (sigma, j, _trace) = Coercion.inh_conv_coerce_to ~program_mode:false ~resolve_tc:true env sigma j t in
+  let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+  let genv = GlobEnv.make ~hypnaming env sigma Glob_ops.empty_lvar in
+  let (sigma, j, _trace) = Coercion.inh_conv_coerce_to ~program_mode:false ~resolve_tc:true genv sigma j t in
   let (ev, _) = destEvar sigma ev in
   let sigma = Evd.define ev j.Environ.uj_val sigma in
   sigma


### PR DESCRIPTION
This module is only really used by Pretyping so it is better to take advantage of the fast named context generation provided by GlobEnv, which is used pervasively by Pretyping.