### PR TITLE
ci-quickchick don't use dune build -p

### DIFF
--- a/dev/ci/scripts/ci-quickchick.sh
+++ b/dev/ci/scripts/ci-quickchick.sh
@@ -10,6 +10,6 @@ git_download quickchick
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/quickchick"
-  dune build -p coq-quickchick @install
-  dune install -p coq-quickchick --prefix=$CI_INSTALL_DIR
+  dune build --root . --only-packages=coq-quickchick @install
+  dune install --root . coq-quickchick --prefix=$CI_INSTALL_DIR
 )

--- a/dev/ci/scripts/ci-quickchick_test.sh
+++ b/dev/ci/scripts/ci-quickchick_test.sh
@@ -8,5 +8,5 @@ ci_dir="$(dirname "$0")"
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
 ( cd "${CI_BUILD_DIR}/quickchick"
-  dune build -p coq-quickchick @runtest @cram --stop-on-first-error
+  dune build --root . --only-packages=coq-quickchick @runtest @cram --stop-on-first-error
 )


### PR DESCRIPTION
Until https://github.com/QuickChick/QuickChick/pull/404 is merged this makes quickchick error instead of quickchick_test because the "ignored partial application" warning becomes an error.
