### PR TITLE
Bump nixpkgs.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   ++ optionals buildIde [
     ocamlPackages.lablgtk3-sourceview3
     glib
-    gnome.adwaita-icon-theme
+    adwaita-icon-theme
     wrapGAppsHook
   ]
   ++ optionals buildDoc [

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/1c0bec249943cd3e03f876554b8af7d1e32a09e1.tar.gz";
-  sha256 = "06wpxiykzrwqsham8v8kzd79nyh0qb707r0svycz32w8j0x6b1mq";
+  url = "https://github.com/NixOS/nixpkgs/archive/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76.tar.gz";
+  sha256 = "sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om+vQOREwiX0=";
 })


### PR DESCRIPTION
It's been a while since we didn't bump nixpkgs. This update provides the latest Sphinx version.