### PR TITLE
Bump version of Sphinx in edge CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2025-02-19-804d667688"
-  EDGE_CACHEKEY: "edge_ubuntu-V2025-02-19-164aadb59f"
+  EDGE_CACHEKEY: "edge_ubuntu-V2025-04-07-f957eb9ff4"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ variables:
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
   BASE_CACHEKEY: "old_ubuntu_lts-V2025-02-19-804d667688"
-  EDGE_CACHEKEY: "edge_ubuntu-V2025-04-07-f957eb9ff4"
+  EDGE_CACHEKEY: "edge_ubuntu-V2025-04-07-dee2054641"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"
 

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -33,8 +33,8 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
       && rm -rf /var/lib/apt/lists /usr/share/doc
 
 # More dependencies of the sphinx doc
-RUN pip3 install --break-system-packages docutils==0.17.1 sphinx==5.3.0 sphinx_rtd_theme==1.0.0 \
-        antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==2.5.0 \
+RUN pip3 install --break-system-packages docutils==0.21.2 sphinx==8.2.3 sphinx_rtd_theme==3.0.2 \
+        antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==2.6.3 \
       && rm -rf ~/.cache/pip
 
 # We need to install OPAM 2.0 manually for now.

--- a/dev/ci/docker/edge_ubuntu/Dockerfile
+++ b/dev/ci/docker/edge_ubuntu/Dockerfile
@@ -50,7 +50,7 @@ ENV NJOBS="2" \
 RUN mkdir -p ~/.config/dune && printf '(lang dune 2.1)\n(jobs %s)\n' $NJOBS > ~/.config/dune/config
 
 # Edge opam is the set of edge packages required by Coq
-ENV COMPILER="4.14.1" \
+ENV COMPILER="4.14.2" \
     BASE_OPAM="zarith.1.13 ounit2.2.2.6 camlzip.1.13" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
     BASE_OPAM_EDGE="dune.3.14.0 dune-build-info.3.14.0 dune-release.2.0.0 ocamlfind.1.9.6 odoc.2.3.1" \


### PR DESCRIPTION
Let's see if this works.

Ideally, we should also try to bump the versions of OCaml packages that we test, but I got lazy and didn't do it.