### PR TITLE
Exposes functionality for inductive types in Ltac2

### DIFF
--- a/doc/changelog/06-Ltac2-language/20475-ltac2_expose_inductive.rst
+++ b/doc/changelog/06-Ltac2-language/20475-ltac2_expose_inductive.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  API functions for inductive types - `Ind.nparams`, `Ind.nparams_uniform`, `Ind.constructor_nargs`, `Ind.constructor_ndecls`, `Constr.Case.inductive`
+  (`#20475 <https://github.com/rocq-prover/rocq/pull/20475>`_,
+  fixes `#10940 <https://github.com/rocq-prover/rocq/issues/10940>`_,
+  by Patrick Nicodemus).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -740,6 +740,10 @@ let () =
   with e when CErrors.noncritical e ->
     throw err_notfound
 
+let () =
+  define "case_to_inductive" (case @-> ret inductive) @@ fun case ->
+  case.ci_ind
+
 let () = define "constr_cast_default" (ret valexpr) (of_cast DEFAULTcast)
 let () = define "constr_cast_vm" (ret valexpr) (of_cast VMcast)
 let () = define "constr_cast_native" (ret valexpr) (of_cast NATIVEcast)
@@ -1299,6 +1303,16 @@ let () =
   else throw err_notfound
 
 let () =
+  define "ind_get_nparams"
+    (ind_data @-> ret int) @@ fun (_, mib) ->
+  mib.Declarations.mind_nparams
+
+let () =
+  define "ind_get_nparams_rec"
+    (ind_data @-> ret int) @@ fun (_, mib) ->
+  mib.Declarations.mind_nparams_rec
+
+let () =
   define "constructor_inductive"
     (constructor @-> ret inductive)
   @@ fun (ind, _) -> ind
@@ -1309,6 +1323,18 @@ let () =
   @@ fun (_, i) ->
   (* WARNING: ML constructors are 1-indexed but Ltac2 constructors are 0-indexed *)
   i-1
+
+let () =
+  define "constructor_nargs"
+    (ind_data @-> ret (array int)) @@ fun ((_,i),mib) ->
+  let open Declarations in
+  mib.mind_packets.(i).mind_consnrealargs
+
+let () =
+  define "constructor_ndecls"
+    (ind_data @-> ret (array int)) @@ fun ((_,i),mib) ->
+  let open Declarations in
+  mib.mind_packets.(i).mind_consnrealdecls
 
 let () =
   define "ind_get_projections" (ind_data @-> ret (option (array projection)))

--- a/test-suite/ltac2/ind.v
+++ b/test-suite/ltac2/ind.v
@@ -18,8 +18,56 @@ Ltac2 Eval
   (* Check the number of constructors *)
   let nconstr := Ind.nconstructors data in
   let () := if Int.equal nconstr 2 then () else Control.throw Not_found in
+  (* Check that we can get the inductive type from a pattern match expression *)
+  let tm := '(match 0 with 0 => 0 | S n => n end) in
+  let ind := match Constr.Unsafe.kind tm with
+   | Constr.Unsafe.Case case _ _ _ _ => Constr.Unsafe.Case.inductive case
+   | _ => Control.throw Not_found end in
+  (if Ind.equal ind nat then () else Control.throw Not_found);
   (* Create a fresh instance *)
   let s := Ind.get_constructor data 1 in
   let s := Env.instantiate (Std.ConstructRef s) in
-  constr:($s 0)
+  constr:($s 0).
+
+Ltac2 Eval
+  let acc := Option.get (Env.get [@Corelib; @Init; @Wf; @Acc]) in
+  let acc := match acc with
+  | Std.IndRef acc => acc
+  | _ => Control.throw Not_found
+  end in
+  let data := Ind.data acc in
+  let () :=
+    if Int.equal (Ind.nparams data) 3 (* A, R, x are parameters. *)
+    then () else Control.throw Not_found in
+  let () :=
+    if Int.equal (Ind.nparams_uniform data) 2 (* A, R are recursively uniform parameters. *)
+    then () else Control.throw Not_found in
+  let () :=
+    if Int.equal (Array.get (Ind.constructor_nargs data) 0) 1
+    then () else Control.throw Not_found in
+  ()
+.
+
+Inductive ltac2_ind_test (A B: Type) (f : A -> B) (a : A) (b:= f a) : A -> B -> Type
+  := c0 (a0 : A) (b0 := f a0) : ltac2_ind_test A B f a a0 b0.
+
+Ltac2 Eval
+  let acc := Option.get (Env.get [@ind; @ltac2_ind_test]) in
+  let acc := match acc with
+  | Std.IndRef acc => acc
+  | _ => Control.throw Not_found
+  end in
+  let data := Ind.data acc in
+  let () :=
+    if Int.equal (Ind.nparams data) 4 (* A, B, f, a are parameters. *)
+    then () else Control.throw Not_found in
+  let () :=
+    if Int.equal (Array.get (Ind.constructor_nargs data) 0) 1
+                 (* a0 is the only argument of c0. *)
+    then () else Control.throw Not_found in
+  let () :=
+    if Int.equal (Array.get (Ind.constructor_ndecls data) 0) 2
+                 (* a0 and b0 can both be bound when pattern matching. *)
+    then () else Control.throw Not_found in
+  ()
 .

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -45,7 +45,12 @@ Module Unsafe.
 (** Low-level access to kernel terms. Use with care! *)
 
 Ltac2 Type case.
-(** A value of [case] is data carried by a pattern match expression that contains a reference to the inductive type being matched on. Given an inductive type, one can use the [case] function below to construct pattern match expressions on that type. *)
+(** A value of [case] is data carried by a pattern match expression that
+    contains a reference to the inductive type being matched on. Given an
+    inductive type, one can use the [case] function below to construct pattern
+    match expressions on that type, or given a pattern match expression one can
+    use the [Case.inductive] function to get the inductive type associated to
+    the pattern match. *)
 
 Ltac2 Type case_invert
 (** A piece of metadata attached to a pattern match expression which
@@ -205,6 +210,8 @@ Module Case.
       module aliases or Include are not considered equal by this
       function. *)
 
+  Ltac2 @ external inductive : case -> inductive := "rocq-runtime.plugins.ltac2" "case_to_inductive".
+  (** Get the inductive type being matched on in a pattern match expression. *)
 End Case.
 
 (** Open recursion combinators *)

--- a/user-contrib/Ltac2/Ind.v
+++ b/user-contrib/Ltac2/Ind.v
@@ -11,24 +11,30 @@
 From Ltac2 Require Import Init.
 
 Ltac2 Type t := inductive.
+(** An [inductive] is a name of a mutually inductive type and the index of an
+    inductive block within that type. *)
 
 Ltac2 @ external equal : t -> t -> bool := "rocq-runtime.plugins.ltac2" "ind_equal".
 (** Equality test. *)
 
 Ltac2 Type data.
-(** Type of data representing inductive blocks. *)
+(** The actual data specified by a concrete declaration of an inductive type,
+    containing, e.g., its constructors and its parameters. A value of type
+    [data] corresponds to one inductive type within a larger mutually inductive
+    block. *)
 
 Ltac2 @ external data : t -> data := "rocq-runtime.plugins.ltac2" "ind_data".
-(** Get the mutual blocks corresponding to an inductive type in the current
-    environment. Panics if there is no such inductive. *)
+(** Get the value named by [t] in the current environment. Panics if [t] is not
+    in the current environment. *)
 
 Ltac2 @ external repr : data -> t := "rocq-runtime.plugins.ltac2" "ind_repr".
-(** Returns the inductive corresponding to the block. Inverse of [data]. *)
+(** Returns the name of the inductive type corresponding to the block. Inverse
+    of [data]. *)
 
 Ltac2 @ external index : t -> int := "rocq-runtime.plugins.ltac2" "ind_index".
 (** Returns the index of the inductive type inside its mutual block. Guaranteed
-    to range between [0] and [nblocks data - 1] where [data] was retrieved
-    using the above function. *)
+    to range between [0] and [nblocks data - 1] where [data] was retrieved using
+    the above function. *)
 
 Ltac2 @ external nblocks : data -> int := "rocq-runtime.plugins.ltac2" "ind_nblocks".
 (** Returns the number of inductive types appearing in a mutual block. *)
@@ -37,14 +43,37 @@ Ltac2 @ external nconstructors : data -> int := "rocq-runtime.plugins.ltac2" "in
 (** Returns the number of constructors appearing in the current block. *)
 
 Ltac2 @ external get_block : data -> int -> data := "rocq-runtime.plugins.ltac2" "ind_get_block".
-(** Returns the block corresponding to the nth inductive type. Index must range
-    between [0] and [nblocks data - 1], otherwise the function panics. *)
+(** [get_block data n] is the block corresponding to the nth inductive type in
+    [data]'s parent mutually inductive type. Index must range between [0] and
+    [nblocks data - 1], otherwise the function panics. *)
 
 Ltac2 @ external get_constructor : data -> int -> constructor := "rocq-runtime.plugins.ltac2" "ind_get_constructor".
 (** Returns the nth constructor of the inductive type. Index must range between
     [0] and [nconstructors data - 1], otherwise the function panics. *)
 
+Ltac2 @ external nparams : data -> int := "rocq-runtime.plugins.ltac2" "ind_get_nparams".
+(** The number of parameters of the inductive type, including both uniform and
+    non-uniform parameters. Does not count local let-ins. *)
+
+Ltac2 @ external nparams_uniform : data -> int := "rocq-runtime.plugins.ltac2" "ind_get_nparams_rec".
+(** The number of recursively uniform (i.e., ordinary) parameters of the
+    inductive type. *)
+
 Ltac2 @ external get_projections : data -> projection array option
   := "rocq-runtime.plugins.ltac2" "ind_get_projections".
 (** Returns the list of projections for a primitive record,
     or [None] if the inductive is not a primitive record. *)
+
+Ltac2 @ external constructor_nargs : data -> int array := "rocq-runtime.plugins.ltac2" "constructor_nargs".
+(** [Array.get (constructor_nargs data) n] is the number of non-parameter
+    arguments accepted by the [n]th constructor of this inductive type. Add
+    [Array.get (constructor_nargs data) n] to [Ind.nparams_data] to get the total
+    number of arguments of the constructor. *)
+
+Ltac2 @ external constructor_ndecls : data -> int array := "rocq-runtime.plugins.ltac2" "constructor_ndecls".
+(** [Array.get (constructor_ndecls data) n] is the number of variables bound in
+    a pattern match expression by the [n]th constructor of this inductive type.
+    Can be greater than [constructor_nargs] if the constructors have local
+    let-bindings, e.g., applied to [Inductive Ind (A : Type) (f : A -> A) : Set
+    := Constr (x : A) (y := f x)] it would return [[|2|]], because in [match t
+    with Constr _ _ x y => e end], [x] and [y] are bound in [e]. *)


### PR DESCRIPTION
Fixes / closes #10940

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.

@SkySkimmer @ppedrot let me know if you have any comments.
- Some of the functionality is simple but the functions that expose a `Constr.rel_context` to the end user, I'm more unsure about, I don't know what invariants these functions should be expected to maintain.
- Perhaps there should be a dedicated Ltac2 `context` type with a similar purpose to `Constr.rel_context`, rather than my ad hoc solution of `(binder * (constr option)) list`?
- There is probably a better place for the function `rel_context_to_local`, but I'm not familiar with the codebase so I don't know where to put it.

I would be okay with dropping the functions which expose a `Constr.rel_context` if this requires more extensive discussion.