### PR TITLE
backport ssrfun.v before release of MathComp 2.4.0

### DIFF
--- a/dev/ci/user-overlays/20478-affeldt-aist-mathcomp-backport.sh
+++ b/dev/ci/user-overlays/20478-affeldt-aist-mathcomp-backport.sh
@@ -1,0 +1,2 @@
+overlay mathcomp https://github.com/proux01/math-comp coq20478 20478
+overlay fcsl_pcm https://github.com/proux01/fcsl-pcm fun_scope 20478

--- a/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_added.rst
+++ b/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  definitions `injective2`, `idempotent_op` and `idempotent_fun` and
+  lemmas `omap_id`, `eq_omap`, `inj_omap`, `omapK`, `inr_inj` and
+  `inl_inj` in `ssrfun.v`
+  (`#20478 <https://github.com/rocq-prover/rocq/pull/20478>`_,
+  by Pierre Roux).

--- a/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_changed.rst
+++ b/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  `%FUN` now delimits scope `function_scope` rather than `fun_scope`
+  in `ssrfun.v`
+  (`#20478 <https://github.com/rocq-prover/rocq/pull/20478>`_,
+  by Pierre Roux).

--- a/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_deprecated.rst
+++ b/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_deprecated.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  `idempotent` in `ssrfun.v`, use `idempotent_op` instead
+  (`#20478 <https://github.com/rocq-prover/rocq/pull/20478>`_,
+  by Pierre Roux).

--- a/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_removed.rst
+++ b/doc/changelog/07-ssreflect/20478-mathcomp_backport_20250407_removed.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  scope `fun_scope` from `ssrfun.v` that was deprecated since 8.20,
+  use `function_scope` instead
+  (`#20478 <https://github.com/rocq-prover/rocq/pull/20478>`_,
+  by Pierre Roux).

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -276,7 +276,7 @@ Require Import ssreflect ssrfun.
   AC -- right commutativity.
  ACA -- self-interchange (inner commutativity), e.g.,
         orbACA : (a || b) || (c || d) = (a || c) || (b || d).
-   b -- a boolean argument, as in andbb : idempotent andb.
+   b -- a boolean argument, as in andbb : idempotent_op andb.
    C -- commutativity, as in andbC : commutative andb,
         or predicate complement, as in predC.
   CA -- left commutativity.
@@ -1033,7 +1033,7 @@ Lemma andTb : left_id true andb.       Proof. by []. Qed.
 Lemma andFb : left_zero false andb.    Proof. by []. Qed.
 Lemma andbT : right_id true andb.      Proof. by case. Qed.
 Lemma andbF : right_zero false andb.   Proof. by case. Qed.
-Lemma andbb : idempotent andb.         Proof. by case. Qed.
+Lemma andbb : idempotent_op andb.      Proof. by case. Qed.
 Lemma andbC : commutative andb.        Proof. by do 2!case. Qed.
 Lemma andbA : associative andb.        Proof. by do 3!case. Qed.
 Lemma andbCA : left_commutative andb.  Proof. by do 3!case. Qed.
@@ -1044,7 +1044,7 @@ Lemma orTb : forall b, true || b.      Proof. by []. Qed.
 Lemma orFb : left_id false orb.        Proof. by []. Qed.
 Lemma orbT : forall b, b || true.      Proof. by case. Qed.
 Lemma orbF : right_id false orb.       Proof. by case. Qed.
-Lemma orbb : idempotent orb.           Proof. by case. Qed.
+Lemma orbb : idempotent_op orb.        Proof. by case. Qed.
 Lemma orbC : commutative orb.          Proof. by do 2!case. Qed.
 Lemma orbA : associative orb.          Proof. by do 3!case. Qed.
 Lemma orbCA : left_commutative orb.    Proof. by do 3!case. Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~~Documented any new / changed **user messages**.~~
  - [ ] ~~Updated **documented syntax** by running `make doc_gram_rsts`.~~

<!-- If this breaks external libraries or plugins in CI: -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
-->
#### Overlays (to be merged before the current PR)

* https://github.com/math-comp/math-comp/pull/1399
* https://github.com/imdea-software/fcsl-pcm/pull/50
