### PR TITLE
Libobject.simple_open only open when depth = 1

### DIFF
--- a/dev/ci/user-overlays/20483-SkySkimmer-simple-open-filtered-open.sh
+++ b/dev/ci/user-overlays/20483-SkySkimmer-simple-open-filtered-open.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi simple-open-filtered-open 20483

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -100,7 +100,7 @@ let inAbbreviation : Id.t -> (bool * abbreviation) -> obj =
   declare_named_object {(default_object "ABBREVIATION") with
     cache_function = cache_abbreviation;
     load_function = load_abbreviation;
-    open_function = simple_open open_abbreviation;
+    open_function = filtered_open open_abbreviation;
     subst_function = subst_abbreviation;
     classify_function = classify_abbreviation }
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1283,12 +1283,9 @@ let subst_prim_token_interpretation (subs,infos) =
 let classify_prim_token_interpretation infos =
     if infos.pt_local then Dispose else Substitute
 
-let open_prim_token_interpretation i o =
-  if Int.equal i 1 then cache_prim_token_interpretation o
-
 let inPrimTokenInterp : prim_token_infos -> obj =
   declare_object {(default_object "PRIM-TOKEN-INTERP") with
-     open_function  = simple_open ~cat:notation_cat open_prim_token_interpretation;
+     open_function  = simple_open ~cat:notation_cat cache_prim_token_interpretation;
      cache_function = cache_prim_token_interpretation;
      subst_function = subst_prim_token_interpretation;
      classify_function = classify_prim_token_interpretation}

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -295,8 +295,8 @@ let option_object name stage act =
       (* Ruled out by classify_function *)
       assert false
   in
-  let open_option i  (l, _ as o) = match l with
-    | OptExport -> if Int.equal i 1 then cache_option o
+  let open_option  (l, _ as o) = match l with
+    | OptExport -> cache_option o
     | OptGlobal -> ()
     | OptLocal | OptDefault ->
       (* Ruled out by classify_function *)

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -114,11 +114,16 @@ val in_filter : cat:category option -> open_filter -> bool
     On [cat:(Some category)], returns whether the filter allows
    opening objects in the given [category]. *)
 
-val simple_open : ?cat:category -> ('i -> 'a -> unit) ->
+val filtered_open : ?cat:category -> ('i -> 'a -> unit) ->
   open_filter -> 'i -> 'a -> unit
 (** Combinator for making objects with simple category-based open
    behaviour. When [cat:None], can be opened by Unfiltered, but also
    by Filtered with a negative set. *)
+
+val simple_open : ?cat:category -> ('a -> unit) ->
+  open_filter -> int -> 'a -> unit
+(** Like [filtered_open], and also requires the int to be 1 to
+    actually open. *)
 
 val filter_eq : open_filter -> open_filter -> bool
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -265,8 +265,6 @@ let cache_tactic_notation (tobj, body) =
   let () = check_key key in
   Tacenv.register_alias key body
 
-let open_tactic_notation i _ = ()
-
 let load_tactic_notation i (tobj, body) =
   let key = tobj.tacobj_key in
   let () = check_key key in
@@ -286,7 +284,7 @@ let ltac_notation_cat = Libobject.create_category "ltac.notations"
 
 let inTacticGrammar : tactic_grammar_obj * Tacenv.alias_tactic -> obj =
   declare_object {(default_object "TacticGrammar") with
-       open_function = simple_open ~cat:ltac_notation_cat open_tactic_notation;
+       (* no open_function for the interp side of tactic notations *)
        load_function = load_tactic_notation;
        cache_function = cache_tactic_notation;
        subst_function = subst_tactic_notation;
@@ -297,9 +295,9 @@ let cache_tactic_syntax tobj =
   extend_tactic_grammar key tobj.tacobj_forml tobj.tacobj_tacgram;
   Pptactic.declare_notation_tactic_pprule key (pprule tobj.tacobj_tacgram)
 
-let open_tactic_syntax i tobj =
+let open_tactic_syntax tobj =
   let key = tobj.tacobj_key in
-  if Int.equal i 1 && not tobj.tacobj_local then
+  if not tobj.tacobj_local then
     extend_tactic_grammar key tobj.tacobj_forml tobj.tacobj_tacgram
 
 let load_tactic_syntax i tobj =
@@ -314,6 +312,7 @@ let subst_tactic_syntax (subst, tobj) =
     tacobj_key = Mod_subst.subst_kn subst tobj.tacobj_key
   }
 
+(* why do we not Drop when local? *)
 let classify_tactic_syntax tacobj = Substitute
 
 let inTacticSyntax : tactic_grammar_obj -> obj =

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -172,7 +172,7 @@ let inMD : tacdef -> obj =
   declare_named_object_gen {(default_object "TAC-DEFINITION") with
      cache_function = cache_md;
      load_function = load_md;
-     open_function = simple_open open_md;
+     open_function = filtered_open open_md;
      subst_function = subst_md;
      classify_function = classify_md}
 
@@ -214,7 +214,9 @@ let inReplace : tacreplace -> obj =
   declare_named_object_gen {(default_object "TAC-REDEFINITION") with
      cache_function = cache_replace;
      load_function = load_replace;
-     open_function = simple_open open_replace;
+     (* should this be simple_open ie only redefine when importing the
+        module containing the redef instead of a parent? *)
+     open_function = filtered_open open_replace;
      subst_function = subst_replace;
      classify_function = classify_replace}
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1209,9 +1209,9 @@ let load_autohint _ h =
   | AddMode { gref; mode } ->
     if superglobal then add_mode name gref mode
 
-let open_autohint i h =
+let open_autohint h =
   let superglobal = superglobal h in
-  if Int.equal i 1 then match h.hint_action with
+  match h.hint_action with
   | AddHints hints ->
     let () =
       if not superglobal then
@@ -1231,7 +1231,7 @@ let open_autohint i h =
     if not superglobal then add_mode h.hint_name gref mode
 
 let cache_autohint o =
-  load_autohint 1 o; open_autohint 1 o
+  load_autohint 1 o; open_autohint o
 
 let subst_autohint (subst, obj) =
   let subst_key gr =

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -10,10 +10,10 @@
 open Libobject
 open Structures
 
-let open_canonical_structure i (o,_) =
+let open_canonical_structure (o,_) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  if Int.equal i 1 then Instance.register env sigma ~warn:false o
+  Instance.register env sigma ~warn:false o
 
 let cache_canonical_structure (o,_) =
   let env = Global.env () in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -117,7 +117,8 @@ let instance_input : instance -> obj =
     { (default_object "type classes instances state") with
       cache_function = cache_instance;
       load_function = load_instance;
-      open_function = simple_open ~cat:Hints.hint_cat open_instance;
+      (* can't simple_open: crappy behaviour when superglobal *)
+      open_function = filtered_open ~cat:Hints.hint_cat open_instance;
       classify_function = classify_instance;
       discharge_function = discharge_instance;
       subst_function = subst_instance }

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -231,10 +231,6 @@ let cache_coercion ?(update=false) c =
   let sigma = Evd.from_env env in
   Coercionops.declare_coercion env sigma ~update c
 
-let open_coercion i o =
-  if Int.equal i 1 then
-    cache_coercion o
-
 let discharge_coercion c =
   if c.coe_local then None
   else
@@ -255,7 +251,7 @@ let coe_cat = create_category "coercions"
 
 let inCoercion : coe_info_typ -> obj =
   declare_object {(default_object "COERCION") with
-    open_function = simple_open ~cat:coe_cat open_coercion;
+    open_function = simple_open ~cat:coe_cat cache_coercion;
     cache_function = cache_coercion;
     subst_function = (fun (subst,c) -> subst_coercion subst c);
     classify_function = classify_coercion;

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -444,7 +444,7 @@ let (objConstant : (Id.t * constant_obj) Libobject.Dyn.tag) =
   declare_named_object_full { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
-    open_function = simple_open open_constant;
+    open_function = filtered_open open_constant;
     classify_function = classify_constant;
     subst_function = ident_subst_function;
     discharge_function = discharge_constant }

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -68,7 +68,7 @@ let objInductive : (Id.t * inductive_obj) Libobject.Dyn.tag =
   declare_named_object_full {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
-    open_function = simple_open open_inductive;
+    open_function = filtered_open open_inductive;
     classify_function = (fun a -> Substitute);
     subst_function = ident_subst_function;
     discharge_function = discharge_inductive;

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -68,7 +68,7 @@ let input_univ_names : universe_name_decl -> Libobject.obj =
     { (default_object "Global universe name state") with
       cache_function = cache_univ_names;
       load_function = load_univ_names;
-      open_function = simple_open open_univ_names;
+      open_function = filtered_open open_univ_names;
       discharge_function = discharge_univ_names;
       classify_function = (fun _ -> Escape) }
 

--- a/vernac/tactic_option.ml
+++ b/vernac/tactic_option.ml
@@ -78,7 +78,8 @@ let declare_tactic_option ?default name =
       { (default_object name) with
         cache_function = cache;
         load_function = load;
-        open_function = simple_open import;
+        (* can't simple_open: crappy behaviour when superglobal *)
+        open_function = filtered_open import;
         classify_function = classify;
         subst_function = subst}
   in


### PR DESCRIPTION
Add filtered_open for those objects which actually need deep opening.

Deep opening should in principle be reserved for name objects, but we observe a number of objects which use it in dubious ways:
- ltac1 and ltac2 tactic redefinitions
- superglobal typeclass instances (https://github.com/rocq-prover/rocq/pull/20486)
- tactic options with default / Global locality
- Enable / Disable Notation (https://github.com/rocq-prover/rocq/pull/20484)

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/800