### PR TITLE
coqdoc recognize "Ltac2" as a Keyword

### DIFF
--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -483,6 +483,7 @@ let gallina_kw_to_hide =
     "Implicit" space+ "Arguments"
   | "Arguments"
   | "Ltac"
+  | "Ltac2"
   | "From"
   | "Require"
   | "Import"


### PR DESCRIPTION
Otherwise it sees "Ltac" followed by "2" and only highlights the "Ltac" part.
