### PR TITLE
Port `rewrite_strat` to Ltac2.

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -257,6 +257,9 @@ let tclBIND = Proof.(>>=)
     it's a specialized "bind". *)
 let tclTHEN = Proof.(>>)
 
+(** Maps a tactic over its result. *)
+let tclMAP = Proof.map
+
 (** [tclIGNORE t] has the same operational content as [t], but drops
     the returned value. *)
 let tclIGNORE = Proof.ignore

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -178,6 +178,9 @@ val tclBIND : 'a tactic -> ('a -> 'b tactic) -> 'b tactic
     it's a specialized "bind". *)
 val tclTHEN : unit tactic -> 'a tactic -> 'a tactic
 
+(** Maps a tactic over its result. *)
+val tclMAP : ('a -> 'b) -> 'a tactic -> 'b tactic
+
 (** [tclIGNORE t] has the same operational content as [t], but drops
     the returned value. *)
 val tclIGNORE : 'a tactic -> unit tactic

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -345,6 +345,9 @@ let std_prefix =
 let ltac1_prefix =
   MPfile (DirPath.make (List.map Id.of_string ["Ltac1"; "Ltac2"]))
 
+let rewrite_prefix =
+  MPfile (DirPath.make (List.map Id.of_string ["Rewrite"; "Ltac2"]))
+
 (** Generic arguments *)
 
 type var_quotation_kind =

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -181,6 +181,9 @@ val std_prefix : ModPath.t
 val ltac1_prefix : ModPath.t
 (** Path where the Ltac1 legacy FFI is defined. *)
 
+val rewrite_prefix : ModPath.t
+(** Path where rewrite strategies are defined in Ltac2 plugin. *)
+
 (** {5 Generic arguments} *)
 
 val wit_ltac2_constr : (raw_tacexpr, Id.Set.t * glb_tacexpr, Util.Empty.t) genarg_type

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -59,6 +59,7 @@ let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = 
 let val_transparent_state : TransparentState.t Val.tag = Val.create "transparent_state"
 let val_pretype_flags = Val.create "pretype_flags"
 let val_expected_type = Val.create "expected_type"
+let val_rewstrategy = Val.create "rewstrategy"
 
 let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
 match Val.eq tag tag' with
@@ -202,6 +203,10 @@ let evar = repr_ext val_evar
 let of_sort ev = of_ext val_sort ev
 let to_sort ev = to_ext val_sort ev
 let sort = repr_ext val_sort
+
+let of_rewstrategy ev = of_ext val_rewstrategy ev
+let to_rewstrategy ev = to_ext val_rewstrategy ev
+let rewstrategy = repr_ext val_rewstrategy
 
 let internal_err =
   let open Names in

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -130,6 +130,10 @@ val of_sort : ESorts.t -> valexpr
 val to_sort : valexpr -> ESorts.t
 val sort : ESorts.t repr
 
+val of_rewstrategy : Rewrite.strategy -> valexpr
+val to_rewstrategy : valexpr -> Rewrite.strategy
+val rewstrategy : Rewrite.strategy repr
+
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
 val pp : Pp.t repr

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -192,6 +192,9 @@ let setoid_rewrite orient c occs id =
   let occs = mk_occurrences occs in
   Rewrite.cl_rewrite_clause (delayed_of_tactic c) orient occs id
 
+let rewrite_strat strat clause =
+  Rewrite.cl_rewrite_clause_strat strat clause
+
 let symmetry cl =
   let cl = mk_clause cl in
   Tactics.intros_symmetry cl
@@ -228,65 +231,82 @@ let get_evaluable_reference = function
 | GlobRef.ConstRef cst -> Proofview.tclUNIT (Evaluable.EvalConstRef cst)
 | r -> Proofview.tclZERO (Tacred.NotEvaluableRef r)
 
+let mk_flags flags =
+  let rConsts = Proofview.Monad.List.map get_evaluable_reference flags.rConst in
+  Proofview.tclMAP (fun rConst -> { flags with rConst }) rConsts
+
+let mk_red_expr : (Tac2types.red_expr -> Redexpr.red_expr Proofview.tactic) =
+  function
+  | Red -> Proofview.tclUNIT Red
+  | Hnf -> Proofview.tclUNIT Hnf
+  | Tac2types.Simpl (flags, occs) ->
+    mk_flags flags >>= fun flags ->
+    let occs = Option.map map_pattern_with_occs occs in
+    Proofview.tclUNIT (Genredexpr.Simpl (flags, occs))
+  | Cbv flags ->
+    Proofview.tclMAP
+      (fun flags -> Cbv flags)
+      (mk_flags flags)
+  | Cbn flags ->
+    Proofview.tclMAP
+      (fun flags -> Cbn flags)
+      (mk_flags flags)
+  | Lazy flags ->
+    Proofview.tclMAP
+      (fun flags -> Lazy flags)
+      (mk_flags flags)
+  | Unfold refs ->
+    let map (gr, occs) = get_evaluable_reference gr >>= fun gr ->
+      Proofview.tclUNIT (mk_occurrences occs, gr)
+    in
+    Proofview.tclMAP (fun refs -> Unfold refs) (Proofview.Monad.List.map map refs)
+  | Fold cs -> Proofview.tclUNIT (Fold cs)
+  | Pattern occs ->
+    let occs = List.map (fun (c, occs) -> (mk_occurrences occs, c)) occs in
+    Proofview.tclUNIT (Pattern occs)
+  | Comp (false, occs) ->
+    let occs = Option.map map_pattern_with_occs occs in
+    Proofview.tclUNIT (CbvVm occs)
+  | Comp (true, occs) ->
+    let occs = Option.map map_pattern_with_occs occs in
+    Proofview.tclUNIT (CbvNative occs)
+
 let reduce r cl =
   let cl = mk_clause cl in
+  mk_red_expr r >>= fun r ->
   Tactics.reduce r cl
 
 let simpl flags where cl =
-  let where = Option.map map_pattern_with_occs where in
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Simpl (flags, where)) cl
+  reduce (Simpl (flags, where)) cl
 
 let cbv flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Cbv flags) cl
+  reduce (Cbv flags) cl
 
 let cbn flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Cbn flags) cl
+  reduce (Cbn flags) cl
 
 let lazy_ flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Lazy flags) cl
+  reduce (Lazy flags) cl
 
 let unfold occs cl =
-  let cl = mk_clause cl in
-  let map (gr, occ) =
-    let occ = mk_occurrences occ in
-    get_evaluable_reference gr >>= fun gr -> Proofview.tclUNIT (occ, gr)
-  in
-  Proofview.Monad.List.map map occs >>= fun occs ->
-  Tactics.reduce (Unfold occs) cl
+  reduce (Unfold occs) cl
 
 let pattern where cl =
-  let where = List.map (fun (c, occ) -> (mk_occurrences occ, c)) where in
-  let cl = mk_clause cl in
-  Tactics.reduce (Pattern where) cl
+  reduce (Pattern where) cl
 
 let vm where cl =
-  let where = Option.map map_pattern_with_occs where in
-  let cl = mk_clause cl in
-  Tactics.reduce (CbvVm where) cl
+  reduce (Comp (false, where)) cl
 
 let native where cl =
-  let where = Option.map map_pattern_with_occs where in
-  let cl = mk_clause cl in
-  Tactics.reduce (CbvNative where) cl
+  reduce (Comp (false, where)) cl
 
 let eval_fun red c =
+  mk_red_expr red >>= fun red ->
   Tac2core.pf_apply begin fun env sigma ->
-  let (redfun, _) = Redexpr.reduction_of_red_expr env red in
-  let (sigma, ans) = redfun env sigma c in
-  Proofview.Unsafe.tclEVARS sigma >>= fun () ->
-  Proofview.tclUNIT ans
+    let (redfun, _) = Redexpr.reduction_of_red_expr env red in
+    let (sigma, ans) = redfun env sigma c in
+    Proofview.Unsafe.tclEVARS sigma >>= fun () ->
+    Proofview.tclUNIT ans
   end
 
 let eval_red c =
@@ -296,48 +316,31 @@ let eval_hnf c =
   eval_fun Hnf c
 
 let eval_simpl flags where c =
-  let where = Option.map map_pattern_with_occs where in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
   eval_fun (Simpl (flags, where)) c
 
 let eval_cbv flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
   eval_fun (Cbv flags) c
 
 let eval_cbn flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
   eval_fun (Cbn flags) c
 
 let eval_lazy flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
   eval_fun (Lazy flags) c
 
 let eval_unfold occs c =
-  let map (gr, occ) =
-    let occ = mk_occurrences occ in
-    get_evaluable_reference gr >>= fun gr -> Proofview.tclUNIT (occ, gr)
-  in
-  Proofview.Monad.List.map map occs >>= fun occs ->
   eval_fun (Unfold occs) c
 
 let eval_fold cl c =
   eval_fun (Fold cl) c
 
 let eval_pattern where c =
-  let where = List.map (fun (pat, occ) -> (mk_occurrences occ, pat)) where in
   eval_fun (Pattern where) c
 
 let eval_vm where c =
-  let where = Option.map map_pattern_with_occs where in
-  eval_fun (CbvVm where) c
+  eval_fun (Comp (false, where)) c
 
 let eval_native where c =
-  let where = Option.map map_pattern_with_occs where in
-  eval_fun (CbvNative where) c
+  eval_fun (Comp (false, where)) c
 
 let on_destruction_arg tac ev arg =
   Proofview.Goal.enter begin fun gl ->

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -49,6 +49,9 @@ val rewrite :
 val setoid_rewrite :
   orientation -> constr_with_bindings tactic -> occurrences -> Id.t option -> unit tactic
 
+val rewrite_strat :
+  Rewrite.strategy -> Id.t option -> unit tactic
+
 val symmetry : clause -> unit tactic
 
 val forward : bool -> unit tactic option option ->
@@ -59,10 +62,12 @@ val assert_ : assertion -> unit tactic
 val letin_pat_tac : evars_flag -> (bool * intro_pattern_naming) option ->
   Name.t -> (Evd.evar_map option * constr) -> clause -> unit tactic
 
-val reduce : Redexpr.red_expr -> clause -> unit tactic
+val mk_red_expr : Tac2types.red_expr -> Redexpr.red_expr tactic
+
+val reduce : Tac2types.red_expr -> clause -> unit tactic
 
 val simpl : GlobRef.t glob_red_flag ->
-  (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+  Tac2types.red_context -> clause -> unit tactic
 
 val cbv : GlobRef.t glob_red_flag -> clause -> unit tactic
 
@@ -74,16 +79,16 @@ val unfold : (GlobRef.t * occurrences) list -> clause -> unit tactic
 
 val pattern : (constr * occurrences) list -> clause -> unit tactic
 
-val vm : (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+val vm : Tac2types.red_context -> clause -> unit tactic
 
-val native : (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+val native : Tac2types.red_context -> clause -> unit tactic
 
 val eval_red : constr -> constr tactic
 
 val eval_hnf : constr -> constr tactic
 
 val eval_simpl : GlobRef.t glob_red_flag ->
-  (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
+  Tac2types.red_context -> constr -> constr tactic
 
 val eval_cbv : GlobRef.t glob_red_flag -> constr -> constr tactic
 
@@ -97,9 +102,9 @@ val eval_fold : constr list -> constr -> constr tactic
 
 val eval_pattern : (EConstr.t * occurrences) list -> constr -> constr tactic
 
-val eval_vm : (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
+val eval_vm : Tac2types.red_context -> constr -> constr tactic
 
-val eval_native : (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
+val eval_native : Tac2types.red_context -> constr -> constr tactic
 
 val discriminate : evars_flag -> destruction_arg option -> unit tactic
 

--- a/plugins/ltac2/tac2types.mli
+++ b/plugins/ltac2/tac2types.mli
@@ -94,3 +94,19 @@ type rewriting =
 type assertion =
 | AssertType of intro_pattern option * constr * unit thunk option
 | AssertValue of Id.t * constr
+
+type red_flag = Names.GlobRef.t Genredexpr.glob_red_flag
+
+type red_context = (Pattern.constr_pattern * occurrences) option
+
+type red_expr =
+| Red
+| Hnf
+| Simpl of red_flag * red_context
+| Cbv of red_flag
+| Cbn of red_flag
+| Lazy of red_flag
+| Unfold of (Names.GlobRef.t * occurrences) list
+| Fold of constr list
+| Pattern of (constr * occurrences) list
+| Comp of (bool * red_context)

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -875,6 +875,11 @@ let apply_rule unify : occurrences_count pure_strategy =
               (occs, res)
     }
 
+let with_no_bindings (c : delayed_open_constr) : delayed_open_constr_with_bindings =
+  (); fun env sigma ->
+    let (sigma, c) = c env sigma in
+    (sigma, (c, NoBindings))
+
 let apply_lemma l2r flags oc by loccs : strategy = { strategy =
   fun ({ state = () ; env ; term1 = t ; evars = (sigma, cstrs) } as input) ->
     let sigma, c = oc sigma in
@@ -1219,9 +1224,6 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
       | _ -> state, Fail
   in { strategy = aux }
 
-let all_subterms = subterm true default_flags
-let one_subterm = subterm false default_flags
-
 (** Requires transitivity of the rewrite step, if not a reduction.
     Not tail-recursive. *)
 
@@ -1338,49 +1340,70 @@ module Strategies =
       let rec aux input = (f { strategy = fun input -> check_interrupt aux input }).strategy input in
       { strategy = aux }
 
+    let fix_tac (f : 'a pure_strategy -> 'a pure_strategy Proofview.tactic) : 'a pure_strategy Proofview.tactic =
+      let forward_def = ref (fun _ -> assert false) in
+      f {strategy = fun input -> check_interrupt !forward_def input} >>= fun f ->
+      forward_def := f.strategy;
+      Proofview.tclUNIT f
+
+    let all_subterms (s : strategy) : strategy = subterm true default_flags s
+
+    let one_subterm (s : strategy) : strategy = subterm false default_flags s
+
     let any (s : 'a pure_strategy) : 'a pure_strategy =
       fix (fun any -> try_ (seq s any))
 
     let repeat (s : 'a pure_strategy) : 'a pure_strategy =
       seq s (any s)
 
-    let bu (s : 'a pure_strategy) : 'a pure_strategy =
+    let bottomup (s : strategy) : strategy =
       fix (fun s' -> seq (choice (progress (all_subterms s')) s) (try_ s'))
 
-    let td (s : 'a pure_strategy) : 'a pure_strategy =
+    let topdown (s : strategy) : strategy =
       fix (fun s' -> seq (choice s (progress (all_subterms s'))) (try_ s'))
 
-    let innermost (s : 'a pure_strategy) : 'a pure_strategy =
+    let innermost (s : strategy) : strategy =
       fix (fun ins -> choice (one_subterm ins) s)
 
-    let outermost (s : 'a pure_strategy) : 'a pure_strategy =
+    let outermost (s : 'a pure_strategy) : strategy =
       fix (fun out -> choice s (one_subterm out))
 
-    let lemmas cs : 'a pure_strategy =
-      List.fold_left (fun tac (l,l2r,by) ->
-        choice tac (apply_lemma l2r rewrite_unif_flags l by AllOccurrences))
+    let one_lemma c l2r by occs : strategy =
+      let strategy ({env} as input) =
+        let c sigma = with_no_bindings c env sigma in
+        let flags = general_rewrite_unif_flags () in
+        (apply_lemma l2r flags c by occs).strategy input
+      in {strategy}
+
+    let lemmas cs : strategy =
+      List.fold_left (fun tac (l,l2r,by) -> choice tac (one_lemma l l2r by AllOccurrences))
         fail cs
 
-    let inj_open hint = (); fun sigma ->
+    let inj_open hint = (); fun _env sigma ->
       let (ctx, lemma) = Autorewrite.RewRule.rew_lemma hint in
       let subst, ctx = UnivGen.fresh_universe_context_set_instance ctx in
       let subst = Sorts.QVar.Map.empty, subst in
       let lemma = Vars.subst_univs_level_constr subst (EConstr.of_constr lemma) in
       let sigma = Evd.merge_context_set UnivRigid sigma ctx in
-      (sigma, (lemma, NoBindings))
+      (sigma, lemma)
 
-    let old_hints (db : string) : 'a pure_strategy =
+    let old_hints (db : string) : strategy =
       let rules = Autorewrite.find_rewrites db in
         lemmas
-          (List.map (fun hint -> (inj_open hint, Autorewrite.RewRule.rew_l2r hint,
-                                  Autorewrite.RewRule.rew_tac hint)) rules)
+          (List.map (fun hint -> (inj_open hint,
+                                  Autorewrite.RewRule.rew_l2r hint,
+                                  Autorewrite.RewRule.rew_tac hint
+                                 )
+                    ) rules)
 
-    let hints (db : string) : 'a pure_strategy = { strategy =
+    let hints (db : string) : strategy = { strategy =
       fun ({ term1 = t; env } as input) ->
       let t = EConstr.Unsafe.to_constr t in
       let rules = Autorewrite.find_matches env db t in
-      let lemma hint = (inj_open hint, Autorewrite.RewRule.rew_l2r hint,
-                        Autorewrite.RewRule.rew_tac hint) in
+      let lemma hint = (inj_open hint,
+                        Autorewrite.RewRule.rew_l2r hint,
+                        Autorewrite.RewRule.rew_tac hint
+                       ) in
       let lems = List.map lemma rules in
       (lemmas lems).strategy input
                                                  }
@@ -1398,24 +1421,28 @@ module Strategies =
                                rew_evars = sigma, cstrevars evars }
                                                            }
 
-    let fold_glob c : 'a pure_strategy = { strategy =
-      fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
-(*         let sigma, (c,_) = Tacinterp.interp_open_constr_with_bindings is env (goalevars evars) c in *)
-        let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
-        let unfolded = match Tacred.red_product env sigma c with
+    let run_fold_in env evars c term typ : rewrite_result =
+      let c = match Tacred.red_product env (goalevars evars) c with
         | None -> user_err Pp.(str "fold: the term is not unfoldable!")
         | Some c -> c
-        in
-          try
-            let _, sigma = Unification.w_unify env sigma CONV ~flags:(Unification.elim_flags ()) unfolded t in
-            let c' = Reductionops.nf_evar sigma c in
-              state, Success { rew_car = ty; rew_from = t; rew_to = c';
-                                  rew_prf = RewCast DEFAULTcast;
-                                  rew_evars = (sigma, snd evars) }
-          with e when CErrors.noncritical e -> state, Fail
-                                         }
+      in try
+        let _, sigma = Unification.w_unify env (goalevars evars) CONV ~flags:(Unification.elim_flags ()) c term in
+        let c' = Reductionops.nf_evar sigma c in
+        Success { rew_car = typ; rew_from = term; rew_to = c';
+                         rew_prf = RewCast DEFAULTcast;
+                         rew_evars = (sigma, cstrevars evars) }
+      with e when CErrors.noncritical e -> Fail
 
+    let fold c : 'a pure_strategy =
+      { strategy = fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
+            state, run_fold_in env evars c t ty
+      }
 
+    let fold_glob c : 'a pure_strategy =
+      { strategy = fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
+            let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
+            state, run_fold_in env (sigma, cstrevars evars) c t ty
+      }
 end
 
 (** The strategy for a single rewrite, dealing with occurrences. *)
@@ -1623,21 +1650,6 @@ let cl_rewrite_clause l left2right occs clause =
 let cl_rewrite_clause_strat strat clause =
   cl_rewrite_clause_strat false strat clause
 
-let apply_glob_constr ((_, c) : _ * EConstr.t delayed_open) l2r occs = (); fun ({ state = () ; env = env } as input) ->
-  let c sigma =
-    let (sigma, c) = c env sigma in
-    (sigma, (c, NoBindings))
-  in
-  let flags = general_rewrite_unif_flags () in
-  (apply_lemma l2r flags c None occs).strategy input
-
-let interp_glob_constr_list env =
-  let make c = (); fun sigma ->
-    let sigma, c = Pretyping.understand_tcc env sigma c in
-    (sigma, (c, NoBindings))
-  in
-  List.map (fun c -> make c, true, None)
-
 (* Syntax for rewriting with strategies *)
 
 type unary_strategy =
@@ -1728,12 +1740,12 @@ let rec strategy_of_ast bindings = function
   | StratUnary (f, s) ->
     let s' = strategy_of_ast bindings s in
     let f' = match f with
-      | Subterms -> all_subterms
-      | Subterm -> one_subterm
+      | Subterms -> Strategies.all_subterms
+      | Subterm -> Strategies.one_subterm
       | Innermost -> Strategies.innermost
       | Outermost -> Strategies.outermost
-      | Bottomup -> Strategies.bu
-      | Topdown -> Strategies.td
+      | Bottomup -> Strategies.bottomup
+      | Topdown -> Strategies.topdown
       | Progress -> Strategies.progress
       | Try -> Strategies.try_
       | Any -> Strategies.any
@@ -1751,13 +1763,9 @@ let rec strategy_of_ast bindings = function
       | [] -> assert false
       | s::strs -> List.fold_left Strategies.choice s strs
     end
-  | StratConstr (c, b) -> { strategy = apply_glob_constr c b AllOccurrences }
+  | StratConstr ((_, c), b) -> Strategies.one_lemma c b None AllOccurrences
   | StratHints (old, id) -> if old then Strategies.old_hints id else Strategies.hints id
-  | StratTerms l -> { strategy =
-    (fun ({ state = () ; env } as input) ->
-     let l' = interp_glob_constr_list env (List.map fst l) in
-     (Strategies.lemmas l').strategy input)
-                    }
+  | StratTerms l -> Strategies.lemmas (List.map (fun (_, c) -> (c, true, None)) l)
   | StratEval r -> { strategy =
     (fun ({ state = () ; env ; evars } as input) ->
      let (sigma, r_interp) = r env (goalevars evars) in

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -104,6 +104,39 @@ val apply_strategy :
   bool * constr ->
   evars -> rewrite_result
 
+module Strategies :
+sig
+  val fail : strategy
+  val id : strategy
+  val refl : strategy
+  val progress : strategy -> strategy
+  val seq : strategy -> strategy -> strategy
+  val choice : strategy -> strategy -> strategy
+  val try_ : strategy -> strategy
+
+  val fix_tac : (strategy -> strategy Proofview.tactic) -> strategy Proofview.tactic
+  val fix : (strategy -> strategy) -> strategy
+
+  val any : strategy -> strategy
+  val repeat : strategy -> strategy
+  val all_subterms : strategy -> strategy
+  val one_subterm : strategy -> strategy
+  val bottomup : strategy -> strategy
+  val topdown : strategy -> strategy
+  val innermost : strategy -> strategy
+  val outermost : strategy -> strategy
+
+  val one_lemma : delayed_open_constr -> bool -> Gentactic.glob_generic_tactic option -> Locus.occurrences -> strategy
+  val lemmas : (delayed_open_constr * bool * Gentactic.glob_generic_tactic option) list -> strategy
+
+  val old_hints : string -> strategy
+  val hints : string -> strategy
+  val reduce : Redexpr.red_expr -> strategy
+
+  val fold : constr -> strategy
+  val fold_glob : Glob_term.glob_constr -> strategy
+end
+
 module Internal :
 sig
 val build_signature :

--- a/test-suite/ltac2/rewrite_strat.v
+++ b/test-suite/ltac2/rewrite_strat.v
@@ -1,0 +1,123 @@
+Require Import Setoid.
+
+From Ltac2 Require Import Ltac2.
+From Ltac2 Require Import Std.
+From Ltac2 Require Import Rewrite.
+
+Parameter X : Set.
+
+Parameter f : X -> X.
+Parameter g : X -> X -> X.
+Parameter h : nat -> X -> X.
+
+Parameter lem0 : forall x, f (f x) = f x.
+Parameter lem1 : forall x, g x x = f x.
+Parameter lem2 : forall n x, h (S n) x = g (h n x) (h n x).
+Parameter lem3 : forall x, h 0 x = x.
+
+#[export] Hint Rewrite lem0 lem1 lem2 lem3 : rew.
+
+Goal forall x, h 6 x = f x.
+  intros.
+  time (rewrite_strat (Rewrite.topdown (Rewrite.term preterm:(lem2) true)) None).
+  time (rewrite_strat (Rewrite.topdown (Rewrite.term preterm:(lem1) true)) None).
+  time (rewrite_strat (Rewrite.topdown (Rewrite.term preterm:(lem0) true)) None).
+  time (rewrite_strat (Rewrite.topdown (Rewrite.term preterm:(lem3) true)) None).
+  reflexivity ().
+Undo 5.
+  time (rewrite_strat (Rewrite.topdown
+          (Rewrite.choice
+             (Rewrite.term preterm:(lem2) true)
+             (Rewrite.term preterm:(lem1) true)
+       )) None).
+  time (rewrite_strat (Rewrite.topdown
+          (Rewrite.choice
+             (Rewrite.term preterm:(lem0) true)
+             (Rewrite.term preterm:(lem3) true)
+       )) None).
+  reflexivity ().
+Undo 3.
+time (rewrite_strat (Rewrite.seq
+                       (Rewrite.topdown
+                          (Rewrite.choice
+                             (Rewrite.term preterm:(lem2) true)
+                             (Rewrite.term preterm:(lem1) true)
+                       ))
+                       (Rewrite.topdown
+                          (Rewrite.choice
+                             (Rewrite.term preterm:(lem0) true)
+                             (Rewrite.term preterm:(lem3) true)
+                          ))
+       ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (Rewrite.topdown
+                         (Rewrite.choice
+                              (Rewrite.choice
+                                 (Rewrite.term preterm:(lem2) true)
+                                 (Rewrite.term preterm:(lem1) true)
+                              )
+                              (Rewrite.choice
+                                 (Rewrite.term preterm:(lem0) true)
+                                 (Rewrite.term preterm:(lem3) true)
+                              )
+                         )
+          ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (Rewrite.topdown
+                         (Rewrite.choice
+                              (Rewrite.term preterm:(lem2) true)
+                              (Rewrite.choice
+                                 (Rewrite.term preterm:(lem1) true)
+                                 (Rewrite.choice
+                                    (Rewrite.term preterm:(lem0) true)
+                                    (Rewrite.term preterm:(lem3) true)
+                                 )
+                            )
+                         )
+       ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (Rewrite.topdown
+                         (Rewrite.choices [
+                              (Rewrite.term preterm:(lem2) true);
+                              (Rewrite.term preterm:(lem1) true);
+                              (Rewrite.term preterm:(lem0) true);
+                              (Rewrite.term preterm:(lem3) true)
+                            ]
+                         )
+          ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (Rewrite.fix_
+                         (fun f =>
+                            Rewrite.seq
+                              (Rewrite.choices [
+                                   (Rewrite.term preterm:(lem2) true);
+                                   (Rewrite.term preterm:(lem1) true);
+                                   (Rewrite.term preterm:(lem0) true);
+                                   (Rewrite.term preterm:(lem3) true);
+                                   (Rewrite.progress (Rewrite.subterms f))
+                                 ])
+                            (Rewrite.try f)
+                         )
+       ) None).
+  reflexivity ().
+Qed.
+
+Goal forall x, h 10 x = f x.
+Proof.
+  intros.
+  time (rewrite_strat (Rewrite.topdown (hints @rew)) None).
+  reflexivity ().
+Qed.
+
+Set Printing All.
+Set Printing Depth 100000.
+
+Ltac2 Notation "my_rewrite_strat" x(preterm) := rewrite_strat (Rewrite.topdown (Rewrite.term x true)) None.
+Goal (forall x, S x = 0) -> 1 = 0.
+intro H.
+my_rewrite_strat H.
+Abort.

--- a/test-suite/success/rewrite_strat.v
+++ b/test-suite/success/rewrite_strat.v
@@ -35,7 +35,7 @@ Undo 3.
   Time rewrite_strat (topdown (choice lem2 lem1); topdown (choice lem0 lem3)).
   reflexivity.
 Undo 2.
-  Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).
+  Time rewrite_strat (topdown (choice (choice lem2 lem1) (choice lem0 lem3))).
   reflexivity.
 Undo 2.
   Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -41,6 +41,8 @@ Ltac2 Type constr.
 Ltac2 Type preterm.
 Ltac2 Type binder.
 
+Ltac2 Type rewstrategy.
+
 Ltac2 Type message.
 Ltac2 Type ('a, 'b, 'c, 'd) format.
 Ltac2 Type exn := [ .. ].

--- a/user-contrib/Ltac2/Rewrite.v
+++ b/user-contrib/Ltac2/Rewrite.v
@@ -1,0 +1,124 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+From Ltac2 Require Import Init.
+From Ltac2 Require Import Std.
+
+Ltac2 Type t := rewstrategy.
+
+(** Failure. *)
+Ltac2 @external fail : unit -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_fail".
+
+(** Success without progress. *)
+Ltac2 @external id : unit -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_id".
+
+(** Success with progress. *)
+Ltac2 @external refl : t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_refl".
+
+(** Applies the argument and fails if no progress was made. *)
+Ltac2 @external progress : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_progress".
+
+(** Applies left, and then right if left succeeded.  *)
+Ltac2 @external seq : t -> t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_seq".
+
+(** Equivalent to [List.fold_left seq (id ())]. *)
+Ltac2 @external seqs : t list -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_seqs".
+
+(** Applies left, and then right if left failed. *)
+Ltac2 @external choice : t -> t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_choice".
+
+(** Equivalent to [List.fold_left choice (fail ())]. *)
+Ltac2 @external choices : t list -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_choices".
+
+(** Equivalent to [choice s (id ())]. *)
+Ltac2 @external try : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_try".
+
+(** Applies the argument until it fails. *)
+Ltac2 @external any : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_any".
+
+(** Equivalent to [seq s (any s)]. *)
+Ltac2 @external repeat : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_repeat".
+
+(** Applies the argument to all immediate subterms of the considered term,
+left-to-right. *)
+Ltac2 @external subterms : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_all_subterms".
+
+(** Applies the argument to the leftmost immediate subterm of the considered
+term on which progress can be made. *)
+Ltac2 @external subterm : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_one_subterm".
+
+(** Traverses the term bottom-up--left-to-right and applies the argument at each
+step as many times as possible. *)
+Ltac2 @external bottomup : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_bottomup".
+
+(** Traverses the term top-down--left-to-right and applies the argument at each
+step as many times as possible. *)
+Ltac2 @external topdown : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_topdown".
+
+(** Traverses the term bottom-up--left-to-right until the argument makes progress. *)
+Ltac2 @external innermost : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_innermost".
+
+(** Traverses the term top-down--left-to-right until the argument makes progress. *)
+Ltac2 @external outermost : t -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_outermost".
+
+(** Unifies the one side of the lemma with the current subterm and on success
+rewrite it to the other side. If the boolean argument is true, rewrites
+left-to-right; otherwise, rewrites right-to-left. *)
+Ltac2 @external term : preterm -> bool -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_one_lemma".
+
+(** Equivalent to [choices (List.map (fun c => term c true)) l]. *)
+Ltac2 @external terms : preterm list -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_lemmas".
+
+(* TODO @radrow this needs documentation *)
+Ltac2 @external old_hints : ident -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_old_hints".
+
+(** Applies hints from rewrite hint database. *)
+Ltac2 @external hints : ident -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_hints".
+
+(** Applies reduction on the term under consideration. *)
+Ltac2 @external eval : reduction -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_reduce".
+
+(** Replaces the term under consideration with the argument if they unify. *)
+Ltac2 @external fold : preterm -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_fold".
+
+(** Fixed point operation for recursive strategies. [fix (fun f => s)] evaluates to
+[s[f / fix (fun f => s)]]. The function provided in the argument is executed only
+_once_ when the strategy is constructed — it cannot be used for dynamically
+manage the rewriting. *)
+Ltac2 @external fix_ : (t -> t) -> t :=
+  "rocq-runtime.plugins.ltac2" "rewstrat_fix".
+
+(* Tactics *)
+
+Ltac2 rewrite_db (hintdb : ident) (i : ident option) : unit :=
+  Std.rewrite_strat (topdown (hints hintdb)) i.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #20482

This PR ports generalized rewriting via `rewrite_strat` to Ltac2. Additionally, it adds Ltac2 representation of reduction expressions which are needed for the `eval` strategy. 

- Adds an opaque Ltac2 type for rewrite strategies
- Implements `rewrite_strat` for Ltac2 to evaluate said strategies with the existing rewriting engine
- Adds an opaque Ltac2 type for reduction expressions
- Centralizes logic of reduction tactics for less duplication

----

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
