### PR TITLE
Ltac2 declare Control.independent of which [enter] is an alias

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -555,14 +555,14 @@ represent several goals, including none. Thus, there is no such thing as
 *the current goal*. Goals are naturally ordered, though.
 
 It is natural to do the same in Ltac2, but we must provide a way to get access
-to a given goal. This is the role of the `enter` primitive, which applies a
+to a given goal. This is the role of the `independent` primitive, which applies a
 tactic to each currently focused goal in turn::
 
-  val enter : (unit -> unit) -> unit
+  val independent : (unit -> unit) -> unit
 
-It is guaranteed that when evaluating `enter f`, `f` is called with exactly one
+It is guaranteed that when evaluating `independent f`, `f` is called with exactly one
 goal under focus. Note that `f` may be called several times, or never, depending
-on the number of goals under focus before the call to `enter`.
+on the number of goals under focus before the call to `independent`.
 
 Accessing the goal data is then implicit in the Ltac2 primitives, and may panic
 if the invariants are not respected. The two essential functions for observing

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1053,9 +1053,8 @@ let () =
 
 (** (unit -> unit) -> unit *)
 let () =
-  define "enter" (thunk unit @-> tac unit) @@ fun f ->
-  let f = Proofview.tclIGNORE (thaw f) in
-  Proofview.tclINDEPENDENT f
+  define "independent" (thunk unit @-> tac unit) @@ fun f ->
+  Proofview.tclINDEPENDENT (thaw f)
 
 (** int -> int -> (unit -> 'a) -> 'a *)
 let () =

--- a/user-contrib/Ltac2/Control.v
+++ b/user-contrib/Ltac2/Control.v
@@ -61,8 +61,11 @@ Ltac2 @ external extend : (unit -> unit) list -> (unit -> unit) -> (unit -> unit
     [e] to all tactics in between. Raises Internal err if [length b + length r]
     is greater than the number of goals under focus.*)
 
-Ltac2 @ external enter : (unit -> unit) -> unit := "rocq-runtime.plugins.ltac2" "enter".
-(** [enter] takes a single tactic [t] and applies [t] in each goal under focus independently. *)
+Ltac2 @external independent : (unit -> unit) -> unit := "rocq-runtime.plugins.ltac2" "independent".
+(** [independent] takes a single tactic [t] and applies [t] in each goal under focus independently. *)
+
+Ltac2 enter := independent.
+(** Alias for [independent]. *)
 
 Ltac2 @ external focus : int -> int -> (unit -> 'a) -> 'a := "rocq-runtime.plugins.ltac2" "focus".
 (** [focus i j tac] focuses a proofview on the goals from index [i] to


### PR DESCRIPTION
The "enter" name is used in ocaml separately from tclINDEPENDENT because it comes with a Goal.t value instead of unit, but in ltac2 it makes more sense IMO to call it "independent".
