### PR TITLE
Ltac2 `only` notation parse ints at level 0

### DIFF
--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -101,7 +101,7 @@ Ltac2 Notation unshelve := Control.unshelve.
 
 Ltac2 cycle := Control.cycle.
 
-Ltac2 Notation "only" startgoal(tactic) endgoal(opt(seq("-", tactic))) ":" tac(thunk(tactic)) :=
+Ltac2 Notation "only" startgoal(tactic(0)) endgoal(opt(seq("-", tactic(0)))) ":" tac(thunk(tactic)) :=
   Control.focus startgoal (Option.default startgoal endgoal) tac.
 
 Ltac2 progress0 tac := Control.enter (fun _ => Control.progress tac).


### PR DESCRIPTION
something like `only Int.add 1 2 - Int.add 2 3 : tac` seems to work currently but IDK that we want to allow it, let's be conservative and force it to be `only (Int.add 1 2) - (Int.add 2 3) : tac`
