### PR TITLE
Use record instead of tuple for UVars.bound_names

### DIFF
--- a/dev/ci/user-overlays/20496-LeoAlexElouan-clarify-bound-names.sh
+++ b/dev/ci/user-overlays/20496-LeoAlexElouan-clarify-bound-names.sh
@@ -1,0 +1,4 @@
+overlay coq_lsp https://github.com/LeoAlexElouan/coq-lsp clarify-bound-names 20496
+overlay lean_importer https://github.com/LeoAlexElouan/rocq-lean-import clarify-bound-names 20496
+overlay metarocq https://github.com/LeoAlexElouan/metarocq clarify-bound-names 20496
+overlay paramcoq https://github.com/LeoAlexElouan/paramcoq clarify-bound-names 20496

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -302,7 +302,7 @@ let ppnamedcontextval e =
   pp (pr_named_context env sigma (named_context_of_val e))
 
 let ppaucontext auctx =
-  let qnas, unas = AbstractContext.names auctx in
+  let {quals = qnas; univs = unas} = AbstractContext.names auctx in
   let prgen pr var_index nas l = match var_index l with
     | Some n -> (match nas.(n) with
         | Anonymous -> pr l

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -357,7 +357,7 @@ let sort_context_set uctx =
 let constraints uctx = snd uctx.local
 
 let compute_instance_binders uctx inst =
-  let (qrev,urev) = snd uctx.names in
+  let (qrev, urev) = snd uctx.names in
   let qinst, uinst = Instance.to_array inst in
   let qmap = function
     | QVar q ->
@@ -370,7 +370,7 @@ let compute_instance_binders uctx inst =
     try Name (Option.get (Level.Map.find lvl urev).uname)
     with Option.IsNone | Not_found -> Anonymous
   in
-  Array.map qmap qinst, Array.map umap uinst
+  {quals = Array.map qmap qinst; univs =  Array.map umap uinst}
 
 let context uctx =
   let qvars = QState.undefined uctx.sort_variables in

--- a/kernel/cPrimitives.ml
+++ b/kernel/cPrimitives.ml
@@ -308,7 +308,7 @@ and ind_or_type =
   | PITT_param : int -> ind_or_type (* DeBruijn index referring to prenex type quantifiers *)
 
 let one_univ =
-  AbstractContext.make ([||],Names.[|Name (Id.of_string "u")|]) Constraints.empty
+  AbstractContext.make { quals = [||]; univs = Names.[|Name (Id.of_string "u")|]} Constraints.empty
 
 let typ_univs (type a) (t : a prim_type) = match t with
   | PT_int63 -> AbstractContext.empty

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -315,7 +315,7 @@ let check_no_increment ~template_univs u =
 
 let make_template_univ_names (u:UVars.Instance.t) : UVars.bound_names =
   let qlen, ulen = UVars.Instance.length u in
-  Array.make qlen Anonymous, Array.make ulen Anonymous
+  {quals = Array.make qlen Anonymous; univs = Array.make ulen Anonymous}
 
 let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
 | Monomorphic_ind_entry | Polymorphic_ind_entry _ -> mie, None, None

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -59,7 +59,7 @@ end = struct
 
   let to_variance_opt o = Option.cata to_variance Invariant o
 
-  let infer_level_eq u variances =
+  let infer_level_eq u (variances : variances) =
     match Level.Map.find_opt u variances.univs with
     | None -> variances
     | Some (Check, expected) ->
@@ -98,7 +98,7 @@ end = struct
     if Level.Map.is_empty univs then raise TrivialVariance;
     {univs; orig_array=us; infer_mode=true}
 
-  let finish variances =
+  let finish (variances : variances) =
     Array.map
       (fun (u,_check) -> to_variance_opt (Option.map snd (Level.Map.find_opt u variances.univs)))
       variances.orig_array

--- a/kernel/uVars.mli
+++ b/kernel/uVars.mli
@@ -97,7 +97,12 @@ val in_punivs : 'a -> 'a puniverses
 
 val eq_puniverses : ('a -> 'a -> bool) -> 'a puniverses -> 'a puniverses -> bool
 
-type bound_names = Names.Name.t array * Names.Name.t array
+
+type bound_names = {
+  quals: Names.Name.t array;
+  univs: Names.Name.t array
+}
+val empty_bound_names : bound_names
 
 (** A vector of universe levels with universe Constraints.t,
     representing local universe variables and associated Constraints.t;

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -188,7 +188,7 @@ let u_ident = Id.of_string "u"
 
 let universe_binders_with_opt_names orig names =
   let open Univ in
-  let qorig, uorig = UVars.AbstractContext.names orig in
+  let {UVars.quals = qorig; UVars.univs = uorig} = UVars.AbstractContext.names orig in
   let qorig, uorig as orig = Array.to_list qorig, Array.to_list uorig in
   let qdecl, udecl = match names with
   | None -> orig

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -14,7 +14,7 @@ let evil name name_f =
   let tc = mkConst tc in
 
   let fe = Declare.definition_entry
-      ~univs:(UState.Polymorphic_entry (UContext.make ([||],[|Anonymous|]) (Instance.of_array ([||],[|u|]),Constraints.empty)), UnivNames.empty_binders)
+      ~univs:(UState.Polymorphic_entry (UContext.make {quals = [||]; univs= [|Anonymous|]} (Instance.of_array ([||],[|u|]),Constraints.empty)), UnivNames.empty_binders)
       ~types:(Term.mkArrowR tc tu)
       (mkLambda (Context.nameR (Id.of_string "x"), tc, mkRel 1))
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -746,7 +746,7 @@ let declare_variable ~name ~kind ~typing_flags d =
           Global.push_section_context uctx;
           let mk_anon_names u =
             let qs, us = UVars.Instance.to_array u in
-            Array.make (Array.length qs) Anonymous, Array.make (Array.length us) Anonymous
+            {UVars.quals = Array.make (Array.length qs) Anonymous; UVars.univs = Array.make (Array.length us) Anonymous}
           in
           Global.push_section_context
             (UVars.UContext.of_context_set mk_anon_names Sorts.QVar.Set.empty body_uctx);

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -156,7 +156,7 @@ let do_universe ~poly l =
     let names = CArray.map_of_list (fun (na,_) -> Name na) l in
     let us = CArray.map_of_list (fun (_,l) -> Level.make l) l in
     let ctx =
-      UVars.UContext.make ([||],names) (UVars.Instance.of_array ([||],us), Constraints.empty)
+      UVars.UContext.make {quals = [||]; univs = names} (UVars.Instance.of_array ([||],us), Constraints.empty)
     in
     Global.push_section_context ctx
 
@@ -174,7 +174,7 @@ let do_constraint ~poly l =
     Global.push_context_set uctx
   | true ->
     let uctx = UVars.UContext.make
-        ([||],[||])
+        UVars.empty_bound_names
         (UVars.Instance.empty,constraints)
     in
     Global.push_section_context uctx


### PR DESCRIPTION
Changed bound names to a record to know more easily what the fields refer to. 

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [X] Added / updated **test-suite**.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/946