### PR TITLE
Unify nametab APIs using functors

### DIFF
--- a/engine/univNames.ml
+++ b/engine/univNames.ml
@@ -39,7 +39,7 @@ let pr_level_with_global_universes ?(binders=empty_binders) l =
 let qualid_of_quality (ctx,_) q =
   match Sorts.QVar.repr q with
   | Global qid ->
-    (try Some (Nametab.shortest_qualid_of_quality ctx qid)
+    (try Some (Nametab.Quality.shortest_qualid_gen (fun id -> Id.Map.mem id ctx) qid)
      with Not_found -> None)
   | _ -> None
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1250,7 +1250,7 @@ let intern_qvar ~local_univs = function
     match local with
     | Some u -> GQVar u
     | None ->
-      try GQVar (Sorts.QVar.make_global (Nametab.locate_quality qid))
+      try GQVar (Sorts.QVar.make_global (Nametab.Quality.locate qid))
       with Not_found ->
         if is_id && local_univs.unb_univs
         then GLocalQVar (CAst.make ?loc:qid.loc (Name (qualid_basename qid)))

--- a/lib/deprecation.ml
+++ b/lib/deprecation.ml
@@ -13,6 +13,7 @@ type 'a with_qf = { depr : t; use_instead : 'a option }
 
 let drop_qf { depr } = depr
 let with_empty_qf depr = { depr; use_instead = None }
+let map_qf f { depr; use_instead } = { depr; use_instead = Option.map f use_instead }
 
 let make ?since ?note () = { since ; note }
 let make_with_qf depr ?use_instead () = { depr; use_instead }

--- a/lib/deprecation.mli
+++ b/lib/deprecation.mli
@@ -13,6 +13,7 @@ type 'a with_qf = { depr : t; use_instead : 'a option }
 
 val drop_qf : 'a with_qf -> t
 val with_empty_qf : t -> 'a with_qf
+val map_qf : ('a -> 'b) -> 'a with_qf -> 'b with_qf
 
 val make : ?since:string -> ?note:string -> unit -> t
 val make_with_qf : t -> ?use_instead:'qf -> unit -> 'qf with_qf

--- a/lib/userWarn.ml
+++ b/lib/userWarn.ml
@@ -22,6 +22,10 @@ let with_empty_qf { depr; warn } = { depr_qf = Option.map Deprecation.with_empty
 let empty = { depr = None; warn = [] }
 let map_qf f { depr_qf; warn_qf } = { depr_qf = Option.map (Deprecation.map_qf f) depr_qf; warn_qf }
 
+let is_empty { depr; warn } = Option.is_empty depr && CList.is_empty warn
+
+let is_empty_qf { depr_qf; warn_qf } = Option.is_empty depr_qf && CList.is_empty warn_qf
+
 let make_warn ~note ?cats () =
   let l = String.split_on_char ',' (Option.default "" cats) in
   let l =

--- a/lib/userWarn.mli
+++ b/lib/userWarn.mli
@@ -19,6 +19,7 @@ type 'a with_qf = { depr_qf : 'a Deprecation.with_qf option; warn_qf : warn list
 
 val drop_qf : 'a with_qf -> t
 val with_empty_qf : t -> 'a with_qf
+val map_qf : ('a -> 'b) -> 'a with_qf -> 'b with_qf
 
 val empty : t
 
@@ -31,3 +32,8 @@ val create_depr_and_user_warnings : ?default:CWarnings.status ->
   object_name:string -> warning_name_base:string ->
   ('a -> Pp.t) -> unit ->
   ?loc:Loc.t -> 'a -> t -> unit
+
+val create_depr_and_user_warnings_qf : ?default:CWarnings.status ->
+  object_name:string -> warning_name_base:string ->
+  pp_qf:('qf -> Pp.t) -> ('a -> Pp.t) -> unit ->
+  ?loc:Loc.t -> 'a -> 'qf with_qf -> unit

--- a/lib/userWarn.mli
+++ b/lib/userWarn.mli
@@ -21,6 +21,8 @@ val drop_qf : 'a with_qf -> t
 val with_empty_qf : t -> 'a with_qf
 val map_qf : ('a -> 'b) -> 'a with_qf -> 'b with_qf
 
+val is_empty : t -> bool
+val is_empty_qf : _ with_qf -> bool
 val empty : t
 
 val make_warn : note:string -> ?cats:string -> unit -> warn

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -125,7 +125,7 @@ let string_of_path sp =
   | [] -> Id.to_string id
   | _ -> (DirPath.to_string sl) ^ "." ^ (Id.to_string id)
 
-let sp_ord sp1 sp2 =
+let compare_full_path sp1 sp2 =
   let (p1,id1) = repr_path sp1
   and (p2,id2) = repr_path sp2 in
   let p_bit = DirPath.compare p1 p2 in
@@ -134,7 +134,7 @@ let sp_ord sp1 sp2 =
 module SpOrdered =
   struct
     type t = full_path
-    let compare = sp_ord
+    let compare = compare_full_path
   end
 
 module Spmap = Map.Make(SpOrdered)

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -36,6 +36,8 @@ type full_path
 
 val eq_full_path : full_path -> full_path -> bool
 
+val compare_full_path : full_path -> full_path -> int
+
 (** Constructors of [full_path] *)
 val make_path : DirPath.t -> Id.t -> full_path
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -84,14 +84,213 @@ type visibility = Until of int | Exactly of int
 
 val map_visibility : (int -> int) -> visibility -> visibility
 
+(** {6 Nametab generic APIs } *)
+
+module type NAMETAB = sig
+  (** Common APIs on name tables. *)
+
+  type elt
+  (** The type of the elements of the name table (eg ModPath.t) *)
+
+  val push : visibility -> full_path -> elt -> unit
+  (** Add an element or modify its visibility.
+      With visibility [Until], assume the element is new.
+      With visibility [Exactly], assume the element is not new.
+  *)
+
+  val remove : full_path -> elt -> unit
+  (** Remove an element. *)
+
+  val shortest_qualid_gen : ?loc:Loc.t -> (Id.t -> bool) -> elt -> qualid
+  (** [shortest_qualid_gen avoid v]: given an object [v] with full
+      name Mylib.A.B.x, try to find the shortest among x, B.x, A.B.x
+      and Mylib.A.B.x that denotes the same object.
+      If [avoid] is [true] on [x] it is assumed to denote something else
+      (so B.x is the shortest qualid that could be returned).
+
+      @raise Not_found for unknown objects. *)
+
+  val shortest_qualid : ?loc:Loc.t -> Id.Set.t -> elt -> qualid
+  (** Like [shortest_qualid_gen] but using an id set instead of a closure. *)
+
+  val pr : elt -> Pp.t
+  (** Print using [shortest_qualid] and empty avoid set. *)
+
+  val locate : qualid -> elt
+  (** Globalize the given user-level reference.
+      If any warnings are associated with the produced object, print
+      them unless [nowarn:true] was given. *)
+
+  val locate_all : qualid -> elt list
+  (** Locate all elements with a given suffix. If the qualid is a
+      valid absolute name, that element is first in the list. *)
+
+  val completion_candidates : qualid -> elt list
+  (** Return the elements that have the qualid as a prefix.
+      UIs will usually compose with [shortest_qualid].
+      Experimental APIs, please tell us if you use it. *)
+
+  val to_path : elt -> full_path
+  (** Return the absolute name for the given element. *)
+
+  val of_path : full_path -> elt
+  (** Return an element bound to an absolute path. *)
+
+  val exists : full_path -> bool
+  (** Returns whether this absolute path is taken. *)
+end
+
+module type WarnedTab = sig
+  (** NAMETAB extended with warnings associated to some of the elements. *)
+
+  include NAMETAB
+
+  type warning_data
+
+  val push : ?wdata:warning_data -> visibility -> full_path -> elt -> unit
+  (** When [visibility] is [Until], [wdata] may be [Some _] in which
+      case the warning data is associated to the element. *)
+
+  val is_warned : elt -> warning_data option
+  (** Return the warning data associated to the element. *)
+
+  val warn : ?loc:Loc.t -> elt -> warning_data -> unit
+  (** Emit the given warning data for the given element (if the warning is not disabled). *)
+
+  val locate : ?nowarn:bool -> qualid -> elt
+  (** Unless [nowarn:false] is given, if the found element is
+      associated to a warning, that warning is emitted. *)
+end
+
+(** {6 Core nametabs } *)
+
+module XRefs : WarnedTab
+  with type elt = Globnames.extended_global_reference
+   and type warning_data := Globnames.extended_global_reference UserWarn.with_qf
+
+module Univs : NAMETAB with type elt = Univ.UGlobal.t
+
+module Quality : NAMETAB with type elt = Sorts.QGlobal.t
+
+(** Module types, modules and open modules/modtypes/sections form three separate name spaces
+    (maybe this will change someday) *)
+module ModTypes : NAMETAB with type elt = ModPath.t
+
+module Modules : NAMETAB with type elt = ModPath.t
+
+module OpenMods : NAMETAB with type elt = GlobDirRef.t
+
+(** {6 Specializations for extended references } *)
+
+(** These functions operate on [XRefs] but are about a subset of
+    [extended_global_reference] for convenience. *)
+
 val push : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> GlobRef.t -> unit
+
+val push_abbreviation : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> Globnames.abbreviation -> unit
+
+val locate : qualid -> GlobRef.t
+
+val locate_all : qualid -> GlobRef.t list
+
+val locate_constant : qualid -> Constant.t
+
+val locate_abbreviation : qualid -> Globnames.abbreviation
+
+val remove_abbreviation : full_path -> Globnames.abbreviation -> unit
+
+val global_of_path : full_path -> GlobRef.t
+
+val path_of_global : GlobRef.t -> full_path
+
+val path_of_abbreviation : Globnames.abbreviation -> full_path
+
+val shortest_qualid_of_global : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
+val shortest_qualid_of_abbreviation : ?loc:Loc.t -> Id.Set.t -> Globnames.abbreviation -> qualid
+
+(** Printing of global references using names as short as possible.
+    @raise Not_found when the reference is not in the global tables. *)
+val pr_global_env : Id.Set.t -> GlobRef.t -> Pp.t
+
+(** Returns in particular the dirpath or the basename of the full path
+   associated to global reference *)
+
+val dirpath_of_global : GlobRef.t -> DirPath.t
+val basename_of_global : GlobRef.t -> Id.t
+
+(** These functions globalize user-level references into global
+    references, like [locate] and co, but raise [GlobalizationError]
+    for unbound qualid and [UserError] for type mismatches (eg
+    [global_inductive] when the qualid is bound to a constructor) *)
+
+val global : qualid -> GlobRef.t
+val global_inductive : qualid -> inductive
+
+(** {6 These functions declare (resp. return) the source location of the object if known } *)
+(* XXX handle as part of the general nametab API? *)
+
+val set_cci_src_loc : Globnames.extended_global_reference -> Loc.t -> unit
+val cci_src_loc : Globnames.extended_global_reference -> Loc.t option
+
+(** {6 Nametab generators } *)
+
+module type ValueType = sig
+  type t
+  val equal : t -> t -> bool
+
+  val is_var : t -> Id.t option
+  (** Is this a variable (not handled by name tables)? *)
+
+  module Map : CSig.UMapS with type key = t
+end
+
+module type StateInfo = sig
+  (** Necessary data to declare the imperative state for a nametab. *)
+
+  val stage : Summary.Stage.t
+  val summary_name : string
+end
+
+(** Generate a nametab, without warning support. *)
+module EasyNoWarn (M:sig include ValueType include StateInfo end) ()
+  : NAMETAB with type elt = M.t
+
+module type WarnInfo = sig
+  type elt
+  type data
+
+  module Map : CSig.UMapS with type key = elt
+
+  val stage : Summary.Stage.t
+  val summary_name : string
+  (** NB: This summary name must NOT be the same as the nametab summary name. *)
+
+  val warn : ?loc:Loc.t -> elt -> data -> unit
+end
+
+(** Add warning support to an existing nametab. *)
+module MakeWarned(M:NAMETAB)(W:WarnInfo with type elt = M.elt) ()
+  : WarnedTab with type elt = M.elt and type warning_data := W.data
+
+module type SimpleWarnS = sig
+  (** Necessary data to declare a simple warning ([UserWarn.create_depr_and_user_warnings_qf]). *)
+  val object_name : string
+  val warning_name_base : string
+end
+
+(** Generate a nametab with simple warning support
+    ([UserWarn.create_depr_and_user_warnings_qf]). *)
+module Easy (M:sig include ValueType include StateInfo include SimpleWarnS end) ()
+  : WarnedTab with type elt = M.t and type warning_data := M.t UserWarn.with_qf
+
+(** {6 legacy APIs } *)
+(* XXX deprecate? *)
+
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_module : visibility -> full_path -> ModPath.t -> unit
 val push_dir : visibility -> full_path -> GlobDirRef.t -> unit
-val push_abbreviation : ?user_warns:Globnames.extended_global_reference UserWarn.with_qf -> visibility -> full_path -> Globnames.abbreviation -> unit
 
 val push_universe : visibility -> full_path -> Univ.UGlobal.t -> unit
-val push_sort : visibility -> full_path -> Sorts.QGlobal.t -> unit
 
 (** Deprecation and user warn info *)
 
@@ -104,34 +303,18 @@ val warn_user_warn_xref : ?loc:Loc.t -> Globnames.extended_global_reference User
 (** These functions globalize a (partially) qualified name or fail with
    [Not_found] *)
 
-val locate : qualid -> GlobRef.t
 val locate_extended : qualid -> Globnames.extended_global_reference
-val locate_constant : qualid -> Constant.t
-val locate_abbreviation : qualid -> Globnames.abbreviation
 val locate_modtype : qualid -> ModPath.t
 val locate_dir : qualid -> GlobDirRef.t
 val locate_module : qualid -> ModPath.t
 val locate_section : qualid -> full_path
 val locate_universe : qualid -> Univ.UGlobal.t
-val locate_quality : qualid -> Sorts.QGlobal.t
 
 val locate_extended_nowarn : qualid -> Globnames.extended_global_reference
-
-(** Remove the binding to an abbreviation *)
-
-val remove_abbreviation : full_path -> Globnames.abbreviation -> unit
-
-(** These functions globalize user-level references into global
-   references, like [locate] and co, but raise a nice error message
-   in case of failure *)
-
-val global : qualid -> GlobRef.t
-val global_inductive : qualid -> inductive
 
 (** These functions locate all global references with a given suffix;
    if [qualid] is valid as such, it comes first in the list *)
 
-val locate_all : qualid -> GlobRef.t list
 val locate_extended_all : qualid -> Globnames.extended_global_reference list
 val locate_extended_all_dir : qualid -> GlobDirRef.t list
 val locate_extended_all_modtype : qualid -> ModPath.t list
@@ -145,7 +328,6 @@ val completion_canditates : qualid -> Globnames.extended_global_reference list
 
 (** Mapping a full path to a global reference *)
 
-val global_of_path : full_path -> GlobRef.t
 val extended_global_of_path : full_path -> Globnames.extended_global_reference
 
 (** {6 These functions tell if the given absolute name is already taken } *)
@@ -155,12 +337,6 @@ val exists_modtype : full_path -> bool
 val exists_module : full_path -> bool
 val exists_dir : full_path -> bool
 val exists_universe : full_path -> bool
-val exists_sort : full_path -> bool
-
-(** {6 These functions declare (resp. return) the source location of the object if known } *)
-
-val set_cci_src_loc : Globnames.extended_global_reference -> Loc.t -> unit
-val cci_src_loc : Globnames.extended_global_reference -> Loc.t option
 
 (** {6 These functions locate qualids into full user names } *)
 
@@ -174,8 +350,6 @@ val full_name_module : qualid -> full_path
 (** Returns the full path bound to a global reference or syntactic
    definition, and the (full) dirpath associated to a module path *)
 
-val path_of_abbreviation : Globnames.abbreviation -> full_path
-val path_of_global : GlobRef.t -> full_path
 val path_of_module : ModPath.t -> full_path
 val path_of_modtype : ModPath.t -> full_path
 
@@ -183,61 +357,14 @@ val path_of_modtype : ModPath.t -> full_path
     @raise Not_found if the universe was not introduced by the user. *)
 val path_of_universe : Univ.UGlobal.t -> full_path
 
-(** Returns in particular the dirpath or the basename of the full path
-   associated to global reference *)
-
-val dirpath_of_global : GlobRef.t -> DirPath.t
-val basename_of_global : GlobRef.t -> Id.t
-
-(** Printing of global references using names as short as possible.
-    @raise Not_found when the reference is not in the global tables. *)
-val pr_global_env : Id.Set.t -> GlobRef.t -> Pp.t
-
-
 (** The [shortest_qualid] functions given an object with [user_name]
    Mylib.A.B.x, try to find the shortest among x, B.x, A.B.x and
    Mylib.A.B.x that denotes the same object.
    @raise Not_found for unknown objects. *)
 
-val shortest_qualid_of_global : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val shortest_qualid_of_abbreviation : ?loc:Loc.t -> Id.Set.t -> Globnames.abbreviation -> qualid
 val shortest_qualid_of_modtype : ?loc:Loc.t -> ModPath.t -> qualid
 val shortest_qualid_of_module : ?loc:Loc.t -> ModPath.t -> qualid
-val shortest_qualid_of_dir : ?loc:Loc.t -> full_path -> qualid
+val shortest_qualid_of_dir : ?loc:Loc.t -> GlobDirRef.t -> qualid
 
 (** In general we have a [UnivNames.universe_binders] around rather than a [Id.Set.t] *)
 val shortest_qualid_of_universe : ?loc:Loc.t -> 'u Id.Map.t -> Univ.UGlobal.t -> qualid
-
-val pr_depr_xref : Globnames.extended_global_reference -> Pp.t
-
-val shortest_qualid_of_quality : ?loc:Loc.t -> 'u Id.Map.t -> Sorts.QGlobal.t -> qualid
-
-(** {5 Generic name handling} *)
-
-(** NOT FOR PUBLIC USE YET. Plugin writers, please do not rely on this API. *)
-
-module type EqualityType =
-sig
-  type t
-  val equal : t -> t -> bool
-end
-
-module type NAMETREE = sig
-  type elt
-  type t
-
-  val empty : t
-  val push : visibility -> full_path -> elt -> t -> t
-  val locate : qualid -> t -> elt
-  val find : full_path -> t -> elt
-  val remove : full_path -> t -> t
-  val exists : full_path -> t -> bool
-  val full_path : qualid -> t -> full_path
-  val shortest_qualid_gen : ?loc:Loc.t -> (Id.t -> bool) -> full_path -> t -> qualid
-  val shortest_qualid : ?loc:Loc.t -> Id.Set.t -> full_path -> t -> qualid
-  val find_prefixes : qualid -> t -> elt list
-  val match_prefixes : qualid -> t -> elt list
-end
-
-module Make (E : EqualityType) :
-  NAMETREE with type elt = E.t

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -565,7 +565,9 @@ let print_ltac_body qid tac =
   | mods ->
     let pr_one mp =
       let qid = try Nametab.shortest_qualid_of_module mp
-        with Not_found -> Nametab.shortest_qualid_of_dir (Libnames.path_of_string (ModPath.to_string mp))
+        with Not_found ->
+        try Nametab.shortest_qualid_of_dir (DirOpenModule mp)
+        with Not_found -> Nametab.shortest_qualid_of_dir (DirOpenModtype mp)
       in
       pr_qualid qid
     in

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -15,27 +15,26 @@ open Tacexpr
 
 (** Nametab for tactics *)
 
-module KnTab = Nametab.Make(KerName)
+module TacticV = struct
+  include KerName
+  let is_var _ = None
+  module Map = KNmap
+  let stage = Summary.Stage.Interp
+  let summary_name = "ltac1tab"
+end
+module TacticTab = Nametab.EasyNoWarn(TacticV)()
 
-let tactic_tab = Summary.ref ~name:"LTAC-NAMETAB" (KnTab.empty, KNmap.empty)
+let push_tactic vis sp kn = TacticTab.push vis sp kn
 
-let push_tactic vis sp kn =
-  let (tab, revtab) = !tactic_tab in
-  let tab = KnTab.push vis sp kn tab in
-  let revtab = KNmap.add kn sp revtab in
-  tactic_tab := (tab, revtab)
+let locate_tactic qid = TacticTab.locate qid
 
-let locate_tactic qid = KnTab.locate qid (fst !tactic_tab)
+let locate_extended_all_tactic qid = TacticTab.locate_all qid
 
-let locate_extended_all_tactic qid = KnTab.find_prefixes qid (fst !tactic_tab)
+let exists_tactic kn = TacticTab.exists kn
 
-let exists_tactic kn = KnTab.exists kn (fst !tactic_tab)
+let path_of_tactic kn = TacticTab.to_path kn
 
-let path_of_tactic kn = KNmap.find kn (snd !tactic_tab)
-
-let shortest_qualid_of_tactic kn =
-  let sp = KNmap.find kn (snd !tactic_tab) in
-  KnTab.shortest_qualid Id.Set.empty sp (fst !tactic_tab)
+let shortest_qualid_of_tactic kn = TacticTab.shortest_qualid Id.Set.empty kn
 
 (** Tactic notations (TacAlias) *)
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -128,10 +128,10 @@ let push_typedef visibility sp kn (_, def) = match def with
   Tac2env.push_type visibility sp kn
 | GTydAlg { galg_constructors = cstrs } ->
   (* Register constructors *)
-  let iter (warn, c, _) =
+  let iter (user_warns, c, _) =
     let spc = change_sp_label sp c in
     let knc = change_kn_label kn c in
-    Tac2env.push_constructor visibility spc knc
+    Tac2env.push_constructor ?user_warns visibility spc knc
   in
   Tac2env.push_type visibility sp kn;
   List.iter iter cstrs
@@ -159,7 +159,7 @@ let define_typedef kn (params, def as qdef) = match def with
   (* Define constructors *)
   let constant = ref 0 in
   let nonconstant = ref 0 in
-  let iter (warn, c, args) =
+  let iter (_warn, c, args) =
     let knc = change_kn_label kn c in
     let tag = if List.is_empty args then next constant else next nonconstant in
     let data = {
@@ -168,7 +168,7 @@ let define_typedef kn (params, def as qdef) = match def with
       cdata_args = args;
       cdata_indx = Some tag;
     } in
-    Tac2env.define_constructor ?warn knc data
+    Tac2env.define_constructor knc data
   in
   Tac2env.define_type kn qdef;
   List.iter iter cstrs
@@ -236,7 +236,8 @@ let push_typext vis prefix def =
   let iter data =
     let spc = Libnames.add_path_suffix prefix.obj_path data.edata_name in
     let knc = KerName.make prefix.obj_mp (Label.of_id data.edata_name) in
-    Tac2env.push_constructor vis spc knc
+    let user_warns = data.edata_warn in
+    Tac2env.push_constructor ?user_warns vis spc knc
   in
   List.iter iter def.typext_expr
 
@@ -249,7 +250,7 @@ let define_typext mp def =
       cdata_args = data.edata_args;
       cdata_indx = None;
     } in
-    Tac2env.define_constructor ?warn:data.edata_warn knc cdata
+    Tac2env.define_constructor knc cdata
   in
   List.iter iter def.typext_expr
 

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -59,7 +59,7 @@ type constructor_data = {
       constructor is a member of an open type. *)
 }
 
-val define_constructor : ?warn:UserWarn.t -> ltac_constructor -> constructor_data -> unit
+val define_constructor : ltac_constructor -> constructor_data -> unit
 val interp_constructor : ltac_constructor -> constructor_data
 
 val find_all_constructors_in_type : type_constant -> constructor_data KNmap.t
@@ -113,17 +113,14 @@ val interp_notation : ltac_notation -> notation_data
 val push_ltac : visibility -> full_path -> tacref -> unit
 val locate_ltac : qualid -> tacref
 val locate_extended_all_ltac : qualid -> tacref list
-val shortest_qualid_of_ltac : Id.Set.t -> tacref -> qualid
+val shortest_qualid_of_ltac : ?loc:Loc.t -> Id.Set.t -> tacref -> qualid
 val path_of_ltac : tacref -> full_path
 
-val push_constructor : visibility -> full_path -> ltac_constructor -> unit
+val push_constructor : ?user_warns:UserWarn.t -> visibility -> full_path -> ltac_constructor -> unit
 val locate_constructor : qualid -> ltac_constructor
 val locate_extended_all_constructor : qualid -> ltac_constructor list
 val shortest_qualid_of_constructor : ltac_constructor -> qualid
 val path_of_constructor : ltac_constructor -> full_path
-
-(** Emit warning if any for the constructor. *)
-val constructor_user_warn : ?loc:Loc.t -> ltac_constructor -> unit
 
 val push_type : visibility -> full_path -> type_constant -> unit
 val locate_type : qualid -> type_constant

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -206,9 +206,7 @@ let get_constructor env var = match var with
 | RelId qid ->
   let c = try Some (Tac2env.locate_constructor qid) with Not_found -> None in
   begin match c with
-  | Some knc ->
-    Tac2env.constructor_user_warn knc ;
-    Other knc
+  | Some knc -> Other knc
   | None ->
     CErrors.user_err ?loc:qid.CAst.loc (str "Unbound constructor " ++ pr_qualid qid)
   end

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -95,7 +95,7 @@ let invent_name prefix (named,cnt) u =
   aux cnt
 
 let check_exists_sort sp =
-  if Nametab.exists_sort sp then
+  if Nametab.Quality.exists sp then
     raise (AlreadyDeclared (Some "Sort", Libnames.basename sp))
   else ()
 
@@ -105,7 +105,7 @@ let qualify_sort i dp id =
 let do_sort_name ~check i dp (id,quality) =
   let i, sp = qualify_sort i dp id in
   if check then check_exists_sort sp;
-  Nametab.push_sort i sp quality
+  Nametab.Quality.push i sp quality
 
 let cache_sort_names (prefix, decl) =
   let depth = Lib.sections_depth () in


### PR DESCRIPTION

TODO deprecate legacy APIs (use ModTypes.locate instead of
locate_modtype etc)
