### PR TITLE
[rfc] Introduce a new ERASEcast kind for evaluation using verified erasure …

### DIFF
--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -343,6 +343,7 @@ let cast_kind_display k =
   | VMcast -> "VMcast"
   | DEFAULTcast -> "DEFAULTcast"
   | NATIVEcast -> "NATIVEcast"
+  | ERASEcast -> "ERASEcast"
 
 let constr_display csr =
   let rec term_display c = match kind c with

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -655,7 +655,7 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CCast (p,Some Constr.DEFAULTcast, t) ->
     CPatCast (coerce_to_cases_pattern_expr p,t)
   | CLambdaN _ | CProdN _ | CSort _ | CLetIn _ | CGeneralization _
-  | CRef (_, Some _) | CCast (_, (Some (VMcast|NATIVEcast) | None), _)
+  | CRef (_, Some _) | CCast (_, (Some (VMcast|NATIVEcast|ERASEcast) | None), _)
   | CFix _ | CCoFix _ | CApp _ | CProj _ | CCases _ | CLetTuple _ | CIf _
   | CPatVar _ | CEvar _
   | CNotation (_,_,(_,_,_,_::_))

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -34,7 +34,7 @@ type existential_key = Evar.t
 type metavariable = int
 
 (* This defines the strategy to use for verifiying a Cast *)
-type cast_kind = VMcast | NATIVEcast | DEFAULTcast
+type cast_kind = VMcast | NATIVEcast | DEFAULTcast | ERASEcast
 
 (* This defines Cases annotations *)
 type case_style = LetStyle | IfStyle | LetPatternStyle | MatchStyle | RegularStyle
@@ -1221,6 +1221,7 @@ let hash_cast_kind = function
 | VMcast -> 0
 | NATIVEcast -> 1
 | DEFAULTcast -> 2
+| ERASEcast -> 3
 
 (* Exported hashing fonction on constr, used mainly in plugins.
    Slight differences from [snd (hash_term t)] above: it ignores binders. *)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -98,7 +98,7 @@ val mkType : Univ.Universe.t -> types
 
 
 (** This defines the strategy to use for verifiying a Cast *)
-type cast_kind = VMcast | NATIVEcast | DEFAULTcast
+type cast_kind = VMcast | NATIVEcast | DEFAULTcast | ERASEcast
 
 (** Constructs the term [t1::t2], i.e. the term t{_ 1} casted with the
    type t{_ 2} (that means t2 is declared as the type of t1). *)

--- a/kernel/eraseconv.ml
+++ b/kernel/eraseconv.ml
@@ -1,0 +1,75 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Constr
+open Conversion
+
+(** The erase evaluation function can either return an evaluated term or an error if the
+    evaluated term cannot be read back *)
+type erase_evaluation_function =
+  Environ.env -> Constr.t -> types -> (Constr.t, unit) result
+
+let erase_evaluation : erase_evaluation_function option ref = ref None
+
+let install_erase_conv fn =
+  match !erase_evaluation with
+  | None -> erase_evaluation := Some fn
+  | Some _ -> CErrors.anomaly Pp.(str"Attempting to install erasure evaluation twice!")
+
+let evaluate_term env c ty =
+  match !erase_evaluation with
+  | None -> Result.Error ()
+  | Some ev -> ev env c ty
+
+let evaluate_args env ctx args =
+  let open Context.Rel.Declaration in
+  if Int.equal (Array.length args) 0 then args else
+  let newargs = Array.make (Array.length args) args.(0) in
+  let ctx = Vars.smash_rel_context ctx in
+  let rec aux ctx n =
+    match ctx with
+    | LocalAssum (_, ty) :: ctx ->
+      let arg' =
+        match evaluate_term env args.(n) ty with
+        | Result.Ok arg' -> arg'
+        | Result.Error () -> args.(n)
+      in
+      newargs.(n) <- arg';
+      (* ctx is a telescope (reverse context) *)
+      aux (List.rev (Vars.subst1_rel_context arg' (List.rev ctx))) (succ n)
+    | LocalDef _ :: _ -> assert false (* Context is smashed beforehand *)
+    | [] -> ()
+  in
+  let () = aux (List.rev ctx) 0 in
+  newargs
+
+let erase_eval env expected_type =
+  let hd, args = Constr.decompose_app expected_type in
+  match Constr.kind hd with
+  | Ind (ind, u) ->
+    if Array.length args > 0 then
+      let specif = (Inductive.lookup_mind_specif env ind, u) in
+      let indty = Inductive.type_of_inductive specif in
+      let paramsctxt = (fst (fst specif)).Declarations.mind_params_ctxt in
+      let nparams = List.length paramsctxt in
+      let ctx, concl = Term.decompose_prod_n_decls nparams indty in
+      let params, indices = CArray.chop (fst (fst specif)).Declarations.mind_nparams args in
+      let instconcl = Vars.(substl (subst_of_rel_context_instance ctx params) concl) in
+      let indsctx, _ = Term.destArity instconcl in
+      let indices' = evaluate_args env indsctx indices in
+      let newty = Term.appvectc hd (Array.append params indices') in
+      Result.Ok newty
+    else Result.Error ()
+  | _ -> Result.Error ()
+
+let erase_conv pb env ty ty' =
+  match erase_eval env ty' with
+  | Result.Ok newty -> default_conv pb env ty newty
+  | Result.Error () -> Result.Error ()

--- a/kernel/eraseconv.mli
+++ b/kernel/eraseconv.mli
@@ -1,0 +1,24 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Constr
+open Conversion
+
+val erase_eval : Environ.env -> Constr.t -> (Constr.t, unit) result
+
+val erase_conv : conv_pb -> types kernel_conversion_function
+
+(** The erase evaluation function can either return an evaluated term or an error if the
+    evaluated term cannot be read back *)
+type erase_evaluation_function =
+  Environ.env -> Constr.t -> types -> (Constr.t, unit) result
+
+(** Link a specific evaluation function. By default it is the function always returning an error. *)
+val install_erase_conv : erase_evaluation_function -> unit

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -375,6 +375,8 @@ let check_cast env c ct k expected_type =
     | NATIVEcast ->
       let sigma = Genlambda.empty_evars env in
       Nativeconv.native_conv CUMUL sigma env ct expected_type
+    | ERASEcast ->
+      Eraseconv.erase_conv CUMUL env ct expected_type
   in
   match ans with
   | Result.Ok () -> ()

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -180,6 +180,8 @@ GRAMMAR EXTEND Gram
                  { CAst.make ~loc @@ CCast(c1, Some VMcast, c2) }
       | c1 = term; "<<:"; c2 = term LEVEL "200" ->
                  { CAst.make ~loc @@ CCast(c1, Some NATIVEcast, c2) }
+      | c1 = term; "<<<:"; c2 = term LEVEL "200" ->
+                 { CAst.make ~loc @@ CCast(c1, Some ERASEcast, c2) }
       | c1 = term; ":>"; c2 = term LEVEL "200" ->
                  { CAst.make ~loc @@ CCast(c1, None, c2) }
       | c1 = term; ":"; c2 = term LEVEL "200" ->

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -743,6 +743,7 @@ let () =
 let () = define "constr_cast_default" (ret valexpr) (of_cast DEFAULTcast)
 let () = define "constr_cast_vm" (ret valexpr) (of_cast VMcast)
 let () = define "constr_cast_native" (ret valexpr) (of_cast NATIVEcast)
+let () = define "constr_cast_erase" (ret valexpr) (of_cast ERASEcast)
 
 let () =
   define "constr_in_context" (ident @-> constr @-> closure @-> tac constr) @@ fun id t c ->

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -143,7 +143,8 @@ let cast_kind_eq t1 t2 = let open Constr in match t1, t2 with
   | DEFAULTcast, DEFAULTcast
   | VMcast, VMcast
   | NATIVEcast, NATIVEcast -> true
-  | (DEFAULTcast | VMcast | NATIVEcast), _ -> false
+  | ERASEcast, ERASEcast -> true
+  | (DEFAULTcast | VMcast | NATIVEcast | ERASEcast), _ -> false
 
 let matching_var_kind_eq k1 k2 = match k1, k2 with
 | FirstOrderPatVar ido1, FirstOrderPatVar ido2 -> Id.equal ido1 ido2

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -607,6 +607,7 @@ let pr_cast = let open Constr in function
     | Some DEFAULTcast -> str ":"
     | Some VMcast-> str "<:"
     | Some NATIVEcast -> str "<<:"
+    | Some ERASEcast -> str "<<<:"
     | None -> str ":>"
 
 type raw_or_glob_genarg =

--- a/test-suite/failure/EraseConv.v
+++ b/test-suite/failure/EraseConv.v
@@ -1,0 +1,2 @@
+Fail Check (2 <<<: nat).
+

--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -344,6 +344,7 @@ Module Cast.
   Ltac2 @ external default : cast := "rocq-runtime.plugins.ltac2" "constr_cast_default".
   Ltac2 @ external vm : cast := "rocq-runtime.plugins.ltac2" "constr_cast_vm".
   Ltac2 @ external native : cast := "rocq-runtime.plugins.ltac2" "constr_cast_native".
+  Ltac2 @ external erase : cast := "rocq-runtime.plugins.ltac2" "constr_cast_erase".
 
   Ltac2 @ external equal : cast -> cast -> bool := "rocq-runtime.plugins.ltac2" "constr_cast_equal".
 


### PR DESCRIPTION
…(to be linked to the kernel through the rocq-verified-extraction plugin)

For Rocq proper, this just adds a new parsing rule for `c <<<: t` which binds to a new cast kind. 
`kernel/eraseconv.ml` is then in charge of transmitting the values to evaluate to a plugin which 
provides a `Environ.env -> Constr.t -> (Constr.t, unit) result`. This is what the 
PR MetaRocq/rocq-verified-extraction#34 provides. 

The interface might seem a bit convoluted but the typing rule is the following, informally: 
When typechecking `c <<<: t`, we infer the type `c : cty` and call eraseconv with `cty` and `t`.
`t` has to be an inductive type applied to parameters and indices. We evaluate all the indices using 
erasure evaluation and then call back regular conversion betwee `cty` and the new `t`.  If this succeeds,
it is dimmed type correct. Outside this fragment, it is a type error. For pretyping, we can hence allow 
`cty` to still contain metavariables and fall back to regular evarconv for the final `cty ~= t'` test, hence 
one does not need to know the value computed by erased evaluation beforehand, it can just be used to fill 
an evar.

We could work on making this plugin more standalone. Right now it needs all of MetaRocq + Malfunction/VerifiedExtraction to produce the .cmxs but we could also make a standalone plugin based on the generated (verified) .mlf file and wrapper ML files.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
   Without an installed erasure function, `x <<<: t` is an error.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.
