### PR TITLE
Stop saying "scope" when talking about ltac2 syntactic classes

### DIFF
--- a/doc/changelog/06-Ltac2-language/20504-ltac2-scope-entry-Changed.rst
+++ b/doc/changelog/06-Ltac2-language/20504-ltac2-scope-entry-Changed.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  the documentation and error messages do not use the term "scope" to describe Ltac2 :ref:`syntactic_classes`
+  (`#20504 <https://github.com/rocq-prover/rocq/pull/20504>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1245,7 +1245,7 @@ Match on values
 Notations
 ---------
 
-.. cmd:: Ltac2 Notation {+ @ltac2_scope } {? : @natural } := @ltac2_expr
+.. cmd:: Ltac2 Notation {+ @ltac2_syntax_class } {? : @natural } := @ltac2_expr
 
    .. todo seems like name maybe should use lident rather than ident, considering:
 
@@ -1436,35 +1436,35 @@ notation definition.
 
 Syntactic classes are described with a form of S-expression:
 
-   .. insertprodn ltac2_scope ltac2_scope
+   .. insertprodn ltac2_syntax_class ltac2_syntax_class
 
    .. prodn::
-      ltac2_scope ::= @string
+      ltac2_syntax_class ::= @string
       | @integer
       | @name
-      | @name ( {+, @ltac2_scope } )
+      | @name ( {+, @ltac2_syntax_class } )
 
 .. todo no syn class for ints or strings?
    parm names are not reserved (e.g the var can be named "list1")
 
 Metasyntactic operations that can be applied to other syntactic classes are:
 
-  :n:`opt(@ltac2_scope)`
-    Parses an optional :token:`ltac2_scope`.  The associated value is either :n:`None` or
+  :n:`opt(@ltac2_syntax_class)`
+    Parses an optional :token:`ltac2_syntax_class`.  The associated value is either :n:`None` or
     enclosed in :n:`Some`
 
-  :n:`list1(@ltac2_scope {? , @string })`
-    Parses a list of one or more :token:`ltac2_scope`\s.  If :token:`string` is specified,
+  :n:`list1(@ltac2_syntax_class {? , @string })`
+    Parses a list of one or more :token:`ltac2_syntax_class`\s.  If :token:`string` is specified,
     items must be separated by :token:`string`.
 
-  :n:`list0(@ltac2_scope {? , @string })`
-    Parses a list of zero or more :token:`ltac2_scope`\s.  If :token:`string` is specified,
+  :n:`list0(@ltac2_syntax_class {? , @string })`
+    Parses a list of zero or more :token:`ltac2_syntax_class`\s.  If :token:`string` is specified,
     items must be separated by :token:`string`.  For zero items, the associated value
     is an empty list.
 
-  :n:`seq({+, @ltac2_scope })`
-    Parses the :token:`ltac2_scope`\s in order.  The associated value is a tuple,
-    omitting :token:`ltac2_scope`\s that are :token:`string`\s.
+  :n:`seq({+, @ltac2_syntax_class })`
+    Parses the :token:`ltac2_syntax_class`\s in order.  The associated value is a tuple,
+    omitting :token:`ltac2_syntax_class`\s that are :token:`string`\s.
     `self` and `next` are not permitted within `seq`.
 
 The following classes represent nonterminals with some special handling.  The
@@ -1525,9 +1525,9 @@ table further down lists the classes that that are handled plainly.
   :n:`next`
     parses an Ltac2 expression at the next level and returns it as is.
 
-  :n:`thunk(@ltac2_scope)`
-    Used for semantic effect only, parses the same as :token:`ltac2_scope`.
-    If :n:`e` is the parsed expression for :token:`ltac2_scope`, `thunk`
+  :n:`thunk(@ltac2_syntax_class)`
+    Used for semantic effect only, parses the same as :token:`ltac2_syntax_class`.
+    If :n:`e` is the parsed expression for :token:`ltac2_syntax_class`, `thunk`
     returns :n:`fun () => e`.
 
   :n:`pattern`

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -40,7 +40,7 @@ deprecated compatibility alias using :cmd:`Notation (abbreviation)`
              Library File (transitively required) @qualid is deprecated since @string__since. @string__note. Use @qualid__use instead.
              Ltac2 alias @qualid is deprecated since @string__since. @string__note.
              Ltac2 definition @qualid is deprecated since @string__since. @string__note.
-             Ltac2 notation {+ @ltac2_scope } is deprecated since @string__since. @string__note.
+             Ltac2 notation {+ @ltac2_syntax_class } is deprecated since @string__since. @string__note.
              Ltac2 constructor @qualid is deprecated since @string__since. @string__note.
              Notation @string is deprecated since @string__since. @string__note. Use @qualid__use instead.
              Tactic @qualid is deprecated since @string__since. @string__note.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1766,11 +1766,11 @@ SPLICE: [
 | subprf
 ]
 
-ltac2_scope: [
+ltac2_syntax_class: [
 | REPLACE syn_node      (* Ltac2 plugin *)
 | WITH name TAG Ltac2
-| REPLACE syn_node "(" LIST1 ltac2_scope SEP "," ")"      (* Ltac2 plugin *)
-| WITH name "(" LIST1 ltac2_scope SEP "," ")" TAG Ltac2
+| REPLACE syn_node "(" LIST1 ltac2_syntax_class SEP "," ")"      (* Ltac2 plugin *)
+| WITH name "(" LIST1 ltac2_syntax_class SEP "," ")" TAG Ltac2
 ]
 
 tac2mode: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2929,11 +2929,11 @@ syn_node: [
 | Prim.ident      (* ltac2 plugin *)
 ]
 
-ltac2_scope: [
+ltac2_syntax_class: [
 | Prim.string      (* ltac2 plugin *)
 | Prim.integer      (* ltac2 plugin *)
 | syn_node      (* ltac2 plugin *)
-| syn_node "(" LIST1 ltac2_scope SEP "," ")"      (* ltac2 plugin *)
+| syn_node "(" LIST1 ltac2_syntax_class SEP "," ")"      (* ltac2 plugin *)
 ]
 
 syn_level: [
@@ -2942,7 +2942,7 @@ syn_level: [
 ]
 
 tac2def_syn: [
-| LIST1 ltac2_scope syn_level ":=" ltac2_expr6      (* ltac2 plugin *)
+| LIST1 ltac2_syntax_class syn_level ":=" ltac2_expr6      (* ltac2 plugin *)
 ]
 
 globref: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -986,7 +986,7 @@ command: [
 | "Ltac2" OPT "mutable" OPT "rec" tac2def_body LIST0 ( "with" tac2def_body )
 | "Ltac2" "Type" OPT "rec" tac2typ_def LIST0 ( "with" tac2typ_def )
 | "Ltac2" "@" "external" ident ":" ltac2_type ":=" string string
-| "Ltac2" "Notation" LIST1 ltac2_scope OPT ( ":" natural ) ":=" ltac2_expr      (* ltac2 plugin *)
+| "Ltac2" "Notation" LIST1 ltac2_syntax_class OPT ( ":" natural ) ":=" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Set" qualid OPT [ "as" ident ] ":=" ltac2_expr
 | "Ltac2" "Notation" ident ":=" ltac2_expr      (* Ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr      (* ltac2 plugin *)
@@ -2037,11 +2037,11 @@ tac2rec_field: [
 | OPT "mutable" ident ":" ltac2_type      (* ltac2 plugin *)
 ]
 
-ltac2_scope: [
+ltac2_syntax_class: [
 | string      (* ltac2 plugin *)
 | integer      (* ltac2 plugin *)
 | name      (* Ltac2 plugin *)
-| name "(" LIST1 ltac2_scope SEP "," ")"      (* Ltac2 plugin *)
+| name "(" LIST1 ltac2_syntax_class SEP "," ")"      (* Ltac2 plugin *)
 ]
 
 ltac2_expr: [

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -446,11 +446,11 @@ GRAMMAR EXTEND Gram
       | id = Prim.ident -> { CAst.make ~loc (Some id) }
     ] ]
   ;
-  ltac2_scope:
+  ltac2_syntax_class:
     [ [ s = Prim.string -> { SexprStr (CAst.make ~loc s) }
       | n = Prim.integer -> { SexprInt (CAst.make ~loc n) }
       | id = syn_node -> { SexprRec (loc, id, []) }
-      | id = syn_node; "("; tok = LIST1 ltac2_scope SEP "," ; ")" ->
+      | id = syn_node; "("; tok = LIST1 ltac2_syntax_class SEP "," ; ")" ->
         { SexprRec (loc, id, tok) }
     ] ]
   ;
@@ -460,7 +460,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_syn:
-    [ [ toks = LIST1 ltac2_scope; n = syn_level; ":=";
+    [ [ toks = LIST1 ltac2_syntax_class; n = syn_level; ":=";
         e = ltac2_expr ->
         { (toks, n, e) }
     ] ]
@@ -472,7 +472,7 @@ GRAMMAR EXTEND Gram
   ;
 END
 
-(* Quotation scopes used by notations *)
+(* Quotation entries used by notations *)
 
 {
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1945,12 +1945,12 @@ let () =
   let pr_top () = assert false in
   Genprint.register_print0 wit_ltac2_tac pr_raw pr_glb pr_top
 
-(** Built-in notation scopes *)
+(** Built-in notation entries *)
 
-let add_scope s f =
-  Tac2entries.register_scope (Id.of_string s) f
+let add_syntax_class s f =
+  Tac2entries.register_syntax_class (Id.of_string s) f
 
-let rec pr_scope = let open CAst in function
+let rec pr_syntax_class = let open CAst in function
 | SexprStr {v=s} -> qstring s
 | SexprInt {v=n} -> Pp.int n
 | SexprRec (_, {v=na}, args) ->
@@ -1958,205 +1958,198 @@ let rec pr_scope = let open CAst in function
   | None -> str "_"
   | Some id -> Id.print id
   in
-  na ++ str "(" ++ prlist_with_sep (fun () -> str ", ") pr_scope args ++ str ")"
+  na ++ str "(" ++ prlist_with_sep (fun () -> str ", ") pr_syntax_class args ++ str ")"
 
-let scope_fail s args =
-  let args = str "(" ++ prlist_with_sep (fun () -> str ", ") pr_scope args ++ str ")" in
-  CErrors.user_err (str "Invalid arguments " ++ args ++ str " in scope " ++ str s)
+let syntax_class_fail s args =
+  let args = str "(" ++ prlist_with_sep (fun () -> str ", ") pr_syntax_class args ++ str ")" in
+  CErrors.user_err (str "Invalid arguments " ++ args ++ str " in syntactic class " ++ str s)
 
 let q_unit = CAst.make @@ CTacCst (AbsKn (Tuple 0))
 
-let add_generic_scope s entry arg =
-  let parse = function
-  | [] ->
-    let scope = Procq.Symbol.nterm entry in
-    let act x = CAst.make @@ CTacExt (arg, x) in
-    Tac2entries.ScopeRule (scope, act)
-  | arg -> scope_fail s arg
-  in
-  add_scope s parse
+let add_expr_syntax_class name entry f =
+  add_syntax_class name begin function
+  | [] -> Tac2entries.SyntaxRule (Procq.Symbol.nterm entry, f)
+  | arg -> syntax_class_fail name arg
+  end
+
+let add_generic_syntax_class s entry arg =
+  add_expr_syntax_class s entry (fun x -> CAst.make @@ CTacExt (arg, x))
 
 open CAst
 
-let () = add_scope "keyword" begin function
+let () = add_syntax_class "keyword" begin function
 | [SexprStr {loc;v=s}] ->
-  let scope = Procq.Symbol.token (Tok.PKEYWORD s) in
-  Tac2entries.ScopeRule (scope, (fun _ -> q_unit))
-| arg -> scope_fail "keyword" arg
+  let syntax_class = Procq.Symbol.token (Tok.PKEYWORD s) in
+  Tac2entries.SyntaxRule (syntax_class, (fun _ -> q_unit))
+| arg -> syntax_class_fail "keyword" arg
 end
 
-let () = add_scope "terminal" begin function
+let () = add_syntax_class "terminal" begin function
 | [SexprStr {loc;v=s}] ->
-  let scope = Procq.Symbol.token (Procq.terminal s) in
-  Tac2entries.ScopeRule (scope, (fun _ -> q_unit))
-| arg -> scope_fail "terminal" arg
+  let syntax_class = Procq.Symbol.token (Procq.terminal s) in
+  Tac2entries.SyntaxRule (syntax_class, (fun _ -> q_unit))
+| arg -> syntax_class_fail "terminal" arg
 end
 
-let () = add_scope "list0" begin function
+let () = add_syntax_class "list0" begin function
 | [tok] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
-  let scope = Procq.Symbol.list0 scope in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
+  let syntax_class = Procq.Symbol.list0 syntax_class in
   let act l = Tac2quote.of_list act l in
-  Tac2entries.ScopeRule (scope, act)
+  Tac2entries.SyntaxRule (syntax_class, act)
 | [tok; SexprStr {v=str}] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
   let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
-  let scope = Procq.Symbol.list0sep scope sep false in
+  let syntax_class = Procq.Symbol.list0sep syntax_class sep false in
   let act l = Tac2quote.of_list act l in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "list0" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "list0" arg
 end
 
-let () = add_scope "list1" begin function
+let () = add_syntax_class "list1" begin function
 | [tok] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
-  let scope = Procq.Symbol.list1 scope in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
+  let syntax_class = Procq.Symbol.list1 syntax_class in
   let act l = Tac2quote.of_list act l in
-  Tac2entries.ScopeRule (scope, act)
+  Tac2entries.SyntaxRule (syntax_class, act)
 | [tok; SexprStr {v=str}] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
   let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
-  let scope = Procq.Symbol.list1sep scope sep false in
+  let syntax_class = Procq.Symbol.list1sep syntax_class sep false in
   let act l = Tac2quote.of_list act l in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "list1" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "list1" arg
 end
 
-let () = add_scope "opt" begin function
+let () = add_syntax_class "opt" begin function
 | [tok] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
-  let scope = Procq.Symbol.opt scope in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
+  let syntax_class = Procq.Symbol.opt syntax_class in
   let act opt = match opt with
   | None ->
     CAst.make @@ CTacCst (AbsKn (Other Core.c_none))
   | Some x ->
     CAst.make @@ CTacApp (CAst.make @@ CTacCst (AbsKn (Other Core.c_some)), [act x])
   in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "opt" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "opt" arg
 end
 
-let () = add_scope "self" begin function
+let () = add_syntax_class "self" begin function
 | [] ->
-  let scope = Procq.Symbol.self in
+  let syntax_class = Procq.Symbol.self in
   let act tac = tac in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "self" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "self" arg
 end
 
-let () = add_scope "next" begin function
+let () = add_syntax_class "next" begin function
 | [] ->
-  let scope = Procq.Symbol.next in
+  let syntax_class = Procq.Symbol.next in
   let act tac = tac in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "next" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "next" arg
 end
 
-let () = add_scope "tactic" begin function
+let () = add_syntax_class "tactic" begin function
 | [] ->
   (* Default to level 5 parsing *)
-  let scope = Procq.Symbol.nterml ltac2_expr "5" in
+  let syntax_class = Procq.Symbol.nterml ltac2_expr "5" in
   let act tac = tac in
-  Tac2entries.ScopeRule (scope, act)
+  Tac2entries.SyntaxRule (syntax_class, act)
 | [SexprInt {loc;v=n}] as arg ->
-  let () = if n < 0 || n > 6 then scope_fail "tactic" arg in
-  let scope = Procq.Symbol.nterml ltac2_expr (string_of_int n) in
+  let () = if n < 0 || n > 6 then syntax_class_fail "tactic" arg in
+  let syntax_class = Procq.Symbol.nterml ltac2_expr (string_of_int n) in
   let act tac = tac in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "tactic" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "tactic" arg
 end
 
-let () = add_scope "thunk" begin function
+let () = add_syntax_class "thunk" begin function
 | [tok] ->
-  let Tac2entries.ScopeRule (scope, act) = Tac2entries.parse_scope tok in
+  let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
   let act e = Tac2quote.thunk (act e) in
-  Tac2entries.ScopeRule (scope, act)
-| arg -> scope_fail "thunk" arg
+  Tac2entries.SyntaxRule (syntax_class, act)
+| arg -> syntax_class_fail "thunk" arg
 end
 
-let () = add_scope "constr" begin function arg ->
+let () = add_syntax_class "constr" begin function arg ->
   let delimiters = List.map (function
       | SexprRec (_, { v = Some s }, []) -> s
-      | _ -> scope_fail "constr" arg)
+      | _ -> syntax_class_fail "constr" arg)
       arg
   in
   let act e = Tac2quote.of_constr ~delimiters e in
-  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+  Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.constr, act)
 end
 
-  let () = add_scope "lconstr" begin function arg ->
+  let () = add_syntax_class "lconstr" begin function arg ->
     let delimiters = List.map (function
         | SexprRec (_, { v = Some s }, []) -> s
-        | _ -> scope_fail "lconstr" arg)
+        | _ -> syntax_class_fail "lconstr" arg)
         arg
     in
     let act e = Tac2quote.of_constr ~delimiters e in
-    Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
+    Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
   end
 
-let () = add_scope "open_constr" begin function arg ->
+let () = add_syntax_class "open_constr" begin function arg ->
   let delimiters = List.map (function
       | SexprRec (_, { v = Some s }, []) -> s
-      | _ -> scope_fail "open_constr" arg)
+      | _ -> syntax_class_fail "open_constr" arg)
       arg
   in
   let act e = Tac2quote.of_open_constr ~delimiters e in
-  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+  Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.constr, act)
 end
 
-let () = add_scope "open_lconstr" begin function arg ->
+let () = add_syntax_class "open_lconstr" begin function arg ->
   let delimiters = List.map (function
       | SexprRec (_, { v = Some s }, []) -> s
-      | _ -> scope_fail "open_lconstr" arg)
+      | _ -> syntax_class_fail "open_lconstr" arg)
       arg
   in
   let act e = Tac2quote.of_open_constr ~delimiters e in
-  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
+  Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
 end
 
 
-let () = add_scope "preterm" begin function arg ->
+let () = add_syntax_class "preterm" begin function arg ->
   let delimiters = List.map (function
       | SexprRec (_, { v = Some s }, []) -> s
-      | _ -> scope_fail "preterm" arg)
+      | _ -> syntax_class_fail "preterm" arg)
       arg
   in
   let act e = Tac2quote.of_preterm ~delimiters e in
-  Tac2entries.ScopeRule (Procq.Symbol.nterm Procq.Constr.constr, act)
+  Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.constr, act)
 end
 
-let add_expr_scope name entry f =
-  add_scope name begin function
-  | [] -> Tac2entries.ScopeRule (Procq.Symbol.nterm entry, f)
-  | arg -> scope_fail name arg
-  end
+let () = add_expr_syntax_class "ident" q_ident (fun id -> Tac2quote.of_anti Tac2quote.of_ident id)
+let () = add_expr_syntax_class "bindings" q_bindings Tac2quote.of_bindings
+let () = add_expr_syntax_class "with_bindings" q_with_bindings Tac2quote.of_bindings
+let () = add_expr_syntax_class "intropattern" q_intropattern Tac2quote.of_intro_pattern
+let () = add_expr_syntax_class "intropatterns" q_intropatterns Tac2quote.of_intro_patterns
+let () = add_expr_syntax_class "destruction_arg" q_destruction_arg Tac2quote.of_destruction_arg
+let () = add_expr_syntax_class "induction_clause" q_induction_clause Tac2quote.of_induction_clause
+let () = add_expr_syntax_class "conversion" q_conversion Tac2quote.of_conversion
+let () = add_expr_syntax_class "orient" q_orient Tac2quote.of_orient
+let () = add_expr_syntax_class "rewriting" q_rewriting Tac2quote.of_rewriting
+let () = add_expr_syntax_class "clause" q_clause Tac2quote.of_clause
+let () = add_expr_syntax_class "hintdb" q_hintdb Tac2quote.of_hintdb
+let () = add_expr_syntax_class "occurrences" q_occurrences Tac2quote.of_occurrences
+let () = add_expr_syntax_class "dispatch" q_dispatch Tac2quote.of_dispatch
+let () = add_expr_syntax_class "strategy" q_strategy_flag Tac2quote.of_strategy_flag
+let () = add_expr_syntax_class "reference" q_reference Tac2quote.of_reference
+let () = add_expr_syntax_class "move_location" q_move_location Tac2quote.of_move_location
+let () = add_expr_syntax_class "pose" q_pose Tac2quote.of_pose
+let () = add_expr_syntax_class "assert" q_assert Tac2quote.of_assertion
+let () = add_expr_syntax_class "constr_matching" q_constr_matching Tac2quote.of_constr_matching
+let () = add_expr_syntax_class "goal_matching" q_goal_matching Tac2quote.of_goal_matching
+let () = add_expr_syntax_class "format" Procq.Prim.lstring Tac2quote.of_format
 
-let () = add_expr_scope "ident" q_ident (fun id -> Tac2quote.of_anti Tac2quote.of_ident id)
-let () = add_expr_scope "bindings" q_bindings Tac2quote.of_bindings
-let () = add_expr_scope "with_bindings" q_with_bindings Tac2quote.of_bindings
-let () = add_expr_scope "intropattern" q_intropattern Tac2quote.of_intro_pattern
-let () = add_expr_scope "intropatterns" q_intropatterns Tac2quote.of_intro_patterns
-let () = add_expr_scope "destruction_arg" q_destruction_arg Tac2quote.of_destruction_arg
-let () = add_expr_scope "induction_clause" q_induction_clause Tac2quote.of_induction_clause
-let () = add_expr_scope "conversion" q_conversion Tac2quote.of_conversion
-let () = add_expr_scope "orient" q_orient Tac2quote.of_orient
-let () = add_expr_scope "rewriting" q_rewriting Tac2quote.of_rewriting
-let () = add_expr_scope "clause" q_clause Tac2quote.of_clause
-let () = add_expr_scope "hintdb" q_hintdb Tac2quote.of_hintdb
-let () = add_expr_scope "occurrences" q_occurrences Tac2quote.of_occurrences
-let () = add_expr_scope "dispatch" q_dispatch Tac2quote.of_dispatch
-let () = add_expr_scope "strategy" q_strategy_flag Tac2quote.of_strategy_flag
-let () = add_expr_scope "reference" q_reference Tac2quote.of_reference
-let () = add_expr_scope "move_location" q_move_location Tac2quote.of_move_location
-let () = add_expr_scope "pose" q_pose Tac2quote.of_pose
-let () = add_expr_scope "assert" q_assert Tac2quote.of_assertion
-let () = add_expr_scope "constr_matching" q_constr_matching Tac2quote.of_constr_matching
-let () = add_expr_scope "goal_matching" q_goal_matching Tac2quote.of_goal_matching
-let () = add_expr_scope "format" Procq.Prim.lstring Tac2quote.of_format
+let () = add_generic_syntax_class "pattern" Procq.Constr.constr Tac2quote.wit_pattern
 
-let () = add_generic_scope "pattern" Procq.Constr.constr Tac2quote.wit_pattern
-
-(** seq scope, a bit hairy *)
+(** seq syntax_class, a bit hairy *)
 
 open Procq
 
@@ -2176,25 +2169,25 @@ let rec make_seq_rule = function
 | [] ->
   Seqrule (Procq.Rule.stop, CvNil)
 | tok :: rem ->
-  let Tac2entries.ScopeRule (scope, f) = Tac2entries.parse_scope tok in
-  let scope =
-    match Procq.generalize_symbol scope with
+  let Tac2entries.SyntaxRule (syntax_class, f) = Tac2entries.parse_syntax_class tok in
+  let syntax_class =
+    match Procq.generalize_symbol syntax_class with
     | None ->
       CErrors.user_err (str "Recursive symbols (self / next) are not allowed in local rules")
-    | Some scope -> scope
+    | Some syntax_class -> syntax_class
   in
   let Seqrule (r, c) = make_seq_rule rem in
-  let r = Procq.Rule.next_norec r scope in
+  let r = Procq.Rule.next_norec r syntax_class in
   let f = match tok with
   | SexprStr _ -> None (* Leave out mere strings *)
   | _ -> Some f
   in
   Seqrule (r, CvCns (c, f))
 
-let () = add_scope "seq" begin fun toks ->
-  let scope =
+let () = add_syntax_class "seq" begin fun toks ->
+  let syntax_class =
     let Seqrule (r, c) = make_seq_rule (List.rev toks) in
     Procq.(Symbol.rules [Rules.make r (apply c [])])
   in
-  Tac2entries.ScopeRule (scope, (fun e -> e))
+  Tac2entries.SyntaxRule (syntax_class, (fun e -> e))
 end

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -583,15 +583,15 @@ type 'a token =
 | TacTerm of string
 | TacNonTerm of Name.t * 'a
 
-type scope_rule =
-| ScopeRule : (raw_tacexpr, _, 'a) Procq.Symbol.t * ('a -> raw_tacexpr) -> scope_rule
+type syntax_class_rule =
+| SyntaxRule : (raw_tacexpr, _, 'a) Procq.Symbol.t * ('a -> raw_tacexpr) -> syntax_class_rule
 
-type scope_interpretation = sexpr list -> scope_rule
+type syntax_class_interpretation = sexpr list -> syntax_class_rule
 
-let scope_table : scope_interpretation Id.Map.t ref = ref Id.Map.empty
+let syntax_class_table : syntax_class_interpretation Id.Map.t ref = ref Id.Map.empty
 
-let register_scope id s =
-  scope_table := Id.Map.add id s !scope_table
+let register_syntax_class id s =
+  syntax_class_table := Id.Map.add id s !syntax_class_table
 
 module ParseToken =
 struct
@@ -601,15 +601,15 @@ let loc_of_token = function
 | SexprInt {loc} -> loc
 | SexprRec (loc, _, _) -> Some loc
 
-let parse_scope = function
+let parse_syntax_class = function
 | SexprRec (_, {loc;v=Some id}, toks) ->
-  if Id.Map.mem id !scope_table then
-    Id.Map.find id !scope_table toks
+  if Id.Map.mem id !syntax_class_table then
+    Id.Map.find id !syntax_class_table toks
   else
-    CErrors.user_err ?loc (str "Unknown scope" ++ spc () ++ Names.Id.print id)
+    CErrors.user_err ?loc (str "Unknown syntactic class" ++ spc () ++ Names.Id.print id)
 | SexprStr {v=str} ->
   let v_unit = CAst.make @@ CTacCst (AbsKn (Tuple 0)) in
-  ScopeRule (Procq.Symbol.token (Tok.PIDENT (Some str)), (fun _ -> v_unit))
+  SyntaxRule (Procq.Symbol.token (Tok.PIDENT (Some str)), (fun _ -> v_unit))
 | tok ->
   let loc = loc_of_token tok in
   CErrors.user_err ?loc (str "Invalid parsing token")
@@ -623,27 +623,27 @@ let parse_token = function
     let () = check_lowercase (CAst.make ?loc:na.CAst.loc id) in
     Name id
   in
-  let scope = parse_scope tok in
-  TacNonTerm (na, scope)
+  let syntax_class = parse_syntax_class tok in
+  TacNonTerm (na, syntax_class)
 | tok ->
   let loc = loc_of_token tok in
   CErrors.user_err ?loc (str "Invalid parsing token")
 
-let rec print_scope = function
+let rec print_syntax_class = function
 | SexprStr s -> str s.CAst.v
 | SexprInt i -> int i.CAst.v
 | SexprRec (_, {v=na}, []) -> Option.cata Id.print (str "_") na
 | SexprRec (_, {v=na}, e) ->
-  Option.cata Id.print (str "_") na ++ str "(" ++ pr_sequence print_scope e ++ str ")"
+  Option.cata Id.print (str "_") na ++ str "(" ++ pr_sequence print_syntax_class e ++ str ")"
 
 let print_token = function
 | SexprStr {v=s} -> quote (str s)
-| SexprRec (_, {v=na}, [tok]) -> print_scope tok
+| SexprRec (_, {v=na}, [tok]) -> print_syntax_class tok
 | _ -> assert false
 
 end
 
-let parse_scope = ParseToken.parse_scope
+let parse_syntax_class = ParseToken.parse_syntax_class
 
 type synext = {
   synext_kn : KerName.t;
@@ -658,11 +658,11 @@ type krule =
   (raw_tacexpr, _, 'act, Loc.t -> raw_tacexpr) Procq.Rule.t *
   ((Loc.t -> (Name.t * raw_tacexpr) list -> raw_tacexpr) -> 'act) -> krule
 
-let rec get_rule (tok : scope_rule token list) : krule = match tok with
+let rec get_rule (tok : syntax_class_rule token list) : krule = match tok with
 | [] -> KRule (Procq.Rule.stop, fun k loc -> k loc [])
-| TacNonTerm (na, ScopeRule (scope, inj)) :: tok ->
+| TacNonTerm (na, SyntaxRule (syntax_class, inj)) :: tok ->
   let KRule (rule, act) = get_rule tok in
-  let rule = Procq.Rule.next rule scope in
+  let rule = Procq.Rule.next rule syntax_class in
   let act k e = act (fun loc acc -> k loc ((na, inj e) :: acc)) in
   KRule (rule, act)
 | TacTerm t :: tok ->
@@ -793,16 +793,16 @@ let inTac2Abbreviation : Id.t -> abbreviation -> obj =
      subst_function = subst_abbreviation;
      classify_function = classify_abbreviation}
 
-let rec string_of_scope = function
+let rec string_of_syntax_class = function
 | SexprStr s -> Printf.sprintf "str(%s)" s.CAst.v
 | SexprInt i -> Printf.sprintf "int(%i)" i.CAst.v
 | SexprRec (_, {v=na}, []) -> Option.cata Id.to_string "_" na
 | SexprRec (_, {v=na}, e) ->
-  Printf.sprintf "%s(%s)" (Option.cata Id.to_string "_" na) (String.concat " " (List.map string_of_scope e))
+  Printf.sprintf "%s(%s)" (Option.cata Id.to_string "_" na) (String.concat " " (List.map string_of_syntax_class e))
 
 let string_of_token = function
 | SexprStr {v=s} -> Printf.sprintf "str(%s)" s
-| SexprRec (_, {v=na}, [tok]) -> string_of_scope tok
+| SexprRec (_, {v=na}, [tok]) -> string_of_syntax_class tok
 | _ -> assert false
 
 let make_fresh_key tokens =

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -36,16 +36,16 @@ val perform_eval : pstate:Declare.Proof.t option -> raw_tacexpr -> unit
 
 (** {5 Notations} *)
 
-type scope_rule =
-| ScopeRule : (raw_tacexpr, _, 'a) Procq.Symbol.t * ('a -> raw_tacexpr) -> scope_rule
+type syntax_class_rule =
+| SyntaxRule : (raw_tacexpr, _, 'a) Procq.Symbol.t * ('a -> raw_tacexpr) -> syntax_class_rule
 
-type scope_interpretation = sexpr list -> scope_rule
+type syntax_class_interpretation = sexpr list -> syntax_class_rule
 
-val register_scope : Id.t -> scope_interpretation -> unit
-(** Create a new scope with the provided name *)
+val register_syntax_class : Id.t -> syntax_class_interpretation -> unit
+(** Create a new syntax class with the provided name *)
 
-val parse_scope : sexpr -> scope_rule
-(** Use this to interpret the subscopes for interpretation functions *)
+val parse_syntax_class : sexpr -> syntax_class_rule
+(** Use this to interpret the syntax class arguments for interpretation functions *)
 
 (** {5 Inspecting} *)
 

--- a/plugins/ltac2/tac2qexpr.mli
+++ b/plugins/ltac2/tac2qexpr.mli
@@ -12,7 +12,7 @@ open Names
 open Tac2expr
 
 (** Quoted variants of Ltac syntactic categories. Contrarily to the former, they
-    sometimes allow anti-quotations. Used for notation scopes. *)
+    sometimes allow anti-quotations. Used for notation syntax classes. *)
 
 type 'a or_anti =
 | QExpr of 'a


### PR DESCRIPTION
"scope" is already used by constr notation scopes, which do not involve the parser, so reusing the word here is confusing.

Also the doc section is already titled "syntactic classes"
