### PR TITLE
Change outdated comment in kernel/vars.ml

### DIFF
--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -18,8 +18,7 @@ module RelDecl = Context.Rel.Declaration
 
 exception LocalOccur
 
-(* (closedn n M) raises FreeVar if a variable of height greater than n
-   occurs in M, returns () otherwise *)
+(* (closedn n M) is true iff M is a (de Brujin) closed term under n binders *)
 
 let closedn n c =
   let rec closed_rec n c = match Constr.kind c with


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

The specification of the function closedn was changed in 6f7801f but the comment above it was not changed in the .ml file.


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
