### PR TITLE
Remove Fail Timeout on infinite reductions in test suite

### DIFF
--- a/test-suite/failure/uip_loop.v
+++ b/test-suite/failure/uip_loop.v
@@ -20,5 +20,5 @@ Definition c : top :=
       (fun x : top => x (top -> top) (fun x => x) x)
       p.
 
-Fail Timeout 1 Eval lazy in c (top -> top) (fun x => x) c.
+(* Fail Timeout 1 Eval lazy in c (top -> top) (fun x => x) c. *)
 (* loops *)

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -163,7 +163,6 @@ Proof.
   now intros [=].
 Qed.
 
-Fail Timeout 1 Eval lazy in omega + 0.
 End omega.
 
 
@@ -184,7 +183,6 @@ Goal forall s, f s = g s.
 Defined.
 
 Eval lazy in g (raise _).
-Fail Timeout 1 Eval lazy in f (raise _).
 
 End stream.
 


### PR DESCRIPTION
They seem to be problematic on windows and some macos versions (according to CI).
