### PR TITLE
Ltac2 Set: only take effect in shallow imports

### DIFF
--- a/dev/ci/user-overlays/20516-SkySkimmer-ltac2-set-export.sh
+++ b/dev/ci/user-overlays/20516-SkySkimmer-ltac2-set-export.sh
@@ -1,0 +1,1 @@
+overlay perennial https://github.com/SkySkimmer/perennial ltac2-set-export 20516

--- a/doc/changelog/06-Ltac2-language/20516-ltac2-set-export-Changed.rst
+++ b/doc/changelog/06-Ltac2-language/20516-ltac2-set-export-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  :cmd:`Ltac2 Set` only takes effect with shallow imports, i.e.
+  `Import Foo` will not run a mutation from (non exported) inner module `Foo.Bar`
+  (`#20516 <https://github.com/rocq-prover/rocq/pull/20516>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -895,9 +895,7 @@ let inTac2Redefinition : redefinition -> obj =
   declare_object
     {(default_object "TAC2-REDEFINITION") with
      cache_function  = perform_redefinition;
-     (* should this be simple_open ie only redefine when importing the
-        module containing the redef instead of a parent? *)
-     open_function   = filtered_open (fun _ -> perform_redefinition);
+     open_function   = simple_open perform_redefinition;
      subst_function = subst_redefinition;
      classify_function = classify_redefinition;
     }

--- a/test-suite/ltac2/rebind.v
+++ b/test-suite/ltac2/rebind.v
@@ -176,3 +176,20 @@ Module Test3.
   (* Import/Export does assume idempotence (!) Change1 only got imported once. *)
   Ltac2 Eval assert_eq_int (Orig.x()) 1.
 End Test3.
+
+Module Depth.
+  Ltac2 mutable x () := 0.
+  Module Outer.
+    Module Inner.
+      Ltac2 Set x := fun () => 1.
+    End Inner.
+  End Outer.
+
+  Ltac2 Eval assert_eq_int (x()) 0.
+
+  Import Outer.
+  Ltac2 Eval assert_eq_int (x()) 0.
+
+  Import Inner.
+  Ltac2 Eval assert_eq_int (x()) 1.
+End Depth.


### PR DESCRIPTION
ie `Import Foo` will not run a mutation from (non exported) inner module Foo.Bar.

Overlays:
- https://github.com/mit-pdos/perennial/pull/225 (should be backwards compatible)