### PR TITLE
Improve README for overlays

### DIFF
--- a/dev/ci/user-overlays/README.md
+++ b/dev/ci/user-overlays/README.md
@@ -8,6 +8,69 @@ ask the external projects to merge their PRs (for example by commenting
 in the external PRs).  External projects are then expected to merge their
 PRs promptly.
 
+## Typical workflow
+
+Overlay files can be created automatically using the script
+[`create_overlays.sh`](../../tools/create_overlays.sh).
+
+- Observe that your changes breaks some external projects `<project1>` ... `<projectn>` in CI
+  (`<projecti>` is the name of a project, without the `ci-` prefix.
+  Note that some jobs run multiple projects, e.g. `plugin:ci-elpi_hb` runs `elpi` and `hb`)
+- If necessary, fork the broken projects from their github pages.
+  (Only needs to be done once per project for the lifetime of your github account)
+  (Ask for help for projects not on github)
+- Compile your PR locally (`make world`).
+- Run `dev/tools/create_overlays.sh <account> <PR> <project1> ... <projectn>`
+  where `<account>` is your github account name and `PR` is the PR number.
+  This will download the given projects to `_build_ci` (and their dependencies),
+  declare your fork (using the account name) as a remote
+  and checkout a new branch for your fixes.
+- For each broken project:
+  - run `make ci-<project>`, e.g. `make ci-elpi`.
+    This should produce the error observed in CI.
+  - Make necessary changes, then rerun the script to verify they work.
+  - From the `_build_ci/<project>` subdirectory, commit your changes to the current
+    branch (it was created by create_overlays).
+  - Push to your fork of the project and create a new PR.  Make sure you pick
+    the correct base branch in the github GUI for the comparison
+    (c.f. `dev/ci/ci-basic-overlay.sh`, e.g. `master` for elpi).
+    If the fix is backwards compatible (preferred for library changes), open the PR as ready
+    and ask for it to be merged (eg "Should be backwards compatible, please merge.").
+    Otherwise (typical for plugin changes, including plugins with optional compilation to support multiple Rocq versions) the PR needs to be merged in sync with the Rocq PR, so open as draft.
+  - link the overlay PR in the Rocq PR (at the end of the opening post add a list
+    ~~~
+    Overlays:
+    - <PR1>
+    - <PR2>
+    ~~~
+    )
+- Commit the overlay file (`git add dev/ci/user-overlays && git commit`),
+  push to the Rocq PR and run full CI
+  (wait for the assignee to run full CI if you don't have the rights)
+- When your PR is merged, the assignee notifies the maintainers of the
+  external project to merge the changes you submitted.  This should happen
+  promptly; the external project's CI will fail until the change is merged.
+- Beer.
+
+Notes:
+- running `create_overlays` multiple times is fine
+- running `make ci-foo` before `create_overlays` it's also fine
+
+So for instance you can have an alternate workflow of
+
+- run `make ci-project1`
+- fix
+- `dev/tools/create_overlays.sh <account> <PR> <project1>`
+- commit, push and PR for project 1
+- run `make ci-project2`
+- fix
+- `dev/tools/create_overlays.sh <account> <PR> <project1> <project2>`
+- commit push and PR for project 2
+- repeat until project `n` is done
+- commit and push overlay file
+
+## Overlay file specification
+
 An overlay file specifies the external PRs that should be applied during CI.
 A single file can cover multiple external projects.  Create your
 overlay file in the `dev/ci/user-overlays` directory.
@@ -43,36 +106,10 @@ If the branch name in the external project differs from the Rocq branch name,
 include the external branch name as `[prbranch]` to apply it when you run
 the test suite locally, e.g. `make ci-elpi`.
 
-Overlay files can be created automatically using the script
-[`create_overlays.sh`](../../tools/create_overlays.sh).
-
-### Branching conventions
+## Branching conventions
 
 We suggest you use the convention of identical branch names for the
 Rocq branch and the CI project branch used in the overlay. For example,
 if your Rocq PR is in your branch `more_efficient_tc` and
 breaks `ltac2`, we suggest you create an `ltac2` overlay with a branch
 named `more_efficient_tc`.
-
-### Typical workflow
-
-- Observe that your changes breaks some external projects in CI
-- Compile your PR.
-- For each broken project, run `make <job name>`, e.g. `make ci-elpi`,
-  which checks out, builds and runs the project in the
-  `_build_ci/<job name>` directory.
-- Make necessary changes, then rerun the script to verify they work.
-- From the `<job name>` subdirectory, commit your changes to a new
-  branch, based on the base branch name listed in `ci-basic-overlay.sh`,
-  for example `master` for elpi.
-- If necessary, fork the external project from the project's github page.
-  (Only needs to be done once, ever.)
-- Push to the external project and create a new PR.  Make sure you pick
-  the correct base branch in the github GUI for the comparison
-  (e.g. `master` for elpi).
-- Create the overlay file, add to your Rocq PR, push the updated version and
-  verify that the external projects now pass.
-- When your PR is merged, the assignee notifies the maintainers of the
-  external project to merge the changes you submitted.  This should happen
-  promptly; the external project's CI will fail until the change is merged.
-- Beer.


### PR DESCRIPTION
(this file is linked in the PR template)

- put the "typical workflow" section before the overlay file spec (most people shouldn't need to care about the spec)

- made the "typical workflow" use create_overlays, and generally I tried to improve this section.
