### PR TITLE
Ltac2: Add `Std.Red` module for conversions and centralize reduction tactics around it

### DIFF
--- a/doc/changelog/06-Ltac2-language/20543-radrow-gh-20482-reductions-Added.rst
+++ b/doc/changelog/06-Ltac2-language/20543-radrow-gh-20482-reductions-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 type for reduction expressions
+  (`#20543 <https://github.com/rocq-prover/rocq/pull/20543>`_,
+  by Radosław Rowicki, with review of Pierre-Marie Pédrot and Gaëtan Gilbert and Jason Gross).

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -59,6 +59,7 @@ let val_ind_data : (Names.Ind.t * Declarations.mutual_inductive_body) Val.tag = 
 let val_transparent_state : TransparentState.t Val.tag = Val.create "transparent_state"
 let val_pretype_flags = Val.create "pretype_flags"
 let val_expected_type = Val.create "expected_type"
+let val_reduction = Val.create "reduction"
 
 let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
 match Val.eq tag tag' with
@@ -236,6 +237,10 @@ let evar = repr_ext val_evar
 let of_sort ev = of_ext val_sort ev
 let to_sort ev = to_ext val_sort ev
 let sort = repr_ext val_sort
+
+let of_reduction ev = of_ext val_reduction ev
+let to_reduction ev = to_ext val_reduction ev
+let reduction = repr_ext val_reduction
 
 let internal_err =
   let open Names in

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -148,6 +148,10 @@ val of_sort : ESorts.t -> valexpr
 val to_sort : valexpr -> ESorts.t
 val sort : ESorts.t repr
 
+val of_reduction : Redexpr.red_expr -> valexpr
+val to_reduction : valexpr -> Redexpr.red_expr
+val reduction : Redexpr.red_expr repr
+
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
 val pp : Pp.t repr

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -65,7 +65,7 @@ let to_red_strength = function
   | ValInt 1 -> Head
   | _ -> assert false
 
-let to_red_flag v = match Value.to_tuple v with
+let to_red_flag v : Tac2types.red_flag = match Value.to_tuple v with
 | [| strength; beta; iota; fix; cofix; zeta; delta; const |] ->
   {
     rStrength = to_red_strength strength;
@@ -81,11 +81,13 @@ let to_red_flag v = match Value.to_tuple v with
 
 let red_flags = make_to_repr to_red_flag
 
-let pattern_with_occs = pair pattern occurrences
-
 let constr_with_occs = pair constr occurrences
 
 let reference_with_occs = pair reference occurrences
+
+let to_red_context = to_option (to_pair to_pattern to_occurrences)
+
+let red_context = make_to_repr to_red_context
 
 let rec to_intro_pattern v = match Value.to_block v with
 | (0, [| b |]) -> IntroForthcoming (Value.to_bool b)
@@ -331,95 +333,71 @@ let () =
 let () = define "tac_exfalso" (unit @-> tac unit) @@ fun () ->
   Tactics.exfalso
 
-let () =
-  define "tac_red" (clause @-> tac unit) (Tac2tactics.reduce Red)
+(** Reductions *)
 
 let () =
-  define "tac_hnf" (clause @-> tac unit) (Tac2tactics.reduce Hnf)
+  define "reduce_in"
+    (reduction @-> clause @-> tac unit)
+    Tac2tactics.reduce_in
 
 let () =
-  define "tac_simpl"
-    (red_flags @-> option pattern_with_occs @-> clause @-> tac unit)
+  define "reduce_constr"
+    (reduction @-> constr @-> tac constr)
+    Tac2tactics.reduce_constr
+
+let () = define "red"
+    (ret reduction)
+    Red
+
+let () = define "hnf"
+    (ret reduction)
+    Hnf
+
+let () =
+  define "simpl"
+    (red_flags @-> red_context @-> tac reduction)
     Tac2tactics.simpl
 
 let () =
-  define "tac_cbv" (red_flags @-> clause @-> tac unit) Tac2tactics.cbv
+  define "cbv"
+    (red_flags @-> tac reduction)
+    Tac2tactics.cbv
 
 let () =
-  define "tac_cbn" (red_flags @-> clause @-> tac unit) Tac2tactics.cbn
+  define "cbn"
+    (red_flags @-> tac reduction)
+    Tac2tactics.cbn
 
 let () =
-  define "tac_lazy" (red_flags @-> clause @-> tac unit) Tac2tactics.lazy_
+  define "lazy"
+    (red_flags @-> tac reduction)
+    Tac2tactics.lazy_
 
 let () =
-  define "tac_unfold"
-    (list reference_with_occs @-> clause @-> tac unit)
+  define "unfold"
+    (list reference_with_occs @-> tac reduction)
     Tac2tactics.unfold
 
 let () =
-  define "tac_fold"
-    (list constr @-> clause @-> tac unit)
-    (fun args cl -> Tac2tactics.reduce (Fold args) cl)
+  define "fold"
+    (list constr @-> ret reduction)
+    (fun cs -> Fold cs)
 
 let () =
-  define "tac_pattern"
-    (list constr_with_occs @-> clause @-> tac unit)
+  define "pattern"
+    (list constr_with_occs @-> ret reduction)
     Tac2tactics.pattern
 
 let () =
-  define "tac_vm"
-    (option pattern_with_occs @-> clause @-> tac unit)
+  define "vm"
+    (red_context @-> ret reduction)
     Tac2tactics.vm
 
 let () =
-  define "tac_native"
-    (option pattern_with_occs @-> clause @-> tac unit)
+  define "native"
+    (red_context @-> ret reduction)
     Tac2tactics.native
 
-(** Reduction functions *)
-
-let () = define "eval_red" (constr @-> tac constr) Tac2tactics.eval_red
-
-let () = define "eval_hnf" (constr @-> tac constr) Tac2tactics.eval_hnf
-
-let () =
-  define "eval_simpl"
-    (red_flags @-> option pattern_with_occs @-> constr @-> tac constr)
-    Tac2tactics.eval_simpl
-
-let () =
-  define "eval_cbv" (red_flags @-> constr @-> tac constr) Tac2tactics.eval_cbv
-
-let () =
-  define "eval_cbn" (red_flags @-> constr @-> tac constr) Tac2tactics.eval_cbn
-
-let () =
-  define "eval_lazy" (red_flags @-> constr @-> tac constr) Tac2tactics.eval_lazy
-
-let () =
-  define "eval_unfold"
-    (list reference_with_occs @-> constr @-> tac constr)
-    Tac2tactics.eval_unfold
-
-let () =
-  define "eval_fold"
-    (list constr @-> constr @-> tac constr)
-    Tac2tactics.eval_fold
-
-let () =
-  define "eval_pattern"
-    (list constr_with_occs @-> constr @-> tac constr)
-    Tac2tactics.eval_pattern
-
-let () =
-  define "eval_vm"
-    (option pattern_with_occs @-> constr @-> tac constr)
-    Tac2tactics.eval_vm
-
-let () =
-  define "eval_native"
-    (option pattern_with_occs @-> constr @-> tac constr)
-    Tac2tactics.eval_native
 
 let () =
   define "tac_change"

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -226,116 +226,65 @@ let get_evaluable_reference = function
 | GlobRef.ConstRef cst -> Proofview.tclUNIT (Evaluable.EvalConstRef cst)
 | r -> Proofview.tclZERO (Tacred.NotEvaluableRef r)
 
-let reduce r cl =
-  let cl = mk_clause cl in
-  Tactics.reduce r cl
+let mk_flags flags =
+  Proofview.Monad.map
+    (fun rConst -> { flags with rConst })
+    (Proofview.Monad.List.map get_evaluable_reference flags.rConst)
 
-let simpl flags where cl =
-  let where = Option.map map_pattern_with_occs where in
+let reduce_in red cl =
   let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Simpl (flags, where)) cl
+  Tactics.reduce red cl
 
-let cbv flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Cbv flags) cl
-
-let cbn flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Cbn flags) cl
-
-let lazy_ flags cl =
-  let cl = mk_clause cl in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  Tactics.reduce (Lazy flags) cl
-
-let unfold occs cl =
-  let cl = mk_clause cl in
-  let map (gr, occ) =
-    let occ = mk_occurrences occ in
-    get_evaluable_reference gr >>= fun gr -> Proofview.tclUNIT (occ, gr)
-  in
-  Proofview.Monad.List.map map occs >>= fun occs ->
-  Tactics.reduce (Unfold occs) cl
-
-let pattern where cl =
-  let where = List.map (fun (c, occ) -> (mk_occurrences occ, c)) where in
-  let cl = mk_clause cl in
-  Tactics.reduce (Pattern where) cl
-
-let vm where cl =
-  let where = Option.map map_pattern_with_occs where in
-  let cl = mk_clause cl in
-  Tactics.reduce (CbvVm where) cl
-
-let native where cl =
-  let where = Option.map map_pattern_with_occs where in
-  let cl = mk_clause cl in
-  Tactics.reduce (CbvNative where) cl
-
-let eval_fun red c =
+let reduce_constr red c =
   Tac2core.pf_apply begin fun env sigma ->
-  let (redfun, _) = Redexpr.reduction_of_red_expr env red in
-  let (sigma, ans) = redfun env sigma c in
-  Proofview.Unsafe.tclEVARS sigma >>= fun () ->
-  Proofview.tclUNIT ans
+    let (redfun, _) = Redexpr.reduction_of_red_expr env red in
+    let (sigma, ans) = redfun env sigma c in
+    Proofview.Unsafe.tclEVARS sigma >>= fun () ->
+    Proofview.tclUNIT ans
   end
 
-let eval_red c =
-  eval_fun Red c
+let simpl flags where =
+  Proofview.Monad.map
+    (fun flags ->
+       let where = Option.map map_pattern_with_occs where in
+       (Simpl (flags, where)))
+    (mk_flags flags)
 
-let eval_hnf c =
-  eval_fun Hnf c
+let cbv flags =
+  Proofview.Monad.map
+    (fun flags -> Cbv flags)
+    (mk_flags flags)
 
-let eval_simpl flags where c =
-  let where = Option.map map_pattern_with_occs where in
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  eval_fun (Simpl (flags, where)) c
+let cbn flags  =
+  Proofview.Monad.map
+    (fun flags -> Cbn flags)
+    (mk_flags flags)
 
-let eval_cbv flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  eval_fun (Cbv flags) c
+let lazy_ flags =
+  Proofview.Monad.map
+    (fun flags -> Lazy flags)
+    (mk_flags flags)
 
-let eval_cbn flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  eval_fun (Cbn flags) c
-
-let eval_lazy flags c =
-  Proofview.Monad.List.map get_evaluable_reference flags.rConst >>= fun rConst ->
-  let flags = { flags with rConst } in
-  eval_fun (Lazy flags) c
-
-let eval_unfold occs c =
+let unfold occs =
   let map (gr, occ) =
     let occ = mk_occurrences occ in
     get_evaluable_reference gr >>= fun gr -> Proofview.tclUNIT (occ, gr)
   in
-  Proofview.Monad.List.map map occs >>= fun occs ->
-  eval_fun (Unfold occs) c
+  Proofview.Monad.map
+    (fun occs -> Unfold occs)
+    (Proofview.Monad.List.map map occs)
 
-let eval_fold cl c =
-  eval_fun (Fold cl) c
+let pattern where =
+  let where = List.map (fun (c, occ) -> (mk_occurrences occ, c)) where in
+  Pattern where
 
-let eval_pattern where c =
-  let where = List.map (fun (pat, occ) -> (mk_occurrences occ, pat)) where in
-  eval_fun (Pattern where) c
-
-let eval_vm where c =
+let vm where =
   let where = Option.map map_pattern_with_occs where in
-  eval_fun (CbvVm where) c
+  CbvVm where
 
-let eval_native where c =
+let native where =
   let where = Option.map map_pattern_with_occs where in
-  eval_fun (CbvNative where) c
+  CbvNative where
 
 let on_destruction_arg tac ev arg =
   Proofview.Goal.enter begin fun gl ->

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -59,47 +59,25 @@ val assert_ : assertion -> unit tactic
 val letin_pat_tac : evars_flag -> (bool * intro_pattern_naming) option ->
   Name.t -> (Evd.evar_map option * constr) -> clause -> unit tactic
 
-val reduce : Redexpr.red_expr -> clause -> unit tactic
+val reduce_in : Redexpr.red_expr -> clause -> unit tactic
 
-val simpl : GlobRef.t glob_red_flag ->
-  (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+val reduce_constr : Redexpr.red_expr -> constr -> constr tactic
 
-val cbv : GlobRef.t glob_red_flag -> clause -> unit tactic
+val simpl : Tac2types.red_flag -> Tac2types.red_context -> Redexpr.red_expr tactic
 
-val cbn : GlobRef.t glob_red_flag -> clause -> unit tactic
+val cbv : Tac2types.red_flag -> Redexpr.red_expr tactic
 
-val lazy_ : GlobRef.t glob_red_flag -> clause -> unit tactic
+val cbn : GlobRef.t glob_red_flag -> Redexpr.red_expr tactic
 
-val unfold : (GlobRef.t * occurrences) list -> clause -> unit tactic
+val lazy_ : GlobRef.t glob_red_flag -> Redexpr.red_expr tactic
 
-val pattern : (constr * occurrences) list -> clause -> unit tactic
+val unfold : (GlobRef.t * occurrences) list -> Redexpr.red_expr tactic
 
-val vm : (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+val pattern : (constr * occurrences) list -> Redexpr.red_expr
 
-val native : (Pattern.constr_pattern * occurrences) option -> clause -> unit tactic
+val vm : Tac2types.red_context -> Redexpr.red_expr
 
-val eval_red : constr -> constr tactic
-
-val eval_hnf : constr -> constr tactic
-
-val eval_simpl : GlobRef.t glob_red_flag ->
-  (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
-
-val eval_cbv : GlobRef.t glob_red_flag -> constr -> constr tactic
-
-val eval_cbn : GlobRef.t glob_red_flag -> constr -> constr tactic
-
-val eval_lazy : GlobRef.t glob_red_flag -> constr -> constr tactic
-
-val eval_unfold : (GlobRef.t * occurrences) list -> constr -> constr tactic
-
-val eval_fold : constr list -> constr -> constr tactic
-
-val eval_pattern : (EConstr.t * occurrences) list -> constr -> constr tactic
-
-val eval_vm : (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
-
-val eval_native : (Pattern.constr_pattern * occurrences) option -> constr -> constr tactic
+val native : Tac2types.red_context -> Redexpr.red_expr
 
 val discriminate : evars_flag -> destruction_arg option -> unit tactic
 

--- a/plugins/ltac2/tac2types.mli
+++ b/plugins/ltac2/tac2types.mli
@@ -104,3 +104,7 @@ type format =
 | FmtAlpha
 | FmtAlpha0
 | FmtMessage
+
+type red_flag = Names.GlobRef.t Genredexpr.glob_red_flag
+
+type red_context = (Pattern.constr_pattern * occurrences) option

--- a/test-suite/output/ltac2_anomaly_backtrace.out
+++ b/test-suite/output/ltac2_anomaly_backtrace.out
@@ -3,7 +3,8 @@ Error: Anomaly "Uncaught exception Not_found."
 Please report at http://rocq-prover.org/bugs/.
 Backtrace:
 Call foo
-Prim <rocq-runtime.plugins.ltac2:eval_hnf>
+Call Std.eval_hnf
+Prim <rocq-runtime.plugins.ltac2:reduce_constr>
 
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR expands Ltac2 stdlib with the `Red.t` type which maps to the internal `Redexpr.red_expr`. The type is opaque and its values are created with constructor functions placed in the `Std.Red` module (in `Std.v`).

Aside from the type, I added two new tactics: `eval_in` for effectful in-goal conversions, and `eval` for pure in-term conversions. All reduction functions (such as `Std.eval_cbv`) and reduction tactics (e.g. `Std.cbv`) are now implemented entirely in Ltac2 as calls to respective constructors from `Std.Red` and `reduce_constr` or `reduce_in` respectively. I removed their implementations from `tac2tactics` and `tac2stdlib`.

### Why

Currently there is no tangible notion of reduction in Ltac2. Instead, reduction functions and tactics are defined as independent externals, as if they were completely unrelated to each other. This results in unnecessary code repetition and limits the expressiveness of the type system on that matter. 

An example where this matters is the missing `eval` strategy for `rewrite_strat` that I implement in #20544, which cannot be constructed as it is parametrized by a reduction specifically (not just any `constr -> constr`). Without the changes, the only solution for `eval` is to grow the hydra and define it in 11 variants as it is done now in other cases.

### Design discussion

The point of the `Red` module is to cope with name clashes between reduction constructors (which should ideally match reduction names) and reduction tactics (which have already been there, and I presume we are bound by backward compatibility). I considered creating a separate file instead of nesting the module, but then I got a cyclic dependency (`Red.v` wanted types from `Std.v`, and reduction tactics from `Std.v` wanted reduction constructors from `Red.v`). The cycle could be solved with a new `Types.v` module to which I would dump all types from `Std`, but I considered that beyond the scope.

The idea of implementing certain `Std` functions in Ltac2 has been suggested in #20491 ([here](https://github.com/rocq-prover/rocq/pull/20491#discussion_r2047103139)).



<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**. (I believe that the existing tests are sufficient) 

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**. (only in `.v` files)
  <!-- Check if the following applies, otherwise remove these lines. -->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
