### PR TITLE
Port `rewrite_strat` to Ltac2

### DIFF
--- a/doc/changelog/06-Ltac2-language/20544-radrow-gh-20482-rewrite_strat-Added.rst
+++ b/doc/changelog/06-Ltac2-language/20544-radrow-gh-20482-rewrite_strat-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Ported `rewrite_strat` to Ltac2 and added the `Rewrite.Strategy` module for describing rewrite strategies
+  (`#20544 <https://github.com/rocq-prover/rocq/pull/20544>`_,
+  fixes `#20482 <https://github.com/rocq-prover/rocq/issues/20482>`_,
+  by Radosław Rowicki with review of Jason Gross and Pierre-Marie Pédrot and Gaëtan Gilbert).

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -153,6 +153,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Ltac2/Pstring.v
     theories/Ltac2/RedFlags.v
     theories/Ltac2/Ref.v
+    theories/Ltac2/Rewrite.v
     theories/Ltac2/Std.v
     theories/Ltac2/String.v
     theories/Ltac2/TransparentState.v

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -60,6 +60,7 @@ let val_transparent_state : TransparentState.t Val.tag = Val.create "transparent
 let val_pretype_flags = Val.create "pretype_flags"
 let val_expected_type = Val.create "expected_type"
 let val_reduction = Val.create "reduction"
+let val_rewstrategy = Val.create "rewstrategy"
 
 let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
 match Val.eq tag tag' with
@@ -241,6 +242,10 @@ let sort = repr_ext val_sort
 let of_reduction ev = of_ext val_reduction ev
 let to_reduction ev = to_ext val_reduction ev
 let reduction = repr_ext val_reduction
+
+let of_rewstrategy ev = of_ext val_rewstrategy ev
+let to_rewstrategy ev = to_ext val_rewstrategy ev
+let rewstrategy = repr_ext val_rewstrategy
 
 let internal_err =
   let open Names in

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -152,6 +152,10 @@ val of_reduction : Redexpr.red_expr -> valexpr
 val to_reduction : valexpr -> Redexpr.red_expr
 val reduction : Redexpr.red_expr repr
 
+val of_rewstrategy : Rewrite.strategy -> valexpr
+val to_rewstrategy : valexpr -> Rewrite.strategy
+val rewstrategy : Rewrite.strategy repr
+
 val of_pp : Pp.t -> valexpr
 val to_pp : valexpr -> Pp.t
 val pp : Pp.t repr

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -399,6 +399,8 @@ let () =
     Tac2tactics.native
 
 
+(** Rewritings *)
+
 let () =
   define "tac_change"
     (option pattern @-> fun1 (array constr) constr @-> clause @-> tac unit)
@@ -413,6 +415,132 @@ let () =
   define "tac_setoid_rewrite"
     (bool @-> uthaw constr_with_bindings @--> occurrences @-> option ident @-> tac unit)
     Tac2tactics.setoid_rewrite
+
+let () =
+  define "tac_rewrite_strat"
+    (rewstrategy @-> option ident @-> tac unit)
+    Tac2tactics.rewrite_strat
+
+let () =
+  define "rewstrat_id"
+    (ret rewstrategy)
+    Rewrite.Strategies.id
+
+let () =
+  define "rewstrat_fail"
+    (ret rewstrategy)
+    Rewrite.Strategies.fail
+
+let () =
+  define "rewstrat_refl"
+    (ret rewstrategy)
+    Rewrite.Strategies.refl
+
+let () =
+  define "rewstrat_progress"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.progress
+
+let () =
+  define "rewstrat_seq"
+    (rewstrategy @-> rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.seq
+
+let () =
+  define "rewstrat_seqs"
+    (list rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.seqs
+
+let () =
+  define "rewstrat_choice"
+    (rewstrategy @-> rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.choice
+
+let () =
+  define "rewstrat_choices"
+    (list rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.choices
+
+let () =
+  define "rewstrat_try"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.try_
+
+let () =
+  define "rewstrat_fix"
+    (closure @-> tac rewstrategy)
+    Tac2tactics.RewriteStrats.fix
+
+let () =
+  define "rewstrat_any"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.any
+
+let () =
+  define "rewstrat_repeat"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.repeat
+
+let () =
+  define "rewstrat_one_subterm"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.one_subterm
+
+let () =
+  define "rewstrat_all_subterms"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.all_subterms
+
+let () =
+  define "rewstrat_bottomup"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.bottomup
+
+let () =
+  define "rewstrat_topdown"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.topdown
+
+let () =
+  define "rewstrat_innermost"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.innermost
+
+let () =
+  define "rewstrat_outermost"
+    (rewstrategy @-> ret rewstrategy)
+    Rewrite.Strategies.outermost
+
+let () =
+  define "rewstrat_hints"
+    (ident @-> ret rewstrategy)
+    Tac2tactics.RewriteStrats.hints
+
+let () =
+  define "rewstrat_old_hints"
+    (ident @-> ret rewstrategy)
+    Tac2tactics.RewriteStrats.old_hints
+
+let () =
+  define "rewstrat_one_lemma"
+    (preterm @-> bool @-> ret rewstrategy)
+    Tac2tactics.RewriteStrats.one_lemma
+
+let () =
+  define "rewstrat_lemmas"
+    (list preterm @-> ret rewstrategy)
+    Tac2tactics.RewriteStrats.lemmas
+
+let () =
+  define "rewstrat_fold"
+    (constr @-> ret rewstrategy)
+    Rewrite.Strategies.fold
+
+let () =
+  define "rewstrat_eval"
+    (reduction @-> ret rewstrategy)
+    Rewrite.Strategies.reduce
+
 
 let () =
   define "tac_inversion"

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -190,6 +190,32 @@ let setoid_rewrite orient c occs id =
   let occs = mk_occurrences occs in
   Rewrite.cl_rewrite_clause (delayed_of_tactic c) orient occs id
 
+let rewrite_strat strat clause =
+  Rewrite.cl_rewrite_clause_strat strat clause
+
+module RewriteStrats =
+struct
+  let fix f =
+    let f s = Proofview.Monad.map Tac2ffi.to_rewstrategy (Tac2val.apply f [Tac2ffi.of_rewstrategy s]) in
+    Rewrite.Strategies.fix_tac f
+
+  let hints i =
+    Rewrite.Strategies.hints (Id.to_string i)
+
+  let old_hints i =
+    Rewrite.Strategies.old_hints (Id.to_string i)
+
+  let one_lemma c l2r =
+    let c env sigma = Pretyping.understand_uconstr env sigma c in
+    Rewrite.Strategies.one_lemma c l2r None AllOccurrences
+
+  let lemmas cs =
+    let mk_c c = (); fun env sigma -> Pretyping.understand_uconstr env sigma c in
+    let mk_c c = (mk_c c, true, None) in
+    let cs = List.map mk_c cs in
+    Rewrite.Strategies.lemmas cs
+end
+
 let symmetry cl =
   let cl = mk_clause cl in
   Tactics.intros_symmetry cl

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -49,6 +49,21 @@ val rewrite :
 val setoid_rewrite :
   orientation -> constr_with_bindings tactic -> occurrences -> Id.t option -> unit tactic
 
+val rewrite_strat : Rewrite.strategy -> Id.t option -> unit tactic
+
+module RewriteStrats :
+sig
+  val fix : Tac2val.closure -> Rewrite.strategy tactic
+
+  val hints : Id.t -> Rewrite.strategy
+
+  val old_hints : Id.t -> Rewrite.strategy
+
+  val one_lemma : Ltac_pretype.closed_glob_constr -> bool -> Rewrite.strategy
+
+  val lemmas : Ltac_pretype.closed_glob_constr list -> Rewrite.strategy
+end
+
 val symmetry : clause -> unit tactic
 
 val forward : bool -> unit tactic option option ->

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -872,6 +872,11 @@ let apply_rule unify : occurrences_count pure_strategy =
               (occs, res)
     }
 
+let with_no_bindings (c : delayed_open_constr) : delayed_open_constr_with_bindings =
+  (); fun env sigma ->
+    let (sigma, c) = c env sigma in
+    (sigma, (c, NoBindings))
+
 let apply_lemma l2r flags oc by loccs : strategy = { strategy =
   fun ({ state = () ; env ; term1 = t ; evars = (sigma, cstrs) } as input) ->
     let sigma, c = oc sigma in
@@ -1247,9 +1252,6 @@ let subterm all flags (s : 'a pure_strategy) : 'a pure_strategy =
       | _ -> state, Fail
   in { strategy = aux }
 
-let all_subterms = subterm true default_flags
-let one_subterm = subterm false default_flags
-
 (** Requires transitivity of the rewrite step, if not a reduction.
     Not tail-recursive. *)
 
@@ -1348,6 +1350,8 @@ module Strategies =
           | Success res -> transitivity state env unfresh cstr res snd
                                            }
 
+    let seqs strs = List.fold_left seq id strs
+
     let choice fst snd : 'a pure_strategy = { strategy =
       fun input ->
         let state, res = fst.strategy input in
@@ -1355,6 +1359,8 @@ module Strategies =
           | Fail -> snd.strategy { input with state }
           | Identity | Success _ -> state, res
                                             }
+
+    let choices strs = List.fold_left choice fail strs
 
     let try_ str : 'a pure_strategy = choice str id
 
@@ -1366,16 +1372,32 @@ module Strategies =
       let rec aux input = (f { strategy = fun input -> check_interrupt aux input }).strategy input in
       { strategy = aux }
 
+    let fix_tac (f : 'a pure_strategy -> 'a pure_strategy Proofview.tactic) : 'a pure_strategy Proofview.tactic =
+      let forward_def =
+        (* The error below happens if you do
+           [rewrite_strat (fix (fun s => rewrite_strat s None; s)) None]
+        *)
+        let err_msg = Pp.str "Rewrite strategy fixed-point variables cannot be executed by \"rewrite_strat\" inside of fix." in
+        ref (fun _ -> user_err err_msg)
+      in
+      f {strategy = fun input -> check_interrupt !forward_def input} >>= fun f ->
+      forward_def := f.strategy;
+      Proofview.tclUNIT f
+
+    let all_subterms (s : 'a pure_strategy) : 'a pure_strategy = subterm true default_flags s
+
+    let one_subterm (s : 'a pure_strategy) : 'a pure_strategy = subterm false default_flags s
+
     let any (s : 'a pure_strategy) : 'a pure_strategy =
       fix (fun any -> try_ (seq s any))
 
     let repeat (s : 'a pure_strategy) : 'a pure_strategy =
       seq s (any s)
 
-    let bu (s : 'a pure_strategy) : 'a pure_strategy =
+    let bottomup (s : 'a pure_strategy) : 'a pure_strategy =
       fix (fun s' -> seq (choice (progress (all_subterms s')) s) (try_ s'))
 
-    let td (s : 'a pure_strategy) : 'a pure_strategy =
+    let topdown (s : 'a pure_strategy) : 'a pure_strategy =
       fix (fun s' -> seq (choice s (progress (all_subterms s'))) (try_ s'))
 
     let innermost (s : 'a pure_strategy) : 'a pure_strategy =
@@ -1384,31 +1406,42 @@ module Strategies =
     let outermost (s : 'a pure_strategy) : 'a pure_strategy =
       fix (fun out -> choice s (one_subterm out))
 
-    let lemmas cs : 'a pure_strategy =
-      List.fold_left (fun tac (l,l2r,by) ->
-        choice tac (apply_lemma l2r rewrite_unif_flags l by AllOccurrences))
+    let one_lemma c l2r by occs : strategy =
+      let strategy ({env} as input) =
+        let c sigma = with_no_bindings c env sigma in
+        let flags = general_rewrite_unif_flags () in
+        (apply_lemma l2r flags c by occs).strategy input
+      in {strategy}
+
+    let lemmas cs : strategy =
+      List.fold_left (fun tac (l,l2r,by) -> choice tac (one_lemma l l2r by AllOccurrences))
         fail cs
 
-    let inj_open hint = (); fun sigma ->
+    let inj_open hint = (); fun _env sigma ->
       let (ctx, lemma) = Autorewrite.RewRule.rew_lemma hint in
       let subst, ctx = UnivGen.fresh_universe_context_set_instance ctx in
       let subst = Sorts.QVar.Map.empty, subst in
       let lemma = Vars.subst_univs_level_constr subst (EConstr.of_constr lemma) in
       let sigma = Evd.merge_context_set UnivRigid sigma ctx in
-      (sigma, (lemma, NoBindings))
+      (sigma, lemma)
 
-    let old_hints (db : string) : 'a pure_strategy =
+    let old_hints (db : string) : strategy =
       let rules = Autorewrite.find_rewrites db in
         lemmas
-          (List.map (fun hint -> (inj_open hint, Autorewrite.RewRule.rew_l2r hint,
-                                  Autorewrite.RewRule.rew_tac hint)) rules)
+          (List.map (fun hint -> (inj_open hint,
+                                  Autorewrite.RewRule.rew_l2r hint,
+                                  Autorewrite.RewRule.rew_tac hint
+                                 )
+                    ) rules)
 
-    let hints (db : string) : 'a pure_strategy = { strategy =
+    let hints (db : string) : strategy = { strategy =
       fun ({ term1 = t; env } as input) ->
       let t = EConstr.Unsafe.to_constr t in
       let rules = Autorewrite.find_matches env db t in
-      let lemma hint = (inj_open hint, Autorewrite.RewRule.rew_l2r hint,
-                        Autorewrite.RewRule.rew_tac hint) in
+      let lemma hint = (inj_open hint,
+                        Autorewrite.RewRule.rew_l2r hint,
+                        Autorewrite.RewRule.rew_tac hint
+                       ) in
       let lems = List.map lemma rules in
       (lemmas lems).strategy input
                                                  }
@@ -1426,24 +1459,28 @@ module Strategies =
                                rew_evars = sigma, cstrevars evars }
                                                            }
 
-    let fold_glob c : 'a pure_strategy = { strategy =
-      fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
-(*         let sigma, (c,_) = Tacinterp.interp_open_constr_with_bindings is env (goalevars evars) c in *)
-        let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
-        let unfolded = match Tacred.red_product env sigma c with
+    let run_fold_in env evars c term typ : rewrite_result =
+      let unfolded = match Tacred.red_product env (goalevars evars) c with
         | None -> user_err Pp.(str "fold: the term is not unfoldable!")
         | Some c -> c
-        in
-          try
-            let _, sigma = Unification.w_unify env sigma CONV ~flags:(Unification.elim_flags ()) unfolded t in
-            let c' = Reductionops.nf_evar sigma c in
-              state, Success { rew_car = ty; rew_from = t; rew_to = c';
-                                  rew_prf = RewCast DEFAULTcast;
-                                  rew_evars = (sigma, snd evars) }
-          with e when CErrors.noncritical e -> state, Fail
-                                         }
+      in try
+        let _, sigma = Unification.w_unify env (goalevars evars) CONV ~flags:(Unification.elim_flags ()) unfolded term in
+        let c' = Reductionops.nf_evar sigma c in
+        Success { rew_car = typ; rew_from = term; rew_to = c';
+                         rew_prf = RewCast DEFAULTcast;
+                         rew_evars = (sigma, cstrevars evars) }
+      with e when CErrors.noncritical e -> Fail
 
+    let fold (c : Evd.econstr) : 'a pure_strategy =
+      { strategy = fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
+            state, run_fold_in env evars c t ty
+      }
 
+    let fold_glob c : 'a pure_strategy =
+      { strategy = fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
+            let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
+            state, run_fold_in env (sigma, cstrevars evars) c t ty
+      }
 end
 
 (** The strategy for a single rewrite, dealing with occurrences. *)
@@ -1657,21 +1694,6 @@ let cl_rewrite_clause l left2right occs clause =
 let cl_rewrite_clause_strat strat clause =
   cl_rewrite_clause_strat false strat clause
 
-let apply_glob_constr ((_, c) : _ * EConstr.t delayed_open) l2r occs = (); fun ({ state = () ; env = env } as input) ->
-  let c sigma =
-    let (sigma, c) = c env sigma in
-    (sigma, (c, NoBindings))
-  in
-  let flags = general_rewrite_unif_flags () in
-  (apply_lemma l2r flags c None occs).strategy input
-
-let interp_glob_constr_list env =
-  let make c = (); fun sigma ->
-    let sigma, c = Pretyping.understand_tcc env sigma c in
-    (sigma, (c, NoBindings))
-  in
-  List.map (fun c -> make c, true, None)
-
 (* Syntax for rewriting with strategies *)
 
 type unary_strategy =
@@ -1762,12 +1784,12 @@ let rec strategy_of_ast bindings = function
   | StratUnary (f, s) ->
     let s' = strategy_of_ast bindings s in
     let f' = match f with
-      | Subterms -> all_subterms
-      | Subterm -> one_subterm
+      | Subterms -> Strategies.all_subterms
+      | Subterm -> Strategies.one_subterm
       | Innermost -> Strategies.innermost
       | Outermost -> Strategies.outermost
-      | Bottomup -> Strategies.bu
-      | Topdown -> Strategies.td
+      | Bottomup -> Strategies.bottomup
+      | Topdown -> Strategies.topdown
       | Progress -> Strategies.progress
       | Try -> Strategies.try_
       | Any -> Strategies.any
@@ -1785,13 +1807,9 @@ let rec strategy_of_ast bindings = function
       | [] -> assert false
       | s::strs -> List.fold_left Strategies.choice s strs
     end
-  | StratConstr (c, b) -> { strategy = apply_glob_constr c b AllOccurrences }
+  | StratConstr ((_, c), b) -> Strategies.one_lemma c b None AllOccurrences
   | StratHints (old, id) -> if old then Strategies.old_hints id else Strategies.hints id
-  | StratTerms l -> { strategy =
-    (fun ({ state = () ; env } as input) ->
-     let l' = interp_glob_constr_list env (List.map fst l) in
-     (Strategies.lemmas l').strategy input)
-                    }
+  | StratTerms l -> Strategies.lemmas (List.map (fun (_, c) -> (c, true, None)) l)
   | StratEval r -> { strategy =
     (fun ({ state = () ; env ; evars } as input) ->
      let (sigma, r_interp) = r env (goalevars evars) in

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -104,6 +104,41 @@ val apply_strategy :
   bool * constr ->
   evars -> rewrite_result
 
+module Strategies :
+sig
+  val fail : strategy
+  val id : strategy
+  val refl : strategy
+  val progress : strategy -> strategy
+  val seq : strategy -> strategy -> strategy
+  val seqs : strategy list -> strategy
+  val choice : strategy -> strategy -> strategy
+  val choices : strategy list -> strategy
+  val try_ : strategy -> strategy
+
+  val fix_tac : (strategy -> strategy Proofview.tactic) -> strategy Proofview.tactic
+  val fix : (strategy -> strategy) -> strategy
+
+  val any : strategy -> strategy
+  val repeat : strategy -> strategy
+  val all_subterms : strategy -> strategy
+  val one_subterm : strategy -> strategy
+  val bottomup : strategy -> strategy
+  val topdown : strategy -> strategy
+  val innermost : strategy -> strategy
+  val outermost : strategy -> strategy
+
+  val one_lemma : delayed_open_constr -> bool -> Gentactic.glob_generic_tactic option -> Locus.occurrences -> strategy
+  val lemmas : (delayed_open_constr * bool * Gentactic.glob_generic_tactic option) list -> strategy
+
+  val old_hints : string -> strategy
+  val hints : string -> strategy
+  val reduce : Redexpr.red_expr -> strategy
+
+  val fold : Evd.econstr -> strategy
+  val fold_glob : Glob_term.glob_constr -> strategy
+end
+
 module Internal :
 sig
 val build_signature :

--- a/test-suite/ltac2/rewrite_strat.v
+++ b/test-suite/ltac2/rewrite_strat.v
@@ -1,0 +1,158 @@
+Require Import Setoid.
+
+From Ltac2 Require Import Ltac2.
+From Ltac2 Require Import Std.
+From Ltac2 Require Import Rewrite.
+
+Import Strategy.
+
+Parameter X : Set.
+
+Parameter f : X -> X.
+Parameter g : X -> X -> X.
+Parameter h : nat -> X -> X.
+
+Parameter lem0 : forall x, f (f x) = f x.
+Parameter lem1 : forall x, g x x = f x.
+Parameter lem2 : forall n x, h (S n) x = g (h n x) (h n x).
+Parameter lem3 : forall x, h 0 x = x.
+
+#[export] Hint Rewrite lem0 lem1 lem2 lem3 : rew.
+
+Goal forall x, h 6 x = f x.
+  intros.
+  time (rewrite_strat (topdown (term preterm:(lem2) true)) None).
+  time (rewrite_strat (topdown (term preterm:(lem1) true)) None).
+  time (rewrite_strat (topdown (term preterm:(lem0) true)) None).
+  time (rewrite_strat (topdown (term preterm:(lem3) true)) None).
+  time (rewrite_strat id None).
+  reflexivity ().
+Undo 6.
+  time (rewrite_strat (topdown
+          (choice
+             (term preterm:(lem2) true)
+             (term preterm:(lem1) true)
+       )) None).
+  time (rewrite_strat (topdown
+          (choice
+             (term preterm:(lem0) true)
+             (term preterm:(lem3) true)
+       )) None).
+  reflexivity ().
+Undo 3.
+  time (rewrite_strat (seq
+                       (topdown
+                          (choice
+                             (term preterm:(lem2) true)
+                             (term preterm:(lem1) true)
+                       ))
+                       (topdown
+                          (choice
+                             (term preterm:(lem0) true)
+                             (term preterm:(lem3) true)
+                          ))
+       ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (topdown
+                         (choice
+                              (choice
+                                 (term preterm:(lem2) true)
+                                 (term preterm:(lem1) true)
+                              )
+                              (choice
+                                 (term preterm:(lem0) true)
+                                 (term preterm:(lem3) true)
+                              )
+                         )
+          ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (topdown
+                         (choice
+                              (term preterm:(lem2) true)
+                              (choice
+                                 (term preterm:(lem1) true)
+                                 (choice
+                                    (term preterm:(lem0) true)
+                                    (term preterm:(lem3) true)
+                                 )
+                            )
+                         )
+       ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (topdown
+                         (choices [
+                              (term preterm:(lem2) true);
+                              (term preterm:(lem1) true);
+                              (term preterm:(lem0) true);
+                              (term preterm:(lem3) true)
+                            ]
+                         )
+          ) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (fix_
+                         (fun f =>
+                            seq
+                              (choices [
+                                   (term preterm:(lem2) true);
+                                   (term preterm:(lem1) true);
+                                   (term preterm:(lem0) true);
+                                   (term preterm:(lem3) true);
+                                   (progress (subterms f))
+                                 ])
+                            (try f)
+                         )
+       ) None).
+  reflexivity ().
+Qed.
+
+Parameter breaker : forall x y, h x y = f y <-> False.
+
+Goal forall x, h 10 x = f x.
+Proof.
+  intros.
+  time (rewrite_strat (topdown (hints @rew)) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (any (outermost (hints @rew))) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (repeat (outermost (hints @rew))) None).
+  reflexivity ().
+Undo 2.
+  time (rewrite_strat (seqs [outermost (Strategy.fold '(6 + ?[?four]))]) None).
+  match! goal with
+  | [|- h (6 + 4) ?x = f ?x] => ()
+  | [|- _] => Control.throw Assertion_failure
+  end.
+Undo 2.
+  time (rewrite_strat (
+            choices [
+                seqs [fail; term preterm:(breaker) true]; (* fail *)
+                seqs [repeat fail; term preterm:(breaker) true];  (* fail *)
+                seqs [progress fail; term preterm:(breaker) true];  (* fail *)
+                seqs [progress id; term preterm:(breaker) true];  (* fail *)
+
+                seqs [id;
+                      progress refl;
+                      any fail;
+                      try fail;
+                      topdown (hints @rew)
+                  ];  (* success *)
+
+                term preterm:(breaker) true  (* unreachable *)
+       ]) None).
+  reflexivity ().
+Qed.
+
+Set Printing All.
+Set Printing Depth 100000.
+
+Ltac2 Notation "my_rewrite_strat" x(preterm) := rewrite_strat (topdown (term x true)) None.
+Goal (forall x, S x = 0) -> 1 = 0.
+intro H.
+my_rewrite_strat H.
+Abort.

--- a/test-suite/success/rewrite_strat.v
+++ b/test-suite/success/rewrite_strat.v
@@ -35,7 +35,7 @@ Undo 3.
   Time rewrite_strat (topdown (choice lem2 lem1); topdown (choice lem0 lem3)).
   reflexivity.
 Undo 2.
-  Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).
+  Time rewrite_strat (topdown (choice (choice lem2 lem1) (choice lem0 lem3))).
   reflexivity.
 Undo 2.
   Time rewrite_strat (topdown (choice lem2 (choice lem1 (choice lem0 lem3)))).

--- a/theories/Ltac2/Rewrite.v
+++ b/theories/Ltac2/Rewrite.v
@@ -1,0 +1,134 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+From Ltac2 Require Import Init.
+From Ltac2 Require Std.
+
+(** Module for rewrite strategies used by [rewrite_strat]. *)
+Module Strategy.
+  Ltac2 Type t.
+
+  (** Failure. *)
+  Ltac2 @external fail : t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_fail".
+
+  (** Success without progress. *)
+  Ltac2 @external id : t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_id".
+
+  (** Success with progress. *)
+  Ltac2 @external refl : t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_refl".
+
+  (** Applies the argument and fails if no progress was made. *)
+  Ltac2 @external progress : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_progress".
+
+  (** Applies left, and then right if left succeeded.  *)
+  Ltac2 @external seq : t -> t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_seq".
+
+  (** Equivalent to [List.fold_left seq id]. *)
+  Ltac2 @external seqs : t list -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_seqs".
+
+  (** Applies left, and then right if left failed. *)
+  Ltac2 @external choice : t -> t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_choice".
+
+  (** Equivalent to [List.fold_left choice fail]. *)
+  Ltac2 @external choices : t list -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_choices".
+
+  (** Equivalent to [choice s id]. *)
+  Ltac2 @external try : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_try".
+
+  (** Applies the argument until it fails. *)
+  Ltac2 @external any : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_any".
+
+  (** Equivalent to [seq s (any s)]. *)
+  Ltac2 @external repeat : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_repeat".
+
+  (** Applies the argument to all immediate subterms of the considered term,
+      left-to-right. *)
+  Ltac2 @external subterms : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_all_subterms".
+
+  (** Applies the argument to the leftmost immediate subterm of the considered
+      term on which progress can be made. *)
+  Ltac2 @external subterm : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_one_subterm".
+
+  (** Traverses the term bottom-up--left-to-right and applies the argument at
+      each step as many times as possible. *)
+  Ltac2 @external bottomup : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_bottomup".
+
+  (** Traverses the term top-down--left-to-right and applies the argument at
+      each step as many times as possible. *)
+  Ltac2 @external topdown : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_topdown".
+
+  (** Traverses the term bottom-up--left-to-right until the argument makes progress. *)
+  Ltac2 @external innermost : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_innermost".
+
+  (** Traverses the term top-down--left-to-right until the argument makes progress. *)
+  Ltac2 @external outermost : t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_outermost".
+
+  (** Unifies the one side of the lemma with the current subterm and on success
+      rewrite it to the other side. If the boolean argument is true, rewrites
+      left-to-right; otherwise, rewrites right-to-left. *)
+  Ltac2 @external term : preterm -> bool -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_one_lemma".
+
+  (** Equivalent to [choices (List.map (fun c => term c true)) l]. *)
+  Ltac2 @external terms : preterm list -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_lemmas".
+
+  (* TODO this needs documentation *)
+  Ltac2 @external old_hints : ident -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_old_hints".
+
+  (** Applies hints from rewrite hint database. *)
+  Ltac2 @external hints : ident -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_hints".
+
+  (** Replaces the term under consideration with the argument if they unify. *)
+  Ltac2 @external fold : constr -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_fold".
+
+  (** Converts the term under consideration. *)
+  Ltac2 @external eval : Std.Red.t -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_eval".
+
+  (** Fixed point operation for recursive strategies. [fix (fun f => s)] evaluates
+      to [s[f / fix (fun f => s)]]. The function provided in the argument is
+      executed only _once_ when the strategy is constructed — it cannot be used
+      for dynamically manage the rewriting. *)
+  Ltac2 @external fix_ : (t -> t) -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_fix".
+
+End Strategy.
+
+(* Tactics *)
+
+(** Runs rewrite strategy on the type of a hypothesis or the goal if the second
+    argument is [None]. *)
+Ltac2 @external rewrite_strat : Strategy.t -> ident option -> unit := "rocq-runtime.plugins.ltac2" "tac_rewrite_strat".
+
+(** Runs rewritings from a hint database on the type of a hypothesis or the goal
+    if the second argument is [None]. The rewritings are applied top-down on all
+    subterms. *)
+Ltac2 rewrite_db (hintdb : ident) (i : ident option) : unit := rewrite_strat (Strategy.topdown (Strategy.hints hintdb)) i.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR adds an Ltac2 type for rewriting strategies and implements `rewrite_strat` for Ltac2. 

The strategy type is opaque and its values are constructed via functions in the new `Rewrite.v` stdlib. The functions connect directly to the `strategy` type in OCaml from the `Rewrite` module which now exposes API for constructing strategies. To this end, I did some tidy-up in `rewrite.ml`, so the API is compatible with values coming from Ltac2.

As for testing, I just ported the existing Ltac1 test for this tactic. The tests are non-exhaustive for some reason — I can fix it in either this PR or a separate one if you wish.

<s>The `eval` strategy is missing as it is waiting for #20543.</s>

Closes #20482 
Reincarnates #20491

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**. 

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.  <-- (only in the .v files)

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
