### PR TITLE
test suite merge `distclean` target (rm .aux) into `clean`

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -223,17 +223,14 @@ run: $(SUBSYSTEMS)
 clean:
 	rm -f trace .csdp.cache .nia.cache .lia.cache
 	rm -f misc/universes/all_stdlib.v
-	$(SHOW) 'RM        <**/*.stamp> <**/*.vo> <**/*.log> <**/*.glob> <**/*.time>'
+	$(SHOW) 'RM        <**/*.stamp> <**/*.vo> <**/*.log> <**/*.glob> <**/*.aux> <**/*.time>'
 	$(HIDE)find . \( \
-	  -name '*.stamp' -o -name '*.vo' -o -name '*.vos' -o -name '*.vok' -o -name '*.log' -o -name '*.glob' -o -name '*.time' \
+	  -name '*.stamp' -o -name '*.vo' -o -name '*.vos' -o -name '*.vok' -o -name '*.log' -o -name '*.glob' -o -name '*.aux' -o -name '*.time' \
 	  \) -exec rm -f {} +
 	$(SHOW) 'RM        <**/*.cmx> <**/*.cmi> <**/*.o> <**/*.test>'
 	$(HIDE)find unit-tests \( \
 	  -name '*.cmx' -o -name '*.cmi' -o -name '*.o' -o -name '*.test' \
 	  \) -exec rm -f {} +
-distclean: clean
-	$(SHOW) 'RM        <**/*.aux>'
-	$(HIDE)find . -name '*.aux' -exec rm -f {} +
 
 #######################################################################
 # Per-subsystem targets


### PR DESCRIPTION
It does not seem useful to keep them separate.
