### PR TITLE
Remove the notation for "only" in Ltac2.

### DIFF
--- a/doc/changelog/04-tactics/20197-ltac2-rename.rst
+++ b/doc/changelog/04-tactics/20197-ltac2-rename.rst
@@ -1,4 +1,4 @@
 - **Added:**
-  Add `rename`, `eassumption`, `cycle`, `only` and `exfalso` Ltac2 notations
+  Add `rename`, `eassumption`, `cycle`, and `exfalso` Ltac2 notations
   (`#20197 <https://github.com/coq/coq/pull/20197>`_,
   by Josselin Poiret).

--- a/test-suite/ltac2/std_tactics.v
+++ b/test-suite/ltac2/std_tactics.v
@@ -162,10 +162,10 @@ Goal nat * bool.
   - exact 0.
 Qed.
 
-(* only *)
+(* focus *)
 Goal bool * nat * nat.
   repeat split.
-  all: only 2 - 3: exact 0.
+  all: Control.focus 2 3 (fun () => exact 0).
   exact true.
 Qed.
 

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -101,9 +101,6 @@ Ltac2 Notation unshelve := Control.unshelve.
 
 Ltac2 cycle := Control.cycle.
 
-Ltac2 Notation "only" startgoal(tactic) endgoal(opt(seq("-", tactic))) ":" tac(thunk(tactic)) :=
-  Control.focus startgoal (Option.default startgoal endgoal) tac.
-
 Ltac2 progress0 tac := Control.enter (fun _ => Control.progress tac).
 
 Ltac2 Notation progress := progress0.


### PR DESCRIPTION
This notation is not well-bracketed and does not play well with developments that would use "only" as a normal identifier. There is furthermore little point in adding it as a notation since it is basically just a call to Control.focus. The reason we had it in Ltac1 was that everything had to go through notations, it is more than time not to repeat the same error in Ltac2.

Since it was added surreptitiously in #20197 which is not part of a released version of Rocq, we can just remove it bluntly.