### PR TITLE
Tweak the output of the test-suite logs.

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -353,11 +353,11 @@ $(addsuffix .log,$(wildcard prerequisite/*.v)): %.v.log: %.v
 	  $(call WITH_TIMER,$@,$(coqc) "$<" $(call get_coq_prog_args,"$<") 2>&1); R=$$?; times; \
 	  if [ $$R != 0 ]; then \
 	    echo $(log_failure); \
-	    echo "    $<...could not be prepared" ; \
+	    echo "    $< ... could not be prepared" ; \
 	    $(FAIL); \
 	  else \
 	    echo $(log_success); \
-	    echo "    $<...correctly prepared" ; \
+	    echo "    $< ... correctly prepared" ; \
 	  fi; \
 	} > "$@"
 	$(HIDE)$(call REPORT_TIMER,$@)
@@ -370,10 +370,10 @@ $(addsuffix .log,$(wildcard bugs/*.v ssr/*.v success/*.v failure/*.v stm/*.v mod
 	  $(call WITH_TIMER,$@,$(coqc) "$<" $(call get_coq_prog_args,"$<") $$opts 2>&1); R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (should be accepted)"; \
+	    echo "    $< ... Error! (should be accepted)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -387,7 +387,7 @@ $(addsuffix .log,$(wildcard bugs/*.v ssr/*.v success/*.v failure/*.v stm/*.v mod
 		-Q $(shell dirname $<) "" -norec $(shell basename $< .v)) 2>&1); R=$$?; \
 	  if [ $$R != 0 ]; then \
 	    echo $(log_failure); \
-	    echo "    $<...could not be checked (Error!)" ; \
+	    echo "    $< ... could not be checked (Error!)" ; \
 	    $(FAIL_CHK); \
 	  fi; \
 	} > "$(shell dirname $<)/$(shell basename $< .v).chk.log"; fi
@@ -401,10 +401,10 @@ $(addsuffix .log,$(wildcard bugs-nocoqchk/*.v)): %.v.log: %.v
 	  $(call WITH_TIMER,$@,$(coqc) "$<" $(call get_coq_prog_args,"$<") 2>&1); R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (bug seems to be opened, please check)"; \
+	    echo "    $< ... Error! (bug seems to be opened, please check)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -428,11 +428,11 @@ $(addsuffix .log,$(wildcard output/*.v)): %.v.log: %.v %.out $(PREREQUISITELOG)
 	  diff -a -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	    rm $$output; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -452,11 +452,11 @@ $(addsuffix .log,$(wildcard output-coqtop/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	  diff -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	    rm $$output; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -470,10 +470,10 @@ $(addsuffix .log,$(wildcard output-coqchk/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	  $(call WITH_TIMER,$@,$(coqc) "$<" $(call get_coq_prog_args,"$<") 2>&1); R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (should be accepted)"; \
+	    echo "    $< ... Error! (should be accepted)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -488,11 +488,11 @@ $(addsuffix .log,$(wildcard output-coqchk/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	  diff -a -u --strip-trailing-cr $*.out $$output 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	    rm $$output; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$(shell dirname $<)/$(shell basename $< .v).chk.log"; fi
@@ -543,10 +543,10 @@ $(addsuffix .log,$(wildcard output-modulo-time/*.v)): %.v.log: %.v %.out
 	  diff  --strip-trailing-cr -b -u $$tmpexpected $$tmpoutput 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	  rm $$tmpoutput; \
@@ -561,10 +561,10 @@ $(addsuffix .log,$(wildcard interactive/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	  $(call WITH_TIMER,$@,$(coqtop) $(call get_coq_prog_args,"$<") < "$<" 2>&1); R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (should be accepted)"; \
+	    echo "    $< ... Error! (should be accepted)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -583,11 +583,11 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	  R=$$?; times; \
 	  if [ $$R != 0 ]; then \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (should be accepted)" ; \
+	    echo "    $< ... Error! (should be accepted)" ; \
 	    $(FAIL); \
 	  elif [ "$$res" = "" ]; then \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (couldn't find a time measure)"; \
+	    echo "    $< ... Error! (couldn't find a time measure)"; \
 	    $(FAIL); \
 	  else \
 	    true "express effective time in centiseconds"; \
@@ -595,7 +595,7 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	    res=`echo "$$res"00 | sed -n -e "s/\([0-9]*\)\.\([0-9][0-9]\).*/\1\2/p"`; \
 	    if [ "$$res" = "" ]; then \
 	      echo $(log_failure); \
-	      echo "    $<...Error! (invalid time measure: $$resorig)"; \
+	      echo "    $< ... Error! (invalid time measure: $$resorig)"; \
 	    else \
 	      true "find expected time * 100"; \
 	      exp=`sed -n -e "s/(\*.*Expected time < \([0-9]\).\([0-9][0-9]\)s.*\*)/\1\2/p" "$<"`; \
@@ -604,10 +604,10 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	      ok=`expr \( $$res \* $(bogomips) \) "<" \( $$exp \* 6120 \)`; \
 	      if [ "$$ok" = 1 ]; then \
 	        echo $(log_success); \
-	        echo "    $<...Ok"; \
+	        echo "    $< ... Ok"; \
 	      else \
 	        echo $(log_failure); \
-	        echo "    $<...Error! (should run faster ($$rescorrected >= $$exp))"; \
+	        echo "    $< ... Error! (should run faster ($$rescorrected >= $$exp))"; \
 	        $(FAIL); \
 	      fi; \
 	    fi; \
@@ -624,10 +624,10 @@ $(addsuffix .log,$(wildcard ideal-features/*.v)): %.v.log: %.v $(PREREQUISITELOG
 	  $(call WITH_TIMER,$@,$(coqc) "$<" $(call get_coq_prog_args,"$<") 2>&1); R=$$?; times; \
 	  if [ $$R != 0 ]; then \
 	      echo $(log_success); \
-	      echo "    $<...still wished"; \
+	      echo "    $< ... still wished"; \
           else \
 	      echo $(log_failure); \
-	      echo "    $<...Good news! (wish seems to be granted, please check)"; \
+	      echo "    $< ... Good news! (wish seems to be granted, please check)"; \
 	      $(FAIL); \
           fi; \
 	} > "$@"
@@ -662,10 +662,10 @@ $(patsubst %.sh,%.log,$(wildcard misc/*.sh)): %.log: %.sh $(PREREQUISITELOG)
 	  $(call WITH_TIMER,$@,"$<" 2>&1); R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error!"; \
+	    echo "    $< ... Error!"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -686,10 +686,10 @@ ide/fake_ide.exe : ide/fake_ide.ml
 	  $(call WITH_TIMER,$@,ide/fake_ide.exe $(coqidetop) "$<" "-q -async-proofs on -async-proofs-tactic-error-resilience off -async-proofs-command-error-resilience off $(call get_coq_prog_args,"$<")" 2>&1); \
 	  if [ $$? = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error!"; \
+	    echo "    $< ... Error!"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -707,10 +707,10 @@ coqwc/%.v.log : coqwc/%.v
 	  diff -u --strip-trailing-cr coqwc/$*.out $$tmpoutput 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	  rm $$tmpoutput; \
@@ -730,10 +730,10 @@ $(patsubst %/run.sh,%.log,$(wildcard coq-makefile/*/run.sh precomputed-time-test
 	  $(call WITH_TIMER,$@,bash run.sh 2>&1,../../$@.time); \
 	if [ $$? = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error!"; \
+	    echo "    $< ... Error!"; \
 	    $(FAIL); \
 	  fi; \
 	) > "$@"
@@ -754,10 +754,10 @@ $(addsuffix .log,$(wildcard coqdoc/*.v)): %.v.log: %.v %.html.out %.tex.out $(PR
 	  grep -v "^%%" Coqdoc.$$f.tex | diff -u --strip-trailing-cr $$f.tex.out - 2>&1; S=$$?; times; \
 	  if [ $$R = 0 -a $$S = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error! (unexpected output)"; \
+	    echo "    $< ... Error! (unexpected output)"; \
 	    $(FAIL); \
 	  fi; \
 	} > "$@"
@@ -774,10 +774,10 @@ tools/%.log : tools/%/run.sh
 	  bash run.sh 2>&1; \
 	if [ $$? = 0 ]; then \
 	    echo $(log_success); \
-	    echo "    $<...Ok"; \
+	    echo "    $< ... Ok"; \
 	  else \
 	    echo $(log_failure); \
-	    echo "    $<...Error!"; \
+	    echo "    $< ... Error!"; \
 	    $(FAIL); \
 	  fi; \
 	) > "$@"

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -31,7 +31,7 @@ TEST      success/fail.v
 ...
 BUILDING SUMMARY FILE
 FAILURES
-    success/fail.v...Error! (should be accepted)
+    success/fail.v ... Error! (should be accepted)
 Makefile:189: recipe for target 'all failed
 make: *** [report] Error 1
 
@@ -48,10 +48,10 @@ Syntax error: [vernac:Vernac.vernac_control] expected after 'Fail' (in [vernac:V
 0m0.000000s 0m0.000000s
 0m0.040000s 0m0.000000s
 ==========> FAILURE <==========
-    success/fail.v...Error! (should be accepted)
+    success/fail.v ... Error! (should be accepted)
 
 FAILURES
-    success/fail.v...Error! (should be accepted)
+    success/fail.v ... Error! (should be accepted)
 Makefile:189: recipe for target 'report' failed
 make: *** [report] Error 1
 

--- a/test-suite/unit-tests/src/utest.ml
+++ b/test-suite/unit-tests/src/utest.ml
@@ -67,10 +67,10 @@ let run_tests ml_fn out_ch tests =
       tot succ (tot - succ);
   if succ = tot then
     cprintf
-      "==========> SUCCESS <==========\n    %s...Ok" ml_fn
+      "==========> SUCCESS <==========\n    %s ... Ok" ml_fn
   else begin
     cprintf
-      "==========> FAILURE <==========\n    %s...Error!" ml_fn;
+      "==========> FAILURE <==========\n    %s ... Error!" ml_fn;
     ceprintf "FAILED    %s.log" ml_fn
   end;
   close_out out_ch


### PR DESCRIPTION
Since the Makefile test-suite does not seem to want to go away in the immediate future, this commit adds a small life-improving tweak to the output of the test-suite logs. Basically, we just add a space after the file name so that it becomes easy to select it in interfaces that split words on spaces. For good typographical measure, we also add a space after the trailing dots.