### PR TITLE
Fix test suite non-quiet mode

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -107,7 +107,7 @@ VERBOSE?=
 
 # if VERBOSE we print the command instead
 # if QUIET we print nothing (except errors)
-SHOW0 := $(if $(VERBOSE) $(QUIET),true,echo)
+SHOW0 := $(if $(strip $(VERBOSE) $(QUIET)),true,echo)
 SHOW := @$(SHOW0)
 HIDE := $(if $(VERBOSE),,@)
 


### PR DESCRIPTION
Because of the space between VERBOSE and QUIET it was always considered quiet.
