### PR TITLE
Add raw printers for Ltac2 commands

### DIFF
--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -981,8 +981,9 @@ let rules = [
 
 {
 
-let pr_ltac2entry _ = mt () (* FIXME *)
-let pr_ltac2expr _ = mt () (* FIXME *)
+let pr_ltac2entry = Tac2print.pr_strexpr
+let pr_ltac2expr e = Tac2print.pr_rawexpr_gen E5 ~avoid:Id.Set.empty e
+let pr_ltac2def_syn (a,b,c) = Tac2entries.pr_register_notation a b c
 
 }
 
@@ -995,7 +996,7 @@ PRINTED BY { pr_ltac2entry }
 END
 
 VERNAC ARGUMENT EXTEND ltac2def_syn
-PRINTED BY { pr_ltac2entry }
+PRINTED BY { pr_ltac2def_syn }
 | [ tac2def_syn(e) ] -> { e }
 END
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1952,18 +1952,8 @@ let () =
 let add_syntax_class s f =
   Tac2entries.register_syntax_class (Id.of_string s) f
 
-let rec pr_syntax_class = let open CAst in function
-| SexprStr {v=s} -> qstring s
-| SexprInt {v=n} -> Pp.int n
-| SexprRec (_, {v=na}, args) ->
-  let na = match na with
-  | None -> str "_"
-  | Some id -> Id.print id
-  in
-  na ++ str "(" ++ prlist_with_sep (fun () -> str ", ") pr_syntax_class args ++ str ")"
-
 let syntax_class_fail s args =
-  let args = str "(" ++ prlist_with_sep (fun () -> str ", ") pr_syntax_class args ++ str ")" in
+  let args = str "(" ++ prlist_with_sep (fun () -> str ", ") Tac2print.pr_syntax_class args ++ str ")" in
   CErrors.user_err (str "Invalid arguments " ++ args ++ str " in syntactic class " ++ str s)
 
 let q_unit = CAst.make @@ CTacCst (AbsKn (Tuple 0))

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -818,6 +818,11 @@ type notation_interpretation_data =
 | Abbreviation of Id.t * Deprecation.t option * raw_tacexpr
 | Synext of bool * KerName.t * Id.Set.t * raw_tacexpr
 
+let pr_register_notation tkn lev body =
+  prlist_with_sep spc Tac2print.pr_syntax_class tkn ++
+  pr_opt (fun n -> str ": " ++ int n) lev ++ spc() ++
+  hov 2 (str ":= " ++ Tac2print.pr_rawexpr_gen E5 ~avoid:Id.Set.empty body)
+
 let register_notation atts tkn lev body =
   let deprecation, local = Attributes.(parse Notations.(deprecation ++ locality)) atts in
   let local = Option.default false local in

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -27,6 +27,8 @@ val register_struct : Attributes.vernac_flags -> strexpr -> unit
 
 type notation_interpretation_data
 
+val pr_register_notation : sexpr list -> int option -> raw_tacexpr -> Pp.t
+
 val register_notation : Attributes.vernac_flags -> sexpr list ->
   int option -> raw_tacexpr -> notation_interpretation_data
 

--- a/plugins/ltac2/tac2print.mli
+++ b/plugins/ltac2/tac2print.mli
@@ -41,6 +41,11 @@ val pr_partial_pat : PartialPat.t -> Pp.t
 
 val pr_rawexpr_gen : exp_level -> avoid:Id.Set.t -> raw_tacexpr -> Pp.t
 
+val pr_syntax_class : sexpr -> Pp.t
+
+(** Print main commands, without the "Ltac2" prefix *)
+val pr_strexpr : strexpr -> Pp.t
+
 (** Utility function *)
 val partial_pat_of_glb_pat : glb_pat -> PartialPat.t
 

--- a/test-suite/output/ltac2_check_globalize.out
+++ b/test-suite/output/ltac2_check_globalize.out
@@ -27,14 +27,14 @@ The command has indeed failed with message:
 This expression has type string but an expression was expected of type 
 int
 let (m : '__α Pattern.goal_matching) :=
-  [(([(None, (Pattern.MatchPattern, pat:(_)))],
-     (Pattern.MatchPattern, pat:(_))),
-    (fun h =>
-     let h := Array.get h 0 in
-     fun _ => fun _ => fun _ => fun _ => Std.clear h));
-    (([], (Pattern.MatchPattern, pat:(_))),
-     (fun _ => fun _ => fun _ => fun _ => fun _ => ()))]
-    : _ Pattern.goal_matching
+  ([(([(None, (Pattern.MatchPattern, pat:(_)))],
+      (Pattern.MatchPattern, pat:(_))),
+     (fun h =>
+      let h := Array.get h 0 in
+      fun _ => fun _ => fun _ => fun _ => Std.clear h));
+     (([], (Pattern.MatchPattern, pat:(_))),
+      (fun _ => fun _ => fun _ => fun _ => fun _ => ()))]
+    : _ Pattern.goal_matching)
 in
 Pattern.lazy_goal_match0 false m :'__α
 constr:(ltac2:(()))

--- a/test-suite/output/ltac2_typed_notations.out
+++ b/test-suite/output/ltac2_typed_notations.out
@@ -3,11 +3,11 @@ The command has indeed failed with message:
 This expression has type bool but an expression was expected of type 
 constr
 fun (b : bool) =>
-let c := b in
-let (m : '__α Pattern.constr_matching) :=
-  [(Pattern.MatchPattern, pat:(true),
-    (fun _ => fun (_ : constr array) => true));
-    (Pattern.MatchPattern, pat:(false),
-     (fun _ => fun (_ : constr array) => false))]
-with (t : constr) := c in
-Pattern.one_match0 t m :'__α : bool
+(let c := b in
+ let (m : '__α Pattern.constr_matching) :=
+   [(Pattern.MatchPattern, pat:(true),
+     (fun _ => fun (_ : constr array) => true));
+     (Pattern.MatchPattern, pat:(false),
+      (fun _ => fun (_ : constr array) => false))]
+ with (t : constr) := c in
+ Pattern.one_match0 t m :'__α : bool)

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -29,3 +29,7 @@ val pr_using : Vernacexpr.section_subset_expr -> Pp.t
 
 (** Prints a vernac expression and closes it with a dot. *)
 val pr_vernac : Vernacexpr.vernac_control -> Pp.t
+
+(** Prints attributes, including surrounding "#[" "]", followed by space
+    (empty on empty list) *)
+val pr_vernac_attributes : Attributes.vernac_flag list -> Pp.t


### PR DESCRIPTION
Slightly tweak printing for type casts: parentheses are required