### PR TITLE
Less global state in extraction

### DIFF
--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -50,14 +50,14 @@ type phase = Pre | Impl | Intf
 val set_phase : phase -> unit
 val get_phase : unit -> phase
 
-val opened_libraries : unit -> ModPath.t list
+val opened_libraries : Table.t -> ModPath.t list
 
 type kind = Term | Type | Cons | Mod
 
-val pp_global_with_key : kind -> KerName.t -> GlobRef.t -> string
-val pp_global : kind -> GlobRef.t -> string
-val pp_global_name : kind -> GlobRef.t -> string
-val pp_module : ModPath.t -> string
+val pp_global_with_key : Table.t -> kind -> KerName.t -> GlobRef.t -> string
+val pp_global : Table.t -> kind -> GlobRef.t -> string
+val pp_global_name : Table.t -> kind -> GlobRef.t -> string
+val pp_module : Table.t -> ModPath.t -> string
 
 val top_visible_mp : unit -> ModPath.t
 (* In [push_visible], the [module_path list] corresponds to

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -25,18 +25,18 @@ val extract_and_compile : opaque_access:Global.indirect_accessor -> qualid list 
 (* For debug / external output via coqtop.byte + Drop : *)
 
 val mono_environment :
- opaque_access:Global.indirect_accessor -> GlobRef.t list -> ModPath.t list -> Miniml.ml_structure
+ Table.t -> opaque_access:Global.indirect_accessor -> GlobRef.t list -> ModPath.t list -> Miniml.ml_structure
 
 (* Used by the Relation Extraction plugin *)
 
 val print_one_decl :
-  Miniml.ml_structure -> ModPath.t -> Miniml.ml_decl -> Pp.t
+  Table.t -> Miniml.ml_structure -> ModPath.t -> Miniml.ml_decl -> Pp.t
 
 (* Used by Extraction Compute *)
 
 val structure_for_compute :
   opaque_access:Global.indirect_accessor -> Environ.env -> Evd.evar_map -> EConstr.t ->
-    Miniml.ml_decl list * Miniml.ml_ast * Miniml.ml_type
+    Table.t * Miniml.ml_decl list * Miniml.ml_ast * Miniml.ml_type
 
 (* Show the extraction of the current ongoing proof *)
 

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -16,23 +16,23 @@ open Environ
 open Evd
 open Miniml
 
-val extract_constant : Global.indirect_accessor -> env -> Constant.t -> constant_body -> ml_decl
+val extract_constant : Table.t -> Global.indirect_accessor -> env -> Constant.t -> constant_body -> ml_decl
 
-val extract_constant_spec : env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
+val extract_constant_spec : Table.t -> env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
 
 (** For extracting "module ... with ..." declaration *)
 
 val extract_with_type :
-  env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
+  Table.t -> env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
 
 val extract_fixpoint :
-  env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
+  Table.t -> env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
 
-val extract_inductive : env -> MutInd.t -> ml_ind
+val extract_inductive : Table.t -> env -> MutInd.t -> ml_ind
 
 (** For Extraction Compute and Show Extraction *)
 
-val extract_constr : env -> evar_map -> EConstr.t -> ml_ast * ml_type
+val extract_constr : Table.t -> env -> evar_map -> EConstr.t -> ml_ast * ml_type
 
 (*s Is a [ml_decl] or a [ml_spec] logical ? *)
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -37,8 +37,8 @@ let pp_bracket_comment s = str"{- " ++ hov 0 s ++ str" -}"
 (* Note: do not shorten [str "foo" ++ fnl ()] into [str "foo\n"],
    the '\n' character interacts badly with the Format boxing mechanism *)
 
-let preamble mod_name comment used_modules usf =
-  let pp_import mp = str ("import qualified "^ string_of_modfile mp) ++ fnl ()
+let preamble table mod_name comment used_modules usf =
+  let pp_import mp = str ("import qualified "^ string_of_modfile table mp) ++ fnl ()
   in
   (if not (usf.magic || usf.tunknown) then mt ()
    else
@@ -102,27 +102,27 @@ let pp_abst = function
 
 (*s The pretty-printer for haskell syntax *)
 
-let pp_global k r =
+let pp_global table k r =
   if is_inline_custom r then str (find_custom r)
-  else str (Common.pp_global k r)
+  else str (Common.pp_global table k r)
 
 (*s Pretty-printing of types. [par] is a boolean indicating whether parentheses
     are needed or not. *)
 
-let rec pp_type par vl t =
+let rec pp_type table par vl t =
   let rec pp_rec par = function
     | Tmeta _ | Tvar' _ -> assert false
     | Tvar i ->
       (try Id.print (List.nth vl (pred i))
        with Failure _ -> (str "a" ++ int i))
-    | Tglob (r,[]) -> pp_global Type r
+    | Tglob (r,[]) -> pp_global table Type r
     | Tglob (gr,l)
         when not (keep_singleton ()) && Rocqlib.check_ref sig_type_name gr ->
-          pp_type true vl (List.hd l)
+          pp_type table true vl (List.hd l)
     | Tglob (r,l) ->
           pp_par par
-            (pp_global Type r ++ spc () ++
-             prlist_with_sep spc (pp_type true vl) l)
+            (pp_global table Type r ++ spc () ++
+             prlist_with_sep spc (pp_type table true vl) l)
     | Tarr (t1,t2) ->
         pp_par par
           (pp_rec true t1 ++ spc () ++ str "->" ++ spc () ++ pp_rec false t2)
@@ -143,7 +143,7 @@ let expr_needs_par = function
   | _        -> false
 
 
-let rec pp_expr par env args =
+let rec pp_expr table par env args =
   let apply st = pp_apply st par args
   and apply2 st = pp_apply2 st par args in
   function
@@ -154,18 +154,18 @@ let rec pp_expr par env args =
         let id = if Id.equal id dummy_name then Id.of_string "__" else id in
         apply (Id.print id)
     | MLapp (f,args') ->
-        let stl = List.map (pp_expr true env []) args' in
-        pp_expr par env (stl @ args) f
+        let stl = List.map (pp_expr table true env []) args' in
+        pp_expr table par env (stl @ args) f
     | MLlam _ as a ->
         let fl,a' = collect_lams a in
         let fl,env' = push_vars (List.map id_of_mlid fl) env in
-        let st = (pp_abst (List.rev fl) ++ pp_expr false env' [] a') in
+        let st = (pp_abst (List.rev fl) ++ pp_expr table false env' [] a') in
         apply2 st
     | MLletin (id,a1,a2) ->
         let i,env' = push_vars [id_of_mlid id] env in
         let pp_id = Id.print (List.hd i)
-        and pp_a1 = pp_expr false env [] a1
-        and pp_a2 = pp_expr (not par && expr_needs_par a2) env' [] a2 in
+        and pp_a1 = pp_expr table false env [] a1
+        and pp_a2 = pp_expr table (not par && expr_needs_par a2) env' [] a2 in
         let pp_def =
           str "let {" ++ cut () ++
           hov 1 (pp_id ++ str " = " ++ pp_a1 ++ str "}")
@@ -173,22 +173,22 @@ let rec pp_expr par env args =
         apply2 (hv 0 (hv 0 (hv 1 pp_def ++ spc () ++ str "in") ++
                        spc () ++ hov 0 pp_a2))
     | MLglob r ->
-        apply (pp_global Term r)
+        apply (pp_global table Term r)
     | MLcons (_,r,a) as c ->
         assert (List.is_empty args);
         begin match a with
           | _ when is_native_char c -> pp_native_char c
           | _ when is_native_string c -> pp_native_string c
-          | [] -> pp_global Cons r
+          | [] -> pp_global table Cons r
           | [a] ->
-            pp_par par (pp_global Cons r ++ spc () ++ pp_expr true env [] a)
+            pp_par par (pp_global table Cons r ++ spc () ++ pp_expr table true env [] a)
           | _ ->
-            pp_par par (pp_global Cons r ++ spc () ++
-                        prlist_with_sep spc (pp_expr true env []) a)
+            pp_par par (pp_global table Cons r ++ spc () ++
+                        prlist_with_sep spc (pp_expr table true env []) a)
         end
     | MLtuple l ->
         assert (List.is_empty args);
-        pp_boxed_tuple (pp_expr true env []) l
+        pp_boxed_tuple (pp_expr table true env []) l
     | MLcase (_,t, pv) when is_custom_match pv ->
         if not (is_regular_match pv) then
           user_err Pp.(str "Cannot mix yet user-given match and general patterns.");
@@ -196,20 +196,20 @@ let rec pp_expr par env args =
           if not (List.is_empty ids) then named_lams (List.rev ids) e
           else dummy_lams (ast_lift 1 e) 1
         in
-        let pp_branch tr = pp_expr true env [] (mkfun tr) ++ fnl () in
+        let pp_branch tr = pp_expr table true env [] (mkfun tr) ++ fnl () in
         let inner =
           str (find_custom_match pv) ++ fnl () ++
           prvect pp_branch pv ++
-          pp_expr true env [] t
+          pp_expr table true env [] t
         in
         apply2 (hov 2 inner)
     | MLcase (typ,t,pv) ->
         apply2
-          (v 0 (str "case " ++ pp_expr false env [] t ++ str " of {" ++
-                fnl () ++ pp_pat env pv))
+          (v 0 (str "case " ++ pp_expr table false env [] t ++ str " of {" ++
+                fnl () ++ pp_pat table env pv))
     | MLfix (i,ids,defs) ->
         let ids',env' = push_vars (List.rev (Array.to_list ids)) env in
-        pp_fix par env' i (Array.of_list (List.rev ids'),defs) args
+        pp_fix table par env' i (Array.of_list (List.rev ids'),defs) args
     | MLexn s ->
         (* An [MLexn] may be applied, but I don't really care. *)
         pp_par par (str "Prelude.error" ++ spc () ++ qs s)
@@ -219,7 +219,7 @@ let rec pp_expr par env args =
          | "" -> str "__"
          | s -> str "__" ++ spc () ++ pp_bracket_comment (str s))
     | MLmagic a ->
-        pp_apply (str "unsafeCoerce") par (pp_expr true env [] a :: args)
+        pp_apply (str "unsafeCoerce") par (pp_expr table true env [] a :: args)
     | MLaxiom s -> pp_par par (str "Prelude.error \"AXIOM TO BE REALIZED (" ++ str s ++ str ")\"")
     | MLuint _ ->
       pp_par par (str "Prelude.error \"EXTRACTION OF UINT NOT IMPLEMENTED\"")
@@ -230,28 +230,28 @@ let rec pp_expr par env args =
     | MLparray _ ->
       pp_par par (str "Prelude.error \"EXTRACTION OF ARRAY NOT IMPLEMENTED\"")
 
-and pp_cons_pat par r ppl =
+and pp_cons_pat table par r ppl =
   pp_par par
-    (pp_global Cons r ++ space_if (not (List.is_empty ppl)) ++ prlist_with_sep spc identity ppl)
+    (pp_global table Cons r ++ space_if (not (List.is_empty ppl)) ++ prlist_with_sep spc identity ppl)
 
-and pp_gen_pat par ids env = function
-  | Pcons (r,l) -> pp_cons_pat par r (List.map (pp_gen_pat true ids env) l)
-  | Pusual r -> pp_cons_pat par r (List.map Id.print ids)
-  | Ptuple l -> pp_boxed_tuple (pp_gen_pat false ids env) l
+and pp_gen_pat table par ids env = function
+  | Pcons (r,l) -> pp_cons_pat table par r (List.map (pp_gen_pat table true ids env) l)
+  | Pusual r -> pp_cons_pat table par r (List.map Id.print ids)
+  | Ptuple l -> pp_boxed_tuple (pp_gen_pat table false ids env) l
   | Pwild -> str "_"
   | Prel n -> Id.print (get_db_name n env)
 
-and pp_one_pat env (ids,p,t) =
+and pp_one_pat table env (ids,p,t) =
   let ids',env' = push_vars (List.rev_map id_of_mlid ids) env in
   hov 2 (str " " ++
-         pp_gen_pat false (List.rev ids') env' p ++
+         pp_gen_pat table false (List.rev ids') env' p ++
          str " ->" ++ spc () ++
-         pp_expr (expr_needs_par t) env' [] t)
+         pp_expr table (expr_needs_par t) env' [] t)
 
-and pp_pat env pv =
+and pp_pat table env pv =
   prvecti
     (fun i x ->
-       pp_one_pat env pv.(i) ++
+       pp_one_pat table env pv.(i) ++
        if Int.equal i (Array.length pv - 1) then str "}" else
          (str ";" ++ fnl ()))
     pv
@@ -259,22 +259,22 @@ and pp_pat env pv =
 (*s names of the functions ([ids]) are already pushed in [env],
     and passed here just for convenience. *)
 
-and pp_fix par env i (ids,bl) args =
+and pp_fix table par env i (ids,bl) args =
   pp_par par
     (v 0
        (v 1 (str "let {" ++ fnl () ++
              prvect_with_sep (fun () -> str ";" ++ fnl ())
-               (fun (fi,ti) -> pp_function env (Id.print fi) ti)
+               (fun (fi,ti) -> pp_function table env (Id.print fi) ti)
                (Array.map2 (fun a b -> a,b) ids bl) ++
              str "}") ++
         fnl () ++ str "in " ++ pp_apply (Id.print ids.(i)) false args))
 
-and pp_function env f t =
+and pp_function table env f t =
   let bl,t' = collect_lams t in
   let bl,env' = push_vars (List.map id_of_mlid bl) env in
   (f ++ pr_binding (List.rev bl) ++
      str " =" ++ fnl () ++ str "  " ++
-     hov 2 (pp_expr false env' [] t'))
+     hov 2 (pp_expr table false env' [] t'))
 
 (*s Pretty-printing of inductive types declaration. *)
 
@@ -283,28 +283,28 @@ let pp_logical_ind packet =
     (Id.print packet.ip_typename ++ str " : logical inductive" ++ fnl () ++
      str "with constructors : " ++ prvect_with_sep spc Id.print packet.ip_consnames)
 
-let pp_singleton kn packet =
-  let name = pp_global Type (GlobRef.IndRef (kn,0)) in
+let pp_singleton table kn packet =
+  let name = pp_global table Type (GlobRef.IndRef (kn,0)) in
   let l = rename_tvars keywords packet.ip_vars in
   hov 2 (str "type " ++ name ++ spc () ++
          prlist_with_sep spc Id.print l ++
          (if not (List.is_empty l) then str " " else mt ()) ++ str "=" ++ spc () ++
-         pp_type false l (List.hd packet.ip_types.(0)) ++ fnl () ++
+         pp_type table false l (List.hd packet.ip_types.(0)) ++ fnl () ++
          pp_comment (str "singleton inductive, whose constructor was " ++
                      Id.print packet.ip_consnames.(0)))
 
-let pp_one_ind ip pl cv =
+let pp_one_ind table ip pl cv =
   let pl = rename_tvars keywords pl in
   let pp_constructor (r,l) =
-    (pp_global Cons r ++
+    (pp_global table Cons r ++
      match l with
        | [] -> (mt ())
        | _  -> (str " " ++
                 prlist_with_sep
-                  (fun () -> (str " ")) (pp_type true pl) l))
+                  (fun () -> (str " ")) (pp_type table true pl) l))
   in
   str (if Array.is_empty cv then "type " else "data ") ++
-  pp_global Type (GlobRef.IndRef ip) ++
+  pp_global table Type (GlobRef.IndRef ip) ++
   prlist_strict (fun id -> str " " ++ pr_lower_id id) pl ++ str " =" ++
   if Array.is_empty cv then str " () -- empty inductive"
   else
@@ -313,27 +313,27 @@ let pp_one_ind ip pl cv =
           prvect_with_sep (fun () -> fnl () ++ str "| ") pp_constructor
             (Array.mapi (fun i c -> GlobRef.ConstructRef (ip,i+1),c) cv)))
 
-let rec pp_ind first kn i ind =
+let rec pp_ind table first kn i ind =
   if i >= Array.length ind.ind_packets then
     if first then mt () else fnl ()
   else
     let ip = (kn,i) in
     let p = ind.ind_packets.(i) in
-    if is_custom (GlobRef.IndRef (kn,i)) then pp_ind first kn (i+1) ind
+    if is_custom (GlobRef.IndRef (kn,i)) then pp_ind table first kn (i+1) ind
     else
       if p.ip_logical then
-        pp_logical_ind p ++ pp_ind first kn (i+1) ind
+        pp_logical_ind p ++ pp_ind table first kn (i+1) ind
       else
-        pp_one_ind ip p.ip_vars p.ip_types ++ fnl () ++
-        pp_ind false kn (i+1) ind
+        pp_one_ind table ip p.ip_vars p.ip_types ++ fnl () ++
+        pp_ind table false kn (i+1) ind
 
 
 (*s Pretty-printing of a declaration. *)
 
-let pp_decl = function
+let pp_decl table = function
   | Dind (kn,i) when i.ind_kind == Singleton ->
-      pp_singleton kn i.ind_packets.(0) ++ fnl ()
-  | Dind (kn,i) -> hov 0 (pp_ind true kn 0 i)
+      pp_singleton table kn i.ind_packets.(0) ++ fnl ()
+  | Dind (kn,i) -> hov 0 (pp_ind table true kn 0 i)
   | Dtype (r, l, t) ->
       if is_inline_custom r then mt ()
       else
@@ -345,12 +345,12 @@ let pp_decl = function
           with Not_found ->
             prlist (fun id -> Id.print id ++ str " ") l ++
             if t == Taxiom then str "= () -- AXIOM TO BE REALIZED" ++ fnl ()
-            else str "=" ++ spc () ++ pp_type false l t
+            else str "=" ++ spc () ++ pp_type table false l t
         in
-        hov 2 (str "type " ++ pp_global Type r ++ spc () ++ st) ++ fnl2 ()
+        hov 2 (str "type " ++ pp_global table Type r ++ spc () ++ st) ++ fnl2 ()
   | Dfix (rv, defs, typs) ->
       let names = Array.map
-        (fun r -> if is_inline_custom r then mt () else pp_global Term r) rv
+        (fun r -> if is_inline_custom r then mt () else pp_global table Term r) rv
       in
       prvecti
         (fun i r ->
@@ -360,40 +360,40 @@ let pp_decl = function
           in
           if void then mt ()
           else
-            hov 2 (names.(i) ++ str " :: " ++ pp_type false [] typs.(i)) ++ fnl () ++
+            hov 2 (names.(i) ++ str " :: " ++ pp_type table false [] typs.(i)) ++ fnl () ++
             (if is_custom r then
                 (names.(i) ++ str " = " ++ str (find_custom r))
              else
-                (pp_function (empty_env ()) names.(i) defs.(i)))
+                (pp_function table (empty_env ()) names.(i) defs.(i)))
             ++ fnl2 ())
         rv
   | Dterm (r, a, t) ->
       if is_inline_custom r then mt ()
       else
-        let e = pp_global Term r in
-        hov 2 (e ++ str " :: " ++ pp_type false [] t) ++ fnl () ++
+        let e = pp_global table Term r in
+        hov 2 (e ++ str " :: " ++ pp_type table false [] t) ++ fnl () ++
           if is_custom r then
             hov 0 (e ++ str " = " ++ str (find_custom r) ++ fnl2 ())
           else
-            hov 0 (pp_function (empty_env ()) e a ++ fnl2 ())
+            hov 0 (pp_function table (empty_env ()) e a ++ fnl2 ())
 
-let rec pp_structure_elem = function
-  | (l,SEdecl d) -> pp_decl d
-  | (l,SEmodule m) -> pp_module_expr m.ml_mod_expr
+let rec pp_structure_elem table = function
+  | (l,SEdecl d) -> pp_decl table d
+  | (l,SEmodule m) -> pp_module_expr table m.ml_mod_expr
   | (l,SEmodtype m) -> mt ()
       (* for the moment we simply discard module type *)
 
-and pp_module_expr = function
-  | MEstruct (mp,sel) -> prlist_strict pp_structure_elem sel
+and pp_module_expr table = function
+  | MEstruct (mp,sel) -> prlist_strict (fun e -> pp_structure_elem table e) sel
   | MEfunctor _ -> mt ()
       (* for the moment we simply discard unapplied functors *)
   | MEident _ | MEapply _ -> assert false
       (* should be expanded in extract_env *)
 
-let pp_struct =
+let pp_struct table =
   let pp_sel (mp,sel) =
     push_visible mp [];
-    let p = prlist_strict pp_structure_elem sel in
+    let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
     pop_visible (); p
   in
   prlist_strict pp_sel
@@ -406,7 +406,7 @@ let haskell_descr = {
   preamble = preamble;
   pp_struct = pp_struct;
   sig_suffix = None;
-  sig_preamble = (fun _ _ _ _ -> mt ());
-  pp_sig = (fun _ -> mt ());
+  sig_preamble = (fun _ _ _ _ _ -> mt ());
+  pp_sig = (fun _ _ -> mt ());
   pp_decl = pp_decl;
 }

--- a/plugins/extraction/haskell.mli
+++ b/plugins/extraction/haskell.mli
@@ -8,5 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val haskell_descr : Miniml.language_descr
+val haskell_descr : Table.t Miniml.language_descr
 

--- a/plugins/extraction/json.mli
+++ b/plugins/extraction/json.mli
@@ -1,1 +1,11 @@
-val json_descr : Miniml.language_descr
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val json_descr : Table.t Miniml.language_descr

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -199,27 +199,27 @@ type unsafe_needs = {
   magic : bool
 }
 
-type language_descr = {
+type 's language_descr = {
   keywords : Id.Set.t;
 
   (* Concerning the source file *)
   file_suffix : string;
-  file_naming : ModPath.t -> string;
+  file_naming : 's -> ModPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
-    Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
     Pp.t;
-  pp_struct : ml_structure -> Pp.t;
+  pp_struct : 's -> ml_structure -> Pp.t;
 
   (* Concerning a possible interface file *)
   sig_suffix : string option;
   (* the second argument is a comment to add to the preamble *)
   sig_preamble :
-    Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
     Pp.t;
-  pp_sig : ml_signature -> Pp.t;
+  pp_sig : 's -> ml_signature -> Pp.t;
 
   (* for an isolated declaration print *)
-  pp_decl : ml_decl -> Pp.t;
+  pp_decl : 's -> ml_decl -> Pp.t;
 
 }

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -199,27 +199,27 @@ type unsafe_needs = {
   magic : bool
 }
 
-type language_descr = {
+type 's language_descr = {
   keywords : Id.Set.t;
 
   (* Concerning the source file *)
   file_suffix : string;
-  file_naming : ModPath.t -> string;
+  file_naming : 's -> ModPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
-    Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
     Pp.t;
-  pp_struct : ml_structure -> Pp.t;
+  pp_struct : 's -> ml_structure -> Pp.t;
 
   (* Concerning a possible interface file *)
   sig_suffix : string option;
   (* the second argument is a comment to add to the preamble *)
   sig_preamble :
-    Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
     Pp.t;
-  pp_sig : ml_signature -> Pp.t;
+  pp_sig : 's -> ml_signature -> Pp.t;
 
   (* for an isolated declaration print *)
-  pp_decl : ml_decl -> Pp.t;
+  pp_decl : 's -> ml_decl -> Pp.t;
 
 }

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -910,29 +910,24 @@ let branch_as_cst (l,_,c) =
    at what position, and then finally return the most frequent
    element and its positions. *)
 
-let census_add, census_max, census_clean =
-  let h = ref [] in
-  let clearf () = h := [] in
+let census_add h k i =
   let rec add k v = function
   | [] -> raise Not_found
   | (k', s) as p :: l ->
     if eq_ml_ast k k' then (k', Int.Set.add v s) :: l
     else p :: add k v l
   in
-  let addf k i =
-    try h := add k i !h
-    with Not_found -> h := (k, Int.Set.singleton i) :: !h
-  in
-  let maxf () =
-    let len = ref 0 and lst = ref Int.Set.empty and elm = ref (MLaxiom "should not appear") in
-    List.iter
-      (fun (e, s) ->
-         let n = Int.Set.cardinal s in
-         if n > !len then begin len := n; lst := s; elm := e end)
-      !h;
-    (!elm,!lst)
-  in
-  (addf,maxf,clearf)
+  try h := add k i !h
+  with Not_found -> h := (k, Int.Set.singleton i) :: !h
+
+let census_max h =
+  let len = ref 0 and lst = ref Int.Set.empty and elm = ref (MLaxiom "should not appear") in
+  List.iter
+    (fun (e, s) ->
+        let n = Int.Set.cardinal s in
+        if n > !len then begin len := n; lst := s; elm := e end)
+    !h;
+  (!elm,!lst)
 
 (* [factor_branches] return the longest possible list of branches
    that have the same factorization, either as a function or as a
@@ -946,15 +941,14 @@ let is_opt_pat (_,p,_) = match p with
 let factor_branches o typ br =
   if Array.exists is_opt_pat br then None (* already optimized *)
   else begin
-    census_clean ();
+    let h = ref [] in
     for i = 0 to Array.length br - 1 do
       if o.opt_case_idr then
-        (try census_add (branch_as_fun typ br.(i)) i with Impossible -> ());
+        (try census_add h (branch_as_fun typ br.(i)) i with Impossible -> ());
       if o.opt_case_cst then
-        (try census_add (branch_as_cst br.(i)) i with Impossible -> ());
+        (try census_add h (branch_as_cst br.(i)) i with Impossible -> ());
     done;
-    let br_factor, br_set = census_max () in
-    census_clean ();
+    let br_factor, br_set = census_max h in
     let n = Int.Set.cardinal br_set in
     if Int.equal n 0 then None
     else if Array.length br >= 2 && n < 2 then None

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1559,11 +1559,11 @@ let manual_inline = function
    we are free to act (AutoInline is set)
    \end{itemize} *)
 
-let inline r t =
+let inline table r t =
   not (to_keep r) (* The user DOES want to keep it *)
   && not (is_inline_custom r)
   && (to_inline r (* The user DOES want to inline it *)
      || (lang () != Haskell &&
-         (is_projection r || is_recursor r ||
+         (is_projection table r || is_recursor table r ||
           manual_inline r || inline_test r t)))
 

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -116,7 +116,7 @@ val dump_unused_vars : ml_ast -> ml_ast
 
 val normalize : ml_ast -> ml_ast
 val optimize_fix : ml_ast -> ml_ast
-val inline : GlobRef.t -> ml_ast -> bool
+val inline : Table.t -> GlobRef.t -> ml_ast -> bool
 
 val is_basic_pattern : ml_pattern -> bool
 val has_deep_pattern : ml_branch array -> bool

--- a/plugins/extraction/modutil.mli
+++ b/plugins/extraction/modutil.mli
@@ -38,5 +38,5 @@ val get_decl_in_structure : GlobRef.t -> ml_structure -> ml_decl
    optimizations. The first argument is the list of objects we want to appear.
 *)
 
-val optimize_struct : GlobRef.t list * ModPath.t list ->
+val optimize_struct : Table.t -> GlobRef.t list * ModPath.t list ->
   ml_structure -> ml_structure

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -59,7 +59,7 @@ let keywords =
 (* Note: do not shorten [str "foo" ++ fnl ()] into [str "foo\n"],
    the '\n' character interacts badly with the Format boxing mechanism *)
 
-let pp_open mp = str ("open "^ string_of_modfile mp) ++ fnl ()
+let pp_open table mp = str ("open "^ string_of_modfile table mp) ++ fnl ()
 
 let pp_comment s = str "(* " ++ hov 0 s ++ str " *)"
 
@@ -77,14 +77,14 @@ let pp_mldummy usf =
     str "let __ = let rec f _ = Obj.repr f in Obj.repr f" ++ fnl ()
   else mt ()
 
-let preamble _ comment used_modules usf =
+let preamble table _ comment used_modules usf =
   pp_header_comment comment ++
-  then_nl (prlist pp_open used_modules) ++
+  then_nl (prlist (fun o -> pp_open table o) used_modules) ++
   then_nl (pp_tdummy usf ++ pp_mldummy usf)
 
-let sig_preamble _ comment used_modules usf =
+let sig_preamble table _ comment used_modules usf =
   pp_header_comment comment ++
-  then_nl (prlist pp_open used_modules) ++
+  then_nl (prlist (fun o -> pp_open table o) used_modules) ++
   then_nl (pp_tdummy usf)
 
 (*s The pretty-printer for Ocaml syntax*)
@@ -94,18 +94,18 @@ let sig_preamble _ comment used_modules usf =
    below should not be altered since they force evaluation order.
 *)
 
-let str_global_with_key k key r =
-  if is_inline_custom r then find_custom r else Common.pp_global_with_key k key r
+let str_global_with_key table k key r =
+  if is_inline_custom r then find_custom r else Common.pp_global_with_key table k key r
 
-let str_global k r = str_global_with_key k (repr_of_r r) r
+let str_global table k r = str_global_with_key table k (repr_of_r r) r
 
-let pp_global_with_key k key r = str (str_global_with_key k key r)
+let pp_global_with_key table k key r = str (str_global_with_key table k key r)
 
-let pp_global k r = str (str_global k r)
+let pp_global table k r = str (str_global table k r)
 
-let pp_global_name k r = str (Common.pp_global k r)
+let pp_global_name table k r = str (Common.pp_global table k r)
 
-let pp_modname mp = str (Common.pp_module mp)
+let pp_modname table mp = str (Common.pp_module table mp)
 
 (* grammar from OCaml 4.06 manual, "Prefix and infix symbols" *)
 
@@ -156,30 +156,30 @@ let kn_of_ind = let open GlobRef in function
   | IndRef (kn,_) -> MutInd.user kn
   | _ -> assert false
 
-let pp_one_field r i = function
-  | Some r' -> pp_global_with_key Term (kn_of_ind (get_ind r)) r'
-  | None -> pp_global Type (get_ind r) ++ str "__" ++ int i
+let pp_one_field table r i = function
+  | Some r' -> pp_global_with_key table Term (kn_of_ind (get_ind r)) r'
+  | None -> pp_global table Type (get_ind r) ++ str "__" ++ int i
 
-let pp_field r fields i = pp_one_field r i (List.nth fields i)
+let pp_field table r fields i = pp_one_field table r i (List.nth fields i)
 
-let pp_fields r fields = List.map_i (pp_one_field r) 0 fields
+let pp_fields table r fields = List.map_i (pp_one_field table r) 0 fields
 
 (*s Pretty-printing of types. [par] is a boolean indicating whether parentheses
     are needed or not. *)
 
-let pp_type par vl t =
+let pp_type table par vl t =
   let rec pp_rec par = function
     | Tmeta _ | Tvar' _ | Taxiom -> assert false
     | Tvar i -> (try pp_tvar (List.nth vl (pred i))
                  with Failure _ -> (str "'a" ++ int i))
     | Tglob (r,[a1;a2]) when is_infix r ->
         pp_par par (pp_rec true a1 ++ str (get_infix r) ++ pp_rec true a2)
-    | Tglob (r,[]) -> pp_global Type r
+    | Tglob (r,[]) -> pp_global table Type r
     | Tglob (gr,l)
         when not (keep_singleton ()) && Rocqlib.check_ref sig_type_name gr ->
         pp_tuple_light pp_rec l
     | Tglob (r,l) ->
-        pp_tuple_light pp_rec l ++ spc () ++ pp_global Type r
+        pp_tuple_light pp_rec l ++ spc () ++ pp_global table Type r
     | Tarr (t1,t2) ->
         pp_par par
           (pp_rec true t1 ++ spc () ++ str "->" ++ spc () ++ pp_rec false t2)
@@ -214,7 +214,7 @@ let expr_needs_par = function
   | MLcase (_,_,pv) -> not (is_ifthenelse pv)
   | _        -> false
 
-let rec pp_expr par env args =
+let rec pp_expr table par env args =
   let apply st = pp_apply st par args
   and apply2 st = pp_apply2 st par args in
   function
@@ -225,24 +225,24 @@ let rec pp_expr par env args =
         let id = if Id.equal id dummy_name then Id.of_string "__" else id in
         apply (Id.print id)
     | MLapp (f,args') ->
-        let stl = List.map (pp_expr true env []) args' in
-        pp_expr par env (stl @ args) f
+        let stl = List.map (pp_expr table true env []) args' in
+        pp_expr table par env (stl @ args) f
     | MLlam _ as a ->
         let fl,a' = collect_lams a in
         let fl = List.map id_of_mlid fl in
         let fl,env' = push_vars fl env in
-        let st = pp_abst (List.rev fl) ++ pp_expr false env' [] a' in
+        let st = pp_abst (List.rev fl) ++ pp_expr table false env' [] a' in
         apply2 st
     | MLletin (id,a1,a2) ->
         let i,env' = push_vars [id_of_mlid id] env in
         let pp_id = Id.print (List.hd i)
-        and pp_a1 = pp_expr false env [] a1
-        and pp_a2 = pp_expr (not par && expr_needs_par a2) env' [] a2 in
+        and pp_a1 = pp_expr table false env [] a1
+        and pp_a2 = pp_expr table (not par && expr_needs_par a2) env' [] a2 in
         hv 0 (apply2 (pp_letin pp_id pp_a1 pp_a2))
-    | MLglob r -> apply (pp_global Term r)
+    | MLglob r -> apply (pp_global table Term r)
     | MLfix (i,ids,defs) ->
         let ids',env' = push_vars (List.rev (Array.to_list ids)) env in
-        pp_fix par env' i (Array.of_list (List.rev ids'),defs) args
+        pp_fix table par env' i (Array.of_list (List.rev ids'),defs) args
     | MLexn s ->
         (* An [MLexn] may be applied, but I don't really care. *)
         pp_par par (str "assert false" ++ spc () ++ str ("(* "^s^" *)"))
@@ -252,7 +252,7 @@ let rec pp_expr par env args =
          | "" -> str "__"
          | s -> str "__" ++ spc () ++ str ("(* "^s^" *)"))
     | MLmagic a ->
-        pp_apply (str "Obj.magic") par (pp_expr true env [] a :: args)
+        pp_apply (str "Obj.magic") par (pp_expr table true env [] a :: args)
     | MLaxiom s ->
         pp_par par (str "failwith \"AXIOM TO BE REALIZED (" ++ str s ++ str ")\"")
     | MLcons (_,r,a) as c ->
@@ -261,26 +261,26 @@ let rec pp_expr par env args =
           | _ when is_native_char c -> pp_native_char c
           | _ when is_native_string c -> pp_native_string c
           | [a1;a2] when is_infix r ->
-            let pp = pp_expr true env [] in
+            let pp = pp_expr table true env [] in
             pp_par par (pp a1 ++ str (get_infix r) ++ pp a2)
-          | _ when is_coinductive r ->
+          | _ when is_coinductive table r ->
             let ne = not (List.is_empty a) in
-            let tuple = space_if ne ++ pp_tuple (pp_expr true env []) a in
-            pp_par par (str "lazy " ++ pp_par ne (pp_global Cons r ++ tuple))
-          | [] -> pp_global Cons r
+            let tuple = space_if ne ++ pp_tuple (pp_expr table true env []) a in
+            pp_par par (str "lazy " ++ pp_par ne (pp_global table Cons r ++ tuple))
+          | [] -> pp_global table Cons r
           | _ ->
-            let fds = get_record_fields r in
+            let fds = get_record_fields table r in
             if not (List.is_empty fds) then
-              pp_record_pat (pp_fields r fds, List.map (pp_expr true env []) a)
+              pp_record_pat (pp_fields table r fds, List.map (pp_expr table true env []) a)
             else
-              let tuple = pp_tuple (pp_expr true env []) a in
-              if String.is_empty (str_global Cons r) (* hack Extract Inductive prod *)
+              let tuple = pp_tuple (pp_expr table true env []) a in
+              if String.is_empty (str_global table Cons r) (* hack Extract Inductive prod *)
               then tuple
-              else pp_par par (pp_global Cons r ++ spc () ++ tuple)
+              else pp_par par (pp_global table Cons r ++ spc () ++ tuple)
         end
     | MLtuple l ->
         assert (List.is_empty args);
-        pp_boxed_tuple (pp_expr true env []) l
+        pp_boxed_tuple (pp_expr table true env []) l
     | MLcase (_, t, pv) when is_custom_match pv ->
         if not (is_regular_match pv) then
           user_err Pp.(str "Cannot mix yet user-given match and general patterns.");
@@ -288,33 +288,33 @@ let rec pp_expr par env args =
           if not (List.is_empty ids) then named_lams (List.rev ids) e
           else dummy_lams (ast_lift 1 e) 1
         in
-        let pp_branch tr = pp_expr true env [] (mkfun tr) ++ fnl () in
+        let pp_branch tr = pp_expr table true env [] (mkfun tr) ++ fnl () in
         let inner =
           str (find_custom_match pv) ++ fnl () ++
           prvect pp_branch pv ++
-          pp_expr true env [] t
+          pp_expr table true env [] t
         in
         apply2 (hov 2 inner)
     | MLcase (typ, t, pv) ->
         let head =
-          if not (is_coinductive_type typ) then pp_expr false env [] t
-          else (str "Lazy.force" ++ spc () ++ pp_expr true env [] t)
+          if not (is_coinductive_type table typ) then pp_expr table false env [] t
+          else (str "Lazy.force" ++ spc () ++ pp_expr table true env [] t)
         in
         (* First, can this match be printed as a mere record projection ? *)
-        (try pp_record_proj par env typ t pv args
+        (try pp_record_proj table par env typ t pv args
          with Impossible ->
            (* Second, can this match be printed as a let-in ? *)
            if Int.equal (Array.length pv) 1 then
-             let s1,s2 = pp_one_pat env pv.(0) in
+             let s1,s2 = pp_one_pat table env pv.(0) in
              hv 0 (apply2 (pp_letin s1 head s2))
            else
              (* Third, can this match be printed as [if ... then ... else] ? *)
-             (try apply2 (pp_ifthenelse env head pv)
+             (try apply2 (pp_ifthenelse table env head pv)
               with Not_found ->
                 (* Otherwise, standard match *)
                 apply2
                   (v 0 (str "match " ++ head ++ str " with" ++ fnl () ++
-                        pp_pat env pv))))
+                        pp_pat table env pv))))
     | MLuint i ->
         assert (args=[]);
         str "(" ++ str (Uint63.compile i) ++ str ")"
@@ -326,14 +326,14 @@ let rec pp_expr par env args =
         str "(" ++ str (Pstring.compile s) ++ str ")"
     | MLparray(t,def) ->
       assert (args=[]);
-      let tuple = pp_array (pp_expr true env []) (Array.to_list t) in
-      let def = pp_expr true env [] def in
+      let tuple = pp_array (pp_expr table true env []) (Array.to_list t) in
+      let def = pp_expr table true env [] def in
       str "(ExtrNative.of_array [|" ++ tuple ++ str "|]" ++ spc () ++ def ++ str")"
 
 
-and pp_record_proj par env typ t pv args =
+and pp_record_proj table par env typ t pv args =
   (* Can a match be printed as a mere record projection ? *)
-  let fields = record_fields_of_type typ in
+  let fields = record_fields_of_type table typ in
   if List.is_empty fields then raise Impossible;
   if not (Int.equal (Array.length pv) 1) then raise Impossible;
   if has_deep_pattern pv then raise Impossible;
@@ -361,8 +361,8 @@ and pp_record_proj par env typ t pv args =
   in
   if is_infix r then raise Impossible;
   let env' = snd (push_vars (List.rev_map id_of_mlid ids) env) in
-  let pp_args = (List.map (pp_expr true env' []) a) @ args in
-  let pp_head = pp_expr true env [] t ++ str "." ++ pp_field r fields idx
+  let pp_args = (List.map (pp_expr table true env' []) a) @ args in
+  let pp_head = pp_expr table true env [] t ++ str "." ++ pp_field table r fields idx
   in
   if magic then
     pp_apply (str "Obj.magic") par (pp_head :: pp_args)
@@ -376,77 +376,77 @@ and pp_record_pat (fields, args) =
      (List.combine fields args) ++
    str " }"
 
-and pp_cons_pat r ppl =
+and pp_cons_pat table r ppl =
   if is_infix r && Int.equal (List.length ppl) 2 then
     List.hd ppl ++ str (get_infix r) ++ List.hd (List.tl ppl)
   else
-    let fields = get_record_fields r in
-    if not (List.is_empty fields) then pp_record_pat (pp_fields r fields, ppl)
-    else if String.is_empty (str_global Cons r) then
+    let fields = get_record_fields table r in
+    if not (List.is_empty fields) then pp_record_pat (pp_fields table r fields, ppl)
+    else if String.is_empty (str_global table Cons r) then
       pp_boxed_tuple identity ppl (* Hack Extract Inductive prod *)
     else
-      pp_global Cons r ++ space_if (not (List.is_empty ppl)) ++ pp_boxed_tuple identity ppl
+      pp_global table Cons r ++ space_if (not (List.is_empty ppl)) ++ pp_boxed_tuple identity ppl
 
-and pp_gen_pat ids env = function
-  | Pcons (r, l) -> pp_cons_pat r (List.map (pp_gen_pat ids env) l)
-  | Pusual r -> pp_cons_pat r (List.map Id.print ids)
-  | Ptuple l -> pp_boxed_tuple (pp_gen_pat ids env) l
+and pp_gen_pat table ids env = function
+  | Pcons (r, l) -> pp_cons_pat table r (List.map (pp_gen_pat table ids env) l)
+  | Pusual r -> pp_cons_pat table r (List.map Id.print ids)
+  | Ptuple l -> pp_boxed_tuple (pp_gen_pat table ids env) l
   | Pwild -> str "_"
   | Prel n -> Id.print (get_db_name n env)
 
-and pp_ifthenelse env expr pv = match pv with
+and pp_ifthenelse table env expr pv = match pv with
   | [|([],tru,the);([],fal,els)|] when
       (is_bool_patt tru "true") && (is_bool_patt fal "false")
       ->
       hv 0 (hov 2 (str "if " ++ expr) ++ spc () ++
             hov 2 (str "then " ++
-                   hov 2 (pp_expr (expr_needs_par the) env [] the)) ++ spc () ++
+                   hov 2 (pp_expr table (expr_needs_par the) env [] the)) ++ spc () ++
             hov 2 (str "else " ++
-                   hov 2 (pp_expr (expr_needs_par els) env [] els)))
+                   hov 2 (pp_expr table (expr_needs_par els) env [] els)))
   | _ -> raise Not_found
 
-and pp_one_pat env (ids,p,t) =
+and pp_one_pat table env (ids,p,t) =
   let ids',env' = push_vars (List.rev_map id_of_mlid ids) env in
-  pp_gen_pat (List.rev ids') env' p,
-  pp_expr (expr_needs_par t) env' [] t
+  pp_gen_pat table (List.rev ids') env' p,
+  pp_expr table (expr_needs_par t) env' [] t
 
-and pp_pat env pv =
+and pp_pat table env pv =
   prvecti
     (fun i x ->
-       let s1,s2 = pp_one_pat env x in
+       let s1,s2 = pp_one_pat table env x in
        hv 2 (hov 4 (str "| " ++ s1 ++ str " ->") ++ spc () ++ hov 2 s2) ++
        if Int.equal i (Array.length pv - 1) then mt () else fnl ())
     pv
 
-and pp_function env t =
+and pp_function table env t =
   let bl,t' = collect_lams t in
   let bl,env' = push_vars (List.map id_of_mlid bl) env in
   match t' with
     | MLcase(Tglob(r,_),MLrel 1,pv) when
-        not (is_coinductive r) && List.is_empty (get_record_fields r) &&
+        not (is_coinductive table r) && List.is_empty (get_record_fields table r) &&
         not (is_custom_match pv) ->
         if not (ast_occurs 1 (MLcase(Tunknown,MLaxiom "",pv))) then
           pr_binding (List.rev (List.tl bl)) ++
           str " = function" ++ fnl () ++
-          v 0 (pp_pat env' pv)
+          v 0 (pp_pat table env' pv)
         else
           pr_binding (List.rev bl) ++
           str " = match " ++ Id.print (List.hd bl) ++ str " with" ++ fnl () ++
-          v 0 (pp_pat env' pv)
+          v 0 (pp_pat table env' pv)
     | _ ->
           pr_binding (List.rev bl) ++
           str " =" ++ fnl () ++ str "  " ++
-          hov 2 (pp_expr false env' [] t')
+          hov 2 (pp_expr table false env' [] t')
 
 (*s names of the functions ([ids]) are already pushed in [env],
     and passed here just for convenience. *)
 
-and pp_fix par env i (ids,bl) args =
+and pp_fix table par env i (ids,bl) args =
   pp_par par
     (v 0 (str "let rec " ++
           prvect_with_sep
             (fun () -> fnl () ++ str "and ")
-            (fun (fi,ti) -> Id.print fi ++ pp_function env ti)
+            (fun (fi,ti) -> Id.print fi ++ pp_function table env ti)
             (Array.map2 (fun id b -> (id,b)) ids bl) ++
           fnl () ++
           hov 2 (str "in " ++ pp_apply (Id.print ids.(i)) false args)))
@@ -456,15 +456,15 @@ and pp_fix par env i (ids,bl) args =
 
 let cut2 () = brk (0,-100000) ++ brk (0,0)
 
-let pp_val e typ =
-  hov 4 (str "(** val " ++ e ++ str " :" ++ spc () ++ pp_type false [] typ ++
+let pp_val table e typ =
+  hov 4 (str "(** val " ++ e ++ str " :" ++ spc () ++ pp_type table false [] typ ++
   str " **)")  ++ cut2 ()
 
 (*s Pretty-printing of [Dfix] *)
 
-let pp_Dfix (rv,c,t) =
+let pp_Dfix table (rv,c,t) =
   let names = Array.map
-    (fun r -> if is_inline_custom r then mt () else pp_global_name Term r) rv
+    (fun r -> if is_inline_custom r then mt () else pp_global_name table Term r) rv
   in
   let rec pp init i =
     if i >= Array.length rv then mt ()
@@ -477,35 +477,35 @@ let pp_Dfix (rv,c,t) =
       else
         let def =
           if is_custom rv.(i) then str " = " ++ str (find_custom rv.(i))
-          else pp_function (empty_env ()) c.(i)
+          else pp_function table (empty_env ()) c.(i)
         in
         (if init then mt () else cut2 ()) ++
-        pp_val names.(i) t.(i) ++
+        pp_val table names.(i) t.(i) ++
         str (if init then "let rec " else "and ") ++ names.(i) ++ def ++
         pp false (i+1)
   in pp true 0
 
 (*s Pretty-printing of inductive types declaration. *)
 
-let pp_equiv param_list name = function
+let pp_equiv table param_list name = function
   | NoEquiv, _ -> mt ()
   | Equiv kn, i ->
-      str " = " ++ pp_parameters param_list ++ pp_global Type (GlobRef.IndRef (MutInd.make1 kn,i))
+      str " = " ++ pp_parameters param_list ++ pp_global table Type (GlobRef.IndRef (MutInd.make1 kn,i))
   | RenEquiv ren, _  ->
       str " = " ++ pp_parameters param_list ++ str (ren^".") ++ name
 
 
-let pp_one_ind prefix ip_equiv pl name cnames ctyps =
+let pp_one_ind table prefix ip_equiv pl name cnames ctyps =
   let pl = rename_tvars keywords pl in
   let pp_constructor i typs =
     (if Int.equal i 0 then mt () else fnl ()) ++
     hov 3 (str "| " ++ cnames.(i) ++
            (if List.is_empty typs then mt () else str " of ") ++
            prlist_with_sep
-            (fun () -> spc () ++ str "* ") (pp_type true pl) typs)
+            (fun () -> spc () ++ str "* ") (pp_type table true pl) typs)
   in
   pp_parameters pl ++ str prefix ++ name ++
-  pp_equiv pl name ip_equiv ++ str " =" ++
+  pp_equiv table pl name ip_equiv ++ str " =" ++
   if Int.equal (Array.length ctyps) 0 then str " |"
   else fnl () ++ v 0 (prvecti pp_constructor ctyps)
 
@@ -516,24 +516,24 @@ let pp_logical_ind packet =
               prvect_with_sep spc Id.print packet.ip_consnames) ++
   fnl ()
 
-let pp_singleton kn packet =
-  let name = pp_global_name Type (GlobRef.IndRef (kn,0)) in
+let pp_singleton table kn packet =
+  let name = pp_global_name table Type (GlobRef.IndRef (kn,0)) in
   let l = rename_tvars keywords packet.ip_vars in
   hov 2 (str "type " ++ pp_parameters l ++ name ++ str " =" ++ spc () ++
-         pp_type false l (List.hd packet.ip_types.(0)) ++ fnl () ++
+         pp_type table false l (List.hd packet.ip_types.(0)) ++ fnl () ++
          pp_comment (str "singleton inductive, whose constructor was " ++
                      Id.print packet.ip_consnames.(0)))
 
-let pp_record kn fields ip_equiv packet =
+let pp_record table kn fields ip_equiv packet =
   let ind = GlobRef.IndRef (kn,0) in
-  let name = pp_global_name Type ind in
-  let fieldnames = pp_fields ind fields in
+  let name = pp_global_name table Type ind in
+  let fieldnames = pp_fields table ind fields in
   let l = List.combine fieldnames packet.ip_types.(0) in
   let pl = rename_tvars keywords packet.ip_vars in
   str "type " ++ pp_parameters pl ++ name ++
-  pp_equiv pl name ip_equiv ++ str " = { "++
+  pp_equiv table pl name ip_equiv ++ str " = { "++
   hov 0 (prlist_with_sep (fun () -> str ";" ++ spc ())
-           (fun (p,t) -> p ++ str " : " ++ pp_type true pl t) l)
+           (fun (p,t) -> p ++ str " : " ++ pp_type table true pl t) l)
   ++ str " }"
 
 let pp_coind pl name =
@@ -542,19 +542,19 @@ let pp_coind pl name =
   pp_parameters pl ++ str "__" ++ name ++ str " Lazy.t" ++
   fnl() ++ str "and "
 
-let pp_ind co kn ind =
+let pp_ind table co kn ind =
   let prefix = if co then "__" else "" in
   let initkwd = str "type " in
   let nextkwd = fnl () ++ str "and " in
   let names =
     Array.mapi (fun i p -> if p.ip_logical then mt () else
-                  pp_global_name Type (GlobRef.IndRef (kn,i)))
+                  pp_global_name table Type (GlobRef.IndRef (kn,i)))
       ind.ind_packets
   in
   let cnames =
     Array.mapi
       (fun i p -> if p.ip_logical then [||] else
-         Array.mapi (fun j _ -> pp_global Cons (GlobRef.ConstructRef ((kn,i),j+1)))
+         Array.mapi (fun j _ -> pp_global table Cons (GlobRef.ConstructRef ((kn,i),j+1)))
            p.ip_types)
       ind.ind_packets
   in
@@ -568,7 +568,7 @@ let pp_ind co kn ind =
       else if p.ip_logical then pp_logical_ind p ++ pp (i+1) kwd
       else
         kwd ++ (if co then pp_coind p.ip_vars names.(i) else mt ()) ++
-        pp_one_ind prefix ip_equiv p.ip_vars names.(i) cnames.(i) p.ip_types ++
+        pp_one_ind table prefix ip_equiv p.ip_vars names.(i) cnames.(i) p.ip_types ++
         pp (i+1) nextkwd
   in
   pp 0 initkwd
@@ -576,19 +576,19 @@ let pp_ind co kn ind =
 
 (*s Pretty-printing of a declaration. *)
 
-let pp_mind kn i =
+let pp_mind table kn i =
   match i.ind_kind with
-    | Singleton -> pp_singleton kn i.ind_packets.(0)
-    | Coinductive -> pp_ind true kn i
-    | Record fields -> pp_record kn fields (i.ind_equiv,0) i.ind_packets.(0)
-    | Standard -> pp_ind false kn i
+    | Singleton -> pp_singleton table kn i.ind_packets.(0)
+    | Coinductive -> pp_ind table true kn i
+    | Record fields -> pp_record table kn fields (i.ind_equiv,0) i.ind_packets.(0)
+    | Standard -> pp_ind table false kn i
 
-let pp_decl = function
+let pp_decl table = function
     | Dtype (r,_,_) when is_inline_custom r -> mt ()
     | Dterm (r,_,_) when is_inline_custom r -> mt ()
-    | Dind (kn,i) -> pp_mind kn i
+    | Dind (kn,i) -> pp_mind table kn i
     | Dtype (r, l, t) ->
-        let name = pp_global_name Type r in
+        let name = pp_global_name table Type r in
         let l = rename_tvars keywords l in
         let ids, def =
           try
@@ -597,7 +597,7 @@ let pp_decl = function
           with Not_found ->
             pp_parameters l,
             if t == Taxiom then str " (* AXIOM TO BE REALIZED *)"
-            else str " =" ++ spc () ++ pp_type false l t
+            else str " =" ++ spc () ++ pp_type table false l t
         in
         hov 2 (str "type " ++ ids ++ name ++ def)
     | Dterm (r, a, t) ->
@@ -605,12 +605,12 @@ let pp_decl = function
           (* If it it is an foreign custom, set the def to ': type =  <quote>foreign_fun_name<quote> '.
              TODO: I'm not sure, but could we use pp_native_string for quoting the custom name of r?
           *)
-          if is_foreign_custom r then str ": " ++ pp_type false [] t ++ str " = \"" ++ str (find_custom r) ++ str "\""
+          if is_foreign_custom r then str ": " ++ pp_type table false [] t ++ str " = \"" ++ str (find_custom r) ++ str "\""
           (* Otherwise, check if it is a regular custom term. *)
           else if is_custom r then str (" = " ^ find_custom r)
-          else pp_function (empty_env ()) a
+          else pp_function table (empty_env ()) a
         in
-        let name = pp_global_name Term r in
+        let name = pp_global_name table Term r in
         (* If it is an foreign custom, begin the expression with 'external'/'foreign' instead of 'let' *)
         let expr_begin = if is_foreign_custom r then str "external " else str "let " in
         (* Make sure that a callback registration is synthesised, if specified for that term. *)
@@ -624,21 +624,21 @@ let pp_decl = function
             cut2 () ++ hov 0 ((str "let () = Stdlib.Callback.register \"") ++ alias ++ (str "\" ") ++ name)
           with Not_found -> (* No callback registration specified for qualid. *)
             mt()
-        in pp_val name t ++ hov 0 (expr_begin ++ name ++ def ++ mt ()) ++ callback_def;
+        in pp_val table name t ++ hov 0 (expr_begin ++ name ++ def ++ mt ()) ++ callback_def;
 
     | Dfix (rv,defs,typs) ->
-        pp_Dfix (rv,defs,typs)
+        pp_Dfix table (rv,defs,typs)
 
-let pp_spec = function
+let pp_spec table = function
   | Sval (r,_) when is_inline_custom r -> mt ()
   | Stype (r,_,_) when is_inline_custom r -> mt ()
-  | Sind (kn,i) -> pp_mind kn i
+  | Sind (kn,i) -> pp_mind table kn i
   | Sval (r,t) ->
-      let def = pp_type false [] t in
-      let name = pp_global_name Term r in
+      let def = pp_type table false [] t in
+      let name = pp_global_name table Term r in
       hov 2 (str "val " ++ name ++ str " :" ++ spc () ++ def)
   | Stype (r,vl,ot) ->
-      let name = pp_global_name Type r in
+      let name = pp_global_name table Type r in
       let l = rename_tvars keywords vl in
       let ids, def =
         try
@@ -649,22 +649,22 @@ let pp_spec = function
           match ot with
             | None -> ids, mt ()
             | Some Taxiom -> ids, str " (* AXIOM TO BE REALIZED *)"
-            | Some t -> ids, str " =" ++ spc () ++ pp_type false l t
+            | Some t -> ids, str " =" ++ spc () ++ pp_type table false l t
       in
       hov 2 (str "type " ++ ids ++ name ++ def)
 
-let rec pp_specif = function
-  | (_,Spec (Sval _ as s)) -> pp_spec s
+let rec pp_specif table = function
+  | (_,Spec (Sval _ as s)) -> pp_spec table s
   | (l,Spec s) ->
      (match Common.get_duplicate (top_visible_mp ()) l with
-      | None -> pp_spec s
+      | None -> pp_spec table s
       | Some ren ->
-         hov 1 (str ("module "^ren^" : sig") ++ fnl () ++ pp_spec s) ++
+         hov 1 (str ("module "^ren^" : sig") ++ fnl () ++ pp_spec table s) ++
          fnl () ++ str "end" ++ fnl () ++
          str ("include module type of struct include "^ren^" end"))
   | (l,Smodule mt) ->
-      let def = pp_module_type [] mt in
-      let name = pp_modname (MPdot (top_visible_mp (), l)) in
+      let def = pp_module_type table [] mt in
+      let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module " ++ name ++ str " :" ++ fnl () ++ def) ++
       (match Common.get_duplicate (top_visible_mp ()) l with
        | None -> Pp.mt ()
@@ -673,25 +673,25 @@ let rec pp_specif = function
          hov 1 (str ("module "^ren^" :") ++ spc () ++
                 str "module type of struct include " ++ name ++ str " end"))
   | (l,Smodtype mt) ->
-      let def = pp_module_type [] mt in
-      let name = pp_modname (MPdot (top_visible_mp (), l)) in
+      let def = pp_module_type table [] mt in
+      let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module type " ++ name ++ str " =" ++ fnl () ++ def) ++
       (match Common.get_duplicate (top_visible_mp ()) l with
        | None -> Pp.mt ()
        | Some ren -> fnl () ++ str ("module type "^ren^" = ") ++ name)
 
-and pp_module_type params = function
+and pp_module_type table params = function
   | MTident kn ->
-      pp_modname kn
+      pp_modname table kn
   | MTfunsig (mbid, mt, mt') ->
-      let typ = pp_module_type [] mt in
-      let name = pp_modname (MPbound mbid) in
-      let def = pp_module_type (MPbound mbid :: params) mt' in
+      let typ = pp_module_type table [] mt in
+      let name = pp_modname table (MPbound mbid) in
+      let def = pp_module_type table (MPbound mbid :: params) mt' in
       str "functor (" ++ name ++ str ":" ++ typ ++ str ") ->" ++ fnl () ++ def
   | MTsig (mp, sign) ->
       push_visible mp params;
       let try_pp_specif l x =
-        let px = pp_specif x in
+        let px = pp_specif table x in
         if Pp.ismt px then l else px::l
       in
       (* We cannot use fold_right here due to side effects in pp_specif *)
@@ -712,37 +712,37 @@ and pp_module_type params = function
       in
       let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)) in
       push_visible mp_mt [];
-      let pp_w = str " with type " ++ ids ++ pp_global Type r in
+      let pp_w = str " with type " ++ ids ++ pp_global table Type r in
       pop_visible();
-      pp_module_type [] mt ++ pp_w ++ str " = " ++ pp_type false vl typ
+      pp_module_type table [] mt ++ pp_w ++ str " = " ++ pp_type table false vl typ
   | MTwith(mt,ML_With_module(idl,mp)) ->
       let mp_mt = msid_of_mt mt in
       let mp_w =
         List.fold_left (fun mp id -> MPdot(mp,Label.of_id id)) mp_mt idl
       in
       push_visible mp_mt [];
-      let pp_w = str " with module " ++ pp_modname mp_w in
+      let pp_w = str " with module " ++ pp_modname table mp_w in
       pop_visible ();
-      pp_module_type [] mt ++ pp_w ++ str " = " ++ pp_modname mp
+      pp_module_type table [] mt ++ pp_w ++ str " = " ++ pp_modname table mp
 
 let is_short = function MEident _ | MEapply _ -> true | _ -> false
 
-let rec pp_structure_elem = function
+let rec pp_structure_elem table = function
   | (l,SEdecl d) ->
      (match Common.get_duplicate (top_visible_mp ()) l with
-      | None -> pp_decl d
+      | None -> pp_decl table d
       | Some ren ->
-         v 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl d) ++
+         v 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl table d) ++
          fnl () ++ str "end" ++ fnl () ++ str ("include "^ren))
   | (l,SEmodule m) ->
       let typ =
         (* virtual printing of the type, in order to have a correct mli later*)
         if Common.get_phase () == Pre then
-          str ": " ++ pp_module_type [] m.ml_mod_type
+          str ": " ++ pp_module_type table [] m.ml_mod_type
         else mt ()
       in
-      let def = pp_module_expr [] m.ml_mod_expr in
-      let name = pp_modname (MPdot (top_visible_mp (), l)) in
+      let def = pp_module_expr table [] m.ml_mod_expr in
+      let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1
         (str "module " ++ name ++ typ ++ str " =" ++
          (if is_short m.ml_mod_expr then spc () else fnl ()) ++ def) ++
@@ -750,26 +750,26 @@ let rec pp_structure_elem = function
        | Some ren -> fnl () ++ str ("module "^ren^" = ") ++ name
        | None -> mt ())
   | (l,SEmodtype m) ->
-      let def = pp_module_type [] m in
-      let name = pp_modname (MPdot (top_visible_mp (), l)) in
+      let def = pp_module_type table [] m in
+      let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module type " ++ name ++ str " =" ++ fnl () ++ def) ++
       (match Common.get_duplicate (top_visible_mp ()) l with
        | None -> mt ()
        | Some ren -> fnl () ++ str ("module type "^ren^" = ") ++ name)
 
-and pp_module_expr params = function
-  | MEident mp -> pp_modname mp
+and pp_module_expr table params = function
+  | MEident mp -> pp_modname table mp
   | MEapply (me, me') ->
-      pp_module_expr [] me ++ str "(" ++ pp_module_expr [] me' ++ str ")"
+      pp_module_expr table [] me ++ str "(" ++ pp_module_expr table [] me' ++ str ")"
   | MEfunctor (mbid, mt, me) ->
-      let name = pp_modname (MPbound mbid) in
-      let typ = pp_module_type [] mt in
-      let def = pp_module_expr (MPbound mbid :: params) me in
+      let name = pp_modname table (MPbound mbid) in
+      let typ = pp_module_type table [] mt in
+      let def = pp_module_expr table (MPbound mbid :: params) me in
       str "functor (" ++ name ++ str ":" ++ typ ++ str ") ->" ++ fnl () ++ def
   | MEstruct (mp, sel) ->
       push_visible mp params;
       let try_pp_structure_elem l x =
-        let px = pp_structure_elem x in
+        let px = pp_structure_elem table x in
         if Pp.ismt px then l else px::l
       in
       (* We cannot use fold_right here due to side effects in pp_structure_elem *)
@@ -803,9 +803,9 @@ let do_struct f s =
   (if not (modular ()) then repeat (List.length s) pop_visible ());
   v 0 p ++ fnl ()
 
-let pp_struct s = do_struct pp_structure_elem s
+let pp_struct table s = do_struct (fun e -> pp_structure_elem table e) s
 
-let pp_signature s = do_struct pp_specif s
+let pp_signature table s = do_struct (fun e -> pp_specif table e) s
 
 let ocaml_descr = {
   keywords = keywords;

--- a/plugins/extraction/ocaml.mli
+++ b/plugins/extraction/ocaml.mli
@@ -8,5 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val ocaml_descr : Miniml.language_descr
+val ocaml_descr : Table.t Miniml.language_descr
 

--- a/plugins/extraction/scheme.mli
+++ b/plugins/extraction/scheme.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val scheme_descr : Miniml.language_descr
+val scheme_descr : Table.t Miniml.language_descr

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -16,12 +16,16 @@ open Declarations
 module Refset' : CSig.USetS with type elt = GlobRef.t
 module Refmap' : CSig.UMapS with type key = GlobRef.t
 
-val safe_basename_of_global : GlobRef.t -> Id.t
+type t
+
+val safe_basename_of_global : t -> GlobRef.t -> Id.t
+
+val make_table : unit -> t
 
 (*s Warning and Error messages. *)
 
-val warning_axioms : unit -> unit
-val warning_opaques : bool -> unit
+val warning_axioms : t -> unit
+val warning_opaques : t -> bool -> unit
 val warning_ambiguous_name : ?loc:Loc.t -> qualid * ModPath.t * GlobRef.t -> unit
 val warning_id : string -> unit
 val error_axiom_scheme : ?loc:Loc.t -> GlobRef.t -> int -> 'a
@@ -50,8 +54,8 @@ val modpath_of_r : GlobRef.t -> ModPath.t
 val label_of_r : GlobRef.t -> Label.t
 val base_mp : ModPath.t -> ModPath.t
 val is_modfile : ModPath.t -> bool
-val string_of_modfile : ModPath.t -> string
-val file_of_modfile : ModPath.t -> string
+val string_of_modfile : t -> ModPath.t -> string
+val file_of_modfile : t -> ModPath.t -> string
 val is_toplevel : ModPath.t -> bool
 val at_toplevel : ModPath.t -> bool
 val mp_length : ModPath.t -> int
@@ -71,41 +75,39 @@ val labels_of_ref : GlobRef.t -> ModPath.t * Label.t list
    [mutual_inductive_body] as checksum. In both case, we should ideally
    also check the env *)
 
-val add_typedef : Constant.t -> constant_body -> ml_type -> unit
-val lookup_typedef : Constant.t -> constant_body -> ml_type option
+val add_typedef : t -> Constant.t -> constant_body -> ml_type -> unit
+val lookup_typedef : t -> Constant.t -> constant_body -> ml_type option
 
-val add_cst_type : Constant.t -> constant_body -> ml_schema -> unit
-val lookup_cst_type : Constant.t -> constant_body -> ml_schema option
+val add_cst_type : t -> Constant.t -> constant_body -> ml_schema -> unit
+val lookup_cst_type : t -> Constant.t -> constant_body -> ml_schema option
 
-val add_ind : MutInd.t -> mutual_inductive_body -> ml_ind -> unit
-val lookup_ind : MutInd.t -> mutual_inductive_body -> ml_ind option
+val add_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind -> unit
+val lookup_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind option
 
-val add_inductive_kind : MutInd.t -> inductive_kind -> unit
-val is_coinductive : GlobRef.t -> bool
-val is_coinductive_type : ml_type -> bool
+val add_inductive_kind : t -> MutInd.t -> inductive_kind -> unit
+val is_coinductive : t -> GlobRef.t -> bool
+val is_coinductive_type : t -> ml_type -> bool
 (* What are the fields of a record (empty for a non-record) *)
 val get_record_fields :
-  GlobRef.t -> GlobRef.t option list
-val record_fields_of_type : ml_type -> GlobRef.t option list
+  t -> GlobRef.t -> GlobRef.t option list
+val record_fields_of_type : t -> ml_type -> GlobRef.t option list
 
-val add_recursors : Environ.env -> MutInd.t -> unit
-val is_recursor : GlobRef.t -> bool
+val add_recursors : t -> Environ.env -> MutInd.t -> unit
+val is_recursor : t -> GlobRef.t -> bool
 
-val add_projection : int -> Constant.t -> inductive -> unit
-val is_projection : GlobRef.t -> bool
-val projection_arity : GlobRef.t -> int
-val projection_info : GlobRef.t -> inductive * int (* arity *)
+val add_projection : t -> int -> Constant.t -> inductive -> unit
+val is_projection : t -> GlobRef.t -> bool
+val projection_arity : t -> GlobRef.t -> int
+val projection_info : t -> GlobRef.t -> inductive * int (* arity *)
 
-val add_info_axiom : GlobRef.t -> unit
-val remove_info_axiom : GlobRef.t -> unit
-val add_log_axiom : GlobRef.t -> unit
-val add_symbol : GlobRef.t -> unit
-val add_symbol_rule : GlobRef.t -> Label.t -> unit
+val add_info_axiom : t -> GlobRef.t -> unit
+val remove_info_axiom : t -> GlobRef.t -> unit
+val add_log_axiom : t -> GlobRef.t -> unit
+val add_symbol : t -> GlobRef.t -> unit
+val add_symbol_rule : t -> GlobRef.t -> Label.t -> unit
 
-val add_opaque : GlobRef.t -> unit
-val remove_opaque : GlobRef.t -> unit
-
-val reset_tables : unit -> unit
+val add_opaque : t -> GlobRef.t -> unit
+val remove_opaque : t -> GlobRef.t -> unit
 
 (*s Output Directory parameter *)
 


### PR DESCRIPTION
Instead of having a splatter of many toplevel references capturing various tables governing extraction, we replace this state with a single record and pass it as a reference to many extraction functions.

This helps a bit with understanding who is supposed to be accessing this state, and it also uncovers at least one dubious behaviour that was causing a memory leak.