### PR TITLE
lib.ml reduce dependence on Global

### DIFF
--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -612,7 +612,7 @@ let discharge_implicits (req,l) =
      let l' =
        try
          List.map (fun (gr, l) ->
-             let vars = Array.map_to_list Constr.destVar (Lib.section_instance gr) in
+             let vars = Array.map_to_list Constr.destVar (Global.section_instance gr) in
              let extra_impls = impls_of_context vars in
              let newimpls = List.map (add_section_impls vars extra_impls) l in
              (gr, newimpls)) l
@@ -638,7 +638,7 @@ let rebuild_implicits (req,l) =
 
   | ImplInteractive (flags,o) ->
       let ref,oldimpls = List.hd l in
-      (if isVarRef ref && Lib.is_in_section ref then ImplLocal else req),
+      (if isVarRef ref && Global.is_in_section ref then ImplLocal else req),
       match o with
       | ImplAuto ->
          let newimpls = compute_global_implicits flags ref in
@@ -669,7 +669,7 @@ let inImplicits : implicits_obj -> obj =
     discharge_function = discharge_implicits;
     rebuild_function = rebuild_implicits }
 
-let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
+let is_local local ref = local || isVarRef ref && Global.is_in_section ref
 
 let declare_implicits_gen req flags ref =
   let imps = compute_global_implicits flags ref in

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1999,11 +1999,11 @@ let discharge_available_scopes map =
       if List.is_empty ltop && List.is_empty lbot then None else Some (ltop, lbot)) map
 
 let discharge_arguments_scope (req,r,scs,_cls,available_scopes) =
-  if req == ArgsScopeNoDischarge || (isVarRef r && Lib.is_in_section r) then None
+  if req == ArgsScopeNoDischarge || (isVarRef r && Global.is_in_section r) then None
   else
     let n =
       try
-        Array.length (Lib.section_instance r)
+        Array.length (Global.section_instance r)
       with
         Not_found (* Not a ref defined in this section *) -> 0 in
     let available_scopes = discharge_available_scopes available_scopes in
@@ -2054,7 +2054,7 @@ let inArgumentsScope : arguments_scope_obj -> obj =
       discharge_function = discharge_arguments_scope;
       rebuild_function = rebuild_arguments_scope }
 
-let is_local local ref = local || isVarRef ref && Lib.is_in_section ref
+let is_local local ref = local || isVarRef ref && Global.is_in_section ref
 
 let declare_arguments_scope_gen req r (scl,cls) =
   Lib.add_leaf (inArgumentsScope (req,r,scl,cls,!scope_class_map))

--- a/library/global.ml
+++ b/library/global.ml
@@ -111,6 +111,45 @@ let open_section () = globalize0 Safe_typing.open_section
 let close_section fs = globalize0_with_summary fs Safe_typing.close_section
 let sections_are_opened () = Safe_typing.sections_are_opened (safe_env())
 
+let sections () = Safe_typing.sections_of_safe_env @@ safe_env ()
+
+let force_sections () = match sections() with
+  | Some s -> s
+  | None ->
+    (* XXX should this be anomaly? *)
+    CErrors.user_err Pp.(str "No open section.")
+
+let section_segment_of_constant con =
+  Section.segment_of_constant con (force_sections ())
+
+let section_segment_of_inductive kn =
+  Section.segment_of_inductive kn (force_sections ())
+
+let section_segment_of_reference = let open GlobRef in function
+| ConstRef c -> section_segment_of_constant c
+| IndRef (kn,_) | ConstructRef ((kn,_),_) ->
+  section_segment_of_inductive kn
+| VarRef _ -> Cooking.empty_cooking_info
+
+let is_in_section ref = match sections () with
+  | None -> false
+  | Some sec ->
+    Section.is_in_section (env ()) ref sec
+
+let section_instance ref =
+  Cooking.instance_of_cooking_info (section_segment_of_reference ref)
+
+let discharge_section_proj_repr p =
+  let ind = Projection.Repr.inductive p in
+  let sec = section_segment_of_reference (GlobRef.IndRef ind) in
+  Cooking.discharge_proj_repr sec p
+
+let discharge_proj_repr p =
+    if is_in_section (Names.GlobRef.IndRef (Names.Projection.Repr.inductive p)) then
+      discharge_section_proj_repr p
+    else
+      p
+
 let start_module id = globalize (Safe_typing.start_module (i2l id))
 let start_modtype id = globalize (Safe_typing.start_modtype (i2l id))
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -90,6 +90,20 @@ val close_section : Summary.Interp.frozen -> unit
 
 val sections_are_opened : unit -> bool
 
+(** {6 Section management for discharge } *)
+
+val section_segment_of_constant : Constant.t -> Cooking.cooking_info
+val section_segment_of_inductive: MutInd.t -> Cooking.cooking_info
+val section_segment_of_reference : GlobRef.t -> Cooking.cooking_info
+
+val section_instance : GlobRef.t -> Constr.t array
+val is_in_section : GlobRef.t -> bool
+
+(** [discharge_proj_repr p] discharges projection [p] if the associated record
+    was defined in the current section. If that is not the case, it returns [p]
+    unchanged. *)
+val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t
+
 (** Interactive modules and module types *)
 
 val start_module : Id.t -> ModPath.t

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -180,11 +180,16 @@ val library_part :  GlobRef.t -> DirPath.t
 
 (** {6 Section management for discharge } *)
 val section_segment_of_constant : Constant.t -> Cooking.cooking_info
+[@@deprecated "Use [Global.section_segment_of_constant]"]
 val section_segment_of_inductive: MutInd.t -> Cooking.cooking_info
+[@@deprecated "Use [Global.section_segment_of_inductive]"]
 val section_segment_of_reference : GlobRef.t -> Cooking.cooking_info
+[@@deprecated "Use [Global.section_segment_of_reference]"]
 
 val section_instance : GlobRef.t -> Constr.t array
+[@@deprecated "Use [Global.section_instance]"]
 val is_in_section : GlobRef.t -> bool
+[@@deprecated "Use [Global.is_in_section]"]
 
 (** {6 Discharge: decrease the section level if in the current section } *)
 
@@ -192,6 +197,7 @@ val is_in_section : GlobRef.t -> bool
     was defined in the current section. If that is not the case, it returns [p]
     unchanged. *)
 val discharge_proj_repr : Projection.Repr.t -> Projection.Repr.t
+[@@deprecated "Use [Global.discharge_proj_repr]"]
 
 (** Compatibility layer *)
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -42,9 +42,9 @@ let subst_rename_args (subst, (_, (r, names as orig))) =
   if r==r' then orig else (r', names)
 
 let discharge_rename_args = function
-  | ReqGlobal, (c, names) as req when not (isVarRef c && Lib.is_in_section c) ->
+  | ReqGlobal, (c, names) as req when not (isVarRef c && Global.is_in_section c) ->
      (try
-       let var_names = Array.map_to_list (fun c -> Name (destVar c)) (Lib.section_instance c) in
+       let var_names = Array.map_to_list (fun c -> Name (destVar c)) (Global.section_instance c) in
        let names = var_names @ names in
        Some (ReqGlobal, (c, names))
      with Not_found -> Some req)

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -504,7 +504,7 @@ module CoercionPrinting =
 
     let discharge = let open GlobRef in function
       | ConstRef _ | ConstructRef _ | IndRef _ as x -> x
-      | VarRef _ as x -> assert (not (Lib.is_in_section x)); x
+      | VarRef _ as x -> assert (not (Global.is_in_section x)); x
 
     let printer x = Nametab.pr_global_env Id.Set.empty x
     let key = ["Printing";"Coercion"]

--- a/pretyping/keys.ml
+++ b/pretyping/keys.ml
@@ -102,7 +102,7 @@ let subst_keys (subst,(k,k')) =
   (subst_key subst k, subst_key subst k')
 
 let discharge_key = function
-  | KGlob (GlobRef.VarRef _ as g) when Lib.is_in_section g -> None
+  | KGlob (GlobRef.VarRef _ as g) when Global.is_in_section g -> None
   | x -> Some x
 
 let discharge_keys (k,k') =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -114,8 +114,8 @@ module ReductionBehaviour = struct
     | false, (gr, b) ->
       let b =
         let gr = GlobRef.ConstRef gr in
-        if Lib.is_in_section gr then
-          let vars = Lib.section_instance gr in
+        if Global.is_in_section gr then
+          let vars = Global.section_instance gr in
           let extra = Array.length vars in
           Option.map (more_args extra) b
         else b

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1184,7 +1184,7 @@ let is_trivial_action = function
 let rec is_section_path = function
 | PathAtom PathAny -> false
 | PathAtom (PathHints grs) ->
-  let check c = isVarRef c && Lib.is_in_section c in
+  let check c = isVarRef c && Global.is_in_section c in
   List.exists check grs
 | PathStar p -> is_section_path p
 | PathSeq (p, q) | PathOr (p, q) -> is_section_path p || is_section_path q
@@ -1337,10 +1337,10 @@ let discharge_autohint obj =
         let filter e = match e with
         | Evaluable.EvalConstRef c -> Some e
         | Evaluable.EvalProjectionRef p ->
-          let p = Lib.discharge_proj_repr p in
+          let p = Global.discharge_proj_repr p in
           Some (Evaluable.EvalProjectionRef p)
         | Evaluable.EvalVarRef id ->
-          if Lib.is_in_section (GlobRef.VarRef id) then None else Some e
+          if Global.is_in_section (GlobRef.VarRef id) then None else Some e
         in
         let grs = List.filter_map filter grs in
         HintsReferences grs
@@ -1352,10 +1352,10 @@ let discharge_autohint obj =
     | AddCut path ->
       if is_section_path path then AddHints [] (* dummy *) else obj.hint_action
     | AddMode { gref; mode } ->
-      if Lib.is_in_section gref then
+      if Global.is_in_section gref then
         if isVarRef gref then AddHints [] (* dummy *)
         else
-          let inst = Lib.section_instance gref in
+          let inst = Global.section_instance gref in
           (* Default mode for discharged parameters is output *)
           let mode = Array.append (Array.make (Array.length inst) ModeOutput) mode in
           AddMode { gref; mode }
@@ -1553,13 +1553,13 @@ let add_hints ~locality dbnames h =
   | HintsTransparencyEntry (HintsReferences grs, _) ->
     let iter gr =
       let gr = global_of_evaluable_reference gr in
-      if is_notlocal locality && isVarRef gr && Lib.is_in_section gr then warn_non_local_section_hint ()
+      if is_notlocal locality && isVarRef gr && Global.is_in_section gr then warn_non_local_section_hint ()
     in
     List.iter iter grs
   | HintsCutEntry p ->
     if is_notlocal locality && is_section_path p then warn_non_local_section_hint ()
   | HintsModeEntry (gr, _) ->
-    if is_notlocal locality && isVarRef gr && Lib.is_in_section gr then warn_non_local_section_hint ()
+    if is_notlocal locality && isVarRef gr && Global.is_in_section gr then warn_non_local_section_hint ()
   in
   if String.List.mem "nocore" dbnames then
     user_err Pp.(str "The hint database \"nocore\" is meant to stay empty.");

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -90,9 +90,9 @@ let disch_ref ref =
   match ref with
   | Evaluable.EvalConstRef c -> Some ref
   | Evaluable.EvalProjectionRef p ->
-    let p = Lib.discharge_proj_repr p in
+    let p = Global.discharge_proj_repr p in
     Some (Evaluable.EvalProjectionRef p)
-  | Evaluable.EvalVarRef id -> if Lib.is_in_section (GlobRef.VarRef id) then None else Some ref
+  | Evaluable.EvalVarRef id -> if Global.is_in_section (GlobRef.VarRef id) then None else Some ref
 
 let discharge_strategy (local,obj) =
   if local then None else

--- a/vernac/canonical.ml
+++ b/vernac/canonical.ml
@@ -22,7 +22,7 @@ let cache_canonical_structure (o,_) =
 
 let discharge_canonical_structure (x, local) =
   let gref = Instance.repr x in
-  if local || (Globnames.isVarRef gref && Lib.is_in_section gref) then None
+  if local || (Globnames.isVarRef gref && Global.is_in_section gref) then None
   else Some (x, local)
 
 let canon_cat = create_category "canonicals"

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -222,7 +222,7 @@ let subst_class (subst,cl) =
 
 let discharge_class cl =
   try
-    let info = Lib.section_segment_of_reference cl.cl_impl in
+    let info = Global.section_segment_of_reference cl.cl_impl in
     let info, _, cl_univs' = Cooking.lift_poly_univs info cl.cl_univs in
     let nprops = List.length cl.cl_props in
     let props, context = List.chop nprops (Discharge.cook_rel_context info (cl.cl_props @ cl.cl_context)) in

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -31,9 +31,9 @@ let subst_bidi_hints (subst, (gr, ohint as orig)) =
   if gr == gr' then orig else (gr', ohint)
 
 let discharge_bidi_hints (gr, ohint) =
-  if Globnames.isVarRef gr && Lib.is_in_section gr then None
+  if Globnames.isVarRef gr && Global.is_in_section gr then None
   else
-    let vars = Lib.section_instance gr in
+    let vars = Global.section_instance gr in
     let n = Array.length vars in
     Some (gr, Option.map ((+) n) ohint)
 

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -235,12 +235,12 @@ let discharge_coercion c =
   if c.coe_local then None
   else
     let n =
-      try Array.length (Lib.section_instance c.coe_value)
+      try Array.length (Global.section_instance c.coe_value)
       with Not_found -> 0
     in
     let nc = { c with
       coe_param = n + c.coe_param;
-      coe_is_projection = Option.map Lib.discharge_proj_repr c.coe_is_projection;
+      coe_is_projection = Option.map Global.discharge_proj_repr c.coe_is_projection;
     } in
     Some nc
 

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -82,7 +82,7 @@ let load_prim _ p = cache_prim p
 
 let subst_prim (subst,(p,c)) = Mod_subst.subst_proj_repr subst p, Mod_subst.subst_constant subst c
 
-let discharge_prim (p,c) = Some (Lib.discharge_proj_repr p, c)
+let discharge_prim (p,c) = Some (Global.discharge_proj_repr p, c)
 
 let inPrim : (Projection.Repr.t * Constant.t) -> Libobject.obj =
   let open Libobject in


### PR DESCRIPTION
is_module_or_modtype and the similar functions are modified to return the correct result in synterp.

The section discharge functions are moved to Global.

This leaves only the interaction between Lib.open/close_section and Global.open/close_section referring to Global in Lib.
