### PR TITLE
Prevent an exponential behaviour in lambda-erasure in extraction.

### DIFF
--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1334,12 +1334,12 @@ let rec kill_dummy = function
       | exception Impossible -> MLletin(id, MLfix(i,fi,Array.map kill_dummy c),kill_dummy e)
       end
   | MLletin(id,c,e) ->
-      begin match kill_dummy_lams [] (kill_dummy_hd c) with
+      let c = kill_dummy c in
+      begin match kill_dummy_lams [] c with
       | (k, c) ->
          let e = kill_dummy (kill_dummy_args k 1 e) in
-         let c = kill_dummy c in
          if is_atomic c then ast_subst c e else MLletin (id, c, e)
-      | exception Impossible -> MLletin(id,kill_dummy c,kill_dummy e)
+      | exception Impossible -> MLletin(id, c, kill_dummy e)
       end
   | a -> ast_map kill_dummy a
 

--- a/test-suite/complexity/bug_17448.v
+++ b/test-suite/complexity/bug_17448.v
@@ -1,0 +1,11 @@
+(* Expected time < 1.00s *)
+Require Import Extraction.
+
+Definition test (f : nat -> nat) (n : nat) : bool.
+Proof.
+refine (let n := _ in match n with 0 => true | S n => false end).
+do 40 refine (let n := _ in f n).
+exact n.
+Defined.
+
+Time Recursive Extraction test.


### PR DESCRIPTION
We factor out the same call to the recursive function [kill_dummy], which is fine because this function cannot raise an Impossible exception. The optimization is sound because basically for any term c,

```
kill_dummy (kill_dummy_lams (kill_dummy c)) = kill_dummy_lams (kill_dummy c).
```

The algorithm is still quadratic or so, but the size of the proof terms shouldn't be that big to be a problem in practice.

Fixes #17448: extraction optimizations performance issue.
