### PR TITLE
document tactics/auto.mli

### DIFF
--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -28,8 +28,8 @@ let compute_secvars gl =
   let hyps = Proofview.Goal.hyps gl in
   secvars_of_hyps hyps
 
-(* tell auto not to reuse already instantiated metas in unification (for
-   compatibility, since otherwise, apply succeeds oftener) *)
+(* Tell auto not to reuse already instantiated metas in unification (for
+   compatibility, since otherwise, apply succeeds more often). *)
 
 open Unification
 
@@ -60,7 +60,7 @@ let auto_unif_flags_of st1 st2 =
 let auto_unif_flags =
   auto_unif_flags_of TransparentState.full TransparentState.empty
 
-(* Try unification with the precompiled clause, then use registered Apply *)
+(* Try unification with the precompiled clause, then use registered Apply. *)
 
 let unify_resolve flags h = Hints.hint_res_pf ~flags h
 let unify_resolve_nodelta h = Hints.hint_res_pf ~flags:auto_unif_flags h

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -18,6 +18,7 @@ open Tactypes
 
 val compute_secvars : Proofview.Goal.t -> Id.Pred.t
 
+(** Default maximum search depth used by [auto] and [trivial]. *)
 val default_search_depth : int
 
 val auto_flags_of_state : TransparentState.t -> Unification.unify_flags
@@ -29,24 +30,26 @@ val unify_resolve : Unification.unify_flags -> hint -> unit Proofview.tactic
    if the term concl matches the pattern pat, (in sense of
    [Pattern.somatches], then replace [?1] [?2] metavars in tacast by the
    right values to build a tactic *)
-
 val conclPattern : constr -> constr_pattern option -> Gentactic.glob_generic_tactic -> unit Proofview.tactic
 
-(** The Auto tactic *)
-
-(** The use of the "core" database can be de-activated by passing
-    "nocore" amongst the databases. *)
-
-(** Auto with more delta. *)
-
-(** auto with default search depth and with the hint database "core" *)
+(** [default_auto] runs the tactic [auto] with:
+    - Maximum search depth [default_search_depth].
+    - The hint database ["core"].
+    - No additional lemma. *)
 val default_auto : unit Proofview.tactic
 
-(** The generic form of auto (second arg [None] means all bases) *)
+(** [gen_auto ?debug depth lemmas hints] runs the tactic [auto].
+    - [debug] controls whether to print a debug trace ([Off] by default). [Off] prints nothing,
+      [Info] prints successful steps, and [Debug] prints all steps (including unsuccessful ones).
+    - [depth] is the maximum search depth. If [None], [default_search_depth] is used.
+    - [lemmas] contains additional lemmas for [auto] to use.
+    - [hints] is a list of hint databases to use. If [None], _all_ existing hint databases are used.
+      By default the ["core"] hint database is included: passing ["nocore"]
+      will disable ["core"]. *)
 val gen_auto : ?debug:debug ->
   int option -> delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic
 
-(** Trivial *)
-
+(** [gen_trivial] runs the tactic [trivial].
+    See [gen_auto] for an explanation of the different options.*)
 val gen_trivial : ?debug:debug ->
   delayed_open_constr list -> hint_db_name list option -> unit Proofview.tactic


### PR DESCRIPTION
It was unclear to me how the arguments of `auto` and `trivial` in `tactics/auto.mli` related to their description [in the refman](https://rocq-prover.org/doc/V8.20.0/refman/proofs/automatic-tactics/auto.html#coq:tacn.auto), so I added documentation to the OCaml code.