### PR TITLE
Bump minimum ocaml version to 4.14.0

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -25,8 +25,8 @@ jobs:
           opam install -j "$NJOBS" ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3 zarith.1.11 dune.3.8.3 yojson.2.1.0 camlzip
           opam list
         env:
-          COMPILER: "4.12.0"
-          FINDLIB_VER: ".1.8.1"
+          COMPILER: "4.14.0"
+          FINDLIB_VER: ".1.9.1"
           OPAMYES: "true"
           MACOSX_DEPLOYMENT_TARGET: "10.11"
           NJOBS: "2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ variables:
   # The $hash is the first 10 characters of the md5 of the Dockerfile. e.g.
   # echo $(md5sum dev/ci/docker/old_ubuntu_lts/Dockerfile | head -c 10)
   # echo $(md5sum dev/ci/docker/edge_ubuntu/Dockerfile | head -c 10)
-  BASE_CACHEKEY: "old_ubuntu_lts-V2025-02-19-804d667688"
+  BASE_CACHEKEY: "old_ubuntu_lts-V2025-04-29-b90c41d539"
   EDGE_CACHEKEY: "edge_ubuntu-V2025-04-07-dee2054641"
   BASE_IMAGE: "$CI_REGISTRY_IMAGE:$BASE_CACHEKEY"
   EDGE_IMAGE: "$CI_REGISTRY_IMAGE:$EDGE_CACHEKEY"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ Build Requirements
 
 To compile Rocq yourself, you need:
 
-- [OCaml](https://ocaml.org/) (version >= 4.09.0)
+- [OCaml](https://ocaml.org/) (version >= 4.14.0)
   (This version of Rocq has been tested up to OCaml 4.14.1, for the 4.x series)
 
   Support for OCaml 5.x remains experimental.
@@ -26,7 +26,7 @@ To compile Rocq yourself, you need:
 
 - The [ZArith library](https://github.com/ocaml/Zarith) >= 1.11
 
-- The [findlib](http://projects.camlcity.org/projects/findlib.html) library (version >= 1.8.1)
+- The [findlib](http://projects.camlcity.org/projects/findlib.html) library (version >= 1.9.1)
 
 - a C compiler
 

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 
 # nix-shell supports the --arg option (see Nix doc) that allows you for
 # instance to do this:
-# $ nix-shell --arg ocamlPackages "(import <nixpkgs> {}).ocaml-ng.ocamlPackages_4_09" --arg buildIde false
+# $ nix-shell --arg ocamlPackages "(import <nixpkgs> {}).ocaml-ng.ocamlPackages_4_14" --arg buildIde false
 
 # You can also compile Rocq and "install" it by running:
 # $ make clean # (only needed if you have left-over compilation files)

--- a/dev/ci/docker/old_ubuntu_lts/Dockerfile
+++ b/dev/ci/docker/old_ubuntu_lts/Dockerfile
@@ -49,12 +49,12 @@ ENV NJOBS="2" \
 RUN mkdir -p ~/.config/dune && printf '(lang dune 2.1)\n(jobs %s)\n' $NJOBS > ~/.config/dune/config
 
 # Base opam is the set of base packages required by Coq
-ENV COMPILER="4.09.0"
+ENV COMPILER="4.14.0"
 
 # Common OPAM packages
 ENV BASE_OPAM="zarith.1.11 ounit2.2.2.6 yojson.1.7.0 camlzip.1.10" \
     CI_OPAM="ocamlgraph.2.0.0 cppo.1.6.9" \
-    BASE_ONLY_OPAM="dune.3.8.3 stdlib-shims.0.1.0 ocamlfind.1.8.1 odoc.2.0.2 num.1.4"
+    BASE_ONLY_OPAM="dune.3.8.3 stdlib-shims.0.1.0 ocamlfind.1.9.1 odoc.2.0.2 num.1.4"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.1.2"
@@ -69,8 +69,10 @@ RUN opam init -a --disable-sandboxing --compiler="$COMPILER" default https://opa
     find ~ '(' -name '*.cmt' -o -name '*.cmti' ')' -delete
 
 # base+32bit switch, note the zarith hack
-RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
-        i386 env CC='gcc -m32' opam install zarith.1.11 && \
+RUN opam switch create "${COMPILER}+32bit" \
+    --packages="ocaml-variants.${COMPILER}+options,ocaml-option-32bit" && \
+    eval $(opam env) && \
+    i386 env CC='gcc -m32' opam install zarith.1.11 && \
     opam install $BASE_OPAM && \
     opam clean -a -c && \
     find ~ '(' -name '*.cmt' -o -name '*.cmti' ')' -delete

--- a/dev/doc/profiling.md
+++ b/dev/doc/profiling.md
@@ -8,7 +8,7 @@ want to profile time or memory consumption. AFAIK, this only works for Linux.
 In Rocq source folder:
 
 ```
-opam switch 4.09.0+trunk+fp
+opam switch 4.14.0+trunk+fp
 make world
 perf record -g _build/install/default/bin/coqc file.v
 perf report -g fractal,callee --no-children

--- a/dev/dune-workspace.all
+++ b/dev/dune-workspace.all
@@ -1,7 +1,5 @@
 (lang dune 2.0)
 
 ; Add custom flags here. Default developer profile is `dev`
-(context (opam (switch 4.09.0)))
-(context (opam (switch 4.09.0+32bit)))
-(context (opam (switch 4.12.0)))
-(context (opam (switch 4.12.0+flambda)))
+(context (opam (switch 4.14.0)))
+(context (opam (switch 4.14.0+32bit)))

--- a/doc/changelog/12-infrastructure-and-dependencies/20576-old-ocaml-Changed.rst
+++ b/doc/changelog/12-infrastructure-and-dependencies/20576-old-ocaml-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  minimum supported OCaml version is now 4.14.0 (instead of 4.09.0),
+  and minimum supported OCamlfind version is now 1.9.1 (instead of 1.8.1)
+  (`#20576 <https://github.com/rocq-prover/rocq/pull/20576>`_,
+  by Gaëtan Gilbert).

--- a/dune-project
+++ b/dune-project
@@ -26,8 +26,8 @@
 (package
  (name rocq-runtime)
  (depends
-  (ocaml (>= 4.09.0))
-  (ocamlfind (>= 1.8.1))
+  (ocaml (>= 4.14.0))
+  (ocamlfind (>= 1.9.1))
   (zarith (>= 1.11))
   (conf-linux-libc-dev (= :os "linux")))
  (conflicts

--- a/rocq-runtime.opam
+++ b/rocq-runtime.opam
@@ -28,8 +28,8 @@ doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.09.0"}
-  "ocamlfind" {>= "1.8.1"}
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {>= "1.9.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}
   "odoc" {with-doc}

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -104,19 +104,19 @@ let check_caml_version prefs caml_version caml_version_nums =
   if caml_version_nums >= [5;0;0] && prefs.nativecompiler <> NativeNo then
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in
     die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0"
-  else if caml_version_nums >= [4;9;0] then
+  else if caml_version_nums >= [4;14;0] then
     cprintf prefs "You have OCaml %s. Good!" caml_version
   else
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in
-    die "You need OCaml 4.09.0 or later."
+    die "You need OCaml 4.14.0 or later."
 
 let check_findlib_version prefs { CamlConf.findlib_version; _ } =
   let findlib_version_nums = generic_version_nums ~name:"findlib" findlib_version in
-  if findlib_version_nums >= [1;8;1] then
+  if findlib_version_nums >= [1;9;1] then
     cprintf prefs "You have OCamlfind %s. Good!" findlib_version
   else
     let () = cprintf prefs "Your version of OCamlfind is %s." findlib_version in
-    die "You need OCamlfind 1.8.1 or later."
+    die "You need OCamlfind 1.9.1 or later."
 
 (** Note, these warnings are only used in Rocq Makefile *)
 (** Explanation of enabled/disabled warnings:


### PR DESCRIPTION
Later PR: remove copies of API which are now available
Remove workaround at https://github.com/rocq-prover/rocq/blob/39fca0b1e6a2a3488d77daae0897453c73e9351b/sysinit/coqinit.ml#L13-L14 ?