### PR TITLE
remove required_module field of prim token notation info

### DIFF
--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -196,7 +196,6 @@ type prim_token_infos = {
   pt_local : bool; (** Is this interpretation local? *)
   pt_scope : scope_name; (** Concerned scope *)
   pt_interp_info : prim_token_interp_info; (** Unique id "pointing" to (un)interp functions, OR a number notation object describing (un)interp functions *)
-  pt_required : required_module; (** Module that should be loaded first *)
   pt_refs : GlobRef.t list; (** Entry points during uninterpretation *)
   pt_in_match : bool (** Is this prim token legal in match patterns ? *)
 }


### PR DESCRIPTION
AFAICT this is useless, we always get it from path_of_global which means the module has been required.

