### PR TITLE
Revert using strip_update_shift_absorb_app for primitive types

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1889,8 +1889,8 @@ let rec knr : 'a. _ -> _ -> pat_state: 'a depth -> _ -> _ -> 'a =
   | FLetIn (_,v,_,bd,e) when red_set info.i_flags fZETA ->
       knit info tab ~pat_state (on_fst (subs_cons v) e) bd stk
   | FInt _ | FFloat _ | FString _ | FArray _ ->
-    (match [@ocaml.warning "-4"] strip_update_shift_absorb_app m stk with
-     | (_, Zprimitive(op,(_,u as c),rargs,nargs)::s) ->
+    (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
+     | (_, _, _, Zprimitive(op,(_,u as c),rargs,nargs)::s) ->
        let (rargs, nargs) = skip_native_args (m::rargs) nargs in
        begin match nargs with
          | [] ->
@@ -1910,7 +1910,7 @@ let rec knr : 'a. _ -> _ -> pat_state: 'a depth -> _ -> _ -> 'a =
            assert (kd = CPrimitives.Kwhnf);
            kni info tab ~pat_state a (Zprimitive(op,c,rargs,nargs)::s)
              end
-     | mstk -> knr_ret info tab ~pat_state mstk)
+     | (depth, _, _, stk) -> knr_ret info tab ~pat_state (m,zshift depth stk))
   | FCaseInvert (ci, u, pms, _p,iv,_c,v,env) when red_set info.i_flags fMATCH ->
     let pms = mk_clos_vect env pms in
     let u = usubst_instance env u in

--- a/test-suite/bugs/bug_20580.v
+++ b/test-suite/bugs/bug_20580.v
@@ -1,0 +1,27 @@
+Require Import PrimInt63.
+
+Open Scope uint63_scope.
+
+Primitive array := #array_type.
+
+Primitive make : forall A, int -> A -> array A := #array_make.
+Arguments make {_} _ _.
+
+Primitive get : forall A, array A -> int -> A := #array_get.
+Arguments get {_} _ _.
+
+Primitive set : forall A, array A -> int -> A -> array A := #array_set.
+Arguments set {_} _ _ _.
+
+Module Inconsistent.
+
+  Inductive CMP (x:array (unit -> nat)) := C.
+
+  Definition F (x:nat) := fun _:unit => x.
+
+  Polymorphic Definition TARGET@{u} := let m := [| F 0; F 0 | F 0 |] in
+                       let m := set m 0 (fun _ => get (set m 1 (F 1)) 0 tt) in
+                       CMP m.
+
+  Polymorphic Cumulative Inductive foo@{u} : Type@{u} := CC (_ : TARGET@{u} = TARGET@{u}).
+End Inconsistent.


### PR DESCRIPTION
(from commit 1596e98d66798f96833d601c97b06cf0b67f1707)

It could put a FLIFT in the head when the head is a FArray, producing an "unreduced" term and causing problems later.

Since by typing there should be no applications there is anyway no point in doing absorb_app.

Fix #20580
