### PR TITLE
Fast path when checking universe constraints Set <= u.

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -55,9 +55,9 @@ let type_in_type g = g.type_in_type
 let check_smaller_expr g (u,n) (v,m) =
   let diff = n - m in
     match diff with
-    | 0 -> G.check_leq g.graph u v
+    | 0 -> Level.is_set u || G.check_leq g.graph u v
     | 1 -> G.check_lt g.graph u v
-    | x when x < 0 -> G.check_leq g.graph u v
+    | x when x < 0 -> Level.is_set u || G.check_leq g.graph u v
     | _ -> false
 
 let exists_bigger g ul l =
@@ -118,7 +118,7 @@ let merge_constraints csts g = Constraints.fold enforce_constraint csts g
 let check_constraint { graph = g; type_in_type; _ } (u,d,v) =
   type_in_type
   || match d with
-  | Le -> G.check_leq g u v
+  | Le -> Level.is_set u || G.check_leq g u v
   | Lt -> G.check_lt g u v
   | Eq -> G.check_eq g u v
 


### PR DESCRIPTION
After the removal of floating universes for template inductive types, this is now a cheap and stupid fast path, as we know that all levels are above Set. I know that the algebraic universe branch is around the corner, but this tweak is both very local and basically for free. Furthermore, it seems to hit fairly often, e.g. about 20% of the checks are of this form in the universe-hungry Metarocq development.