### PR TITLE
Add an option to set the bound on the message view.

### DIFF
--- a/doc/changelog/10-rocqide/20597-rocqide-buffer-length-option-Fixed.rst
+++ b/doc/changelog/10-rocqide/20597-rocqide-buffer-length-option-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  added an option to control the maximum length of the message view
+  in RocqIDE
+  (`#20597 <https://github.com/rocq-prover/rocq/pull/20597>`_,
+  fixes `#20420 <https://github.com/rocq-prover/rocq/issues/20420>`_,
+  by Pierre-Marie Pédrot).

--- a/ide/rocqide/preferences.ml
+++ b/ide/rocqide/preferences.ml
@@ -418,6 +418,12 @@ let line_ending =
 let document_tabs_pos =
   new preference ~name:["document_tabs_pos"] ~init:"top" ~repr:Repr.(string)
 
+let message_tab_capped =
+  new preference ~name:["message_tab_capped"] ~init:true ~repr:Repr.(bool)
+
+let message_tab_length =
+  new preference ~name:["message_tab_length"] ~init:1000 ~repr:Repr.(int)
+
 (* let background_color = *)
 (*   new preference ~name:["background_color"] ~init:"cornsilk" ~repr:Repr.(string) *)
 

--- a/ide/rocqide/preferences.mli
+++ b/ide/rocqide/preferences.mli
@@ -96,6 +96,8 @@ val stop_before : bool preference
 val reset_on_tab_switch : bool preference
 val line_ending : line_ending preference
 val document_tabs_pos : string preference
+val message_tab_capped : bool preference
+val message_tab_length : int preference
 (* val background_color : string preference *)
 val processing_color : string preference
 val processed_color : string preference

--- a/ide/rocqide/preferences_ui.ml
+++ b/ide/rocqide/preferences_ui.ml
@@ -457,6 +457,12 @@ let configure ?(apply = fun () -> ()) parent =
         pcombo "Position:" labels initial setter;
       ]
   in
+  let config_message_tabs =
+    create_pref_box "Message tabs" [
+        pbool "Cap message length" message_tab_capped;
+        pint "Length limit" message_tab_length;
+      ]
+  in
 
   let config_font =
     let preview_text = "Goal (∃n : nat, n ≤ 0)∧(∀x,y,z, x∈y⋃z↔x∈y∨x∈z)." in
@@ -675,7 +681,7 @@ let configure ?(apply = fun () -> ()) parent =
           pref_section "Project" ~icon:`PAGE_SETUP [project_management];
         ];
       pref_section "Editor" ~icon:`EDIT [editor_appearance; editor_behavior];
-      pref_section "Appearance" ~icon:`ZOOM_FIT [config_window; config_document_tabs] ~children:[
+      pref_section "Appearance" ~icon:`ZOOM_FIT [config_window; config_document_tabs; config_message_tabs] ~children:[
           pref_section "Font" ~icon:`SELECT_FONT [config_font];
           pref_section "Colors" ~icon:`SELECT_COLOR [config_highlight; config_color];
           pref_section "Tags" ~icon:`SELECT_COLOR [config_tags];

--- a/ide/rocqide/wg_MessageView.ml
+++ b/ide/rocqide/wg_MessageView.ml
@@ -162,8 +162,8 @@ let message_view sid : message_view =
   let add_msg msg =
     let mlines = insert_msg msg in
     msgs := (msg, mlines) :: !msgs;
-    let max_lines = 1000 in
-    if buffer#line_count > max_lines then begin
+    let max_lines = message_tab_length#get in
+    if message_tab_capped#get && buffer#line_count > max_lines then begin
       let rec trim lcnt res msgs =
         match msgs with
         | (m,len) :: tl when lcnt < max_lines ->


### PR DESCRIPTION
For some reason this was hardwired to 1000 lines in f3f165b, but this is very annoying when trying to read long debug messages. Instead of removing the limit, we let the user set it to an arbitrary value.

Fixes #20420