### PR TITLE
Fix anomaly message in end_compilation_checks

### DIFF
--- a/library/lib.ml
+++ b/library/lib.ml
@@ -170,7 +170,7 @@ let end_compilation_checks dir =
           if not (Names.DirPath.equal m dir) then
             CErrors.anomaly Pp.(str "The current open module has name"
               ++ spc () ++ DirPath.print m ++ spc () ++ str "and not"
-              ++ spc () ++ DirPath.print m ++ str ".");
+              ++ spc () ++ DirPath.print dir ++ str ".");
   in
   ()
 


### PR DESCRIPTION
As an anomaly it shouldn't be possible to trigger it, but if it ever gets triggered it should be correct.
