### PR TITLE
Move flags from flags.ml to more precise locations

### DIFF
--- a/dev/ci/user-overlays/20606-SkySkimmer-clean-flags.sh
+++ b/dev/ci/user-overlays/20606-SkySkimmer-clean-flags.sh
@@ -1,0 +1,1 @@
+overlay vsrocq https://github.com/SkySkimmer/vscoq clean-flags 20606

--- a/doc/plugin_tutorial/tuto2/src/g_tuto2.mlg
+++ b/doc/plugin_tutorial/tuto2/src/g_tuto2.mlg
@@ -498,17 +498,17 @@ END
 
      - Feedback.msg_info    : Pp.t -> unit
      - Feedback.msg_notice  : Pp.t -> unit
-     - Feedback.msg_warning : Pp.t -> unit
      - Feedback.msg_debug   : Pp.t -> unit
 
   to give user a textual feedback. Examples of some of these can be
   found in tuto0.
 
-  --- Signaling Errors ---
+  --- Signaling Errors and Warnings ---
 
-  While there is a Feedback.msg_error, when signaling an error,
-  it is currently better practice to use user_err. There is an example of
-  this in tuto0.
+  While there is a Feedback.msg_error and Feedback.msg_warning, when
+  signaling an error or warning, it is currently better practice to
+  use CErrors or the CWarnings APIs. There are examples of this in
+  tuto0.
 *)
 
 (* -------------------------------------------------------------------------- *)

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -195,7 +195,7 @@ has type :n:`@type`.
      If specified, :token:`ident_decl` is automatically
      declared as a coercion to the class of its type.  See :ref:`coercions`.
 
-   The :n:`Inline` clause is only relevant inside functors.  See :cmd:`Module`.
+   The :n:`Inline` clause is only relevant inside module types used for functor arguments.  See :cmd:`Module`.
 
 .. example:: Simple assumptions
 

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -104,11 +104,21 @@ together, as well as a means of massive abstraction.
    :cmd:`Include` commands is equivalent to giving them all in a single
    non-interactive :cmd:`Module` command.
 
-   The ! prefix indicates that any assumption command (such as :cmd:`Axiom`) with an :n:`Inline` clause
-   in the type of the functor arguments will be ignored.
+.. opt:: Inline Level
 
-   .. todo: What is an Inline directive?  sb command but still unclear.  Maybe referring to the
-      "inline" in functor_app_annot?  or assumption_token Inline assum_list?
+   Controls inlining of parameters (declared by e.g. :cmd:`Axiom`) in
+   functor application. The default is 100.
+
+   A functor application with `[inline at level A]` will inline all
+   parameters declared with `Inline(B)` with `B <= A`.
+
+   :cmd:`Parameter` declaration with `Inline` uses the value of this option
+   unless an explicit level is provided (with `Inline(level)`).
+
+   Functor application implicitly uses `[inline at level n]` where `n`
+   is the value of this option, unless `[inline at level]` or `[no
+   inline]` (or the prefix `!` which is equivalent to the suffix `[no
+   inline]`) is explicitly provided.
 
 .. cmd:: Module Type @ident {* @module_binder } {* <: @module_type_inl } {? := {+<+ @module_type_inl } }
 

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -110,7 +110,6 @@ struct
   (** Use the current logger. The buffer is also flushed. *)
   let print_debug   s = make (fun _ -> Feedback.msg_debug s)
   let print_info    s = make (fun _ -> Feedback.msg_info s)
-  let print_warning s = make (fun _ -> Feedback.msg_warning s)
   let print_notice  s = make (fun _ -> Feedback.msg_notice s)
 
   let run = fun x ->

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -64,7 +64,6 @@ module NonLogical : sig
 
   (** Loggers. The buffer is also flushed. *)
   val print_debug : Pp.t -> unit t
-  val print_warning : Pp.t -> unit t
   val print_notice : Pp.t -> unit t
   val print_info : Pp.t -> unit t
 

--- a/ide/rocqide/rocqide.ml
+++ b/ide/rocqide/rocqide.ml
@@ -1837,7 +1837,7 @@ let read_rocqide_args argv =
       filter_rocqtop rocqtop project_files bindings_files out args
     |"-xml-debug"::args ->
       set_debug ();
-      Flags.xml_debug := true;
+      (* xml_debug ref only exists in coqidetop *)
       filter_rocqtop rocqtop project_files bindings_files ("-xml-debug"::out) args
     |"-coqtop-flags" :: flags :: args->
       RocqDriver.ideslave_rocqtop_flags := Some flags;

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -264,12 +264,10 @@ let parse_warnings items =
 (* For compatibility, we accept "none" *)
 let parse_flags s =
   if is_none_keyword s then begin
-      Flags.make_warn false;
       set_all_warnings_status Disabled;
       "none"
     end
   else begin
-      Flags.make_warn true;
       let flags = flags_of_string s in
       let flags = normalize_flags flags in
       parse_warnings flags;

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -65,10 +65,6 @@ let verbosely f x = without_option quiet f x
 let if_silent f x = if !quiet then f x
 let if_verbose f x = if not !quiet then f x
 
-let warn = ref true
-let make_warn flag = warn := flag;  ()
-let if_warn f x = if !warn then f x
-
 (* Level of inlining during a functor application *)
 
 let default_inline_level = 100

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -66,8 +66,4 @@ let inline_level = ref default_inline_level
 let set_inline_level = (:=) inline_level
 let get_inline_level () = !inline_level
 
-(* Default output directory *)
-
-let output_directory = ref None
-
 let test_mode = ref false

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -55,7 +55,6 @@ let in_synterp_phase = ref None
 (* Translate *)
 let beautify = ref false
 let beautify_file = ref false
-let record_comments = ref false
 
 (* Silent / Verbose *)
 let quiet = ref false

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -43,8 +43,6 @@ let async_proofs_is_worker () = !async_proofs_worker_id <> "master"
 
 let load_vos_libraries = ref false
 
-let xml_debug = ref false
-
 let in_debugger = ref false
 let in_ml_toplevel = ref false
 

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -59,11 +59,4 @@ let verbosely f x = without_option quiet f x
 let if_silent f x = if !quiet then f x
 let if_verbose f x = if not !quiet then f x
 
-(* Level of inlining during a functor application *)
-
-let default_inline_level = 100
-let inline_level = ref default_inline_level
-let set_inline_level = (:=) inline_level
-let get_inline_level () = !inline_level
-
 let test_mode = ref false

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -22,7 +22,6 @@ let with_modified_ref ?(restore=true) r nf f x =
 
 let with_option o f x = with_modified_ref ~restore:false o (fun _ -> true) f x
 let without_option o f x = with_modified_ref ~restore:false o (fun _ -> false) f x
-let with_extra_values o l f x = with_modified_ref o (fun ol -> ol@l) f x
 
 (* hide the [restore] option as internal *)
 let with_modified_ref r nf f x = with_modified_ref r nf f x

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -41,8 +41,6 @@ let with_options ol f x =
 let async_proofs_worker_id = ref "master"
 let async_proofs_is_worker () = !async_proofs_worker_id <> "master"
 
-let load_vos_libraries = ref false
-
 let in_debugger = ref false
 let in_ml_toplevel = ref false
 

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -53,7 +53,6 @@ val raw_print : bool ref
 (* Beautify command line flags, should move to printing? *)
 val beautify : bool ref
 val beautify_file : bool ref
-val record_comments : bool ref
 
 (* Rocq quiet mode. Note that normal mode is called "verbose" here,
    whereas [quiet] suppresses normal output such as goals in rocq repl *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -63,10 +63,6 @@ val verbosely : ('a -> 'b) -> 'a -> 'b
 val if_silent : ('a -> unit) -> 'a -> unit
 val if_verbose : ('a -> unit) -> 'a -> unit
 
-val warn : bool ref
-val make_warn : bool -> unit
-val if_warn : ('a -> unit) -> 'a -> unit
-
 (** [with_modified_ref r nf f x] Temporarily modify a reference in the
     call to [f x] . Be very careful with these functions, it is very
     easy to fall in the typical problem with effects:

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -76,11 +76,6 @@ val with_options : bool ref list -> ('a -> 'b) -> 'a -> 'b
 (** Temporarily deactivate an option *)
 val without_option : bool ref -> ('a -> 'b) -> 'a -> 'b
 
-(** Level of inlining during a functor application *)
-val set_inline_level : int -> unit
-val get_inline_level : unit -> int
-val default_inline_level : int
-
 (** Flag set when the test-suite is called.
     - display verbose information for [Fail]
     - print quickfix info in error printers *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -40,7 +40,6 @@ val async_proofs_is_worker : unit -> bool
 val load_vos_libraries : bool ref
 
 (** Debug flags *)
-val xml_debug : bool ref
 val in_debugger : bool ref
 val in_ml_toplevel : bool ref
 

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -35,10 +35,6 @@
 val async_proofs_worker_id : string ref
 val async_proofs_is_worker : unit -> bool
 
-(** Flag to indicate that .vos files should be loaded for dependencies
-    instead of .vo files. Used by -vos and -vok options. *)
-val load_vos_libraries : bool ref
-
 (** Debug flags *)
 val in_debugger : bool ref
 val in_ml_toplevel : bool ref

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -84,7 +84,7 @@ val default_inline_level : int
 (** Default output directory *)
 val output_directory : CUnix.physical_path option ref
 
-
-(** Flag set when the test-suite is called. Its only effect to display
-    verbose information for [Fail] *)
+(** Flag set when the test-suite is called.
+    - display verbose information for [Fail]
+    - print quickfix info in error printers *)
 val test_mode : bool ref

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -76,9 +76,6 @@ val with_options : bool ref list -> ('a -> 'b) -> 'a -> 'b
 (** Temporarily deactivate an option *)
 val without_option : bool ref -> ('a -> 'b) -> 'a -> 'b
 
-(** Temporarily extends the reference to a list *)
-val with_extra_values : 'c list ref -> 'c list -> ('a -> 'b) -> 'a -> 'b
-
 (** Level of inlining during a functor application *)
 val set_inline_level : int -> unit
 val get_inline_level : unit -> int

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -81,9 +81,6 @@ val set_inline_level : int -> unit
 val get_inline_level : unit -> int
 val default_inline_level : int
 
-(** Default output directory *)
-val output_directory : CUnix.physical_path option ref
-
 (** Flag set when the test-suite is called.
     - display verbose information for [Fail]
     - print quickfix info in error printers *)

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -228,9 +228,11 @@ let warn_using_current_directory =
            strbrk "Output directory is unset, using \"" ++ str s ++ str "\"." ++ spc () ++
            strbrk "Use command line option \"-output-directory to set a default directory.")
 
+let output_directory = ref None
+
 let get_output_path filename =
   if not (Filename.is_relative filename) then filename
-  else match !Flags.output_directory with
+  else match !output_directory with
   | None ->
     let pwd = Sys.getcwd () in
     warn_using_current_directory pwd;

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -62,6 +62,10 @@ val where_in_path :
     default output directory if [fname] is not absolute *)
 val get_output_path : CUnix.physical_path -> CUnix.physical_path
 
+(** Default output directory. Make sure to emit a warning if using
+    this directly (cf extraction Table.output_directory) *)
+val output_directory : CUnix.physical_path option ref
+
 (** [find_file_in_path ?warn loadpath filename] returns the directory
     name and long name of the first physical occurrence [filename] in
     one of the directory of the [loadpath];

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -379,9 +379,11 @@ let push_string s = Buffer.add_string current_comment s
 
 let dbg = CDebug.create ~name:"comment-lexing" ()
 
+let record_comments = ref false
+
 let comment_stop ep =
   let current_s = Buffer.contents current_comment in
-  (if !Flags.record_comments && Buffer.length current_comment > 0 then
+  (if !record_comments && Buffer.length current_comment > 0 then
     let bp = match !comment_begin with
         Some bp -> bp
       | None ->

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -97,3 +97,5 @@ module LexerDiff :
   with type keyword_state = keyword_state
    and type te = Tok.t
    and type 'c pattern = 'c Tok.p
+
+val record_comments : bool ref

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -189,7 +189,7 @@ let vm_state =
   ((), { Mod_typing.vm_handler })
 
 let expand_mexpr env mp me =
-  let inl = Some (Flags.get_inline_level()) in
+  let inl = Declaremods.default_inline_level() in
   (* hack: in order not to overwrite the module binding mp, we first give it a
      name that should not be part of the env and then substitute it away *)
   let mp0 = ModPath.dummy in
@@ -200,7 +200,7 @@ let expand_mexpr env mp me =
   Modops.subst_modtype_signature_and_resolver mp0 mp sign reso
 
 let expand_modtype env mp me =
-  let inl = Some (Flags.get_inline_level()) in
+  let inl = Declaremods.default_inline_level () in
   let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let mtb, _cst, _ = Mod_typing.translate_modtype state vm_state env mp inl ([],me) in
   mtb

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -563,7 +563,7 @@ let { Goptions.get = output_directory } =
     ~key:output_directory_key ()
 
 let output_directory () =
-  match output_directory (), !Flags.output_directory with
+  match output_directory (), !System.output_directory with
   | Some dir, _ | None, Some dir ->
       (* Ensure that the directory exists *)
       System.mkdir dir;

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -179,6 +179,9 @@ let add_load_vernacular opts verb s =
 let add_set_option opts opt_name value =
   { opts with pre = { opts.pre with injections = OptionInjection (opt_name, value) :: opts.pre.injections }}
 
+let add_set_warnings opts flags =
+  add_set_option opts ["Warnings"] (OptionSet (Some flags))
+
 let add_set_debug opts flags =
   add_set_option opts ["Debug"] (OptionSet (Some flags))
 
@@ -344,10 +347,7 @@ let parse_args ~init arglist : t * string list =
     |"-topfile" ->
       { oval with config = { oval.config with logic = { oval.config.logic with toplevel_name = TopPhysical (next()) }}}
 
-    |"-w" | "-W" ->
-      let w = next () in
-      if w = "none" then add_set_option oval ["Warnings"] (OptionSet(Some w))
-      else add_set_option oval ["Warnings"] (OptionSet (Some w))
+    |"-w" | "-W" -> add_set_warnings oval (next())
 
     |"-bytecode-compiler" ->
       { oval with config = { oval.config with enable_VM = get_bool ~opt (next ()) }}
@@ -403,7 +403,8 @@ let parse_args ~init arglist : t * string list =
     |"-boot" -> { oval with pre = { oval.pre with boot = true }}
     |"-profile-ltac" -> add_set_option oval ["Ltac"; "Profiling"] (OptionSet None)
     |"-q" -> { oval with pre = { oval.pre with load_rcfile = false; }}
-    |"-quiet"|"-silent" -> { oval with config = { oval.config with quiet = true } }
+    |"-quiet"|"-silent" ->
+      add_set_warnings { oval with config = { oval.config with quiet = true } } "-all"
     |"-time" -> { oval with config = { oval.config with time = Some ToFeedback }}
     |"-time-file" -> { oval with config = { oval.config with time = Some (ToFile (next())) }}
     | "-profile" -> { oval with config = { oval.config with profile = Some (next()) } }

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -195,7 +195,7 @@ let init_document opts =
   (* beautify *)
   if opts.config.beautify then begin
     Flags.beautify := true;
-    Flags.record_comments := true;
+    CLexer.record_comments := true;
   end;
 
   if opts.config.quiet then begin

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -187,7 +187,7 @@ let init_document opts =
   Nativelib.output_dir := opts.config.native_output_dir;
 
   (* Default output dir *)
-  Flags.output_directory := opts.config.output_directory;
+  System.output_directory := opts.config.output_directory;
 
   (* Test mode *)
   Flags.test_mode := opts.config.test_mode;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -200,7 +200,6 @@ let init_document opts =
 
   if opts.config.quiet then begin
     Flags.quiet := true;
-    Flags.make_warn false;
   end;
 
   ()

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -114,10 +114,10 @@ let parse arglist : t =
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
         |"-vos" ->
-          Flags.load_vos_libraries := true;
+          Loadpath.load_vos_libraries := true;
           { oval with compilation_mode = BuildVos }
         |"-vok" ->
-          Flags.load_vos_libraries := true;
+          Loadpath.load_vos_libraries := true;
           { oval with compilation_mode = BuildVok }
 
         (* Glob options *)

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -123,7 +123,7 @@ let init_document opts stm_options injections =
      guaranteed in the past, but now is thanks to the STM API.
   *)
   (* Next line allows loading .vos files when in interactive mode *)
-  Flags.load_vos_libraries := true;
+  Loadpath.load_vos_libraries := true;
   let open Vernac.State in
   let doc, sid =
     Stm.(new_doc

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -64,7 +64,7 @@ let declare_global ~coe ~try_assum_as_instance ~local ~kind ?user_warns ~univs ~
   let (uentry, ubinders) = univs in
   let inl = let open Declaremods in match inline with
     | NoInline -> None
-    | DefaultInline -> Some (Flags.get_inline_level())
+    | DefaultInline -> Declaremods.default_inline_level()
     | InlineAt i -> Some i
   in
   let decl = match body with

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -28,6 +28,8 @@ type inline =
   | DefaultInline
   | InlineAt of int
 
+val default_inline_level : unit -> int option
+
 (** Kinds of modules *)
 
 type module_params = (lident list * (Constrexpr.module_ast * inline)) list

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -20,6 +20,8 @@ type t = {
   path_installed : bool; (* true for automatically added paths (assumed installed), false for command line paths *)
 }
 
+let load_vos_libraries = ref false
+
 let load_paths = Summary.ref ([] : t list) ~stage:Summary.Stage.Synterp ~name:"LOADPATHS"
 
 let logical p = p.path_logical
@@ -187,7 +189,7 @@ module Error = struct
               ])
 
   let lib_not_found dir =
-    let vos = !Flags.load_vos_libraries in
+    let vos = !load_vos_libraries in
     let vos_msg = if vos then [Pp.str " (while searching for a .vos file)"] else [] in
     CErrors.user_err
       Pp.(seq ([ str "Cannot find library "; Names.DirPath.print dir; str" in loadpath"]@vos_msg))
@@ -211,7 +213,7 @@ let select_vo_file ~find base =
       let lpath, file = find name in
       Some (lpath, file)
     with Not_found -> None in
-  if !Flags.load_vos_libraries
+  if !load_vos_libraries
   then begin
     match find ".vos" with
     | Some (_, vos) as resvos when (Unix.stat vos).Unix.st_size > 0 -> resvos

--- a/vernac/loadpath.mli
+++ b/vernac/loadpath.mli
@@ -95,3 +95,7 @@ type vo_path =
   }
 
 val add_vo_path : vo_path -> unit
+
+(** Flag to indicate that .vos files should be loaded for dependencies
+    instead of .vo files. Used by -vos and -vok options. *)
+val load_vos_libraries : bool ref

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -248,7 +248,7 @@ let err_notfound_library ?from qid =
   | Some from -> str " with prefix " ++ DirPath.print from
   in
   let bonus =
-    if !Flags.load_vos_libraries then mt ()
+    if !Loadpath.load_vos_libraries then mt ()
     else str " (while searching for a .vos file)"
   in
   strbrk "Unable to locate library " ++ pr_qualid qid ++ prefix ++ bonus

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -155,8 +155,7 @@ let gen_logger dbg warn ?qf ?pre_hdr level msg = let open Feedback in match leve
   | Debug   -> msgnl_with !std_ft (make_body dbg  dbg_hdr ?pre_hdr ?qf msg)
   | Info    -> msgnl_with !std_ft (make_body dbg info_hdr ?pre_hdr ?qf msg)
   | Notice  -> msgnl_with !std_ft (make_body noq info_hdr ?pre_hdr ?qf msg)
-  | Warning -> Flags.if_warn (fun () ->
-               msgnl_with !err_ft (make_body warn warn_hdr ?pre_hdr ?qf msg)) ()
+  | Warning -> msgnl_with !err_ft (make_body warn warn_hdr ?pre_hdr ?qf msg)
   | Error   -> msgnl_with !err_ft (make_body noq   err_hdr ?pre_hdr ?qf msg)
 
 (** Standard loggers *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2005,16 +2005,6 @@ let () =
       optwrite = (fun b -> Flags.raw_print := b) }
 
 let () =
-  declare_int_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
-      optkey   = ["Inline";"Level"];
-      optread  = (fun () -> Some (Flags.get_inline_level ()));
-      optwrite = (fun o ->
-                   let lev = Option.default Flags.default_inline_level o in
-                   Flags.set_inline_level lev) }
-
-let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;


### PR DESCRIPTION
The more precise location for Flags.warn is the past, ie it is deleted.

Overlays:
- https://github.com/rocq-prover/vscoq/pull/1086