### PR TITLE
Move print_parentheses ref to constrextern

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -54,7 +54,7 @@ let print_coercions = ref false
 
 (* This forces printing of parentheses even when
    it is implied by associativity/precedence *)
-let print_parentheses = Notation_ops.print_parentheses
+let print_parentheses = ref false
 
 (* This forces printing universe names of Type{.} *)
 let print_universes = Detyping.print_universes
@@ -83,7 +83,7 @@ let is_reserved_type na t =
   | Name id ->
     try
       let pat = Reserve.find_reserved_type id in
-      let _ = match_notation_constr ~print_univ:false t ~vars:Id.Set.empty ([],pat) in
+      let _ = match_notation_constr ~print_parentheses:true ~print_univ:false t ~vars:Id.Set.empty ([],pat) in
       true
     with Not_found | No_match -> false
 
@@ -1339,7 +1339,9 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
         (* Try matching ... *)
         let vars, uvars = vars in
         let terms,termlists,binders,binderlists =
-          match_notation_constr ~print_univ:(!print_universes) t ~vars pat in
+          match_notation_constr ~print_parentheses:!print_parentheses ~print_univ:(!print_universes)
+            t ~vars pat
+        in
         let lev_after = if List.is_empty args then lev_after else Some Notation.app_level in
         (* Try externing extra args... *)
         let extra_args =

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -83,9 +83,7 @@ val pr_notation_info :
 
 exception No_match
 
-val print_parentheses : bool ref
-
-val match_notation_constr : print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
+val match_notation_constr : print_parentheses:bool -> print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
       ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
       ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
       ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -123,7 +123,9 @@ let revert_reserved_type t =
         then I've introduced a bug... *)
     let filter _ pat =
       try
-        let _ = match_notation_constr ~print_univ:false t ~vars:Id.Set.empty ([], pat) in
+        let _ = match_notation_constr ~print_parentheses:true ~print_univ:false
+            t ~vars:Id.Set.empty ([], pat)
+        in
         true
       with No_match -> false
     in


### PR DESCRIPTION
This requires using constant print_parentheses:true in some namegen hook related to Implicit Type. We already use constant print_univs:true there so this seems reasonable, and this hook is used in internalization which we anyway don't want to depend on the current printing options.
