### PR TITLE
Document undocumented options

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -268,6 +268,15 @@ This behavior can be relaxed via the following flag:
    Note that this extracted code might not compile or run properly,
    depending of the use of these remaining implicit arguments.
 
+Accessing opaque proofs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. flag:: Extraction AccessOpaque
+
+   By default extraction will treat opaque proofs (concluded with
+   :cmd:`Qed`) as though they were transparent. Turning this :term:`flag` off
+   will instead treat them as axioms.
+
 Realizing axioms
 ~~~~~~~~~~~~~~~~
 

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -63,6 +63,8 @@ or only for reals by ``Require Import Lra``.
 
    This :term:`flag` (set by default) instructs :tacn:`nra` to cache its results in the file `.nra.cache`
 
+.. flag:: Lia Depth
+   :undocumented:
 
 The tactics solve propositional formulas parameterized by atomic
 arithmetic expressions interpreted over a domain :math:`D \in \{\mathbb{Z},\mathbb{Q},\mathbb{R}\}`.

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -892,6 +892,14 @@ However elimination to `Type` or to a polymorphic sort with `s := Prop` is allow
         : Type@{s|max(u,v)}
         := pair { pr1 : A; pr2 : B pr1 }.
 
+.. flag:: Printing Sort Qualities
+
+   By default when :flag:`Printing Universes` is on, sorts at floating
+   sort qualities will print their quality. Turning this :term:`flag` off will
+   instead print them as though the quality was `Type` (which it will
+   become at the end of the definition unless it is unified with
+   another rigid quality).
+
 Explicit Sorts
 ---------------
 

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -6070,7 +6070,7 @@ Commands and options
   fixes `#13562 <https://github.com/coq/coq/issues/13562>`_,
   by Pierre-Marie Pédrot).
 - **Deprecated:**
-  the :flag:`Regular Subst Tactic` flag
+  the `Regular Subst Tactic` flag
   (`#14336 <https://github.com/coq/coq/pull/14336>`_,
   by Pierre-Marie Pédrot).
 - **Added:**

--- a/doc/sphinx/language/core/primitive.rst
+++ b/doc/sphinx/language/core/primitive.rst
@@ -113,6 +113,12 @@ values (of type :g:`float`) written in hexadecimal notation and
 wrapped into the :g:`Float64.of_float` constructor, e.g.:
 :g:`Float64.of_float (0x1p+0)`.
 
+.. flag:: Printing Float
+
+   When off, primitive floats use a low level hexadecimal representation.
+
+   On by default.
+
 .. _primitive-arrays:
 
 Primitive Arrays

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -252,7 +252,7 @@ Printing of hidden subterms
    In order to be able to cheaply reconstruct the types of the
    variables bound by `in` and `as`, `match` terms contain the
    polymorphic universe instance and the parameters of the inductive
-   which is being matched. When this flag is on (it is off by
+   which is being matched. When this :term:`flag` is on (it is off by
    default), this information is displayed as a :term:`volatile cast` around
    the match discriminee.
 

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -2474,6 +2474,13 @@ performance issue.
 
    This :term:`flag` enables and disables the profiler.
 
+.. opt:: Ltac Profiling Cutoff @string
+
+   Reading the string as a floating point number, ltac profiles are
+   printed without entries faster than the cutoff (in seconds).
+
+   `2.0` by default.
+
 .. cmd:: Show Ltac Profile {? {| CutOff @integer | @string } }
 
    Prints the profile.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -598,6 +598,15 @@ one or more of its hypotheses.
    :ref:`Managingthelocalcontext`, :ref:`caseanalysisandinduction`,
    :ref:`printing_constructions_full`.
 
+Automatic clearing of hypotheses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. flag:: Default Clearing Used Hypotheses
+
+   When this :term:`flag` is on (it is off by default), some tactics
+   will automatically clear their hypothesis arguments.
+
+   For instance when `H` is an hypothesis, `apply H` will clear `H`.
 
 .. _applyingtheorems:
 

--- a/doc/sphinx/proofs/automatic-tactics/logic.rst
+++ b/doc/sphinx/proofs/automatic-tactics/logic.rst
@@ -111,6 +111,19 @@ Solvers for logic and equality
 
    Note that this tactic is only available after a ``Require Import Rtauto``.
 
+   .. flag:: Rtauto Check
+
+      Turning this :term:`flag` on checks the produced proof term at tactic
+      time instead of just proof closing (:cmd:`Qed`) time. Mostly
+      useful for debugging failures at proof closing time. Off by default.
+
+   .. flag:: Rtauto Verbose
+
+      Make :tacn:`rtauto` print some debug info while running when on. Off by default.
+
+   .. flag:: Rtauto Pruning
+      :undocumented:
+
 .. tacn:: firstorder {? @ltac_expr } {? using {+, @qualid } } {? with {+ @ident } }
 
    An experimental extension of :tacn:`tauto` to

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -305,30 +305,6 @@ Rewriting with Leibniz and setoid equality
       If the hypothesis is itself dependent in the goal, it is replaced by the proof of
       reflexivity of equality.
 
-   .. flag:: Regular Subst Tactic
-
-      This :term:`flag` controls the behavior of :tacn:`subst`. When it is
-      activated (it is by default), :tacn:`subst` also deals with the following corner cases:
-
-      + A context with ordered hypotheses :n:`@ident__1 = @ident__2`
-        and :n:`@ident__1 = t`, or :n:`t′ = @ident__1` with `t′` not
-        a variable, and no other hypotheses of the form :n:`@ident__2 = u`
-        or :n:`u = @ident__2`; without the flag, a second call to
-        subst would be necessary to replace :n:`@ident__2` by `t` or
-        `t′` respectively.
-      + The presence of a recursive equation which without the flag would
-        be a cause of failure of :tacn:`subst`.
-      + A context with cyclic dependencies as with hypotheses :n:`@ident__1 = f @ident__2`
-        and :n:`@ident__2 = g @ident__1` which without the
-        flag would be a cause of failure of :tacn:`subst`.
-
-      Additionally, it prevents a :term:`local definition <context-local definition>`
-      such as :n:`@ident := t` from being
-      unfolded which otherwise would exceptionally unfold in configurations
-      containing hypotheses of the form :n:`@ident = u`, or :n:`u′ = @ident`
-      with `u′` not a variable. Finally, it preserves the initial order of
-      hypotheses, which without the flag it may break.
-
    .. exn:: Cannot find any non-recursive equality over @ident.
       :undocumented:
 
@@ -634,6 +610,11 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
      constant :n:`@qualid` or is the constant used
      in the notation :n:`@string` (see :n:`@reference`)
    - subterms matching a pattern :n:`@one_term`
+
+   .. flag:: SimplIsCbn
+
+      When this :term:`flag` is on, :tacn:`simpl` and `simpl` in
+      :n:`@red_expr` behave as :tacn:`cbn`. Off by default.
 
 .. tacn:: cbn {? @reductions } @simple_occurrences
 

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -432,6 +432,17 @@ The following options modify the behavior of ``Proof using``.
    When this :term:`flag` is on, :cmd:`Qed` suggests
    a ``using`` annotation if the user did not provide one.
 
+.. flag:: Keep Admitted Variables
+
+   When on, proofs terminated with :cmd:`Admitted` use the section
+   variables from `Proof using` if one was provided (including through
+   `Default Proof Using`), otherwise the variables used in the partial
+   proof (including any variables visible from the still open goals).
+
+   When off, only the section variables used in the type are used.
+
+   On by default.
+
 ..  _`nameaset`:
 
 Name a set of section hypotheses for ``Proof using``

--- a/doc/sphinx/using/libraries/funind.rst
+++ b/doc/sphinx/using/libraries/funind.rst
@@ -412,3 +412,18 @@ Generation of induction principles with ``Functional`` ``Scheme``
          Generate graph for @qualid
 
    Internal debugging commands.
+
+Flags
+-----
+
+.. flag:: Functional Induction Rewrite Dependent
+
+   Makes FunInd use dependent :tacn:`subst`  instead of :tacn:`simple subst`.
+   On by default.
+
+.. flag:: Function_raw_tcc
+
+   When Function is using a well-founded relation, this flag (when
+   set) prevents the post-processing of the tcc (type checking
+   conditions) generated for termination. (The post-processing is
+   basically conjunction splitting + auto.) Off by default.

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -87,7 +87,7 @@ let is_incompatible_eq env sigma t =
       | _ -> false
     with e when CErrors.noncritical e -> false
   in
-  if res then observe (str "is_incompatible_eq " ++ pr_leconstr_env env sigma t);
+  if res then observe (fun () -> str "is_incompatible_eq " ++ pr_leconstr_env env sigma t);
   res
 
 let pf_get_new_id id env =
@@ -138,7 +138,7 @@ let isAppConstruct env sigma t =
   try
     let t', l = find_rectype env sigma t in
     observe
-      ( str "isAppConstruct : "
+      (fun () -> str "isAppConstruct : "
       ++ Printer.pr_leconstr_env env sigma t
       ++ str " -> "
       ++ Printer.pr_leconstr_env env sigma (applist (t', l)) );
@@ -150,7 +150,7 @@ exception NoChange
 let change_eq env sigma hyp_id (context : rel_context) x t end_of_type =
   let nochange ?t' msg =
     observe
-      ( str ("Not treating ( " ^ msg ^ " )")
+      (fun () -> str ("Not treating ( " ^ msg ^ " )")
       ++ pr_leconstr_env env sigma t
       ++ str "    "
       ++
@@ -521,7 +521,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
                            | App (f, [|_; _; args2|]) -> args2
                            | _ ->
                              observe
-                               ( str "cannot compute new term value : "
+                               (fun () -> str "cannot compute new term value : "
                                ++ Tacmach.pr_gls g' ++ fnl ()
                                ++ str "last hyp is"
                                ++ pr_leconstr_env env sigma new_term_value_eq );
@@ -1033,17 +1033,17 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
               f_body )
       in
       observe
-        ( str "full_params := "
+        (fun () -> str "full_params := "
         ++ prlist_with_sep spc
              (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
              full_params );
       observe
-        ( str "princ_params := "
+        (fun () -> str "princ_params := "
         ++ prlist_with_sep spc
              (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
              princ_params );
       observe
-        ( str "fbody_with_full_params := "
+        (fun () -> str "fbody_with_full_params := "
         ++ pr_leconstr_env (Global.env ()) !evd fbody_with_full_params );
       let all_funs_with_full_params =
         Array.map

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1370,7 +1370,7 @@ let make_scheme evd (fas : (Constr.pconstant * UnivGen.QualityOrSet.t) list) : _
       List.map (* we can now compute the other principles *)
         (fun scheme_type ->
           incr i;
-          observe (Printer.pr_lconstr_env env sigma scheme_type);
+          observe (fun () -> Printer.pr_lconstr_env env sigma scheme_type);
           let type_concl = Term.strip_prod_decls scheme_type in
           let applied_f =
             List.hd (List.rev (snd (Constr.decompose_app_list type_concl)))
@@ -1387,7 +1387,7 @@ let make_scheme evd (fas : (Constr.pconstant * UnivGen.QualityOrSet.t) list) : _
                 let g = fst (Constr.decompose_app applied_g) in
                 if Constr.equal f g then raise (Found_type j);
                 observe
-                  Pp.(
+                  Pp.(fun () ->
                     Printer.pr_lconstr_env env sigma f
                     ++ str " <> "
                     ++ Printer.pr_lconstr_env env sigma g))
@@ -1450,7 +1450,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
               Reductionops.nf_zeta env !evd type_of_lemma
             in
             observe
-              Pp.(
+              Pp.(fun () ->
                 str "type_of_lemma := "
                 ++ Printer.pr_leconstr_env env !evd type_of_lemma);
             (type_of_lemma, type_info))
@@ -1517,7 +1517,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
             in
             let type_of_lemma = Reductionops.nf_zeta env !evd type_of_lemma in
             observe
-              Pp.(
+              Pp.(fun () ->
                 str "type_of_lemma := "
                 ++ Printer.pr_leconstr_env env !evd type_of_lemma);
             (type_of_lemma, type_info))

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -307,13 +307,10 @@ let { Goptions.get = do_rewrite_dependent } =
     ~value:true
     ()
 
-let { Goptions.get = do_observe } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Function_debug"]
-    ~value:false
-    ()
+let observe_flag, observe = CDebug.create_full ~name:"funind" ()
 
-let observe strm = if do_observe () then Feedback.msg_debug strm else ()
+let do_observe () = CDebug.get_flag observe_flag
+
 let debug_queue = Stack.create ()
 
 let print_debug_queue b e =

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -75,7 +75,7 @@ val observe_tac :
   -> unit Proofview.tactic
 
 (* val function_debug : bool ref  *)
-val observe : Pp.t -> unit
+val observe : CDebug.t
 val do_observe : unit -> bool
 val do_rewrite_dependent : unit -> bool
 


### PR DESCRIPTION
For the ones where I don't know what they do I put a stub:

- Lia Depth 
- Rtauto Pruning
- Function_raw_tcc

and Function_debug was turned into a CDebug flag.

Also Regular Subst Tactic does not exist anymore, not sure if its doc still applies to `simple subst` or it it's something else.
