### PR TITLE
Doc: add note about Printing Parentheses not adding parens to applications

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -641,7 +641,8 @@ Displaying information about notations
 .. flag:: Printing Parentheses
 
    When this :term:`flag` is on, parentheses are printed even if
-   implied by associativity and precedence. Default is off.
+   implied by associativity and precedence (applications are still printed without parentheses, i.e. `(f x) y`
+   is printed as `f x y` regardless of this flag). Default is off.
 
 .. seealso::
 


### PR DESCRIPTION


We could instead change it to add parentheses to applications but that would probably make seriously unreadable terms.
