### PR TITLE
Ensure that Proofview.focus_context returns undefined evars

### DIFF
--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -97,7 +97,7 @@ type focus_context
    new nearly identical function every time. Hence the generic name. *)
 (* In this version: the goals in the context, as a "zipper" (the first
    list is in reversed order). *)
-val focus_context : focus_context -> Evar.t list * Evar.t list
+val focus_context : Evd.evar_map -> focus_context -> Evar.t list * Evar.t list
 
 (** [focus i j] focuses a proofview on the goals from index [i] to
     index [j] (inclusive, goals are indexed from [1]). I.e. goals

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -130,7 +130,7 @@ let proof p =
     | [_] -> []
     | a::l -> f a :: (map_minus_one f l)
   in
-  let map (FocusElt (_, _, c)) = Proofview.focus_context c in
+  let map (FocusElt (_, _, c)) = Proofview.focus_context sigma c in
   let stack = map_minus_one map p.focus_stack in
   (goals,stack,sigma)
 
@@ -377,7 +377,7 @@ let data { proofview; focus_stack; entry; name; poly } =
     | [_] -> []
     | a::l -> f a :: (map_minus_one f l)
   in
-  let map (FocusElt (_, _, c)) = Proofview.focus_context c in
+  let map (FocusElt (_, _, c)) = Proofview.focus_context sigma c in
   let stack = map_minus_one map focus_stack in
   { sigma; goals; entry; stack; name; poly }
 

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -34,7 +34,7 @@
 (* Type of a proof. *)
 type t
 
-type data =
+type data = private
   { sigma : Evd.evar_map
   (** A representation of the evar_map [EJGA wouldn't it better to just return the proofview?] *)
   ; goals : Evar.t list


### PR DESCRIPTION
This is implicitly expected by the two callers of this function. The PR also contains two tiny related cleanups that would be too bothersome to submit as a distinct PR.

Fixes #20500.
