### PR TITLE
`decompose` uses non dependent pattern matching for records

### DIFF
--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -100,7 +100,7 @@ let rec general_decompose_aux recognizer id =
   let rec_flag, mkelim =
     match (Environ.lookup_mind (fst ind) env).mind_record with
     | NotRecord -> true, Elim
-    | FakeRecord | PrimRecord _ -> false, Case true
+    | FakeRecord | PrimRecord _ -> false, Case false
   in
   let branchsigns = Tacticals.compute_constructor_signatures env ~rec_flag (ind, u) in
   let next_tac bas =


### PR DESCRIPTION
AFAICT this does not change visible behaviour, except by allowing

~~~coq
Set Primitive Projections.
Inductive Foo := { p : option Foo }.

Goal forall x : Foo, x = x.
  intros x.
  decompose [Foo] x.
~~~

instead of producing error dependent case analysis not allowed.

With `p : Foo` instead of `option Foo` we get an infinite loop, but that's what the user asked for so IMO it's ok.
