### PR TITLE
Only save global sorts in their origin .vo

### DIFF
--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -492,6 +492,7 @@ let push_qualities ctx env =
   { env with env_qualities = Sorts.QVar.Set.union env.env_qualities ctx }
 
 let push_quality_set qs env =
+  assert Sorts.QVar.Set.(is_empty @@ inter qs env.env_qualities);
   { env with
     env_qualities = Sorts.QVar.Set.union qs env.env_qualities }
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1514,7 +1514,7 @@ let export ~output_native_objects senv dir =
     comp_name = dir;
     comp_mod = mb;
     comp_univs = senv.univ;
-    comp_qualities = Environ.qualities senv.env;
+    comp_qualities = senv.qualities;
     comp_deps = Array.of_list comp_deps;
     comp_flags = permanent_flags
   } in


### PR DESCRIPTION
instead of copying them in every dependant's .vo

(Environ.qualities is all known qualities, senv.qualities is new qualities for this file)
