### PR TITLE
Centralize the global state of extraction

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -191,12 +191,21 @@ type t = {
   (* fields below are read-only *)
   modular : bool;
   library : bool;
+  extrcompute : bool;
+  (*s Extraction modes: modular or monolithic, library or minimal ?
+
+  Nota:
+  - Recursive Extraction : monolithic, minimal
+  - Separate Extraction : modular, minimal
+  - Extraction Library : modular, library
+  *)
 }
 
-let make ~modular ~library () = {
+let make ~modular ~library ~extrcompute () = {
   table = Table.make_table ();
   modular;
   library;
+  extrcompute;
 }
 
 let get_table s = s.table
@@ -204,6 +213,8 @@ let get_table s = s.table
 let get_modular s = s.modular
 
 let get_library s = s.library
+
+let get_extrcompute s = s.extrcompute
 
 end
 

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -399,12 +399,6 @@ let get_mpfiles_content mp =
   try get_mpfiles_content mp
   with Not_found -> failwith "get_mpfiles_content"
 
-type reset_kind = AllButExternal | Everything
-
-let reset_renaming_tables table flag =
-  let () = State.reset table in
-  if flag == Everything then clear_mpfiles_content ()
-
 (*S Renaming functions *)
 
 (* This function creates from [id] a correct uppercase/lowercase identifier.

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -276,9 +276,9 @@ let params_ren_add, params_ren_mem =
 
 type visible_layer = { mp : ModPath.t;
                        params : ModPath.t list;
-                       mutable content : Label.t KMap.t; }
+                       content : Label.t KMap.t; }
 
-let pop_visible, push_visible, get_visible =
+let pop_visible, push_visible, add_visible, get_visible =
   let vis = ref [] in
   register_cleanup (fun () -> vis := []);
   let pop () =
@@ -292,14 +292,14 @@ let pop_visible, push_visible, get_visible =
   and push mp mps =
     vis := { mp = mp; params = mps; content = KMap.empty } :: !vis
   and get () = !vis
-  in (pop,push,get)
+  and add ks l = match !vis with
+  | [] -> assert false
+  | v :: r -> vis := { v with content = KMap.add ks l v.content } :: r
+  in (pop,push,add,get)
 
 let get_visible_mps () = List.map (function v -> v.mp) (get_visible ())
 let top_visible () = match get_visible () with [] -> assert false | v::_ -> v
 let top_visible_mp () = (top_visible ()).mp
-let add_visible ks l =
-  let visible = top_visible () in
-  visible.content <- KMap.add ks l visible.content
 
 (* table of local module wrappers used to provide non-ambiguous names *)
 

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -190,16 +190,20 @@ type t = {
   table : Table.t;
   (* fields below are read-only *)
   modular : bool;
+  library : bool;
 }
 
-let make ~modular () = {
+let make ~modular ~library () = {
   table = Table.make_table ();
   modular;
+  library;
 }
 
 let get_table s = s.table
 
 let get_modular s = s.modular
+
+let get_library s = s.library
 
 end
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -52,6 +52,7 @@ sig
   val get_extrcompute : t -> bool
   val get_keywords : t -> Id.Set.t
   val get_phase : t -> phase
+  val get_duplicate : t -> ModPath.t -> Label.t -> string option
 
   (** Setters *)
   val set_phase : t -> phase -> t
@@ -80,8 +81,6 @@ val top_visible_mp : unit -> ModPath.t
    module parameters, the innermost one coming first in the list *)
 val push_visible : ModPath.t -> ModPath.t list -> unit
 val pop_visible : modular:bool -> phase:phase -> unit -> unit
-
-val get_duplicate : ModPath.t -> Label.t -> string option
 
 type reset_kind = AllButExternal | Everything
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -47,18 +47,23 @@ val get_db_name : int -> env -> Id.t
 
 type phase = Pre | Impl | Intf
 
-val set_phase : phase -> unit
-val get_phase : unit -> phase
-
 module State :
 sig
   type t
   val make : modular:bool -> library:bool -> extrcompute:bool -> keywords:Id.Set.t -> unit -> t
+
+  (** Getters *)
+
   val get_table : t -> Table.t
   val get_modular : t -> bool
   val get_library : t -> bool
   val get_extrcompute : t -> bool
   val get_keywords : t -> Id.Set.t
+  val get_phase : t -> phase
+
+  (** Setters *)
+  val set_phase : t -> phase -> t
+
 end
 
 val opened_libraries : State.t -> ModPath.t list
@@ -74,7 +79,7 @@ val top_visible_mp : unit -> ModPath.t
 (* In [push_visible], the [module_path list] corresponds to
    module parameters, the innermost one coming first in the list *)
 val push_visible : ModPath.t -> ModPath.t list -> unit
-val pop_visible : modular:bool -> unit -> unit
+val pop_visible : modular:bool -> phase:phase -> unit -> unit
 
 val get_duplicate : ModPath.t -> Label.t -> string option
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -53,10 +53,11 @@ val get_phase : unit -> phase
 module State :
 sig
   type t
-  val make : modular:bool -> library:bool -> unit -> t
+  val make : modular:bool -> library:bool -> extrcompute:bool -> unit -> t
   val get_table : t -> Table.t
   val get_modular : t -> bool
   val get_library : t -> bool
+  val get_extrcompute : t -> bool
 end
 
 val opened_libraries : State.t -> ModPath.t list

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -88,7 +88,7 @@ val pp_global : State.t -> kind -> GlobRef.t -> string
 val pp_global_name : State.t -> kind -> GlobRef.t -> string
 val pp_module : State.t -> ModPath.t -> string
 
-val clear_mpfiles_content : unit -> unit
+(* val clear_mpfiles_content : unit -> unit *)
 
 (** Special hack for constants of type Ascii.ascii : if an
     [Extract Inductive ascii => char] has been declared, then

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -53,8 +53,9 @@ val get_phase : unit -> phase
 module State :
 sig
   type t
-  val make : unit -> t
+  val make : modular:bool -> unit -> t
   val get_table : t -> Table.t
+  val get_modular : t -> bool
 end
 
 val opened_libraries : State.t -> ModPath.t list
@@ -70,7 +71,7 @@ val top_visible_mp : unit -> ModPath.t
 (* In [push_visible], the [module_path list] corresponds to
    module parameters, the innermost one coming first in the list *)
 val push_visible : ModPath.t -> ModPath.t list -> unit
-val pop_visible : unit -> unit
+val pop_visible : modular:bool -> unit -> unit
 
 val get_duplicate : ModPath.t -> Label.t -> string option
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -65,6 +65,10 @@ sig
 
   val get_top_visible_mp : t -> ModPath.t
 
+  (** Cleanup *)
+
+  val reset : t -> unit
+
 end
 
 type env = Id.t list * Id.Set.t
@@ -84,9 +88,7 @@ val pp_global : State.t -> kind -> GlobRef.t -> string
 val pp_global_name : State.t -> kind -> GlobRef.t -> string
 val pp_module : State.t -> ModPath.t -> string
 
-type reset_kind = AllButExternal | Everything
-
-val reset_renaming_tables : State.t -> reset_kind -> unit
+val clear_mpfiles_content : unit -> unit
 
 (** Special hack for constants of type Ascii.ascii : if an
     [Extract Inductive ascii => char] has been declared, then

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -50,14 +50,21 @@ type phase = Pre | Impl | Intf
 val set_phase : phase -> unit
 val get_phase : unit -> phase
 
-val opened_libraries : Table.t -> ModPath.t list
+module State :
+sig
+  type t
+  val make : unit -> t
+  val get_table : t -> Table.t
+end
+
+val opened_libraries : State.t -> ModPath.t list
 
 type kind = Term | Type | Cons | Mod
 
-val pp_global_with_key : Table.t -> kind -> KerName.t -> GlobRef.t -> string
-val pp_global : Table.t -> kind -> GlobRef.t -> string
-val pp_global_name : Table.t -> kind -> GlobRef.t -> string
-val pp_module : Table.t -> ModPath.t -> string
+val pp_global_with_key : State.t -> kind -> KerName.t -> GlobRef.t -> string
+val pp_global : State.t -> kind -> GlobRef.t -> string
+val pp_global_name : State.t -> kind -> GlobRef.t -> string
+val pp_module : State.t -> ModPath.t -> string
 
 val top_visible_mp : unit -> ModPath.t
 (* In [push_visible], the [module_path list] corresponds to

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -57,6 +57,14 @@ sig
   (** Setters *)
   val set_phase : t -> phase -> t
 
+  (** Reader-like *)
+
+  val with_visibility : t -> ModPath.t -> ModPath.t list -> (t -> 'a) -> 'a
+  (* the [module_path list] corresponds to module parameters, the innermost one
+    coming first in the list *)
+
+  val get_top_visible_mp : t -> ModPath.t
+
 end
 
 type env = Id.t list * Id.Set.t
@@ -75,12 +83,6 @@ val pp_global_with_key : State.t -> kind -> KerName.t -> GlobRef.t -> string
 val pp_global : State.t -> kind -> GlobRef.t -> string
 val pp_global_name : State.t -> kind -> GlobRef.t -> string
 val pp_module : State.t -> ModPath.t -> string
-
-val top_visible_mp : unit -> ModPath.t
-(* In [push_visible], the [module_path list] corresponds to
-   module parameters, the innermost one coming first in the list *)
-val push_visible : ModPath.t -> ModPath.t list -> unit
-val pop_visible : modular:bool -> phase:phase -> unit -> unit
 
 type reset_kind = AllButExternal | Everything
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -37,14 +37,6 @@ val pr_binding : Id.t list -> Pp.t
 
 val rename_id : Id.t -> Id.Set.t -> Id.t
 
-type env = Id.t list * Id.Set.t
-val empty_env : unit -> env
-
-val rename_vars: Id.Set.t -> Id.t list -> env
-val rename_tvars: Id.Set.t -> Id.t list -> Id.t list
-val push_vars : Id.t list -> env -> Id.t list * env
-val get_db_name : int -> env -> Id.t
-
 type phase = Pre | Impl | Intf
 
 module State :
@@ -66,6 +58,14 @@ sig
 
 end
 
+type env = Id.t list * Id.Set.t
+val empty_env : State.t -> unit -> env
+
+val rename_vars: Id.Set.t -> Id.t list -> env
+val rename_tvars: Id.Set.t -> Id.t list -> Id.t list
+val push_vars : Id.t list -> env -> Id.t list * env
+val get_db_name : int -> env -> Id.t
+
 val opened_libraries : State.t -> ModPath.t list
 
 type kind = Term | Type | Cons | Mod
@@ -85,7 +85,7 @@ val get_duplicate : ModPath.t -> Label.t -> string option
 
 type reset_kind = AllButExternal | Everything
 
-val reset_renaming_tables : Id.Set.t -> reset_kind -> unit
+val reset_renaming_tables : State.t -> reset_kind -> unit
 
 (** Special hack for constants of type Ascii.ascii : if an
     [Extract Inductive ascii => char] has been declared, then

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -53,11 +53,12 @@ val get_phase : unit -> phase
 module State :
 sig
   type t
-  val make : modular:bool -> library:bool -> extrcompute:bool -> unit -> t
+  val make : modular:bool -> library:bool -> extrcompute:bool -> keywords:Id.Set.t -> unit -> t
   val get_table : t -> Table.t
   val get_modular : t -> bool
   val get_library : t -> bool
   val get_extrcompute : t -> bool
+  val get_keywords : t -> Id.Set.t
 end
 
 val opened_libraries : State.t -> ModPath.t list
@@ -79,9 +80,7 @@ val get_duplicate : ModPath.t -> Label.t -> string option
 
 type reset_kind = AllButExternal | Everything
 
-val reset_renaming_tables : reset_kind -> unit
-
-val set_keywords : Id.Set.t -> unit
+val reset_renaming_tables : Id.Set.t -> reset_kind -> unit
 
 (** Special hack for constants of type Ascii.ascii : if an
     [Extract Inductive ascii => char] has been declared, then

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -53,9 +53,10 @@ val get_phase : unit -> phase
 module State :
 sig
   type t
-  val make : modular:bool -> unit -> t
+  val make : modular:bool -> library:bool -> unit -> t
   val get_table : t -> Table.t
   val get_modular : t -> bool
+  val get_library : t -> bool
 end
 
 val opened_libraries : State.t -> ModPath.t list

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -496,12 +496,12 @@ let module_filename table mp =
 let print_one_decl table struc mp decl =
   let d = descr () in
   reset_renaming_tables (State.get_keywords table) AllButExternal;
-  set_phase Pre;
+  let table = State.set_phase table Pre in
   ignore (d.pp_struct table struc);
-  set_phase Impl;
+  let table = State.set_phase table Impl in
   push_visible mp [];
   let ans = d.pp_decl table decl in
-  pop_visible ~modular:(State.get_modular table) ();
+  pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
   v 0 ans
 
 (*s Extraction of a ml struct to a file. *)
@@ -551,7 +551,7 @@ let print_structure_to_file table (fn,si,mo) dry struc =
       else struct_ast_search (function MLmagic _ -> true | _ -> false) struc }
   in
   (* First, a dry run, for computing objects to rename or duplicate *)
-  set_phase Pre;
+  let table = State.set_phase table Pre in
   ignore (d.pp_struct table struc);
   let opened = opened_libraries table in
   (* Print the implementation *)
@@ -560,7 +560,7 @@ let print_structure_to_file table (fn,si,mo) dry struc =
   let comment = get_comment () in
   begin try
     (* The real printing of the implementation *)
-    set_phase Impl;
+    let table = State.set_phase table Impl in
     pp_with ft (d.preamble table mo comment opened unsafe_needs);
     pp_with ft (d.pp_struct table struc);
     Format.pp_print_flush ft ();
@@ -576,7 +576,7 @@ let print_structure_to_file table (fn,si,mo) dry struc =
        let cout = open_out si in
        let ft = formatter false (Some cout) in
        begin try
-         set_phase Intf;
+         let table = State.set_phase table Intf in
          pp_with ft (d.sig_preamble table mo comment opened unsafe_needs);
          pp_with ft (d.pp_sig table (signature_of_structure struc));
          Format.pp_print_flush ft ();

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -601,7 +601,6 @@ let print_structure_to_file table (fn,si,mo) dry struc =
 let init ?(compute=false) ?(inner=false) modular library =
   if not inner then check_inside_section ();
   let keywords = (descr ()).keywords in
-  let () = Common.clear_mpfiles_content () in
   let state = State.make ~modular ~library ~extrcompute:compute ~keywords () in
   if modular && lang () == Scheme then error_scheme ();
   state
@@ -640,8 +639,7 @@ let full_extr opaque_access f (refs,mps) =
   List.iter (fun mp -> if is_modfile mp then error_MPfile_as_mod mp true) mps;
   let struc = optimize_struct table (refs,mps) (mono_environment table ~opaque_access refs mps) in
   let () = warns table in
-  print_structure_to_file table (mono_filename f) false struc;
-  Common.clear_mpfiles_content ()
+  print_structure_to_file table (mono_filename f) false struc
 
 let full_extraction ~opaque_access f lr =
   full_extr opaque_access f (locate_ref lr)
@@ -666,7 +664,7 @@ let separate_extraction ~opaque_access lr =
     | (MPdot _ | MPbound _), _ -> assert false
   in
   let () = List.iter print struc in
-  Common.clear_mpfiles_content ()
+  ()
 
 (*s Simple extraction in the Rocq toplevel. The vernacular command
     is \verb!Extraction! [qualid]. *)
@@ -684,7 +682,6 @@ let simple_extraction ~opaque_access r =
         else mt ()
       in
       let ans = flag ++ print_one_decl table struc (modpath_of_r r) d in
-      let () = Common.clear_mpfiles_content () in
       Feedback.msg_notice ans
   | _ -> assert false
 
@@ -719,7 +716,7 @@ let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
     | _ -> assert false
   in
   let () = List.iter print struc in
-  Common.clear_mpfiles_content ()
+  ()
 
 (** For extraction compute, we flatten all the module structure,
     getting rid of module types or unapplied functors *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -368,7 +368,7 @@ and extract_mexpr table access venv env mp = function
       let sign, delta = expand_mexpr env mp me in
       extract_msignature table access venv env mp delta ~all:true sign
   | MEident mp ->
-      if is_modfile mp && not (modular ()) then error_MPfile_as_mod mp false;
+      if is_modfile mp && not (State.get_modular table) then error_MPfile_as_mod mp false;
       Visit.add_mp_all venv mp; Miniml.MEident mp
   | MEapply (me, arg) ->
       Miniml.MEapply (extract_mexpr table access venv env mp me,
@@ -501,7 +501,7 @@ let print_one_decl table struc mp decl =
   set_phase Impl;
   push_visible mp [];
   let ans = d.pp_decl table decl in
-  pop_visible ();
+  pop_visible ~modular:(State.get_modular table) ();
   v 0 ans
 
 (*s Extraction of a ml struct to a file. *)
@@ -605,12 +605,11 @@ let reset () =
 let init ?(compute=false) ?(inner=false) modular library =
   if not inner then check_inside_section ();
   set_keywords (descr ()).keywords;
-  set_modular modular;
   set_library library;
   set_extrcompute compute;
   reset ();
   if modular && lang () == Scheme then error_scheme ();
-  State.make ()
+  State.make ~modular ()
 
 let warns table =
   let table = State.get_table table in

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -499,9 +499,9 @@ let print_one_decl table struc mp decl =
   let table = State.set_phase table Pre in
   ignore (d.pp_struct table struc);
   let table = State.set_phase table Impl in
-  push_visible mp [];
-  let ans = d.pp_decl table decl in
-  pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
+  let ans = State.with_visibility table mp [] begin fun table ->
+    d.pp_decl table decl
+  end in
   v 0 ans
 
 (*s Extraction of a ml struct to a file. *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -361,7 +361,7 @@ let rec extract_structure table access venv env mp reso ~all = function
 
 and extract_mexpr table access venv env mp = function
   | MEwith _ -> assert false (* no 'with' syntax for modules *)
-  | me when lang () != Ocaml || Table.is_extrcompute () ->
+  | me when lang () != Ocaml || State.get_extrcompute table ->
       (* In Haskell/Scheme, we expand everything.
          For now, we also extract everything, dead code will be removed later
          (see [Modutil.optimize_struct]. *)
@@ -605,10 +605,9 @@ let reset () =
 let init ?(compute=false) ?(inner=false) modular library =
   if not inner then check_inside_section ();
   set_keywords (descr ()).keywords;
-  set_extrcompute compute;
   reset ();
   if modular && lang () == Scheme then error_scheme ();
-  State.make ~modular ~library ()
+  State.make ~modular ~library ~extrcompute:compute ()
 
 let warns table =
   let table = State.get_table table in

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -25,18 +25,18 @@ val extract_and_compile : opaque_access:Global.indirect_accessor -> qualid list 
 (* For debug / external output via coqtop.byte + Drop : *)
 
 val mono_environment :
- Table.t -> opaque_access:Global.indirect_accessor -> GlobRef.t list -> ModPath.t list -> Miniml.ml_structure
+ Common.State.t -> opaque_access:Global.indirect_accessor -> GlobRef.t list -> ModPath.t list -> Miniml.ml_structure
 
 (* Used by the Relation Extraction plugin *)
 
 val print_one_decl :
-  Table.t -> Miniml.ml_structure -> ModPath.t -> Miniml.ml_decl -> Pp.t
+  Common.State.t -> Miniml.ml_structure -> ModPath.t -> Miniml.ml_decl -> Pp.t
 
 (* Used by Extraction Compute *)
 
 val structure_for_compute :
   opaque_access:Global.indirect_accessor -> Environ.env -> Evd.evar_map -> EConstr.t ->
-    Table.t * Miniml.ml_decl list * Miniml.ml_ast * Miniml.ml_type
+    Common.State.t * Miniml.ml_decl list * Miniml.ml_ast * Miniml.ml_type
 
 (* Show the extraction of the current ongoing proof *)
 

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -481,7 +481,7 @@ and extract_really_ind table env kn mib =
        (cf Vector and bug #2570) *)
     let equiv =
       if lang () != Ocaml ||
-         (not (modular ()) && at_toplevel (MutInd.modpath kn)) ||
+         (not (Common.State.get_modular table) && at_toplevel (MutInd.modpath kn)) ||
          KerName.equal (MutInd.canonical kn) (MutInd.user kn)
       then
         NoEquiv

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -696,7 +696,7 @@ let rec extract_term table env sg mle mlt c args =
                in
                let b = new_meta () in
                (* If [mlt] cannot be unified with an arrow type, then magic! *)
-               let magic = needs_magic (mlt, Tarr (a, b)) in
+               let magic = needs_magic ~compute:(Common.State.get_extrcompute table) (mlt, Tarr (a, b)) in
                let d' = extract_term table env' sg (Mlenv.push_type mle a) b d [] in
                put_magic_if magic (MLlam (id, d')))
     | LetIn (n, c1, t1, c2) ->
@@ -735,7 +735,7 @@ let rec extract_term table env sg mle mlt c args =
     | Rel n ->
         (* As soon as the expected [mlt] for the head is known, *)
         (* we unify it with an fresh copy of the stored type of [Rel n]. *)
-        let extract_rel mlt = put_magic (mlt, Mlenv.get mle n) (MLrel n)
+        let extract_rel mlt = put_magic ~compute:(Common.State.get_extrcompute table) (mlt, Mlenv.get mle n) (MLrel n)
         in extract_app table env sg mle mlt extract_rel args
     | Case (ci, u, pms, r, iv, c0, br) ->
         (* If invert_case then this is a match that will get erased later, but right now we don't care. *)
@@ -756,7 +756,7 @@ let rec extract_term table env sg mle mlt c args =
          | LocalDef (_,_,ty) -> ty
        in
        let vty = extract_type table env sg [] 0 ty [] in
-       let extract_var mlt = put_magic (mlt,vty) (MLglob (GlobRef.VarRef v)) in
+       let extract_var mlt = put_magic ~compute:(Common.State.get_extrcompute table) (mlt,vty) (MLglob (GlobRef.VarRef v)) in
        extract_app table env sg mle mlt extract_var args
     | Int i -> assert (args = []); MLuint i
     | Float f -> assert (args = []); MLfloat f
@@ -775,7 +775,7 @@ and extract_maybe_term table env sg mle mlt c =
   try check_default env sg (type_of env sg c);
     extract_term table env sg mle mlt c []
   with NotDefault d ->
-    put_magic (mlt, Tdummy d) (MLdummy d)
+    put_magic ~compute:(Common.State.get_extrcompute table) (mlt, Tdummy d) (MLdummy d)
 
 (*s Generic way to deal with an application. *)
 
@@ -818,9 +818,9 @@ and extract_cst_app table env sg mle mlt kn args =
   (* We compare stored and expected types in two steps. *)
   (* First, can [kn] be applied to all args ? *)
   let metas = List.map new_meta args in
-  let magic1 = needs_magic (type_recomp (metas, a), instantiated) in
+  let magic1 = needs_magic ~compute:(Common.State.get_extrcompute table) (type_recomp (metas, a), instantiated) in
   (* Second, is the resulting type compatible with the expected type [mlt] ? *)
-  let magic2 = needs_magic (a, mlt) in
+  let magic2 = needs_magic ~compute:(Common.State.get_extrcompute table) (a, mlt) in
   (* The internal head receives a magic if [magic1] *)
   let head = put_magic_if magic1 (MLglob (GlobRef.ConstRef kn)) in
   (* Now, the extraction of the arguments. *)
@@ -885,8 +885,8 @@ and extract_cons_app table env sg mle mlt (((kn,i) as ip,j) as cp) args =
   let metas = List.map new_meta args' in
   (* If stored and expected types differ, then magic! *)
   let a = new_meta () in
-  let magic1 = needs_magic (type_cons, type_recomp (metas, a)) in
-  let magic2 = needs_magic (a, mlt) in
+  let magic1 = needs_magic ~compute:(Common.State.get_extrcompute table) (type_cons, type_recomp (metas, a)) in
+  let magic2 = needs_magic ~compute:(Common.State.get_extrcompute table) (a, mlt) in
   let head mla =
     if mi.ind_kind == Singleton then
       put_magic_if magic1 (List.hd mla) (* assert (List.length mla = 1) *)

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -16,23 +16,23 @@ open Environ
 open Evd
 open Miniml
 
-val extract_constant : Table.t -> Global.indirect_accessor -> env -> Constant.t -> constant_body -> ml_decl
+val extract_constant : Common.State.t -> Global.indirect_accessor -> env -> Constant.t -> constant_body -> ml_decl
 
-val extract_constant_spec : Table.t -> env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
+val extract_constant_spec : Common.State.t -> env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
 
 (** For extracting "module ... with ..." declaration *)
 
 val extract_with_type :
-  Table.t -> env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
+  Common.State.t -> env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
 
 val extract_fixpoint :
-  Table.t -> env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
+  Common.State.t -> env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
 
-val extract_inductive : Table.t -> env -> MutInd.t -> ml_ind
+val extract_inductive : Common.State.t -> env -> MutInd.t -> ml_ind
 
 (** For Extraction Compute and Show Extraction *)
 
-val extract_constr : Table.t -> env -> evar_map -> EConstr.t -> ml_ast * ml_type
+val extract_constr : Common.State.t -> env -> evar_map -> EConstr.t -> ml_ast * ml_type
 
 (*s Is a [ml_decl] or a [ml_spec] logical ? *)
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -394,7 +394,7 @@ let pp_struct table =
   let pp_sel (mp,sel) =
     push_visible mp [];
     let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible ~modular:(State.get_modular table) (); p
+    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
   in
   prlist_strict pp_sel
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -394,7 +394,7 @@ let pp_struct table =
   let pp_sel (mp,sel) =
     push_visible mp [];
     let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible (); p
+    pop_visible ~modular:(State.get_modular table) (); p
   in
   prlist_strict pp_sel
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -391,11 +391,9 @@ and pp_module_expr table = function
       (* should be expanded in extract_env *)
 
 let pp_struct table =
-  let pp_sel (mp,sel) =
-    push_visible mp [];
-    let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
-  in
+  let pp_sel (mp,sel) = State.with_visibility table mp [] begin fun table ->
+    prlist_strict (fun e -> pp_structure_elem table e) sel
+  end in
   prlist_strict pp_sel
 
 let file_naming state mp = file_of_modfile (State.get_table state) mp

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -38,7 +38,7 @@ let pp_bracket_comment s = str"{- " ++ hov 0 s ++ str" -}"
    the '\n' character interacts badly with the Format boxing mechanism *)
 
 let preamble table mod_name comment used_modules usf =
-  let pp_import mp = str ("import qualified "^ string_of_modfile table mp) ++ fnl ()
+  let pp_import mp = str ("import qualified "^ string_of_modfile (State.get_table table) mp) ++ fnl ()
   in
   (if not (usf.magic || usf.tunknown) then mt ()
    else
@@ -398,11 +398,12 @@ let pp_struct table =
   in
   prlist_strict pp_sel
 
+let file_naming state mp = file_of_modfile (State.get_table state) mp
 
 let haskell_descr = {
   keywords = keywords;
   file_suffix = ".hs";
-  file_naming = string_of_modfile;
+  file_naming = file_naming;
   preamble = preamble;
   pp_struct = pp_struct;
   sig_suffix = None;

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -364,7 +364,7 @@ let pp_decl table = function
             (if is_custom r then
                 (names.(i) ++ str " = " ++ str (find_custom r))
              else
-                (pp_function table (empty_env ()) names.(i) defs.(i)))
+                (pp_function table (empty_env table ()) names.(i) defs.(i)))
             ++ fnl2 ())
         rv
   | Dterm (r, a, t) ->
@@ -375,7 +375,7 @@ let pp_decl table = function
           if is_custom r then
             hov 0 (e ++ str " = " ++ str (find_custom r) ++ fnl2 ())
           else
-            hov 0 (pp_function table (empty_env ()) e a ++ fnl2 ())
+            hov 0 (pp_function table (empty_env table ()) e a ++ fnl2 ())
 
 let rec pp_structure_elem table = function
   | (l,SEdecl d) -> pp_decl table d

--- a/plugins/extraction/haskell.mli
+++ b/plugins/extraction/haskell.mli
@@ -8,5 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val haskell_descr : Table.t Miniml.language_descr
+val haskell_descr : Common.State.t Miniml.language_descr
 

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -271,7 +271,7 @@ let pp_struct table mls =
     push_visible mp [];
     let p = prlist_with_sep pr_comma identity
       (List.concat (List.map (pp_structure_elem table) sel)) in
-    pop_visible (); p
+    pop_visible ~modular:(State.get_modular table) (); p
   in
   str "," ++ fnl () ++
   str "  " ++ qs "declarations" ++ str ": [" ++ fnl () ++

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -56,7 +56,7 @@ let preamble table mod_name comment used_modules usf =
     ("need_magic", json_bool (usf.magic));
     ("need_dummy", json_bool (usf.mldummy));
     ("used_modules", json_list
-      (List.map (fun mf -> json_str (file_of_modfile table mf)) used_modules))
+      (List.map (fun mf -> json_str (file_of_modfile (State.get_table table) mf)) used_modules))
   ]
 
 
@@ -279,11 +279,12 @@ let pp_struct table mls =
   str "  ]" ++ fnl () ++
   str "}" ++ fnl ()
 
+let file_naming state mp = file_of_modfile (State.get_table state) mp
 
 let json_descr = {
   keywords = Id.Set.empty;
   file_suffix = ".json";
-  file_naming = file_of_modfile;
+  file_naming = file_naming;
   preamble = preamble;
   pp_struct = pp_struct;
   sig_suffix = None;

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -267,12 +267,11 @@ and pp_module_expr table = function
       (* should be expansed in extract_env *)
 
 let pp_struct table mls =
-  let pp_sel (mp,sel) =
-    push_visible mp [];
+  let pp_sel (mp,sel) = State.with_visibility table mp [] begin fun table ->
     let p = prlist_with_sep pr_comma identity
       (List.concat (List.map (pp_structure_elem table) sel)) in
-    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
-  in
+    p
+  end in
   str "," ++ fnl () ++
   str "  " ++ qs "declarations" ++ str ": [" ++ fnl () ++
   str "    " ++ hov 0 (prlist_with_sep pr_comma pp_sel mls) ++ fnl () ++

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -271,7 +271,7 @@ let pp_struct table mls =
     push_visible mp [];
     let p = prlist_with_sep pr_comma identity
       (List.concat (List.map (pp_structure_elem table) sel)) in
-    pop_visible ~modular:(State.get_modular table) (); p
+    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
   in
   str "," ++ fnl () ++
   str "  " ++ qs "declarations" ++ str ": [" ++ fnl () ++

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -243,14 +243,14 @@ let pp_decl table = function
           ("what", json_str "fixgroup:item");
           ("name", json_global table Term rv.(i));
           ("type", json_type table [] typs.(i));
-          ("value", json_function table (empty_env ()) defs.(i))
+          ("value", json_function table (empty_env table ()) defs.(i))
         ]) rv))
     ]
   | Dterm (r, a, t) -> json_dict [
       ("what", json_str "decl:term");
       ("name", json_global table Term r);
       ("type", json_type table [] t);
-      ("value", json_function table (empty_env ()) a)
+      ("value", json_function table (empty_env table ()) a)
     ]
 
 let rec pp_structure_elem table = function

--- a/plugins/extraction/json.mli
+++ b/plugins/extraction/json.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val json_descr : Table.t Miniml.language_descr
+val json_descr : Common.State.t Miniml.language_descr

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -129,15 +129,15 @@ let rec mgu = function
   | Taxiom, Taxiom -> ()
   | _ -> raise Impossible
 
-let skip_typing () = lang () == Scheme || is_extrcompute ()
+let skip_typing ~compute () = lang () == Scheme || compute
 
-let needs_magic p =
-  if skip_typing () then false
+let needs_magic ~compute p =
+  if skip_typing ~compute () then false
   else try mgu p; false with Impossible -> true
 
 let put_magic_if b a = if b then MLmagic a else a
 
-let put_magic p a = if needs_magic p then MLmagic a else a
+let put_magic ~compute p a = if needs_magic ~compute p then MLmagic a else a
 
 let generalizable a =
   lang () != Ocaml ||

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -22,9 +22,9 @@ val type_subst_vect : ml_type array -> ml_type -> ml_type
 
 val instantiation : ml_schema -> ml_type
 
-val needs_magic : ml_type * ml_type -> bool
+val needs_magic : compute:bool -> ml_type * ml_type -> bool
 val put_magic_if : bool -> ml_ast -> ml_ast
-val put_magic : ml_type * ml_type -> ml_ast -> ml_ast
+val put_magic : compute:bool -> ml_type * ml_type -> ml_ast -> ml_ast
 
 val generalizable : ml_ast -> bool
 

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -404,18 +404,18 @@ let check_for_remaining_implicits struc =
 let optimize_struct table to_appear struc =
   let subst = ref (Refmap'.empty : ml_ast Refmap'.t) in
   let opt_struc =
-    List.map (fun (mp,lse) -> (mp, optim_se table true (fst to_appear) subst lse))
+    List.map (fun (mp,lse) -> (mp, optim_se (Common.State.get_table table) true (fst to_appear) subst lse))
       struc
   in
   let mini_struc =
-    if library () then
+    if Common.State.get_library table then
       List.filter (fun (_,lse) -> not (List.is_empty lse)) opt_struc
     else
       begin
         reset_needed ();
         List.iter add_needed (fst to_appear);
         List.iter add_needed_mp (snd to_appear);
-        depcheck_struct table opt_struc
+        depcheck_struct (Common.State.get_table table) opt_struc
       end
   in
   let () = check_for_remaining_implicits mini_struc in

--- a/plugins/extraction/modutil.mli
+++ b/plugins/extraction/modutil.mli
@@ -38,5 +38,5 @@ val get_decl_in_structure : GlobRef.t -> ml_structure -> ml_decl
    optimizations. The first argument is the list of objects we want to appear.
 *)
 
-val optimize_struct : Table.t -> GlobRef.t list * ModPath.t list ->
+val optimize_struct : Common.State.t -> GlobRef.t list * ModPath.t list ->
   ml_structure -> ml_structure

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -656,7 +656,7 @@ let pp_spec table = function
 let rec pp_specif table = function
   | (_,Spec (Sval _ as s)) -> pp_spec table s
   | (l,Spec s) ->
-     (match Common.get_duplicate (top_visible_mp ()) l with
+     (match Common.State.get_duplicate table (top_visible_mp ()) l with
       | None -> pp_spec table s
       | Some ren ->
          hov 1 (str ("module "^ren^" : sig") ++ fnl () ++ pp_spec table s) ++
@@ -666,7 +666,7 @@ let rec pp_specif table = function
       let def = pp_module_type table [] mt in
       let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module " ++ name ++ str " :" ++ fnl () ++ def) ++
-      (match Common.get_duplicate (top_visible_mp ()) l with
+      (match Common.State.get_duplicate table (top_visible_mp ()) l with
        | None -> Pp.mt ()
        | Some ren ->
          fnl () ++
@@ -676,7 +676,7 @@ let rec pp_specif table = function
       let def = pp_module_type table [] mt in
       let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module type " ++ name ++ str " =" ++ fnl () ++ def) ++
-      (match Common.get_duplicate (top_visible_mp ()) l with
+      (match Common.State.get_duplicate table (top_visible_mp ()) l with
        | None -> Pp.mt ()
        | Some ren -> fnl () ++ str ("module type "^ren^" = ") ++ name)
 
@@ -729,7 +729,7 @@ let is_short = function MEident _ | MEapply _ -> true | _ -> false
 
 let rec pp_structure_elem table = function
   | (l,SEdecl d) ->
-     (match Common.get_duplicate (top_visible_mp ()) l with
+     (match Common.State.get_duplicate table (top_visible_mp ()) l with
       | None -> pp_decl table d
       | Some ren ->
          v 1 (str ("module "^ren^" = struct") ++ fnl () ++ pp_decl table d) ++
@@ -746,14 +746,14 @@ let rec pp_structure_elem table = function
       hov 1
         (str "module " ++ name ++ typ ++ str " =" ++
          (if is_short m.ml_mod_expr then spc () else fnl ()) ++ def) ++
-      (match Common.get_duplicate (top_visible_mp ()) l with
+      (match Common.State.get_duplicate table (top_visible_mp ()) l with
        | Some ren -> fnl () ++ str ("module "^ren^" = ") ++ name
        | None -> mt ())
   | (l,SEmodtype m) ->
       let def = pp_module_type table [] m in
       let name = pp_modname table (MPdot (top_visible_mp (), l)) in
       hov 1 (str "module type " ++ name ++ str " =" ++ fnl () ++ def) ++
-      (match Common.get_duplicate (top_visible_mp ()) l with
+      (match Common.State.get_duplicate table (top_visible_mp ()) l with
        | None -> mt ()
        | Some ren -> fnl () ++ str ("module type "^ren^" = ") ++ name)
 

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -477,7 +477,7 @@ let pp_Dfix table (rv,c,t) =
       else
         let def =
           if is_custom rv.(i) then str " = " ++ str (find_custom rv.(i))
-          else pp_function table (empty_env ()) c.(i)
+          else pp_function table (empty_env table ()) c.(i)
         in
         (if init then mt () else cut2 ()) ++
         pp_val table names.(i) t.(i) ++
@@ -608,7 +608,7 @@ let pp_decl table = function
           if is_foreign_custom r then str ": " ++ pp_type table false [] t ++ str " = \"" ++ str (find_custom r) ++ str "\""
           (* Otherwise, check if it is a regular custom term. *)
           else if is_custom r then str (" = " ^ find_custom r)
-          else pp_function table (empty_env ()) a
+          else pp_function table (empty_env table ()) a
         in
         let name = pp_global_name table Term r in
         (* If it is an foreign custom, begin the expression with 'external'/'foreign' instead of 'let' *)

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -697,7 +697,7 @@ and pp_module_type table params = function
       (* We cannot use fold_right here due to side effects in pp_specif *)
       let l = List.fold_left try_pp_specif [] sign in
       let l = List.rev l in
-      pop_visible ~modular:(State.get_modular table) ();
+      pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
       str "sig" ++ fnl () ++
       (if List.is_empty l then mt ()
        else
@@ -713,7 +713,7 @@ and pp_module_type table params = function
       let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)) in
       push_visible mp_mt [];
       let pp_w = str " with type " ++ ids ++ pp_global table Type r in
-      pop_visible ~modular:(State.get_modular table) ();
+      pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
       pp_module_type table [] mt ++ pp_w ++ str " = " ++ pp_type table false vl typ
   | MTwith(mt,ML_With_module(idl,mp)) ->
       let mp_mt = msid_of_mt mt in
@@ -722,7 +722,7 @@ and pp_module_type table params = function
       in
       push_visible mp_mt [];
       let pp_w = str " with module " ++ pp_modname table mp_w in
-      pop_visible ~modular:(State.get_modular table) ();
+      pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
       pp_module_type table [] mt ++ pp_w ++ str " = " ++ pp_modname table mp
 
 let is_short = function MEident _ | MEapply _ -> true | _ -> false
@@ -737,7 +737,7 @@ let rec pp_structure_elem table = function
   | (l,SEmodule m) ->
       let typ =
         (* virtual printing of the type, in order to have a correct mli later*)
-        if Common.get_phase () == Pre then
+        if Common.State.get_phase table == Pre then
           str ": " ++ pp_module_type table [] m.ml_mod_type
         else mt ()
       in
@@ -775,7 +775,7 @@ and pp_module_expr table params = function
       (* We cannot use fold_right here due to side effects in pp_structure_elem *)
       let l = List.fold_left try_pp_structure_elem [] sel in
       let l = List.rev l in
-      pop_visible ~modular:(State.get_modular table) ();
+      pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) ();
       str "struct" ++ fnl () ++
       (if List.is_empty l then mt ()
        else
@@ -798,10 +798,10 @@ let do_struct table f s =
     let p = prlist_sep_nonempty cut2 f sel in
     (* for monolithic extraction, we try to simulate the unavailability
        of [MPfile] in names by artificially nesting these [MPfile] *)
-    (if modular then pop_visible ~modular ()); p
+    (if modular then pop_visible ~modular ~phase:(State.get_phase table) ()); p
   in
   let p = prlist_sep_nonempty cut2 ppl s in
-  (if not modular then repeat (List.length s) (fun () -> pop_visible ~modular ()) ());
+  (if not modular then repeat (List.length s) (fun () -> pop_visible ~modular ~phase:(State.get_phase table) ()) ());
   v 0 p ++ fnl ()
 
 let pp_struct table s = do_struct table (fun e -> pp_structure_elem table e) s

--- a/plugins/extraction/ocaml.mli
+++ b/plugins/extraction/ocaml.mli
@@ -8,5 +8,5 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val ocaml_descr : Table.t Miniml.language_descr
+val ocaml_descr : Common.State.t Miniml.language_descr
 

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -227,7 +227,7 @@ let pp_struct table =
   let pp_sel (mp,sel) =
     push_visible mp [];
     let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible ~modular:(State.get_modular table) (); p
+    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
   in
   prlist_strict pp_sel
 

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -227,7 +227,7 @@ let pp_struct table =
   let pp_sel (mp,sel) =
     push_visible mp [];
     let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible (); p
+    pop_visible ~modular:(State.get_modular table) (); p
   in
   prlist_strict pp_sel
 

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -224,11 +224,9 @@ and pp_module_expr table = function
       (* should be expanded in extract_env *)
 
 let pp_struct table =
-  let pp_sel (mp,sel) =
-    push_visible mp [];
-    let p = prlist_strict (fun e -> pp_structure_elem table e) sel in
-    pop_visible ~modular:(State.get_modular table) ~phase:(State.get_phase table) (); p
-  in
+  let pp_sel (mp,sel) = State.with_visibility table mp [] begin fun table ->
+    prlist_strict (fun e -> pp_structure_elem table e) sel
+  end in
   prlist_strict pp_sel
 
 let file_naming state mp = file_of_modfile (State.get_table state) mp

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -99,7 +99,7 @@ let rec pp_expr table env args =
                  (if List.is_empty args' then mt () else spc ()) ++
                  prlist_with_sep spc (pp_cons_args table env) args')
         in
-        if is_coinductive table r then paren (str "delay " ++ st) else st
+        if is_coinductive (State.get_table table) r then paren (str "delay " ++ st) else st
     | MLtuple _ -> user_err Pp.(str "Cannot handle tuples in Scheme yet.")
     | MLcase (_,_,pv) when not (is_regular_match pv) ->
         user_err Pp.(str "Cannot handle general patterns in Scheme yet.")
@@ -116,7 +116,7 @@ let rec pp_expr table env args =
                  ++ pp_expr table env [] t)))
     | MLcase (typ,t, pv) ->
         let e =
-          if not (is_coinductive_type table typ) then pp_expr table env [] t
+          if not (is_coinductive_type (State.get_table table) typ) then pp_expr table env [] t
           else paren (str "force" ++ spc () ++ pp_expr table env [] t)
         in
         apply (v 3 (paren (str "match " ++ e ++ fnl () ++ pp_pat table env pv)))
@@ -141,7 +141,7 @@ let rec pp_expr table env args =
             paren (str "Prelude.error \"EXTRACTION OF PARRAY NOT IMPLEMENTED\"")
 
 and pp_cons_args table env = function
-  | MLcons (_,r,args) when is_coinductive table r ->
+  | MLcons (_,r,args) when is_coinductive (State.get_table table) r ->
       paren (pp_global table Cons r ++
              (if List.is_empty args then mt () else spc ()) ++
              prlist_with_sep spc (pp_cons_args table env) args)
@@ -231,10 +231,12 @@ let pp_struct table =
   in
   prlist_strict pp_sel
 
+let file_naming state mp = file_of_modfile (State.get_table state) mp
+
 let scheme_descr = {
   keywords = keywords;
   file_suffix = ".scm";
-  file_naming = file_of_modfile;
+  file_naming = file_naming;
   preamble = preamble;
   pp_struct = pp_struct;
   sig_suffix = None;

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -199,7 +199,7 @@ let pp_decl table = function
             hov 2
               (paren (str "define " ++ names.(i) ++ spc () ++
                         (if is_custom r then str (find_custom r)
-                         else pp_expr table (empty_env ()) [] defs.(i)))
+                         else pp_expr table (empty_env table ()) [] defs.(i)))
                ++ fnl ()) ++ fnl ())
         rv
   | Dterm (r, a, _) ->
@@ -207,7 +207,7 @@ let pp_decl table = function
       else
         hov 2 (paren (str "define " ++ pp_global table Term r ++ spc () ++
                         (if is_custom r then str (find_custom r)
-                         else pp_expr table (empty_env ()) [] a)))
+                         else pp_expr table (empty_env table ()) [] a)))
         ++ fnl2 ()
 
 let rec pp_structure_elem table = function

--- a/plugins/extraction/scheme.mli
+++ b/plugins/extraction/scheme.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val scheme_descr : Table.t Miniml.language_descr
+val scheme_descr : Common.State.t Miniml.language_descr

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -249,11 +249,7 @@ Nota:
  - Extraction Library : modular, library
 *)
 
-let modular_ref = ref false
 let library_ref = ref false
-
-let set_modular b = modular_ref := b
-let modular () = !modular_ref
 
 let set_library b = library_ref := b
 let library () = !library_ref

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -249,11 +249,6 @@ Nota:
  - Extraction Library : modular, library
 *)
 
-let extrcompute = ref false
-
-let set_extrcompute b = extrcompute := b
-let is_extrcompute () = !extrcompute
-
 (*s Printing. *)
 
 (* The following functions work even on objects not in [Global.env ()].

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -249,11 +249,6 @@ Nota:
  - Extraction Library : modular, library
 *)
 
-let library_ref = ref false
-
-let set_library b = library_ref := b
-let library () = !library_ref
-
 let extrcompute = ref false
 
 let set_extrcompute b = extrcompute := b

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -167,9 +167,6 @@ Nota:
  - Extraction Library : modular, library
 *)
 
-val set_modular : bool -> unit
-val modular : unit -> bool
-
 val set_library : bool -> unit
 val library : unit -> bool
 

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -167,9 +167,6 @@ Nota:
  - Extraction Library : modular, library
 *)
 
-val set_library : bool -> unit
-val library : unit -> bool
-
 val set_extrcompute : bool -> unit
 val is_extrcompute : unit -> bool
 

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -159,17 +159,6 @@ val file_comment : unit -> string
 type lang = Ocaml | Haskell | Scheme | JSON
 val lang : unit -> lang
 
-(*s Extraction modes: modular or monolithic, library or minimal ?
-
-Nota:
- - Recursive Extraction : monolithic, minimal
- - Separate Extraction : modular, minimal
- - Extraction Library : modular, library
-*)
-
-val set_extrcompute : bool -> unit
-val is_extrcompute : unit -> bool
-
 (*s Table for custom inlining *)
 
 val to_inline : GlobRef.t -> bool


### PR DESCRIPTION
Follow-up of #20562. Now virtually all the global state of extraction has been moved to a single abstract type that exposes a few accessors depending on the nature of the state, i.e. static, reader-like or state-like. This state is wrapped together with the global table type used in the lower layers of extraction.

This probably fixes a few hidden bugs in the implementation, including potential memory leaks, and may introduce new ones, when e.g. messing with exceptions. In practice I don't think it matters. It seems in any case like the implementation was not really thoroughly designed given the previous level of spaghettiness of the state. At least now we can start enforcing some invariants on it.