### PR TITLE
ltac2: register names for terms and type definitions in VtSideff

### DIFF
--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1004,18 +1004,20 @@ PRINTED BY { pr_ltac2expr }
 | [ _ltac2_expr(e) ] -> { e }
 END
 
+{
+
+let names_of_strexpr = function
+| StrVal(_, _, l) ->
+  List.concat_map (fun (na, _) -> match na.CAst.v with Anonymous -> [] | Name id -> [id]) l
+| StrTyp(_, l) ->
+  List.map (fun (qid, _, _) -> Libnames.qualid_basename qid) l
+| _ -> []
+
+}
+
 VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
 | #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => {
-  VtSideff (
-    (match e with
-      | StrVal(_, _, l) ->
-        List.concat_map (function
-          | ({CAst.v=na}, _) -> match na with Anonymous -> [] | Name id -> [id]) l
-      | StrTyp(_, l) ->
-        List.map (function
-          | (qid, _, _) -> Libnames.qualid_basename qid) l
-      | _ -> []),
-      VtLater)
+    VtSideff (names_of_strexpr e, VtLater)
   } -> {
     Tac2entries.register_struct raw_attributes e
   }

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1005,8 +1005,19 @@ PRINTED BY { pr_ltac2expr }
 END
 
 VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
-| #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => { Vernacextend.classify_as_sideeff } -> {
-  Tac2entries.register_struct raw_attributes e
+| #[ raw_attributes ] [ "Ltac2" ltac2_entry(e) ] => {
+  VtSideff (
+    (match e with
+      | StrVal(_, _, l) ->
+        List.concat_map (function
+          | ({CAst.v=na}, _) -> match na with Anonymous -> [] | Name id -> [id]) l
+      | StrTyp(_, l) ->
+        List.map (function
+          | (qid, _, _) -> Libnames.qualid_basename qid) l
+      | _ -> []),
+      VtLater)
+  } -> {
+    Tac2entries.register_struct raw_attributes e
   }
 | #[ raw_attributes ] [ "Ltac2" "Notation" ltac2def_syn(e) ] => { Vernacextend.(VtSideff ([], VtNow)) } SYNTERP AS synterpv {
     let (toks, n, body) = e in


### PR DESCRIPTION
## Description

This PR introduces a change to set names of `ltac2` term and type definitions in `VtSideff`. This is done similarly to how it is done for `ltac`.

My motivation for this change is for ltac2 definitions to be visible in `vscoq` symbols. The `vscoq` language server uses the toplevel names from `VtSideff` to index the workspace symbol search and file outline.

e.g.
![image](https://github.com/user-attachments/assets/7365640f-932b-4e3f-b553-4d27636d575f)

## Checklist

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
