### PR TITLE
[tauto] change proof search strategy

### DIFF
--- a/dev/ci/user-overlays/20627-fajb-tauto.sh
+++ b/dev/ci/user-overlays/20627-fajb-tauto.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/fajb/stdlib tauto 20627

--- a/dev/ci/user-overlays/20627-fajb-tauto.sh
+++ b/dev/ci/user-overlays/20627-fajb-tauto.sh
@@ -1,1 +1,12 @@
 overlay stdlib https://github.com/fajb/stdlib tauto 20627
+
+overlay bedrock2 https://github.com/fajb/bedrock2 tauto 20627
+# Make PRs against https://github.com/mit-plv/bedrock2 base branch master
+
+overlay corn https://github.com/fajb/corn tauto 20627
+
+overlay vst https://github.com/fajb/VST tauto 20627
+
+overlay coq_dpdgraph https://github.com/fajb/coq-dpdgraph tauto 20627
+
+overlay metarocq https://github.com/fajb/metarocq tauto 20627

--- a/doc/changelog/04-tactics/20627-tauto.rst
+++ b/doc/changelog/04-tactics/20627-tauto.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The proof search of `tauto` and `intuition` has slightly changed and should scale better.
+  This may break proof scripts relying on the generated names
+  but also prove a few more goals (with dependent hypotheses).
+  (`#20627 <https://github.com/rocq-prover/rocq/pull/20627>`_,
+  by Frédéric Besson).

--- a/test-suite/success/Tauto.v
+++ b/test-suite/success/Tauto.v
@@ -242,3 +242,18 @@ Proof.
    intuition.
 Qed.
 
+(** Useless hypotheses
+(https://rocq-prover.zulipchat.com/#narrow/channel/237977-Rocq-users/topic/tauto.20hangs.20even.20though.20goal.20is.20an.20assumption) *)
+
+Lemma tauto_hang_nor_more
+  (P1 P2 P3 Q : Prop)
+  (H1 : ~ P1 -> ~ ~ P2 /\ ~ ~ P3)
+  (H2 : ~ P2 -> ~ ~ P1 /\ ~ ~ P3)
+  (H3 : ~ P3 -> ~ ~ P1 /\ ~ ~ P2)
+  (H'1 : ~ ~ P1 -> ~ ~ Q \/ ~ Q)
+  (H'2 : ~ ~ P2 -> ~ ~ Q \/ ~ Q)
+  (H'3 : ~ ~ P3 -> ~ ~ Q \/ ~ Q)
+  : ~ ~ P1 -> ~ ~ Q \/ ~ Q.
+Proof.
+  Timeout 1 tauto.
+Qed.

--- a/theories/Corelib/Init/Tauto.v
+++ b/theories/Corelib/Init/Tauto.v
@@ -25,15 +25,23 @@ Local Ltac not_dep_intros :=
 
 Local Ltac axioms flags :=
   match reverse goal with
-    | |- ?X1 => is_unit_or_eq flags X1; constructor 1
+    | |- ?X1 => is_unit_or_eq flags X1; is_ground X1; constructor 1
+    | H:?X1 |- _ => is_empty flags X1; elim H
+    | H:?X1 |- ?X1 => exact H
+  end.
+
+Local Ltac eaxioms flags :=
+  match reverse goal with
+    | |- ?X1 => is_unit_or_eq flags X1 ;constructor 1
     | H:?X1 |- _ => is_empty flags X1; elim H
     | _ => assumption
   end.
 
+
 Local Ltac simplif flags :=
   not_dep_intros;
   repeat
-     (match reverse goal with
+     (axioms flags || match reverse goal with
       | id: ?X1 |- _ => is_conj flags X1; elim id; do 2 intro; clear id
       | id: (Corelib.Init.Logic.iff _ _) |- _ => elim id; do 2 intro; clear id
       | id: (Corelib.Init.Logic.not _) |- _ => red in id
@@ -71,7 +79,7 @@ Local Ltac simplif flags :=
 
 Local Ltac tauto_intuit flags t_reduce t_solver :=
  let rec t_tauto_intuit :=
- (simplif flags; axioms flags
+ (simplif flags; eaxioms flags
  || match reverse goal with
     | id:forall(_: forall (_: ?X1), ?X2), ?X3|- _ =>
   cut X3;


### PR DESCRIPTION
The PR makes a minimal modification to the proof-search of `tauto` so that `axioms` are checked for each time a new formula is generated.

+ This may avoid performing a costly proof search (see  https://rocq-prover.zulipchat.com/#narrow/channel/237977-Rocq-users/topic/tauto.20hangs.20even.20though.20goal.20is.20an.20assumption)
+ This may also solve a few more goals e.g
```coq
  Goal forall (A B:Prop) (F: A /\ B -> Prop) (H : A /\ B), F H -> A /\ B.
```
and therefore, this is not backward compatible.
+ This is probably slower on average (checking for axioms scans the whole context over and over again).

PS:  Here are a few possible further optimisations.
- Perform case-split as a last resort i.e move 
  ```coq 
          | id: ?X1 |- _ => is_disj flags X1; elim id; intro; clear id
   ``` 
as the last case. 
- For `tauto`, to prove `A /\ B` , instead of performing a `split`, assert the clause
    `A -> B -> A /\ B`    
- For `tauto`, to prove `A \/ B`, instead of trying `left` and `right`, assert the clauses
   `A -> A \/ B` and `B -> A \/ B` 
- If the conclusion is `False`, turn  hypotheses  `(A -> B) -> C ` into `(A /\ ~ B) \/ C` i.e turn backtracking into a case split.

