### PR TITLE
Allow type ascriptions on recursive Ltac2 tactic definitions.

### DIFF
--- a/doc/changelog/06-Ltac2-language/20629-ltac2-rec-ascr-Added.rst
+++ b/doc/changelog/06-Ltac2-language/20629-ltac2-rec-ascr-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Support for type ascriptions on recursive tactic definitions
+  (`#20629 <https://github.com/rocq-prover/rocq/pull/20629>`_,
+  by Rodolphe Lepigre).

--- a/test-suite/ltac2/typing.v
+++ b/test-suite/ltac2/typing.v
@@ -70,3 +70,7 @@ Print Ltac2 tuple0.
 Fail Ltac2 not_a_value := { contents := 0 }.
 Fail Ltac2 not_a_value := "nope".
 Fail Ltac2 not_a_value := list_length [].
+
+(** Type ascriptions. *)
+Ltac2 rec loop : 'a -> 'b := fun x => loop x.
+Fail Ltac2 rec loop2 : bool -> bool := fun x => if x then loop2 false else 0.


### PR DESCRIPTION
This allows the following:
```coq
Require Import Ltac2.Ltac2.
Ltac2 rec loop : 'a -> 'b := fun x => loop x.
```
which used to fail with:
```
Error: Recursive tactic definitions must be functions
```