### PR TITLE
Fix `Print Ltac2.foo` parsing

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -167,6 +167,7 @@ DELETE: [
 | test_qualid_with_or_lpar_or_rbrac
 | test_leftsquarebracket_equal
 | test_sort_qvar
+| test_ltac2_ident
 ]
 
 (* additional nts to be spliced *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -696,7 +696,7 @@ command: [
 | "Ltac2" ltac2_entry      (* ltac2 plugin *)
 | "Ltac2" "Notation" ltac2def_syn      (* ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr6      (* ltac2 plugin *)
-| "Print" "Ltac2" reference      (* ltac2 plugin *)
+| "Print" test_ltac2_ident "Ltac2" reference      (* ltac2 plugin *)
 | "Print" "Ltac2" "Type" reference      (* ltac2 plugin *)
 | "Locate" "Ltac2" reference      (* ltac2 plugin *)
 | "Print" "Ltac2" "Signatures"      (* ltac2 plugin *)
@@ -3330,6 +3330,10 @@ tac2mode: [
 | "par" ":" ltac2_expr6 ltac2_use_default      (* ltac2 plugin *)
 | subprf      (* ltac2 plugin *)
 | OPT toplevel_selector subprf_with_selector      (* ltac2 plugin *)
+]
+
+test_ltac2_ident: [
+| test_ltac2_ident_aux      (* ltac2 plugin *)
 ]
 
 ltac1_expr_in_env: [

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1076,10 +1076,20 @@ END
 
 open Stdarg
 
+let test_ltac2_ident_aux =
+  let open Procq.Lookahead in
+  to_entry "test_ltac2_ident" begin
+    lk_kw "Ltac2" >> lk_ident
+  end
+
 }
 
+VERNAC ARGUMENT EXTEND test_ltac2_ident PRINTED BY { fun _ -> Pp.mt() }
+| [ test_ltac2_ident_aux(x) ] -> { x }
+END
+
 VERNAC COMMAND EXTEND Ltac2Printers CLASSIFIED AS QUERY
-| [ "Print" "Ltac2" reference(tac) ] -> { Tac2entries.print_ltac2 tac }
+| [ "Print" test_ltac2_ident(_test) "Ltac2" reference(tac) ] -> { Tac2entries.print_ltac2 tac }
 | [ "Print" "Ltac2" "Type" reference(tac) ] -> { Tac2entries.print_ltac2_type tac }
 | [ "Locate" "Ltac2" reference(r) ] -> { Tac2entries.print_located_tactic r }
 | [ "Print" "Ltac2" "Signatures" ] -> { Tac2entries.print_signatures () }

--- a/test-suite/bugs/bug_19424.v
+++ b/test-suite/bugs/bug_19424.v
@@ -1,0 +1,4 @@
+Require Import Ltac2.Ltac2.
+
+Print Ltac2.Control.throw.
+(* Error: Syntax error: 'Signatures' or 'Type' or [reference] expected after 'Ltac2' (in [command]). *)


### PR DESCRIPTION
Fix #19424