### PR TITLE
Use `;` instead of `|` to separate sorts and univs (eg `Type@{s;u}`)

### DIFF
--- a/doc/changelog/02-specification-language/20635-new-sort-sep-syntax-Added.rst
+++ b/doc/changelog/02-specification-language/20635-new-sort-sep-syntax-Added.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  in :ref:`sort polymorphic <sort-polymorphism>` instances, sorts can be separated from universes using `;` instead of `|`.
+  This is less ambiguous as `|` is also used to separate universes and constraints when declaring sort polymorphic objects,
+  and in such declarations when constraints are unspecified it allows omitting the `|`
+  (`Definition foo@{s;u} := ...` instead of `Definition foo@{s|u|+} := ...`)
+  (`#20635 <https://github.com/rocq-prover/rocq/pull/20635>`_,
+  by Gaëtan Gilbert).

--- a/doc/changelog/02-specification-language/20635-new-sort-sep-syntax-Deprecated.rst
+++ b/doc/changelog/02-specification-language/20635-new-sort-sep-syntax-Deprecated.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  in :ref:`sort polymorphic <sort-polymorphism>` instances, separating sorts from universes using `|` instead of `;` (the later being possible since this version)
+  (`#20635 <https://github.com/rocq-prover/rocq/pull/20635>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -530,15 +530,15 @@ Explicit Universes
    universe_name ::= @qualid
    | Set
    | Prop
-   univ_annot ::= @%{ {* @univ_level_or_quality } {? %| {* @univ_level_or_quality } } %}
+   univ_annot ::= @%{ {* @univ_level_or_quality } {? {| %| | ; } {* @univ_level_or_quality } } %}
    univ_level_or_quality ::= Set
    | SProp
    | Prop
    | Type
    | _
    | @qualid
-   univ_decl ::= @%{ {? {* @ident } %| } {* @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
-   cumul_univ_decl ::= @%{ {? {* @ident } %| } {* {? {| + | = | * } } @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
+   univ_decl ::= @%{ {? {* @ident } {| %| | ; } } {* @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
+   cumul_univ_decl ::= @%{ {? {* @ident } {| %| | ; } } {* {? {| + | = | * } } @ident } {? + } {? %| {*, @univ_constraint } {? + } } %}
    univ_constraint ::= @universe_name {| < | = | <= } @universe_name
 
 The syntax has been extended to allow users to explicitly bind names
@@ -800,22 +800,30 @@ All sort quality variables must be explicitly bound.
 
 .. rocqtop:: all
 
-   Polymorphic Definition sort@{s | u |} := Type@{s|u}.
+   Polymorphic Definition sort@{s ; u} := Type@{s;u}.
 
-To help the parser, both `|` in the :n:`@univ_decl` are required.
+.. note::
+
+   The following deprecated syntax is equivalent:
+
+   .. rocqtop:: all warn
+
+      Polymorphic Definition sort'@{s | u |} := Type@{s|u}.
+
+   To help the parser, both `|` in the :n:`@univ_decl` are required.
 
 Sort quality variables of a sort polymorphic definition may be
 instantiated by the concrete values `SProp`, `Prop` and `Type` or by a
 bound variable.
 
-Instantiating `s` in `Type@{s|u}` with the impredicative `Prop` or
+Instantiating `s` in `Type@{s;u}` with the impredicative `Prop` or
 `SProp` produces `Prop` or `SProp` respectively regardless of the
 instantiation fof `u`.
 
 .. rocqtop:: all
 
-   Eval cbv in sort@{Prop|Set}.
-   Eval cbv in sort@{Type|Set}.
+   Eval cbv in sort@{Prop;Set}.
+   Eval cbv in sort@{Type;Set}.
 
 When no explicit instantiation is provided or `_` is used, a temporary
 variable is generated. Temporary sort variables are instantiated with
@@ -856,7 +864,7 @@ For instance
 
    Set Universe Polymorphism.
 
-   Inductive Squash@{s|u|} (A:Type@{s|u}) : Prop := squash (_:A).
+   Inductive Squash@{s;u} (A:Type@{s;u}) : Prop := squash (_:A).
 
 Elimination to `Prop` and `SProp` is always allowed, so `Squash_ind`
 and `Squash_sind` are automatically defined.
@@ -868,12 +876,12 @@ However elimination to `Type` or to a polymorphic sort with `s := Prop` is allow
 
 .. rocqtop:: all
 
-   Definition Squash_Prop_rect A (P:Squash@{Prop|_} A -> Type)
+   Definition Squash_Prop_rect A (P:Squash@{Prop;_} A -> Type)
      (H:forall x, P (squash _ x))
      : forall s, P s
      := fun s => match s with squash _ x => H x end.
 
-   Definition Squash_Prop_srect@{s|u +|} A (P:Squash@{Prop|_} A -> Type@{s|u})
+   Definition Squash_Prop_srect@{s;u +} A (P:Squash@{Prop;_} A -> Type@{s;u})
      (H:forall x, P (squash _ x))
      : forall s, P s
      := fun s => match s with squash _ x => H x end.
@@ -888,8 +896,8 @@ However elimination to `Type` or to a polymorphic sort with `s := Prop` is allow
    .. rocqtop:: all
 
       Set Primitive Projections.
-      Record sigma@{s|u v|} (A:Type@{s|u}) (B:A -> Type@{s|v})
-        : Type@{s|max(u,v)}
+      Record sigma@{s;u v} (A:Type@{s;u}) (B:A -> Type@{s;v})
+        : Type@{s;max(u,v)}
         := pair { pr1 : A; pr2 : B pr1 }.
 
 Explicit Sorts
@@ -933,19 +941,19 @@ Similar to universes, fresh global sorts can be declared with the :cmd:`Sort`.
     Print Sorts.
 
     (* Universe of g-sorted type. *)
-    Definition G@{l|} : Type@{l+1} := Type@{g|l}.
+    Definition G@{l|} : Type@{l+1} := Type@{g;l}.
 
     Section LocalSorts.
       Sort u v w.
 
-      Definition arr2@{l|} (A : Type@{u|l}) (B : Type@{v|l}) (C : Type@{w|l}) : Type@{w|l} :=
+      Definition arr2@{l|} (A : Type@{u;l}) (B : Type@{v;l}) (C : Type@{w;l}) : Type@{w;l} :=
         A -> B -> C.
 
       Print Sorts.
 
       Sort x y.
 
-      Definition arr1@{l|} (X : Type@{x|l}) (Y : Type@{y|l}) : Type@{y|l} :=
+      Definition arr1@{l|} (X : Type@{x;l}) (Y : Type@{y;l}) : Type@{y;l} :=
         X -> Y.
 
       Print Sorts.
@@ -956,7 +964,7 @@ Similar to universes, fresh global sorts can be declared with the :cmd:`Sort`.
     Print Sorts.
 
     (* Equivalent definition of arr2 outside the section LocalSorts. *)
-    Definition arr2'@{u v w | l |} (A : Type@{u|l}) (B : Type@{v|l}) (C : Type@{w|l}) : Type@{w|l} :=
+    Definition arr2'@{u v w ; l |} (A : Type@{u;l}) (B : Type@{v;l}) (C : Type@{w;l}) : Type@{w;l} :=
         A -> B -> C.
 
     (* All sort declarations of the section are bound, even the unused one. *)

--- a/doc/sphinx/language/core/sorts.rst
+++ b/doc/sphinx/language/core/sorts.rst
@@ -17,7 +17,7 @@ Sorts
    | SProp
    | Type
    | Type @%{ _ %}
-   | Type @%{ {? @qualid %| } @universe %}
+   | Type @%{ {? @qualid {| %| | ; } } @universe %}
    universe ::= max ( {+, @universe_expr } )
    | _
    | @universe_expr

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -166,8 +166,12 @@ DELETE: [
 | test_variance_ident
 | test_qualid_with_or_lpar_or_rbrac
 | test_leftsquarebracket_equal
+| test_old_sort_qvar
 | test_sort_qvar
 | test_ltac2_ident
+| test_doublepipe_univ_decl
+| test_doublepipe_cumul_univ_decl
+| test_semicolon_cumul_univ_decl
 ]
 
 (* additional nts to be spliced *)
@@ -329,9 +333,10 @@ scope_delimiter: [
 ]
 
 sort: [
-| REPLACE "Type" "@{" reference "|" universe "}"
-| WITH "Type" "@{" OPT [ qualid "|" ] universe "}"
+| REPLACE "Type" "@{" reference ";" universe "}"
+| WITH "Type" "@{" OPT [ qualid [ "|" | ";" ] ] universe "}"
 | DELETE "Type" "@{" universe "}"
+| DELETE "Type" "@{" reference "|" universe "}"
 ]
 
 term100: [
@@ -642,15 +647,17 @@ inline: [
 ]
 
 univ_decl: [
-| REPLACE "@{" test_univ_decl LIST0 identref "|" LIST0 identref [ "+" | ] univ_decl_constraints
-| WITH    "@{" OPT [ LIST0 identref "|" ] LIST0 identref  OPT "+"  OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
+| REPLACE "@{" LIST0 identref ";" LIST0 identref [ "+" | ] univ_decl_constraints
+| WITH    "@{" OPT [ LIST0 identref [ "|" | ";" ] ] LIST0 identref  OPT "+"  OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
 | DELETE "@{" LIST0 identref [ "+" | ] univ_decl_constraints
+| DELETE "@{" LIST0 identref "|" LIST0 identref [ "+" | ] univ_decl_constraints
 ]
 
 cumul_univ_decl: [
-| REPLACE "@{" test_cumul_univ_decl LIST0 identref "|" LIST0 variance_identref [ "+" | ] univ_decl_constraints
-| WITH "@{" OPT [ LIST0 identref "|" ] LIST0 variance_identref    OPT "+"   OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
+| REPLACE "@{" LIST0 identref ";" LIST0 variance_identref [ "+" | ] univ_decl_constraints
+| WITH "@{" OPT [ LIST0 identref [ "|" | ";" ] ] LIST0 variance_identref    OPT "+"   OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
 | DELETE "@{" LIST0 variance_identref [ "+" | ] univ_decl_constraints
+| DELETE "@{" LIST0 identref "|" LIST0 variance_identref [ "+" | ] univ_decl_constraints
 ]
 
 of_type: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -27,7 +27,8 @@ sort: [
 | "SProp"
 | "Type"
 | "Type" "@{" "_" "}"
-| "Type" "@{" test_sort_qvar reference "|" universe "}"
+| "Type" "@{" test_old_sort_qvar reference "|" universe "}"
+| "Type" "@{" test_sort_qvar reference ";" universe "}"
 | "Type" "@{" universe "}"
 ]
 
@@ -184,7 +185,7 @@ evar_instance: [
 ]
 
 univ_annot: [
-| "@{" LIST0 univ_level_or_quality OPT [ "|" LIST0 univ_level_or_quality ] "}"
+| "@{" LIST0 univ_level_or_quality OPT [ [ "|" | ";" ] LIST0 univ_level_or_quality ] "}"
 |
 ]
 
@@ -954,7 +955,8 @@ univ_decl_constraints: [
 ]
 
 univ_decl: [
-| "@{" test_univ_decl LIST0 identref "|" LIST0 identref [ "+" | ] univ_decl_constraints
+| "@{" test_doublepipe_univ_decl LIST0 identref "|" LIST0 identref [ "+" | ] univ_decl_constraints
+| "@{" LIST0 identref ";" LIST0 identref [ "+" | ] univ_decl_constraints
 | "@{" LIST0 identref [ "+" | ] univ_decl_constraints
 ]
 
@@ -970,7 +972,8 @@ variance_identref: [
 ]
 
 cumul_univ_decl: [
-| "@{" test_cumul_univ_decl LIST0 identref "|" LIST0 variance_identref [ "+" | ] univ_decl_constraints
+| "@{" test_doublepipe_cumul_univ_decl LIST0 identref "|" LIST0 variance_identref [ "+" | ] univ_decl_constraints
+| "@{" test_semicolon_cumul_univ_decl LIST0 identref ";" LIST0 variance_identref [ "+" | ] univ_decl_constraints
 | "@{" LIST0 variance_identref [ "+" | ] univ_decl_constraints
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -280,7 +280,7 @@ sort: [
 | "SProp"
 | "Type"
 | "Type" "@{" "_" "}"
-| "Type" "@{" OPT [ qualid "|" ] universe "}"
+| "Type" "@{" OPT [ qualid [ "|" | ";" ] ] universe "}"
 ]
 
 universe: [
@@ -300,7 +300,7 @@ universe_name: [
 ]
 
 univ_annot: [
-| "@{" LIST0 univ_level_or_quality OPT [ "|" LIST0 univ_level_or_quality ] "}"
+| "@{" LIST0 univ_level_or_quality OPT [ [ "|" | ";" ] LIST0 univ_level_or_quality ] "}"
 ]
 
 univ_level_or_quality: [
@@ -313,11 +313,11 @@ univ_level_or_quality: [
 ]
 
 univ_decl: [
-| "@{" OPT [ LIST0 ident "|" ] LIST0 ident OPT "+" OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
+| "@{" OPT [ LIST0 ident [ "|" | ";" ] ] LIST0 ident OPT "+" OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
 ]
 
 cumul_univ_decl: [
-| "@{" OPT [ LIST0 ident "|" ] LIST0 ( OPT [ "+" | "=" | "*" ] ident ) OPT "+" OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
+| "@{" OPT [ LIST0 ident [ "|" | ";" ] ] LIST0 ( OPT [ "+" | "=" | "*" ] ident ) OPT "+" OPT [ "|" LIST0 univ_constraint SEP "," OPT "+" ] "}"
 ]
 
 univ_constraint: [

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -174,7 +174,7 @@ struct
       let v = Option.map (fun v -> v.(i)) variance in
       pr_opt_no_spc Variance.pr v ++ prl u
     in
-    (if Array.is_empty q then mt() else prvect_with_sep spc (Quality.pr prq) q ++ strbrk " | ")
+    (if Array.is_empty q then mt() else prvect_with_sep spc (Quality.pr prq) q ++ strbrk " ; ")
     ++ prvecti_with_sep spc ppu u
 
   let equal (xq,xu) (yq,yu) =

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -80,11 +80,21 @@ let test_array_closing =
     lk_kw "|" >> lk_kw "]" >> check_no_space
   end
 
+let test_old_sort_qvar =
+  let open Procq.Lookahead in
+  to_entry "test_old_sort_qvar" begin
+    lk_ident >> lk_list lk_field >> lk_kw "|"
+  end
+
 let test_sort_qvar =
   let open Procq.Lookahead in
   to_entry "test_sort_qvar" begin
-    lk_ident >> lk_list lk_field >> lk_kw "|"
+    lk_ident >> lk_list lk_field >> lk_kw ";"
   end
+
+let warn_old_sort_syntax =
+  CWarnings.create ~name:"deprecated-sort-poly-syntax" ~category:Deprecation.Version.v9_1
+    Pp.(fun () -> fmt "Separating sorts from universes with \"|\" is deprecated.@ Use \";\" instead.")
 
 type univ_level_or_quality =
   | SProp | Prop | Set | Type | Anon of Loc.t | Global of Libnames.qualid
@@ -139,8 +149,13 @@ GRAMMAR EXTEND Gram
       | "SProp" -> { None, UNamed [CSProp, 0] }
       | "Type" -> { None, UAnonymous {rigid=UnivRigid} }
       | "Type"; "@{"; "_"; "}" -> { None, UAnonymous {rigid=UnivFlexible false} }
-      | "Type"; "@{"; test_sort_qvar; q = reference; "|"; u = universe; "}" ->
-        { Some (CQVar q), u }
+      | "Type"; "@{"; test_old_sort_qvar; q = reference; pipe_loc = [ "|" -> { loc } ]; u = universe; "}" -> {
+          warn_old_sort_syntax ~loc:pipe_loc ();
+          Some (CQVar q), u
+        }
+      | "Type"; "@{"; test_sort_qvar; q = reference; ";"; u = universe; "}" -> {
+          Some (CQVar q), u
+        }
       | "Type"; "@{"; u = universe; "}" -> { None, u } ] ]
   ;
   sort_quality_or_set:
@@ -312,11 +327,13 @@ GRAMMAR EXTEND Gram
       | -> { [] } ] ]
   ;
   univ_annot:
-    [ [ "@{"; l = LIST0 univ_level_or_quality; l' = OPT [ "|"; l' = LIST0 univ_level_or_quality -> { l' } ]; "}" ->
+    [ [ "@{"; l = LIST0 univ_level_or_quality; l' = OPT [ is_pipe = [ "|" -> { Some loc } | ";" -> { None } ]; l' = LIST0 univ_level_or_quality -> { is_pipe, l' } ]; "}" ->
         {
           let l, l' = match l' with
             | None -> [], List.map (force_univ_level ~loc) l
-            | Some l' -> List.map (force_quality ~loc) l, List.map (force_univ_level ~loc) l'
+            | Some (is_pipe, l') ->
+              let () = Option.iter (fun loc -> warn_old_sort_syntax ~loc ()) is_pipe in
+              List.map (force_quality ~loc) l, List.map (force_univ_level ~loc) l'
           in
           Some (l,l')
         }

--- a/parsing/g_constr.mli
+++ b/parsing/g_constr.mli
@@ -14,3 +14,5 @@ val ensure_fixannot : unit Procq.Entry.t
 val test_name_colon : unit Procq.Entry.t
 val test_array_opening : unit Procq.Entry.t
 val test_array_closing : unit Procq.Entry.t
+
+val warn_old_sort_syntax : ?loc:Loc.t -> unit -> unit

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -220,7 +220,7 @@ let pr_quality_expr q = match q with
 
 let pr_quality_univ (q, l) = match q with
   | None -> pr_univ l
-  | Some q ->  pr_qvar_expr q ++ spc() ++ str "|" ++ spc () ++ pr_univ l
+  | Some q ->  pr_qvar_expr q ++ spc() ++ str ";" ++ spc () ++ pr_univ l
 
 let pr_univ_annot pr x = str "@{" ++ pr x ++ str "}"
 
@@ -248,7 +248,7 @@ let pr_patvar = pr_id
 
 let pr_inside_universe_instance (ql,ul) =
   (if List.is_empty ql then mt()
-   else prlist_with_sep spc pr_quality_expr ql ++ strbrk " | ")
+   else prlist_with_sep spc pr_quality_expr ql ++ strbrk " ; ")
   ++ prlist_with_sep spc pr_univ_level_expr ul
 
 let pr_universe_instance l =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -288,10 +288,7 @@ let pr_universe_instance_binder evd inst csts =
   let open Univ in
   let prqvar = Termops.pr_evd_qvar evd in
   let prlev = Termops.pr_evd_level evd in
-  let pcsts = if Constraints.is_empty csts then begin
-      if fst (UVars.Instance.length inst) = 0 then mt()
-      else str " |"
-    end
+  let pcsts = if Constraints.is_empty csts then mt()
     else strbrk " | " ++
          prlist_with_sep pr_comma
            (fun (u,d,v) -> hov 0 (prlev u ++ pr_constraint_type d ++ prlev v))

--- a/test-suite/bugs/bug_18314.v
+++ b/test-suite/bugs/bug_18314.v
@@ -12,7 +12,7 @@ Section Well_founded.
 
  Global Arguments Acc_inv [x] _ [y] _, [x] _ y _.
 
- Fail Polymorphic Definition Fix_F@{s|u|} (P:A -> Type@{s|u}) (F:forall {x:A}, (forall y:A, R y x -> P y) -> P x)
+ Fail Polymorphic Definition Fix_F@{s;u|} (P:A -> Type@{s;u}) (F:forall {x:A}, (forall y:A, R y x -> P y) -> P x)
    := fix Fix_F {x:A} (a:Acc x) {struct a} : P x :=
      F (fun (y:A) (h:R y x) => Fix_F (Acc_inv a h)).
 

--- a/test-suite/bugs/bug_18455.v
+++ b/test-suite/bugs/bug_18455.v
@@ -1,15 +1,15 @@
 Set Universe Polymorphism.
 Set Implicit Arguments.
-Cumulative Record prod@{s|*a *b|} (A : Type@{s|a}) (B : Type@{s|b}) : Type@{s|max(a,b)} := pair {
+Cumulative Record prod@{s;*a *b|} (A : Type@{s;a}) (B : Type@{s;b}) : Type@{s;max(a,b)} := pair {
   fst : A;
   snd : B
   }.
-Definition flip_prod@{s|a b|} [A : Type@{s|a}] [B : Type@{s|b}] (v : prod A B) : prod B A
+Definition flip_prod@{s;a b|} [A : Type@{s;a}] [B : Type@{s;b}] (v : prod A B) : prod B A
   := {| fst := snd v; snd := fst v |}.
 
 (* We need to specify univs here (maybe will be fixed someday?) *)
 Fail Definition and@{|} : Prop -> Prop -> Prop := prod.
-Definition and@{|} : Prop -> Prop -> Prop := prod@{Prop|Set Set}.
+Definition and@{|} : Prop -> Prop -> Prop := prod@{Prop;Set Set}.
 
 (* but not here (with minim to set on) *)
 Definition conj@{|} : forall [A B : Prop], A -> B -> and A B := pair.

--- a/test-suite/bugs/bug_18594.v
+++ b/test-suite/bugs/bug_18594.v
@@ -1,6 +1,6 @@
 Set Universe Polymorphism.
 
-Lemma foo@{s| |} (A:Type@{s|Set}) (a:A) : A.
+Lemma foo@{s; |} (A:Type@{s;Set}) (a:A) : A.
 Proof.
   exact a.
 Qed.

--- a/test-suite/bugs/bug_18831.v
+++ b/test-suite/bugs/bug_18831.v
@@ -2,7 +2,7 @@
 
 Set Universe Polymorphism.
 
-Inductive and@{s|u v|} (A:Type@{s|u}) (B:Type@{s|v}) : Type@{s|max(u,v)} := conj (_:A) (_:B).
+Inductive and@{s;u v|} (A:Type@{s;u}) (B:Type@{s;v}) : Type@{s;max(u,v)} := conj (_:A) (_:B).
 
 Lemma foo (A B:Prop) (x:and A B) : A.
 Proof.

--- a/test-suite/bugs/bug_18845.v
+++ b/test-suite/bugs/bug_18845.v
@@ -1,9 +1,9 @@
 Set Universe Polymorphism.
 
-Inductive Box@{s|u|} (A:Type@{s|u}) := box (_:A).
+Inductive Box@{s;u|} (A:Type@{s;u}) := box (_:A).
 
-Definition t1@{s|u|} (A:Type@{s|u}) (x y : A) := box _ x.
-Definition t2@{s|u|} (A:Type@{s|u}) (x y : A) := box _ y.
+Definition t1@{s;u|} (A:Type@{s;u}) (x y : A) := box _ x.
+Definition t2@{s;u|} (A:Type@{s;u}) (x y : A) := box _ y.
 
 Check fun A:SProp => eq_refl : t1 A = t2 A. (* What is in "test-suite/success/sort_polymorphism.v" *)
 Check fun (A : SProp) => (fun (x : t1 A = t2 A) => x) eq_refl. (* Slight variation *)

--- a/test-suite/bugs/bug_18978.v
+++ b/test-suite/bugs/bug_18978.v
@@ -3,15 +3,15 @@ Set Universe Polymorphism.
 Set Printing Universes.
 
 (* Fully explicit definition: we would like to spare the annotation u *)
-Definition id@{s|u|} (A : Type@{s|u}) (a : A) : A := a.
+Definition id@{s;u|} (A : Type@{s;u}) (a : A) : A := a.
 
 
 (* Some kind of typical ambiguity can be simulated by rebinding Type to an auxilliary definition T*)
-Definition T@{s|u|} := Type@{s|u}.
-Definition idT@{s|+|} (A : T@{s|_}) (a : A) : A := a.
+Definition T@{s;u|} := Type@{s;u}.
+Definition idT@{s;+|} (A : T@{s;_}) (a : A) : A := a.
 
 (* The actual problem *)
-Definition id0@{s|+|} (A : Type@{s|_}) (a : A) : A := a.
+Definition id0@{s;+|} (A : Type@{s;_}) (a : A) : A := a.
 (*
 Error:
 Syntax error: [universe] expected after '|' (in [sort]).

--- a/test-suite/bugs/bug_19039.v
+++ b/test-suite/bugs/bug_19039.v
@@ -1,11 +1,11 @@
 Set Universe Polymorphism.
 
-Inductive eq@{s|u|} (A:Type@{s|u}) (x:A) : A -> Prop :=
+Inductive eq@{s;u|} (A:Type@{s;u}) (x:A) : A -> Prop :=
   eq_refl : eq A x x.
 
-Inductive bool@{s| |} : Type@{s|Set} := true | false.
+Inductive bool@{s; |} : Type@{s;Set} := true | false.
 
-Lemma foo@{s| |} : forall (b : bool@{s|}),
+Lemma foo@{s; |} : forall (b : bool@{s;}),
     eq _ b true ->
     eq _ match b with
     | true => b

--- a/test-suite/bugs/bug_19072.v
+++ b/test-suite/bugs/bug_19072.v
@@ -1,15 +1,15 @@
 Set Universe Polymorphism.
 
-Definition demo@{srt|u |} : True.
+Definition demo@{srt;u |} : True.
 Proof.
   abstract exact I.
 Defined.
 
 (* abstract doesn't restrict named qualities and universes
    (debatable behaviour but that's what it does currently) *)
-Check demo@{Type|Set}.
+Check demo@{Type;Set}.
 
-Definition baz@{q|u|} (A:Type@{q|u}) (x:A) : A.
+Definition baz@{q;u|} (A:Type@{q;u}) (x:A) : A.
 Proof.
   abstract exact x.
 Defined.

--- a/test-suite/bugs/bug_19203.v
+++ b/test-suite/bugs/bug_19203.v
@@ -1,18 +1,18 @@
 Set Universe Polymorphism.
 
-Inductive bool@{q| |} : Type@{q|Set} := | true : bool | false : bool.
+Inductive bool@{q; |} : Type@{q;Set} := | true : bool | false : bool.
 
-Definition nand@{q| |} (a b : bool@{q|}) : bool@{q|} :=
+Definition nand@{q; |} (a b : bool@{q;}) : bool@{q;} :=
   match a , b with
   | true , true => false
   | _ , _ => true
   end.
 
-Inductive seq@{q|u|} {A : Type@{q|u}} (a : A) : A -> Type@{q|u} := | srefl : seq a a.
+Inductive seq@{q;u|} {A : Type@{q;u}} (a : A) : A -> Type@{q;u} := | srefl : seq a a.
 Arguments srefl {_ _}.
 
-Definition seq_elim@{q|u v|} :=
-  fun (A : Type@{q|u}) (x : A) (P : A -> Type@{q|v}) (f : P x) (a : A) (e : seq x a) =>
+Definition seq_elim@{q;u v|} :=
+  fun (A : Type@{q;u}) (x : A) (P : A -> Type@{q;v}) (f : P x) (a : A) (e : seq x a) =>
   match e in (seq _ a0) return (P a0) with
   | srefl => f
   end.
@@ -21,13 +21,13 @@ Register seq as core.eq.type.
 Register srefl as core.eq.refl.
 Register seq_elim as core.eq.rect.
 
-Lemma foo@{q| |} (f : bool@{q|} -> bool@{q|}) (x : bool@{q|}) : seq (f true) (f true).
+Lemma foo@{q; |} (f : bool@{q;} -> bool@{q;}) (x : bool@{q;}) : seq (f true) (f true).
 Proof.
   remember (f true) as b eqn : ftrue.
   reflexivity.
 Qed.
 
-Lemma f3_eq_f@{q| |} (f : bool@{q|} -> bool@{q|}) (x : bool@{q|}) : seq (f (f (f x))) (f x).
+Lemma f3_eq_f@{q; |} (f : bool@{q;} -> bool@{q;}) (x : bool@{q;}) : seq (f (f (f x))) (f x).
 Proof.
   remember (f true) as b eqn : ftrue.
 

--- a/test-suite/bugs/bug_19203_2.v
+++ b/test-suite/bugs/bug_19203_2.v
@@ -1,6 +1,6 @@
 Set Universe Polymorphism.
 
-Inductive eq@{s s'|u|} {A:Type@{s|u}} (a:A) : A -> Type@{s'|Set} := refl : eq a a.
+Inductive eq@{s s';u|} {A:Type@{s;u}} (a:A) : A -> Type@{s';Set} := refl : eq a a.
 
 Register eq as core.eq.type.
 Register refl as core.eq.refl.

--- a/test-suite/bugs/bug_19215.v
+++ b/test-suite/bugs/bug_19215.v
@@ -24,7 +24,7 @@ Notation "~ x" := (not x) : type_scope.
 
 Register not as core.not.type.
 
-Polymorphic Inductive eq@{s s'|u v|} (A:Type@{s|u}) (x:A) : A -> Type@{s'|v} :=
+Polymorphic Inductive eq@{s s';u v|} (A:Type@{s;u}) (x:A) : A -> Type@{s';v} :=
     eq_refl : x = x :>A
 
 where "x = y :> A" := (@eq A x y) : type_scope.
@@ -32,15 +32,15 @@ where "x = y :> A" := (@eq A x y) : type_scope.
 Arguments eq {A} x _.
 Arguments eq_refl {A x} , [A] x.
 
-Polymorphic Definition eq_elim@{s s' | u v w |} [A:Type@{s|u}] [x:A]
-  (P : forall a : A, x = a :> A -> Type@{s'|w}) :
-  P x (eq_refl@{s s'|u v} x) -> forall [a : A] (e : x = a :> A), P a e :=
+Polymorphic Definition eq_elim@{s s' ; u v w |} [A:Type@{s;u}] [x:A]
+  (P : forall a : A, x = a :> A -> Type@{s';w}) :
+  P x (eq_refl@{s s';u v} x) -> forall [a : A] (e : x = a :> A), P a e :=
   fun t _ e => match e with eq_refl => t end.
 
-Polymorphic Definition eq_ind@{s | u|} [A] [x] P := @eq_elim@{s Prop|u Set Set} A x (fun a _ => P a).
+Polymorphic Definition eq_ind@{s ; u|} [A] [x] P := @eq_elim@{s Prop;u Set Set} A x (fun a _ => P a).
 
-Polymorphic Definition eq_singleton@{s s' | u v|} [A:Type@{s|u}] [x:A]
-  (P : forall a : A, (eq@{s Prop|u Set} x a) -> Type@{s'|v}) :
+Polymorphic Definition eq_singleton@{s s' ; u v|} [A:Type@{s;u}] [x:A]
+  (P : forall a : A, (eq@{s Prop;u Set} x a) -> Type@{s';v}) :
   P x (eq_refl x) -> forall [a : A] (e : x = a :> A), P a e :=
   fun t _ e => match e with eq_refl => t end.
 
@@ -61,7 +61,7 @@ Arguments eq_sind [A] x P _ y _ : rename.
 Arguments eq_rec [A] x P _ y _ : rename.
 Arguments eq_rect [A] x P _ y _ : rename.
 
-Notation "x = y" := (eq@{_ Prop|_ Set} x y) : type_scope.
+Notation "x = y" := (eq@{_ Prop;_ Set} x y) : type_scope.
 Notation "x <> y  :> T" := (~ x = y :>T) : type_scope.
 Notation "x <> y" := (~ (x = y)) : type_scope.
 
@@ -76,21 +76,21 @@ Register eq_elim as core.eq.rect.
 
   Section equality.
 
-    Theorem eq_sym@{s|u|} (A : Type@{s|u}) (x y : A) : x = y -> y = x.
+    Theorem eq_sym@{s;u|} (A : Type@{s;u}) (x y : A) : x = y -> y = x.
     Proof.
       destruct 1; trivial.
     Defined.
 
     Register eq_sym as core.eq.sym.
 
-    Theorem eq_trans@{s|u|} (A : Type@{s|u}) (x y z : A) : x = y -> y = z -> x = z.
+    Theorem eq_trans@{s;u|} (A : Type@{s;u}) (x y z : A) : x = y -> y = z -> x = z.
     Proof.
       destruct 2; trivial.
     Defined.
 
     Register eq_trans as core.eq.trans.
 
-    Theorem f_equal@{s s'|u v|} (A : Type@{s|u}) (B : Type@{s'|v})
+    Theorem f_equal@{s s';u v|} (A : Type@{s;u}) (B : Type@{s';v})
       (x y : A) (f : A -> B) : x = y -> f x = f y.
     Proof.
       destruct 1; trivial.

--- a/test-suite/bugs/bug_19231.v
+++ b/test-suite/bugs/bug_19231.v
@@ -1,3 +1,3 @@
 Set Universe Polymorphism.
 
-Fail Lemma vroom@{q| |} : (True : Type@{q|_}).
+Fail Lemma vroom@{q; |} : (True : Type@{q;_}).

--- a/test-suite/bugs/bug_19325.v
+++ b/test-suite/bugs/bug_19325.v
@@ -1,7 +1,7 @@
 Set Universe Polymorphism.
 
-Definition relation@{s|u|} (A : Type@{s|u}) := A -> Set.
-Axiom fail@{a s|a u+|+} : forall {A : Type@{s|u}}, relation@{s|u} (A -> A).
+Definition relation@{s;u|} (A : Type@{s;u}) := A -> Set.
+Axiom fail@{a s;a u+|+} : forall {A : Type@{s;u}}, relation@{s;u} (A -> A).
 
 Arguments fail {A}%_type _.
 

--- a/test-suite/bugs/bug_19327.v
+++ b/test-suite/bugs/bug_19327.v
@@ -1,6 +1,6 @@
 Set Universe Polymorphism.
 
-Inductive Box@{s|u|} (A:Type@{s|u}) : Type@{s|u} :=
+Inductive Box@{s;u|} (A:Type@{s;u}) : Type@{s;u} :=
 | box : A -> Box A.
 Arguments box {_} _.
 

--- a/test-suite/bugs/bug_19872.v
+++ b/test-suite/bugs/bug_19872.v
@@ -1,4 +1,4 @@
-Polymorphic Inductive eq@{s s'|l +|} {A:Type@{s|l}} (x:A) : A -> Type@{s'|_} :=
+Polymorphic Inductive eq@{s s';l +|} {A:Type@{s;l}} (x:A) : A -> Type@{s';_} :=
   eq_refl : eq x x.
 
 Check eq 0 0 : SProp.

--- a/test-suite/bugs/bug_20261.v
+++ b/test-suite/bugs/bug_20261.v
@@ -1,5 +1,5 @@
 
 Set Universe Polymorphism.
-Lemma foo@{s|u|} : True.
-Check Type@{s|u}.
+Lemma foo@{s;u|} : True.
+Check Type@{s;u}.
 Abort.

--- a/test-suite/bugs/bug_7723.v
+++ b/test-suite/bugs/bug_7723.v
@@ -47,13 +47,13 @@ End LocalClosure.
 
 Module QVar.
 
-  Definition bar@{q|i|} := Type@{q|i}.
+  Definition bar@{q;i|} := Type@{q;i}.
 
-  Definition gbar@{q1 q2|i j|} := bar@{q2|i}.
+  Definition gbar@{q1 q2;i j|} := bar@{q2;i}.
 
   Eval vm_compute in gbar.
 
-  Definition gprop := Eval vm_compute in gbar@{Type Prop|Set Set}.
+  Definition gprop := Eval vm_compute in gbar@{Type Prop;Set Set}.
   Check eq_refl : gprop = Prop.
 
 End QVar.

--- a/test-suite/output/DebugRelevances.out
+++ b/test-suite/output/DebugRelevances.out
@@ -13,12 +13,12 @@ fun (A : (* Relevant *) SProp) (a : (* Irrelevant *) A) => a
      : forall A : (* Relevant *) SProp, A -> A
 
 Arguments bar A%_type_scope a
-baz@{s | u |} =
+baz@{s ; u} =
 fun (A : (* Relevant *) Type) (a : (* s *) A) => a
      : forall A : (* Relevant *) Type, A -> A
 
 Arguments baz A%_type_scope a
-boz@{s s' | u |} =
+boz@{s s' ; u} =
 fun (A B : (* Relevant *) Type) (a : (* s *) hide) (_ : (* s' *) hide) => a
      : forall A B : (* Relevant *) Type, hide -> hide -> hide
 

--- a/test-suite/output/DebugRelevances.v
+++ b/test-suite/output/DebugRelevances.v
@@ -5,10 +5,10 @@ Set Printing Relevance Marks.
 Definition foo (A:Type) (a:A) := a.
 Definition foo' (A:Prop) (a:A) := a.
 Definition bar (A:SProp) (a:A) := a.
-Definition baz@{s|u|} (A:Type@{s|u}) (a:A) := a.
+Definition baz@{s;u|} (A:Type@{s;u}) (a:A) := a.
 
-Definition hide@{s|u|} {A:Type@{s|u}} := A.
-Definition boz@{s s'|u|} (A:Type@{s|u}) (B:Type@{s'|u}) (a:@hide A) (b:@hide B) := a.
+Definition hide@{s;u|} {A:Type@{s;u}} := A.
+Definition boz@{s s';u|} (A:Type@{s;u}) (B:Type@{s';u}) (a:@hide A) (b:@hide B) := a.
 
 Print foo.
 Print foo'.

--- a/test-suite/output/DeclareSort.out
+++ b/test-suite/output/DeclareSort.out
@@ -1,16 +1,16 @@
 File "./output/DeclareSort.v", line 4, characters 35-36:
 The command has indeed failed with message:
 In environment
-A : Type@{s | _}
-The term "A" has type "Type@{s | _}" while it is expected to have type
- "Type@{s' | _}"
+A : Type@{s ; _}
+The term "A" has type "Type@{s ; _}" while it is expected to have type
+ "Type@{s' ; _}"
 (universe inconsistency: Cannot enforce Type@{s | Set} <=
 Type@{s' | DeclareSort.21}).
 File "./output/DeclareSort.v", line 6, characters 35-36:
 The command has indeed failed with message:
 In environment
-A : Type@{s | _}
-The term "A" has type "Type@{s | _}" while it is expected to have type 
+A : Type@{s ; _}
+The term "A" has type "Type@{s ; _}" while it is expected to have type 
 "Type" (universe inconsistency: Cannot enforce Type@{s | Set} <=
 DeclareSort.22).
 File "./output/DeclareSort.v", line 8, characters 26-27:
@@ -18,41 +18,41 @@ The command has indeed failed with message:
 In environment
 A : Set
 The term "A" has type "Set" while it is expected to have type 
-"Type@{s | _}" (universe inconsistency: Cannot enforce Set <=
+"Type@{s ; _}" (universe inconsistency: Cannot enforce Set <=
 Type@{s | DeclareSort.23}).
-fun A : Type@{s | _} => A : Type@{s | _}
-     : Type@{s | _} -> Type@{s | _}
+fun A : Type@{s ; _} => A : Type@{s ; _}
+     : Type@{s ; _} -> Type@{s ; _}
 foo
-     : Type@{S1 | _} -> Type@{S2 | _}
-foo@{S2 |  |} : Type -> Type
+     : Type@{S1 ; _} -> Type@{S2 ; _}
+foo@{S2 ; } : Type -> Type
 
 foo is universe polymorphic
 Arguments foo _%_type_scope
 Expands to: Constant DeclareSort.foo
 Declared in library DeclareSort, line 17, characters 8-11
-foo@{S2 |  |} : Type@{S1 | Set} -> Type@{S2 | Set}
-(* S2 |  |=  *)
+foo@{S2 ; } : Type@{S1 ; Set} -> Type@{S2 ; Set}
+(* S2 ;  |=  *)
 
 foo is universe polymorphic
 Arguments foo _%_type_scope
 Expands to: Constant DeclareSort.foo
 Declared in library DeclareSort, line 17, characters 8-11
-foo@{SProp | } : Type@{S1 | Set} -> SProp
-     : Type@{S1 | Set} -> SProp
-foo@{Type | } : Type@{S1 | Set} -> Set
-     : Type@{S1 | Set} -> Set
+foo@{SProp ; } : Type@{S1 ; Set} -> SProp
+     : Type@{S1 ; Set} -> SProp
+foo@{Type ; } : Type@{S1 ; Set} -> Set
+     : Type@{S1 ; Set} -> Set
 File "./output/DeclareSort.v", line 29, characters 11-14:
 The command has indeed failed with message:
-The term "foo@{α6 | }" has type "Type@{S1 | Set} -> Type@{α6 | Set}"
+The term "foo@{α6 ; }" has type "Type@{S1 ; Set} -> Type@{α6 ; Set}"
 while it is expected to have type "SProp -> ?T"
 (universe inconsistency: Cannot enforce SProp <= Type@{S1 | Set}).
 File "./output/DeclareSort.v", line 30, characters 11-14:
 The command has indeed failed with message:
-The term "foo@{α8 | }" has type "Type@{S1 | Set} -> Type@{α8 | Set}"
+The term "foo@{α8 ; }" has type "Type@{S1 ; Set} -> Type@{α8 ; Set}"
 while it is expected to have type "Set -> ?T"
 (universe inconsistency: Cannot enforce Set <= Type@{S1 | Set}).
-foo@{Type | } : Type@{S1 | Set} -> Set
-     : Type@{S1 | Set} -> Set
+foo@{Type ; } : Type@{S1 ; Set} -> Set
+     : Type@{S1 ; Set} -> Set
 File "./output/DeclareSort.v", line 35, characters 4-18:
 The command has indeed failed with message:
 Cannot declare global sort qualities inside module types.

--- a/test-suite/output/DeclareSort.v
+++ b/test-suite/output/DeclareSort.v
@@ -1,20 +1,20 @@
 Sort s.
 Sort s'.
 
-Fail Check fun (A:Type@{s|Set}) => A : Type@{s'|_}.
+Fail Check fun (A:Type@{s;Set}) => A : Type@{s';_}.
 
-Fail Check fun (A:Type@{s|Set}) => A : Type.
+Fail Check fun (A:Type@{s;Set}) => A : Type.
 
-Fail Check fun (A:Set) => A : Type@{s|_}.
+Fail Check fun (A:Set) => A : Type@{s;_}.
 
-Check fun (A:Type@{s|Set}) => A : Type@{s|_}.
+Check fun (A:Type@{s;Set}) => A : Type@{s;_}.
 
 Section S.
   Sort S1.
   Local Set Universe Polymorphism.
   Sort S2.
 
-  Axiom foo : Type@{S1|Set} -> Type@{S2|Set}.
+  Axiom foo : Type@{S1;Set} -> Type@{S2;Set}.
   Check foo.
 
 End S.
@@ -28,7 +28,7 @@ Check foo : _ -> Set.
 
 Fail Check foo : SProp -> _.
 Fail Check foo : Set -> _.
-Check foo : Type@{S1|Set} -> Set.
+Check foo : Type@{S1;Set} -> Set.
 
 Module Type T.
   Module M.

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -47,23 +47,23 @@ sunit is not universe polymorphic
 sunit may only be eliminated to produce values whose type is SProp.
 Expands to: Inductive Inductive.sunit
 Declared in library Inductive, line 38, characters 10-15
-sempty@{q |  |} : Type@{q | Set}
-(* q |  |=  *)
+sempty@{q ; } : Type@{q ; Set}
+(* q ;  |=  *)
 
 sempty is universe polymorphic
-sempty@{q | } may only be eliminated to produce values whose type is in sort quality q,
+sempty@{q ; } may only be eliminated to produce values whose type is in sort quality q,
   unless instantiated such that the quality SProp
   is equal to the instantiation of q, or to qualities smaller
   (SProp <= Prop <= Type, and all variables <= Type)
   than the instantiation of q.
 Expands to: Inductive Inductive.sempty
 Declared in library Inductive, line 44, characters 22-28
-ssig@{q1 q2 q3 | a b |} :
-forall A : Type@{q1 | a}, (A -> Type@{q2 | b}) -> Type@{q3 | max(a,b)}
-(* q1 q2 q3 | a b |=  *)
+ssig@{q1 q2 q3 ; a b} :
+forall A : Type@{q1 ; a}, (A -> Type@{q2 ; b}) -> Type@{q3 ; max(a,b)}
+(* q1 q2 q3 ; a b |=  *)
 
 ssig is universe polymorphic
-ssig@{q1 q2 q3 | a b} may only be eliminated to produce values whose type is in sort quality q3,
+ssig@{q1 q2 q3 ; a b} may only be eliminated to produce values whose type is in sort quality q3,
   unless instantiated such that the qualities q1, q2 and Prop
   are equal to the instantiation of q3, or to qualities smaller
   (SProp <= Prop <= Type, and all variables <= Type)
@@ -71,11 +71,11 @@ ssig@{q1 q2 q3 | a b} may only be eliminated to produce values whose type is in 
 Arguments ssig A%_type_scope B%_function_scope
 Expands to: Inductive Inductive.ssig
 Declared in library Inductive, line 48, characters 22-26
-BoxP@{q | a |} : Type@{q | a} -> Prop
-(* q | a |=  *)
+BoxP@{q ; a} : Type@{q ; a} -> Prop
+(* q ; a |=  *)
 
 BoxP is universe polymorphic
-BoxP@{q | a} may only be eliminated to produce values whose type is SProp or Prop,
+BoxP@{q ; a} may only be eliminated to produce values whose type is SProp or Prop,
   unless instantiated such that the quality q is SProp or Prop.
 Arguments BoxP A%_type_scope
 Expands to: Inductive Inductive.BoxP

--- a/test-suite/output/Inductive.v
+++ b/test-suite/output/Inductive.v
@@ -41,18 +41,18 @@ About sunit.
 
 Set Universe Polymorphism.
 
-Polymorphic Inductive sempty@{q| |} : Type@{q|Set} := .
+Polymorphic Inductive sempty@{q; |} : Type@{q;Set} := .
 
 About sempty.
 
-Polymorphic Inductive ssig@{q1 q2 q3|a b|}
-  (A:Type@{q1|a})
-  (B:A -> Type@{q2|b})
-  : Type@{q3|max(a,b)}
+Polymorphic Inductive ssig@{q1 q2 q3;a b|}
+  (A:Type@{q1;a})
+  (B:A -> Type@{q2;b})
+  : Type@{q3;max(a,b)}
   := sexist (a:A) (b:B a).
 
 About ssig.
 
-Polymorphic Inductive BoxP@{q|a|} (A:Type@{q|a}) : Prop := boxP (_:A).
+Polymorphic Inductive BoxP@{q;a|} (A:Type@{q;a}) : Prop := boxP (_:A).
 
 About BoxP.

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -148,7 +148,7 @@ Entry term is
 Entry univ_annot is
 [ LEFTA
   [ "@{"; LIST0 univ_level_or_quality;
-    OPT [ "|"; LIST0 univ_level_or_quality ]; "}"
+    OPT [ [ "|" | ";" ]; LIST0 univ_level_or_quality ]; "}"
   |  ] ]
 
 Entry fix_decls is

--- a/test-suite/output/SortQuality.out
+++ b/test-suite/output/SortQuality.out
@@ -1,14 +1,14 @@
 Type
-Type@{α1 | SortQuality.21}
-Type@{α1 | SortQuality.21}
+Type@{α1 ; SortQuality.21}
+Type@{α1 ; SortQuality.21}
 Type
 A
-     : Type@{s | _}
+     : Type@{s ; _}
 A
-     : Type@{s | u}
+     : Type@{s ; u}
 (* {u} |=  *)
 A
-     : Type@{s | u}
+     : Type@{s ; u}
 (* {u} |=  *)
 A
-     : Type@{s | _}
+     : Type@{s ; _}

--- a/test-suite/output/SortQuality.v
+++ b/test-suite/output/SortQuality.v
@@ -19,7 +19,7 @@ End M1.
 
 Module M2.
   Set Universe Polymorphism.
-  Lemma foo@{s|u|} (A : Type@{s|u}) : True.
+  Lemma foo@{s;u|} (A : Type@{s;u}) : True.
   Proof.
   Check A.
   Set Printing Universes.

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -274,3 +274,25 @@ Tactic failure: Not equal (due to universes).
 eq_rect
      : forall (A : Type@{eq_rect.u1}) (x : A) (P : A -> Type@{eq_rect.u0}),
        P x -> forall y : A, x = y -> P y
+File "./output/UnivBinders.v", line 259, characters 18-19:
+Warning: Separating sorts from universes with "|" is deprecated.
+Use ";" instead.
+[deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]
+File "./output/UnivBinders.v", line 259, characters 33-34:
+Warning: Separating sorts from universes with "|" is deprecated.
+Use ";" instead.
+[deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]
+File "./output/UnivBinders.v", line 265, characters 16-17:
+Warning: Separating sorts from universes with "|" is deprecated.
+Use ";" instead.
+[deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]
+id@{Prop ; Set}
+     : forall A : Prop, A -> A
+id@{SProp ; Set}
+     : forall A : SProp, A -> A
+id3@{s ; u} =
+fun (A : Type@{s ; u}) (a : A) => a
+     : forall A : Type@{s ; u}, A -> A
+(* s ; u |= Set < u *)
+
+Arguments id3 A%_type_scope a

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -249,3 +249,21 @@ End Collision.
 Module Schemes.
   Check eq_rect.
 End Schemes.
+
+Module SortPoly.
+
+  Set Warnings "deprecated-sort-poly-syntax".
+
+  Definition idu@{u} (A:Type@{u}) (a:A) := a.
+
+  Definition id@{s|u|} (A:Type@{s|u}) (a:A) := a.
+
+  Definition id2@{s;u} (A:Type@{s;u}) (a:A) := a.
+
+  Definition id3@{s ; u | Set < u} (A:Type@{s;u}) (a:A) := a.
+
+  Check id@{Prop|Set}.
+  Check id@{SProp;Set}.
+  Print id3.
+
+End SortPoly.

--- a/test-suite/output/bug_20242.out
+++ b/test-suite/output/bug_20242.out
@@ -1,8 +1,8 @@
 File "./output/bug_20242.v", line 5, characters 49-60:
 The command has indeed failed with message:
 Signature components for field B do not match: expected type
-"foo@{Type | A.A.u0} bug_20242.B.A" but found type
-"foo@{SProp | bug_20242.26} bug_20242.B.A".
+"foo@{Type ; A.A.u0} bug_20242.B.A" but found type
+"foo@{SProp ; bug_20242.26} bug_20242.B.A".
 Error: The module B needs to be closed.
 
 

--- a/test-suite/output/bug_20242.v
+++ b/test-suite/output/bug_20242.v
@@ -1,4 +1,4 @@
-Polymorphic Record foo@{s|u|} (x : Type@{s|u}) := {}.
+Polymorphic Record foo@{s;u|} (x : Type@{s;u}) := {}.
 Inductive sEmpty : SProp := .
 Module Type A. Axiom A : Type. Axiom B : foo A. End A.
 Unset Universe Checking.

--- a/test-suite/output/sort_poly_elim_error.out
+++ b/test-suite/output/sort_poly_elim_error.out
@@ -1,15 +1,15 @@
 File "./output/sort_poly_elim_error.v", line 8, characters 0-108:
 The command has indeed failed with message:
 Incorrect elimination of "p" in the inductive type
-"sum@{Prop | sort_poly_elim_error.23 sort_poly_elim_error.24}":
+"sum@{Prop ; sort_poly_elim_error.23 sort_poly_elim_error.24}":
 the return type has sort "Type" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Type"
 because proofs can be eliminated only to build proofs.
 File "./output/sort_poly_elim_error.v", line 19, characters 0-106:
 The command has indeed failed with message:
-Incorrect elimination of "x" in the inductive type "sBox@{s s' | u}":
-the return type has sort "Type@{s | u}"
+Incorrect elimination of "x" in the inductive type "sBox@{s s' ; u}":
+the return type has sort "Type@{s ; u}"
 while it should be in sort quality s'.
 Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
 is only allowed on a predicate in the same sort quality.

--- a/test-suite/output/sort_poly_elim_error.v
+++ b/test-suite/output/sort_poly_elim_error.v
@@ -1,11 +1,11 @@
 Set Universe Polymorphism.
-Inductive sum@{s|u v|} (A : Type@{s|u}) (B : Type@{s|v}) : Type@{s|max(u,v)} :=
+Inductive sum@{s;u v|} (A : Type@{s;u}) (B : Type@{s;v}) : Type@{s;max(u,v)} :=
   | inl : A -> sum A B
   | inr : B -> sum A B.
 Arguments inl {A B}.
 Arguments inr {A B}.
 
-Fail Check (fun p : sum@{Prop|_ _} True False => match p return Set with inl a => unit | inr b => bool end).
+Fail Check (fun p : sum@{Prop;_ _} True False => match p return Set with inl a => unit | inr b => bool end).
 (*
 Error: Incorrect elimination of "p" in the inductive type "sum":
 the return type has sort "Type@{Set+1}" while it should be at some variable quality.
@@ -14,9 +14,9 @@ because wrong arity.
 *)
 
 
-Inductive sBox@{s s'|u|} (A:Type@{s|u}) : Type@{s'|u} := sbox (_:A).
+Inductive sBox@{s s';u|} (A:Type@{s;u}) : Type@{s';u} := sbox (_:A).
 
-Fail Definition elim@{s s'|u|} (A:Type@{s|u}) (x:sBox@{s s'|u} A) : A :=
+Fail Definition elim@{s s';u|} (A:Type@{s;u}) (x:sBox@{s s';u} A) : A :=
   match x with sbox _ v => v end.
 
 Inductive sP : SProp := sC.

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -71,12 +71,12 @@ Record primprod (A B : Type) := { fst: A; snd: B }.
 
 (* Example with even more pattern constructions, mostly for terms *)
 Universe idu.
-#[unfold_fix, universes(polymorphic)] Symbol id@{q| |} : forall A : Type@{q|idu}, A -> A.
+#[unfold_fix, universes(polymorphic)] Symbol id@{q; } : forall A : Type@{q;idu}, A -> A.
 
 Rewrite Rules id_rew :=
-| @{q|u+|+} |- id _ Type@{q|u} => Type@{q|u}
+| @{q;u+|+} |- id _ Type@{q;u} => Type@{q;u}
 
-| @{q|u+|+} |- id Type@{q|u} (forall (x : ?A), ?P) => forall x, id Type@{q|u} ?P
+| @{q;u+|+} |- id Type@{q;u} (forall (x : ?A), ?P) => forall x, id Type@{q;u} ?P
 | id (forall (x : ?A), ?P) ?f => fun (x : ?A) => id ?P (?f x)
 
 | @{u+} |- id Type@{u} (?A * ?B)%type => (id Type@{u} ?A * id Type@{u} ?B)%type

--- a/test-suite/success/rewrule_quality_match.v
+++ b/test-suite/success/rewrule_quality_match.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; coq-prog-args: ("-allow-rewrite-rules") -*- *)
 
-#[universes(polymorphic)] Symbol irrel@{q|u|} : forall {A : Type@{q|u}}, A -> bool.
+#[universes(polymorphic)] Symbol irrel@{q;u} : forall {A : Type@{q;u}}, A -> bool.
 
 Rewrite Rule id_rew :=
 | irrel@{SProp|_} _ => true

--- a/test-suite/success/sort_poly.v
+++ b/test-suite/success/sort_poly.v
@@ -5,28 +5,28 @@ Module Syntax.
 
   Definition foo@{u| Set < u} := Type@{u}.
 
-  Definition bar@{s | u | Set < u} := Type@{u}.
+  Definition bar@{s ; u | Set < u} := Type@{u}.
   Set Printing Universes.
   Print bar.
 
-  Definition baz@{s | | } := Type@{s | Set}.
+  Definition baz@{s ; } := Type@{s ; Set}.
   Print baz.
 
-  Definition potato@{s | + | } := Type.
+  Definition potato@{s ; + } := Type.
 
-  Check eq_refl : Prop = baz@{Prop | }.
+  Check eq_refl : Prop = baz@{Prop ; }.
 
-  Inductive bob@{s| |} : Prop := .
+  Inductive bob@{s ; } : Prop := .
 End Syntax.
 
 Module Reduction.
 
-  Definition qsort@{s | u |} := Type@{s | u}.
+  Definition qsort@{s ; u } := Type@{s ; u}.
 
   Monomorphic Universe U.
 
   Definition tU := Type@{U}.
-  Definition qU := qsort@{Type | U}.
+  Definition qU := qsort@{Type ; U}.
 
   Definition q1 := Eval lazy in qU.
   Check eq_refl : q1 = tU.
@@ -37,31 +37,31 @@ Module Reduction.
   Definition q3 := Eval native_compute in qU.
   Check eq_refl : q3 = tU.
 
-  Definition exfalso@{s|u|} (A:Type@{s|u}) (H:False) : A := match H with end.
+  Definition exfalso@{s;u|} (A:Type@{s;u}) (H:False) : A := match H with end.
 
-  Definition exfalsoVM := Eval vm_compute in exfalso@{Type|Set}.
-  Definition exfalsoNative := Eval native_compute in exfalso@{Type|Set}.
+  Definition exfalsoVM := Eval vm_compute in exfalso@{Type;Set}.
+  Definition exfalsoNative := Eval native_compute in exfalso@{Type;Set}.
 
-  Fixpoint iter@{s|u|} (A:Type@{s|u}) (f:A -> A) n x :=
+  Fixpoint iter@{s;u|} (A:Type@{s;u}) (f:A -> A) n x :=
     match n with
     | 0 => x
     | S k => iter A f k (f x)
     end.
 
-  Definition iterType := Eval lazy in iter@{Type|_}.
-  Definition iterSProp := Eval lazy in iter@{SProp|_}.
+  Definition iterType := Eval lazy in iter@{Type;_}.
+  Definition iterSProp := Eval lazy in iter@{SProp;_}.
 
 End Reduction.
 
 Module Conversion.
 
-  Inductive Box@{s|u|} (A:Type@{s|u}) := box (_:A).
+  Inductive Box@{s;u|} (A:Type@{s;u}) := box (_:A).
 
-  Definition t1@{s|u|} (A:Type@{s|u}) (x y : A) := box _ x.
-  Definition t2@{s|u|} (A:Type@{s|u}) (x y : A) := box _ y.
+  Definition t1@{s;u|} (A:Type@{s;u}) (x y : A) := box _ x.
+  Definition t2@{s;u|} (A:Type@{s;u}) (x y : A) := box _ y.
 
-  Definition t1'@{s|u|} (A:Type@{s|u}) (x y : A) := x.
-  Definition t2'@{s|u|} (A:Type@{s|u}) (x y : A) := y.
+  Definition t1'@{s;u|} (A:Type@{s;u}) (x y : A) := x.
+  Definition t2'@{s;u|} (A:Type@{s;u}) (x y : A) := y.
 
   Fail Check eq_refl : t1 nat = t2 nat.
   Fail Check eq_refl : t1' nat = t2' nat.
@@ -69,53 +69,53 @@ Module Conversion.
   Check fun A:SProp => eq_refl : t1 A = t2 A.
   Check fun A:SProp => eq_refl : box _ (t1' A) = box _ (t2' A).
 
-  Definition ignore@{s|u|} {A:Type@{s|u}} (x:A) := tt.
-  Definition unfold_ignore@{s|u|} (A:Type@{s|u}) : ignore (t1 A) = ignore (t2 A) := eq_refl.
+  Definition ignore@{s;u|} {A:Type@{s;u}} (x:A) := tt.
+  Definition unfold_ignore@{s;u|} (A:Type@{s;u}) : ignore (t1 A) = ignore (t2 A) := eq_refl.
 
   Definition t (A:SProp) := Eval lazy in t1 A.
 
-  Axiom v@{s| |} : forall (A:Type@{s|Set}), bool -> A.
-  Fail Check fun P (x:P (v@{Type|} nat true)) => x : P (v nat false).
+  Axiom v@{s; |} : forall (A:Type@{s;Set}), bool -> A.
+  Fail Check fun P (x:P (v@{Type;} nat true)) => x : P (v nat false).
   Check fun (A:SProp) P (x:P (v A true)) => x : P (v A false).
 
 End Conversion.
 
 Module Inference.
-  Definition zog@{s| |} (A:Type@{s|Set}) := A.
+  Definition zog@{s; |} (A:Type@{s;Set}) := A.
 
   (* implicit instance of zog gets a variable which then gets unified with s from the type of A *)
-  Definition zag@{s| |} (A:Type@{s|Set}) := zog A.
+  Definition zag@{s; |} (A:Type@{s;Set}) := zog A.
 
   (* implicit type of A gets unified to Type@{s|Set} *)
-  Definition zig@{s| |} A := zog@{s|} A.
+  Definition zig@{s; |} A := zog@{s;} A.
 
   (* Unfortunately casting a hole to a sort (while typing A on the
      left of the arrow) produces a rigid univ level. It gets a
      constraint "= Set" but rigids don't get substituted away for (bad)
      reasons. This is why we need the 2 "+". *)
-  Definition zig'@{s| + | +} A := A -> zog@{s|} A.
+  Definition zig'@{s; + | +} A := A -> zog@{s;} A.
 
   (* different manually bound sort variables don't unify *)
-  Fail Definition zog'@{s s'| |} (A:Type@{s|Set}) := zog@{s'|} A.
+  Fail Definition zog'@{s s'; |} (A:Type@{s;Set}) := zog@{s';} A.
 End Inference.
 
 Module Inductives.
-  Inductive foo1@{s| |} : Type@{s|Set} := .
+  Inductive foo1@{s; |} : Type@{s;Set} := .
   Fail Check foo1_sind.
 
-  Fail Definition foo1_False@{s|+|+} (x:foo1@{s|}) : False := match x return False with end.
+  Fail Definition foo1_False@{s;+|+} (x:foo1@{s;}) : False := match x return False with end.
   (* XXX error message is bad *)
 
-  Inductive foo2@{s| |} := Foo2 : Type@{s|Set} -> foo2.
+  Inductive foo2@{s; |} := Foo2 : Type@{s;Set} -> foo2.
   Check foo2_rect.
 
-  Inductive foo3@{s| |} (A:Type@{s|Set}) := Foo3 : A -> foo3 A.
+  Inductive foo3@{s; |} (A:Type@{s;Set}) := Foo3 : A -> foo3 A.
   Check foo3_rect.
 
-  Fail Inductive foo4@{s|u v|v < u} : Type@{v} := C (_:Type@{s|u}).
+  Fail Inductive foo4@{s;u v|v < u} : Type@{v} := C (_:Type@{s;u}).
 
-  Inductive foo5@{s| |} (A:Type@{s|Set}) : Prop := Foo5 (_ : A).
-  Definition foo5_ind'@{s| |} : forall (A : Type@{s|Set}) (P : Prop), (A -> P) -> foo5 A -> P
+  Inductive foo5@{s; |} (A:Type@{s;Set}) : Prop := Foo5 (_ : A).
+  Definition foo5_ind'@{s; |} : forall (A : Type@{s;Set}) (P : Prop), (A -> P) -> foo5 A -> P
     := foo5_ind.
 
   (* TODO unify sort variable instead of failing *)
@@ -127,15 +127,15 @@ Module Inductives.
 
   Definition foo5_Prop_rect (A:Prop) (P:foo5 A -> Type)
     (H : forall a, P (Foo5 A a))
-    (f : foo5@{Prop|} A)
+    (f : foo5@{Prop;} A)
     : P f
     := match f with Foo5 _ a => H a end.
 
   (* all sort poly output with nonzero contructors are squashed (avoid interfering with uip) *)
-  Inductive foo6@{s| |} : Type@{s|Set} := Foo6.
+  Inductive foo6@{s; |} : Type@{s;Set} := Foo6.
   Fail Check foo6_sind.
 
-  Fail Definition foo6_rect@{s|+|+} (P:foo6@{s|} -> Type)
+  Fail Definition foo6_rect@{s;+|+} (P:foo6@{s;} -> Type)
     (H : P Foo6)
     (f : foo6)
     : P f
@@ -150,41 +150,41 @@ Module Inductives.
 
   Definition foo6_prop_rect (P:foo6 -> Type)
     (H : P Foo6)
-    (f : foo6@{Prop|})
+    (f : foo6@{Prop;})
     : P f
     := match f with Foo6 => H end.
 
   Definition foo6_type_rect (P:foo6 -> Type)
     (H : P Foo6)
-    (f : foo6@{Type|})
+    (f : foo6@{Type;})
     : P f
     := match f with Foo6 => H end.
 
-  Definition foo6_qsort_rect@{s|u|} (P:foo6 -> Type@{s|u})
+  Definition foo6_qsort_rect@{s;u|} (P:foo6 -> Type@{s;u})
     (H : P Foo6)
-    (f : foo6@{s|})
+    (f : foo6@{s;})
     : P f
     := match f with Foo6 => H end.
 
-  Fail Definition foo6_2qsort_rect@{s s'|u|} (P:foo6 -> Type@{s|u})
+  Fail Definition foo6_2qsort_rect@{s s';u|} (P:foo6 -> Type@{s;u})
     (H : P Foo6)
-    (f : foo6@{s'|})
+    (f : foo6@{s';})
     : P f
     := match f with Foo6 => H end.
 
-  Inductive foo7@{s| |} : Type@{s|Set} := Foo7_1 | Foo7_2.
+  Inductive foo7@{s; |} : Type@{s;Set} := Foo7_1 | Foo7_2.
   Fail Check foo7_sind.
   Fail Check foo7_ind.
 
   Definition foo7_prop_ind (P:foo7 -> Prop)
     (H : P Foo7_1) (H' : P Foo7_2)
-    (f : foo7@{Prop|})
+    (f : foo7@{Prop;})
     : P f
     := match f with Foo7_1 => H | Foo7_2 => H' end.
 
   Fail Definition foo7_prop_rect (P:foo7 -> Type)
     (H : P Foo7_1) (H' : P Foo7_2)
-    (f : foo7@{Prop|})
+    (f : foo7@{Prop;})
     : P f
     := match f with Foo7_1 => H | Foo7_2 => H' end.
 
@@ -192,27 +192,27 @@ Module Inductives.
   Set Warnings "+records".
 
   (* the SProp instantiation may not be primitive so the whole thing must be nonprimitive *)
-  Fail Record R1@{s| |} : Type@{s|Set} := {}.
+  Fail Record R1@{s; |} : Type@{s;Set} := {}.
 
   (* the Type instantiation may not be primitive *)
-  Fail Record R2@{s| |} (A:SProp) : Type@{s|Set} := { R2f1 : A }.
+  Fail Record R2@{s; |} (A:SProp) : Type@{s;Set} := { R2f1 : A }.
 
   (* R3@{SProp Type|} may not be primitive  *)
-  Fail Record R3@{s s'| |} (A:Type@{s|Set}) : Type@{s'|Set} := { R3f1 : A }.
+  Fail Record R3@{s s'; |} (A:Type@{s;Set}) : Type@{s';Set} := { R3f1 : A }.
 
-  Record R4@{s| |} (A:Type@{s|Set}) : Type@{s|Set} := { R4f1 : A}.
+  Record R4@{s; |} (A:Type@{s;Set}) : Type@{s;Set} := { R4f1 : A}.
 
   (* non SProp instantiation must be squashed *)
-  Fail Record R5@{s| |} (A:Type@{s|Set}) : SProp := { R5f1 : A}.
+  Fail Record R5@{s; |} (A:Type@{s;Set}) : SProp := { R5f1 : A}.
   Fail #[warnings="-non-primitive-record"]
-    Record R5@{s| |} (A:Type@{s|Set}) : SProp := { R5f1 : A}.
+    Record R5@{s; |} (A:Type@{s;Set}) : SProp := { R5f1 : A}.
   #[warnings="-non-primitive-record,-cannot-define-projection"]
-    Record R5@{s| |} (A:Type@{s|Set}) : SProp := { R5f1 : A}.
+    Record R5@{s; |} (A:Type@{s;Set}) : SProp := { R5f1 : A}.
   Fail Check R5f1.
   Definition R5f1_sprop (A:SProp) (r:R5 A) : A := let (f) := r in f.
   Fail Definition R5f1_prop (A:Prop) (r:R5 A) : A := let (f) := r in f.
 
-  Record R6@{s| |} (A:Type@{s|Set}) := { R6f1 : A; R6f2 : nat }.
+  Record R6@{s; |} (A:Type@{s;Set}) := { R6f1 : A; R6f2 : nat }.
   Check fun (A:SProp) (x y : R6 A) =>
           eq_refl : Conversion.box _ x.(R6f1 _) = Conversion.box _ y.(R6f1 _).
   Fail Check fun (A:Prop) (x y : R6 A) =>
@@ -220,51 +220,51 @@ Module Inductives.
   Fail Check fun (A:SProp) (x y : R6 A) =>
           eq_refl : Conversion.box _ x.(R6f2 _) = Conversion.box _ y.(R6f2 _).
 
-  #[projections(primitive=no)] Record R7@{s| |} (A:Type@{s|Set}) := { R7f1 : A; R7f2 : nat }.
-  Check R7@{SProp|} : SProp -> Set.
-  Check R7@{Type|} : Set -> Set.
+  #[projections(primitive=no)] Record R7@{s; |} (A:Type@{s;Set}) := { R7f1 : A; R7f2 : nat }.
+  Check R7@{SProp;} : SProp -> Set.
+  Check R7@{Type;} : Set -> Set.
 
-  Inductive sigma@{s|u v|} (A:Type@{s|u}) (B:A -> Type@{s|v}) : Type@{s|max(u,v)}
+  Inductive sigma@{s;u v|} (A:Type@{s;u}) (B:A -> Type@{s;v}) : Type@{s;max(u,v)}
     := pair : forall x : A, B x -> sigma A B.
 
-  Definition sigma_srect@{s|k +|} A B
-    (P : sigma@{s|_ _} A B -> Type@{s|k})
+  Definition sigma_srect@{s;k +|} A B
+    (P : sigma@{s;_ _} A B -> Type@{s;k})
     (H : forall x b, P (pair _ _ x b))
     (s:sigma A B)
     : P s
     := match s with pair _ _ x b => H x b end.
 
   (* squashed because positive type with >0 constructors *)
-  Fail Definition sigma_srect'@{s sk|k +|} A B
-    (P : sigma@{s|_ _} A B -> Type@{sk|k})
+  Fail Definition sigma_srect'@{s sk;k +|} A B
+    (P : sigma@{s;_ _} A B -> Type@{sk;k})
     (H : forall x b, P (pair _ _ x b))
     (s:sigma A B)
     : P s
     := match s with pair _ _ x b => H x b end.
 
   (* even though it's squashed, we can still define the projections *)
-  Definition pr1@{s|+|} {A B} (s:sigma@{s|_ _} A B) : A
+  Definition pr1@{s;+|} {A B} (s:sigma@{s;_ _} A B) : A
     := match s with pair _ _ x _ => x end.
 
-  Definition pr2@{s|+|} {A B} (s:sigma@{s|_ _} A B) : B (pr1 s)
+  Definition pr2@{s;+|} {A B} (s:sigma@{s;_ _} A B) : B (pr1 s)
     := match s with pair _ _ _ y => y end.
 
   (* but we can't prove eta *)
-  Inductive seq@{s|u|} (A:Type@{s|u}) (a:A) : A -> Prop := seq_refl : seq A a a.
+  Inductive seq@{s;u|} (A:Type@{s;u}) (a:A) : A -> Prop := seq_refl : seq A a a.
   Arguments seq_refl {_ _}.
 
-  Definition eta@{s|+|+} A B (s:sigma@{s|_ _} A B) : seq _ s (pair A B (pr1 s) (pr2 s)).
+  Definition eta@{s;+|+} A B (s:sigma@{s;_ _} A B) : seq _ s (pair A B (pr1 s) (pr2 s)).
   Proof.
     Fail destruct s.
   Abort.
 
   (* sigma as a primitive record works better *)
-  Record Rsigma@{s|u v|} (A:Type@{s|u}) (B:A -> Type@{s|v}) : Type@{s|max(u,v)}
+  Record Rsigma@{s;u v|} (A:Type@{s;u}) (B:A -> Type@{s;v}) : Type@{s;max(u,v)}
     := Rpair { Rpr1 : A; Rpr2 : B Rpr1 }.
 
   (* match desugared to primitive projections using definitional eta *)
-  Definition Rsigma_srect@{s sk|k +|} A B
-    (P : Rsigma@{s|_ _} A B -> Type@{sk|k})
+  Definition Rsigma_srect@{s sk;k +|} A B
+    (P : Rsigma@{s;_ _} A B -> Type@{sk;k})
     (H : forall x b, P (Rpair _ _ x b))
     (s:Rsigma A B)
     : P s
@@ -272,19 +272,19 @@ Module Inductives.
 
   (* sort polymorphic exists (we could also make B sort poly)
      can't be a primitive record since the first projection isn't defined at all sorts *)
-  Inductive sexists@{s|u|} (A:Type@{s|u}) (B:A -> Prop) : Prop
+  Inductive sexists@{s;u|} (A:Type@{s;u}) (B:A -> Prop) : Prop
     := sexist : forall a:A, B a -> sexists A B.
 
   (* we can eliminate to Prop *)
   Check sexists_ind.
 
-  Inductive sigma3@{s s' s''|u v| } (A:Type@{s|u}) (P:A -> Type@{s'|v}) :
-    Type@{s''|max(u,v)} :=
+  Inductive sigma3@{s s' s'';u v| } (A:Type@{s;u}) (P:A -> Type@{s';v}) :
+    Type@{s'';max(u,v)} :=
     exist3 : forall x:A, P x -> sigma3 A P.
 
   Arguments exist3 {_ _}.
 
-  Definition π1@{s s'|u v|} {A:Type@{s|u}} {P:A -> Type@{s'|v}} (p : sigma3@{_ _ Type|_ _} A P) : A :=
+  Definition π1@{s s';u v|} {A:Type@{s;u}} {P:A -> Type@{s';v}} (p : sigma3@{_ _ Type;_ _} A P) : A :=
     match p return A with exist3 a _ => a end.
 
 End Inductives.

--- a/test-suite/success/sort_poly_extraction.v
+++ b/test-suite/success/sort_poly_extraction.v
@@ -1,20 +1,20 @@
 Require Extraction.
 
 Set Universe Polymorphism.
-Definition foo@{s| |} := tt.
+Definition foo@{s; |} := tt.
 
-Definition bar := foo@{Prop|}.
+Definition bar := foo@{Prop;}.
 
 Extraction bar.
 
 (* the actual problem only appears once we have inductives with sort poly output: *)
 
-Inductive Pair@{s|u|} (A:Type@{s|u}) : Type@{s|u} := pair : A -> A -> Pair A.
+Inductive Pair@{s;u|} (A:Type@{s;u}) : Type@{s;u} := pair : A -> A -> Pair A.
 
-Definition use_pair@{s|+|} A (k:A->nat) (x:Pair@{s|_} A) :=
+Definition use_pair@{s;+|} A (k:A->nat) (x:Pair@{s;_} A) :=
   k (match x with pair _ x _ => x end).
 
-Definition make_pair := pair@{Prop|_} _ I I.
+Definition make_pair := pair@{Prop;_} _ I I.
 
 Definition hell := use_pair True (fun _ => 0) make_pair.
 

--- a/theories/Corelib/ssr/ssreflect.v
+++ b/theories/Corelib/ssr/ssreflect.v
@@ -443,8 +443,8 @@ Proof. exact: rest step. Qed.
 
 Register ssr_have as plugins.ssreflect.ssr_have.
 
-Polymorphic Lemma ssr_have_upoly@{s1 s2|u1 u2|}
-  (Plemma : Type@{s1|u1})  (Pgoal : Type@{s2|u2})
+Polymorphic Lemma ssr_have_upoly@{s1 s2;u1 u2}
+  (Plemma : Type@{s1;u1})  (Pgoal : Type@{s2;u2})
   (step : Plemma) (rest : Plemma -> Pgoal) : Pgoal.
 Proof. exact: rest step. Qed.
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -224,15 +224,18 @@ let test_variance_ident =
     lk_kws ["=";"+";"*"] >> lk_ident
   end
 
-let test_univ_decl =
+let test_doublepipe_univ_decl =
   let open Procq.Lookahead in
-  to_entry "test_univ_decl" (lk_ident_list >> lk_kw "|" >> lk_ident_list >> (lk_kw "+" <+> lk_empty) >> (lk_kw "|" <+> lk_kw "|}"))
+  to_entry "test_doublepipe_univ_decl" (lk_ident_list >> lk_kw "|" >> lk_ident_list >> (lk_kw "+" <+> lk_empty) >> (lk_kw "|" <+> lk_kw "|}"))
 
-let test_cumul_univ_decl =
+let test_doublepipe_cumul_univ_decl =
   let open Procq.Lookahead in
   let lk_list_variance_ident = lk_list (lk_kw "+" <+> lk_kw "*" <+> lk_kw "=" <+> lk_ident) in
-  to_entry "test_cumul_univ_decl" (lk_ident_list >> lk_kw "|" >> lk_list_variance_ident >> (lk_kw "+" <+> lk_empty) >> (lk_kw "|" <+> lk_kw "|}"))
+  to_entry "test_doublepipe_cumul_univ_decl" (lk_ident_list >> lk_kw "|" >> lk_list_variance_ident >> (lk_kw "+" <+> lk_empty) >> (lk_kw "|" <+> lk_kw "|}"))
 
+let test_semicolon_cumul_univ_decl =
+  let open Procq.Lookahead in
+  to_entry "test_semicolon_cumul_univ_decl" (lk_ident_list >> lk_kw ";")
 
 }
 
@@ -349,9 +352,20 @@ GRAMMAR EXTEND Gram
       | ext = [ "}" -> { true } | bar_cbrace -> { false } ] -> { ([], ext) } ] ]
   ;
   univ_decl:
-    [ [ "@{" ; test_univ_decl; l0 = LIST0 identref; "|";  l = LIST0 identref; ext = [ "+" -> { true } | -> { false } ];
+    [ [ "@{" ; test_doublepipe_univ_decl; l0 = LIST0 identref; pipe_loc = [ "|" -> { loc } ];  l = LIST0 identref; ext = [ "+" -> { true } | -> { false } ];
          cs = univ_decl_constraints
          ->
+         { let open UState in
+           G_constr.warn_old_sort_syntax ~loc:pipe_loc ();
+         { univdecl_qualities = l0;
+           univdecl_extensible_qualities = false;
+           univdecl_instance = l;
+           univdecl_extensible_instance = ext;
+           univdecl_constraints = fst cs;
+           univdecl_extensible_constraints = snd cs } }
+    | "@{" ; l0 = LIST0 identref; ";";  l = LIST0 identref; ext = [ "+" -> { true } | -> { false } ];
+        cs = univ_decl_constraints
+        ->
          { let open UState in
          { univdecl_qualities = l0;
            univdecl_extensible_qualities = false;
@@ -385,7 +399,20 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   cumul_univ_decl:
-    [ [ "@{" ; test_cumul_univ_decl; l0 = LIST0 identref; "|";
+    [ [ "@{" ; test_doublepipe_cumul_univ_decl; l0 = LIST0 identref; pipe_loc = [ "|" -> { loc } ];
+        l = LIST0 variance_identref; ext = [ "+" -> { true } | -> { false } ];
+         cs = univ_decl_constraints
+         ->
+         { let open UState in
+           G_constr.warn_old_sort_syntax ~loc:pipe_loc ();
+         { univdecl_qualities = l0;
+           univdecl_extensible_qualities = false;
+           univdecl_instance = l;
+           univdecl_extensible_instance = ext;
+           univdecl_constraints = fst cs;
+           univdecl_extensible_constraints = snd cs } }
+
+       | "@{" ; test_semicolon_cumul_univ_decl; l0 = LIST0 identref; ";";
         l = LIST0 variance_identref; ext = [ "+" -> { true } | -> { false } ];
          cs = univ_decl_constraints
          ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -67,7 +67,7 @@ let pr_full_univ_name_list = function
   | None -> mt()
   | Some (ql, ul) ->
     str "@{" ++ prlist_with_sep spc pr_lname ql ++
-    (if List.is_empty ql then mt() else strbrk " | ") ++
+    (if List.is_empty ql then mt() else strbrk " ; ") ++
     prlist_with_sep spc pr_lname ul ++ str "}"
 
 let pr_variance_lident (lid,v) =
@@ -77,7 +77,7 @@ let pr_variance_lident (lid,v) =
 let pr_univdecl_qualities l extensible =
   (* "extensible" not really supported in syntax currently *)
   if List.is_empty l then mt()
-  else prlist_with_sep spc pr_lident l ++ strbrk " | "
+  else prlist_with_sep spc pr_lident l ++ strbrk " ; "
 
 let pr_univdecl_instance l extensible =
   prlist_with_sep spc pr_lident l ++


### PR DESCRIPTION
I think @mattam82 has a version of this change in some branch, it seems worth upstreaming.