### PR TITLE
ci-algebra_tactics: disable native compute

### DIFF
--- a/dev/ci/scripts/ci-algebra_tactics.sh
+++ b/dev/ci/scripts/ci-algebra_tactics.sh
@@ -9,6 +9,8 @@ git_download algebra_tactics
 
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
+export COQEXTRAFLAGS='-native-compiler no'
+
 ( cd "${CI_BUILD_DIR}/algebra_tactics"
   make
   make install

--- a/dev/ci/scripts/ci-relation_algebra.sh
+++ b/dev/ci/scripts/ci-relation_algebra.sh
@@ -9,6 +9,8 @@ git_download relation_algebra
 
 if [ "$DOWNLOAD_ONLY" ]; then exit 0; fi
 
+export COQEXTRAFLAGS='-native-compiler no'
+
 ( cd "${CI_BUILD_DIR}/relation_algebra"
   make .merlin
   make


### PR DESCRIPTION
It seems to break on some test: https://gitlab.inria.fr/coq/coq/-/jobs/5738407 
~~~
COQNATIVE examples/from_sander.vo
Fatal error: exception Stack overflow
~~~

(I think the test wasn't run until https://github.com/math-comp/algebra-tactics/pull/116)
