### PR TITLE
Remove KerPair.SyntacticOrd

### DIFF
--- a/dev/ci/user-overlays/20642-SkySkimmer-rm-synord.sh
+++ b/dev/ci/user-overlays/20642-SkySkimmer-rm-synord.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi rm-synord 20642

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -105,15 +105,15 @@ module RefHash =
 struct
   type t = my_global_reference
   let equal gr1 gr2 = match gr1, gr2 with
-  | ConstRef c1, ConstRef c2 -> Constant.SyntacticOrd.equal c1 c2
-  | IndRef i1, IndRef i2 -> Ind.SyntacticOrd.equal i1 i2
-  | ConstructRef c1, ConstructRef c2 -> Construct.SyntacticOrd.equal c1 c2
+  | ConstRef c1, ConstRef c2 -> Constant.UserOrd.equal c1 c2
+  | IndRef i1, IndRef i2 -> Ind.UserOrd.equal i1 i2
+  | ConstructRef c1, ConstructRef c2 -> Construct.UserOrd.equal c1 c2
   | _ -> false
   open Hashset.Combine
   let hash = function
-  | ConstRef c -> combinesmall 1 (Constant.SyntacticOrd.hash c)
-  | IndRef i -> combinesmall 2 (Ind.SyntacticOrd.hash i)
-  | ConstructRef c -> combinesmall 3 (Construct.SyntacticOrd.hash c)
+  | ConstRef c -> combinesmall 1 (Constant.UserOrd.hash c)
+  | IndRef i -> combinesmall 2 (Ind.UserOrd.hash i)
+  | ConstructRef c -> combinesmall 3 (Construct.UserOrd.hash c)
 end
 
 module RefTable = Hashtbl.Make(RefHash)

--- a/kernel/hConstr.ml
+++ b/kernel/hConstr.ml
@@ -261,9 +261,9 @@ let hash_kind = let open Hashset.Combine in function
   | LetIn (na,b,t,c) -> combinesmall 6 (combine4 (hash_annot na) b.hash t.hash c.hash)
   | App (h,args) -> combinesmall 7 (Array.fold_left (fun hash c -> combine hash c.hash) h.hash args)
   | Evar _ -> assert false
-  | Const (c,u) -> combinesmall 9 (combine (Constant.SyntacticOrd.hash c) (UVars.Instance.hash u))
-  | Ind (ind,u) -> combinesmall 10 (combine (Ind.SyntacticOrd.hash ind) (UVars.Instance.hash u))
-  | Construct (c,u) -> combinesmall 11 (combine (Construct.SyntacticOrd.hash c) (UVars.Instance.hash u))
+  | Const (c,u) -> combinesmall 9 (combine (Constant.UserOrd.hash c) (UVars.Instance.hash u))
+  | Ind (ind,u) -> combinesmall 10 (combine (Ind.UserOrd.hash ind) (UVars.Instance.hash u))
+  | Construct (c,u) -> combinesmall 11 (combine (Construct.UserOrd.hash c) (UVars.Instance.hash u))
   | Case (_,u,pms,(p,_),_,c,bl) ->
     let hash_ctx (bnd,c) =
       Array.fold_left (fun hash na -> combine (hash_annot na) hash) c.hash bnd
@@ -280,7 +280,7 @@ let hash_kind = let open Hashset.Combine in function
     combinesmall 14 (combine3 (hash_array hash_annot lna) (hash_array hash tl) (hash_array hash bl))
   | Meta _ -> assert false
   | Rel n -> combinesmall 16 n
-  | Proj (p,_,c) -> combinesmall 17 (combine (Projection.SyntacticOrd.hash p) c.hash)
+  | Proj (p,_,c) -> combinesmall 17 (combine (Projection.UserOrd.hash p) c.hash)
   | Int i -> combinesmall 18 (Uint63.hash i)
   | Float f -> combinesmall 19 (Float64.hash f)
   | String s -> combinesmall 20 (Pstring.hash s)
@@ -329,9 +329,9 @@ let of_kind_nohashcons = function
 
 let eq_leaf c c' = match kind c, c'.kind with
   | Var i, Var i' -> Id.equal i i'
-  | Const (c,u), Const (c',u') -> Constant.SyntacticOrd.equal c c' && UVars.Instance.equal u u'
-  | Ind (i,u), Ind (i',u') -> Ind.SyntacticOrd.equal i i' && UVars.Instance.equal u u'
-  | Construct (c,u), Construct (c',u') -> Construct.SyntacticOrd.equal c c' && UVars.Instance.equal u u'
+  | Const (c,u), Const (c',u') -> Constant.UserOrd.equal c c' && UVars.Instance.equal u u'
+  | Ind (i,u), Ind (i',u') -> Ind.UserOrd.equal i i' && UVars.Instance.equal u u'
+  | Construct (c,u), Construct (c',u') -> Construct.UserOrd.equal c c' && UVars.Instance.equal u u'
   | _ -> false
 
 let nonrel_leaf tbl c = match kind c with

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -376,9 +376,6 @@ sig
   module UserOrd : EqType with type t = t
   (** Equality functions over the user name. *)
 
-  module SyntacticOrd : EqType with type t = t
-  (** Equality functions using both names, for low-level uses. *)
-
   val canonize : t -> t
   (** Returns the canonical version of the name *)
 end


### PR DESCRIPTION
AFAICT all users work fine with UserOrd (equal user names imply equal canonical names as long as we don't backtrack to change the definition of a module, and the data structures using SyntacticOrd do not exist across such backtracks)

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/847