### PR TITLE
More type enforced "instantiation" of constr patterns

### DIFF
--- a/dev/ci/user-overlays/20644-SkySkimmer-instantiate-pat.sh
+++ b/dev/ci/user-overlays/20644-SkySkimmer-instantiate-pat.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp instantiate-pat 20644
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi instantiate-pat 20644
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician instantiate-pat 20644

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -352,7 +352,7 @@ let pattern_of_string ?env s =
     | Some e -> e
   in
   let constr = Procq.parse_string Procq.Constr.cpattern s in
-  let (_, pat) = Constrintern.intern_constr_pattern env (Evd.from_env env) constr in
+  let (_, pat) = Constrintern.interp_constr_pattern env (Evd.from_env env) constr in
   pat
 
 let dirpath_of_string_list s =

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -29,7 +29,9 @@ val extern_cases_pattern : Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
 val extern_glob_constr : extern_env -> 'a glob_constr_g -> constr_expr
 val extern_glob_type : ?impargs:Glob_term.binding_kind list -> extern_env -> 'a glob_constr_g -> constr_expr
 val extern_constr_pattern : names_context -> Evd.evar_map ->
-  _ constr_pattern_r -> constr_expr
+  constr_pattern -> constr_expr
+val extern_uninstantiated_pattern : names_context -> Evd.evar_map ->
+  uninstantiated_pattern -> constr_expr
 val extern_closed_glob : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name ->
   env -> Evd.evar_map -> closed_glob_constr -> constr_expr
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2775,16 +2775,14 @@ let interp_type_evars ?program_mode env sigma ?(impls=empty_internalization_env)
   interp_constr_evars_gen ?program_mode env sigma IsType ~impls c
 
 (* Miscellaneous *)
-
 let intern_constr_pattern env sigma ?(as_type=false) ?strict_check ?(ltacvars=empty_ltac_sign) c =
   let c = intern_gen (if as_type then IsType else WithoutTypeConstraint)
             ?strict_check ~pattern_mode:true ~ltacvars env sigma c in
   pattern_of_glob_constr env c
 
-let intern_uninstantiated_constr_pattern env sigma ?(as_type=false) ?strict_check ?(ltacvars=empty_ltac_sign) c =
-  let c = intern_gen (if as_type then IsType else WithoutTypeConstraint)
-            ?strict_check ~pattern_mode:true ~ltacvars env sigma c in
-  uninstantiated_pattern_of_glob_constr env c
+let interp_constr_pattern env sigma ?as_type ?strict_check c =
+  let ids, pat = intern_constr_pattern env sigma ?as_type ?strict_check c in
+  ids, Patternops.interp_pattern env sigma Glob_ops.empty_lvar pat
 
 let intern_core kind env sigma ?strict_check ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
       { Genintern.intern_ids = ids; Genintern.notation_variable_status = vl } c =

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -142,7 +142,7 @@ val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
 (** Without typing *)
 val intern_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
-    constr_pattern_expr -> Id.Set.t * [`uninstantiated] constr_pattern_r
+    constr_pattern_expr -> Id.Set.t * uninstantiated_pattern
 
 val interp_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?strict_check:bool ->

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -142,11 +142,11 @@ val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
 (** Without typing *)
 val intern_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
-    constr_pattern_expr -> Id.Set.t * constr_pattern
-
-val intern_uninstantiated_constr_pattern :
-  env -> evar_map -> ?as_type:bool -> ?strict_check:bool -> ?ltacvars:ltac_sign ->
     constr_pattern_expr -> Id.Set.t * [`uninstantiated] constr_pattern_r
+
+val interp_constr_pattern :
+  env -> evar_map -> ?as_type:bool -> ?strict_check:bool ->
+    constr_pattern_expr -> Id.Set.t * constr_pattern
 
 (** Returns None if it's an abbreviation not bound to a name, raises an error
     if not existing *)

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -51,7 +51,7 @@ let empty_glob_sign ~strict env = {
    in the environment by the effective calls to Intro, Inversion, etc
    The [constr_expr] field is [None] in TacDef though *)
 type glob_constr_and_expr = Glob_term.glob_constr * Constrexpr.constr_expr option
-type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.constr_pattern
+type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * [`uninstantiated] Pattern.constr_pattern_r
 
 type ('raw, 'glb) intern_fun = glob_sign -> 'raw -> glob_sign * 'glb
 type 'glb ntn_subst_fun = ntnvar_status Id.Map.t -> (Id.t -> Glob_term.glob_constr option) -> 'glb -> 'glb

--- a/interp/genintern.ml
+++ b/interp/genintern.ml
@@ -51,7 +51,7 @@ let empty_glob_sign ~strict env = {
    in the environment by the effective calls to Intro, Inversion, etc
    The [constr_expr] field is [None] in TacDef though *)
 type glob_constr_and_expr = Glob_term.glob_constr * Constrexpr.constr_expr option
-type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * [`uninstantiated] Pattern.constr_pattern_r
+type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.uninstantiated_pattern
 
 type ('raw, 'glb) intern_fun = glob_sign -> 'raw -> glob_sign * 'glb
 type 'glb ntn_subst_fun = ntnvar_status Id.Map.t -> (Id.t -> Glob_term.glob_constr option) -> 'glb -> 'glb

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -41,7 +41,7 @@ val empty_glob_sign : strict:bool -> Environ.env -> glob_sign
    in the environment by the effective calls to Intro, Inversion, etc
    The [constr_expr] field is [None] in TacDef though *)
 type glob_constr_and_expr = Glob_term.glob_constr * Constrexpr.constr_expr option
-type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.constr_pattern
+type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * [`uninstantiated] Pattern.constr_pattern_r
 
 (** {5 Internalization functions} *)
 

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -41,7 +41,7 @@ val empty_glob_sign : strict:bool -> Environ.env -> glob_sign
    in the environment by the effective calls to Intro, Inversion, etc
    The [constr_expr] field is [None] in TacDef though *)
 type glob_constr_and_expr = Glob_term.glob_constr * Constrexpr.constr_expr option
-type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * [`uninstantiated] Pattern.constr_pattern_r
+type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.uninstantiated_pattern
 
 (** {5 Internalization functions} *)
 

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -96,7 +96,7 @@ let subst_constr_with_occurrences subst (l,c) = (l,subst_glob_constr subst c)
 let subst_glob_constr_or_pattern subst (bvars,c,p) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  (bvars,subst_glob_constr subst c,subst_pattern env sigma subst p)
+  (bvars,subst_glob_constr subst c,subst_uninstantiated_pattern env sigma subst p)
 
 let subst_glob_red_expr subst =
   Redops.map_red_expr_gen

--- a/plugins/ltac/tactic_matching.mli
+++ b/plugins/ltac/tactic_matching.mli
@@ -35,7 +35,7 @@ val match_term :
   Environ.env ->
   Evd.evar_map ->
   EConstr.constr ->
-  (Constr_matching.binding_bound_vars * Constr_matching.instantiated_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
+  (Constr_matching.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
   Tacexpr.glob_tactic_expr t Proofview.tactic
 
 (** [match_goal env sigma hyps concl rules] matches the goal
@@ -48,5 +48,5 @@ val match_goal:
   Evd.evar_map ->
   EConstr.named_context ->
   EConstr.constr ->
-  (Constr_matching.binding_bound_vars * Constr_matching.instantiated_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
+  (Constr_matching.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
   Tacexpr.glob_tactic_expr t Proofview.tactic

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -882,7 +882,6 @@ let () =
     Proofview.tclOR (return (m_ctx, ans)) (fun _ -> of_ans s)
   in
   pf_apply @@ fun env sigma ->
-  let pat = Constr_matching.instantiate_pattern env sigma Id.Map.empty pat in
   let ans = Constr_matching.match_subterm env sigma (Id.Set.empty,pat) c in
   of_ans ans
 
@@ -911,7 +910,6 @@ let () =
     Proofview.tclOR (return (m_ctx,ans)) (fun _ -> of_ans s)
   in
   pf_apply @@ fun env sigma ->
-  let pat = Constr_matching.instantiate_pattern env sigma Id.Map.empty pat in
   let ans = Constr_matching.match_subterm env sigma (Id.Set.empty,pat) c in
   of_ans ans
 

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -122,7 +122,7 @@ let () =
       ltac_extra = extra;
     }
     in
-    let _, pat = Constrintern.intern_uninstantiated_constr_pattern env sigma ~strict_check ~as_type:false ~ltacvars c in
+    let _, pat = Constrintern.intern_constr_pattern env sigma ~strict_check ~as_type:false ~ltacvars c in
     GlbVal pat, gtypref t_pattern
   in
   let subst subst c =

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -128,9 +128,9 @@ let () =
   let subst subst c =
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    Patternops.subst_pattern env sigma subst c
+    Patternops.subst_uninstantiated_pattern env sigma subst c
   in
-  let print env sigma pat = str "pat:(" ++ Printer.pr_lconstr_pattern_env env sigma pat ++ str ")" in
+  let print env sigma pat = str "pat:(" ++ Printer.pr_uninstantiated_lconstr_pattern_env env sigma pat ++ str ")" in
   let raw_print env sigma pat = str "pat:(" ++ Ppconstr.pr_constr_pattern_expr env sigma pat ++ str ")" in
   let interp env c =
     let ist = to_lvar env in

--- a/plugins/ltac2/tac2match.ml
+++ b/plugins/ltac2/tac2match.ml
@@ -180,7 +180,6 @@ module PatternMatching (E:StaticEnvironment) = struct
             | Some nctx -> Proofview.tclOR (k (Some m_ctx) nctx) (fun e -> (map s e).stream k ctx)
         }
       in
-      let p = Constr_matching.instantiate_pattern E.env E.sigma Id.Map.empty p in
       map (Constr_matching.match_subterm E.env E.sigma (Id.Set.empty,p) term) imatching_error
 
   let hyp_match_type pat hyps =

--- a/plugins/ltac2/tac2quote.mli
+++ b/plugins/ltac2/tac2quote.mli
@@ -126,7 +126,7 @@ val of_format : lstring -> raw_tacexpr
 
 (** {5 Generic arguments} *)
 
-val wit_pattern : (Constrexpr.constr_expr, [`uninstantiated] Pattern.constr_pattern_r) Arg.tag
+val wit_pattern : (Constrexpr.constr_expr, Pattern.uninstantiated_pattern) Arg.tag
 
 val wit_ident : (Id.t, Id.t) Arg.tag
 

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -24,42 +24,6 @@ open Context.Rel.Declaration
 open Ltac_pretype
 (*i*)
 
-let error_instantiate_pattern id l =
-  let is = match l with
-  | [_] -> "is"
-  | _ -> "are"
-  in
-  user_err  (str "Cannot substitute the term bound to " ++ Id.print id
-    ++ strbrk " in pattern because the term refers to " ++ pr_enum Id.print l
-    ++ strbrk " which " ++ str is ++ strbrk " not bound in the pattern.")
-
-type instantiated_pattern = constr_pattern
-
-let instantiate_pattern env sigma lvar c =
-  let open EConstr in
-  let open Vars in
-  let rec aux vars = function
-  | PVar id as x ->
-      (try
-        let ctx,c = Id.Map.find id lvar in
-        try
-          let inst =
-            List.map
-              (fun id -> mkRel (List.index Name.equal (Name id) vars))
-              ctx
-          in
-          let c = substl inst c in
-          pattern_of_constr env sigma c
-        with Not_found (* List.index failed *) ->
-          let vars =
-            List.map_filter (function Name id -> Some id | _ -> None) vars in
-          error_instantiate_pattern id (List.subtract Id.equal ctx vars)
-       with Not_found (* Map.find failed *) ->
-         x)
-  | c ->
-      map_pattern_with_binders (fun id vars -> id::vars) aux vars c in
-  if Id.Map.is_empty lvar then c else aux [] c
-
 (* Given a term with second-order variables in it,
    represented by Meta's, and possibly applied using [SOAPP] to
    terms, this function will perform second-order, binding-preserving,

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -437,7 +437,7 @@ let matches_core env sigma allow_bound_rels
          | PFix _ | PCoFix _| PEvar _ | PInt _ | PFloat _
          | PString _ | PArray _), _ -> raise PatternMatchingFailure
 
-      | PUninstantiated _, _ -> .
+      | PExtra e, _ -> Util.Empty.abort e
 
   in
   sorec [] env ((Id.Map.empty,Id.Set.empty), Id.Map.empty) pat c

--- a/pretyping/constr_matching.mli
+++ b/pretyping/constr_matching.mli
@@ -17,12 +17,6 @@ open Environ
 open Pattern
 open Ltac_pretype
 
-type instantiated_pattern
-
-val instantiate_pattern : Environ.env ->
-  Evd.evar_map -> extended_patvar_map ->
-  constr_pattern -> instantiated_pattern
-
 type binding_bound_vars = Id.Set.t
 
 (** [PatternMatchingFailure] is the exception raised when pattern
@@ -53,7 +47,7 @@ val matches_head : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
    variables or metavariables have the same name, the metavariable,
    or else the rightmost bound variable, takes precedence *)
 val extended_matches :
-  env -> Evd.evar_map -> binding_bound_vars * instantiated_pattern ->
+  env -> Evd.evar_map -> binding_bound_vars * constr_pattern ->
   constr -> bound_ident_map * extended_patvar_map
 
 (** [is_matching pat c] just tells if [c] matches against [pat] *)
@@ -79,7 +73,7 @@ type matching_result =
    corresponding to each **closed** subterm of [c] matching [pat],
    considering application contexts as well. *)
 val match_subterm : env -> Evd.evar_map ->
-  binding_bound_vars * instantiated_pattern -> constr ->
+  binding_bound_vars * constr_pattern -> constr ->
   matching_result IStream.t
 
 (** [is_matching_appsubterm pat c] tells if a subterm of [c] matches

--- a/pretyping/pattern.mli
+++ b/pretyping/pattern.mli
@@ -51,7 +51,3 @@ type constr_pattern = [ `any ] constr_pattern_r
 
 (** Nota : in a [PCase], the array of branches might be shorter than
     expected, denoting the use of a final "_ => _" branch *)
-
-type _ pattern_kind =
-  | Any
-  | Uninstantiated : [`uninstantiated] pattern_kind

--- a/pretyping/pattern.mli
+++ b/pretyping/pattern.mli
@@ -20,9 +20,6 @@ type case_info_pattern =
       cip_ind : inductive option;
       cip_extensible : bool (** does this match end with _ => _ ? *) }
 
-type 'i uninstantiated_pattern =
-  | PGenarg : Genarg.glob_generic_argument -> [ `uninstantiated ] uninstantiated_pattern
-
 type 'i constr_pattern_r =
   | PRef of GlobRef.t
   | PVar of Id.t
@@ -45,9 +42,11 @@ type 'i constr_pattern_r =
   | PFloat of Float64.t
   | PString of Pstring.t
   | PArray of 'i constr_pattern_r array * 'i constr_pattern_r * 'i constr_pattern_r
-  | PUninstantiated of 'i uninstantiated_pattern
+  | PExtra of 'i
 
-type constr_pattern = [ `any ] constr_pattern_r
+type constr_pattern = Util.Empty.t constr_pattern_r
+
+type uninstantiated_pattern = Genarg.glob_generic_argument constr_pattern_r
 
 (** Nota : in a [PCase], the array of branches might be shorter than
     expected, denoting the use of a final "_ => _" branch *)

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -68,7 +68,7 @@ let rec constr_pattern_eq env (p1:constr_pattern) p2 = match p1, p2 with
 | PArray (t1, def1, ty1), PArray (t2, def2, ty2) ->
   Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) t1 t2 && constr_pattern_eq env def1 def2
   && constr_pattern_eq env ty1 ty2
-| PUninstantiated _, _ -> .
+| PExtra e, _ -> Util.Empty.abort e
 | (PRef _ | PVar _ | PEvar _ | PRel _ | PApp _ | PSoApp _
    | PLambda _ | PProd _ | PLetIn _ | PSort _ | PMeta _
    | PIf _ | PCase _ | PFix _ | PCoFix _ | PProj _ | PInt _
@@ -110,7 +110,7 @@ let rec occurn_pattern : 'a. _ -> 'a constr_pattern_r -> _
      Array.exists (occurn_pattern n) tl || Array.exists (occurn_pattern (n+Array.length tl)) bl
   | PArray (t,def,ty) ->
     Array.exists (occurn_pattern n) t || occurn_pattern n def || occurn_pattern n ty
-  | PUninstantiated (PGenarg _) -> false
+  | PExtra _ -> false (* XXX dubious behaviour *)
 
 let noccurn_pattern n c = not (occurn_pattern n c)
 
@@ -131,7 +131,7 @@ let rec head_pattern_bound (t:constr_pattern) =
     | PLambda _ -> raise BoundPattern
     | PCoFix _ | PInt _ | PFloat _ | PString _ | PArray _ ->
       anomaly ~label:"head_pattern_bound" (Pp.str "not a type.")
-    | PUninstantiated _ -> .
+    | PExtra e -> Util.Empty.abort e
 
 let head_of_constr_reference sigma c = match EConstr.kind sigma c with
   | Const (sp,_) -> GlobRef.ConstRef sp
@@ -261,14 +261,14 @@ let map_pattern_with_binders_gen (type a b) g f fgen l : a constr_pattern_r -> b
      PCoFix (ln,(lna,Array.map (f l) tl,Array.map (f l') bl))
   | PArray (t,def,ty) -> PArray (Array.map (f l) t, f l def, f l ty)
   | PEvar (ev,ps) -> PEvar (ev, List.map (f l) ps)
-  | PUninstantiated (PGenarg _ as x) -> fgen l (x:a uninstantiated_pattern)
+  | PExtra x -> fgen l x
   (* Non recursive *)
   | (PVar _ | PRel _ | PRef _  | PSort _  | PMeta _ | PInt _
     | PFloat _ | PString _ as x) -> x
 
 let map_pattern_with_binders (type a) g f l (p:a constr_pattern_r) : a constr_pattern_r =
-  let fgen _ : a uninstantiated_pattern -> a constr_pattern_r = function
-    | PGenarg _ as x -> PUninstantiated x
+  let fgen _ : a -> a constr_pattern_r = function
+    | x -> PExtra x
   in
   map_pattern_with_binders_gen g f fgen l p
 
@@ -278,9 +278,9 @@ let rec liftn_pattern k n = function
 
 let lift_pattern k = liftn_pattern k 1
 
-let rec subst_pattern
-  : 'a. _ -> _ -> _ -> 'a constr_pattern_r -> 'a constr_pattern_r
-  = fun (type a) env sigma subst (pat: a constr_pattern_r) ->
+let rec subst_pattern_gen
+  : 'a. (_ -> 'a -> 'a) -> _ -> _ -> _ -> 'a constr_pattern_r -> 'a constr_pattern_r
+  = fun (type a) gsubst env sigma subst (pat: a constr_pattern_r) ->
   match pat with
   | PRef ref ->
     let ref',t = subst_global subst ref in
@@ -294,43 +294,43 @@ let rec subst_pattern
   | PInt _
   | PFloat _
   | PString _ -> pat
-  | PUninstantiated (PGenarg g) -> PUninstantiated (PGenarg (Gensubst.generic_substitute subst g))
+  | PExtra g -> PExtra (gsubst subst g)
   | PProj (p,c) ->
       let p' = Projection.map (subst_mind subst) p in
-      let c' = subst_pattern env sigma subst c in
+      let c' = subst_pattern_gen gsubst env sigma subst c in
         if p' == p && c' == c then pat else
           PProj(p',c')
   | PApp (f,args) ->
-      let f' = subst_pattern env sigma subst f in
-      let args' = Array.Smart.map (subst_pattern env sigma subst) args in
+      let f' = subst_pattern_gen gsubst env sigma subst f in
+      let args' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) args in
         if f' == f && args' == args then pat else
           PApp (f',args')
   | PSoApp (i,args) ->
-      let args' = List.Smart.map (subst_pattern env sigma subst) args in
+      let args' = List.Smart.map (subst_pattern_gen gsubst env sigma subst) args in
         if args' == args then pat else
           PSoApp (i,args')
   | PLambda (name,c1,c2) ->
-      let c1' = subst_pattern env sigma subst c1 in
-      let c2' = subst_pattern env sigma subst c2 in
+      let c1' = subst_pattern_gen gsubst env sigma subst c1 in
+      let c2' = subst_pattern_gen gsubst env sigma subst c2 in
         if c1' == c1 && c2' == c2 then pat else
           PLambda (name,c1',c2')
   | PProd (name,c1,c2) ->
-      let c1' = subst_pattern env sigma subst c1 in
-      let c2' = subst_pattern env sigma subst c2 in
+      let c1' = subst_pattern_gen gsubst env sigma subst c1 in
+      let c2' = subst_pattern_gen gsubst env sigma subst c2 in
         if c1' == c1 && c2' == c2 then pat else
           PProd (name,c1',c2')
   | PLetIn (name,c1,t,c2) ->
-      let c1' = subst_pattern env sigma subst c1 in
-      let t' = Option.Smart.map (subst_pattern env sigma subst) t in
-      let c2' = subst_pattern env sigma subst c2 in
+      let c1' = subst_pattern_gen gsubst env sigma subst c1 in
+      let t' = Option.Smart.map (subst_pattern_gen gsubst env sigma subst) t in
+      let c2' = subst_pattern_gen gsubst env sigma subst c2 in
         if c1' == c1 && t' == t && c2' == c2 then pat else
           PLetIn (name,c1',t',c2')
   | PSort _
   | PMeta _ -> pat
   | PIf (c,c1,c2) ->
-      let c' = subst_pattern env sigma subst c in
-      let c1' = subst_pattern env sigma subst c1 in
-      let c2' = subst_pattern env sigma subst c2 in
+      let c' = subst_pattern_gen gsubst env sigma subst c in
+      let c1' = subst_pattern_gen gsubst env sigma subst c1 in
+      let c2' = subst_pattern_gen gsubst env sigma subst c2 in
         if c' == c && c1' == c1 && c2' == c2 then pat else
           PIf (c',c1',c2')
   | PCase (cip,typ,c,branches) ->
@@ -338,13 +338,13 @@ let rec subst_pattern
       let ind' = Option.Smart.map (subst_ind subst) ind in
       let cip' = if ind' == ind then cip else { cip with cip_ind = ind' } in
       let map ((nas, typ) as t) =
-        let typ' = subst_pattern env sigma subst typ in
+        let typ' = subst_pattern_gen gsubst env sigma subst typ in
         if typ' == typ then t else (nas, typ')
       in
       let typ' = Option.Smart.map map typ in
-      let c' = subst_pattern env sigma subst c in
+      let c' = subst_pattern_gen gsubst env sigma subst c in
       let subst_branch ((i,n,c) as br) =
-        let c' = subst_pattern env sigma subst c in
+        let c' = subst_pattern_gen gsubst env sigma subst c in
         if c' == c then br else (i,n,c')
       in
       let branches' = List.Smart.map subst_branch branches in
@@ -352,21 +352,27 @@ let rec subst_pattern
       then pat
       else PCase(cip', typ', c', branches')
   | PFix (lni,(lna,tl,bl)) ->
-      let tl' = Array.Smart.map (subst_pattern env sigma subst) tl in
-      let bl' = Array.Smart.map (subst_pattern env sigma subst) bl in
+      let tl' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) tl in
+      let bl' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) bl in
       if bl' == bl && tl' == tl then pat
       else PFix (lni,(lna,tl',bl'))
   | PCoFix (ln,(lna,tl,bl)) ->
-      let tl' = Array.Smart.map (subst_pattern env sigma subst) tl in
-      let bl' = Array.Smart.map (subst_pattern env sigma subst) bl in
+      let tl' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) tl in
+      let bl' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) bl in
       if bl' == bl && tl' == tl then pat
       else PCoFix (ln,(lna,tl',bl'))
   | PArray (t,def,ty) ->
-      let t' = Array.Smart.map (subst_pattern env sigma subst) t in
-      let def' = subst_pattern env sigma subst def in
-      let ty' = subst_pattern env sigma subst ty in
+      let t' = Array.Smart.map (subst_pattern_gen gsubst env sigma subst) t in
+      let def' = subst_pattern_gen gsubst env sigma subst def in
+      let ty' = subst_pattern_gen gsubst env sigma subst ty in
       if def' == def && t' == t && ty' == ty then pat
       else PArray (t',def',ty')
+
+let subst_pattern env sigma subst p =
+  subst_pattern_gen (fun _ e -> Util.Empty.abort e) env sigma subst p
+
+let subst_uninstantiated_pattern env sigma subst p =
+  subst_pattern_gen Gensubst.generic_substitute env sigma subst p
 
 let mkPLetIn na b t c = PLetIn(na,b,t,c)
 let mkPProd na t u = PProd(na,t,u)
@@ -412,7 +418,7 @@ let error_instantiate_pattern id l =
 
 let interp_pattern env sigma ist p =
   let fgen vars = function
-    | PGenarg (GenArg (Glbwit tag,g)) -> interp_pat tag env sigma ist g
+    | Genarg.GenArg (Glbwit tag,g) -> interp_pat tag env sigma ist g
   in
   let rec aux vars = function
     | PVar id as x ->
@@ -509,7 +515,7 @@ let rec pat_of_raw metas vars : _ -> _ constr_pattern_r = DAst.with_loc_val (fun
         let name = Genarg.(ArgT.repr (get_arg_tag tag)) in
         user_err ?loc (str "This quotation is not supported in patterns (" ++ str name ++ str ").")
     in
-    PUninstantiated (PGenarg g)
+    PExtra g
   | GCast (c,_,t) ->
       let () =
         (* Checks that there are no pattern variables in the type *)

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -49,9 +49,7 @@ val legacy_bad_pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr
    a pattern; variables bound in [l] are replaced by the pattern to which they
     are bound *)
 
-val pattern_of_glob_constr : Environ.env -> glob_constr -> Id.Set.t * constr_pattern
-
-val uninstantiated_pattern_of_glob_constr : Environ.env -> glob_constr -> Id.Set.t * [`uninstantiated] constr_pattern_r
+val pattern_of_glob_constr : Environ.env -> glob_constr -> Id.Set.t * [`uninstantiated] constr_pattern_r
 
 val map_pattern_with_binders : (Name.t -> 'a -> 'a) ->
   ('a -> 'i constr_pattern_r -> 'i constr_pattern_r) -> 'a -> 'i constr_pattern_r -> 'i constr_pattern_r

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -18,7 +18,8 @@ open EConstr
 
 val constr_pattern_eq : Environ.env -> constr_pattern -> constr_pattern -> bool
 
-val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> 'i constr_pattern_r -> 'i constr_pattern_r
+val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> constr_pattern -> constr_pattern
+val subst_uninstantiated_pattern : Environ.env -> Evd.evar_map -> substitution -> uninstantiated_pattern -> uninstantiated_pattern
 
 val noccurn_pattern : int -> _ constr_pattern_r -> bool
 
@@ -49,7 +50,7 @@ val legacy_bad_pattern_of_constr : Environ.env -> Evd.evar_map -> EConstr.constr
    a pattern; variables bound in [l] are replaced by the pattern to which they
     are bound *)
 
-val pattern_of_glob_constr : Environ.env -> glob_constr -> Id.Set.t * [`uninstantiated] constr_pattern_r
+val pattern_of_glob_constr : Environ.env -> glob_constr -> Id.Set.t * uninstantiated_pattern
 
 val map_pattern_with_binders : (Name.t -> 'a -> 'a) ->
   ('a -> 'i constr_pattern_r -> 'i constr_pattern_r) -> 'a -> 'i constr_pattern_r -> 'i constr_pattern_r
@@ -61,6 +62,6 @@ val lift_pattern : int -> 'i constr_pattern_r -> 'i constr_pattern_r
 type 'a pat_interp_fun = Environ.env -> Evd.evar_map -> Ltac_pretype.ltac_var_map
   -> 'a -> Pattern.constr_pattern
 
-val interp_pattern : [`uninstantiated] constr_pattern_r pat_interp_fun
+val interp_pattern : uninstantiated_pattern pat_interp_fun
 
 val register_interp_pat : (_, 'g, _) Genarg.genarg_type -> 'g pat_interp_fun -> unit

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -115,6 +115,10 @@ let pr_lconstr_pattern_env env sigma c =
   pr_lconstr_pattern_expr env sigma (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
 let pr_constr_pattern_env env sigma c =
   pr_constr_pattern_expr env sigma (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
+let pr_uninstantiated_lconstr_pattern_env env sigma c =
+  pr_lconstr_pattern_expr env sigma (extern_uninstantiated_pattern (Termops.names_of_rel_context env) sigma c)
+let pr_uninstantiated_constr_pattern_env env sigma c =
+  pr_constr_pattern_expr env sigma (extern_uninstantiated_pattern (Termops.names_of_rel_context env) sigma c)
 
 let pr_cases_pattern t =
   pr_cases_pattern_expr (extern_cases_pattern Names.Id.Set.empty t)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -110,9 +110,13 @@ val pr_lglob_constr_env    : env -> evar_map -> 'a glob_constr_g -> Pp.t
 
 val pr_glob_constr_env     : env -> evar_map -> 'a glob_constr_g -> Pp.t
 
-val pr_lconstr_pattern_env : env -> evar_map -> _ constr_pattern_r -> Pp.t
+val pr_lconstr_pattern_env : env -> evar_map -> constr_pattern -> Pp.t
 
-val pr_constr_pattern_env  : env -> evar_map -> _ constr_pattern_r -> Pp.t
+val pr_constr_pattern_env  : env -> evar_map -> constr_pattern -> Pp.t
+
+val pr_uninstantiated_lconstr_pattern_env : env -> evar_map -> uninstantiated_pattern -> Pp.t
+
+val pr_uninstantiated_constr_pattern_env  : env -> evar_map -> uninstantiated_pattern -> Pp.t
 
 val pr_cases_pattern       : cases_pattern -> Pp.t
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -255,7 +255,7 @@ let add_class cl =
 let intern_info {hint_priority;hint_pattern} =
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let hint_pattern = Option.map (Constrintern.intern_constr_pattern env sigma) hint_pattern in
+  let hint_pattern = Option.map (Constrintern.interp_constr_pattern env sigma) hint_pattern in
   {hint_priority;hint_pattern}
 
 (** TODO: add subinstances *)

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -96,7 +96,7 @@ let interp_hints ~poly h =
         "Declaring arbitrary terms as hints is forbidden. You must declare a \
         toplevel constant instead.")
   in
-  let fp = Constrintern.intern_constr_pattern env sigma in
+  let fp = Constrintern.interp_constr_pattern env sigma in
   let fres (info, b, r) =
     let gr = fi r in
     let info =
@@ -114,7 +114,7 @@ let interp_hints ~poly h =
     | HintsProjections -> HintsProjections
     | HintsReferences lhints -> HintsReferences (List.map fr lhints)
   in
-  let fp = Constrintern.intern_constr_pattern (Global.env ()) in
+  let fp = Constrintern.interp_constr_pattern (Global.env ()) in
   match h with
   | HintsResolve lhints -> HintsResolveEntry (List.map fres lhints)
   | HintsResolveIFF (l2r, lc, n) ->

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -88,7 +88,7 @@ let interp_search_item env sigma =
              which fails, not seeing that A can be Prop; so we use an
              untyped pattern as a fallback (i.e w/o no insertion of
              coercions, no compilation of pattern-matching) *)
-          snd (Constrintern.intern_constr_pattern env sigma ~as_type:head pat) in
+          snd (Constrintern.interp_constr_pattern env sigma ~as_type:head pat) in
       GlobSearchSubPattern (where,head,pat)
   | SearchString ((Anywhere,false),s,None)
       when Id.is_valid_ident_part s && String.equal (String.drop_simple_quotes s) s ->
@@ -131,7 +131,7 @@ let () =
 
 let interp_search env sigma s r =
   let r = interp_search_restriction r in
-  let get_pattern c = snd (Constrintern.intern_constr_pattern env sigma c) in
+  let get_pattern c = snd (Constrintern.interp_constr_pattern env sigma c) in
   let warnlist = ref [] in
   let pr_search ref kind env sigma c =
     let pr = pr_global ref in


### PR DESCRIPTION
Now we really have `Pattern.constr_pattern` for evaluated patterns,
and `[`uninstantiated] Pattern.constr_pattern_r` for globalized but
not evaluated patterns.

Although it seems to turn the `Any -> user_err ?loc (str "Quotations
not allowed in this pattern.")` branch in Patternops.pattern_of_raw into dead code, in fact it was already dead code as the only genarg which has a registered pattern internalization function (for Genintern.generic_intern_pat) is the ltac2 `$` so the only genarg we can see in constr_pattern_r is that one. Then we have 2 cases:

- pattern in ltac2 code, in which case it was already using
  `Uninstantiated` instead of `Any`
- other pattern (ltac, Hint Extern, etc), in which case no ltac2 variables are bound so
  internalization of `$` fails before we reach pattern_of_glob_constr.


Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/100
- https://github.com/ejgallego/coq-lsp/pull/958
- https://github.com/LPCIC/coq-elpi/pull/824