### PR TITLE
Use opam install instead of make in github CI

### DIFF
--- a/.github/workflows/ci-github.yml
+++ b/.github/workflows/ci-github.yml
@@ -44,11 +44,5 @@ jobs:
           ocaml-compiler: 4.14
           dune-cache: true
 
-      - name: 🐫🐪🐫 Get Rocq dependencies
-        run: opam install --deps-only ${{ matrix.packages }}
-
-      - name: 🧱 Build Rocq
-        run: opam exec -- make world
-
-      - name: 🐛 Test Rocq
-        run: opam exec -- make -j 4 -C test-suite DISABLED_SUBSYSTEMS='${{ matrix.test_disabled }}'
+      - name: 🧱 Build & test Rocq
+        run: opam install ${{ matrix.packages }}

--- a/test-suite/tools/coq_config_to_make.ml
+++ b/test-suite/tools/coq_config_to_make.ml
@@ -46,6 +46,9 @@ let canonical_path_name p =
     Filename.concat current p
 
 let find_in_PATH f =
+  let f = if Coq_config.arch_is_win32 && Filename.extension f <> ".exe" then f^".exe"
+    else f
+  in
   if Filename.basename f <> f then Some f
   else match Sys.getenv_opt "PATH" with
   | None -> None


### PR DESCRIPTION
Note that this includes the test suite since we have it as a separate package.

Will need to adapt the disabled subsystems but first let's see if this breaks in other ways.