### PR TITLE
Use a uniform representation for inductive nodes in extraction.

### DIFF
--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -217,7 +217,7 @@ let rec extract_structure_spec table venv env mp reso = function
       else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
   | (l,SFBmind _) :: msig ->
       let mind = make_mind reso mp l in
-      let s = Sind (mind, extract_inductive table env mind) in
+      let s = Sind (extract_inductive table env mind) in
       let specs = extract_structure_spec table venv env mp reso msig in
       if logical_spec s then specs
       else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
@@ -330,7 +330,7 @@ let rec extract_structure table access venv env mp reso ~all = function
       let mind = make_mind reso mp l in
       let b = Visit.needed_ind venv mind in
       if all || b then
-        let d = Dind (mind, extract_inductive table env mind) in
+        let d = Dind (extract_inductive table env mind) in
         if (not b) && (logical_decl d) then ms
         else
           let () = Visit.add_decl_deps venv d in

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -508,9 +508,12 @@ and extract_really_ind table env kn mib =
            let ar = EConstr.of_constr ar in
            let info = (fst (flag_of_type env sg ar) = Info) in
            let s,v = if info then type_sign_vl env sg ar else [],[] in
-           let t = Array.make (Array.length mip.mind_nf_lc) [] in
+           let ncons = Array.length mip.mind_nf_lc in
+           let t = Array.make ncons [] in
            { ip_typename = mip.mind_typename;
+             ip_typename_ref = GlobRef.IndRef (kn, i);
              ip_consnames = mip.mind_consnames;
+             ip_consnames_ref = Array.init ncons (fun j -> GlobRef.ConstructRef ((kn, i), j + 1));
              ip_logical = not info;
              ip_sign = s;
              ip_vars = v;

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1249,7 +1249,7 @@ let logical_decl = function
   | Dfix (_,av,tv) ->
       (Array.for_all isMLdummy av) &&
       (Array.for_all isTdummy tv)
-  | Dind (_,i) -> Array.for_all (fun ip -> ip.ip_logical) i.ind_packets
+  | Dind i -> Array.for_all (fun ip -> ip.ip_logical) i.ind_packets
   | _ -> false
 
 (*s Is a [ml_spec] logical ? *)
@@ -1257,5 +1257,5 @@ let logical_decl = function
 let logical_spec = function
   | Stype (_, _, Some (Tdummy _)) -> true
   | Sval (_,Tdummy _) -> true
-  | Sind (_,i) -> Array.for_all (fun ip -> ip.ip_logical) i.ind_packets
+  | Sind i -> Array.for_all (fun ip -> ip.ip_logical) i.ind_packets
   | _ -> false

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -215,10 +215,10 @@ and json_function table env t =
 
 let json_ind table ip pl cv = json_dict [
     ("what", json_str "decl:ind");
-    ("name", json_global table Type (GlobRef.IndRef ip));
+    ("name", json_global table Type ip.ip_typename_ref);
     ("argnames", json_list (List.map json_id pl));
     ("constructors", json_listarr (Array.mapi (fun idx c -> json_dict [
-        ("name", json_global table Cons (GlobRef.ConstructRef (ip, idx+1)));
+        ("name", json_global table Cons ip.ip_consnames_ref.(idx));
         ("argtypes", json_list (List.map (json_type table pl) c))
       ]) cv))
   ]
@@ -227,9 +227,9 @@ let json_ind table ip pl cv = json_dict [
 (*s Pretty-printing of a declaration. *)
 
 let pp_decl table = function
-  | Dind (kn, defs) -> prvecti_with_sep pr_comma
+  | Dind defs -> prvecti_with_sep pr_comma
     (fun i p -> if p.ip_logical then str ""
-     else json_ind table (kn, i) p.ip_vars p.ip_types) defs.ind_packets
+     else json_ind table p p.ip_vars p.ip_types) defs.ind_packets
   | Dtype (r, l, t) -> json_dict [
       ("what", json_str "decl:type");
       ("name", json_global table Type r);

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -71,7 +71,9 @@ type inductive_kind =
 
 type ml_ind_packet = {
   ip_typename : Id.t;
+  ip_typename_ref : GlobRef.t;
   ip_consnames : Id.t array;
+  ip_consnames_ref : GlobRef.t array;
   ip_logical : bool;
   ip_sign : signature;
   ip_vars : Id.t list;

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -143,13 +143,13 @@ and ml_pattern =
 (*s ML declarations. *)
 
 type ml_decl =
-  | Dind  of MutInd.t * ml_ind
+  | Dind  of ml_ind
   | Dtype of GlobRef.t * Id.t list * ml_type
   | Dterm of GlobRef.t * ml_ast * ml_type
   | Dfix  of GlobRef.t array * ml_ast array * ml_type array
 
 type ml_spec =
-  | Sind  of MutInd.t * ml_ind
+  | Sind  of ml_ind
   | Stype of GlobRef.t * Id.t list * ml_type option
   | Sval  of GlobRef.t * ml_type
 

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -71,7 +71,9 @@ type inductive_kind =
 
 type ml_ind_packet = {
   ip_typename : Id.t;
+  ip_typename_ref : GlobRef.t;
   ip_consnames : Id.t array;
+  ip_consnames_ref : GlobRef.t array;
   ip_logical : bool;
   ip_sign : signature;
   ip_vars : Id.t list;

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -143,13 +143,13 @@ and ml_pattern =
 (*s ML declarations. *)
 
 type ml_decl =
-  | Dind  of MutInd.t * ml_ind
+  | Dind  of ml_ind
   | Dtype of GlobRef.t * Id.t list * ml_type
   | Dterm of GlobRef.t * ml_ast * ml_type
   | Dfix  of GlobRef.t array * ml_ast array * ml_type array
 
 type ml_spec =
-  | Sind  of MutInd.t * ml_ind
+  | Sind  of ml_ind
   | Stype of GlobRef.t * Id.t list * ml_type option
   | Sval  of GlobRef.t * ml_type
 


### PR DESCRIPTION
We do not need to store the inductive reference in the node since it is actually systematically derived from the data in the block. This is actually cleaner since it requires less fiddling with indices.