### PR TITLE
Fix wrong threading of cv_pb/pb in unification.ml

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1194,7 +1194,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
         (* Fast path for projections. *)
         | Proj (p1,_,c1), Proj (p2,_,c2) when Environ.QConstant.equal env
             (Projection.constant p1) (Projection.constant p2) ->
-          (try unify_same_proj curenvnb pb {opt with at_top = true}
+          (try unify_same_proj curenvnb CONV {opt with at_top = true}
                substn c1 c2
            with ex when precatchable_exception ex ->
              unify_not_same_head curenvnb pb opt substn ~nargs cM cN)

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1082,7 +1082,7 @@ let fast_occur_meta_or_undefined_evar sigma (c, gnd) = match gnd with
 | Ground -> false
 | NotGround -> true
 
-let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags m n =
+let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n =
   let mk_expand_subst substn =
     let metasubst = if flags.use_metas_eagerly_in_conv_on_closed_terms then substn.subst_metas else subst.subst_metas in
     let evarsubst = if flags.use_evars_eagerly_in_conv_on_closed_terms then substn.subst_evars else subst.subst_evars in
@@ -1152,7 +1152,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
         | Evar (evk,_ as ev), Evar (evk',_)
             when is_evar_allowed flags evk
               && Evar.equal evk evk' ->
-            begin match constr_cmp cv_pb env sigma flags cM cN with
+            begin match constr_cmp pb env sigma flags cM cN with
             | Some sigma ->
               push_sigma sigma substn
             | None ->
@@ -1194,7 +1194,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
         (* Fast path for projections. *)
         | Proj (p1,_,c1), Proj (p2,_,c2) when Environ.QConstant.equal env
             (Projection.constant p1) (Projection.constant p2) ->
-          (try unify_same_proj curenvnb cv_pb {opt with at_top = true}
+          (try unify_same_proj curenvnb pb {opt with at_top = true}
                substn c1 c2
            with ex when precatchable_exception ex ->
              unify_not_same_head curenvnb pb opt substn ~nargs cM cN)
@@ -1367,7 +1367,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
         if Array.length l1 == 0 then error_cannot_unify (fst curenvnb) sigma (cM,cN)
         else
           Array.fold_left2 (unirec_rec curenvnb CONV opta ~nargs:0)
-            (unirec_rec curenvnb CONV optf substn f1 f2 ~nargs:(Array.length l1)) l1 l2
+            (unirec_rec curenvnb pb optf substn f1 f2 ~nargs:(Array.length l1)) l1 l2
     with ex when precatchable_exception ex ->
     try reduce curenvnb pb {opt with with_types = false} substn cM cN
     with ex when precatchable_exception ex ->
@@ -1393,7 +1393,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
     let sigma = substn.subst_sigma in
     try canonical_projections curenvnb pb opt cM cN substn
     with ex when precatchable_exception ex ->
-    match constr_cmp cv_pb env sigma flags ~nargs cM cN with
+    match constr_cmp pb env sigma flags ~nargs cM cN with
     | Some sigma -> push_sigma sigma substn
     | None ->
         try reduce curenvnb pb opt substn cM cN
@@ -1594,8 +1594,8 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
       let (m, _) = m in
       let (n, _) = n in
       let ans = match flags.modulo_conv_on_closed_terms with
-        | Some convflags -> careful_infer_conv ~pb:cv_pb ~ts:convflags env sigma m n
-        | _ -> constr_cmp cv_pb env sigma flags m n in
+        | Some convflags -> careful_infer_conv ~pb ~ts:convflags env sigma m n
+        | _ -> constr_cmp pb env sigma flags m n in
       match ans with
       | Some sigma -> ans
       | None ->
@@ -1608,7 +1608,7 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
   in
     let a = match res with
     | Some sigma -> push_sigma sigma subst
-    | None -> unirec_rec (env,0) cv_pb opt subst (fst m) (fst n) in
+    | None -> unirec_rec (env,0) pb opt subst (fst m) (fst n) in
     debug_tactic_unification (fun () -> str "Leaving unification with success");
     a
   with e ->

--- a/test-suite/bugs/bug_21167_1.v
+++ b/test-suite/bugs/bug_21167_1.v
@@ -1,0 +1,26 @@
+Set Universe Polymorphism.
+Set Polymorphic Inductive Cumulativity.
+
+Record pType@{u} : Type@{u+1} := { pointed_type : Type@{u} }.
+
+Class IsGraph@{u} (A : Type@{u}) : Set := { }.
+
+Record CatEquiv@{u} {A : Type@{u}} {G : IsGraph@{u} A} (a b : A) : Set := {}.
+
+Declare Instance isgraph_ptype@{u v|u < v} : IsGraph@{v} pType@{u}.
+
+Axiom pfiber@{u} : pType@{u}.
+
+Set Typeclasses Debug.
+
+Axiom pequiv_pfiber : CatEquiv pfiber pfiber.
+(* succeeds on master, on this PR fails with
+Illegal application:
+The term "@CatEquiv@{Top.29}" of type "forall A : Type@{Top.29}, IsGraph@{Top.29} A -> A -> A -> Set"
+cannot be applied to the terms
+ "pType@{Top.30}" : "Type@{Top.30+1}"
+ "isgraph_ptype@{Top.32 Top.29}" : "IsGraph@{Top.29} pType@{Top.32}"
+ "pfiber@{Top.30}" : "pType@{Top.30}"
+ "pfiber@{Top.31}" : "pType@{Top.31}"
+The 2nd term has type "IsGraph@{Top.29} pType@{Top.32}" which should be a subtype of
+ "IsGraph@{Top.29} pType@{Top.30}". *)


### PR DESCRIPTION
Spotted while debugging my new universes branch.
We could sometimes use `CUMUL` instead of `CONV`, e.g. while unifying arguments of applications. This could result in unsatisfiable constraints being sent to the kernel.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????
 TODO

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.
