### PR TITLE
Monomorphize sort polymorphic code in extraction.

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -235,7 +235,6 @@ type t = {
   (* fields below are read-only *)
   modular : bool;
   library : bool;
-  extrcompute : bool;
   (*s Extraction modes: modular or monolithic, library or minimal ?
 
   Nota:
@@ -258,12 +257,11 @@ let make_state kw = {
   mpfiles_content = MPmap.empty;
 }
 
-let make ~modular ~library ~extrcompute ~keywords () = {
+let make ~modular ~library ~keywords () = {
   table = Table.make_table ();
   state = ref (make_state keywords);
   modular;
   library;
-  extrcompute;
   keywords;
   phase = Impl;
   visibility = [];
@@ -274,8 +272,6 @@ let get_table s = s.table
 let get_modular s = s.modular
 
 let get_library s = s.library
-
-let get_extrcompute s = s.extrcompute
 
 let get_keywords s = s.keywords
 

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -701,7 +701,7 @@ let is_ascii_registered () =
   Rocqlib.has_ref ascii_type_name
   && Rocqlib.has_ref ascii_constructor_name
 
-let ascii_type_ref () = Rocqlib.lib_ref ascii_type_name
+let ascii_type_ref () = { glob = Rocqlib.lib_ref ascii_type_name }
 
 let check_extract_ascii () =
   try
@@ -713,21 +713,27 @@ let check_extract_ascii () =
     String.equal (find_custom @@ ascii_type_ref ()) (char_type)
   with Not_found -> false
 
+let is_constructor r = match r.glob with GlobRef.ConstructRef _ -> true | _ -> false
+
 let is_list_cons l =
- List.for_all (function MLcons (_,GlobRef.ConstructRef(_,_),[]) -> true | _ -> false) l
+ List.for_all (function MLcons (_, r, []) -> is_constructor r | _ -> false) l
 
 let is_native_char = function
   | MLcons(_,gr,l) ->
     is_ascii_registered ()
-    && Rocqlib.check_ref ascii_constructor_name gr
+    && Rocqlib.check_ref ascii_constructor_name gr.glob
     && check_extract_ascii ()
     && is_list_cons l
   | _ -> false
 
+let get_constructor r = match r.glob with
+| GlobRef.ConstructRef(_, j) -> j
+| _ -> assert false
+
 let get_native_char c =
   let rec cumul = function
     | [] -> 0
-    | MLcons(_,GlobRef.ConstructRef(_,j),[])::l -> (2-j) + 2 * (cumul l)
+    | MLcons(_, r, [])::l -> (2 - get_constructor r) + 2 * (cumul l)
     | _ -> assert false
   in
   let l = match c with MLcons(_,_,l) -> l | _ -> assert false in
@@ -748,7 +754,7 @@ let is_string_registered () =
   && Rocqlib.has_ref empty_string_name
   && Rocqlib.has_ref string_constructor_name
 
-let string_type_ref () = Rocqlib.lib_ref string_type_name
+let string_type_ref () = { glob = Rocqlib.lib_ref string_type_name }
 
 let check_extract_string () =
   try
@@ -766,10 +772,10 @@ let check_extract_string () =
 
 let rec is_native_string_rec empty_string_ref string_constructor_ref = function
   (* "EmptyString" constructor *)
-  | MLcons(_, gr, []) -> Rocqlib.check_ref empty_string_ref gr
+  | MLcons(_, gr, []) -> Rocqlib.check_ref empty_string_ref gr.glob
   (* "String" constructor *)
   | MLcons(_, gr, [hd; tl]) ->
-      Rocqlib.check_ref string_constructor_ref gr
+      Rocqlib.check_ref string_constructor_ref gr.glob
       && is_native_char hd
       && is_native_string_rec empty_string_ref string_constructor_ref tl
   (* others *)
@@ -780,11 +786,15 @@ let rec is_native_string_rec empty_string_ref string_constructor_ref = function
    requested.  Then we check every character via
    [is_native_string_rec]. *)
 
+let is_string_constructor = function
+| GlobRef.ConstructRef (ind, _) -> Rocqlib.check_ref string_type_name (GlobRef.IndRef ind)
+| _ -> false
+
 let is_native_string c =
   match c with
-  | MLcons(_, GlobRef.ConstructRef(ind, j), l) ->
+  | MLcons(_, gr, l) ->
       is_string_registered ()
-      && Rocqlib.check_ref string_type_name (GlobRef.IndRef ind)
+      && is_string_constructor gr.glob
       && check_extract_string ()
       && is_native_string_rec empty_string_name string_constructor_name c
   | _ -> false
@@ -795,10 +805,10 @@ let get_native_string c =
   let buf = Buffer.create 64 in
   let rec get = function
     (* "EmptyString" constructor *)
-    | MLcons(_, gr, []) when Rocqlib.check_ref empty_string_name gr ->
+    | MLcons(_, gr, []) when Rocqlib.check_ref empty_string_name gr.glob ->
         Buffer.contents buf
     (* "String" constructor *)
-    | MLcons(_, gr, [hd; tl]) when Rocqlib.check_ref string_constructor_name gr ->
+    | MLcons(_, gr, [hd; tl]) when Rocqlib.check_ref string_constructor_name gr.glob ->
         Buffer.add_char buf (get_native_char hd);
         get tl
     (* others *)

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -467,12 +467,16 @@ let ref_renaming_fun table (k,r) =
   let l = if lang () != Ocaml && not (State.get_modular table) then [""] else l in
   let s =
     let idg = safe_basename_of_global (State.get_table table) r in
+    let app_suf s = match InfvInst.encode r.inst with
+    | None -> s
+    | Some suf -> s ^ "__" ^ suf
+    in
     match l with
     | [""] -> (* this happens only at toplevel of the monolithic case *)
       let globs = State.get_global_ids table in
       let id = next_ident_away (kindcase_id k idg) globs in
-      Id.to_string id
-    | _ -> modular_rename table k idg
+      app_suf (Id.to_string id)
+    | _ -> app_suf (modular_rename table k idg)
   in
   let () = State.add_global_ids table (Id.of_string s) in
   s::l
@@ -701,7 +705,9 @@ let is_ascii_registered () =
   Rocqlib.has_ref ascii_type_name
   && Rocqlib.has_ref ascii_constructor_name
 
-let ascii_type_ref () = { glob = Rocqlib.lib_ref ascii_type_name }
+let ascii_type_ref () =
+  (* FIXME: support sort poly? *)
+  { glob = Rocqlib.lib_ref ascii_type_name; inst = InfvInst.empty }
 
 let check_extract_ascii () =
   try
@@ -754,7 +760,9 @@ let is_string_registered () =
   && Rocqlib.has_ref empty_string_name
   && Rocqlib.has_ref string_constructor_name
 
-let string_type_ref () = { glob = Rocqlib.lib_ref string_type_name }
+let string_type_ref () =
+  (* FIXME: support sort poly? *)
+  { glob = Rocqlib.lib_ref string_type_name; inst = InfvInst.empty }
 
 let check_extract_string () =
   try

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -42,14 +42,13 @@ type phase = Pre | Impl | Intf
 module State :
 sig
   type t
-  val make : modular:bool -> library:bool -> extrcompute:bool -> keywords:Id.Set.t -> unit -> t
+  val make : modular:bool -> library:bool -> keywords:Id.Set.t -> unit -> t
 
   (** Getters *)
 
   val get_table : t -> Table.t
   val get_modular : t -> bool
   val get_library : t -> bool
-  val get_extrcompute : t -> bool
   val get_keywords : t -> Id.Set.t
   val get_phase : t -> phase
   val get_duplicate : t -> ModPath.t -> Label.t -> string option

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -82,9 +82,9 @@ val opened_libraries : State.t -> ModPath.t list
 
 type kind = Term | Type | Cons | Mod
 
-val pp_global_with_key : State.t -> kind -> KerName.t -> GlobRef.t -> string
-val pp_global : State.t -> kind -> GlobRef.t -> string
-val pp_global_name : State.t -> kind -> GlobRef.t -> string
+val pp_global_with_key : State.t -> kind -> KerName.t -> global -> string
+val pp_global : State.t -> kind -> global -> string
+val pp_global_name : State.t -> kind -> global -> string
 val pp_module : State.t -> ModPath.t -> string
 
 (* val clear_mpfiles_content : unit -> unit *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -60,19 +60,28 @@ module type VISIT = sig
   (* Add reference / ... in the visit lists.
      These functions silently add the mp of their arg in the mp list *)
   val add_ref : t -> global -> unit
-  val add_kn : t -> KerName.t -> unit
+  val add_kn : t -> KerName.t -> InfvInst.t -> unit
   val add_decl_deps : t -> ml_decl -> unit
   val add_spec_deps : t -> ml_spec -> unit
 
   (* Test functions:
      is a particular object a needed dependency for the current extraction ? *)
-  val needed_ind : t -> MutInd.t -> bool
-  val needed_cst : t -> Constant.t -> bool
+  val needed_ind : t -> MutInd.t -> InfvInst.t -> bool
+  val needed_cst : t -> Constant.t -> InfvInst.t -> bool
   val needed_mp : t -> ModPath.t -> bool
   val needed_mp_all : t -> ModPath.t -> bool
 end
 
 module Visit : VISIT = struct
+  module KNOrd =
+  struct
+    type t = KerName.t * InfvInst.t
+    let compare (kn1, i1) (kn2, i2) =
+      let c = KerName.compare kn1 kn2 in
+      if Int.equal c 0 then InfvInst.compare i1 i2 else c
+  end
+  module KNset = Set.Make(KNOrd)
+
   type t =
       { mutable kn : KNset.t;
         mutable mp : MPset.t;
@@ -84,8 +93,8 @@ module Visit : VISIT = struct
     mp_all = MPset.empty;
   }
   (* the accessor functions *)
-  let needed_ind v i = KNset.mem (MutInd.user i) v.kn
-  let needed_cst v c = KNset.mem (Constant.user c) v.kn
+  let needed_ind v i inst = KNset.mem (MutInd.user i, inst) v.kn
+  let needed_cst v c inst = KNset.mem (Constant.user c, inst) v.kn
   let needed_mp v mp = MPset.mem mp v.mp || MPset.mem mp v.mp_all
   let needed_mp_all v mp = MPset.mem mp v.mp_all
   let add_mp v mp =
@@ -94,10 +103,10 @@ module Visit : VISIT = struct
     check_loaded_modfile mp;
     v.mp <- MPset.union (prefixes_mp mp) v.mp;
     v.mp_all <- MPset.add mp v.mp_all
-  let add_kn v kn = v.kn <- KNset.add kn v.kn; add_mp v (KerName.modpath kn)
+  let add_kn v kn inst = v.kn <- KNset.add (kn, inst) v.kn; add_mp v (KerName.modpath kn)
   let add_ref v r = let open GlobRef in match r.glob with
-    | ConstRef c -> add_kn v (Constant.user c)
-    | IndRef (ind,_) | ConstructRef ((ind,_),_) -> add_kn v (MutInd.user ind)
+    | ConstRef c -> add_kn v (Constant.user c) r.inst
+    | IndRef (ind,_) | ConstructRef ((ind,_),_) -> add_kn v (MutInd.user ind) r.inst
     | VarRef _ -> assert false
   let add_decl_deps v decl =
     decl_iter_references (fun kn -> add_ref v kn) (fun r -> add_ref v r) (fun r -> add_ref v r) decl
@@ -105,8 +114,20 @@ module Visit : VISIT = struct
     spec_iter_references (fun r -> add_ref v r) (fun r -> add_ref v r) (fun r -> add_ref v r) spec
 end
 
+let get_mono_inst_univs = function
+| Monomorphic -> [InfvInst.empty]
+| Polymorphic uctx -> InfvInst.generate uctx
+
+let get_mono_inst = function
+| SFBconst cb -> get_mono_inst_univs cb.const_universes
+| SFBmind mib -> get_mono_inst_univs mib.mind_universes
+| SFBrules _ -> [InfvInst.empty]
+| SFBmodule _ | SFBmodtype _ -> assert false
+
 let add_field_label venv mp = function
-  | (lab, (SFBconst _|SFBmind _ | SFBrules _)) -> Visit.add_kn venv (KerName.make mp lab)
+  | (lab, (SFBconst _|SFBmind _ | SFBrules _  as f)) ->
+    let insts = get_mono_inst f in
+    List.iter (fun inst -> Visit.add_kn venv (KerName.make mp lab) inst) insts
   | (lab, (SFBmodule _|SFBmodtype _)) -> Visit.add_mp_all venv (MPdot (mp,lab))
 
 let rec add_labels venv mp = function
@@ -209,18 +230,32 @@ let make_mind resolver mp l =
 
 let rec extract_structure_spec table venv env mp reso = function
   | [] -> []
-  | (l,SFBconst cb) :: msig ->
-      let c = make_cst reso mp l in
-      let s = extract_constant_spec table env c cb in
-      let specs = extract_structure_spec table venv env mp reso msig in
+  | (l, SFBconst cb) :: msig ->
+    let insts = get_mono_inst_univs cb.const_universes in
+    let c = make_cst reso mp l in
+    let map inst = extract_constant_spec table env c inst cb in
+    let consts = List.map map insts in
+    let specs = extract_structure_spec table venv env mp reso msig in
+    let fold s specs =
       if logical_spec s then specs
-      else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
-  | (l,SFBmind _) :: msig ->
-      let mind = make_mind reso mp l in
-      let s = Sind (extract_inductive table env mind) in
-      let specs = extract_structure_spec table venv env mp reso msig in
+      else
+        let () = Visit.add_spec_deps venv s in
+        (l, Spec s) :: specs
+    in
+    List.fold_right fold consts specs
+  | (l, SFBmind mib) :: msig ->
+    let insts = get_mono_inst_univs mib.mind_universes in
+    let mind = make_mind reso mp l in
+    let map inst = Sind (extract_inductive table env mind inst) in
+    let minds = List.map map insts in
+    let specs = extract_structure_spec table venv env mp reso msig in
+    let fold s specs =
       if logical_spec s then specs
-      else begin Visit.add_spec_deps venv s; (l,Spec s) :: specs end
+      else
+        let () = Visit.add_spec_deps venv s in
+        (l, Spec s) :: specs
+    in
+    List.fold_right fold minds specs
   | (l, SFBrules _) :: msig ->
       let specs = extract_structure_spec table venv env mp reso msig in
       specs
@@ -246,6 +281,13 @@ and extract_mexpr_spec table venv env mp1 (me_struct_o,me_alg) = match me_alg wi
     let () = Visit.add_mp_all venv mp in
     MTident mp
   | MEwith(me',WithDef(idl,(c,ctx)))->
+      let () = match ctx with
+      | None -> ()
+      | Some auctx ->
+        (* XXX *)
+        if Array.is_empty (UVars.AbstractContext.names auctx).quals then ()
+        else user_err Pp.(str "Extraction of \"with Definition\" clauses not supported for sort polymorphic definitions.")
+      in
       let me_struct,delta = flatten_modtype env mp1 me' me_struct_o in
       let env' = env_for_mtb_with_def env mp1 me_struct delta idl in
       let mt = extract_mexpr_spec table venv env mp1 (None,me') in
@@ -255,7 +297,7 @@ and extract_mexpr_spec table venv env mp1 (me_struct_o,me_alg) = match me_alg wi
          | None -> mt
          | Some (vl,typ) ->
             let () = type_iter_references (fun r -> Visit.add_ref venv r) typ in
-            MTwith(mt,ML_With_type(idl,vl,typ)))
+            MTwith (mt, ML_With_type (InfvInst.empty, idl, vl, typ)))
   | MEwith(me',WithMod(idl,mp))->
       let () = Visit.add_mp_all venv mp in
       MTwith (extract_mexpr_spec table venv env mp1 (None, me'), ML_With_module(idl, mp))
@@ -300,47 +342,60 @@ and extract_mbody_spec : 'a. State.t -> _ -> _ -> _ -> 'a generic_module_body ->
 
 let rec extract_structure table access venv env mp reso ~all = function
   | [] -> []
-  | (l,SFBconst cb) :: struc ->
-      (try
-         let sg = Evd.from_env env in
-         let vl,recd,struc = factor_fix env sg l cb struc in
-         let vc = Array.map (make_cst reso mp) vl in
-         let ms = extract_structure table access venv env mp reso ~all struc in
-         let b = Array.exists (Visit.needed_cst venv) vc in
-         if all || b then
-           let d = extract_fixpoint table env sg vc recd in
-           if (not b) && (logical_decl d) then ms
-           else
-            let () = Visit.add_decl_deps venv d in
-            (l, SEdecl d) :: ms
-         else ms
-       with Impossible ->
-         let ms = extract_structure table access venv env mp reso ~all struc in
-         let c = make_cst reso mp l in
-         let b = Visit.needed_cst venv c in
-         if all || b then
-           let d = extract_constant table access env c cb in
-           if (not b) && (logical_decl d) then ms
-           else
-            let () = Visit.add_decl_deps venv d in
-            (l, SEdecl d) :: ms
-         else ms)
-  | (l,SFBmind mib) :: struc ->
-      let ms = extract_structure table access venv env mp reso ~all struc in
-      let mind = make_mind reso mp l in
-      let b = Visit.needed_ind venv mind in
+  | (l, SFBconst cb) :: struc ->
+    let sg = Evd.from_env env in
+    let fix, struc = match factor_fix env sg l cb struc with
+    | (vl, recd, struc) -> Some (vl, recd), struc
+    | exception Impossible -> None, struc
+    in
+    let ms = extract_structure table access venv env mp reso ~all struc in
+    let insts = get_mono_inst_univs cb.const_universes in
+    let c = make_cst reso mp l in
+    let map inst = match fix with
+    | None ->
+      let b = Visit.needed_cst venv c inst in
       if all || b then
-        let d = Dind (extract_inductive table env mind) in
-        if (not b) && (logical_decl d) then ms
+        let d = extract_constant table access env c inst cb in
+        if (not b) && (logical_decl d) then None
+        else
+        let () = Visit.add_decl_deps venv d in
+        Some (l, SEdecl d)
+      else None
+    | Some (vl, recd) ->
+      let vc = Array.map (make_cst reso mp) vl in
+      let b = Array.exists (fun vf -> Visit.needed_cst venv vf inst) vc in
+      if all || b then
+        let d = extract_fixpoint table env sg vc inst recd in
+        if (not b) && (logical_decl d) then None
         else
           let () = Visit.add_decl_deps venv d in
-          (l, SEdecl d) :: ms
-      else ms
+          Some (l, SEdecl d)
+      else None
+    in
+    let consts = List.map_filter map insts in
+    consts @ ms
+  | (l, SFBmind mib) :: struc ->
+    let ms = extract_structure table access venv env mp reso ~all struc in
+    let insts = get_mono_inst_univs mib.mind_universes in
+    let mind = make_mind reso mp l in
+    let map inst =
+      let b = Visit.needed_ind venv mind inst in
+      if all || b then
+        let d = Dind (extract_inductive table env mind inst) in
+        if (not b) && (logical_decl d) then None
+        else
+          let () = Visit.add_decl_deps venv d in
+          Some (l, SEdecl d)
+      else None
+    in
+    let inds = List.map_filter map insts in
+    inds @ ms
   | (l, SFBrules rrb) :: struc ->
-      let b = List.exists (fun (cst, _) -> Visit.needed_cst venv cst) rrb.rewrules_rules in
+      let inst = InfvInst.empty in (* FIXME ? *)
+      let b = List.exists (fun (cst, _) -> Visit.needed_cst venv cst inst) rrb.rewrules_rules in
       let ms = extract_structure table access venv env mp reso ~all struc in
       if all || b then begin
-        List.iter (fun (cst, _) -> Table.add_symbol_rule (State.get_table table) { glob = ConstRef cst } l) rrb.rewrules_rules;
+        List.iter (fun (cst, _) -> Table.add_symbol_rule (State.get_table table) { glob = ConstRef cst; inst } l) rrb.rewrules_rules;
         ms
       end else ms
   | (l,SFBmodule mb) :: struc ->
@@ -618,16 +673,20 @@ let rec locate_ref = function
   | qid::l ->
       let mpo = try Some (Nametab.locate_module qid) with Not_found -> None
       and ro =
-        try Some { glob = Smartlocate.global_with_alias qid }
+        try
+          let gr = Smartlocate.global_with_alias qid in
+          let inst = Environ.universes_of_global (Global.env ()) gr in
+          Some (List.map (fun inst -> { glob = gr; inst }) (InfvInst.generate inst))
         with Nametab.GlobalizationError _ | UserError _ -> None
       in
       match mpo, ro with
         | None, None -> Nametab.error_global_not_found ~info:Exninfo.null qid
-        | None, Some r -> let refs,mps = locate_ref l in r::refs,mps
+        | None, Some r ->
+          let refs, mps = locate_ref l in r @ refs,mps
         | Some mp, None -> let refs,mps = locate_ref l in refs,mp::mps
         | Some mp, Some r ->
-           warning_ambiguous_name ?loc:qid.CAst.loc (qid,mp,r.glob);
-           let refs,mps = locate_ref l in refs,mp::mps
+          let () = warning_ambiguous_name ?loc:qid.CAst.loc (qid, mp, (List.hd r).glob) in
+          let refs,mps = locate_ref l in refs,mp::mps
 
 (*s Recursive extraction in the Rocq toplevel. The vernacular command is
     \verb!Recursive Extraction! [qualid1] ... [qualidn]. Also used when
@@ -762,10 +821,11 @@ let show_extraction ~pstate =
   let sigma, env = Declare.Proof.get_current_context pstate in
   let trms = Proof.partial_proof prf in
   let extr_term t =
+    (* FIXME: substitute relevances with ground ones *)
     let ast, ty = extract_constr table env sigma t in
     let mp = Lib.current_mp () in
     let l = Label.of_id (Declare.Proof.get_name pstate) in
-    let fake_ref = { glob = GlobRef.ConstRef (Constant.make2 mp l) } in
+    let fake_ref = { glob = GlobRef.ConstRef (Constant.make2 mp l); inst = InfvInst.empty } in
     let decl = Dterm (fake_ref, ast, ty) in
     print_one_decl table [] mp decl
   in

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -25,7 +25,7 @@ val extract_and_compile : opaque_access:Global.indirect_accessor -> qualid list 
 (* For debug / external output via coqtop.byte + Drop : *)
 
 val mono_environment :
- Common.State.t -> opaque_access:Global.indirect_accessor -> GlobRef.t list -> ModPath.t list -> Miniml.ml_structure
+ Common.State.t -> opaque_access:Global.indirect_accessor -> Miniml.global list -> ModPath.t list -> Miniml.ml_structure
 
 (* Used by the Relation Extraction plugin *)
 

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -32,12 +32,6 @@ val mono_environment :
 val print_one_decl :
   Common.State.t -> Miniml.ml_structure -> ModPath.t -> Miniml.ml_decl -> Pp.t
 
-(* Used by Extraction Compute *)
-
-val structure_for_compute :
-  opaque_access:Global.indirect_accessor -> Environ.env -> Evd.evar_map -> EConstr.t ->
-    Common.State.t * Miniml.ml_decl list * Miniml.ml_ast * Miniml.ml_type
-
 (* Show the extraction of the current ongoing proof *)
 
 val show_extraction : pstate:Declare.Proof.t -> unit

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -107,7 +107,12 @@ let push_rel_assum (n, t) env =
 let push_rels_assum assums =
   EConstr.push_rel_context (List.map (fun (x,t) -> LocalAssum (x,t)) assums)
 
-let get_body lconstr = EConstr.of_constr lconstr
+let qmono uctx inst lconstr = match uctx with
+| Monomorphic -> EConstr.of_constr lconstr
+| Polymorphic uctx ->
+  let inst = InfvInst.instantiate uctx inst in
+  let lconstr = Vars.subst_instance_constr inst lconstr in
+  EConstr.of_constr lconstr
 
 let get_opaque access env c =
   EConstr.of_constr
@@ -244,18 +249,6 @@ let parse_ind_args si args relmax =
          | _ -> parse (i+1) (j+1) s)
   in parse 1 1 si
 
-let check_sort_poly sigma gr u =
-  let u = EConstr.EInstance.kind sigma u in
-  let qs, _ = UVars.Instance.to_array u in
-  if Array.exists (function
-      | Sorts.Quality.QConstant (QSProp|QProp) -> true
-      | QConstant QType | QVar _ -> false)
-      qs
-  then CErrors.user_err
-      Pp.(str "Cannot extract nontrivial sort polymorphism" ++ spc()
-          ++ str "(instantiation of " ++ Nametab.pr_global_env Id.Set.empty gr.glob
-          ++ spc() ++ str "using Prop or SProp).")
-
 let relevance_of_projection_repr mib p =
   let _mind,i = Names.Projection.Repr.inductive p in
   match mib.mind_record with
@@ -378,8 +371,8 @@ let rec extract_type (table : Common.State.t) env sg db j c args =
                else let n' = List.nth db (n-1) in
                if Int.equal n' 0 then Tunknown else Tvar n')
     | Const (kn,u) ->
-        let r = { glob = GlobRef.ConstRef kn } in
-        let () = check_sort_poly sg r u in
+        let inst = InfvInst.ground (EConstr.EInstance.kind sg u) in
+        let r = { glob = GlobRef.ConstRef kn; inst } in
         let typ = type_of env sg (EConstr.mkConstU (kn,u)) in
         (match flag_of_type env sg typ with
            | (Logic,_) -> assert false (* Cf. logical cases above *)
@@ -388,16 +381,17 @@ let rec extract_type (table : Common.State.t) env sg db j c args =
              mlt
            | (Info, Default) ->
                (* Not an ML type, for example [(c:forall X, X->X) Type nat] *)
-               (match (lookup_constant kn env).const_body with
+               let cb = lookup_constant kn env in
+               (match cb.const_body with
                  | Undef _  | OpaqueDef _ | Primitive _ | Symbol _ -> Tunknown (* Brutal approx ... *)
                   | Def lbody ->
                       (* We try to reduce. *)
-                      let newc = applistc (get_body lbody) args in
+                      let newc = applistc (qmono cb.const_universes inst lbody) args in
                       extract_type table env sg db j newc []))
     | Ind ((kn, i), u) ->
-        let r = { glob = GlobRef.IndRef (kn, i) } in
-        let () = check_sort_poly sg r u in
-        let s = (extract_ind table env kn).ind_packets.(i).ip_sign in
+        let inst = InfvInst.ground (EConstr.EInstance.kind sg u) in
+        let r = { glob = GlobRef.IndRef (kn, i); inst } in
+        let s = (extract_ind table env kn inst).ind_packets.(i).ip_sign in
         extract_type_app table env sg db (r, s) args
     | Proj (p,r,t) ->
        (* Let's try to reduce, if it hasn't already been done. *)
@@ -413,7 +407,7 @@ let rec extract_type (table : Common.State.t) env sg db j c args =
         | LocalDef (_,body,_) ->
            extract_type table env sg db j (EConstr.applist (body,args)) []
         | LocalAssum (_,ty) ->
-           let r = { glob = GlobRef.VarRef v } in
+           let r = { glob = GlobRef.VarRef v; inst = InfvInst.empty } in
            (match flag_of_type env sg ty with
             | (Logic,_) -> assert false (* Cf. logical cases above *)
             | (Info, TypeScheme) ->
@@ -463,19 +457,19 @@ and extract_type_scheme table env sg db c p =
 
 (* First, a version with cache *)
 
-and extract_ind table env kn = (* kn is supposed to be in long form *)
+and extract_ind table env kn inst = (* kn is supposed to be in long form *)
   let mib = Environ.lookup_mind kn env in
-  match lookup_ind (Common.State.get_table table) kn mib with
+  match lookup_ind (Common.State.get_table table) kn inst mib with
   | Some ml_ind -> ml_ind
   | None ->
      try
-       extract_really_ind table env kn mib
+       extract_really_ind table env kn inst mib
      with SingletonInductiveBecomesProp ind ->
        error_singleton_become_prop ind
 
 (* Then the real function *)
 
-and extract_really_ind table env kn mib =
+and extract_really_ind table env kn inst mib =
     (* First, if this inductive is aliased via a Module,
        we process the original inductive if possible.
        When at toplevel of the monolithic case, we cannot do much
@@ -488,23 +482,28 @@ and extract_really_ind table env kn mib =
         NoEquiv
       else
         begin
-          ignore (extract_ind table env (MutInd.make1 (MutInd.canonical kn)));
+          ignore (extract_ind table env (MutInd.make1 (MutInd.canonical kn)) inst);
           Equiv (MutInd.canonical kn)
         end
+    in
+    let env, u = match mib.mind_universes with
+    | Monomorphic -> env, UVars.Instance.empty
+    | Polymorphic uctx ->
+      (* FIXME: we should probably push the levels *)
+      env, InfvInst.instantiate uctx inst
     in
     (* Everything concerning parameters. *)
     (* We do that first, since they are common to all the [mib]. *)
     let mip0 = mib.mind_packets.(0) in
     let ndecls = List.length mib.mind_params_ctxt in
     let npar = mib.mind_nparams in
-    let epar = push_rel_context mib.mind_params_ctxt env in
+    let epar = push_rel_context (Vars.subst_instance_context u mib.mind_params_ctxt) env in
     let sg = Evd.from_env env in
     (* First pass: we store inductive signatures together with *)
     (* their type var list. *)
     let packets =
       Array.mapi
         (fun i mip ->
-           let (_,u),_ = UnivGen.fresh_inductive_instance env (kn,i) in
            let ar = Inductive.type_of_inductive ((mib,mip),u) in
            let ar = EConstr.of_constr ar in
            let info = (fst (flag_of_type env sg ar) = Info) in
@@ -512,9 +511,9 @@ and extract_really_ind table env kn mib =
            let ncons = Array.length mip.mind_nf_lc in
            let t = Array.make ncons [] in
            { ip_typename = mip.mind_typename;
-             ip_typename_ref = { glob = GlobRef.IndRef (kn, i) };
+             ip_typename_ref = { glob = GlobRef.IndRef (kn, i); inst };
              ip_consnames = mip.mind_consnames;
-             ip_consnames_ref = Array.init ncons (fun j -> { glob = GlobRef.ConstructRef ((kn, i), j + 1) });
+             ip_consnames_ref = Array.init ncons (fun j -> { glob = GlobRef.ConstructRef ((kn, i), j + 1); inst });
              ip_logical = not info;
              ip_sign = s;
              ip_vars = v;
@@ -522,7 +521,7 @@ and extract_really_ind table env kn mib =
         mib.mind_packets
     in
 
-    add_ind (Common.State.get_table table) kn mib
+    add_ind (Common.State.get_table table) kn inst mib
       {ind_kind = Standard;
        ind_nparams = npar;
        ind_packets = Array.map fst packets;
@@ -551,7 +550,7 @@ and extract_really_ind table env kn mib =
     let ind_info =
       try
         let ip = (kn, 0) in
-        let r = { glob = GlobRef.IndRef ip } in
+        let r = { glob = GlobRef.IndRef ip; inst } in
         if is_custom r then raise (I Standard);
         if mib.mind_finite == CoFinite then raise (I Coinductive);
         if not (Int.equal mib.mind_ntypes 1) then raise (I Standard);
@@ -577,7 +576,7 @@ and extract_really_ind table env kn mib =
           List.skipn mib.mind_nparams (names_prod mip0.mind_user_lc.(0)) in
         assert (Int.equal (List.length field_names) (List.length typ));
         let mp = MutInd.modpath kn in
-        let implicits = implicits_of_global { glob = (GlobRef.ConstructRef (ip,1)) } in
+        let implicits = implicits_of_global { glob = (GlobRef.ConstructRef (ip,1)); inst } in
         let ty = Inductive.type_of_inductive ((mib,mip0),u) in
         let nparams = nb_default_params env sg (EConstr.of_constr ty) in
         let rec select_fields i l typs = match l,typs with
@@ -591,7 +590,7 @@ and extract_really_ind table env kn mib =
               (* Is it safe to use [id] for projections [foo.id] ? *)
               if List.for_all ((==) Keep) (type2signature table env typ)
               then (* for OCaml inlining: *) add_projection (Common.State.get_table table) nparams knp ip;
-              Some { glob = GlobRef.ConstRef knp } :: (select_fields (i+1) l typs)
+              Some { glob = GlobRef.ConstRef knp; inst } :: (select_fields (i+1) l typs)
           | _ -> assert false
         in
         let field_glob = select_fields (1+npar) field_names typ in
@@ -605,8 +604,8 @@ and extract_really_ind table env kn mib =
              ind_packets = Array.map fst packets;
              ind_equiv = equiv }
     in
-    add_ind (Common.State.get_table table) kn mib i;
-    add_inductive_kind (Common.State.get_table table) kn i.ind_kind;
+    add_ind (Common.State.get_table table) kn inst mib i;
+    add_inductive_kind (Common.State.get_table table) kn inst i.ind_kind;
     i
 
 (*s [extract_type_cons] extracts the type of an inductive
@@ -635,7 +634,7 @@ and mlt_env table env r = let open GlobRef in match r.glob with
      match cb.const_body with
      | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> None
      | Def l_body ->
-        match lookup_typedef (Common.State.get_table table) kn cb with
+        match lookup_typedef (Common.State.get_table table) kn r.inst cb with
         | Some _ as o -> o
         | None ->
            let sg = Evd.from_env env in
@@ -643,11 +642,11 @@ and mlt_env table env r = let open GlobRef in match r.glob with
            (* FIXME not sure if we should instantiate univs here *) in
            match flag_of_type env sg typ with
            | Info,TypeScheme ->
-              let body = get_body l_body in
+              let body = qmono cb.const_universes r.inst l_body in
               let s = type_sign env sg typ in
               let db = db_from_sign s in
               let t = extract_type_scheme table env sg db body (List.length s)
-              in add_typedef (Common.State.get_table table) kn cb t; Some t
+              in add_typedef (Common.State.get_table table) kn r.inst cb t; Some t
            | _ -> None
 
 and expand table env = type_expand (mlt_env table env)
@@ -658,18 +657,18 @@ let type_expunge_from_sign table env = type_expunge_from_sign (mlt_env table env
 
 (*s Extraction of the type of a constant. *)
 
-let record_constant_type table env sg kn opt_typ =
+let record_constant_type table env sg kn inst opt_typ =
   let cb = lookup_constant kn env in
-  match lookup_cst_type (Common.State.get_table table) kn cb with
+  match lookup_cst_type (Common.State.get_table table) kn inst cb with
   | Some schema -> schema
   | None ->
      let typ = match opt_typ with
-       | None -> EConstr.of_constr cb.const_type
+       | None -> qmono cb.const_universes inst cb.const_type
        | Some typ -> typ
      in
      let mlt = extract_type table env sg [] 1 typ [] in
      let schema = (type_maxvar mlt, mlt) in
-     let () = add_cst_type (Common.State.get_table table) kn cb schema in
+     let () = add_cst_type (Common.State.get_table table) kn inst cb schema in
      schema
 
 (*S Extraction of a term. *)
@@ -724,12 +723,8 @@ let rec extract_term table env sg mle mlt c args =
           let mle' = Mlenv.push_std_type mle (Tdummy d) in
           ast_pop (extract_term table env' sg mle' mlt c2 args'))
     | Const (kn,u) ->
-        let r = { glob = ConstRef kn } in
-        let () = check_sort_poly sg r u in
         extract_cst_app table env sg mle mlt (kn, u) args
     | Construct (cp,u) ->
-        let r = { glob = ConstructRef cp } in
-        let () = check_sort_poly sg r u in
         extract_cons_app table env sg mle mlt (cp, u) args
     | Proj (p, _, c) ->
         let p = Projection.repr p in
@@ -747,7 +742,7 @@ let rec extract_term table env sg mle mlt c args =
         (* If invert_case then this is a match that will get erased later, but right now we don't care. *)
         let (ip, r, iv, c0, br) = EConstr.expand_case env sg (ci, u, pms, r, iv, c0, br) in
         let ip = ci.ci_ind in
-        extract_app table env sg mle mlt (extract_case table env sg mle (ip,c0,br)) args
+        extract_app table env sg mle mlt (extract_case table env sg mle (ip, u, c0, br)) args
     | Fix ((_,i),recd) ->
         extract_app table env sg mle mlt (extract_fix table env sg mle i recd) args
     | CoFix (i,recd) ->
@@ -762,7 +757,7 @@ let rec extract_term table env sg mle mlt c args =
          | LocalDef (_,_,ty) -> ty
        in
        let vty = extract_type table env sg [] 0 ty [] in
-       let r = { glob = GlobRef.VarRef v } in
+       let r = { glob = GlobRef.VarRef v; inst = InfvInst.empty } in
        let extract_var mlt = put_magic (mlt,vty) (MLglob r) in
        extract_app table env sg mle mlt extract_var args
     | Int i -> assert (args = []); MLuint i
@@ -810,8 +805,9 @@ and make_mlargs table env sg e s args typs =
 (*s Extraction of a constant applied to arguments. *)
 
 and extract_cst_app table env sg mle mlt (kn, u) args =
+  let inst = InfvInst.ground (EConstr.EInstance.kind sg u) in
   (* First, the [ml_schema] of the constant, in expanded version. *)
-  let nb,t = record_constant_type table env sg kn None in
+  let nb, t = record_constant_type table env sg kn inst None in
   let schema = nb, expand table env t in
   (* Can we instantiate types variables for this constant ? *)
   (* In Ocaml, inside the definition of this constant, the answer is no. *)
@@ -829,7 +825,7 @@ and extract_cst_app table env sg mle mlt (kn, u) args =
   (* Second, is the resulting type compatible with the expected type [mlt] ? *)
   let magic2 = needs_magic (a, mlt) in
   (* The internal head receives a magic if [magic1] *)
-  let r = { glob = GlobRef.ConstRef kn } in
+  let r = { glob = GlobRef.ConstRef kn; inst } in
   let head = put_magic_if magic1 (MLglob r) in
   (* Now, the extraction of the arguments. *)
   let s_full = type2signature table env (snd schema) in
@@ -874,14 +870,15 @@ and extract_cst_app table env sg mle mlt (kn, u) args =
 and extract_cons_app table env sg mle mlt (cp, u) args =
   let ((kn, i) as ip, j) = cp in
   (* First, we build the type of the constructor, stored in small pieces. *)
-  let mi = extract_ind table env kn in
+  let inst = InfvInst.ground (EConstr.EInstance.kind sg u) in
+  let mi = extract_ind table env kn inst in
   let params_nb = mi.ind_nparams in
   let oi = mi.ind_packets.(i) in
   let nb_tvars = List.length oi.ip_vars
   and types = List.map (expand table env) oi.ip_types.(j-1) in
   let list_tvar = List.map (fun i -> Tvar i) (List.interval 1 nb_tvars) in
-  let gind = { glob = GlobRef.IndRef ip } in
-  let gcstr = { glob = GlobRef.ConstructRef cp } in
+  let gind = { glob = GlobRef.IndRef ip; inst } in
+  let gcstr = { glob = GlobRef.ConstructRef cp; inst } in
   let type_cons = type_recomp (types, Tglob (gind, list_tvar)) in
   let type_cons = instantiation (nb_tvars, type_cons) in
   (* Then, the usual variables [s], [ls], [la], ... *)
@@ -926,12 +923,13 @@ and extract_cons_app table env sg mle mlt (cp, u) args =
 
 (*S Extraction of a case. *)
 
-and extract_case table env sg mle ((kn,i) as ip,c,br) mlt =
+and extract_case table env sg mle ((kn,i) as ip, u, c, br) mlt =
   (* [br]: bodies of each branch (in functional form) *)
   (* [ni]: number of arguments without parameters in each branch *)
   let ni = constructors_nrealargs env ip in
   let br_size = Array.length br in
-  let gind = { glob = GlobRef.IndRef ip } in
+  let inst = InfvInst.ground (EConstr.EInstance.kind sg u) in
+  let gind = { glob = GlobRef.IndRef ip; inst } in
   assert (Int.equal (Array.length ni) br_size);
   if Int.equal br_size 0 then begin
     add_recursors (Common.State.get_table table) env kn; (* May have passed unseen if logical ... *)
@@ -952,7 +950,7 @@ and extract_case table env sg mle ((kn,i) as ip,c,br) mlt =
         snd (case_expunge s e)
       end
     else
-      let mi = extract_ind table env kn in
+      let mi = extract_ind table env kn inst in
       let oi = mi.ind_packets.(i) in
       let metas = Array.init (List.length oi.ip_vars) new_meta in
       (* The extraction of the head. *)
@@ -960,7 +958,7 @@ and extract_case table env sg mle ((kn,i) as ip,c,br) mlt =
       let a = extract_term table env sg mle type_head c [] in
       (* The extraction of each branch. *)
       let extract_branch i =
-        let r = { glob = GlobRef.ConstructRef (ip,i+1) } in
+        let r = { glob = GlobRef.ConstructRef (ip, i + 1); inst } in
         (* The types of the arguments of the corresponding constructor. *)
         let f t = type_subst_vect metas (expand table env t) in
         let l = List.map f oi.ip_types.(i) in
@@ -1026,16 +1024,17 @@ let rec gentypvar_ok sg c = match EConstr.kind sg c with
 
 (*s From a constant to a ML declaration. *)
 
-let extract_std_constant table env sg kn body typ =
+let extract_std_constant table env sg kn inst body typ =
+  (* expects body and typ to be already substituted w.r.t. inst *)
   reset_meta_count ();
   (* The short type [t] (i.e. possibly with abbreviations). *)
-  let t = snd (record_constant_type table env sg kn (Some typ)) in
+  let t = snd (record_constant_type table env sg kn inst (Some typ)) in
   (* The real type [t']: without head products, expanded, *)
   (* and with [Tvar] translated to [Tvar'] (not instantiable). *)
   let l,t' = type_decomp (expand table env (var2var' t)) in
   let s = List.map (type2sign table env) l in
   (* Check for user-declared implicit information *)
-  let s = sign_with_implicits { glob = GlobRef.ConstRef kn } s 0 in
+  let s = sign_with_implicits { glob = GlobRef.ConstRef kn; inst } s 0 in
   (* Decomposing the top level lambdas of [body].
      If there isn't enough, it's ok, as long as remaining args
      aren't to be pruned (and initial lambdas aren't to be all
@@ -1081,19 +1080,19 @@ let extract_std_constant table env sg kn body typ =
   trm, type_expunge_from_sign table env s t
 
 (* Extracts the type of an axiom, honors the Extraction Implicit declaration. *)
-let extract_axiom table env sg kn typ =
+let extract_axiom table env sg kn inst typ =
   reset_meta_count ();
   (* The short type [t] (i.e. possibly with abbreviations). *)
-  let t = snd (record_constant_type table env sg kn (Some typ)) in
+  let t = snd (record_constant_type table env sg kn inst (Some typ)) in
   (* The real type [t']: without head products, expanded, *)
   (* and with [Tvar] translated to [Tvar'] (not instantiable). *)
   let l,_ = type_decomp (expand table env (var2var' t)) in
   let s = List.map (type2sign table env) l in
   (* Check for user-declared implicit information *)
-  let s = sign_with_implicits { glob = GlobRef.ConstRef kn } s 0 in
+  let s = sign_with_implicits { glob = GlobRef.ConstRef kn; inst } s 0 in
   type_expunge_from_sign table env s t
 
-let extract_fixpoint table env sg vkn (fi,ti,ci) =
+let extract_fixpoint table env sg vkn inst (fi,ti,ci) =
   let n = Array.length vkn in
   let types = Array.make n (Tdummy Kprop)
   and terms = Array.make n (MLdummy Kprop) in
@@ -1108,7 +1107,7 @@ let extract_fixpoint table env sg vkn (fi,ti,ci) =
   for i = 0 to n-1 do
     if info_of_quality (sort_of env sg ti.(i)) != Logic then
       try
-        let e,t = extract_std_constant table env sg vkn.(i)
+        let e,t = extract_std_constant table env sg vkn.(i) inst
                    (EConstr.Vars.substl sub ci.(i)) ti.(i) in
         terms.(i) <- e;
         types.(i) <- t;
@@ -1116,12 +1115,12 @@ let extract_fixpoint table env sg vkn (fi,ti,ci) =
         error_singleton_become_prop ind
   done;
   current_fixpoints := [];
-  Dfix (Array.map (fun kn -> { glob = GlobRef.ConstRef kn }) vkn, terms, types)
+  Dfix (Array.map (fun kn -> { glob = GlobRef.ConstRef kn; inst }) vkn, terms, types)
 
-let extract_constant table access env kn cb =
+let extract_constant table access env kn inst cb =
   let sg = Evd.from_env env in
-  let r = { glob = GlobRef.ConstRef kn } in
-  let typ = EConstr.of_constr cb.const_type in
+  let r = { glob = GlobRef.ConstRef kn; inst } in
+  let typ = qmono cb.const_universes inst cb.const_type in
   let warn_info () = if not (is_custom r) then add_info_axiom (Common.State.get_table table) r in
   let warn_log () = if not (constant_has_body cb) then add_log_axiom (Common.State.get_table table) r
   in
@@ -1137,11 +1136,11 @@ let extract_constant table access env kn cb =
     in Dtype (r, vl, t)
   in
   let mk_ax () =
-    let t = extract_axiom table env sg kn typ in
+    let t = extract_axiom table env sg kn inst typ in
     Dterm (r, MLaxiom (Constant.to_string kn), t)
   in
   let mk_def c =
-    let e,t = extract_std_constant table env sg kn c typ in
+    let e,t = extract_std_constant table env sg kn inst c typ in
     Dterm (r,e,t)
   in
   try
@@ -1156,10 +1155,11 @@ let extract_constant table access env kn cb =
           | Primitive _ | Undef _ -> warn_info (); mk_typ_ax ()
           | Def c ->
              (match Structures.PrimitiveProjections.find_opt kn with
-              | None -> mk_typ (get_body c)
+              | None -> mk_typ (qmono cb.const_universes inst c)
               | Some p ->
                 let body = fake_match_projection env p in
-                mk_typ (EConstr.of_constr body))
+                let body = qmono cb.const_universes inst body in
+                mk_typ body)
           | OpaqueDef c ->
             add_opaque (Common.State.get_table table) r;
             if access_opaque () then mk_typ (get_opaque access env c)
@@ -1170,10 +1170,10 @@ let extract_constant table access env kn cb =
           | Primitive _ | Undef _ -> warn_info (); mk_ax ()
           | Def c ->
              (match Structures.PrimitiveProjections.find_opt kn with
-              | None -> mk_def (get_body c)
+              | None -> mk_def (qmono cb.const_universes inst c)
               | Some p ->
                 let body = fake_match_projection env p in
-                mk_def (EConstr.of_constr body))
+                mk_def (qmono cb.const_universes inst body))
           | OpaqueDef c ->
             add_opaque (Common.State.get_table table) r;
             if access_opaque () then mk_def (get_opaque access env c)
@@ -1181,10 +1181,10 @@ let extract_constant table access env kn cb =
   with SingletonInductiveBecomesProp ind ->
     error_singleton_become_prop ind
 
-let extract_constant_spec table env kn cb =
+let extract_constant_spec table env kn inst cb =
   let sg = Evd.from_env env in
-  let r = { glob = GlobRef.ConstRef kn } in
-  let typ = EConstr.of_constr cb.const_type in
+  let r = { glob = GlobRef.ConstRef kn; inst } in
+  let typ = qmono cb.const_universes inst cb.const_type in
   try
     match flag_of_type env sg typ with
     | (Logic, TypeScheme) ->
@@ -1197,11 +1197,11 @@ let extract_constant_spec table env kn cb =
           | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> Stype (r, vl, None)
           | Def body ->
               let db = db_from_sign s in
-              let body = get_body body in
+              let body = qmono cb.const_universes inst body in
               let t = extract_type_scheme table env sg db body (List.length s)
               in Stype (r, vl, Some t))
     | (Info, Default) ->
-        let t = snd (record_constant_type table env sg kn (Some typ)) in
+        let t = snd (record_constant_type table env sg kn inst (Some typ)) in
         Sval (r, type_expunge table env t)
   with SingletonInductiveBecomesProp ind ->
     error_singleton_become_prop ind
@@ -1232,11 +1232,11 @@ let extract_constr table env sg c =
   with SingletonInductiveBecomesProp ind ->
     error_singleton_become_prop ind
 
-let extract_inductive table env kn =
-  let ind = extract_ind table env kn in
-  add_recursors (Common.State.get_table table) env kn;
+let extract_inductive table env kn inst =
+  let ind = extract_ind table env kn inst in
+  let () = add_recursors (Common.State.get_table table) env kn in
   let f i j l =
-    let r = { glob = GlobRef.ConstructRef ((kn, i), j + 1) } in
+    let r = { glob = GlobRef.ConstructRef ((kn, i), j + 1); inst } in
     let implicits = implicits_of_global r in
     let rec filter i = function
       | [] -> []

--- a/plugins/extraction/extraction.mli
+++ b/plugins/extraction/extraction.mli
@@ -16,9 +16,9 @@ open Environ
 open Evd
 open Miniml
 
-val extract_constant : Common.State.t -> Global.indirect_accessor -> env -> Constant.t -> constant_body -> ml_decl
+val extract_constant : Common.State.t -> Global.indirect_accessor -> env -> Constant.t -> InfvInst.t -> constant_body -> ml_decl
 
-val extract_constant_spec : Common.State.t -> env -> Constant.t -> ('a, 'b) pconstant_body -> ml_spec
+val extract_constant_spec : Common.State.t -> env -> Constant.t -> InfvInst.t -> ('a, 'b) pconstant_body -> ml_spec
 
 (** For extracting "module ... with ..." declaration *)
 
@@ -26,9 +26,9 @@ val extract_with_type :
   Common.State.t -> env -> evar_map -> EConstr.t -> ( Id.t list * ml_type ) option
 
 val extract_fixpoint :
-  Common.State.t -> env -> evar_map -> Constant.t array -> EConstr.rec_declaration -> ml_decl
+  Common.State.t -> env -> evar_map -> Constant.t array -> InfvInst.t -> EConstr.rec_declaration -> ml_decl
 
-val extract_inductive : Common.State.t -> env -> MutInd.t -> ml_ind
+val extract_inductive : Common.State.t -> env -> MutInd.t -> InfvInst.t -> ml_ind
 
 (** For Extraction Compute and Show Extraction *)
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -117,7 +117,7 @@ let rec pp_type table par vl t =
        with Failure _ -> (str "a" ++ int i))
     | Tglob (r,[]) -> pp_global table Type r
     | Tglob (gr,l)
-        when not (keep_singleton ()) && Rocqlib.check_ref sig_type_name gr ->
+        when not (keep_singleton ()) && Rocqlib.check_ref sig_type_name gr.glob ->
           pp_type table true vl (List.hd l)
     | Tglob (r,l) ->
           pp_par par

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -12,6 +12,8 @@
 
 open Names
 
+type global = { glob : GlobRef.t }
+
 (* The [signature] type is used to know how many arguments a CIC
    object expects, and what these arguments will become in the ML
    object. *)
@@ -25,10 +27,9 @@ open Names
 type kill_reason =
   | Ktype
   | Kprop
-  | Kimplicit of GlobRef.t * int  (* n-th arg of a cst or construct *)
+  | Kimplicit of global * int  (* n-th arg of a cst or construct *)
 
 type sign = Keep | Kill of kill_reason
-
 
 (* Convention: outmost lambda/product gives the head of the list. *)
 
@@ -38,7 +39,7 @@ type signature = sign list
 
 type ml_type =
   | Tarr    of ml_type * ml_type
-  | Tglob   of GlobRef.t * ml_type list
+  | Tglob   of global * ml_type list
   | Tvar    of int
   | Tvar'   of int (* same as Tvar, used to avoid clash *)
   | Tmeta   of ml_meta (* used during ML type reconstruction *)
@@ -59,7 +60,7 @@ type inductive_kind =
   | Singleton
   | Coinductive
   | Standard
-  | Record of GlobRef.t option list (* None for anonymous field *)
+  | Record of global option list (* None for anonymous field *)
 
 (* A [ml_ind_packet] is the miniml counterpart of a [one_inductive_body].
    If the inductive is logical ([ip_logical = false]), then all other fields
@@ -71,9 +72,9 @@ type inductive_kind =
 
 type ml_ind_packet = {
   ip_typename : Id.t;
-  ip_typename_ref : GlobRef.t;
+  ip_typename_ref : global;
   ip_consnames : Id.t array;
-  ip_consnames_ref : GlobRef.t array;
+  ip_consnames_ref : global array;
   ip_logical : bool;
   ip_sign : signature;
   ip_vars : Id.t list;
@@ -119,8 +120,8 @@ and ml_ast =
   | MLapp    of ml_ast * ml_ast list
   | MLlam    of ml_ident * ml_ast
   | MLletin  of ml_ident * ml_ast * ml_ast
-  | MLglob   of GlobRef.t
-  | MLcons   of ml_type * GlobRef.t * ml_ast list
+  | MLglob   of global
+  | MLcons   of ml_type * global * ml_ast list
   | MLtuple  of ml_ast list
   | MLcase   of ml_type * ml_ast * ml_branch array
   | MLfix    of int * Id.t array * ml_ast array
@@ -134,24 +135,24 @@ and ml_ast =
   | MLparray of ml_ast array * ml_ast
 
 and ml_pattern =
-  | Pcons   of GlobRef.t * ml_pattern list
+  | Pcons   of global * ml_pattern list
   | Ptuple  of ml_pattern list
   | Prel    of int (** Cf. the idents in the branch. [Prel 1] is the last one. *)
   | Pwild
-  | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
+  | Pusual  of global (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
 
 (*s ML declarations. *)
 
 type ml_decl =
   | Dind  of ml_ind
-  | Dtype of GlobRef.t * Id.t list * ml_type
-  | Dterm of GlobRef.t * ml_ast * ml_type
-  | Dfix  of GlobRef.t array * ml_ast array * ml_type array
+  | Dtype of global * Id.t list * ml_type
+  | Dterm of global * ml_ast * ml_type
+  | Dfix  of global array * ml_ast array * ml_type array
 
 type ml_spec =
   | Sind  of ml_ind
-  | Stype of GlobRef.t * Id.t list * ml_type option
-  | Sval  of GlobRef.t * ml_type
+  | Stype of global * Id.t list * ml_type option
+  | Sval  of global * ml_type
 
 type ml_specif =
   | Spec of ml_spec

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -12,7 +12,35 @@
 
 open Names
 
-type global = { glob : GlobRef.t }
+(* Informativity data for sort polymorphism *)
+module InfvInst :
+sig
+  type t
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+
+  val empty : t
+  (** No bound sort variables *)
+
+  val generate : UVars.AbstractContext.t -> t list
+  (** 2^n possible instances for this context *)
+
+  val default : UVars.AbstractContext.t -> t
+  (** All sorts informative *)
+
+  val ground : UVars.Instance.t -> t
+  (** From a ground instance returns an informativity instance *)
+
+  val instantiate : UVars.AbstractContext.t -> t -> UVars.Instance.t
+  (** The other way around *)
+
+  val encode : t -> string option
+  (** A string that can be used as an identifier suffix, guaranteed to be
+      injective for instances of the same length. *)
+
+end
+
+type global = { glob : GlobRef.t; inst : InfvInst.t }
 
 (* The [signature] type is used to know how many arguments a CIC
    object expects, and what these arguments will become in the ML
@@ -167,7 +195,7 @@ and ml_module_type =
   | MTwith of ml_module_type * ml_with_declaration
 
 and ml_with_declaration =
-  | ML_With_type of Id.t list * Id.t list * ml_type
+  | ML_With_type of InfvInst.t * Id.t list * Id.t list * ml_type
   | ML_With_module of Id.t list * ModPath.t
 
 and ml_module_sig = (Label.t * ml_specif) list

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -12,6 +12,8 @@
 
 open Names
 
+type global = { glob : GlobRef.t }
+
 (* The [signature] type is used to know how many arguments a CIC
    object expects, and what these arguments will become in the ML
    object. *)
@@ -25,7 +27,7 @@ open Names
 type kill_reason =
   | Ktype
   | Kprop
-  | Kimplicit of GlobRef.t * int  (* n-th arg of a cst or construct *)
+  | Kimplicit of global * int  (* n-th arg of a cst or construct *)
 
 type sign = Keep | Kill of kill_reason
 
@@ -38,7 +40,7 @@ type signature = sign list
 
 type ml_type =
   | Tarr    of ml_type * ml_type
-  | Tglob   of GlobRef.t * ml_type list
+  | Tglob   of global * ml_type list
   | Tvar    of int
   | Tvar'   of int (* same as Tvar, used to avoid clash *)
   | Tmeta   of ml_meta (* used during ML type reconstruction *)
@@ -59,7 +61,7 @@ type inductive_kind =
   | Singleton
   | Coinductive
   | Standard
-  | Record of GlobRef.t option list (* None for anonymous field *)
+  | Record of global option list (* None for anonymous field *)
 
 (* A [ml_ind_packet] is the miniml counterpart of a [one_inductive_body].
    If the inductive is logical ([ip_logical = false]), then all other fields
@@ -71,9 +73,9 @@ type inductive_kind =
 
 type ml_ind_packet = {
   ip_typename : Id.t;
-  ip_typename_ref : GlobRef.t;
+  ip_typename_ref : global;
   ip_consnames : Id.t array;
-  ip_consnames_ref : GlobRef.t array;
+  ip_consnames_ref : global array;
   ip_logical : bool;
   ip_sign : signature;
   ip_vars : Id.t list;
@@ -119,8 +121,8 @@ and ml_ast =
   | MLapp    of ml_ast * ml_ast list
   | MLlam    of ml_ident * ml_ast
   | MLletin  of ml_ident * ml_ast * ml_ast
-  | MLglob   of GlobRef.t
-  | MLcons   of ml_type * GlobRef.t * ml_ast list
+  | MLglob   of global
+  | MLcons   of ml_type * global * ml_ast list
   | MLtuple  of ml_ast list
   | MLcase   of ml_type * ml_ast * ml_branch array
   | MLfix    of int * Id.t array * ml_ast array
@@ -134,24 +136,24 @@ and ml_ast =
   | MLparray of ml_ast array * ml_ast
 
 and ml_pattern =
-  | Pcons   of GlobRef.t * ml_pattern list
+  | Pcons   of global * ml_pattern list
   | Ptuple  of ml_pattern list
   | Prel    of int (** Cf. the idents in the branch. [Prel 1] is the last one. *)
   | Pwild
-  | Pusual  of GlobRef.t (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
+  | Pusual  of global (** Shortcut for Pcons (r,[Prel n;...;Prel 1]) **)
 
 (*s ML declarations. *)
 
 type ml_decl =
   | Dind  of ml_ind
-  | Dtype of GlobRef.t * Id.t list * ml_type
-  | Dterm of GlobRef.t * ml_ast * ml_type
-  | Dfix  of GlobRef.t array * ml_ast array * ml_type array
+  | Dtype of global * Id.t list * ml_type
+  | Dterm of global * ml_ast * ml_type
+  | Dfix  of global array * ml_ast array * ml_type array
 
 type ml_spec =
   | Sind  of ml_ind
-  | Stype of GlobRef.t * Id.t list * ml_type option
-  | Sval  of GlobRef.t * ml_type
+  | Stype of global * Id.t list * ml_type option
+  | Sval  of global * ml_type
 
 type ml_specif =
   | Spec of ml_spec

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -129,15 +129,15 @@ let rec mgu = function
   | Taxiom, Taxiom -> ()
   | _ -> raise Impossible
 
-let skip_typing ~compute () = lang () == Scheme || compute
+let skip_typing () = lang () == Scheme
 
-let needs_magic ~compute p =
-  if skip_typing ~compute () then false
+let needs_magic p =
+  if skip_typing () then false
   else try mgu p; false with Impossible -> true
 
 let put_magic_if b a = if b then MLmagic a else a
 
-let put_magic ~compute p a = if needs_magic ~compute p then MLmagic a else a
+let put_magic p a = if needs_magic p then MLmagic a else a
 
 let generalizable a =
   lang () != Ocaml ||

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -23,6 +23,8 @@ exception Impossible
 
 (*S Names operations. *)
 
+let eq_global g1 g2 = GlobRef.CanOrd.equal g1.glob g2.glob (* FIXME *)
+
 let anonymous_name = Id.of_string "x"
 let dummy_name = Id.of_string "_"
 
@@ -58,7 +60,7 @@ let rec eq_ml_type t1 t2 = match t1, t2 with
 | Tarr (tl1, tr1), Tarr (tl2, tr2) ->
   eq_ml_type tl1 tl2 && eq_ml_type tr1 tr2
 | Tglob (gr1, t1), Tglob (gr2, t2) ->
-  GlobRef.CanOrd.equal gr1 gr2 && List.equal eq_ml_type t1 t2
+  eq_global gr1 gr2 && List.equal eq_ml_type t1 t2
 | Tvar i1, Tvar i2 -> Int.equal i1 i2
 | Tvar' i1, Tvar' i2 -> Int.equal i1 i2
 | Tmeta m1, Tmeta m2 -> eq_ml_meta m1 m2
@@ -120,7 +122,7 @@ let rec mgu = function
       | None -> m.contents <- Some t)
   | Tarr(a, b), Tarr(a', b') ->
       mgu (a, a'); mgu (b, b')
-  | Tglob (r,l), Tglob (r',l') when GlobRef.CanOrd.equal r r' ->
+  | Tglob (r,l), Tglob (r',l') when eq_global r r' ->
        List.iter mgu (List.combine l l')
   | Tdummy _, Tdummy _ -> ()
   | Tvar i, Tvar j when Int.equal i j -> ()
@@ -270,7 +272,7 @@ let rec var2var' = function
   | Tglob (r,l) -> Tglob (r, List.map var2var' l)
   | a -> a
 
-type abbrev_map = GlobRef.t -> ml_type option
+type abbrev_map = global -> ml_type option
 
 (*s Delta-reduction of type constants everywhere in a ML type [t].
    [env] is a function of type [ml_type_env]. *)
@@ -384,9 +386,9 @@ let rec eq_ml_ast t1 t2 = match t1, t2 with
   eq_ml_ident na1 na2 && eq_ml_ast t1 t2
 | MLletin (na1, c1, t1), MLletin (na2, c2, t2) ->
   eq_ml_ident na1 na2 && eq_ml_ast c1 c2 && eq_ml_ast t1 t2
-| MLglob gr1, MLglob gr2 -> GlobRef.CanOrd.equal gr1 gr2
+| MLglob gr1, MLglob gr2 -> eq_global gr1 gr2
 | MLcons (t1, gr1, c1), MLcons (t2, gr2, c2) ->
-  eq_ml_type t1 t2 && GlobRef.CanOrd.equal gr1 gr2 && List.equal eq_ml_ast c1 c2
+  eq_ml_type t1 t2 && eq_global gr1 gr2 && List.equal eq_ml_ast c1 c2
 | MLtuple t1, MLtuple t2 ->
   List.equal eq_ml_ast t1 t2
 | MLcase (t1, c1, p1), MLcase (t2, c2, p2) ->
@@ -408,13 +410,13 @@ let rec eq_ml_ast t1 t2 = match t1, t2 with
 
 and eq_ml_pattern p1 p2 = match p1, p2 with
 | Pcons (gr1, p1), Pcons (gr2, p2) ->
-  GlobRef.CanOrd.equal gr1 gr2 && List.equal eq_ml_pattern p1 p2
+  eq_global gr1 gr2 && List.equal eq_ml_pattern p1 p2
 | Ptuple p1, Ptuple p2 ->
   List.equal eq_ml_pattern p1 p2
 | Prel i1, Prel i2 ->
   Int.equal i1 i2
 | Pwild, Pwild -> true
-| Pusual gr1, Pusual gr2 -> GlobRef.CanOrd.equal gr1 gr2
+| Pusual gr1, Pusual gr2 -> eq_global gr1 gr2
 | _ -> false
 
 and eq_ml_branch (id1, p1, t1) (id2, p2, t2) =
@@ -689,11 +691,11 @@ let is_regular_match br =
           | _ -> raise Impossible
       in
       let ind = match get_r br.(0) with
-        | GlobRef.ConstructRef (ind,_) -> ind
+        | { glob = GlobRef.ConstructRef (ind,_) } -> ind
         | _ -> raise Impossible
       in
       let is_ref i tr = match get_r tr with
-      | GlobRef.ConstructRef (ind', j) -> Ind.CanOrd.equal ind ind' && Int.equal j (i + 1)
+      | { glob = GlobRef.ConstructRef (ind', j) } -> Ind.CanOrd.equal ind ind' && Int.equal j (i + 1)
       | _ -> false
       in
       Array.for_all_i is_ref 0 br
@@ -839,12 +841,16 @@ let rec tmp_head_lams = function
   reduction (this helps the inlining of recursors).
 *)
 
+let is_constant g = match g.glob with
+| GlobRef.ConstRef _ -> true
+| _ -> false
+
 let rec ast_glob_subst s t = match t with
-  | MLapp ((MLglob ((GlobRef.ConstRef kn) as refe)) as f, a) ->
+  | MLapp ((MLglob refe) as f, a) when is_constant refe ->
       let a = List.map (fun e -> tmp_head_lams (ast_glob_subst s e)) a in
       (try linear_beta_red a (Refmap'.find refe s)
        with Not_found -> MLapp (f, a))
-  | MLglob ((GlobRef.ConstRef kn) as refe) ->
+  | MLglob refe when is_constant refe ->
       (try Refmap'.find refe s with Not_found -> t)
   | _ -> ast_map (ast_glob_subst s) t
 
@@ -1004,7 +1010,7 @@ let rec iota_red i lift br ((typ,r,a) as cons) =
   if i >= Array.length br then raise Impossible;
   let (ids,p,c) = br.(i) in
   match p with
-    | Pusual r' | Pcons (r',_) when not (GlobRef.CanOrd.equal r' r) -> iota_red (i+1) lift br cons
+    | Pusual r' | Pcons (r',_) when not (eq_global r' r) -> iota_red (i+1) lift br cons
     | Pusual r' ->
       let c = named_lams (List.rev ids) c in
       let c = ast_lift lift c
@@ -1523,7 +1529,7 @@ open Declareops
 let inline_test r t =
   if not (auto_inline ()) then false
   else
-    let c = match r with GlobRef.ConstRef c -> c | _ -> assert false in
+    let c = match r.glob with GlobRef.ConstRef c -> c | _ -> assert false in
     let has_body =
       Environ.mem_constant c (Global.env()) && constant_has_body (Global.lookup_constant c)
     in
@@ -1551,7 +1557,7 @@ let manual_inline_set =
     ]
     Cset_env.empty
 
-let manual_inline = function
+let manual_inline g = match g.glob with
   | GlobRef.ConstRef c -> Cset_env.mem c manual_inline_set
   | _ -> false
 

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -58,7 +58,7 @@ val type_recomp : ml_type list * ml_type -> ml_type
 
 val var2var' : ml_type -> ml_type
 
-type abbrev_map = GlobRef.t -> ml_type option
+type abbrev_map = global -> ml_type option
 
 val type_expand : abbrev_map -> ml_type -> ml_type
 val type_simpl : ml_type -> ml_type
@@ -116,7 +116,7 @@ val dump_unused_vars : ml_ast -> ml_ast
 
 val normalize : ml_ast -> ml_ast
 val optimize_fix : ml_ast -> ml_ast
-val inline : Table.t -> GlobRef.t -> ml_ast -> bool
+val inline : Table.t -> global -> ml_ast -> bool
 
 val is_basic_pattern : ml_pattern -> bool
 val has_deep_pattern : ml_branch array -> bool

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -22,9 +22,9 @@ val type_subst_vect : ml_type array -> ml_type -> ml_type
 
 val instantiation : ml_schema -> ml_type
 
-val needs_magic : compute:bool -> ml_type * ml_type -> bool
+val needs_magic : ml_type * ml_type -> bool
 val put_magic_if : bool -> ml_ast -> ml_ast
-val put_magic : compute:bool -> ml_type * ml_type -> ml_ast -> ml_ast
+val put_magic : ml_type * ml_type -> ml_ast -> ml_ast
 
 val generalizable : ml_ast -> bool
 

--- a/plugins/extraction/modutil.mli
+++ b/plugins/extraction/modutil.mli
@@ -16,7 +16,7 @@ open Miniml
 val struct_ast_search : (ml_ast -> bool) -> ml_structure -> bool
 val struct_type_search : (ml_type -> bool) -> ml_structure -> bool
 
-type do_ref = GlobRef.t -> unit
+type do_ref = global -> unit
 
 val type_iter_references : do_ref -> ml_type -> unit
 val ast_iter_references : do_ref -> do_ref -> do_ref -> ml_ast -> unit
@@ -29,7 +29,7 @@ val mtyp_of_mexpr : ml_module_expr -> ml_module_type
 
 val msid_of_mt : ml_module_type -> ModPath.t
 
-val get_decl_in_structure : GlobRef.t -> ml_structure -> ml_decl
+val get_decl_in_structure : global -> ml_structure -> ml_decl
 
 (* Some transformations of ML terms. [optimize_struct] simplify
    all beta redexes (when the argument does not occur, it is just
@@ -38,5 +38,5 @@ val get_decl_in_structure : GlobRef.t -> ml_structure -> ml_decl
    optimizations. The first argument is the list of objects we want to appear.
 *)
 
-val optimize_struct : Common.State.t -> GlobRef.t list * ModPath.t list ->
+val optimize_struct : Common.State.t -> global list * ModPath.t list ->
   ml_structure -> ml_structure

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -149,7 +149,7 @@ let get_infix r =
 
 let get_ind r = let open GlobRef in match r.glob with
   | IndRef _ -> r
-  | ConstructRef (ind,_) -> { glob = IndRef ind }
+  | ConstructRef (ind,_) -> { glob = IndRef ind; inst = r.inst }
   | _ -> assert false
 
 let kn_of_ind r = let open GlobRef in match r.glob with
@@ -487,16 +487,16 @@ let pp_Dfix table (rv,c,t) =
 
 (*s Pretty-printing of inductive types declaration. *)
 
-let pp_equiv table param_list name = function
+let pp_equiv table param_list name inst = function
   | NoEquiv, _ -> mt ()
   | Equiv kn, i ->
-    let r = { glob = GlobRef.IndRef (MutInd.make1 kn, i) } in
+    let r = { glob = GlobRef.IndRef (MutInd.make1 kn, i); inst } in
     str " = " ++ pp_parameters param_list ++ pp_global table Type r
   | RenEquiv ren, _  ->
       str " = " ++ pp_parameters param_list ++ str (ren^".") ++ name
 
 
-let pp_one_ind table prefix ip_equiv pl name cnames ctyps =
+let pp_one_ind table prefix inst ip_equiv pl name cnames ctyps =
   let pl = rename_tvars keywords pl in
   let pp_constructor i typs =
     (if Int.equal i 0 then mt () else fnl ()) ++
@@ -506,7 +506,7 @@ let pp_one_ind table prefix ip_equiv pl name cnames ctyps =
             (fun () -> spc () ++ str "* ") (pp_type table true pl) typs)
   in
   pp_parameters pl ++ str prefix ++ name ++
-  pp_equiv table pl name ip_equiv ++ str " =" ++
+  pp_equiv table pl name inst ip_equiv ++ str " =" ++
   if Int.equal (Array.length ctyps) 0 then str " |"
   else fnl () ++ v 0 (prvecti pp_constructor ctyps)
 
@@ -532,7 +532,7 @@ let pp_record table fields ip_equiv packet =
   let l = List.combine fieldnames packet.ip_types.(0) in
   let pl = rename_tvars keywords packet.ip_vars in
   str "type " ++ pp_parameters pl ++ name ++
-  pp_equiv table pl name ip_equiv ++ str " = { "++
+  pp_equiv table pl name ind.inst ip_equiv ++ str " = { "++
   hov 0 (prlist_with_sep (fun () -> str ";" ++ spc ())
            (fun (p,t) -> p ++ str " : " ++ pp_type table true pl t) l)
   ++ str " }"
@@ -568,8 +568,9 @@ let pp_ind table co ind =
       if is_custom ip then pp (i+1) kwd
       else if p.ip_logical then pp_logical_ind p ++ pp (i+1) kwd
       else
+        let inst = p.ip_typename_ref.inst in
         kwd ++ (if co then pp_coind p.ip_vars names.(i) else mt ()) ++
-        pp_one_ind table prefix ip_equiv p.ip_vars names.(i) cnames.(i) p.ip_types ++
+        pp_one_ind table prefix inst ip_equiv p.ip_vars names.(i) cnames.(i) p.ip_types ++
         pp (i+1) nextkwd
   in
   pp 0 initkwd
@@ -704,14 +705,14 @@ and pp_module_type table params = function
        else
          v 1 (str " " ++ prlist_with_sep cut2 identity l) ++ fnl ())
       ++ str "end"
-  | MTwith(mt,ML_With_type(idl,vl,typ)) ->
+  | MTwith(mt,ML_With_type (rlv, idl, vl, typ)) ->
       let ids = pp_parameters (rename_tvars keywords vl) in
       let mp_mt = msid_of_mt mt in
       let l,idl' = List.sep_last idl in
       let mp_w =
         List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl'
       in
-      let r = { glob = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)) } in
+      let r = { glob = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)); inst = rlv } in
       let pp_w = State.with_visibility table mp_mt [] begin fun table ->
         str " with type " ++ ids ++ pp_global table Type r
       end in

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -13,12 +13,12 @@ open Libnames
 open Miniml
 open Declarations
 
-module Refset' : CSig.USetS with type elt = GlobRef.t
-module Refmap' : CSig.UMapS with type key = GlobRef.t
+module Refset' : CSig.USetS with type elt = global
+module Refmap' : CSig.UMapS with type key = global
 
 type t
 
-val safe_basename_of_global : t -> GlobRef.t -> Id.t
+val safe_basename_of_global : t -> global -> Id.t
 
 val make_table : unit -> t
 
@@ -28,16 +28,16 @@ val warning_axioms : t -> unit
 val warning_opaques : t -> bool -> unit
 val warning_ambiguous_name : ?loc:Loc.t -> qualid * ModPath.t * GlobRef.t -> unit
 val warning_id : string -> unit
-val error_axiom_scheme : ?loc:Loc.t -> GlobRef.t -> int -> 'a
-val error_constant : ?loc:Loc.t -> GlobRef.t -> 'a
-val error_inductive : ?loc:Loc.t -> GlobRef.t -> 'a
+val error_axiom_scheme : ?loc:Loc.t -> global -> int -> 'a
+val error_constant : ?loc:Loc.t -> global -> 'a
+val error_inductive : ?loc:Loc.t -> global -> 'a
 val error_nb_cons : unit -> 'a
 val error_module_clash : ModPath.t -> ModPath.t -> 'a
 val error_no_module_expr : ModPath.t -> 'a
 val error_singleton_become_prop : inductive -> 'a
 val error_unknown_module : ?loc:Loc.t -> qualid -> 'a
 val error_scheme : unit -> 'a
-val error_not_visible : GlobRef.t -> 'a
+val error_not_visible : global -> 'a
 val error_MPfile_as_mod : ModPath.t -> bool -> 'a
 val check_inside_section : unit -> unit
 val check_loaded_modfile : ModPath.t -> unit
@@ -48,10 +48,10 @@ val info_file : string -> unit
 
 (*s utilities about [module_path] and [kernel_names] and [GlobRef.t] *)
 
-val occur_kn_in_ref : MutInd.t -> GlobRef.t -> bool
-val repr_of_r : GlobRef.t -> KerName.t
-val modpath_of_r : GlobRef.t -> ModPath.t
-val label_of_r : GlobRef.t -> Label.t
+val occur_kn_in_ref : MutInd.t -> global -> bool
+val repr_of_r : global -> KerName.t
+val modpath_of_r : global -> ModPath.t
+val label_of_r : global -> Label.t
 val base_mp : ModPath.t -> ModPath.t
 val is_modfile : ModPath.t -> bool
 val string_of_modfile : t -> ModPath.t -> string
@@ -63,7 +63,7 @@ val prefixes_mp : ModPath.t -> MPset.t
 val common_prefix_from_list :
   ModPath.t -> ModPath.t list -> ModPath.t option
 val get_nth_label_mp : int -> ModPath.t -> Label.t
-val labels_of_ref : GlobRef.t -> ModPath.t * Label.t list
+val labels_of_ref : global -> ModPath.t * Label.t list
 
 (*s Some table-related operations *)
 
@@ -85,29 +85,27 @@ val add_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind -> unit
 val lookup_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind option
 
 val add_inductive_kind : t -> MutInd.t -> inductive_kind -> unit
-val is_coinductive : t -> GlobRef.t -> bool
+val is_coinductive : t -> global -> bool
 val is_coinductive_type : t -> ml_type -> bool
 (* What are the fields of a record (empty for a non-record) *)
 val get_record_fields :
-  t -> GlobRef.t -> GlobRef.t option list
-val record_fields_of_type : t -> ml_type -> GlobRef.t option list
+  t -> global -> global option list
+val record_fields_of_type : t -> ml_type -> global option list
 
 val add_recursors : t -> Environ.env -> MutInd.t -> unit
-val is_recursor : t -> GlobRef.t -> bool
+val is_recursor : t -> global -> bool
 
 val add_projection : t -> int -> Constant.t -> inductive -> unit
-val is_projection : t -> GlobRef.t -> bool
-val projection_arity : t -> GlobRef.t -> int
-val projection_info : t -> GlobRef.t -> inductive * int (* arity *)
+val is_projection : t -> global -> bool
 
-val add_info_axiom : t -> GlobRef.t -> unit
-val remove_info_axiom : t -> GlobRef.t -> unit
-val add_log_axiom : t -> GlobRef.t -> unit
-val add_symbol : t -> GlobRef.t -> unit
-val add_symbol_rule : t -> GlobRef.t -> Label.t -> unit
+val add_info_axiom : t -> global -> unit
+val remove_info_axiom : t -> global -> unit
+val add_log_axiom : t -> global-> unit
+val add_symbol : t -> global -> unit
+val add_symbol_rule : t -> global -> Label.t -> unit
 
-val add_opaque : t -> GlobRef.t -> unit
-val remove_opaque : t -> GlobRef.t -> unit
+val add_opaque : t -> global -> unit
+val remove_opaque : t -> global -> unit
 
 (*s Output Directory parameter *)
 
@@ -161,24 +159,24 @@ val lang : unit -> lang
 
 (*s Table for custom inlining *)
 
-val to_inline : GlobRef.t -> bool
-val to_keep : GlobRef.t -> bool
+val to_inline : global -> bool
+val to_keep : global -> bool
 
 (*s Table for implicits arguments *)
 
-val implicits_of_global : GlobRef.t -> Int.Set.t
+val implicits_of_global : global -> Int.Set.t
 
 (*s Table for user-given custom ML extractions. *)
 
 (* UGLY HACK: registration of a function defined in [extraction.ml] *)
 val type_scheme_nb_args_hook : (Environ.env -> Constr.t -> int) Hook.t
 
-val is_custom : GlobRef.t -> bool
-val is_inline_custom : GlobRef.t -> bool
-val is_foreign_custom : GlobRef.t -> bool
-val find_callback : GlobRef.t -> string option
-val find_custom : GlobRef.t -> string
-val find_type_custom : GlobRef.t -> string list * string
+val is_custom : global -> bool
+val is_inline_custom : global -> bool
+val is_foreign_custom : global -> bool
+val find_callback : global -> string option
+val find_custom : global -> string
+val find_type_custom : global -> string list * string
 
 val is_custom_match : ml_branch array -> bool
 val find_custom_match : ml_branch array -> string

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -75,16 +75,16 @@ val labels_of_ref : global -> ModPath.t * Label.t list
    [mutual_inductive_body] as checksum. In both case, we should ideally
    also check the env *)
 
-val add_typedef : t -> Constant.t -> constant_body -> ml_type -> unit
-val lookup_typedef : t -> Constant.t -> constant_body -> ml_type option
+val add_typedef : t -> Constant.t -> InfvInst.t -> constant_body -> ml_type -> unit
+val lookup_typedef : t -> Constant.t -> InfvInst.t -> constant_body -> ml_type option
 
-val add_cst_type : t -> Constant.t -> constant_body -> ml_schema -> unit
-val lookup_cst_type : t -> Constant.t -> constant_body -> ml_schema option
+val add_cst_type : t -> Constant.t -> InfvInst.t -> constant_body -> ml_schema -> unit
+val lookup_cst_type : t -> Constant.t -> InfvInst.t -> constant_body -> ml_schema option
 
-val add_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind -> unit
-val lookup_ind : t -> MutInd.t -> mutual_inductive_body -> ml_ind option
+val add_ind : t -> MutInd.t -> InfvInst.t -> mutual_inductive_body -> ml_ind -> unit
+val lookup_ind : t -> MutInd.t ->  InfvInst.t -> mutual_inductive_body -> ml_ind option
 
-val add_inductive_kind : t -> MutInd.t -> inductive_kind -> unit
+val add_inductive_kind : t -> MutInd.t -> InfvInst.t -> inductive_kind -> unit
 val is_coinductive : t -> global -> bool
 val is_coinductive_type : t -> ml_type -> bool
 (* What are the fields of a record (empty for a non-record) *)

--- a/test-suite/success/sort_poly_extraction.v
+++ b/test-suite/success/sort_poly_extraction.v
@@ -18,4 +18,37 @@ Definition make_pair := pair@{Prop|_} _ I I.
 
 Definition hell := use_pair True (fun _ => 0) make_pair.
 
-Recursive Extraction hell.
+Extraction TestCompile hell.
+
+(* Some tests *)
+
+Module Foo.
+
+Definition foo@{s1 s2| |} := fun (A : Type@{s1|Set}) (x : A) => x.
+
+Definition foo0 := foo@{SProp Type|}.
+Definition foo1 := foo@{Type SProp|}.
+
+Inductive T@{s| |} : Type@{s|Set} := O : T | S : T -> T.
+
+Inductive box@{s1 s2| |} (A : Type@{s1|Set}) (B : Type@{s2|Set}) : Type@{Set} := Box : A -> B -> box A B.
+
+Definition bar (A : Type) (x : A) := 0.
+
+Definition qux := bar (forall A : Prop, A -> A) foo@{Prop Type|}.
+
+End Foo.
+
+Extraction TestCompile Foo.
+
+(* Check module subtyping *)
+
+Module Type S.
+Inductive box@{s1 s2| |} (A : Type@{s1|Set}) (B : Type@{s2|Set}) : Type@{Set} := Box : A -> B -> box A B.
+End S.
+
+Module Bar : S.
+Inductive box@{s1 s2| |} (A : Type@{s1|Set}) (B : Type@{s2|Set}) : Type@{Set} := Box : A -> B -> box A B.
+End Bar.
+
+Extraction TestCompile Bar.

--- a/test-suite/success/sort_poly_extraction.v
+++ b/test-suite/success/sort_poly_extraction.v
@@ -5,7 +5,7 @@ Definition foo@{s| |} := tt.
 
 Definition bar := foo@{Prop|}.
 
-Fail Extraction bar.
+Extraction bar.
 
 (* the actual problem only appears once we have inductives with sort poly output: *)
 
@@ -18,4 +18,4 @@ Definition make_pair := pair@{Prop|_} _ I I.
 
 Definition hell := use_pair True (fun _ => 0) make_pair.
 
-Fail Recursive Extraction hell.
+Recursive Extraction hell.


### PR DESCRIPTION
For each sort-polymorphic declaration, we generate 2^n extracted declarations where n is the number of quantified sorts. The code relies on global references in extraction being replaced by a globref + a monomorphic instance. Some bits of code are still not extremely clean, and this PR needs testing and polishing but seems to work for simple examples.

TODO:
- ~~Write tests.~~
- ~~Try to write the code in a way that doesn't trigger a gazillion of reserved identifiers when using sort-poly definitions.~~
- ~~Maybe find a better naming scheme? Currently the name of a sort-poly definition is built out of the base name + a suffix. The suffix is empty when all sorts are relevant, and is made of X and O indicating the erasure status for each sort in order otherwise.~~ This was deemed appropriate by @mattam82 and @SkySkimmer .