### PR TITLE
Ltac2 add $hyp:id quotation for dynamic hypotheses (where &id is static)

### DIFF
--- a/doc/changelog/06-Ltac2-language/20656-ltac2-hyp-var-Added.rst
+++ b/doc/changelog/06-Ltac2-language/20656-ltac2-hyp-var-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  antiquotation `$hyp:id` in terms for dynamically named hypotheses,
+  i.e. `let x := @y in constr:($hyp:x)` is equivalent to `constr:(&y)`
+  (`#20656 <https://github.com/rocq-prover/rocq/pull/20656>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -823,6 +823,14 @@ Similarly variables of type `preterm` have an antiquotation
 
 It is equivalent to pretyping the preterm with the appropriate typing constraint.
 
+Variables of type `ident` have an antiquotation
+
+.. prodn:: term += $preterm:@lident
+
+interpreting the ident as an hypothesis. This is for dynamically-named
+hypotheses where `&` is for statically-named hypotheses, in other
+words `let x := @y in constr:($hyp:x)` is equivalent to `constr:(&y)`.
+
 Variables of type `pattern` have an antiquotation
 
 .. prodn:: term += $pattern:@lident

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -349,6 +349,11 @@ let csubst_instance subst ctx =
   in
   List.fold_right fold ctx SList.empty
 
+let ext_rev_subst (subst, _, _) id0 =
+  match Id.Map.find id0 subst.csubst_rev with
+  | SRel n -> EConstr.mkRel (subst.csubst_len - n)
+  | SVar id -> EConstr.mkVar id
+
 let default_ext_instance (subst, _, ctx) =
   csubst_instance subst (named_context_of_val ctx)
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -237,6 +237,8 @@ type ext_named_context =
 
 val default_ext_instance : ext_named_context -> constr SList.t
 
+val ext_rev_subst : ext_named_context -> Id.t -> constr
+
 val push_rel_decl_to_named_context : hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context
 

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -303,6 +303,7 @@ type var_quotation_kind =
   | ConstrVar
   | PretermVar
   | PatternVar
+  | HypVar
 
 let wit_ltac2_constr = Genarg.make0 "ltac2:in-constr"
 let wit_ltac2_var_quotation = Genarg.make0 "ltac2:quotation"

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -190,6 +190,7 @@ type var_quotation_kind =
   | ConstrVar
   | PretermVar
   | PatternVar
+  | HypVar
 
 val wit_ltac2_var_quotation : (lident option * lident, var_quotation_kind * Id.t, Util.Empty.t) genarg_type
 (** Ltac2 quotations for variables "$x" or "$kind:foo" in Gallina terms.

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -29,6 +29,7 @@ let t_string = rocq_type "string"
 let t_constr = rocq_type "constr"
 let t_preterm = rocq_type "preterm"
 let t_pattern = rocq_type "pattern"
+let t_ident = rocq_type "ident"
 let t_bool = rocq_type "bool"
 
 let ltac2_env : Tac2typing_env.t Genintern.Store.field =
@@ -2145,6 +2146,7 @@ let intern_var_quotation_gen ~ispat ist (kind, { CAst.v = id; loc }) =
       | "constr" -> ConstrVar
       | "preterm" -> PretermVar
       | "pattern" -> PatternVar
+      | "hyp" -> HypVar
       | _ ->
         CErrors.user_err ?loc:kind.loc
           Pp.(str "Unknown Ltac2 variable quotation kind" ++ spc() ++ Id.print kind.v)
@@ -2162,6 +2164,11 @@ let intern_var_quotation_gen ~ispat ist (kind, { CAst.v = id; loc }) =
       if not ispat
       then CErrors.user_err ?loc Pp.(str "pattern quotations not supported outside tactic patterns.")
       else t_pattern
+    | HypVar ->
+      (* XXX allow this? *)
+      if ispat
+      then CErrors.user_err ?loc Pp.(str "hyp quotations not supported in tactic patterns.")
+      else t_ident
   in
   let env = match Genintern.Store.get ist.extra ltac2_env with
     | None ->

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -178,6 +178,16 @@ let interp_ltac_variable ?loc typing_fun env sigma id : Evd.evar_map * unsafe_ju
 
 let interp_ltac_id env id = ltac_interp_id env.lvar id
 
+let lookup_renamed globenv id =
+  let env = renamed_env globenv in
+  (* optimization: if id is in the original named context it will
+     be the same in the extended context *)
+  match EConstr.lookup_named id env with
+  | d -> EConstr.mkVar id
+  | exception Not_found ->
+    let (_, _, sign) as ext = Lazy.force globenv.extra in
+    Evarutil.ext_rev_subst ext id
+
 type 'a obj_interp_fun =
   ?loc:Loc.t -> poly:bool -> t -> Evd.evar_map -> Evardefine.type_constraint ->
   'a -> unsafe_judgment * Evd.evar_map

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -65,6 +65,10 @@ val new_evar : t -> evar_map -> ?src:Evar_kinds.t Loc.located ->
 
 val new_type_evar : t -> evar_map -> src:Evar_kinds.t Loc.located -> evar_map * constr
 
+(** Lookup the ident in the context that would be used for an evar in
+    this environment, producing a term (Var or Rel) valid in [renamed_env]. *)
+val lookup_renamed : t -> Id.t -> constr
+
 (** [hide_variable env id] tells to hide the binding of [id] in
     the ltac environment part of [env]. It is useful e.g.
     for the dual status of [y] as term and binder. This is the case

--- a/test-suite/output/ltac2_hyp_var.out
+++ b/test-suite/output/ltac2_hyp_var.out
@@ -1,0 +1,22 @@
+File "./output/ltac2_hyp_var.v", line 3, characters 16-18:
+The command has indeed failed with message:
+Unbound value id
+- : constr = constr:(fun (_ : nat) (x : bool) => eq_refl : (x, x) = (x, x))
+File "./output/ltac2_hyp_var.v", line 7, characters 33-40:
+The command has indeed failed with message:
+Hypothesis "x" (value of ltac2 variable "id") not found.
+File "./output/ltac2_hyp_var.v", line 8, characters 49-56:
+The command has indeed failed with message:
+In environment
+x : nat
+The term "x" has type "nat" while it is expected to have type "bool".
+- : constr = constr:(fun x : nat => x : nat)
+- : constr = constr:(fun x0 : bool => eq_refl : (x0, x) = (x0, x))
+- : constr = constr:(x : nat)
+File "./output/ltac2_hyp_var.v", line 18, characters 36-43:
+The command has indeed failed with message:
+In environment
+x : nat
+The term "x" has type "nat" while it is expected to have type "bool".
+- : constr = constr:(fun (_ : nat) (_0 : bool) => eq_refl : _0 = _0)
+- : constr = constr:(fun (_0 : nat) (_ : bool) => eq_refl : _0 = _0)

--- a/test-suite/output/ltac2_hyp_var.v
+++ b/test-suite/output/ltac2_hyp_var.v
@@ -1,0 +1,25 @@
+Require Import Ltac2.Ltac2.
+
+Fail Check $hyp:id.
+
+Ltac2 Eval let id := @x in '(fun (x:nat) (x : bool) => eq_refl : (x, &x) = (x, $hyp:id)).
+
+Fail Ltac2 Eval let id := @x in '$hyp:id.
+Fail Ltac2 Eval let id := @x in '(fun x : nat => $hyp:id : bool).
+
+Ltac2 Eval let id := @x in constr:(fun x => $hyp:id : nat).
+
+Section S.
+  Variable x : nat.
+
+  Ltac2 Eval let id := @x in '(fun x : bool => eq_refl : (x, &x) = (x, $hyp:id)).
+
+  Ltac2 Eval let id := @x in '($hyp:id : nat).
+  Fail Ltac2 Eval let id := @x in '($hyp:id : bool).
+End S.
+
+Set Mangle Names.
+
+Ltac2 Eval let id := @x in '(fun (x:nat) (x:bool) => eq_refl : &x = $hyp:id :> bool).
+
+Ltac2 Eval let id := @_1 in '(fun (x:nat) (x:bool) => eq_refl : &_1 = $hyp:id :> nat).


### PR DESCRIPTION
ie `let x := @y in '($hyp:x)` is equivalent to `'&y`
