### PR TITLE
Clean up Ccprojectability implementation

### DIFF
--- a/plugins/cc/ccprojectability.ml
+++ b/plugins/cc/ccprojectability.ml
@@ -55,15 +55,12 @@ let is_field_i_dependent env sigma cnstr i =
   in
   is_field_i_dependent_rec (i-1)
 
-let fresh_id env id =
-  Namegen.next_ident_away id (Environ.ids_of_named_context_val @@ Environ.named_context_val env)
-
 (*this builds a projection in the simply typed case*)
 let build_simple_projection env sigma intype cnstr special default =
   let open Context in
   let ci = (snd (fst cnstr)) in
   let body = Combinators.make_selector env sigma ~pos:ci ~special ~default (mkRel 1) intype in
-  let id = fresh_id env (Id.of_string "t") in
+  let id = Id.of_string "t" in
   mkLambda (make_annot (Name id) ERelevance.relevant, intype, body)
 
 let (let*) m f = match m with

--- a/plugins/cc/ccprojectability.ml
+++ b/plugins/cc/ccprojectability.ml
@@ -8,13 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Names
+open EConstr
+open Inductiveops
 
 (* This represents how a term is getting extracted from another term *)
 type term_extraction =
 (* The term that is getting extracted *)
 | Id of EConstr.t
 (* The rel term that is getting extracted, the rel term from wich its getting extracted, The constructor from which to extract, Type of the Cosntructor that is getting extracted, index (1 based) to extract from, further extraction *)
-| Extraction of (EConstr.t * EConstr.t * (Names.constructor * EConstr.EInstance.t) * EConstr.t * int * term_extraction)
+| Extraction of (EConstr.t * EConstr.t * (constructor * EInstance.t) * EConstr.t * int * term_extraction)
 
 (* this represents how a term is getting composed from an inductive type *)
 type term_composition =
@@ -38,18 +41,18 @@ type projection_type =
 
 (*get the ith (1 based) argument in a series of prods*)
 let get_ith_arg sigma i term =
-  let (rels_to_arg, rest) = EConstr.decompose_prod_n sigma (i-1) term in
-  let (arg_name, arg_type,rest) = EConstr.destProd sigma rest in
+  let (rels_to_arg, rest) = decompose_prod_n sigma (i-1) term in
+  let (arg_name, arg_type,rest) = destProd sigma rest in
   (rels_to_arg, (arg_name, arg_type), rest)
 
 (*determin if the ith (1 based real constructor arguments without parametes) field of a constructor depends on its other fields*)
 let is_field_i_dependent env sigma cnstr i =
-  let constructor_type = Inductiveops.e_type_of_constructor env sigma cnstr in
-  let ind_n_params = Inductiveops.inductive_nparams env (fst (fst cnstr)) in
+  let constructor_type = e_type_of_constructor env sigma cnstr in
+  let ind_n_params = inductive_nparams env (fst (fst cnstr)) in
   let (field_rel_context, (_, field_type), _) = get_ith_arg sigma (i + ind_n_params) constructor_type in
   let rec is_field_i_dependent_rec i =
     if i <= 0 then false
-    else if Termops.dependent sigma (EConstr.mkRel i) field_type then true
+    else if Termops.dependent sigma (mkRel i) field_type then true
     else is_field_i_dependent_rec (i-1)
   in
   is_field_i_dependent_rec (i-1)
@@ -59,8 +62,6 @@ let fresh_id env id =
 
 (*this builds a projection in the simply typed case*)
 let build_simple_projection env sigma intype cnstr special default =
-  let open EConstr in
-  let open Names in
   let open Context in
   let ci = (snd (fst cnstr)) in
   let body = Combinators.make_selector env sigma ~pos:ci ~special ~default (mkRel 1) intype in
@@ -71,11 +72,11 @@ let build_simple_projection env sigma intype cnstr special default =
 let find_term_composition env sigma cnstr argindex env_field_type ind env_ind_params env_ind_args =
   (*first we need to get some information about the inductive type*)
   let env_ind_n_params = Array.length env_ind_params in
-  let rel_type_of_constructor = Inductiveops.type_of_constructor env cnstr in
+  let rel_type_of_constructor = type_of_constructor env cnstr in
   let (rel_field_context, (rel_field_annot, rel_field_type), rel_field_rest) = get_ith_arg sigma (argindex+env_ind_n_params) rel_type_of_constructor in
-  let (rel_target_context, rel_target_type) = EConstr.decompose_prod sigma rel_field_rest in
-  let rel_field_type_lifted = EConstr.Vars.lift (List.length rel_target_context + 1) rel_field_type in
-  let (_, rel_args) = EConstr.decompose_app sigma rel_target_type in
+  let (rel_target_context, rel_target_type) = decompose_prod sigma rel_field_rest in
+  let rel_field_type_lifted = Vars.lift (List.length rel_target_context + 1) rel_field_type in
+  let (_, rel_args) = decompose_app sigma rel_target_type in
   let (rel_ind_params, rel_ind_args) = CArray.chop env_ind_n_params rel_args in
   (*the actual recursive search for the term_composition*)
   let rec find_term_composition_rec env sigma rel_term_to_compose env_term_to_compose =
@@ -92,7 +93,7 @@ let find_term_composition env sigma cnstr argindex env_field_type ind env_ind_pa
         | None ->
           begin match rel_term_to_compose_kind with
           | App (rel_f,rel_args) ->
-            let (env_f,env_args) = EConstr.decompose_app sigma env_term_to_compose in
+            let (env_f,env_args) = decompose_app sigma env_term_to_compose in
             let (sigma, f_composition) = find_term_composition_rec env sigma rel_f env_f in
             begin match f_composition with
             | Some f_composition ->
@@ -138,13 +139,13 @@ let find_term_composition env sigma cnstr argindex env_field_type ind env_ind_pa
       (Array.to_seqi terms_to_extract_from)
   (*finds the term_extraction for a given term*)
   and find_term_extraction env sigma term_to_extract term_to_extract_from type_of_term_to_extract_from =
-    if EConstr.eq_constr_nounivs sigma term_to_extract term_to_extract_from then
+    if eq_constr_nounivs sigma term_to_extract term_to_extract_from then
       Some (Id term_to_extract)
     else match EConstr.kind sigma term_to_extract_from with
     | App (f, args) ->
       begin match EConstr.kind sigma f with
       | Construct c ->
-          let (_, env_args) = EConstr.decompose_app sigma type_of_term_to_extract_from in
+          let (_, env_args) = decompose_app sigma type_of_term_to_extract_from in
           let first_arg_option =
             find_arg env sigma term_to_extract args env_args
           in
@@ -176,8 +177,8 @@ let rec build_term_extraction env sigma default rel_term_to_extract_from env_ter
   | Id term_getting_extracted -> rel_term_to_extract_from
   (* The term that is getting extracted, the term from wich its getting extracted, The constructor from which zu extract, index (1 based without params) to extract from, further extraction *)
   | Extraction (rel_term_getting_extracted, rel_next_term_to_extrect_from, (cnstr, u), env_next_term_to_extract_from, index, next_extraction) ->
-    let cnstr_n_args = Inductiveops.constructor_nrealargs env cnstr in
-    let special = build_term_extraction env sigma default (EConstr.mkRel (cnstr_n_args-(index-1))) env_next_term_to_extract_from next_extraction in
+    let cnstr_n_args = constructor_nrealargs env cnstr in
+    let special = build_term_extraction env sigma default (mkRel (cnstr_n_args-(index-1))) env_next_term_to_extract_from next_extraction in
     let pos = snd cnstr in
     let (_, match_type) = Typing.type_of env sigma env_term_to_extract_from in
     Combinators.make_selector env sigma ~pos ~special ~default rel_term_to_extract_from match_type
@@ -194,33 +195,31 @@ let rec build_term_composition env sigma term_composition ind_params n_ind_param
   (* type to compose, indec term to extract from, index (1 based) index to compose from, extraction for the given type *)
   | FromIndex (env_type_to_compose, index_to_compose_from, index_index, extraction) ->
     let type_to_extract_from = ind_args.(index_index-1) in
-    build_term_extraction env sigma env_type_to_compose (EConstr.mkRel (n_ind_args-(index_index-1))) type_to_extract_from extraction
+    build_term_extraction env sigma env_type_to_compose (mkRel (n_ind_args-(index_index-1))) type_to_extract_from extraction
   (* (f type to compose, composition for f), array of (arg type to compose, composition for arg)*)
   | Composition ((f_to_compose , f_composition),  arg_compositions) ->
     let f_extraction_term = build_term_composition env sigma f_composition ind_params n_ind_params ind_args n_ind_args in
     let arg_extraction_terms = Array.map (fun (_,arg_composition) -> build_term_composition env sigma arg_composition ind_params n_ind_params ind_args n_ind_args) arg_compositions in
-    EConstr.mkApp (f_extraction_term, arg_extraction_terms)
+    mkApp (f_extraction_term, arg_extraction_terms)
 
 (*replaces all rel variables corresponding to indices in a match statment with the index definition in the inductive definition*)
 let match_indices env sigma cnst_summary term_to_match n_ind_args max_free_rel =
   let rec replace_rec n t = match EConstr.kind sigma t with
   | Rel i ->
     if i <= n_ind_args + n && i > n then
-      cnst_summary.Inductiveops.cs_concl_realargs.(n_ind_args-i)
+      cnst_summary.cs_concl_realargs.(n_ind_args-i)
     else t
   | _ -> EConstr.map_with_binders sigma (fun n -> n+1) replace_rec n t
   in
   EConstr.map_with_binders sigma (fun n -> n+1) replace_rec 0 term_to_match
 
 let make_annot_numbered s i r =
-  Context.make_annot (Names.Name.mk_name (Nameops.make_ident s i)) r
+  Context.make_annot (Name.mk_name (Nameops.make_ident s i)) r
 
 (*makes a match statement where the index variables in the branches get replaced by the index definitions inside the inductive definition*)
 let make_selector_match_indices env sigma ~pos ~special c (ind_fam, ind_args) return_type composition_type_template =
-  let open Inductiveops in
-  let open EConstr in
   let n_ind_args = List.length ind_args in
-  let indt = Inductiveops.IndType (ind_fam, ind_args) in
+  let indt = IndType (ind_fam, ind_args) in
   let (ind, _),_ = dest_ind_family ind_fam in
   let () = Tacred.check_privacy env ind in
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
@@ -231,9 +230,9 @@ let make_selector_match_indices env sigma ~pos ~special c (ind_fam, ind_args) re
     let max_free_rel = Option.default 0 (Int.Set.max_elt_opt (Termops.free_rels sigma composition_type_template)) in
     let matched_template = match_indices env sigma cstrs.(i-1) composition_type_template n_ind_args max_free_rel in
     let endpt = if Int.equal i pos then
-      EConstr.mkLambda (Context.make_annot Names.Name.Anonymous EConstr.ERelevance.relevant, matched_template, EConstr.Vars.lift 1 special)
+      mkLambda (Context.make_annot Name.Anonymous ERelevance.relevant, matched_template, Vars.lift 1 special)
     else
-      EConstr.mkLambda (make_annot_numbered "t" None EConstr.ERelevance.relevant, matched_template, EConstr.mkRel 1)
+      mkLambda (make_annot_numbered "t" None ERelevance.relevant, matched_template, mkRel 1)
     in
     let args = cstrs.(i-1).cs_args in
     it_mkLambda_or_LetIn endpt args
@@ -242,19 +241,19 @@ let make_selector_match_indices env sigma ~pos ~special c (ind_fam, ind_args) re
     List.map build_branch(CList.interval 1 (Array.length mip.mind_consnames)) in
   let rci = ERelevance.relevant in (* TODO relevance *)
   let ci = make_case_info env ind RegularStyle in
-  Inductiveops.make_case_or_project env sigma indt ci (p, rci) c (Array.of_list brl)
+  make_case_or_project env sigma indt ci (p, rci) c (Array.of_list brl)
 
 (*builds a projection in the dependently typed case where a term_composition was found for the fields type*)
 let build_dependent_projection_with_term_composition env sigma cnstr default special argty term_composition ((ind, ind_params) as ind_fam) ind_args =
   let n_ind_params = List.length ind_params in
   let n_ind_args = List.length ind_args in
   let composition_type_template = build_term_composition env sigma term_composition (Array.of_list ind_params) n_ind_params (Array.of_list ind_args) n_ind_args in
-  let return_type = EConstr.Vars.lift 1 (
-    EConstr.mkProd (Context.make_annot Names.Name.Anonymous EConstr.ERelevance.relevant, composition_type_template, EConstr.Vars.lift 1 composition_type_template)
+  let return_type = Vars.lift 1 (
+    mkProd (Context.make_annot Name.Anonymous ERelevance.relevant, composition_type_template, Vars.lift 1 composition_type_template)
   ) in
-  let e_match = make_selector_match_indices  env sigma ~pos:(snd (fst cnstr)) ~special (EConstr.mkRel 1) (Inductiveops.make_ind_family ind_fam, ind_args) return_type composition_type_template in
-  let match_default = EConstr.mkApp (e_match, [|default|]) in
-  let proj = EConstr.mkLambda (make_annot_numbered "e" None EConstr.ERelevance.relevant, argty, match_default) in
+  let e_match = make_selector_match_indices  env sigma ~pos:(snd (fst cnstr)) ~special (mkRel 1) (make_ind_family ind_fam, ind_args) return_type composition_type_template in
+  let match_default = mkApp (e_match, [|default|]) in
+  let proj = mkLambda (make_annot_numbered "e" None ERelevance.relevant, argty, match_default) in
   proj
 
 (*checks the projectability of the given field and builds the according projection. If the field is found to be NotProjectable the simply typed projection generation is tried*)
@@ -265,14 +264,14 @@ let build_projection env sigma
   default (*p.p_lhs so the thing inside the constructor*)
   special (*Rel (nargs-argind+1) so the debrujin index of the field to project directly after binding*)
   argty (*type of the constructor term that is getting projected*) =
-  let Inductiveops.IndType (ind_family,ind_args) =
-    try Inductiveops.find_rectype env sigma argty
+  let IndType (ind_family,ind_args) =
+    try find_rectype env sigma argty
     with Not_found ->
       CErrors.user_err
         Pp.(str "Cannot discriminate on inductive constructors with \
                  dependent types.") in
-  let (ind, ind_params) = Inductiveops.dest_ind_family ind_family in
-  let cnstr = (fst cnstr, EConstr.EInstance.make (snd cnstr)) in
+  let (ind, ind_params) = dest_ind_family ind_family in
+  let cnstr = (fst cnstr, EInstance.make (snd cnstr)) in
   let (sigma, proj_result) = projectability_test env sigma cnstr argindex field_type ind (Array.of_list ind_params) (Array.of_list ind_args) in
   match proj_result with
   | Simple | NotProjectable ->

--- a/plugins/cc/ccprojectability.ml
+++ b/plugins/cc/ccprojectability.ml
@@ -48,12 +48,7 @@ let is_field_i_dependent env sigma cnstr i =
   let constructor_type = e_type_of_constructor env sigma cnstr in
   let ind_n_params = inductive_nparams env (fst (fst cnstr)) in
   let (_, (_, field_type), _) = get_ith_arg sigma (i + ind_n_params) constructor_type in
-  let rec is_field_i_dependent_rec i =
-    if i <= 0 then false
-    else if Termops.dependent sigma (mkRel i) field_type then true
-    else is_field_i_dependent_rec (i-1)
-  in
-  is_field_i_dependent_rec (i-1)
+  not (Vars.noccur_between sigma 1 (i - 1) field_type)
 
 (*this builds a projection in the simply typed case*)
 let build_simple_projection env sigma intype cnstr special default =


### PR DESCRIPTION
Follow-up of #19700. We make the style more Rocq-like, use a few built-in primitives and remove some cruft.