### PR TITLE
Search: allow typos when searching by string

### DIFF
--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -83,6 +83,11 @@ val edit_distance : ?limit:int -> string -> string -> int
 
     copied from ocaml 5.4 *)
 
+val edit_distance_substring : ?limit:int -> pattern:string -> string -> int
+(** [edit_distance_substring ?limit ~pattern s1]
+    is the minimum [edit_distance ?limit pattern s2]
+    where [s2] is a substring of [s1]. *)
+
 (** {6 Generic operations} **)
 
 module Set : CSet.ExtS with type elt = t

--- a/doc/changelog/08-vernac-commands-and-options/20660-search-fuzzy-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/20660-search-fuzzy-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  approximate matching in :cmd:`Search`, controlled by new option :opt:`Fuzzy Search`.
+  Currently only when searching by name (:n:`Search @string`)
+  (`#20660 <https://github.com/rocq-prover/rocq/pull/20660>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -162,6 +162,14 @@ described elsewhere
         put it between single quotes or explicitly provide a scope.
         See :ref:`this example <search-disambiguate-notation>`.
 
+     .. opt:: Fuzzy Search
+
+        Objects whose name contains a string differing by at most the
+        value of this option (default 2) are also included in the
+        search output. Set to 0 to search for only exact matches. To
+        avoid overly verbose results exact matching is always used
+        when the searched string has length 4 or less.
+
    :n:`hyp:`
       The provided pattern or reference is matched against any subterm
       of an hypothesis of the type of the objects.  See :ref:`this

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -307,6 +307,13 @@ andb_true_intro:
   forall [b1 b2 : bool], b1 = true /\ b2 = true -> (b1 && b2)%bool = true
 andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
 andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
+and_comm: forall A B : Prop, A /\ B <-> B /\ A
+eq_id_comm_r:
+  forall [A : Type] (f : A -> A) (Hf : forall a : A, f a = a) (a : A),
+  f_equal f (Hf a) = Hf (f a)
+eq_id_comm_l:
+  forall [A : Type] (f : A -> A) (Hf : forall a : A, a = f a) (a : A),
+  f_equal f (Hf a) = Hf (f a)
 h: n <> newdef n
 h': newdef n <> n
 h: n <> newdef n
@@ -315,13 +322,13 @@ h: n <> newdef n
 h: n <> newdef n
 h: n <> newdef n
 h': newdef n <> n
-File "./output/Search.v", line 23, characters 2-23:
+File "./output/Search.v", line 31, characters 2-23:
 The command has indeed failed with message:
 [Focus] No such goal.
-File "./output/Search.v", line 24, characters 2-25:
+File "./output/Search.v", line 32, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
-File "./output/Search.v", line 25, characters 2-25:
+File "./output/Search.v", line 33, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
 h: P n

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -318,6 +318,13 @@ andb_true_intro:
   forall [b1 b2 : bool], b1 = true /\ b2 = true -> (b1 && b2)%bool = true
 andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
 andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
+and_comm: forall A B : Prop, A /\ B <-> B /\ A
+eq_id_comm_r:
+  forall [A : Type] (f : A -> A) (Hf : forall a : A, f a = a) (a : A),
+  f_equal f (Hf a) = Hf (f a)
+eq_id_comm_l:
+  forall [A : Type] (f : A -> A) (Hf : forall a : A, a = f a) (a : A),
+  f_equal f (Hf a) = Hf (f a)
 h: n <> newdef n
 h': newdef n <> n
 h: n <> newdef n
@@ -326,13 +333,13 @@ h: n <> newdef n
 h: n <> newdef n
 h: n <> newdef n
 h': newdef n <> n
-File "./output/Search.v", line 24, characters 2-23:
+File "./output/Search.v", line 32, characters 2-23:
 The command has indeed failed with message:
 [Focus] No such goal.
-File "./output/Search.v", line 25, characters 2-25:
+File "./output/Search.v", line 33, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
-File "./output/Search.v", line 26, characters 2-25:
+File "./output/Search.v", line 34, characters 2-25:
 The command has indeed failed with message:
 Query commands only support the single numbered goal selector.
 h: P n

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -7,6 +7,14 @@ Search (@eq _ _ true).
 Search (@eq _ _ _) true -false.         (* andb_prop *)
 Search (@eq _ _ _) true -false "prop" -"intro".  (* andb_prop *)
 
+Search "add_comm".
+(* currently set to return results whose name contains a substring
+   with edit distance <=2 from the pattern:
+
+  - and_comm (mutate the first "d")
+  - eq_id_comm_r and eq_id_comm_l (mutate the "a" and second "d")
+*)
+
 Definition newdef := fun x:nat => x.
 
 Goal forall n:nat, n <> newdef n -> newdef n <> n -> False.

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -212,6 +212,13 @@ let module_filter : _ -> filter_function = fun mods ref kind env sigma typ ->
 
 let name_of_reference ref = Id.to_string (Nametab.basename_of_global ref)
 
+let string_contains_upto ?(limit=2) ~pattern s =
+  (* for small patterns, allowing edits produces bad results *)
+  if String.length pattern <= 4 then String.string_contains ~where:s ~what:pattern
+  else
+    let d = CString.edit_distance_substring ~limit:(limit+1) ~pattern s in
+     d <= limit
+
 let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> match query with
 | GlobSearchSubPattern (where,head,pat) ->
   let open Context.Rel.Declaration in
@@ -229,8 +236,7 @@ let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> ma
         if head then Constr_matching.is_matching_head
         else Constr_matching.is_matching_appsubterm ~closed:false in
       f env sigma pat (EConstr.of_constr typ)) typl
-| GlobSearchString s ->
-  String.string_contains ~where:(name_of_reference gr) ~what:s
+| GlobSearchString s -> string_contains_upto ~pattern:s (name_of_reference gr)
 | GlobSearchKind k -> (match kind with None -> false | Some k' -> k = k')
 | GlobSearchFilter f -> f gr
 

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -210,6 +210,17 @@ let module_filter : _ -> filter_function = fun mods ref kind env sigma typ ->
 
 let name_of_reference ref = Id.to_string (Nametab.basename_of_global ref)
 
+let { Goptions.get = search_limit } =
+  Goptions.declare_int_option_and_ref ~key:["Fuzzy"; "Search"] ~value:2 ()
+
+let string_contains_upto ?limit ~pattern s =
+  let limit = search_limit() in
+  (* for small patterns, allowing edits produces bad results *)
+  if String.length pattern <= 4 || limit = 0 then String.string_contains ~where:s ~what:pattern
+  else
+    let d = CString.edit_distance_substring ~limit:(limit+1) ~pattern s in
+     d <= limit
+
 let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> match query with
 | GlobSearchSubPattern (where,head,pat) ->
   let open Context.Rel.Declaration in
@@ -227,8 +238,7 @@ let search_filter : _ -> filter_function = fun query gr kind env sigma typ -> ma
         if head then Constr_matching.is_matching_head
         else Constr_matching.is_matching_appsubterm ~closed:false in
       f env sigma pat (EConstr.of_constr typ)) typl
-| GlobSearchString s ->
-  String.string_contains ~where:(name_of_reference gr) ~what:s
+| GlobSearchString s -> string_contains_upto ~pattern:s (name_of_reference gr)
 | GlobSearchKind k -> (match kind with None -> false | Some k' -> k = k')
 | GlobSearchFilter f -> f gr
 


### PR DESCRIPTION
For experimentation I set to to require exact substring match when the searched string has length <= 4, and allow edit distance <= 2 otherwise. These 2 numbers could be turned into user-settable options.

IDK if these are good defaults.

Also not sure if constant ints is the right way to work. eg with longer input strings we may want to allow more typos so maybe `2` should be `min 2 (2% of input string length)` or some such thing.

Probably needs user feedback to progress.

(also no idea how performant this is)