### PR TITLE
Add anchors in Corelib html index

### DIFF
--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -9,7 +9,7 @@ through the <tt>Require Import</tt> command.</p>
 <p>The core library is composed of the following subdirectories:</p>
 
 <dl>
-  <dt id="Init"> <b>Init</b>:
+  <dt id="Init"> <a href="#Init"><b>Init</b></a>:
     The prelude (automatically loaded when starting Coq)
   </dt>
   <dd>

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -9,7 +9,7 @@ through the <tt>Require Import</tt> command.</p>
 <p>The core library is composed of the following subdirectories:</p>
 
 <dl>
-  <dt> <a id="Init"><b>Init</b></a>:
+  <dt id="Init"> <b>Init</b>:
     The prelude (automatically loaded when starting Coq)
   </dt>
   <dd>
@@ -31,7 +31,7 @@ through the <tt>Require Import</tt> command.</p>
     (theories/Init/Prelude.v)
   </dd>
 
-  <dt> <a id="Binary-numbers"><b>Binary numbers</b></a>:
+  <dt id="Binary-numbers"> <b>Binary numbers</b>:
     Basic definitions of binary arithmetic
   </dt>
   <dd>
@@ -41,7 +41,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/BinNums/IntDef.v
   </dd>
 
-  <dt> <a id="Cyclic"><b>Cyclic</b></a>:
+  <dt id="Cyclic"> <b>Cyclic</b>:
     63-bits-based cyclic arithmetic
   </dt>
   <dd>
@@ -51,7 +51,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Cyclic/Int63/Sint63Axioms.v
   </dd>
 
-  <dt> <a id="Floats"><b>Floats</b></a>:
+  <dt id="Floats"> <b>Floats</b>:
     Floating-point arithmetic
   </dt>
   <dd>
@@ -62,14 +62,14 @@ through the <tt>Require Import</tt> command.</p>
     theories/Floats/FloatAxioms.v
   </dd>
 
-  <dt> <a id="Relations"><b>Relations</b></a>:
+  <dt id="Relations"> <b>Relations</b>:
        Relations (definitions)
   </dt>
   <dd>
     theories/Relations/Relation_Definitions.v
   </dd>
 
-  <dt> <a id="Classes"><b>Classes</b></a>:
+  <dt id="Classes"> <b>Classes</b>:
   </dt>
   <dd>
     theories/Classes/Init.v
@@ -82,20 +82,20 @@ through the <tt>Require Import</tt> command.</p>
     theories/Classes/SetoidTactics.v
   </dd>
 
-  <dt> <a id="Setoids"><b>Setoids</b></a>:
+  <dt id="Setoids"> <b>Setoids</b>:
   </dt>
   <dd>
     theories/Setoids/Setoid.v
   </dd>
 
-  <dt> <a id="Lists"><b>Lists</b></a>:
+  <dt id="Lists"> <b>Lists</b>:
     Polymorphic lists
   </dt>
   <dd>
     theories/Lists/ListDef.v
   </dd>
 
-  <dt> <a id="Program"><b>Program</b></a>:
+  <dt id="Program"> <b>Program</b>:
     Support for dependently-typed programming
   </dt>
   <dd>
@@ -105,7 +105,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Program/Utils.v
   </dd>
 
-  <dt> <a id="SSReflect"><b>SSReflect</b></a>:
+  <dt id="SSReflect"> <b>SSReflect</b>:
     Base libraries for the SSReflect proof language and the
     small scale reflection formalization technique
   </dt>
@@ -117,7 +117,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/ssr/ssrfun.v
   </dd>
 
-  <dt> <a id="Ltac2"><b>Ltac2</b></a>:
+  <dt id="Ltac2"> <b>Ltac2</b>:
     The Ltac2 tactic programming language
   </dt>
   <dd>
@@ -159,7 +159,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Unification.v
   </dd>
 
-  <dt> <a id="Compat"><b>Compat</b></a>:
+  <dt id="Compat"> <b>Compat</b>:
     Compatibility wrappers for previous versions of Coq
   </dt>
   <dd>
@@ -171,7 +171,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Compat/Coq819.v
   </dd>
 
-  <dt> <a id="Array"><b>Array</b></a>:
+  <dt id="Array"> <b>Array</b>:
     Persistent native arrays
   </dt>
   <dd>
@@ -179,7 +179,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Array/ArrayAxioms.v
   </dd>
 
-  <dt> <a id="Primitive-strings><b>Primitive strings</b></a>:
+  <dt id="Primitive-strings> <b>Primitive strings</b>:
     Native string type
   </dt>
   <dd>

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -9,7 +9,7 @@ through the <tt>Require Import</tt> command.</p>
 <p>The core library is composed of the following subdirectories:</p>
 
 <dl>
-  <dt> <b>Init</b>:
+  <dt> <a id="Init"><b>Init</b></a>:
     The prelude (automatically loaded when starting Coq)
   </dt>
   <dd>
@@ -31,7 +31,7 @@ through the <tt>Require Import</tt> command.</p>
     (theories/Init/Prelude.v)
   </dd>
 
-  <dt> <b>Binary numbers</b>:
+  <dt> <a id="Binary-numbers"><b>Binary numbers</b></a>:
     Basic definitions of binary arithmetic
   </dt>
   <dd>
@@ -41,7 +41,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/BinNums/IntDef.v
   </dd>
 
-  <dt> <b>Cyclic</b>:
+  <dt> <a id="Cyclic"><b>Cyclic</b></a>:
     63-bits-based cyclic arithmetic
   </dt>
   <dd>
@@ -51,7 +51,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Cyclic/Int63/Sint63Axioms.v
   </dd>
 
-  <dt> <b>Floats</b>:
+  <dt> <a id="Floats"><b>Floats</b></a>:
     Floating-point arithmetic
   </dt>
   <dd>
@@ -62,14 +62,14 @@ through the <tt>Require Import</tt> command.</p>
     theories/Floats/FloatAxioms.v
   </dd>
 
-  <dt> <b>Relations</b>:
+  <dt> <a id="Relations"><b>Relations</b></a>:
        Relations (definitions)
   </dt>
   <dd>
     theories/Relations/Relation_Definitions.v
   </dd>
 
-  <dt> <b>Classes</b>:
+  <dt> <a id="Classes"><b>Classes</b></a>:
   </dt>
   <dd>
     theories/Classes/Init.v
@@ -82,20 +82,20 @@ through the <tt>Require Import</tt> command.</p>
     theories/Classes/SetoidTactics.v
   </dd>
 
-  <dt> <b>Setoids</b>:
+  <dt> <a id="Setoids"><b>Setoids</b></a>:
   </dt>
   <dd>
     theories/Setoids/Setoid.v
   </dd>
 
-  <dt> <b>Lists</b>:
+  <dt> <a id="Lists"><b>Lists</b></a>:
     Polymorphic lists
   </dt>
   <dd>
     theories/Lists/ListDef.v
   </dd>
 
-  <dt> <b>Program</b>:
+  <dt> <a id="Program"><b>Program</b></a>:
     Support for dependently-typed programming
   </dt>
   <dd>
@@ -105,7 +105,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Program/Utils.v
   </dd>
 
-  <dt> <b>SSReflect</b>:
+  <dt> <a id="SSReflect"><b>SSReflect</b></a>:
     Base libraries for the SSReflect proof language and the
     small scale reflection formalization technique
   </dt>
@@ -117,7 +117,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/ssr/ssrfun.v
   </dd>
 
-  <dt> <b>Ltac2</b>:
+  <dt> <a id="Ltac2"><b>Ltac2</b></a>:
     The Ltac2 tactic programming language
   </dt>
   <dd>
@@ -159,7 +159,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Unification.v
   </dd>
 
-  <dt> <b>Compat</b>:
+  <dt> <a id="Compat"><b>Compat</b></a>:
     Compatibility wrappers for previous versions of Coq
   </dt>
   <dd>
@@ -171,7 +171,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Compat/Coq819.v
   </dd>
 
-  <dt> <b>Array</b>:
+  <dt> <a id="Array"><b>Array</b></a>:
     Persistent native arrays
   </dt>
   <dd>
@@ -179,7 +179,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Array/ArrayAxioms.v
   </dd>
 
-  <dt> <b>Primitive strings</b>
+  <dt> <a id="Primitive-strings><b>Primitive strings</b></a>:
     Native string type
   </dt>
   <dd>

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -31,7 +31,7 @@ through the <tt>Require Import</tt> command.</p>
     (theories/Init/Prelude.v)
   </dd>
 
-  <dt id="Binary-numbers"> <b>Binary numbers</b>:
+  <dt id="Binary-numbers"> <a href="#Binary-numbers">Binary numbers</b></a>:
     Basic definitions of binary arithmetic
   </dt>
   <dd>
@@ -41,7 +41,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/BinNums/IntDef.v
   </dd>
 
-  <dt id="Cyclic"> <b>Cyclic</b>:
+  <dt id="Cyclic"> <a href="#Cyclic"><b>Cyclic</b></a>:
     63-bits-based cyclic arithmetic
   </dt>
   <dd>
@@ -51,7 +51,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Numbers/Cyclic/Int63/Sint63Axioms.v
   </dd>
 
-  <dt id="Floats"> <b>Floats</b>:
+  <dt id="Floats"> <a href="#Floats"><b>Floats</b></a>:
     Floating-point arithmetic
   </dt>
   <dd>
@@ -62,14 +62,14 @@ through the <tt>Require Import</tt> command.</p>
     theories/Floats/FloatAxioms.v
   </dd>
 
-  <dt id="Relations"> <b>Relations</b>:
+  <dt id="Relations"> <a href="#Relations"><b>Relations</b></a>:
        Relations (definitions)
   </dt>
   <dd>
     theories/Relations/Relation_Definitions.v
   </dd>
 
-  <dt id="Classes"> <b>Classes</b>:
+  <dt id="Classes"> <a href="#Classes"><b>Classes</b></a>:
   </dt>
   <dd>
     theories/Classes/Init.v
@@ -82,20 +82,20 @@ through the <tt>Require Import</tt> command.</p>
     theories/Classes/SetoidTactics.v
   </dd>
 
-  <dt id="Setoids"> <b>Setoids</b>:
+  <dt id="Setoids"> <a href="#Setoids"><b>Setoids</b></a>:
   </dt>
   <dd>
     theories/Setoids/Setoid.v
   </dd>
 
-  <dt id="Lists"> <b>Lists</b>:
+  <dt id="Lists"> <a href="#Lists"><b>Lists</b></a>:
     Polymorphic lists
   </dt>
   <dd>
     theories/Lists/ListDef.v
   </dd>
 
-  <dt id="Program"> <b>Program</b>:
+  <dt id="Program"> <a href="#Program"><b>Program</b></a>:
     Support for dependently-typed programming
   </dt>
   <dd>
@@ -105,7 +105,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Program/Utils.v
   </dd>
 
-  <dt id="SSReflect"> <b>SSReflect</b>:
+  <dt id="SSReflect"> <a href="#SSReflect"><b>SSReflect</b></a>:
     Base libraries for the SSReflect proof language and the
     small scale reflection formalization technique
   </dt>
@@ -117,7 +117,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/ssr/ssrfun.v
   </dd>
 
-  <dt id="Ltac2"> <b>Ltac2</b>:
+  <dt id="Ltac2"> <a href="#Ltac2"><b>Ltac2</b></a>:
     The Ltac2 tactic programming language
   </dt>
   <dd>
@@ -159,7 +159,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Unification.v
   </dd>
 
-  <dt id="Compat"> <b>Compat</b>:
+  <dt id="Compat"> <a href="#Compat"><b>Compat</b></a>:
     Compatibility wrappers for previous versions of Coq
   </dt>
   <dd>
@@ -171,7 +171,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Compat/Coq819.v
   </dd>
 
-  <dt id="Array"> <b>Array</b>:
+  <dt id="Array"> <a href="#Array"><b>Array</b></a>:
     Persistent native arrays
   </dt>
   <dd>
@@ -179,7 +179,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Array/ArrayAxioms.v
   </dd>
 
-  <dt id="Primitive-strings> <b>Primitive strings</b>:
+  <dt id="Primitive-strings"> <a href="#Primitive-strings"><b>Primitive strings</b></a>:
     Native string type
   </dt>
   <dd>


### PR DESCRIPTION
This is to make it possible to refer to these list items in links (e.g. for https://github.com/rocq-prover/rocq/issues/20450).

Not a web person, so there may be better ways to do it.