### PR TITLE
Change introduction to Ltac2 refman page

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -8,11 +8,13 @@ Ltac2
 General design
 --------------
 
-There are various alternatives to Ltac1, such as Mtac or Rtac for instance.
-While those alternatives can be quite different from Ltac1, we designed
-Ltac2 to be as close as reasonably possible to Ltac1, while fixing its
-:ref:`defects <ltac_defects>`.
+Ltac2 is a tactics metalanguage for Rocq. It is mostly used to write new
+tactics using a mix of :cmd:`Ltac2` definitions and :cmd:`Ltac2 Notation`\s.
+Ltac2 provides an API in the various modules of the Ltac2 library, see
+`<https://rocq-prover.org/doc/V9.0.0/corelib/index.html#Ltac2>`_.
 
+Ltac2 is designed to be as close as reasonably possible to Ltac1, while fixing its
+:ref:`defects <ltac_defects>`.
 In particular, Ltac2 is:
 
 - a member of the ML family of languages, i.e.

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -11,7 +11,7 @@ General design
 Ltac2 is a tactics metalanguage for Rocq. It is mostly used to write new
 tactics using a mix of :cmd:`Ltac2` definitions and :cmd:`Ltac2 Notation`\s.
 Ltac2 provides an API in the various modules of the Ltac2 library, see
-`<https://rocq-prover.org/doc/V9.0.0/corelib/index.html#Ltac2>`_.
+`<https://rocq-prover.org/corelib/index.html#Ltac2>`_.
 
 Ltac2 is designed to be as close as reasonably possible to Ltac1, while fixing its
 :ref:`defects <ltac_defects>`.

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -11,7 +11,7 @@ General design
 Ltac2 is a tactics metalanguage for Rocq. It is mostly used to write new
 tactics using a mix of :cmd:`Ltac2` definitions and :cmd:`Ltac2 Notation`\s.
 Ltac2 provides an API in the various modules of the Ltac2 library, see
-`<https://rocq-prover.org/corelib/index.html#Ltac2>`_.
+`the relevant section of Corelib's documentation <../../corelib/index.html#Ltac2>`_.
 
 Ltac2 is designed to be as close as reasonably possible to Ltac1, while fixing its
 :ref:`defects <ltac_defects>`.


### PR DESCRIPTION
I don't think the average user cares about other tactics languages when browsing this part of the tutorial.
Other tactics languages are already mentioned in the "Creating new tactics" part of the refman.

Add a reference to the Ltac2 part of the Rocq website.

Prerequisite: #20680

Fixes / closes: #20450

Rendered: https://coq.gitlabpages.inria.fr/-/coq/-/jobs/5805727/artifacts/_build/default/doc/refman-html/proof-engine/ltac2.html?highlight=ltac2