### PR TITLE
Option to internalize a qualid passed to an Ltac as a constr with its impargs

### DIFF
--- a/doc/changelog/05-Ltac-language/20682-ltac1-depr-noninserted-implicits-Added.rst
+++ b/doc/changelog/05-Ltac-language/20682-ltac1-depr-noninserted-implicits-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  flag :flag:`Ltac Always Insert Implicits` to interprete a :n:`@qualid` argument to a ltac as a term (with insertion of any implicit arguments, unfolding notations, etc)
+  in a toplevel :cmd:`Ltac` definition instead of interpreting it as the reference without implicit arguments.
+  Note that tactics in proof scripts already interpret :n:`@qualid` arguments as terms, so enabling the flag unifies the two behaviours
+  (`#20682 <https://github.com/rocq-prover/rocq/pull/20682>`_,
+  by Hugo Herbelin and Gaëtan Gilbert).

--- a/doc/changelog/05-Ltac-language/20682-ltac1-depr-noninserted-implicits-Deprecated.rst
+++ b/doc/changelog/05-Ltac-language/20682-ltac1-depr-noninserted-implicits-Deprecated.rst
@@ -1,0 +1,7 @@
+- **Deprecated:**
+  interpreting a :n:`@qualid` argument to a ltac as a term (with insertion of any implicit arguments, unfolding notations, etc)
+  in a toplevel :cmd:`Ltac` definition instead of interpreting it as the reference without implicit arguments.
+  Enable flag :flag:`Ltac Always Insert Implicits` to get the future behaviour.
+  Note that tactics in proof scripts already interpret :n:`@qualid` arguments as terms, so enabling the flag unifies the two behaviours
+  (`#20682 <https://github.com/rocq-prover/rocq/pull/20682>`_,
+  by Hugo Herbelin and Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1939,6 +1939,27 @@ Defining |Ltac| symbols
       - :n:`Ltac @qualid {+ @name } := @ltac_expr`
       - :n:`Ltac @qualid := fun {+ @name } => @ltac_expr`
 
+   By default, ltac applications to a :n:`@qualid` inside a toplevel
+   :cmd:`Ltac`'s body can behave differently from the same application in
+   proof scripts: in proof scripts the :n:`@qualid` is interpreted as
+   a term, but in toplevel :cmd:`Ltac` it is interpreted as a
+   reference. This typically produces different results when the
+   reference has maximally inserted arguments.
+
+   This separate interpretation is deprecated in favour of the proof script behaviour.
+
+.. warn:: Interpretation of @qualid in toplevel definition is different from its interpretation in proof scripts
+   :name: ltac-non-inserted-implicits
+
+   This warning is produced when the deprecated toplevel
+   interpretation is used and differs from the proof script
+   interpretation.
+
+.. flag:: Ltac Always Insert Implicits
+
+   Enable this flag to get the non-deprecated proof script
+   interpretation even in toplevel definitions.
+
 Printing |Ltac| tactics
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test-suite/bugs/bug_20682_1.v
+++ b/test-suite/bugs/bug_20682_1.v
@@ -1,0 +1,12 @@
+Module M.
+  Axiom foo : bool.
+End M.
+Import M.
+
+Ltac bli H := inversion H.
+
+Goal forall n m:nat, Some n = Some m -> True /\ True.
+  intros n m.
+  (* NB bug only occurred with intro not intros *)
+  intro foo; split; bli foo.
+Abort.

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -63,3 +63,11 @@ Ltac foo :=
 
 goal 2 is:
  forall a : nat, a = 0
+File "./output/ltac.v", line 94, characters 0-22:
+Warning: Interpretation of foo in toplevel definition
+is different from its interpretation in proof scripts:
+got @foo but in proof scripts foo would be produced.
+Use "Set Ltac Always Insert Implicits" to always get the later result.
+[ltac-non-inserted-implicits,deprecated-since-9.1,deprecated,default]
+Ltac tac2 := tac1 @foo
+Ltac tac3 := tac1 foo

--- a/test-suite/output/ltac.v
+++ b/test-suite/output/ltac.v
@@ -83,3 +83,21 @@ end.
 intro.
 Show.
 Abort.
+
+Module StrictModeImplicits.
+(* Insertion of implicits in strict mode *)
+
+Definition foo {A:Type} (a:A) := a.
+
+Ltac tac1 c := apply c.
+
+Ltac tac2 := tac1 foo.
+
+Set Ltac Always Insert Implicits.
+
+Ltac tac3 := tac1 foo.
+
+Print tac2.
+Print tac3.
+
+End StrictModeImplicits.

--- a/theories/Corelib/Classes/Init.v
+++ b/theories/Corelib/Classes/Init.v
@@ -23,7 +23,7 @@ Global Typeclasses Opaque id const flip compose arrow impl iff not all.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 
-Ltac class_apply c := autoapply c with typeclass_instances.
+Tactic Notation "class_apply" open_constr(c) := autoapply c with typeclass_instances.
 
 (** The unconvertible typeclass, to test that two objects of the same type are
    actually different. *)


### PR DESCRIPTION
This was the case in non-strict mode (via interpretation at runtime), but, in strict mode, it was instead the reference without its maximal implicit arguments.

Also deprecate the old strict mode internalization.

For compat with enabling the option, the main impact is on "class_apply" which we reformulate as a tactic notation to ensure that its argument is always interpreted as a term.

Replaces https://github.com/rocq-prover/rocq/pull/17084 in a more backward compatible way.
