### PR TITLE
Remove the hypnaming API from Evarutil.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -34,10 +34,7 @@ sig
   val variables : Environ.env -> t
 end
 
-type naming_mode =
-  | RenameExistingBut of VarSet.t
-  | FailIfConflict
-  | ProgramNaming of VarSet.t
+type naming_mode = VarSet.t
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -559,7 +559,6 @@ let resolve_and_replace_implicits exptyp env sigma rt =
   let binder_holes = ref [] in
   let ctx =
     let open Pretyping in
-    let open Evarutil in
     (* Intercept the pretyper for holes and record the generated evar *)
     let register_evar kind loc evk = match kind with
     | GImplicitArg (grk, pk, bk) -> implicit_holes := ((loc, grk, pk, bk), evk) :: !implicit_holes
@@ -591,8 +590,7 @@ let resolve_and_replace_implicits exptyp env sigma rt =
       patvars_abstract = false;
       unconstrained_sorts = false;
     } in
-    let vars = Evarutil.VarSet.variables (Global.env ()) in
-    let hypnaming = RenameExistingBut vars in
+    let hypnaming = Evarutil.VarSet.variables (Global.env ()) in
     let genv = GlobEnv.make ~hypnaming env sigma Glob_ops.empty_lvar in
     let pretyper = { default_pretyper with pretype_hole; pretype_type } in
     let sigma', _ = eval_pretyper pretyper ~flags:pretype_flags (Some exptyp) genv sigma rt in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -505,8 +505,7 @@ let remove_current_pattern eqn =
     | [] -> anomaly (Pp.str "Empty list of patterns.")
 
 let push_current_pattern ~program_mode sigma (cur,ty) eqn =
-  let vars = VarSet.variables (Global.env ()) in
-  let hypnaming = if program_mode then ProgramNaming vars else RenameExistingBut vars in
+  let hypnaming = VarSet.variables (Global.env ()) in
   match eqn.patterns with
     | pat::pats ->
         let r = ERelevance.relevant in (* TODO relevance *)
@@ -1358,8 +1357,7 @@ let build_branch ~program_mode initial current realargs deps (realnames,curname)
   let typs' =
     List.map_i (fun i d -> (mkRel i, map_constr (lift i) d)) 1 typs in
 
-  let vars = VarSet.variables (Global.env ()) in
-  let hypnaming = if program_mode then ProgramNaming vars else RenameExistingBut vars in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let typs,extenv = push_rel_context ~hypnaming sigma typs pb.env in
 
   let typs' =
@@ -1455,8 +1453,7 @@ let build_branch ~program_mode initial current realargs deps (realnames,curname)
 (**********************************************************************)
 (* Main compiling descent *)
 let compile ~program_mode sigma pb =
-  let vars = VarSet.variables (Global.env ()) in
-  let hypnaming = if program_mode then ProgramNaming vars else RenameExistingBut vars in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let rec compile sigma pb =
     match pb.tomatch with
       | Pushed cur :: rest -> match_current sigma { pb with tomatch = rest } cur
@@ -1722,7 +1719,7 @@ let adjust_to_extended_env_and_remove_deps env extenv sigma subst t =
   (subst0, t0)
 
 let push_binder sigma d (k,env,subst) =
-  let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+  let hypnaming = VarSet.variables (Global.env ()) in
   (k+1,snd (push_rel ~hypnaming sigma d env),List.map (fun (na,u,d) -> (na,lift 1 u,d)) subst)
 
 let rec list_assoc_in_triple x = function
@@ -1846,7 +1843,7 @@ let build_tycon ?loc env tycon_env s subst tycon extenv sigma t =
  *)
 
 let build_inversion_problem ~program_mode loc env sigma tms t =
-  let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let make_patvar t (subst,avoid) =
     let id = next_name_away (named_hd !!env sigma t Anonymous) avoid in
     DAst.make @@ PatVar (Name id), ((id,t)::subst, Id.Set.add id avoid) in
@@ -2106,8 +2103,7 @@ let prepare_predicate_from_arsign_tycon ~program_mode env sigma loc tomatchs ars
   in
   assert (len == 0);
   let p = predicate 0 c in
-  let vars = VarSet.variables (Global.env ()) in
-  let hypnaming = if program_mode then ProgramNaming vars else RenameExistingBut vars in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let arsign,env' = List.fold_right_map (push_rel_context ~hypnaming sigma) arsign env in
   try let sigma' = fst (Typing.type_of !!env' sigma p) in
         Some (sigma', p, arsign)
@@ -2170,7 +2166,7 @@ let prepare_predicate ?loc ~program_mode typing_fun env sigma tomatchs arsign ty
     (* Some type annotation *)
     | Some rtntyp ->
       (* We extract the signature of the arity *)
-      let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+      let hypnaming = VarSet.variables (Global.env ()) in
       let building_arsign,envar = List.fold_right_map (push_rel_context ~hypnaming sigma) arsign env in
       let sigma, rtnsort = Evd.new_sort_variable univ_flexible sigma in
       let sigma, predcclj = typing_fun (Some (mkSort rtnsort)) envar sigma rtntyp in
@@ -2425,7 +2421,7 @@ let build_ineqs env sigma prevpatterns curpats curpat_sign_len =
 
 let constrs_of_pats typing_fun env sigma eqns tomatchs sign neqs arity =
   let i = ref 0 in
-  let hypnaming = ProgramNaming (VarSet.variables (Global.env ())) in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let (sigma, x, y, z) =
     List.fold_left
       (fun (sigma, branches, eqns, prevpatterns) eqn ->
@@ -2702,7 +2698,7 @@ let context_of_arsign l =
 
 let compile_program_cases ?loc style (typing_function, sigma) tycon env
     (predopt, tomatchl, eqns) =
-  let hypnaming = ProgramNaming (VarSet.variables (Global.env ())) in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let typing_fun tycon env sigma = function
     | Some t ->	typing_function tycon env sigma t
     | None -> coq_unit_judge !!env sigma in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -824,8 +824,7 @@ struct
     let open Context.Rel.Declaration in
     let pretype tycon env sigma c = eval_pretyper self ~flags tycon env sigma c in
     let pretype_type tycon env sigma c = eval_type_pretyper self ~flags tycon env sigma c in
-    let vars = VarSet.variables (Global.env ()) in
-    let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+    let hypnaming = VarSet.variables (Global.env ()) in
     let rec type_bl env sigma ctxt = function
       | [] -> sigma, ctxt
       | (na,_,bk,None,ty)::bl ->
@@ -1272,8 +1271,7 @@ struct
     let sigma, j = eval_type_pretyper self ~flags dom_valcon env sigma c1 in
     let name = {binder_name=name; binder_relevance=ESorts.relevance_of_sort j.utj_type} in
     let var = LocalAssum (name, j.utj_val) in
-    let vars = VarSet.variables (Global.env ()) in
-    let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+    let hypnaming = VarSet.variables (Global.env ()) in
     let var',env' = push_rel ~hypnaming sigma var env in
     let sigma, j' = eval_pretyper self ~flags rng env' sigma c2 in
     let name = get_name var' in
@@ -1285,8 +1283,7 @@ struct
     let open Context.Rel.Declaration in
     let pretype_type tycon env sigma c = eval_type_pretyper self ~flags tycon env sigma c in
     let sigma, j = pretype_type empty_valcon env sigma c1 in
-    let vars = VarSet.variables (Global.env ()) in
-    let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+    let hypnaming = VarSet.variables (Global.env ()) in
     let sigma, name, j' = match name with
       | Anonymous ->
         let sigma, j = pretype_type empty_valcon env sigma c2 in
@@ -1325,8 +1322,7 @@ struct
     let r = Retyping.relevance_of_term !!env sigma j.uj_val in
     let var = LocalDef (make_annot name r, j.uj_val, t) in
     let tycon = lift_tycon 1 tycon in
-    let vars = VarSet.variables (Global.env ()) in
-    let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+    let hypnaming = VarSet.variables (Global.env ()) in
     let var, env = push_rel ~hypnaming sigma var env in
     let sigma, j' = pretype tycon env sigma c2 in
     let name = get_name var in
@@ -1372,8 +1368,7 @@ struct
           | _ -> assert false
         in aux 1 1 (List.rev nal) cs.cs_args, true in
     let fsign = Context.Rel.map (whd_betaiota !!env sigma) fsign in
-    let vars = VarSet.variables (Global.env ()) in
-    let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+    let hypnaming = VarSet.variables (Global.env ()) in
     let fsign,env_f = push_rel_context ~hypnaming sigma fsign env in
     let obj indt rci p v f =
       if not record then
@@ -1457,8 +1452,7 @@ struct
       let indt = build_dependent_inductive !!env indf in
       let psign = LocalAssum (make_annot na indr, indt) :: arsgn in (* For locating names in [po] *)
       let predenv = Cases.make_return_predicate_ltac_lvar env sigma na c cj.uj_val in
-      let vars = VarSet.variables (Global.env ()) in
-      let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+      let hypnaming = VarSet.variables (Global.env ()) in
       let psign,env_p = push_rel_context ~hypnaming sigma psign predenv in
       let sigma, pred, p = match po with
         | Some p ->
@@ -1703,8 +1697,7 @@ let ise_pretype_gen (flags : inference_flags) env sigma lvar kind c =
       | NoUseTC -> false
       | UseTC | UseTCForConv -> true
   } in
-  let vars = VarSet.variables (Global.env ()) in
-  let hypnaming = if flags.program_mode then ProgramNaming vars else RenameExistingBut vars in
+  let hypnaming = VarSet.variables (Global.env ()) in
   let env = GlobEnv.make ~hypnaming env sigma lvar in
   let sigma', c', c'_ty = match kind with
     | WithoutTypeConstraint ->

--- a/tactics/eClause.ml
+++ b/tactics/eClause.ml
@@ -80,7 +80,7 @@ let make_evar_clause env sigma ?len t =
       let inst, ctx, args, subst = match inst with
       | None ->
         (* Dummy type *)
-        let hypnaming = RenameExistingBut (VarSet.variables (Global.env ())) in
+        let hypnaming = VarSet.variables (Global.env ()) in
         let ctx, _, args, subst = push_rel_context_to_named_context ~hypnaming env sigma mkProp in
         Some (ctx, args, subst), ctx, args, subst
       | Some (ctx, args, subst) -> inst, ctx, args, subst


### PR DESCRIPTION
All callers where behaving as if it were RenameExistingBut, hence only the varset matters.