### PR TITLE
Wrap Lambda nodes in a dummy indirection.

### DIFF
--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -17,7 +17,9 @@ type reloc_table = (int * int) array
 
 type case_annot = case_info * reloc_table * Declarations.recursivity_kind
 
-type 'v lambda =
+type 'v lambda
+
+type 'v node =
 | Lrel          of Name.t * int
 | Lvar          of Id.t
 | Levar         of Evar.t * 'v lambda array (* arguments *)
@@ -56,8 +58,11 @@ val empty_evars : Environ.env -> evars
 
 (** {5 Manipulation functions} *)
 
+val node : 'v lambda -> 'v node
 val mkLapp : 'v lambda -> 'v lambda array -> 'v lambda
 val mkLlam : Name.t binder_annot array -> 'v lambda -> 'v lambda
+val unsafe_mkPArray : 'v lambda array -> 'v lambda -> 'v lambda
+val unsafe_mkPArray_val : 'v -> 'v lambda -> 'v lambda
 val decompose_Llam : 'v lambda -> Name.t binder_annot array * 'v lambda
 val decompose_Llam_Llet : 'v lambda -> (Name.t binder_annot * 'v lambda option) array * 'v lambda
 

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1129,7 +1129,7 @@ let extract_prim env ml_of l =
     let params, args_ty, _ = CPrimitives.types p in
     List.length params, Array.of_list args_ty in
   let rec aux l =
-    match l with
+    match node l with
     | Lprim (kn, p, args) ->
       let prefix = env.env_const_prefix (fst kn) in
       let nparams, targs = type_args p in
@@ -1238,7 +1238,7 @@ let compile_prim env decl cond paux =
     add_decl decl (compile_cond cond paux)
 
  let rec ml_of_lam env l t =
-  match t with
+  match node t with
   | Lrel(id ,i) -> get_rel env id i
   | Lvar id -> get_var env id
   | Levar(evk, args) ->

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -20,12 +20,12 @@ type lambda = Nativevalues.t Genlambda.lambda
 (** Simplification of lambda expression *)
 
 let is_value lc =
-  match lc with
+  match node lc with
   | Lval _ | Lint _ | Luint _ | Lfloat _ | Lstring _ -> true
   | _ -> false
 
 let get_value lc =
-  match lc with
+  match node lc with
   | Lval v -> v
   | Lint tag -> Nativevalues.mk_int tag
   | Luint i -> Nativevalues.mk_uint i

--- a/kernel/vmlambda.ml
+++ b/kernel/vmlambda.ml
@@ -15,12 +15,12 @@ let get_lval (_, v) = v
 (* Translation of constructor *)
 
 let is_value lc =
-  match lc with
+  match node lc with
   | Lval _ | Lint _ | Luint _ | Lfloat _ | Lstring _ -> true
   | _ -> false
 
 let get_value lc =
-  match lc with
+  match node lc with
   | Luint i -> val_of_uint i
   | Lval (_, v) -> v
   | Lint i -> val_of_int i
@@ -31,7 +31,7 @@ let get_value lc =
 let hash_block tag args =
   let open Hashset.Combine in
   let fold accu v =
-    let h = match v with
+    let h = match node v with
     | Luint i -> Uint63.hash i
     | Lint i -> Hashtbl.hash (i : int)
     | Lfloat f -> Float64.hash f


### PR DESCRIPTION
For now this is an isomorphim but it will allow adding annotations.

This is the uncontroversial part extracted from #20634. It makes it easier to experiment with the code and is very cheap as evidenced by the bench on the other PR. Hence I would argue that we can already merge this as a cleanup.