### PR TITLE
Coqtop.py also searches for "rocq top" command

### DIFF
--- a/doc/tools/coqrst/repl/coqtop.py
+++ b/doc/tools/coqrst/repl/coqtop.py
@@ -58,15 +58,10 @@ class CoqTop:
             self.args = (args or []) + ["-q"] + ["-color", "on"] * color
         else:
             rocqb = os.path.join(os.getenv("COQBIN", ""), "rocq")
-            if pexpect.utils.which(rocqb):
-                self.coqtop_bin = rocqb
-                self.args = ["top"] + args + ["-q"] + ["-color", "on"] * color
-            else:
-                self.args = (args or []) + ["-q"] + ["-color", "on"] * color
-                coqtopb = os.path.join(os.getenv("COQBIN", ""), "coqtop")
-                self.coqtop_bin = coqtopb
-                if not pexpect.utils.which(coqtopb):
-                    raise ValueError("coqtop binary not found: '{}'".format(self.coqtop_bin))
+            self.coqtop_bin = rocqb
+            self.args = ["top"] + args + ["-q"] + ["-color", "on"] * color
+            if not pexpect.utils.which(rocqb):
+                raise ValueError("rocq binary not found: '{}'".format(self.coqtop_bin))
         self.coqtop = None
         self.debugfile = None
 

--- a/doc/tools/coqrst/repl/coqtop.py
+++ b/doc/tools/coqrst/repl/coqtop.py
@@ -53,10 +53,20 @@ class CoqTop:
                            the ansicolors module)
         :param args:       Additional arguments to coqtop.
         """
-        self.coqtop_bin = coqtop_bin or os.path.join(os.getenv('COQBIN', ""), "coqtop")
-        if not pexpect.utils.which(self.coqtop_bin):
-            raise ValueError("coqtop binary not found: '{}'".format(self.coqtop_bin))
-        self.args = (args or []) + ["-q"] + ["-color", "on"] * color
+        if coqtop_bin and pexpect.utils.which(coqtop_bin):
+            self.coqtop_bin = coqtop_bin
+            self.args = (args or []) + ["-q"] + ["-color", "on"] * color
+        else:
+            rocqb = os.path.join(os.getenv("COQBIN", ""), "rocq")
+            if pexpect.utils.which(rocqb):
+                self.coqtop_bin = rocqb
+                self.args = ["top"] + args + ["-q"] + ["-color", "on"] * color
+            else:
+                self.args = (args or []) + ["-q"] + ["-color", "on"] * color
+                coqtopb = os.path.join(os.getenv("COQBIN", ""), "coqtop")
+                self.coqtop_bin = coqtopb
+                if not pexpect.utils.which(coqtopb):
+                    raise ValueError("coqtop binary not found: '{}'".format(self.coqtop_bin))
         self.coqtop = None
         self.debugfile = None
 


### PR DESCRIPTION
With this, (hopefully) we can `make refman-html` without a coqdoc program.