### PR TITLE
Provide names for exns with quotes in doc

### DIFF
--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -192,6 +192,7 @@ The basic assertion command is:
 
    .. exn:: Nested proofs are discouraged and not allowed by default. This error probably means that you forgot to close the last "Proof." with "Qed." or "Defined.". \
             If you really intended to use nested proofs, you can do so by turning the "Nested Proofs Allowed" flag on.
+      :name: Nested proofs are discouraged and not allowed by default
 
       You are asserting a new statement when you're already in proof mode.
       This feature, called nested proofs, is disabled by default.

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -403,6 +403,7 @@ Rewriting with definitional equality
       :undocumented:
 
    .. exn:: Found an "at" clause without "with" clause
+      :name: Found an at clause without with clause
       :undocumented:
 
    .. tacn:: now_show @one_type

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -471,6 +471,7 @@ Name a set of section hypotheses for ``Proof using``
       are deprecated. See the warnings below and in the :cmd:`Proof using` command.
 
    .. exn:: "All" is a predefined collection containing all variables. It can't be redefined.
+      :name: All is a predefined collection containing all variables. It can't be redefined.
 
       When issuing a :cmd:`Proof using` command, **All** used as a collection name always means
       "use all variables".

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -594,6 +594,7 @@ Enabling and disabling notations
       No previously defined notation satisfies the given constraints.
 
    .. exn:: More than one interpretation bound to this notation, confirm with the "all" modifier.
+      :name: More than one interpretation bound to this notation, confirm with the all modifier
 
       Use :n:`all` to allow enabling or disabling multiple
       notations in a single command.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
I just gave `:name:` for 4 exceptions which had double quotes in them, making the quotes disappear.
I don't know if it's a good enough solution, but all 4 links now work.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20684

Rendered: https://coq.gitlabpages.inria.fr/-/coq/-/jobs/5811577/artifacts/_build/default/doc/refman-html/coq-exnindex.html