### PR TITLE
Slightly improve formatting of dynlink debug message

### DIFF
--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -199,8 +199,8 @@ end = struct
     dbg_dynlink Pp.(fun () ->
         str "for " ++ prlist_with_sep spc (fun {lib} -> str lib) plugins ++
         str ":" ++ fnl() ++
-        str "all deps " ++ prlist_with_sep spc str allplugins ++ fnl() ++
-        str "filtered " ++ prlist_with_sep spc (fun (_,{lib}) -> str lib) deps);
+        v 2 (str "all deps:" ++ spc() ++ prlist_with_sep spc str allplugins) ++ fnl() ++
+        v 2 (str "filtered deps:" ++ spc() ++ prlist_with_sep spc (fun (_,{lib}) -> str lib) deps));
     deps
 
   let digest s =


### PR DESCRIPTION
Example output:
~~~
  for coq-lsp.serlib.ltac:
  all deps:
    unix
    threads.posix
    threads
    base.base_internalhash_types
    base.caml
    base.shadow_stdlib
    sexplib0
    base
    ppx_compare.runtime-lib
    ppx_deriving.runtime
    ppx_deriving_yojson.runtime
    ppx_sexp_conv.runtime-lib
    ppx_hash.runtime-lib
    findlib.internal
    findlib
    dynlink
    findlib.dynload
    memprof-limits
    str
    rocq-runtime.clib
    rocq-runtime.config
    rocq-runtime.boot
    rocq-runtime.perf
    rocq-runtime.lib
    rocq-runtime.gramlib
    rocq-runtime.vm
    rocq-runtime.kernel
    rocq-runtime.library
    rocq-runtime.engine
    rocq-runtime.pretyping
    zarith
    rocq-runtime.interp
    rocq-runtime.parsing
    rocq-runtime.proofs
    rocq-runtime.printing
    rocq-runtime.tactics
    rocq-runtime.vernac
    bigarray
    parsexp
    sexplib
    seq
    yojson
    coq-lsp.serlib
    rocq-runtime.plugins.ltac
    coq-lsp.serlib.ltac
  filtered deps:
    base.base_internalhash_types
    base.caml
    base.shadow_stdlib
    sexplib0
    base
    ppx_compare.runtime-lib
    ppx_deriving.runtime
    ppx_deriving_yojson.runtime
    ppx_sexp_conv.runtime-lib
    ppx_hash.runtime-lib
    bigarray
    parsexp
    sexplib
    seq
    yojson
    coq-lsp.serlib
    coq-lsp.serlib.ltac
~~~

Before it would look like
~~~
  for coq-lsp.serlib.ltac:
  all deps unix
  threads.posix
  threads
  ...
  coq-lsp.serlib.ltac
  filtered base.base_internalhash_types
  base.caml
  base.shadow_stdlib
  ...
  coq-lsp.serlib.ltac
~~~
so it was hard to tell when the "filtered" part started.
