### PR TITLE
Stop using "dummy_value" in native compute

### DIFF
--- a/kernel/dune
+++ b/kernel/dune
@@ -39,4 +39,4 @@
 ; In dev profile, we check the kernel against a more strict set of
 ; warnings.
 (env
- (dev (flags :standard -w @a-4-40-44-50)))
+ (dev (flags :standard -w @a-4-40-42-44-50)))

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1836,7 +1836,7 @@ let pp_mllam fmt l =
     | MLfloat f -> Format.fprintf fmt "(%s)" (Float64.compile f)
     | MLstring s -> Format.fprintf fmt "(%s)" (Pstring.compile s)
     | MLsetref (s, body) ->
-        Format.fprintf fmt "@[%s@ :=@\n %a@]" s pp_mllam body
+        Format.fprintf fmt "@[%s@ :=@\n Some (%a)@]" s pp_mllam body
     | MLsequence(l1,l2) ->
         Format.fprintf fmt "@[%a;@\n%a@]" pp_mllam l1 pp_mllam l2
     | MLarray arr ->

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -183,8 +183,6 @@ let fresh_gnormtbl l =
 
 (** Symbols (pre-computed values) **)
 
-let dummy_symb = SymbValue (dummy_value ())
-
 let eq_symbol sy1 sy2 =
   match sy1, sy2 with
   | SymbValue v1, SymbValue v2 -> (=) v1 v2 (** FIXME: how is this even valid? *)
@@ -287,8 +285,12 @@ let push_symbol x =
 let symbols_tbl_name = Ginternal "symbols_tbl"
 
 let get_symbols () =
-  let tbl = Array.make (HashtblSymbol.length symb_tbl) dummy_symb in
-  HashtblSymbol.iter (fun x i -> tbl.(i) <- x) symb_tbl; tbl
+  match HashtblSymbol.to_seq symb_tbl () with
+  | Nil -> [||]
+  | Cons ((x,_), rest) ->
+    let tbl = Array.make (HashtblSymbol.length symb_tbl) x in
+    Seq.iter (fun (x, i) -> tbl.(i) <- x) rest;
+    tbl
 
 (** Lambda to Mllambda **)
 

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -180,6 +180,7 @@ let native_conv_gen (type err) pb sigma env (state, check) t1 t2 =
   debug_native_compiler (fun () -> Pp.str "Running test...");
   let t0 = Sys.time () in
   let (rt1, rt2) = Nativelib.execute_library ~prefix fn upds in
+  let rt1 = Option.get rt1 and rt2 = Option.get rt2 in
   let t1 = Sys.time () in
   let time_info = Format.sprintf "Evaluation done in %.5f@." (t1 -. t0) in
   debug_native_compiler (fun () -> Pp.str time_info);

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 open Util
-open Nativevalues
 open Nativecode
 open CErrors
 
@@ -75,8 +74,8 @@ let get_include_dirs () =
 (* Pointer to the function linking an ML object into Rocq's toplevel *)
 let load_obj = ref (fun _x -> () : string -> unit)
 
-let rt1 = ref (dummy_value ())
-let rt2 = ref (dummy_value ())
+let rt1 = ref None
+let rt2 = ref None
 
 let get_ml_filename () =
   let temp_dir = Lazy.force my_temp_dir in
@@ -178,8 +177,8 @@ let compile_library (code, symb) fn =
   delay_cleanup_file fn
 
 let execute_library ~prefix f upds =
-  rt1 := dummy_value ();
-  rt2 := dummy_value ();
+  rt1 := None;
+  rt2 := None;
   if not (Sys.file_exists f) then
     CErrors.user_err Pp.(str "Cannot find native compiler file " ++ str f);
   if Dynlink.is_native then Dynlink.loadfile f else !load_obj f;

--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -40,7 +40,7 @@ val compile_library : native_library -> string -> unit
     in [rt1] and [rt2] *)
 val execute_library :
   prefix:string -> string -> Nativecode.code_location_updates ->
-  Nativevalues.t * Nativevalues.t
+  Nativevalues.t option * Nativevalues.t option
 
 (** [enable_library] marks the given library for dynamic loading
     the next time [link_libraries] is called. *)
@@ -49,5 +49,5 @@ val enable_library : string -> Names.DirPath.t -> unit
 val link_libraries : unit -> unit
 
 (* used for communication with the loaded libraries *)
-val rt1 : Nativevalues.t ref
-val rt2 : Nativevalues.t ref
+val rt1 : Nativevalues.t option ref
+val rt2 : Nativevalues.t option ref

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Util
-open CErrors
 open Names
 open Values
 open Constr
@@ -249,11 +248,6 @@ let mk_block tag args =
     Obj.set_field r i (Obj.magic args.(i))
   done;
   (Obj.magic r : t)
-
-(* Two instances of dummy_value should not be pointer equal, otherwise
- comparing them as terms would succeed *)
-let dummy_value : unit -> t =
-  fun () -> of_fun (fun _ -> anomaly ~label:"native" (Pp.str "Evaluation failed."))
 
 let cast_accu v = (Obj.magic v:accumulator)
 [@@ocaml.inline always]

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -112,7 +112,6 @@ val mk_string : Pstring.t -> t
 val napply : t -> t array -> t
 (* Functions over accumulators *)
 
-val dummy_value : unit -> t
 val atom_of_accu : accumulator -> atom
 val args_of_accu : accumulator -> t list
 val accu_nargs : accumulator -> int

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -505,6 +505,7 @@ let native_norm env sigma c ty =
     let profiler_pid = if profile then start_profiler () else None in
     let t0 = Unix.gettimeofday () in
     let (rt1, _) = Nativelib.execute_library ~prefix fn upd in
+    let rt1 = Option.get rt1 in
     let t1 = Unix.gettimeofday () in
     if profile then stop_profiler profiler_pid;
     let time_info = Format.sprintf "native_compute: Evaluation done in %.5f" (t1 -. t0) in


### PR DESCRIPTION

NB: there was a comment saying "Two instances of dummy_value should
not be pointer equal, otherwise comparing them as terms would succeed"
but when I tried to `assert (dummy_value () != dummy_value ())` the assertion failed...
