### PR TITLE
ssr: skip impargs in pattern FO unif

### DIFF
--- a/dev/ci/user-overlays/20707-gares-sspart-FO-ignore-imparg.sh
+++ b/dev/ci/user-overlays/20707-gares-sspart-FO-ignore-imparg.sh
@@ -1,0 +1,2 @@
+overlay coquelicot https://gitlab.inria.fr/qvermand/coquelicot ssrpat-FO-ignore-imparg 20707
+overlay perennial https://github.com/proux01/perennial ssrpat-FO-ignore-imparg 20707

--- a/doc/changelog/07-ssreflect/20707-ssrpat-FO-ignore-imparg-Changed.rst
+++ b/doc/changelog/07-ssreflect/20707-ssrpat-FO-ignore-imparg-Changed.rst
@@ -1,0 +1,10 @@
+- **Changed:**
+  rewrite pattern selection algorithm made more robust in face of changes
+  to implicit arguments shape. This changes can result in a different
+  pattern selection in some corner cases.
+  The option `Set SsrMatching LegacyFoUnif` can be used to obtain the
+  previous behavior when repairing scripts
+  (`#20707 <https://github.com/rocq-prover/rocq/pull/20707>`_,
+  fixes `#16763 <https://github.com/rocq-prover/rocq/issues/16763>`_,
+  by Enrico Tassi with help from Georges Gonthier, Pierre Roux and
+  Quentin Vermande).

--- a/test-suite/ssr/rew_FO.v
+++ b/test-suite/ssr/rew_FO.v
@@ -1,0 +1,46 @@
+From Corelib Require Import ssreflect.
+
+Axiom R : Type.
+Axiom op : nat -> R -> R -> R.
+
+Axiom lemma : forall n x y z, op n (op n x y) z = z.
+
+Arguments op {_} _ _.
+
+Goal forall a b c : R, @op (0+1) (@op 1 a b) c =
+                       @op 2 (@op 2 a b) c.
+intros a b c.
+Show.
+rewrite lemma.
+Show.
+match goal with
+| |- c = _ => idtac "ok"
+end.
+Abort.
+
+Record foo := F { f : nat }.
+
+Definition c := F (1 + 2).
+
+Goal (forall x, 1 + (1 + x) = 5) -> 1 + f c = 1 + (1 + 7) .
+Show.
+move->.
+Show.
+match goal with |- 5 = 1 + (1 + 7) => idtac "ok" end.
+Abort.
+
+Goal (forall x, 1 + (1 + x) = 5) -> 1 + f c = 1 + (1 + 7) .
+Show.
+Set SsrMatching LegacyFoUnif.
+move->.
+Unset SsrMatching LegacyFoUnif.
+Show.
+match goal with |- 1 + f c = 5 => idtac "ok" end.
+Abort.
+
+Goal (forall x, 1 + (S x) = 5) -> 1 + f c = 1 + (1 + 7) .
+Show.
+move->.
+Show.
+match goal with |- 1 + f c = 1 + 5 => idtac "ok" end.
+Abort.


### PR DESCRIPTION
This is an attempt to make changes in the algebraic hierarchy of mathcomp less painful.

When a structure s with op1 and op2 is broken into s1 with op1 and s2 with op2 it may be the case that lemmas involving both operations have a type like `forall i:sj, op1 i x (op2 i y) z = ..` where an instance of the structure sj (join of s1 and s2) occurs non linearly. A concrete goal may have after the split the shape `op1 canon_s1_on_T x (op2 (sj_to_s2 canon_sj_on_T) y) z` or something like that, while before both ops would have the same canonical instance on T (the type of x, y, z).
Because of the 2 syntactically different instances the FO pass makes a different choice than before.

#### This PR tries to avoid breakage by making the FO pass do

- ignore implicit arguments of constants, e.g. structure instances
  - ~in one case the real arg is implicit because it is followed by a phantom, hence I use the shortest list of impargs~
    Not needed/used anymore, but still valid: rewrite takes the shortest list of impargs among the existing ones.
- ignore subterms that are FO-different but the pattern is is a proj
- reduce the goal subterm if it is not equal to the pattern and is a proj (applied to a CS instance) 
- fail to match if the pattern contains more evars that the matched goal (i.e. if it contains non-instantiated variables)

- flags `Set SsrMatching LegacyFoUnif` makes it behave as before, so one can compare old/new using the same version of Rocq and/or give up fixing a proof.


#### Things tried and abandoned

- completely disable FO pass
  - lemmas with shape `_ (if ..)` or `_ f g` rely on the FO pass. I tried adjusting the HO one to behave the same (use the first arg key rigidly) but some lemmas nee more keys...
  - some rewritings become very surprising, even in algebra, eg (_ * _ * _) since some defs compute and can expose *
- do not ignore `proj _ = t` problems, since in groups we have plenty of set/group lemmas, with gval that would behave surprisingly, eg `x \in <[x]> || x \in G` where `G : group`, the second one has an explicit gval, the former none, the lemma has it.

- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
   I don't think the FO pass was ever documented, and I'm not so sure it should. This PR contains the details for the braves.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->

- [x] https://github.com/math-comp/math-comp/pull/1438
- [x] https://github.com/math-comp/odd-order/pull/69
- [x] https://github.com/math-comp/analysis/pull/1641
- [x] https://github.com/jasmin-lang/jasmin/pull/1209
- [x] https://github.com/math-comp/multinomials/pull/103
- [x] https://github.com/math-comp/real-closed/pull/78
- [x] https://github.com/rocq-community/coqeal/pull/109
- [x] https://github.com/math-comp/Abel/pull/101
- [x] https://github.com/rocq-community/gaia/pull/28
- [x] https://github.com/rocq-community/apery/pull/35
- [x] https://github.com/rocq-community/graph-theory/pull/47
- [x] https://gitlab.inria.fr/coquelicot/coquelicot/-/merge_requests/14
- [x] https://github.com/uwplse/verdi/pull/148
- [x] https://github.com/MetaRocq/metarocq/pull/1190
- [x] https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/1124
- [x] https://github.com/mit-pdos/perennial/pull/279

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
