### PR TITLE
Fix #20679: avoid spurious newline in rocqdoc blocks.

### DIFF
--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -137,13 +137,12 @@
     margin-top: 0.5em !important;
 }
 
-.coqdoc, .coqtop dl {
+.coqdoc > span, .coqtop dl {
     margin: 12px; /* Copied from RTD theme */
 }
 
-.coqdoc {
+.coqdoc > span {
     display: block;
-    white-space: pre;
 }
 
 .coqtop dt, .coqtop dd {
@@ -156,7 +155,7 @@
 }
 
 /* FIXME: Specific to the RTD theme */
-.coqdoc, .coqtop dt, .coqtop dd, pre { /* pre added because of production lists */
+.coqdoc > span, .coqtop dt, .coqtop dd, pre { /* pre added because of production lists */
     font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace !important; /* Copied from RTD theme */
     font-size: 12px !important; /* Copied from RTD theme */
     line-height: 1.5 !important; /* Copied from RTD theme */


### PR DESCRIPTION
Adjust the CSS selectors of rocqdoc to be closer to the ones of rocqtop.

Fix #20679