### PR TITLE
Tweak the native compilation scheme of cofixpoints.

### DIFF
--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1804,18 +1804,18 @@ let pp_mllam fmt l =
     | MLlocal ln -> Format.fprintf fmt "@[%a@]" pp_lname ln
     | MLglobal g -> Format.fprintf fmt "@[%a@]" pp_gname g
     | MLprimitive (p, args) ->
-      Format.fprintf fmt "@[%a@ %a@]" pp_primitive p (pp_args true) args
+      Format.fprintf fmt "@[<2>%a@ %a@]" pp_primitive p (pp_args true) args
     | MLlam(ids,body) ->
-        Format.fprintf fmt "@[(fun%a@ ->@\n %a)@]"
+        Format.fprintf fmt "@[(fun%a ->@ %a)@]"
           pp_ldecls ids pp_mllam body
     | MLletrec(defs, body) ->
         Format.fprintf fmt "@[(%a@ in@\n%a)@]" pp_letrec defs
           pp_mllam body
     | MLlet(id,def,body) ->
-        Format.fprintf fmt "@[(let@ %a@ =@\n %a@ in@\n%a)@]"
+        Format.fprintf fmt "@[(@[let@ %a@ =@ %a@ in@]@\n%a)@]"
           pp_lname id pp_mllam def pp_mllam body
     | MLapp(f, args) ->
-        Format.fprintf fmt "@[%a@ %a@]" pp_mllam f (pp_args true) args
+        Format.fprintf fmt "@[<2>%a@ %a@]" pp_mllam f (pp_args true) args
     | MLif(t,l1,l2) ->
         Format.fprintf fmt "@[(if %a then@\n  %a@\nelse@\n  %a)@]"
           pp_mllam t pp_mllam l1 pp_mllam l2
@@ -1828,7 +1828,7 @@ let pp_mllam fmt l =
         pp_mllam c accu pp_mllam accu_br (pp_branches prefix ind) br
 
     | MLconstruct(prefix,ind,tag,args) ->
-        Format.fprintf fmt "@[(Obj.magic (%s%a) : Nativevalues.t)@]"
+        Format.fprintf fmt "@[<2>(Obj.magic@ @[<2>(%s%a)@] : Nativevalues.t)@]"
           (string_of_construct prefix ~constant:false ind tag) pp_cargs args
     | MLint i -> pp_int fmt i
     | MLuint i -> Format.fprintf fmt "(%s)" (Uint63.compile i)
@@ -1883,12 +1883,12 @@ let pp_mllam fmt l =
     | _ -> pp_mllam fmt l
 
   and pp_args sep fmt args =
-    let sep = if sep then " " else "," in
+    let sep = if sep then "" else "," in
     let len = Array.length args in
     if len > 0 then begin
       Format.fprintf fmt "%a" pp_blam args.(0);
       for i = 1 to len - 1 do
-        Format.fprintf fmt "%s%a" sep pp_blam args.(i)
+        Format.fprintf fmt "%s@ %a" sep pp_blam args.(i)
       done
     end
 
@@ -1896,8 +1896,8 @@ let pp_mllam fmt l =
     let len = Array.length args in
     match len with
     | 0 -> ()
-    | 1 -> Format.fprintf fmt " %a" pp_blam args.(0)
-    | _ -> Format.fprintf fmt "(%a)" (pp_args false) args
+    | 1 -> Format.fprintf fmt "@ %a" pp_blam args.(0)
+    | _ -> Format.fprintf fmt "@ @[<2>(%a)@]" (pp_args false) args
 
   and pp_cparam fmt param =
     match param with
@@ -1946,7 +1946,7 @@ let pp_mllam fmt l =
         let pp_rec_pos fmt rec_pos =
           Format.fprintf fmt "@[[| %i" rec_pos.(0);
           for i = 1 to Array.length rec_pos - 1 do
-            Format.fprintf fmt "; %i" rec_pos.(i)
+            Format.fprintf fmt ";@ %i" rec_pos.(i)
           done;
           Format.fprintf fmt " |]@]" in
         Format.fprintf fmt "mk_fix_accu %a %i" pp_rec_pos rec_pos start
@@ -1994,9 +1994,9 @@ let pp_mllam fmt l =
 
 let pp_array fmt t =
   let len = Array.length t in
-  Format.fprintf fmt "@[[|";
+  Format.fprintf fmt "@[<2>[|";
   for i = 0 to len - 2 do
-    Format.fprintf fmt "%a; " pp_mllam t.(i)
+    Format.fprintf fmt "%a;@ " pp_mllam t.(i)
   done;
   if len > 0 then
     Format.fprintf fmt "%a" pp_mllam t.(len - 1);
@@ -2009,7 +2009,7 @@ let pp_cofix fmt (gn, s) =
   in
   let pp_knot fmt n =
     for i = 0 to n - 1 do
-      Format.fprintf fmt "let () = (%a).(%i) <- Obj.magic (%a) in@\n" pp_gname gn i pp_mllam s.(i)
+      Format.fprintf fmt "@[<2>let () = (%a).(%i) <-@ Obj.magic @[<2>(%a)@] in@]@\n" pp_gname gn i pp_mllam s.(i)
     done
   in
   let len = Array.length s in

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -310,7 +310,7 @@ type primitive =
   | Is_string
   | Is_parray
   | Cast_accu
-  | Upd_cofix
+  | Array_get
   | Force_cofix
   | Mk_uint
   | Mk_float
@@ -351,7 +351,7 @@ let eq_primitive p1 p2 =
   | Is_string, Is_string
   | Is_parray, Is_parray
   | Cast_accu, Cast_accu
-  | Upd_cofix, Upd_cofix
+  | Array_get, Array_get
   | Force_cofix, Force_cofix
   | Mk_uint, Mk_uint
   | Mk_float, Mk_float
@@ -401,7 +401,7 @@ let eq_primitive p1 p2 =
     | Is_string
     | Is_parray
     | Cast_accu
-    | Upd_cofix
+    | Array_get
     | Force_cofix
     | Mk_uint
     | Mk_float
@@ -447,7 +447,7 @@ let primitive_hash = function
      combinesmall 9 (Id.hash id)
   | Is_int -> 11
   | Cast_accu -> 12
-  | Upd_cofix -> 13
+  | Array_get -> 13
   | Force_cofix -> 14
   | Mk_uint -> 15
   | Mk_int -> 16
@@ -792,6 +792,7 @@ let decompose_MLlam c =
 type global =
 (*  | Gtblname of gname * Id.t array *)
   | Gtblnorm of gname * lname array * mllambda array
+  | Gtblcofix of gname * lname array * mllambda array
   | Gtblfixtype of gname * lname array * mllambda array
   | Glet of gname * mllambda
   | Gletcase of
@@ -805,6 +806,7 @@ type global =
 let eq_global g1 g2 =
   match g1, g2 with
   | Gtblnorm (gn1,lns1,mls1), Gtblnorm (gn2,lns2,mls2)
+  | Gtblcofix (gn1,lns1,mls1), Gtblcofix (gn2,lns2,mls2)
   | Gtblfixtype (gn1,lns1,mls1), Gtblfixtype (gn2,lns2,mls2) ->
       Int.equal (Array.length lns1) (Array.length lns2) &&
       Int.equal (Array.length mls1) (Array.length mls2) &&
@@ -836,26 +838,32 @@ let hash_global g =
       let env = push_lnames 0 LNmap.empty lns in
       let hmls = hash_mllambda_array gn nlns env (combine nlns nmls) mls in
       combinesmall 1 hmls
-  | Gtblfixtype (gn,lns,mls) ->
+  | Gtblcofix (gn,lns,mls) ->
       let nlns = Array.length lns in
       let nmls = Array.length mls in
       let env = push_lnames 0 LNmap.empty lns in
       let hmls = hash_mllambda_array gn nlns env (combine nlns nmls) mls in
       combinesmall 2 hmls
+  | Gtblfixtype (gn,lns,mls) ->
+      let nlns = Array.length lns in
+      let nmls = Array.length mls in
+      let env = push_lnames 0 LNmap.empty lns in
+      let hmls = hash_mllambda_array gn nlns env (combine nlns nmls) mls in
+      combinesmall 3 hmls
   | Glet (gn, def) ->
-      combinesmall 3 (hash_mllambda gn 0 LNmap.empty def)
+      combinesmall 4 (hash_mllambda gn 0 LNmap.empty def)
   | Gletcase (gn,lns,annot,c,accu,br) ->
       let nlns = Array.length lns in
       let env = push_lnames 0 LNmap.empty lns in
       let t = MLmatch (annot,c,accu,br) in
-      combinesmall 4 (combine nlns (hash_mllambda gn nlns env t))
+      combinesmall 5 (combine nlns (hash_mllambda gn nlns env t))
   | Gopen s -> combinesmall 5 (String.hash s)
   | Gtype (ind, arr) ->
     let hash_aux acc (tag,ar) =
       combine3 acc (Int.hash tag) (Int.hash ar)
     in
-    combinesmall 6 (combine (Ind.CanOrd.hash ind) (Array.fold_left hash_aux 0 arr))
-  | Gcomment s -> combinesmall 7 (String.hash s)
+    combinesmall 7 (combine (Ind.CanOrd.hash ind) (Array.fold_left hash_aux 0 arr))
+  | Gcomment s -> combinesmall 8 (String.hash s)
 
 let global_stack = ref ([] : global list)
 
@@ -885,6 +893,9 @@ let push_global_fixtype gn params body =
 
 let push_global_norm gn params body =
   push_global gn (Gtblnorm (gn, params, body))
+
+let push_global_cofix gn params self =
+  push_global gn (Gtblcofix (gn, params, self))
 
 let push_global_case gn params annot a accu bs =
   push_global gn (Gletcase (gn, params, annot, a, accu, bs))
@@ -1430,22 +1441,22 @@ let compile_prim env decl cond paux =
       let env_t = restart_env env in
       let ml_t = Array.map (ml_of_lam env_t l) tt in
       let params_t = fv_params env_t in
-      let args_t = fv_args env !(env_t.env_named) !(env_t.env_urel) in
+      let args_t = Array.map (fun id -> MLlocal id) params_t in
       let gft = fresh_gfixtype l in
       let gft = push_global_fixtype gft params_t ml_t in
       let mk_type = MLapp(MLglobal gft, args_t) in
       (* Compilation of norm_i *)
       let ndef = Array.length ids in
-      let lf,env_n = push_rels (restart_env env) ids in
+      let lf,env_n = push_rels env_t ids in
       let t_params = Array.make ndef [||] in
-      let t_norm_f = Array.make ndef (Gnorm (l,-1)) in
+      let t_norm_f = Array.init ndef (fun _i -> fresh_gnorm l) in
       let ml_of_fix i body =
         let idsi,bodyi = decompose_Llam body in
         let paramsi, envi = push_rels env_n idsi in
-        t_norm_f.(i) <- fresh_gnorm l;
         let bodyi = ml_of_lam envi l bodyi in
         t_params.(i) <- paramsi;
-        mkMLlam paramsi bodyi in
+        mkMLlam paramsi bodyi
+      in
       let tnorm = Array.mapi ml_of_fix tb in
       let fvn,fvr = !(env_n.env_named), !(env_n.env_urel) in
       let fv_params = fv_params env_n in
@@ -1456,43 +1467,28 @@ let compile_prim env decl cond paux =
       let norm = fresh_gnormtbl l in
       let norm = push_global_norm norm fv_params
         (Array.map (fun g -> mkMLapp (MLglobal g) fv_args') t_norm_f) in
-      (* Compilation of fix *)
+      (* Compilation of cofix *)
       let fv_args = fv_args env fvn fvr in
-      let mk_norm = MLapp(MLglobal norm, fv_args) in
-      let lnorm = fresh_lname Anonymous in
-      let ltype = fresh_lname Anonymous in
-      let lf, _env = push_rels env ids in
-      let lf_args = Array.map (fun id -> MLlocal id) lf in
-      let upd i _lname cont =
-        let paramsi = t_params.(i) in
-        let pargsi = Array.map (fun id -> MLlocal id) paramsi in
-        let uniti = fresh_lname Anonymous in
-        let body =
-          MLlam(Array.append paramsi [|uniti|],
-                MLapp(MLglobal t_norm_f.(i),
-                      Array.concat [fv_args;lf_args;pargsi])) in
-        MLsequence(MLprimitive (Upd_cofix, [|lf_args.(i);body|]),
-                   cont) in
-      let upd = Array.fold_right_i upd lf lf_args.(start) in
-      let mk_let i lname cont =
-        MLlet(lname,
-              MLprimitive ((Mk_cofix i),[| MLlocal ltype; MLlocal lnorm|]),
-              cont) in
-      let init = Array.fold_right_i mk_let lf upd in
-      MLlet(lnorm, mk_norm, MLlet(ltype, mk_type, init))
-  (*
-      let mkrec i lname =
-        let paramsi = t_params.(i) in
-        let pargsi = Array.map (fun id -> MLlocal id) paramsi in
-        let uniti = fresh_lname Anonymous in
-        let body =
-          MLapp( MLprimitive(Mk_cofix i),
-                 [|mk_type;mk_norm;
-                   MLlam([|uniti|],
-                         MLapp(MLglobal t_norm_f.(i),
-                               Array.concat [fv_args;lf_args;pargsi]))|]) in
-        (lname, paramsi, body) in
-      MLletrec(Array.mapi mkrec lf, lf_args.(start)) *)
+      let mk_norm = MLapp(MLglobal norm, fv_args') in
+
+      let knot = fresh_gnormtbl l in
+      let map i g =
+        (* fun args -> cofix (fun () -> tb_i fv tbl args) *)
+        let unit = fresh_lname Anonymous in
+        let args = Array.map (fun id -> MLlocal id) t_params.(i) in
+        let mk_let i lname cont =
+          MLlet (lname, MLprimitive (Array_get, [|MLglobal knot; MLint i|]), cont)
+        in
+        let self = Array.map (fun id -> MLlocal id) lf in
+        let body = mkMLapp (MLglobal g) (Array.concat [fv_args'; self; args]) in
+        let body = MLlam ([|unit|], Array.fold_right_i mk_let lf body) in
+        let typs = mk_type in
+        let self = mk_norm in
+        mkMLlam t_params.(i) (MLprimitive ((Mk_cofix i), [| typs; self; body; MLarray args |]))
+      in
+      (* Tie the knot *)
+      let knot = push_global_cofix knot fv_params (Array.mapi map t_norm_f) in
+      MLprimitive (Array_get, [|MLapp (MLglobal knot, fv_args); MLint start|])
 
   | Lint tag -> MLprimitive (Mk_int, [|MLint tag|])
 
@@ -1965,7 +1961,7 @@ let pp_mllam fmt l =
     | Is_string -> Format.fprintf fmt "is_string"
     | Is_parray -> Format.fprintf fmt "is_parray"
     | Cast_accu -> Format.fprintf fmt "cast_accu"
-    | Upd_cofix -> Format.fprintf fmt "upd_cofix"
+    | Array_get -> Format.fprintf fmt "Array.get"
     | Force_cofix -> Format.fprintf fmt "force_cofix"
     | Mk_uint -> Format.fprintf fmt "mk_uint"
     | Mk_float -> Format.fprintf fmt "mk_float"
@@ -2005,6 +2001,19 @@ let pp_array fmt t =
   if len > 0 then
     Format.fprintf fmt "%a" pp_mllam t.(len - 1);
   Format.fprintf fmt "|]@]"
+
+let pp_cofix fmt (gn, s) =
+  let pp_dummy fmt len =
+    let dummy = String.concat "; " (List.make len "0") in
+    Format.fprintf fmt "@[(Obj.magic [|%s|] : Nativevalues.t array)@]" dummy
+  in
+  let pp_knot fmt n =
+    for i = 0 to n - 1 do
+      Format.fprintf fmt "let () = (%a).(%i) <- Obj.magic (%a) in@\n" pp_gname gn i pp_mllam s.(i)
+    done
+  in
+  let len = Array.length s in
+  Format.fprintf fmt "@[let %a = %a in@\n%a%a@]" pp_gname gn pp_dummy len pp_knot len pp_gname gn
 
 let type_of_global gn c = match gn with
   | Ginternal "symbols_tbl" -> ""
@@ -2047,6 +2056,9 @@ let pp_global fmt g =
   | Gtblnorm (g, params, t) ->
       Format.fprintf fmt "@[let %a %a : Nativevalues.t array = let Refl = Nativevalues.t_eq in@\n  %a@]@\n@." pp_gname g
         pp_ldecls params pp_array t
+  | Gtblcofix (g, params, s) ->
+      Format.fprintf fmt "@[let %a%a : Nativevalues.t array = let Refl = Nativevalues.t_eq in@\n  %a@]@\n@." pp_gname g
+        pp_ldecls params pp_cofix (g, s);
   | Gletcase(gn,params,annot,a,accu,bs) ->
       Format.fprintf fmt "@[(* Hash = %i *)@\nlet rec %a %a : Nativevalues.t = let Refl = Nativevalues.t_eq in@\n  %a@]@\n@."
       (hash_global g)

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -135,12 +135,13 @@ and conv_atom env pb lvl a1 a2 cu =
         if not (Int.equal s1 s2) || not (Array.equal Int.equal rp1 rp2) then raise NotConvertible;
         if f1 == f2 then cu
         else conv_fix env lvl t1 f1 t2 f2 cu
-    | Acofix (t1, f1, s1, _), Acofix (t2, f2, s2, _) ->
+    | Acofix (t1, f1, s1, args1, _), Acofix (t2, f2, s2, args2, _) ->
         if not (Int.equal s1 s2) then raise NotConvertible;
-        if f1 == f2 then cu
+        if f1 == f2 && args1 == args2 then cu
+        else if not (Int.equal (Array.length f1) (Array.length f2) && Int.equal (Array.length args1) (Array.length args2)) then
+          raise NotConvertible
         else
-          if not (Int.equal (Array.length f1) (Array.length f2)) then raise NotConvertible
-          else conv_fix env lvl t1 f1 t2 f2 cu
+          Array.fold_left2 (fun cu v1 v2 -> conv_val env CONV lvl v1 v2 cu) (conv_fix env lvl t1 f1 t2 f2 cu) args1 args2
     | Aproj((ind1, i1), ac1), Aproj((ind2, i2), ac2) ->
        if not (Ind.CanOrd.equal ind1 ind2 && Int.equal i1 i2) then raise NotConvertible
        else conv_accu env CONV lvl ac1 ac2 cu

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -60,7 +60,7 @@ type atom =
   | Avar of Id.t
   | Acase of annot_sw * accumulator * t * t
   | Afix of t array * t array * rec_pos * int
-  | Acofix of t array * t array * int * vcofix
+  | Acofix of t array * t array * int * t array * vcofix
   | Aevar of Evar.t * t array (* arguments *)
   | Aproj of (inductive * int) * accumulator
 
@@ -90,10 +90,9 @@ val mk_sort_accu : Sorts.t -> UVars.Instance.t -> t
 val mk_var_accu : Id.t -> t
 val mk_sw_accu : annot_sw -> accumulator -> t -> (t -> t)
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t
-val mk_cofix_accu : int -> t array -> t array -> t
+val mk_cofix_accu : int -> t array -> t array -> t -> t array -> t
 val mk_evar_accu : Evar.t -> t array -> t
 val mk_proj_accu : (inductive * int) -> accumulator -> t
-val upd_cofix : t -> t -> unit
 val force_cofix : t -> t
 val mk_const : tag -> t
 val mk_block : tag -> t array -> t

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -362,16 +362,17 @@ and nf_atom_type env sigma atom =
       let norm_body i v = nf_val env sigma (napply v fargs) (lift nbfix tt.(i)) in
       let ft = Array.mapi norm_body ft in
       mkFix((rp,s),(names,tt,ft)), tt.(s)
-  | Acofix(tt,ft,s,_) ->
+  | Acofix (tt, ft, s, args, _) ->
       let tt = Array.map (fun t -> nf_type_sort env sigma t) tt in
       let tt = Array.map fst tt and rt = Array.map snd tt in
       let name = Name (Id.of_string "Fcofix") in
       let lvl = nb_rel env in
       let names = Array.map (fun s -> make_annot name (Sorts.relevance_of_sort s)) rt in
       let fargs = mk_rels_accu lvl (Array.length ft) in
+      let _, args = nf_args env sigma (Array.rev_to_list args) tt.(s) in
       let env = push_rec_types (names,tt,[||]) env in
       let ft = Array.mapi (fun i v -> nf_val env sigma (napply v fargs) tt.(i)) ft in
-      mkCoFix(s,(names,tt,ft)), tt.(s)
+      mkApp (mkCoFix(s,(names,tt,ft)), Array.of_list args), tt.(s)
   | Aevar(evk,args) ->
     nf_evar env sigma evk args
   | Aproj(p,c) ->

--- a/test-suite/bugs/bug_20719.v
+++ b/test-suite/bugs/bug_20719.v
@@ -1,0 +1,29 @@
+CoInductive strm := { hd : nat; tl : strm }.
+
+Definition foobar (i : unit) :=
+  cofix seq n := {| hd := match i with tt => n end; tl := seq (S n) |}.
+
+CoFixpoint seq n := {| hd := n; tl := seq (S n) |}.
+
+Check (@eq_refl (nat -> strm) seq) <<: foobar tt = seq.
+Check (@eq_refl (nat -> strm) seq) <: foobar tt = seq.
+
+Check eq_refl 5 <<: hd (foobar tt 5) = 5.
+Check eq_refl 5 <: hd (foobar tt 5) = 5.
+
+Check eq_refl 5 <<: hd (seq 5) = 5.
+Check eq_refl 5 <: hd (seq 5) = 5.
+
+CoFixpoint dummy (i : bool) := {| hd := 0; tl := dummy i |}.
+
+Fail Check (eq_refl (dummy true)) <: (dummy true) = (dummy false).
+Fail Check (eq_refl (dummy true)) <<: (dummy true) = (dummy false).
+
+Set Warnings "-non-recursive".
+
+CoInductive lazy T := Lazy : T -> lazy T.
+CoFixpoint of_fun {T} f := Lazy T (f tt).
+Definition force {T} v : T := match v with Lazy _ v => v end.
+
+Check eq_refl 42 <<: (force (of_fun (fun _ => 42))) = 42.
+Check eq_refl 42 <: (force (of_fun (fun _ => 42))) = 42.


### PR DESCRIPTION
Instead of conflating the application of functional cofix values with the forcing of the node, we implement cofixes directly as a loop in memory and rely on the fact that they are always passed as fully η-expanded functions by the Genlambda caller.

This is more efficient as we get more sharing and perform less applications when forcing cofixes.

This should make #20699 work as expected.