### PR TITLE
Reduce projections during unification

### DIFF
--- a/dev/ci/user-overlays/20730-Tragicus-reduce-projs.sh
+++ b/dev/ci/user-overlays/20730-Tragicus-reduce-projs.sh
@@ -1,0 +1,1 @@
+overlay metarocq https://github.com/Tragicus/metacoq rocq20730 20730

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -154,11 +154,10 @@ val evar_unify : Evarsolve.unifier
 
 (**/**)
 (* For debugging *)
-module Cs_keys_cache : sig type t end
 
 val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
   env -> evar_map -> conv_pb ->
-  Cs_keys_cache.t ->
+  (state * state) ->
   bool option -> state -> state ->
       Evarsolve.unification_result
 

--- a/test-suite/bugs/bug_5198.v
+++ b/test-suite/bugs/bug_5198.v
@@ -29,7 +29,7 @@ Definition SRepAdd : forall (_ _ : SRep), SRep
   := let v := (fun x y => barrett_reduce_function_bundled (CarryAdd x y)) in
      v.
 Definition SRepAdd' : forall (_ _ : SRep), SRep
-  := (fun x y => barrett_reduce_function_bundled (CarryAdd x y)).
+  := (fun x y => barrett_reduce_function_bundled (@CarryAdd (f (S O) O) _ x y)).
 (* Error:
 In environment
 x : SRep


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Unifying structures is very slow (see e.g. https://github.com/math-comp/math-comp/pull/1365). So whenever we see a projection, we can try to reduce it. This also simplifies the Canonical Structures procedure (e.g. gets rid of the "keys" and ~~restores the previous reduction strategy~~ avoids backtracking in the reduction strategy).

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [x] Opened **overlay** pull requests.

### Overlays:
- https://github.com/MetaRocq/metarocq/pull/1185

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
