### PR TITLE
Search is possible in open interactive modules

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/20733-search-in-open-module.rst
+++ b/doc/changelog/08-vernac-commands-and-options/20733-search-in-open-module.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  :cmd:`Search` now accepts open modules, including the current file with
+  the  `in`, `inside` and `outside` filters.
+  (`#20733 <https://github.com/coq/coq/pull/20733>`_,
+  fixes `#14010 <https://github.com/coq/coq/issues/14010>`_,
+  by Pierre Rousselin, with a lot of help by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -210,6 +210,14 @@ described elsewhere
    * :n:`{| inside | in } {+ @qualid }` - limit the search to the specified modules
    * :n:`outside {+ @qualid }` - exclude the specified modules from the search
 
+   The specified modules can be the current file or a currently opened module.
+   For instance, when using Rocq interactively in a file `Foo.v`, the command
+   :g:`Search _ in Foo.` displays every (non-blacklisted) constants previously
+   defined in the file `Foo`.
+   Inside a :cmd:`Module` `A`, :g:`Search _ in A` similarly displays every
+   constant defined up to this point in the :cmd:`Module` `A`.
+   See :ref:`this example <search-current-module>`.
+
    .. exn:: Module/section @qualid not found.
 
       There is no constant in the environment named :n:`@qualid`, where :n:`@qualid`
@@ -320,6 +328,31 @@ described elsewhere
       .. rocqtop:: all reset
 
          Search (nat -> nat -> nat) -bool [ is:Definition | is:Fixpoint ].
+
+   .. _search-current-module:
+
+   .. example:: Search in current file or :cmd:`Module`
+
+      The following example shows how to filter `Search` output in an
+      interactive session. Note that with `rocq top`, the current pseudo-file
+      is named `Top`, it can be replaced with the name of the current file
+      (without the trailing `.v`) when using an IDE.
+
+      .. rocqtop:: all reset
+
+         Definition b := 42.
+
+         Search _ in Top.
+
+         Module A.
+
+         Definition a := 12.
+
+         Search _ in A.
+
+         End A.
+
+         Search _ in Top.
 
 .. cmd:: SearchPattern @one_pattern {? {| inside | in | outside } {+ @qualid } }
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -157,7 +157,8 @@ let start_compilation s mp =
   }
   in
   synterp_state := st;
-  interp_state := initial_stk
+  interp_state := initial_stk;
+  Nametab.OpenMods.push (Until 1) path (DirOpenModule mp)
 
 let end_compilation_checks dir =
   let () = match find_entries_p is_opening_node !interp_state with

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -802,6 +802,8 @@ let locate_module qid = Modules.locate qid
 
 let full_name_module qid = Modules.to_path (locate_module qid)
 
+let full_name_open_mod qid = OpenMods.to_path (locate_dir qid)
+
 let locate_section qid =
   match locate_dir qid with
     | GlobDirRef.DirOpenSection dir -> dir

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -342,6 +342,7 @@ val exists_universe : full_path -> bool
 
 val full_name_modtype : qualid -> full_path
 val full_name_module : qualid -> full_path
+val full_name_open_mod : qualid -> full_path
 
 (** {6 Reverse lookup }
   Finding user names corresponding to the given

--- a/test-suite/TestSearchOpenMod.out
+++ b/test-suite/TestSearchOpenMod.out
@@ -1,0 +1,8 @@
+b: nat
+a: nat
+a: nat
+improbable_name12345: nat
+improbable_name12345: nat
+b: nat
+A.improbable_name12345: nat
+A.a: nat

--- a/test-suite/TestSearchOpenMod.v
+++ b/test-suite/TestSearchOpenMod.v
@@ -1,0 +1,14 @@
+Definition b := 0.
+Search _ in TestSearchOpenMod.
+Module A.
+Definition a := 42.
+Search _ in A. (* a: nat *)
+Search _ in TestSearchOpenMod.A. (* a: nat *)
+Definition improbable_name12345 := 41.
+Search "improbable_name12345" inside A.
+Search "improbable_name12345" in TestSearchOpenMod.A.
+Search "improbable_name12345" outside A.
+Search "improbable_name12345" outside TestSearchOpenMod.
+End A.
+Search _ in TestSearchOpenMod.
+Search "improbable_name12345" outside TestSearchOpenMod.

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -19,15 +19,24 @@ open Search
 open Vernacexpr
 open Goptions
 
-let global_module qid =
-  try Nametab.full_name_module qid
+let open_or_global_module qid =
+  try Nametab.full_name_open_mod qid
   with Not_found ->
+    try Nametab.full_name_module qid
+    with Not_found ->
+      user_err ?loc:qid.CAst.loc
+       (str "Module/Section " ++ Ppconstr.pr_qualid qid ++ str " not found.")
+
+(*
+let global_module qid =
     user_err ?loc:qid.CAst.loc
      (str "Module/Section " ++ Ppconstr.pr_qualid qid ++ str " not found.")
-
+*)
 let interp_search_restriction = function
-  | SearchOutside l -> SearchOutside (List.map global_module l)
-  | SearchInside l -> SearchInside (List.map global_module l)
+  | SearchOutside l ->
+      SearchOutside (List.map open_or_global_module l)
+  | SearchInside l ->
+      SearchInside (List.map open_or_global_module l)
 
 let kind_searcher env = Decls.(function
   (* Kinds referring to the keyword introducing the object *)


### PR DESCRIPTION
Searching in an opened module is possible, and in the current file, considered an opened module.
So here is what we have at the moment:
```coq
Definition b := 0.
Locate b. (* testsearch.b *)
Search _ in testsearch.
(* Module/Section testsearch not found *)
Module A.
Definition a := 42.
Locate a.
Search _ in A. (* a: nat *)
Search _ in testsearch.A. (* a: nat *)
Definition improbable_name12345 := 41.
Search "improbable_name12345" inside A.
Search "improbable_name12345" in testsearch.A.
Search "improbable_name12345" outside A.
Search "improbable_name12345" outside testsearch.
End A.
Search _ in testsearch.
Search "improbable_name12345" outside testsearch.
```

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #14010


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
        [Rendered](https://coq.gitlabpages.inria.fr/-/coq/-/jobs/5851674/artifacts/_build/default/doc/refman-html/proof-engine/vernacular-commands.html?highlight=search#coq:cmd.Search)

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
