### PR TITLE
Update parallel-proof-processing.rst

### DIFF
--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -81,7 +81,7 @@ Alternatively, if the :cmd:`Proof using` included unneeded variables, they becom
 extra parameters of the theorem, which may generate errors.
 This :ref:`example <example-print-using>` shows an example of an unneeded variable.
 One possible error is `(in proof <theorem name>) Attempt to save an incomplete proof`,
-which may indicate that the named theorem refers to an an earlier theorem that has
+which may indicate that the named theorem refers to an earlier theorem that has
 an incorrect annotation.
 
 Automatic suggestion of proof annotations


### PR DESCRIPTION
fix(docs): remove duplicated word “an” in async proof-processing chapter

Corrected the doubled “an” in the sentence “refers to an an earlier theorem”
inside the Asynchronous and Parallel Proof Processing documentation.

I may not be clever enough to wrangle Rocq itself, but I can still spot typos
like a champ. Happy to help in my own small way!

<!-- Thank you for your contribution. -->

Fixes / closes: N/A

- [x] Updated **documentation**.