### PR TITLE
Improve "cannot define a fixpoint" error message (with elim constraints)

### DIFF
--- a/dev/ci/user-overlays/20738-SkySkimmer-improve-fixpoint-no-elim.sh
+++ b/dev/ci/user-overlays/20738-SkySkimmer-improve-fixpoint-no-elim.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/SkySkimmer/stdlib improve-fixpoint-no-elim 20738

--- a/test-suite/output/FixpointNoElim.out
+++ b/test-suite/output/FixpointNoElim.out
@@ -1,0 +1,10 @@
+File "./output/FixpointNoElim.v", line 4, characters 0-48:
+Warning: Not a truly recursive fixpoint. [non-recursive,fixpoints,default]
+File "./output/FixpointNoElim.v", line 4, characters 0-48:
+The command has indeed failed with message:
+Recursive definition of bar is ill-formed.
+Cannot define a fixpoint
+with principal argument living in sort "Type@{α3 ; Set}"
+to produce a value in sort "Set"
+because "Type@{α3 ; Set}" does not eliminate to "Set".
+Recursive definition is: "fun _ : foo => I".

--- a/test-suite/output/FixpointNoElim.v
+++ b/test-suite/output/FixpointNoElim.v
@@ -1,0 +1,4 @@
+Set Universe Polymorphism.
+Inductive foo@{s;} : Type@{s;Set} := XX.
+
+Fail Fixpoint bar@{s;} (f:foo@{s;}) : True := I.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -541,10 +541,13 @@ let explain_ill_formed_fix_body env sigma names i = function
           | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
      str "Recursive call to " ++ called ++ str " has not enough arguments"
   | FixpointOnNonEliminable (s, s') ->
-     str "Cannot define a fixpoint on " ++ Printer.pr_sort sigma s ++
-       strbrk " on a value living in " ++ Printer.pr_sort sigma s' ++
-       str ": " ++ Printer.pr_sort sigma s ++ str " does not eliminate in " ++
-       Printer.pr_sort sigma s'
+  let pr_sort u = quote @@ Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u in
+    fmt "Cannot define a fixpoint@ with principal argument living in sort %t@ \
+         to produce a value in sort %t@ because %t does not eliminate to %t"
+      (fun () -> pr_sort s)
+      (fun () -> pr_sort s')
+      (fun () -> pr_sort s)
+      (fun () -> pr_sort s')
 
 let explain_ill_formed_cofix_body env sigma = function
   (* CoFixpoint guard errors *)


### PR DESCRIPTION
- force printing universes on to avoid printing sort variables as Type
- add quotes
- more intentional break hints and slightly improve wording

Close #20722

Overlays:
- https://github.com/rocq-prover/stdlib/pull/171