### PR TITLE
Fix reversible coercion mechanism in the presence of identity coercions

### DIFF
--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -666,8 +666,8 @@ let lookup_reversible_path_to_common_point env sigma ~src_expected ~src_inferred
   | [] -> raise Not_found
   | c :: cs ->
       let reversible = lookup_path_between_class_reflexive (c_expected,c) in
-      if path_is_reversible reversible then
-        let direct = lookup_path_between_class_reflexive (c_inferred,c) in
+      let direct = lookup_path_between_class_reflexive (c_inferred,c) in
+      if path_is_reversible reversible && not (path_is_identity reversible && path_is_identity direct) then
         class_has_args c_expected, class_has_args c_inferred, reversible, direct
       else
         aux cs

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -299,6 +299,9 @@ let lookup_pattern_path_between env (s,t) =
 let path_is_reversible p =
   List.for_all (fun c -> c.coe_reversible) p
 
+let path_is_identity p =
+  List.for_all (fun c -> c.coe_is_identity) p
+
 (* rajouter une coercion dans le graphe *)
 
 let path_printer : ((cl_typ * cl_typ) * inheritance_path -> Pp.t) ref =

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -95,6 +95,7 @@ val lookup_pattern_path_between :
   env -> inductive * inductive -> (constructor * int) list
 
 val path_is_reversible : inheritance_path -> bool
+val path_is_identity : inheritance_path -> bool
 
 (**/**)
 (* Crade *)

--- a/test-suite/bugs/bug_20740.v
+++ b/test-suite/bugs/bug_20740.v
@@ -1,0 +1,27 @@
+Structure C := {
+  Ty :> Type;
+
+  coercion_to_unit : Ty -> unit
+}.
+
+#[reversible]
+Coercion coercion_to_unit : Ty >-> unit.
+
+Structure A_ := {
+  term_a : unit
+}.
+Definition A : Type := {| coercion_to_unit := term_a |}.
+Identity Coercion coe_A : A >-> Ty.
+Canonical a (x : unit) := {| term_a := x |}.
+
+Structure B_ := {
+  term_b : unit
+}.
+Definition B : Type := {| coercion_to_unit := term_b |}.
+Identity Coercion coe_B : B >-> Ty.
+Canonical b (x : unit) := {| term_b := x |}.
+
+Check (fun x : unit => x : A).
+Check (fun x : unit => x : B).
+
+Check (fun x : A => x : B). (* this should work *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
If:
- coercion class `A1` is (reverse) coercible to class `C` through class `B`, with the coercion between `A1` and `B` an identity coercion `id_A1`;
- coercion class `A2` is coercible to class `C` through class `B`, with the coercion between `A2` and `B` an identity coercion `id_A2`

Then we prevent class `B` from being picked as the common source class for the reverse coercion. 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20740


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
