### PR TITLE
Support comments in rocqtop directive

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -473,13 +473,13 @@ Ltac2 models backtracking computations using streams of values: the head of a no
 
 Backtracking failures (empty streams) are moreover decorated with exceptions to inform the reason of failure. These exceptions are then passed to the tail of a non-empty backtracking computation. The following Ltac2 type summarizes the model for backtracking computations
 
-  .. rocqtop:: in
+.. rocqtop:: in
 
-    Ltac2 Type rec 'a backtracking_stream :=
-      [ EmptyStream(exn)
-      | ConsStream('a, (exn -> 'a backtracking_stream)) ].
+  Ltac2 Type rec 'a backtracking_stream :=
+    [ EmptyStream(exn) (* backtracking failure holding an exception *)
+    | ConsStream('a, (exn -> 'a backtracking_stream)) ] (* backtracking success *).
 
-where `EmptyStream` is a backtracking failure holding an exception and `ConsStream` is a backtracking success with a value `'a` as its head and a backtracking handler parameterized by an exception. When sequenced with additional backtracking computations, a backtracking success may lead to a failure with an exception that will be passed to the handler.
+where `ConsStream` is a backtracking success with a value of type `'a` as its head and a backtracking handler parameterized by an exception. When sequenced with additional backtracking computations, a backtracking success may lead to a failure with an exception that will be passed to the handler.
 
 
 In practice, the backtracking aspects of Ltac2's computations can be accessed through the following primitives, defined in the `Control` module::

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -762,10 +762,10 @@ class CoqtopBlocksTransform(Transform):
         ['A.\n', 'B.']
 
         >>> split_lines('A.\n\nB.''')
-        ['A.\n\n', 'B.']
+        ['A.\n', '\nB.']
 
         >>> split_lines('A.\n\nB.\n''')
-        ['A.\n\n', 'B.']
+        ['A.\n', '\nB.']
 
         >>> split_lines("SearchPattern (_ + _ = _ + _).\n"
         ...             "SearchPattern (nat -> bool).\n"
@@ -791,13 +791,13 @@ class CoqtopBlocksTransform(Transform):
         comment = r"\(\*.*\*\)"
         # the end of a chunk is marked by
         # a period (\.)
-        # optional blanks or comments (?:\s*|{comment})*
+        # optional blanks or comments (?:[ \t]*|{comment})*
         # followed by a newline \n
         # We capture everything starting from the '.' to recover it afterwards
-        end_of_chunk = fr"(\.(?:\s*|{comment})*\n)"
+        blank = r"[ \t]"
+        end_of_chunk = fr"(\.(?:{blank}*|{comment})*\n)"
         splits = re.split(end_of_chunk, source.strip())
-        chunks = [splits[i:i+2] for i in range(0, len(splits), 2)]
-        return list(map(lambda e : ''.join(e), chunks))
+        return [''.join(splits[i:i+2]) for i in range(0, len(splits), 2)]
 
     @staticmethod
     def parse_options(node):


### PR DESCRIPTION
Changed split_lines so that it does not split when a comment ends a line

In split_lines we now capture the end of the line (with spaces and comments, etc) to make them whole again after re.split.

I also changed ltac2.rst to include an example of snippet which was not accepted before.

@kyoDralliam: is it what you wanted in this refman page?

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #20438
