### PR TITLE
Add some Ltac1CompatNotations

### DIFF
--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -402,9 +402,9 @@ let () =
 (** Rewritings *)
 
 let () =
-  define "tac_change"
-    (option pattern @-> fun1 (array constr) constr @-> clause @-> tac unit)
-    Tac2tactics.change
+  define "tac_change_gen"
+    (bool @-> option pattern @-> fun1 (array constr) constr @-> clause @-> tac unit) @@
+    fun check pat c cl -> Tac2tactics.change ~check pat c cl
 
 let () =
   define "tac_rewrite"

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -165,14 +165,14 @@ let specialize c pat =
   let pat = Option.map mk_intro_pattern pat in
   Tactics.specialize c pat
 
-let change pat c cl =
+let change ~check pat c cl =
   Proofview.Goal.enter begin fun gl ->
   let c subst env sigma =
     let subst = Array.map_of_list snd (Id.Map.bindings subst) in
     Tacred.Changed (delayed_of_tactic (c subst) env sigma)
   in
   let cl = mk_clause cl in
-  Tactics.change ~check:true pat c cl
+  Tactics.change ~check pat c cl
   end
 
 let rewrite ev rw cl by =

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -41,7 +41,7 @@ val split_with_bindings : evars_flag -> bindings -> unit tactic
 
 val specialize : constr_with_bindings -> intro_pattern option -> unit tactic
 
-val change : Pattern.constr_pattern option -> (constr array, constr) Tac2ffi.fun1 -> clause -> unit tactic
+val change : check:bool -> Pattern.constr_pattern option -> (constr array, constr) Tac2ffi.fun1 -> clause -> unit tactic
 
 val rewrite :
   evars_flag -> rewriting list -> clause -> unit thunk option -> unit tactic

--- a/theories/Ltac2/Control.v
+++ b/theories/Ltac2/Control.v
@@ -37,6 +37,15 @@ Ltac2 @ external case : (unit -> 'a) -> ('a * (exn -> 'a)) result := "rocq-runti
   [case] reifies a backtracking computation into an inspectable value, it allows the programmer to make explicit the effects which are normally implicit (i.e., they do not appear in the type system).
 *)
 
+(** If the first tactic has any successes then use it, otherwise use the other tactic. *)
+Ltac2 orelse t f :=
+  match case t with
+  | Err e => f e
+  | Val ans =>
+      let (x, k) := ans in
+      plus (fun _ => x) k
+  end.
+
 Ltac2 once_plus (run : unit -> 'a) (handle : exn -> 'a) : 'a :=
   once (fun () => plus run handle).
 (** [once_plus run handle] is [once] applied to [plus run handle]. *)

--- a/theories/Ltac2/Ltac1CompatNotations.v
+++ b/theories/Ltac2/Ltac1CompatNotations.v
@@ -15,6 +15,113 @@
    or if they are really wanted.
 *)
 
-Require Import Ltac2.Init Ltac2.Std.
+From Corelib.Init Require Import Ltac Tactics.
+From Ltac2 Require Import Init Notations.
+From Ltac2 Require Std Control Constr Ltac1.
+
+Ltac2 Notation t1(thunk(self)) "+" t2(thunk(self)) : 2 := Control.plus t1 (fun _ => t2 ()).
+
+(* abstract: in Notations *)
+
+Ltac2 Notation "absurd" c(constr) : 1 := ltac1:(c |- absurd c) (Ltac1.of_constr c).
+
+(* admit, apply, assert: in Notations *)
+
+Ltac2 Type exn ::= [ Succeeded ].
+
+(* XXX drops backtrace *)
+Ltac2 assert_succeeds0 (tac:unit -> unit) :=
+  Control.orelse (fun () => Control.once tac; Control.zero Succeeded)
+    (fun e => match e with Succeeded => () | _ => Control.zero e end).
+Ltac2 Notation "assert_succeeds" tac(thunk(tactic(3))) : 1 := assert_succeeds0 tac.
+
+(* XXX could also accept "tac:unit -> 'a", do we want to? *)
+Ltac2 assert_fails0 (tac:unit -> unit) :=
+  match Control.case tac with
+  | Val ((),_) => Control.backtrack_tactic_failure "succeeds"
+  | Err _ => ()
+  end.
+Ltac2 Notation "assert_fails" tac(thunk(tactic(3))) : 1 := assert_fails0 tac.
+
+(* assumption, auto: in Notations *)
+
+Ltac2 Notation "autoapply" c(constr) "with" id(ident) : 1 :=
+  ltac1:(c id |- autoapply c with id) (Ltac1.of_constr c) (Ltac1.of_ident id).
+
+(* autorewrite, autounfold, autounfold_one: TODO *)
+
+(* btauto: TODO (or don't) *)
+
+(* case, case_eq: TODO *)
+
+(* cbn, cbv, change: in Notations *)
+
+Ltac2 Notation "change_no_check" c(conversion) cl(opt(clause)) : 1 :=
+  let (pat, c) := c in
+  Std.change_no_check pat c (default_on_concl cl).
+
+(* classical_left/right: TODO *)
+
+(* clear: in Notations *)
+
+(* clear dependent, clearbody: TODO *)
+
+(* cofix: TODO *)
+
+(* compare: TODO (or don't) *)
+
+(* compute: TODO (or let people use cbv) *)
+
+(* congruence: in Notations *)
+
+Ltac2 Notation "constr_eq" c1(constr) c2(constr) : 1 :=
+  ltac1:(c1 c2 |- constr_eq c1 c2) (Ltac1.of_constr c1) (Ltac1.of_constr c2).
+
+Ltac2 Notation "constr_eq_nounivs" c1(constr) c2(constr) : 1 :=
+  ltac1:(c1 c2 |- constr_eq_nounivs c1 c2) (Ltac1.of_constr c1) (Ltac1.of_constr c2).
+
+Ltac2 Notation "constr_eq_strict" c1(constr) c2(constr) : 1 :=
+  if Constr.equal c1 c2 then ()
+  else Control.backtrack_tactic_failure "Not equal".
+
+(* constructor: in Notations *)
+
+(* context: not sure *)
+
+Ltac2 Notation "contradict" id(ident) : 1 := ltac1:(id |- contradict id) (Ltac1.of_ident id).
+
+(* contradiction, convert, cut: TODO *)
+
+(* cycle: in Notations *)
+
+(* TODO:
+  debug auto
+  debug eauto
+  debug trivial
+  decide
+  decide equality
+  decompose
+  decompose record
+  decompose sum
+  dependent destruction
+  dependent generalize_eqs
+  dependent generalize_eqs_vars
+  dependent induction
+  dependent inversion
+  dependent inversion_clear
+  dependent rewrite
+  dependent simple inversion
+  destauto
+*)
+
+(* destruct: in Notations *)
+
+(* dintuition: TODO *)
+
+(* discriminate, do: in Notations *)
+
+(* dtauto: TODO *)
+
+(* e-z: not checked yet *)
 
 Ltac2 Notation "transitivity" c(constr) := Std.transitivity c.

--- a/theories/Ltac2/Std.v
+++ b/theories/Ltac2/Std.v
@@ -293,8 +293,13 @@ Ltac2 eval_vm (ctx : (pattern * occurrences) option) (c : constr) : constr := ev
 
 Ltac2 eval_native (ctx : (pattern * occurrences) option) (c : constr) : constr := eval (Red.native ctx) c.
 
+Local Ltac2 @external change_gen : bool -> pattern option -> (constr array -> constr) -> clause -> unit := "rocq-runtime.plugins.ltac2" "tac_change_gen".
 
-Ltac2 @ external change : pattern option -> (constr array -> constr) -> clause -> unit := "rocq-runtime.plugins.ltac2" "tac_change".
+Ltac2 change (pat:pattern option) (c:constr array -> constr) (cl:clause) : unit :=
+  change_gen true pat c cl.
+
+Ltac2 change_no_check (pat:pattern option) (c:constr array -> constr) (cl:clause) : unit :=
+  change_gen false pat c cl.
 
 Ltac2 @ external rewrite : evar_flag -> rewriting list -> clause -> (unit -> unit) option -> unit := "rocq-runtime.plugins.ltac2" "tac_rewrite".
 


### PR DESCRIPTION
I went through
https://rocq-prover.org/doc/master/refman/coq-tacindex.html in order (skipping SSR tactics), adding the easy ones and adding a TODO comment for the rest.

(currently stopped after "d" tactics)
