### PR TITLE
Fix level of Ltac1CompatNotations transitivity notation

### DIFF
--- a/theories/Ltac2/Ltac1CompatNotations.v
+++ b/theories/Ltac2/Ltac1CompatNotations.v
@@ -17,4 +17,4 @@
 
 Require Import Ltac2.Init Ltac2.Std.
 
-Ltac2 Notation "transitivity" c(constr) := Std.transitivity c.
+Ltac2 Notation "transitivity" c(constr) : 1 := Std.transitivity c.


### PR DESCRIPTION
Ltac1 does not create a syntax rule for it (because the only arg is constr) so it's parsed as an application.
