### PR TITLE
Ltac2 autodetect notation levels + manual fixes

### DIFF
--- a/doc/changelog/06-Ltac2-language/20759-ltac2-nota-levels-Changed.rst
+++ b/doc/changelog/06-Ltac2-language/20759-ltac2-nota-levels-Changed.rst
@@ -1,0 +1,12 @@
+- **Changed:**
+  :cmd:`Ltac2 Notation` without an explicit level puts the notation at level `1` instead of `5`
+  when it starts with a string which is an identifier.
+  Various notations have consequently changed level (e.g. `apply`).
+  (`#20759 <https://github.com/rocq-prover/rocq/pull/20759>`_,
+  fixes `#20616 <https://github.com/rocq-prover/rocq/issues/20616>`_,
+  by Gaëtan Gilbert).
+- **Changed:**
+  well parenthesized notations (`match!`, `lazy_match!`, etc) are now at level `0` instead of `5`,
+  and `now` is at level `1` instead of `6` (its argument is still at level `6`)
+  (`#20759 <https://github.com/rocq-prover/rocq/pull/20759>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1272,7 +1272,12 @@ Notations
 
    :cmd:`Ltac2 Notation` provides a way to extend the syntax of Ltac2 tactics.  The left-hand
    side (before the `:=`) defines the syntax to recognize and gives formal parameter
-   names for the syntactic values.  :n:`@natural` is the level of the notation.
+   names for the syntactic values.
+
+   :n:`@natural` is the level of the notation. When not provided, if
+   the notation starts with a string which is an identifier (e.g.
+   `"apply"`) the level is `1`, otherwise it is `5`.
+
    When the notation is used, the values are substituted
    into the right-hand side.  In the following example, `x` is the formal parameter name and
    `constr` is its :ref:`syntactic class<syntactic_classes>`.  `print` and `of_constr` are

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -821,7 +821,12 @@ let register_notation atts tkn lev body =
           user_err (str "Notation levels must range between 0 and 6")
       in
       n
-    | None -> 5
+    | None ->
+      (* autodetect level *)
+      begin match entries with
+        | TacTerm s :: _ when Names.Id.is_valid s -> 1
+        | _ -> 5
+      end
     in
     let key = make_fresh_key tkn in
     let ext = {

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -203,13 +203,17 @@ Ltac2 Notation eright := eright.
 Ltac2 constructor0 ev n bnd :=
   enter_h ev (fun ev bnd => Std.constructor_n ev n bnd) bnd.
 
-Ltac2 Notation "constructor" := Control.enter (fun () => Std.constructor false).
-Ltac2 Notation constructor := constructor.
-Ltac2 Notation "constructor" n(tactic) bnd(thunk(with_bindings)) := constructor0 false n bnd.
+Local Ltac2 constructor1 ev x :=
+  match x with
+  | None => Control.enter (fun () => Std.constructor ev)
+  | Some (tac, bnd) => constructor0 ev tac bnd
+  end.
 
-Ltac2 Notation "econstructor" := Control.enter (fun () => Std.constructor true).
-Ltac2 Notation econstructor := econstructor.
-Ltac2 Notation "econstructor" n(tactic) bnd(thunk(with_bindings)) := constructor0 true n bnd.
+Ltac2 Notation constructor := constructor1 false None.
+Ltac2 Notation "constructor" x(opt(seq(tactic,thunk(with_bindings)))) := constructor1 false x.
+
+Ltac2 Notation econstructor := constructor1 true None.
+Ltac2 Notation "econstructor" x(opt(seq(tactic,thunk(with_bindings)))) := constructor1 true x.
 
 Ltac2 specialize0 c pat :=
   enter_h false (fun _ c => Std.specialize c pat) c.

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -636,7 +636,7 @@ Ltac2 Notation f_equal := Std.f_equal ().
 (** now *)
 
 Ltac2 now0 t := t (); ltac1:(easy_forward_decl).
-Ltac2 Notation "now" t(thunk(self)) : 6 := now0 t.
+Ltac2 Notation "now" t(thunk(tactic(6))) := now0 t.
 
 (** profiling *)
 

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -14,33 +14,33 @@ Require Ltac2.Control Ltac2.Fresh Ltac2.Option Ltac2.Pattern Ltac2.Array Ltac2.I
 
 (** Constr matching *)
 
-Ltac2 Notation "lazy_match!" t(tactic(6)) "with" m(constr_matching) "end" :=
+Ltac2 Notation "lazy_match!" t(tactic(6)) "with" m(constr_matching) "end" : 0 :=
   Pattern.lazy_match0 t m.
 
-Ltac2 Notation "multi_match!" t(tactic(6)) "with" m(constr_matching) "end" :=
+Ltac2 Notation "multi_match!" t(tactic(6)) "with" m(constr_matching) "end" : 0 :=
   Pattern.multi_match0 t m.
 
-Ltac2 Notation "match!" t(tactic(6)) "with" m(constr_matching) "end" :=
+Ltac2 Notation "match!" t(tactic(6)) "with" m(constr_matching) "end" : 0 :=
   Pattern.one_match0 t m.
 
 (** Goal matching *)
 
-Ltac2 Notation "lazy_match!" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "lazy_match!" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.lazy_goal_match0 false m.
 
-Ltac2 Notation "multi_match!" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "multi_match!" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.multi_goal_match0 false m.
 
-Ltac2 Notation "match!" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "match!" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.one_goal_match0 false m.
 
-Ltac2 Notation "lazy_match!" "reverse" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "lazy_match!" "reverse" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.lazy_goal_match0 true m.
 
-Ltac2 Notation "multi_match!" "reverse" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "multi_match!" "reverse" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.multi_goal_match0 true m.
 
-Ltac2 Notation "match!" "reverse" "goal" "with" m(goal_matching) "end" :=
+Ltac2 Notation "match!" "reverse" "goal" "with" m(goal_matching) "end" : 0 :=
   Pattern.one_goal_match0 true m.
 
 (** Tacticals *)


### PR DESCRIPTION
Manual fixes: the well-parenthesized "match!" notations go at level 0, now is at level 1 with arg at level 6.

Autodetect simple heuristic:
- starts with ident (or ident-like keyword): level 1
- otherwise level 5

NB: we could autodetect notations that are just an ident to be level 0
but then it can factor badly.

(typically this means that if we define an infix `+` for backtracking at any level above application level, `apply foo + apply bar` will work)

Fix #20616