### PR TITLE
Remove the hint_term type from the Hints API.

### DIFF
--- a/dev/ci/user-overlays/20781-ppedrot-hints-remove-hint-ref.sh
+++ b/dev/ci/user-overlays/20781-ppedrot-hints-remove-hint-ref.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi hints-remove-hint-ref 20781
+
+overlay equations https://github.com/ppedrot/Coq-Equations hints-remove-hint-ref 20781
+
+overlay fiat_parsers https://github.com/ppedrot/fiat hints-remove-hint-ref 20781

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1039,8 +1039,8 @@ let make_mode ref m =
     else m'
 
 let make_trivial env sigma r =
-  let name = name_of_hint r in
-  let c,ctx = fresh_global_or_constr env sigma r in
+  let name = Some r in
+  let c,ctx = fresh_global_or_constr env sigma (IsGlobRef r) in
   let sigma = merge_context_set_opt sigma ctx in
   let t = hnf_constr env sigma (Retyping.get_type_of env sigma c) in
   let hd = head_constr sigma t in
@@ -1414,7 +1414,7 @@ let add_resolves env sigma clist ~locality dbnames =
     (fun dbname ->
       let r =
         List.flatten (List.map (fun (pri, hnf, gr) ->
-          make_resolves env sigma (true, hnf) pri ~check:true gr) clist)
+          make_resolves env sigma (true, hnf) pri ~check:true (IsGlobRef gr)) clist)
       in
       let check (_, hint) = match hint.code.obj with
       | ERes_pf { rhint_term = c; rhint_type = cty; rhint_uctx = ctx } ->
@@ -1493,8 +1493,8 @@ type hnf = bool
 type nonrec hint_info = hint_info
 
 type hints_entry =
-  | HintsResolveEntry of (hint_info * hnf * hint_term) list
-  | HintsImmediateEntry of hint_term list
+  | HintsResolveEntry of (hint_info * hnf * GlobRef.t) list
+  | HintsImmediateEntry of GlobRef.t list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of Evaluable.t list
   | HintsTransparencyEntry of Evaluable.t hints_transparency_target * bool
@@ -1576,8 +1576,6 @@ let add_hints ~locality dbnames h =
       add_transparency lhints b ~locality dbnames
   | HintsExternEntry (info, tacexp) ->
       add_externs info tacexp ~locality dbnames
-
-let hint_globref gr = IsGlobRef gr
 
 let warn_non_reference_hint_using =
   CWarnings.create ~name:"non-reference-hint-using" ~category:CWarnings.CoreCategories.deprecated

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -166,11 +166,9 @@ type hint_db = Hint_db.t
 
 type hnf = bool
 
-type hint_term
-
 type hints_entry =
-  | HintsResolveEntry of (hint_info * hnf * hint_term) list
-  | HintsImmediateEntry of hint_term list
+  | HintsResolveEntry of (hint_info * hnf * GlobRef.t) list
+  | HintsImmediateEntry of GlobRef.t list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of Evaluable.t list
   | HintsTransparencyEntry of Evaluable.t hints_transparency_target * bool
@@ -197,8 +195,6 @@ val current_db_names : unit -> String.Set.t
 val current_pure_db : unit -> hint_db list
 
 val add_hints : locality:hint_locality -> hint_db_name list -> hints_entry -> unit
-
-val hint_globref : GlobRef.t -> hint_term
 
 (** A constr which is Hint'ed will be:
    - (1) used as an Exact, if it does not start with a product

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -47,11 +47,10 @@ let set_typeclass_mode ~locality c b =
     (Hints.HintsModeEntry (c, b))
 
 let add_instance_hint gr ~locality info =
-  let inst = Hints.hint_globref gr in
      Flags.silently (fun () ->
        Hints.add_hints ~locality [typeclasses_db]
           (Hints.HintsResolveEntry
-             [info, false, inst])) ()
+             [info, false, gr])) ()
 
 (* short names without opening all Hints *)
 type locality = Hints.hint_locality = Local | Export | SuperGlobal

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -62,7 +62,7 @@ let project_hint ~poly pri l2r r =
       cb
   in
   let info = {Typeclasses.hint_priority = pri; hint_pattern = None} in
-  (info, true, Hints.hint_globref (GlobRef.ConstRef c))
+  (info, true, GlobRef.ConstRef c)
 
 (* Only error when we have to (axioms may be instantiated if from functors)
    XXX maybe error if not from a functor argument?
@@ -88,11 +88,9 @@ let interp_hints ~poly h =
   in
   let fr r = soft_evaluable ?loc:r.CAst.loc (fref r) in
   let fi c =
-    let open Hints in
     match rectify_hint_constr c with
     | Some c ->
-      let gr = Smartlocate.global_with_alias c in
-      (hint_globref gr)
+      Smartlocate.global_with_alias c
     | None ->
       CErrors.user_err (Pp.strbrk
         "Declaring arbitrary terms as hints is forbidden. You must declare a \
@@ -136,7 +134,7 @@ let interp_hints ~poly h =
           let gr = GlobRef.ConstructRef c in
           ( empty_hint_info
           , true
-          , hint_globref gr ))
+          , gr ))
     in
     HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))
   | HintsExtern (pri, patcom, tacexp) ->


### PR DESCRIPTION
Since we removed the generic constr hint feature, this is now useless.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/837
- https://github.com/mattam82/Coq-Equations/pull/657
- https://github.com/mit-plv/fiat/pull/123