### PR TITLE
Simplify some uses of pr_global_env

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -805,7 +805,7 @@ let warn_abstract_large_num =
     (fun (ty,f) ->
       strbrk "To avoid stack overflow, large numbers in " ++
       pr_qualid ty ++ strbrk " are interpreted as applications of " ++
-      Nametab.pr_global_env (Termops.vars_of_env (Global.env ())) f ++ strbrk ".")
+      Termops.pr_global_env (Global.env ()) f ++ strbrk ".")
 
 (***********************************************************************)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -211,12 +211,12 @@ let discharge_Function finfos = Some finfos
 
 let pr_ocst env sigma c =
   Option.fold_right
-    (fun v acc -> Printer.pr_global_env (Termops.vars_of_env env) (ConstRef v))
+    (fun v acc -> Termops.pr_global_env env (ConstRef v))
     c (mt ())
 
 let pr_info env sigma f_info =
   str "function_constant := "
-  ++ Printer.pr_global_env (Termops.vars_of_env env) (ConstRef f_info.function_constant)
+  ++ Termops.pr_global_env env (ConstRef f_info.function_constant)
   ++ fnl ()
   ++ str "function_constant_type := "
   ++ ( try

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -377,8 +377,7 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_evaluable_reference_env env = function
     | Evaluable.EvalVarRef id -> pr_id id
-    | Evaluable.EvalConstRef sp ->
-      Nametab.pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef sp)
+    | Evaluable.EvalConstRef sp -> Termops.pr_global_env env (GlobRef.ConstRef sp)
     | Evaluable.EvalProjectionRef p ->
       str "TODO projection" (* TODO *)
 

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -36,7 +36,7 @@ let warn_abstract_large_num_no_op =
     (fun f ->
       strbrk "The 'abstract after' directive has no effect when " ++
       strbrk "the parsing function (" ++
-      Nametab.pr_global_env (Termops.vars_of_env (Global.env ())) f ++ strbrk ") targets an " ++
+      Termops.pr_global_env (Global.env ()) f ++ strbrk ") targets an " ++
       strbrk "option type.")
 
 let get_constructors ind =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -309,9 +309,9 @@ let pr_puniverses f env sigma (c,u) =
 let pr_existential_key = Termops.pr_existential_key
 let pr_existential env sigma ev = pr_lconstr_env env sigma (mkEvar ev)
 
-let pr_constant env cst = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef cst)
-let pr_inductive env ind = pr_global_env (Termops.vars_of_env env) (GlobRef.IndRef ind)
-let pr_constructor env cstr = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstructRef cstr)
+let pr_constant env cst = Termops.pr_global_env env (GlobRef.ConstRef cst)
+let pr_inductive env ind = Termops.pr_global_env env (GlobRef.IndRef ind)
+let pr_constructor env cstr = Termops.pr_global_env env (GlobRef.ConstructRef cstr)
 
 let pr_pconstant = pr_puniverses pr_constant
 let pr_pinductive = pr_puniverses pr_inductive
@@ -1094,7 +1094,7 @@ let pr_assumptionset env sigma s =
         Names.Constant.print kn
     in
     let safe_pr_global env gr =
-      try pr_global_env (Termops.vars_of_env env) gr
+      try Termops.pr_global_env env gr
       with Not_found ->
         let open GlobRef in match gr with
         | VarRef id -> Id.print id


### PR DESCRIPTION
Simplify some uses of `pr_global_env` by using `Termops.pr_global_env`.