### PR TITLE
Backtrack on eta in tactic unification

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1569,7 +1569,9 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env cv_pb flags 
       let fold u1 u s = unirec_rec curenvnb pb opt' s u1 (substl ks u) in
       let foldl acc l1 l2 =
         try List.fold_right2 fold l1 l2 acc
-        with Invalid_argument _ -> assert false (* check_conv_record ensures lengths coincide *)
+        with Invalid_argument _ ->
+          (* assert false (\* check_conv_record ensures lengths coincide *\) *)
+          error_cannot_unify (fst curenvnb) sigma (cM,cN)
       in
       let substn = foldl substn us2 us in
       let substn = match params1 with None -> substn | Some params1 -> foldl substn params1 params in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -828,7 +828,7 @@ let expand_table_key ~metas ts env sigma args = function
         end
         | exception NotEvaluableConst _ -> None
       else None
-  | VarKey id -> (try named_body id env |> Option.map (fun c -> (EConstr.of_constr c, args)) with Not_found -> None)
+  | VarKey id -> named_body id env |> Option.map (fun c -> (EConstr.of_constr c, args))
   | RelKey _ -> None
 
 let unfold_projection env p r stk =


### PR DESCRIPTION
*Dev log*

Wednesday:
- @mattam82 conjectures that the looping behavior in itree is likely due to `unify_app` posing entirely ill-typed unification problems of which there are now more and more interesting examples that eventually lead to divergence.
- We tried to confirm this with extra typechecking in `unify_app` but this turns out to be not so easy to get right, even just for debugging purposes.
- We instead try to restrict `unify_app` to problems with the same had symbol on either side (as is done in `evarconv`?). This *should* mostly work because the alternative routes taken *should* end up performing the necessary reduction steps to find the same solutions.
- Instead, we can barely build stdlib with failures in `auto` on the most basic of unification problems. In particular, we cannot unify `f ?x = projT1 (existT f some_proof) y` in unification triggered by hint application through `auto`. 
- After about six hours of very, very painful hours of `printf` debugging, I can confidently claim the following:
  The unification `f ?x = projT1 (existT f some_proof) y` triggered by hint application in `auto` should very clearly not succeed and the fact that it does succeed on master is a testament to how messed up tactic unification truly is.
  To expand on that: Hint application in `auto` calls `unify_resolve_nodelta` and by the very name of that function this unification attempt should fail. It does not fail because of the following steps.
  1. Through `unify_app` we arrive at `f = projT1 (existT f some_proof)` (and a trivial sub-problem `?x = y`).
    While the types happen to match up in this case, this step is not actually justified by any kind of type agreement or in any other way in the code and should not be performed. However, we get lucky this time.
  2. Since we have stripped off `?x` from `f ?x`, both sides of the unification problem are now free of evars. This fact allows us to go straight to conversion in `expand`. Conversion, unlike the entire rest of the unification, runs with full `delta`.
  3. We reduce both sides to `f` and happily succeed.
* Since `f` and `projT1` are not the same symbol, our current (uncommitted) code will not attempt `unify_app` on them.
* That means we end up calling `expand` with `f ?x` instead of just `f`, the difference being that `f ?x` is not evar free.
* For that reason, we do not attempt conversion but instead try to reduce the terms in the normal way which is blocked because `delta` is disabled everywhere except in conversion.

Thursday:
* TODO: the problem above can be fixed by ~~deleting tactic unification and every development that depends on it, including corelib and stdlib~~ emulating the old behavior but only in so far as it pertains to conversion calls. A sketch of what to do:
  1. For `f x_0 .. x_m ~ g y_0 .. y_n` find the smallest `0 < k <= min m n` such that `f x_0 .. x_(m-k)` and `g y_0 .. y_(n - k)` are evar free. If there is no such prefix, continue without changing the terms.
  2. Attempt to solve  `f x_0 .. x_(m-k) ~= g y_0 .. y_(n - k)`  using conversion. If that succeeds, solve the remaining unification problems `[x_(m-k+1); ..; x_m] ~=
y_(n-k+1); ..; y_n]` in the usual pairwise fashion.
  3. If it fails, do not attempt conversion on any of the prefixes. Even if it did succeed, there is no way those partial successes can lead to progress. Instead, continue without changing the terms.
  
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Also improves avoids wasted work in trying to unfold variables without bodies.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
