### PR TITLE
Require that a module is already declared before checking subtyping.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -217,9 +217,8 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
   | MEapply (f,mp) ->
     let sign, delta = check_mexpr env opac f mp_mse res in
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
-    let mtb = Modops.module_type_of_module (lookup_module mp env) in
     let state = (Environ.universes env, Conversion.checked_universes) in
-    let _ : UGraph.t = Subtyping.check_subtypes state env mp mtb (MPbound farg_id) farg_b in
+    let _ : UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
     let subst = Mod_subst.map_mbid farg_id mp (Mod_subst.empty_delta_resolver mp) in
     Modops.subst_signature subst mp_mse fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")
@@ -255,7 +254,8 @@ let rec check_module env opac mp mb opacify =
     let mtb1 = mk_mtb sign delta
     and mtb2 = mk_mtb (mod_type mb) delta_mb in
     let state = (Environ.universes env, Conversion.checked_universes) in
-    let _ : UGraph.t = Subtyping.check_subtypes state env mp mtb1 mp mtb2 in
+    let env = Modops.add_module mp (module_body_of_type mtb1) env in
+    let _ : UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
     ()
   in
   opac

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -170,11 +170,10 @@ let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
     if List.is_empty idl then
       (* Toplevel module definition *)
       let new_mb = lookup_module new_mp env in
-      let new_mtb = module_type_of_module new_mb in
       let cst = match Mod_declarations.mod_expr old with
         | Abstract ->
           let mtb_old = module_type_of_module old in
-          let cst = Subtyping.check_subtypes (cst, ustate) env' new_mp new_mtb (MPdot (mp, lab)) mtb_old in
+          let cst = Subtyping.check_subtypes (cst, ustate) env' new_mp (MPdot (mp, lab)) mtb_old in
           cst
         | Algebraic (MENoFunctor (MEident(mp'))) ->
           check_modpath_equiv env' new_mp mp';
@@ -251,7 +250,7 @@ let rec translate_apply ustate env inl mp subst (sign, reso, cst) args = match a
     else subst_modtype subst_codom subst (MPbound farg_id) farg_b
   in
   let mtb = module_type_of_module (lookup_module mp1 env) in
-  let cst = Subtyping.check_subtypes (cst, ustate) env mp1 mtb (MPbound farg_id) farg_b in
+  let cst = Subtyping.check_subtypes (cst, ustate) env mp1 (MPbound farg_id) farg_b in
   let mp_delta = discr_resolver mp1 mtb in
   let mp_delta = inline_delta_resolver env inl mp1 farg_id farg_b mp_delta in
   let nsubst = map_mbid farg_id mp1 mp_delta in
@@ -325,7 +324,8 @@ let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) resty
   | Some (params_mte,inl) ->
     let res_mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl params_mte in
     let auto_mtb = mk_modtype sign reso in
-    let cst = Subtyping.check_subtypes (cst, ustate) env mp auto_mtb mp res_mtb in
+    let env = Modops.add_module mp (module_body_of_type auto_mtb) env in
+    let cst = Subtyping.check_subtypes (cst, ustate) env mp mp res_mtb in
     let impl = match alg with
     | Some e -> Algebraic e
     | None ->

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1427,7 +1427,8 @@ let add_include me is_module inl senv =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
       let state = check_state senv in
-      let (_ : UGraph.t) = Subtyping.check_subtypes state senv.env mp_sup mb (MPbound mbid) mtb in
+      let env = Modops.add_module mp_sup (module_body_of_type mb) senv.env in
+      let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver
       in

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -343,8 +343,11 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 equiv
     in
     check_structure cst ~nargs:0 env (mod_type mtb1) (mod_type mtb2) equiv subst1 subst2
 
-let check_subtypes state env mp_sup sup mp_super super =
-  let env = add_module mp_sup (module_body_of_type sup) env in
+let check_subtypes state env mp_sup mp_super super =
+  let sup = match Environ.lookup_module mp_sup env with
+  | mb -> module_type_of_module mb
+  | exception Not_found -> assert false
+  in
   check_modtypes state [] env
     mp_sup (strengthen sup mp_sup) mp_super super empty_subst
     (map_mp mp_super mp_sup (mod_delta sup)) false

--- a/kernel/subtyping.mli
+++ b/kernel/subtyping.mli
@@ -12,4 +12,4 @@ open Names
 open Mod_declarations
 open Environ
 
-val check_subtypes : ('a, UGraph.univ_inconsistency) Conversion.universe_state -> env -> ModPath.t -> module_type_body -> ModPath.t -> module_type_body -> 'a
+val check_subtypes : ('a, UGraph.univ_inconsistency) Conversion.universe_state -> env -> ModPath.t -> ModPath.t -> module_type_body -> 'a


### PR DESCRIPTION
The previous code was unconditionally adding the module to the environment, but in some cases the caller was either already performing this addition or had the module already be part of the environment. In order to get a clear invariant, we move this implicit declaration to the caller instead.