### PR TITLE
Automatically generated goal names

### DIFF
--- a/dev/ci/user-overlays/20809-ppedrot-autonaming-goals.sh
+++ b/dev/ci/user-overlays/20809-ppedrot-autonaming-goals.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/ppedrot/coq-tactician autonaming-goals 20809

--- a/doc/changelog/14-misc/20809-autonaming-goals-Added.rst
+++ b/doc/changelog/14-misc/20809-autonaming-goals-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Goal names can be automatically generated for :tacn:`induction`,
+  :tacn:`destruct` and :tacn:`eapply` by using the :flag:`Generate Goal Names` flag
+  (`#20809 <https://github.com/rocq-prover/rocq/pull/20809>`_,
+  by Dario Halilovic).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -432,7 +432,7 @@ Selectors can also be used nested within a tactic expression with the
    .. prodn::
       goal_selector ::= {+, @range_selector }
       range_selector ::= @natural
-      | [ @ident ]
+      | [ @qualid ]
       | @natural - @natural
 
    Applies :token:`ltac_expr3` to the selected goals.  (At the beginning of a
@@ -446,10 +446,10 @@ Selectors can also be used nested within a tactic expression with the
    :n:`{+, @range_selector }`
       The selected goals are the union of the specified :token:`range_selector`\s.
 
-   :n:`[ @ident ]`
-      Limits the application of :token:`ltac_expr3` to the goal previously named
-      :token:`ident` by the user (see :ref:`existential-variables`).  This works
-      even when the goal is not in focus.
+   :n:`[ @qualid ]`
+      Limits the application of :token:`ltac_expr3` to the goal named
+      :token:`qualid` (see :ref:`existential-variables`).  This works even when
+      the goal is not in focus.
 
    :n:`@natural`
       Selects a single goal.

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -610,15 +610,15 @@ Curly braces
    :n:`[ @qualid ]: %{`
      Focuses on the goal named :token:`qualid` even if the goal is not in focus.
      Goals are :term:`existential variables <existential variable>`, which don't
-     have names by default.  You can give a name to a goal by using
-     :n:`refine ?[@ident]`.
+     have names by default, unless you enable the :flag:`Generate Goal Names`
+     flag. You can give a name to a goal by using :n:`refine ?[@ident]`.
 
+   .. _example-working-with-named-goals:
    .. example:: Working with named goals
 
       .. rocqtop:: in
 
          Ltac name_goal name := refine ?[name].  (* for convenience *)
-         Set Printing Goal Names.  (* show goal names, e.g. "(?base)" and "(?step)" *)
 
       .. rocqtop:: all
 
@@ -743,6 +743,76 @@ When a focused goal is proved, Rocq displays a message suggesting use of
    - "None": this makes bullets inactive.
    - "Strict Subproofs": this makes bullets active (this is the default behavior).
 
+.. _named_goals:
+
+Named goals
+~~~~~~~~~~~
+
+You can focus on a goal by using its name. Goals do not have a name by default,
+but a name can be given by using :n:`refine ?[@ident]`, or generated using the
+:flag:`Generate Goal Names` flag.
+
+.. flag:: Generate Goal Names
+
+   Enable automatic generation of goal names for the :tacn:`induction`,
+   :tacn:`destruct` and :tacn:`eapply` tactics. For :tacn:`induction` and
+   :tacn:`destruct`, the subgoal takes the name of the corresponding
+   constructor. For :tacn:`eapply`, the subgoal takes the name of the
+   corresponding hypothesis.
+
+   This option makes it possible to write proofs with multiple subgoals that do
+   not depend on the order in which constructors were defined. If you use
+   bullets or numbers instead, reordering constructors will break the proof.
+
+   .. example:: Automatic generation of goal names
+
+      Continuing the example from :ref:`here <example-working-with-named-goals>`,
+      names are generated for both the base case and the induction case.
+
+      .. rocqtop:: all
+
+         Set Generate Goal Names.
+
+         Goal forall n, n + 0 = n.
+         Proof.
+         induction n.
+         [O]: { (* O is the name of the constructor for zero. *)
+           reflexivity.
+
+      .. rocqtop:: in
+
+         }
+
+      This also gives a name to goals that come from a binder or hypothesis:
+
+      .. rocqtop:: all reset
+
+         Set Generate Goal Names.
+
+         Goal exists n : nat, n = n.
+         eexists.
+         [n]: exact 0.
+         reflexivity.
+         Qed.
+
+   .. example:: Conflicting names
+
+      If several goals generate the same name (e.g. when doing nested case
+      analysis or induction), *qualified names* are used to disambiguate them,
+      using the qualified name of the parent as the basis for the fully
+      qualified name.
+
+      .. rocqtop:: all abort
+
+         Set Generate Goal Names.
+
+         Goal forall n m, n + m = m + n.
+         Proof.
+         intros. induction m.
+         [O]: {
+           simpl. induction n.
+
+
 Other focusing commands
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -775,7 +845,7 @@ Shelving goals
 Goals can be :gdef:`shelved` so they are no longer displayed in the proof state.
 Shelved goals can be unshelved with the :cmd:`Unshelve` command, which
 makes all shelved goals visible in the proof state.  You can use
-the goal selector :n:`[ @ident ]: %{` to focus on a single shelved goal
+the goal selector :n:`[ @qualid ]: %{` to focus on a single shelved goal
 (see :ref:`here <focus_shelved_goal>`).  Currently there's no single command or
 tactic that unshelves goals by name.
 

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -584,7 +584,7 @@ subgoals are also focused.  The two focusing constructs are
 Curly braces
 ~~~~~~~~~~~~
 
-.. tacn:: {? {| @natural | [ @ident ] } : } %{
+.. tacn:: {? {| @natural | [ @qualid ] } : } %{
           %}
    :name: {; }
 
@@ -607,8 +607,8 @@ Curly braces
 
 .. _focus_shelved_goal:
 
-   :n:`[ @ident ]: %{`
-     Focuses on the goal named :token:`ident` even if the goal is not in focus.
+   :n:`[ @qualid ]: %{`
+     Focuses on the goal named :token:`qualid` even if the goal is not in focus.
      Goals are :term:`existential variables <existential variable>`, which don't
      have names by default.  You can give a name to a goal by using
      :n:`refine ?[@ident]`.
@@ -650,7 +650,7 @@ Curly braces
    .. exn:: No such goal (@natural).
       :undocumented:
 
-   .. exn:: No such goal (@ident).
+   .. exn:: No such goal (@qualid).
       :undocumented:
 
    .. exn:: Brackets do not support multi-goal selectors.

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -941,7 +941,7 @@ Requesting information
 ----------------------
 
 
-.. cmd:: Show {? {| @ident | @natural } }
+.. cmd:: Show {? {| @qualid | @natural } }
 
    Displays the current goals.
 
@@ -952,8 +952,8 @@ Requesting information
    :n:`@natural`
      Display only the :token:`natural`\-th goal.
 
-   :n:`@ident`
-     Displays the named goal :token:`ident`. This is useful in
+   :n:`@qualid`
+     Displays the named goal :token:`qualid`. This is useful in
      particular to display a shelved goal but only works if the
      corresponding existential variable has been named by the user
      (see :ref:`existential-variables`) as in the following example.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1339,8 +1339,8 @@ command: [
 
 | DELETE "Show"
 | DELETE "Show" natural
-| DELETE "Show" ident
-| "Show" OPT [ ident | natural ]
+| DELETE "Show" fullyqualid
+| "Show" OPT [ fullyqualid | natural ]
 | DELETE "Show" "Ltac" "Profile"
 | REPLACE "Show" "Ltac" "Profile" "CutOff" integer
 | WITH "Show" "Ltac" "Profile" OPT [ "CutOff" integer | string ]

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1759,8 +1759,8 @@ tactic_mode: [
 | MOVETO simple_tactic subprf
 | REPLACE OPT toplevel_selector "{"
 (* semantically restricted *)
-| WITH OPT ( [ natural | "[" ident "]" ] ":" ) "{"
-| MOVETO simple_tactic OPT ( [ natural | "[" ident "]" ] ":" ) "{"
+| WITH OPT ( [ natural | "[" fullyqualid "]" ] ":" ) "{"
+| MOVETO simple_tactic OPT ( [ natural | "[" fullyqualid "]" ] ":" ) "{"
 | DELETE command
 | DELETENT
 ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1375,7 +1375,7 @@ simple_reserv: [
 range_selector: [
 | natural "-" natural
 | natural
-| test_bracket_ident "[" ident "]"
+| test_bracket_ident "[" fullyqualid "]"
 ]
 
 goal_selector: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -523,7 +523,7 @@ command: [
 | "Unfocused"
 | "Show"
 | "Show" natural
-| "Show" ident
+| "Show" fullyqualid
 | "Show" "Existentials"
 | "Show" "Universes"
 | "Show" "Conjectures"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -837,7 +837,7 @@ command: [
 | "Focus" OPT natural
 | "Unfocus"
 | "Unfocused"
-| "Show" OPT [ ident | natural ]
+| "Show" OPT [ qualid | natural ]
 | "Show" "Existentials"
 | "Show" "Universes"
 | "Show" "Conjectures"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2333,7 +2333,7 @@ goal_selector: [
 
 range_selector: [
 | natural
-| "[" ident "]"
+| "[" qualid "]"
 | natural "-" natural
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1413,7 +1413,7 @@ simple_tactic: [
 | "replace" OPT [ "->" | "<-" ] one_term "with" one_term OPT occurrences OPT ( "by" ltac_expr3 )
 | "typeclasses" "eauto" OPT [ "bfs" | "dfs" | "best_effort" ] OPT nat_or_var OPT ( "with" LIST1 ident )
 | "setoid_replace" one_term "with" one_term OPT ( "using" "relation" one_term ) OPT ( "in" ident ) OPT ( "at" LIST1 int_or_var ) OPT ( "by" ltac_expr3 )
-| OPT ( [ natural | "[" ident "]" ] ":" ) "{"
+| OPT ( [ natural | "[" qualid "]" ] ":" ) "{"
 | [ LIST1 "-" | LIST1 "+" | LIST1 "*" ]
 | "}"
 | "try" ltac_expr3

--- a/engine/evarnames.ml
+++ b/engine/evarnames.ml
@@ -1,0 +1,392 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open Nameops
+
+(** This file contains methods for manipulating qualified evar names. *)
+
+module EvSet = Evar.Set
+module EvMap = Evar.Map
+
+(** If true, this option enables automatic generation of goal names. *)
+let { Goptions.get = generate_goal_names } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Generate";"Goal";"Names"]
+    ~value:false
+    ()
+
+(** Internal representation of qualified evar names.
+
+    Example: "x.y.z" is represented as [{ basename: "z"; path: ["y"; "x"] }]
+
+    To convert to and from [Id.t] (with dots), use [EvarQualid.to_id] and [EvarQualid.of_id]. *)
+module EvarQualid :
+sig
+  type t =
+    { basename: Id.t;
+      path: Id.t list }
+
+  val of_list : Id.t list -> t
+  val of_id : Id.t -> t
+
+  val to_id : t -> Id.t
+end =
+struct
+  type t =
+    { basename: Id.t;
+      path: Id.t list }
+
+  let of_list l =
+    match List.rev l with
+    | basename :: path -> { basename; path }
+    | [] -> failwith "of_list"
+
+  let of_id id =
+    let parts = String.split_on_char '.' (Id.to_string id) in
+    of_list (List.map Id.of_string parts)
+
+  let to_id { basename; path } =
+    let parts = List.rev_map Id.to_string (basename :: path) in
+    Id.of_string_soft (String.concat "." parts)
+end
+
+let of_list l = EvarQualid.to_id (EvarQualid.of_list l)
+
+(** Module for evar name resolution, using a reversed trie.
+
+    Example: given evars "true.A" (?X1), "true.A" (?X2) and "false.A" (?X3), we
+    have the following trie:
+
+    [
+    {
+      A -> {
+        true (?X1, ?X2),
+        false (?X3)
+      }
+    }
+    ]
+
+    In this representation, determining whether a qualified name is unambiguous
+    amounts to checking whether the node has a single value. For example, "A"
+    does not resolve to an evar, "true.A" is ambiguous (?X1, ?X2), while
+    "false.A" (?X3) is unambiguous.
+ *)
+module NameResolution :
+sig
+  type t
+
+  (** Returns an empty trie. *)
+  val empty : t
+
+  (** Adds a new binding for the evar at the shortest unambiguous suffix of the
+      given qualified name, if possible. If there is no such suffix, creates an
+      ambiguous node. *)
+  val add : EvarQualid.t -> Evar.t -> t -> t
+
+  (** Transfers the qualified name of the first evar to the second evar. *)
+  val transfer : EvarQualid.t -> Evar.t -> Evar.t -> t -> t
+
+  (** Removes the qualified name of the given evar from name resolution. *)
+  val remove : EvarQualid.t -> Evar.t -> t -> t
+
+  (** Returns the shortest unambiguous name of the given qualified name.
+      Raises [Not_found] if the evar is not present at a suffix of the qualified
+      name. *)
+  val shortest_name : EvarQualid.t -> Evar.t -> t -> EvarQualid.t
+
+  (** Returns the list of bindings for the given qualified name. *)
+  val find : EvarQualid.t -> t -> Evar.t list
+
+  (** Returns true if there exists a binding that has the given basename. *)
+  val mem_basename : Id.t -> t -> bool
+end =
+struct
+  (** Represents a trie node. For code deduplication reasons, the root is also a node
+      with an empty value. *)
+  type t =
+    { value: Evar.t list;
+      children: t Id.Map.t }
+
+  open EvarQualid
+
+  let empty =
+    { value = []; children = Id.Map.empty }
+
+  let is_empty { value; children } =
+    CList.is_empty value && Id.Map.is_empty children
+
+  let rec add path ev node =
+    match path with
+    | segment :: rest ->
+       let update = function
+         | Some child -> Some (add rest ev child)
+         | None -> Some { value = [ev]; children = Id.Map.empty }
+       in
+       { node with children = Id.Map.update segment update node.children }
+    | [] ->
+       { node with value = ev :: node.value }
+
+  let add { basename; path } ev trie = add (basename :: path) ev trie
+
+  let rec transfer path ev ev' node =
+    match path with
+    | segment :: rest ->
+       { node with children = Id.Map.modify segment (fun _ child -> transfer rest ev ev' child) node.children }
+    | [] ->
+       { node with value = ev' :: CList.remove Evar.equal ev node.value }
+
+  let transfer { basename; path } ev ev' trie = transfer (basename :: path) ev ev' trie
+
+  let[@tail_mod_cons] rec shortest_name path ev node =
+    if CList.mem ev node.value then []
+    else
+      match path with
+      | segment :: rest -> segment :: shortest_name rest ev (Id.Map.find segment node.children)
+      | [] -> raise Not_found
+
+  let shortest_name { basename; path } ev trie =
+    match shortest_name (basename :: path) ev trie with
+    | basename :: path -> { basename; path }
+    | [] -> assert false
+
+  let rec find path node =
+    match path with
+    | segment :: rest ->
+       begin match Id.Map.find_opt segment node.children with
+       | Some segment -> find rest segment
+       | None -> []
+       end
+    | [] -> node.value
+
+  let find { basename; path } trie = find (basename :: path) trie
+
+  let rec remove path ev node =
+    match path with
+    | segment :: rest ->
+       let update_child = function
+         | Some child -> remove rest ev child
+         | None -> None
+       in
+       let node = { node with children = Id.Map.update segment update_child node.children } in
+       (* Prune empty nodes. *)
+       if is_empty node then None else Some node
+    | [] ->
+       let node = { node with value = CList.remove Evar.equal ev node.value } in
+       if is_empty node then None else Some node
+
+  let remove { basename; path } ev trie =
+    match remove (basename :: path) ev trie with
+    | Some trie -> trie
+    | None -> empty
+
+  let mem_basename basename trie =
+    Id.Map.mem basename trie.children
+end
+
+type t =
+  { basename_map : Id.t EvMap.t;
+    (** Map from evar to basename. *)
+
+    name_resolution : NameResolution.t;
+    (** Trie for resolving qualified names to evars. *)
+
+    fresh_gen : Fresh.t;
+    (** Fresh basename generator (to support [refine ?[?A]]) *)
+
+    parent_map : Evar.t EvMap.t;
+    (** Map from evar to its parent, if any. *)
+
+    children_map : EvSet.t EvMap.t;
+    (** Map from an evar to its children that are pending. Essentially the
+        reverse of [parent_map]. *)
+
+    removed_evars : EvSet.t;
+    (** Set of evars marked for removal, and thus unfocusable, whose names are still used as
+        the parent of an open goal. *)
+  }
+
+let empty =
+  { basename_map = EvMap.empty;
+    name_resolution = NameResolution.empty;
+    fresh_gen = Fresh.empty;
+    parent_map = EvMap.empty;
+    children_map = EvMap.empty;
+    removed_evars = EvSet.empty
+  }
+
+(** Returns the absolute path of [ev], obtained by following the [parent_map]. *)
+let[@tail_mod_cons] rec path ev evn =
+  match EvMap.find_opt ev evn.parent_map with
+  | Some parent ->
+     begin match EvMap.find_opt parent evn.basename_map with
+     | Some parent_name -> parent_name :: path parent evn
+     | None -> []
+     end
+  | None -> []
+
+(** Return the absolute qualified name of [ev]. *)
+let absolute_name ev evn =
+  match EvMap.find_opt ev evn.basename_map with
+  | Some basename -> Some EvarQualid.{ basename; path = path ev evn }
+  | None -> None
+
+(** Returns the shortest name that resolves to [ev], or [None] if [ev] does not
+    resolve to a name. *)
+let shortest_name ev evn =
+  match absolute_name ev evn with
+  | Some name -> Some (NameResolution.shortest_name name ev evn.name_resolution)
+  | None -> None
+
+let register_parent ev parent evn =
+  let add_child = function
+    | Some children -> Some (EvSet.add ev children)
+    | None -> Some (EvSet.singleton ev)
+  in
+  { evn with
+    parent_map = EvMap.add ev parent evn.parent_map;
+    children_map = EvMap.update parent add_child evn.children_map }
+
+let add basename ev ?parent evn =
+  let evn =
+    match parent with
+    | Some parent -> register_parent ev parent evn
+    | None -> evn
+  in
+  let qualid = EvarQualid.{ basename; path = path ev evn } in
+  { evn with
+    basename_map = EvMap.add ev basename evn.basename_map;
+    name_resolution = NameResolution.add qualid ev evn.name_resolution;
+    fresh_gen = Fresh.add basename evn.fresh_gen }
+
+let add_fresh basename ev ?parent evn =
+  let evn =
+    match parent with
+    | Some parent -> register_parent ev parent evn
+    | None -> evn
+  in
+  let qualid = EvarQualid.{ basename; path = path ev evn } in
+  match NameResolution.find qualid evn.name_resolution with
+  | [] -> add basename ev evn (* No need to give the parent since it's already registered *)
+  | _ ->
+     (* Generate a fresh basename and try again. *)
+     let basename, fresh_gen = Fresh.fresh basename evn.fresh_gen in
+     add basename ev { evn with fresh_gen }
+
+let rec remove ev evn =
+  match EvMap.find_opt ev evn.basename_map with
+  | None -> evn
+  | Some basename ->
+    (* When defining an evar and making its name unresolvable, there are two scenarios:
+       - The evar has no remaining children, in which case we can safely remove
+         it from all maps since it is not used for name resolution. We also try
+         to remove recursively its parent, since solving the evar might have
+         closed the parent.
+       - The evar has some children which might rely on the parent's name for
+         name resolution. In that case, we simply add it to [removed_evars] (so
+         that [name_of ev] fails), and removal will occur when all children will
+         be solved. *)
+    let children =
+      match EvMap.find_opt ev evn.children_map with
+      | Some children -> children
+      | None -> EvSet.empty
+    in
+    if EvSet.is_empty children then
+      let parent = EvMap.find_opt ev evn.parent_map in
+      let name_resolution =
+        match shortest_name ev evn with
+        | Some name -> NameResolution.remove name ev evn.name_resolution
+        | None -> assert false
+      in
+      let evn =
+        { basename_map = EvMap.remove ev evn.basename_map;
+          name_resolution;
+          fresh_gen =
+            (* If the basename still exists in the new trie, do not remove. *)
+            if NameResolution.mem_basename basename name_resolution then evn.fresh_gen
+            else Fresh.remove basename evn.fresh_gen;
+          children_map = EvMap.remove ev evn.children_map;
+          parent_map = EvMap.remove ev evn.parent_map;
+          removed_evars = EvSet.remove ev evn.removed_evars;
+        }
+      in
+      (* If there is a parent, try to remove it recursively as well. *)
+      match parent with
+      | Some parent ->
+         let evn = remove parent evn in
+         (* Rollback if removal failed. *)
+         { evn with removed_evars = EvSet.remove ev evn.removed_evars }
+      | None -> evn
+    else
+      (* Mark [ev] as deleted. *)
+      { evn with removed_evars = EvSet.add ev evn.removed_evars }
+
+let transfer_name ev ev' evn =
+  (* We assume that [ev] is an open goal, hence undefined and
+     has no children. *)
+
+  (* Transfer the name. *)
+  let basename_map, name_resolution =
+    match shortest_name ev evn with
+    | Some name ->
+       let basename_map = EvMap.add ev' name.basename (EvMap.remove ev evn.basename_map) in
+       let name_resolution = NameResolution.transfer name ev ev' evn.name_resolution in
+       basename_map, name_resolution
+    | None -> (* [ev] has no name. *)
+       evn.basename_map, evn.name_resolution
+  in
+  (* If [ev] has a parent, we update the parent's children. *)
+  let parent_map, children_map =
+    match EvMap.find_opt ev evn.parent_map with
+    | Some parent ->
+       let parent_map = EvMap.add ev' parent (EvMap.remove ev evn.parent_map) in
+       let children_map = EvMap.modify parent (fun _ children -> EvSet.add ev' (EvSet.remove ev children)) evn.children_map in
+       parent_map, children_map
+    | None ->
+       evn.parent_map, evn.children_map
+  in
+  { evn with basename_map; name_resolution; parent_map; children_map }
+
+let name_of ev evn =
+  match shortest_name ev evn with
+  | Some name ->
+     let conflicts = NameResolution.find name evn.name_resolution in
+     begin match conflicts with
+     | [_] -> Some (EvarQualid.to_id name)
+     | _ ->
+        (* If the qualified name is ambiguous, we append a suffix corresponding to the insertion index in the list. *)
+        let i = CList.length conflicts - CList.index Evar.equal ev conflicts - 1 in
+        if i == -1 then Some (EvarQualid.to_id name)
+        else Some (EvarQualid.to_id EvarQualid.{ name with basename = Id.of_string @@ (Id.to_string name.basename) ^ (string_of_int i) })
+     end
+  | None -> None
+
+let has_name ev evn =
+  not (EvSet.mem ev evn.removed_evars) && EvMap.mem ev evn.basename_map
+
+let has_unambiguous_name ev evn =
+  match shortest_name ev evn with
+  | Some name ->
+     begin match NameResolution.find name evn.name_resolution with
+     | [e] when Evar.equal e ev -> not (EvSet.mem ev evn.removed_evars)
+     | _ -> false
+     end
+  | None -> false
+
+let resolve id evn =
+  let qualid = EvarQualid.of_id id in
+  let evs = NameResolution.find qualid evn.name_resolution in
+  let open Pp in
+  match evs with
+  | [] -> raise Not_found
+  | [ev] ->
+     if EvSet.mem ev evn.removed_evars then raise Not_found
+     else ev
+  | _ :: _ :: _ -> CErrors.user_err (str "Ambiguous name " ++ Id.print id )

--- a/engine/evarnames.mli
+++ b/engine/evarnames.mli
@@ -1,0 +1,54 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+
+(** Whether the [Generate Goal Names] option is enabled. *)
+val generate_goal_names : unit -> bool
+
+(** Creates a qualified name from a list of identifiers. *)
+val of_list : Id.t list -> Id.t
+
+(** Represents an evar name map. *)
+type t
+
+(** Returns an empty name map. *)
+val empty : t
+
+(** Adds a binding for the given undefined evar to the given basename.
+    The absolute path is obtained using the parent of the evar. *)
+val add : Id.t -> Evar.t -> ?parent:Evar.t -> t -> t
+
+(** Adds a (potentially fresh) binding for the given undefined evar to the given
+    basename by first checking for conflicts. *)
+val add_fresh : Id.t -> Evar.t -> ?parent:Evar.t -> t -> t
+
+(** Removes the name of the given evar.
+    This indicates that the evar was defined, and therefore is no longer
+    accessible by name. *)
+val remove : Evar.t -> t -> t
+
+(** Transfers the name of the first evar to the second. *)
+val transfer_name : Evar.t -> Evar.t -> t -> t
+
+(** Returns the qualified name associated to the evar, if any. *)
+val name_of : Evar.t -> t -> Id.t option
+
+(** Returns [true] if the evar has a name.
+    Equivalent to [name_of ev <> None] but faster since it does not compute the
+    fully qualified name of [ev]. *)
+val has_name : Evar.t -> t -> bool
+
+(** Returns [true] if the evar has a name that is unambiguous. *)
+val has_unambiguous_name : Evar.t -> t -> bool
+
+(** Resolves the given (partially) qualified name to an evar.
+    If the name resolution failed, raises [Not_found]. *)
+val resolve : Id.t -> t -> Evar.t

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -400,18 +400,16 @@ let ext_named_context_of_env ~hypnaming env sigma =
 
 let new_pure_evar = Evd.new_pure_evar
 
-let next_evar_name sigma naming = match naming with
+let next_evar_name naming = match naming with
 | IntroAnonymous -> None
-| IntroIdentifier id -> Some id
-| IntroFresh id ->
-  let id = Nameops.Fresh.next id (Evd.evar_names sigma) in
-  Some id
+| IntroFresh id -> Some (id, true)
+| IntroIdentifier id -> Some (id, false)
 
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
-let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?typeclass_candidate
+let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = IntroAnonymous) ?parent ?typeclass_candidate
     ?rrpat ?hypnaming env evd typ =
-  let name = next_evar_name evd naming in
+  let name = next_evar_name naming in
   let hypnaming = match hypnaming with
   | Some n -> n
   | None -> VarSet.variables (Global.env ())
@@ -427,7 +425,7 @@ let new_evar ?src ?filter ?relevance ?abstract_arguments ?candidates ?(naming = 
   | Some r -> r
   | None -> ERelevance.relevant (* FIXME: relevant_of_type not defined yet *)
   in
-  let (evd, evk) = new_pure_evar sign evd typ' ?src ?rrpat ?filter ~relevance ?abstract_arguments ?candidates ?name
+  let (evd, evk) = new_pure_evar sign evd typ' ?src ?rrpat ?filter ~relevance ?abstract_arguments ?candidates ?name ?parent
     ?typeclass_candidate in
   (evd, EConstr.mkEvar (evk, instance))
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -24,7 +24,7 @@ val new_meta : unit -> metavariable
 
 (** {6 Creating a fresh evar given their type and context} *)
 
-val next_evar_name : evar_map -> intro_pattern_naming_expr -> Id.t option
+val next_evar_name : intro_pattern_naming_expr -> (Id.t * bool) option
 
 module VarSet :
 sig
@@ -41,6 +41,7 @@ val new_evar :
   ?relevance:ERelevance.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
+  ?parent:Evar.t ->
   ?typeclass_candidate:bool ->
   ?rrpat:bool ->
   ?hypnaming:naming_mode ->
@@ -51,7 +52,8 @@ val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   relevance:ERelevance.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
-  ?name:Id.t ->
+  ?name:(Id.t * bool) ->
+  ?parent:Evar.t ->
   ?typeclass_candidate:bool ->
   ?rrpat:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -37,6 +37,9 @@ type 'a puniverses = 'a * einstance
 
 (** {5 Existential variables and unification states} *)
 
+(** If true, enables generation of goal names. *)
+val generate_goal_names : unit -> bool
+
 (** {6 Evar filters} *)
 
 module Filter :
@@ -193,7 +196,8 @@ val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   relevance:erelevance ->
   ?abstract_arguments:Abstraction.t -> ?candidates:econstr list ->
-  ?name:Id.t ->
+  ?name:(Id.t * bool) ->
+  ?parent:Evar.t ->
   ?typeclass_candidate:bool ->
   ?rrpat:bool ->
   named_context_val -> evar_map -> etypes -> evar_map * Evar.t
@@ -372,15 +376,19 @@ val downcast : Evar.t-> etypes -> evar_map -> evar_map
 (** Change the type of an undefined evar to a new type assumed to be a
     subtype of its current type; subtyping must be ensured by caller *)
 
+(** {6 Evar names} *)
+
 val evar_ident : Evar.t -> evar_map -> Id.t option
 
-val evar_has_ident : Evar.t -> evar_map -> bool
+val evar_has_name : Evar.t -> evar_map -> bool
 
-val rename : Evar.t -> Id.t -> evar_map -> evar_map
+val evar_has_unambiguous_name : Evar.t -> evar_map -> bool
+
+val add_name : Evar.t -> Id.t -> ?parent:Evar.t -> evar_map -> evar_map
+
+val transfer_name : Evar.t -> Evar.t -> evar_map -> evar_map
 
 val evar_key : Id.t -> evar_map -> Evar.t
-
-val evar_names : evar_map -> Nameops.Fresh.t
 
 val dependent_evar_ident : Evar.t -> evar_map -> Id.t
 

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -67,6 +67,7 @@ let rocqide_known_option table = List.mem table [
   ["Printing";"Universes"];
   ["Printing";"Unfocused"];
   ["Printing";"Goal";"Names"];
+  ["Generate";"Goal";"Names"];
   ["Diffs"]]
 
 let is_known_option cmd = match cmd with

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1159,12 +1159,9 @@ let thin id sigma goal =
       Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false hyps sigma ~relevance concl
     in
     let sigma = Evd.remove_future_goal sigma evk in
-    let id = Evd.evar_ident goal sigma in
+    let sigma = Evd.transfer_name goal evk sigma in
     let proof = EConstr.mkEvar (evk, Evd.evar_identity_subst @@ Evd.find_undefined sigma evk) in
-    let sigma = Evd.define goal proof sigma in
-    match id with
-    | None -> sigma
-    | Some id -> Evd.rename evk id sigma
+    Evd.define goal proof sigma
 
 (*
 let pr_ist { lfun= lfun } =

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -98,7 +98,7 @@ let new_evar env sigma ?src ?rrpat ?(naming = Namegen.IntroAnonymous) ?relevance
   let ext = Lazy.force env.extra in
   let instance = Evarutil.default_ext_instance ext in
   let typ' = csubst_subst sigma (ext_csubst ext) typ in
-  let name = Evarutil.next_evar_name sigma naming in
+  let name = Evarutil.next_evar_name naming in
   let relevance = match relevance with
     | Some r -> r
     | None -> Retyping.relevance_of_type env.static_env sigma typ

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -666,9 +666,20 @@ let rec pr_evars_int_hd pr sigma i = function
 
 let pr_evars_int ?(flags=current_combined()) sigma ~shelf ~given_up i evs =
   let pr_status i =
-    if List.mem i shelf then str " (shelved)"
-    else if List.mem i given_up then str " (given up)"
-    else mt () in
+    let status =
+      if List.mem i shelf then [str "shelved"]
+      else if List.mem i given_up then [str "given up"]
+      else [] in
+    (* Check whether the evar has an unfocusable name *)
+    let status =
+      if not (Evd.evar_has_unambiguous_name i sigma)  then str "only printing" :: status
+      else status
+    in
+    begin match status with
+    | [] -> mt ()
+    | s :: [] -> str " (" ++ s ++ str ")"
+    | s1 :: s2 :: _ -> str " (" ++ s2 ++ str "; " ++ s1 ++ str ")"
+    end in
   pr_evars_int_hd
     (fun i evk evi ->
       str "Existential " ++ int i ++ str " =" ++

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -46,7 +46,7 @@ let { Goptions.get = should_gname } =
     ()
 
 let print_goal_name sigma ev =
-  should_gname () || Evd.evar_has_ident ev sigma
+  should_gname () || Evd.evar_has_unambiguous_name ev sigma
 
 let current_combined = PrintingFlags.current
 let current_extern = PrintingFlags.Extern.current

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -79,14 +79,10 @@ let generic_refine ~typecheck f gl =
     (* Nothing to do, the goal has been solved by side-effect *)
     sigma
   | Some self ->
-    match principal with
-    | None -> Evd.define self c sigma
-    | Some evk ->
-        let id = Evd.evar_ident self sigma in
-        let sigma = Evd.define self c sigma in
-        match id with
-        | None -> sigma
-        | Some id -> Evd.rename evk id sigma
+     let sigma = match principal with
+     | None -> sigma
+     | Some evk -> Evd.transfer_name self evk sigma
+     in Evd.define self c sigma
   in
   (* Mark goals *)
   let sigma = Proofview.Unsafe.mark_as_goals sigma (Evd.FutureGoals.comb future_goals) in

--- a/test-suite/output/Existentials.out
+++ b/test-suite/output/Existentials.out
@@ -1,4 +1,6 @@
-Existential 1 = ?Goal : [p : nat  q := S p : nat  n : nat  m : nat |- ?y = m]
+Existential 1 =
+?Goal : [p : nat  q := S p : nat  n : nat  m : nat |- ?y = m] (only printing)
 Existential 2 =
-?y : [p : nat  q := S p : nat  n : nat  m : nat |- nat] (p, q cannot be used) (shelved)
-Existential 3 = ?Goal0 : [q : nat  n : nat  m : nat |- n = ?y]
+?y : [p : nat  q := S p : nat  n : nat  m : nat |- nat] (p, q cannot be used) (shelved; only printing)
+Existential 3 =
+?Goal0 : [q : nat  n : nat  m : nat |- n = ?y] (only printing)

--- a/test-suite/output/bug_19138.out
+++ b/test-suite/output/bug_19138.out
@@ -1,2 +1,2 @@
-Existential 1 = ?f : [ |- False]
-Existential 1 = ?f : [ |- False]
+Existential 1 = ?f : [ |- False] (only printing)
+Existential 1 = ?f : [ |- False] (only printing)

--- a/test-suite/success/GenerateGoalNames.v
+++ b/test-suite/success/GenerateGoalNames.v
@@ -1,0 +1,30 @@
+(* -*- mode: coq -*- *)
+
+Set Generate Goal Names.
+
+Axiom A : forall (x : nat) P, x = x -> P.
+
+(* eapply *)
+Goal 0 = 0.
+Proof.
+  eapply A.
+  [x]: exact 0.
+  reflexivity.
+Qed.
+
+(* destruct *)
+Goal forall A, A \/ A -> A.
+Proof.
+  intros A H.
+  destruct H.
+  [or_introl]: assumption.
+  [or_intror]: assumption.
+Qed.
+
+(* induction *)
+Goal forall x : list nat, x = x.
+Proof.
+  induction x.
+  [nil]: reflexivity.
+  [cons]: reflexivity.
+Qed.

--- a/test-suite/success/QualifiedGoalNames.v
+++ b/test-suite/success/QualifiedGoalNames.v
@@ -1,0 +1,45 @@
+(* -*- mode: coq -*- *)
+
+Set Generate Goal Names.
+
+Goal forall a b : bool, a = a.
+Proof.
+  intros.
+  destruct a.
+  [true]: destruct b.
+  [true.true]: reflexivity.
+  [true.false]: reflexivity.
+  [false]: reflexivity.
+Qed.
+
+Goal forall a b c : bool, a = a.
+Proof.
+  intros.
+  destruct a.
+  all: destruct b.
+  all: destruct c.
+  [true.true.true]: reflexivity.
+  [true.true.false]: reflexivity.
+  [true.false.true]: reflexivity.
+  [true.false.false]: reflexivity.
+  [false.true.true]: reflexivity.
+  [false.true.false]: reflexivity.
+  [false.false.true]: reflexivity.
+  [false.false.false]: reflexivity.
+Qed.
+
+Goal forall n m : nat, n + m = m + n.
+Proof.
+  intros.
+  induction m; simpl.
+  [O]: {
+    induction n.
+    [O.O]: reflexivity.
+    [O.S]: { simpl. congruence. }
+  }
+  [S]: {
+    induction n.
+    [S.O]: { rewrite <- IHm. reflexivity. }
+    [S.S]: { rewrite <- IHm. auto. }
+  }
+Qed.

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -90,7 +90,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Unfocused" -> { VernacSynPure VernacUnfocused }
       | IDENT "Show" -> { VernacSynPure (VernacShow (ShowGoal OpenSubgoals)) }
       | IDENT "Show"; n = natural -> { VernacSynPure (VernacShow (ShowGoal (NthGoal n))) }
-      | IDENT "Show"; id = ident -> { VernacSynPure (VernacShow (ShowGoal (GoalId id))) }
+      | IDENT "Show"; id = fullyqualid -> {
+      let id = Evarnames.of_list id.CAst.v in VernacSynPure (VernacShow (ShowGoal (GoalId id))) }
       | IDENT "Show"; IDENT "Existentials" -> { VernacSynPure (VernacShow ShowExistentials) }
       | IDENT "Show"; IDENT "Universes" -> { VernacSynPure (VernacShow ShowUniverses) }
       | IDENT "Show"; IDENT "Conjectures" -> { VernacSynPure (VernacShow ShowProofNames) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1020,7 +1020,8 @@ GRAMMAR EXTEND Gram
   range_selector:
     [ [ n = natural ; "-" ; m = natural -> { Proofview.RangeSelector (n, m) }
       | n = natural -> { Proofview.NthSelector n }
-      | test_bracket_ident; "["; id = ident; "]" -> { Proofview.IdSelector id } ] ]
+      | test_bracket_ident; "["; id = fullyqualid; "]" -> {
+      let id = Evarnames.of_list id.CAst.v in Proofview.IdSelector id } ] ]
   ;
   goal_selector:
   [ [ l = LIST1 range_selector SEP "," -> { Goal_select.SelectList l } ] ]


### PR DESCRIPTION
This PR adds the possibility to have automatically generated goal names through the `Generate Goal Names` option. This also includes qualified goal names and showing the difference between focusable and non-focusable printing names in `Show Existentials`.

Requires #20813 to be merged first.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.
- [x] Opened **overlay** pull requests.

Overlays:
- https://github.com/rocq-prover/stdlib/pull/186
- https://github.com/PrincetonUniversity/VST/pull/834
- https://github.com/coq-tactician/coq-tactician/pull/121