### PR TITLE
Congruence tactics now handle primitive ints / floats / strings

### DIFF
--- a/doc/changelog/04-tactics/20810-cctac-primitive-values-Added.rst
+++ b/doc/changelog/04-tactics/20810-cctac-primitive-values-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  congruence tactics now handle primitive ints, floats and strings
+  (`#20810 <https://github.com/rocq-prover/rocq/pull/20810>`_,
+  fixes `#20011 <https://github.com/rocq-prover/rocq/issues/20011>`_,
+  by Pierre-Marie Pédrot).

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -18,6 +18,7 @@ type pa_constructor =
 
 type constructor =
 | Construct of pconstructor
+| Int of Uint63.t
 | String of Pstring.t
 
 type cinfo =

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -16,8 +16,12 @@ type pa_constructor =
       arity : int;
       args  : int list}
 
+type constructor =
+| Construct of pconstructor
+| String of Pstring.t
+
 type cinfo =
-    {ci_constr: pconstructor; (* inductive type *)
+    {ci_constr: constructor; (* inductive type *)
      ci_arity: int;     (* # args *)
      ci_nhyps: int}     (* # projectable args *)
 

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -19,6 +19,7 @@ type pa_constructor =
 type constructor =
 | Construct of pconstructor
 | Int of Uint63.t
+| Float of Float64.t
 | String of Pstring.t
 
 type cinfo =

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -113,7 +113,7 @@ and edge_proof env sigma uf ((i,j),eq)=
       let cinfo= get_constructor_info uf ipac.cnode in
       let cstr = match cinfo.ci_constr with
       | Construct c -> c
-      | Int _ | String _ -> assert false
+      | Int _ | Float _ | String _ -> assert false
       in
       pinject p cstr cinfo.ci_nhyps k in
   ptrans (ptrans pi pij) pj

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -11,7 +11,6 @@
 (* This file uses the (non-compressed) union-find structure to generate *)
 (* proof-trees that will be transformed into proof-terms in cctac.mlg   *)
 
-open Constr
 open Ccalgo
 open Pp
 
@@ -21,7 +20,7 @@ type rule=
   | Refl of ATerm.t
   | Trans of proof*proof
   | Congr of proof*proof
-  | Inject of proof*pconstructor*int*int
+  | Inject of proof*Constr.pconstructor*int*int
 and proof =
     {p_lhs:ATerm.t;p_rhs:ATerm.t;p_rule:rule}
 
@@ -112,7 +111,11 @@ and edge_proof env sigma uf ((i,j),eq)=
     | Injection (ti,ipac,tj,jpac,k) -> (* pi_k ipac = p_k jpac *)
       let p=ind_proof env sigma uf ti ipac tj jpac in
       let cinfo= get_constructor_info uf ipac.cnode in
-      pinject p cinfo.ci_constr cinfo.ci_nhyps k in
+      let cstr = match cinfo.ci_constr with
+      | Construct c -> c
+      | String _ -> assert false
+      in
+      pinject p cstr cinfo.ci_nhyps k in
   ptrans (ptrans pi pij) pj
 
 and constr_proof env sigma uf i ipac=

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -113,7 +113,7 @@ and edge_proof env sigma uf ((i,j),eq)=
       let cinfo= get_constructor_info uf ipac.cnode in
       let cstr = match cinfo.ci_constr with
       | Construct c -> c
-      | String _ -> assert false
+      | Int _ | String _ -> assert false
       in
       pinject p cstr cinfo.ci_nhyps k in
   ptrans (ptrans pi pij) pj

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Ccalgo
-open Constr
 
 type rule =
 | Ax of axiom
@@ -22,7 +21,7 @@ type rule =
 | Congr of proof * proof
   (** ⊢ f = g :: forall x : A, B -> ⊢ t = u :: A -> f t = g u :: B{t}
       Assumes that B{t} ≡ B{u} for this to make sense! *)
-| Inject of proof * pconstructor * int * int
+| Inject of proof * Constr.pconstructor * int * int
   (** ⊢ ci v = ci w :: Ind(args) -> ⊢ v = w :: T
       where T is the type of the n-th argument of ci, assuming they coincide *)
 and proof =

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -70,7 +70,7 @@ let rec decompose_term env sigma t =
         let u = EInstance.kind sigma u in
         let oib = Environ.lookup_mind (fst ind) env in
         let nargs = constructor_nallargs env cstr in
-        ATerm.mkConstructor env {ci_constr = (cstr, u);
+        ATerm.mkConstructor env {ci_constr = Construct (cstr, u);
                        ci_arity=nargs;
                        ci_nhyps=nargs-oib.mind_nparams}
     | Ind c ->
@@ -87,6 +87,8 @@ let rec decompose_term env sigma t =
         let p' = Projection.map canon_mind p in
         let c = Retyping.expand_projection env sigma p' c [] in
         decompose_term env sigma c
+    | String s ->
+        ATerm.mkConstructor env { ci_constr = String s; ci_arity = 0; ci_nhyps = 0 }
     | _ ->
        let t = Termops.strip_outer_cast sigma t in
        if closed0 sigma t then ATerm.mkSymb (EConstr.to_constr ~abort_on_undefined_evars:false sigma t) else raise Not_found

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -89,6 +89,8 @@ let rec decompose_term env sigma t =
         decompose_term env sigma c
     | String s ->
         ATerm.mkConstructor env { ci_constr = String s; ci_arity = 0; ci_nhyps = 0 }
+    | Int i ->
+        ATerm.mkConstructor env { ci_constr = Int i; ci_arity = 0; ci_nhyps = 0 }
     | _ ->
        let t = Termops.strip_outer_cast sigma t in
        if closed0 sigma t then ATerm.mkSymb (EConstr.to_constr ~abort_on_undefined_evars:false sigma t) else raise Not_found

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -91,6 +91,8 @@ let rec decompose_term env sigma t =
         ATerm.mkConstructor env { ci_constr = String s; ci_arity = 0; ci_nhyps = 0 }
     | Int i ->
         ATerm.mkConstructor env { ci_constr = Int i; ci_arity = 0; ci_nhyps = 0 }
+    | Float f ->
+        ATerm.mkConstructor env { ci_constr = Float f; ci_arity = 0; ci_nhyps = 0 }
     | _ ->
        let t = Termops.strip_outer_cast sigma t in
        if closed0 sigma t then ATerm.mkSymb (EConstr.to_constr ~abort_on_undefined_evars:false sigma t) else raise Not_found

--- a/test-suite/success/congruence_prim.v
+++ b/test-suite/success/congruence_prim.v
@@ -1,0 +1,22 @@
+Require Import Corelib.Numbers.Cyclic.Int63.PrimInt63.
+Require Import Corelib.Strings.PrimString.
+Require Import Corelib.Floats.PrimFloat.
+
+Inductive Box (A : Type) := box : A -> Box A.
+
+Arguments box {A}.
+
+Goal box 0%uint63 = box 1%uint63 -> False.
+Proof.
+congruence.
+Abort.
+
+Goal box "true"%pstring = box "false"%pstring -> False.
+Proof.
+congruence.
+Qed.
+
+Goal box 1.0%float = box 2.0%float -> False.
+Proof.
+congruence.
+Qed.

--- a/theories/Corelib/Floats/PrimFloat.v
+++ b/theories/Corelib/Floats/PrimFloat.v
@@ -63,8 +63,9 @@ Primitive compare := #float64_compare.
 (** Boolean Leibniz equality *)
 Module Leibniz.
 Primitive eqb := #float64_equal.
-Register eqb as num.float.leibniz.eqb.
 End Leibniz.
+
+Register Leibniz.eqb as num.float.leibniz.eqb.
 
 Primitive mul := #float64_mul.
 

--- a/theories/Corelib/Strings/PrimString.v
+++ b/theories/Corelib/Strings/PrimString.v
@@ -18,6 +18,13 @@ Primitive cat : string -> string -> string := #string_cat.
 
 Primitive compare : string -> string -> comparison := #string_compare.
 
+Definition eqb (s1 s2 : string) := match compare s1 s2 with
+| Eq => true
+| Lt | Gt => false
+end.
+
+Register eqb as strings.pstring.eqb.
+
 Module Export PStringNotations.
   Record string_wrapper := wrap_string {string_wrap : string}.
   Definition id_string (s : string) : string := s.


### PR DESCRIPTION
I didn't implement congruence for arrays yet, this requires a little bit more work.

Fixes #20011.