### PR TITLE
install vsrocq

### DIFF
--- a/dev/ci/scripts/ci-vsrocq.sh
+++ b/dev/ci/scripts/ci-vsrocq.sh
@@ -18,4 +18,5 @@ fi
   make dune-files
   dune build --root . --only-packages=vsrocq-language-server @install
   dune runtest --root .
+  dune install --root . vsrocq-language-server --prefix="$CI_INSTALL_DIR"
 )


### PR DESCRIPTION
By installing vsrocq, one can use the lang-server in _build_ci