### PR TITLE
Implement Extensible Attributes on Definitions

### DIFF
--- a/dev/ci/user-overlays/20812-SkySkimmer-extensible-attributes.sh
+++ b/dev/ci/user-overlays/20812-SkySkimmer-extensible-attributes.sh
@@ -1,0 +1,1 @@
+overlay mtac2 https://github.com/SkySkimmer/Mtac2 extensible-attributes 20812

--- a/test-suite/misc/attributes.sh
+++ b/test-suite/misc/attributes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+cd misc/attributes/
+
+rm -rf _test
+mkdir _test
+find . -maxdepth 1 -not -name . -not -name _test -exec cp -r '{}' -t _test ';'
+cd _test
+
+rocq makefile -f _CoqProject -o Makefile
+
+make
+
+if ! [ -e theories/attr.vo ]; then
+  >&2 echo Missing attr.vo after successful compilation
+  exit 1
+fi

--- a/test-suite/misc/attributes/_CoqProject
+++ b/test-suite/misc/attributes/_CoqProject
@@ -1,0 +1,7 @@
+src/META.rocq-test-suite.plugins.attribute_plugin
+-Q theories Attributes
+-I src
+
+src/attribute.ml
+src/attribute_plugin.mlpack
+theories/attr.v

--- a/test-suite/misc/attributes/src/META.rocq-test-suite
+++ b/test-suite/misc/attributes/src/META.rocq-test-suite
@@ -1,0 +1,11 @@
+package "attribute" (
+    directory = "."
+    version = "dev"
+    description = "A test plugin"
+    requires = ""
+    archive(byte) = "attribute_plugin.cma"
+    archive(native) = "attribute_plugin.cmxa"
+    plugin(byte) = "attribute_plugin.cma"
+    plugin(native) = "attribute_plugin.cmxs"
+)
+directory = "."

--- a/test-suite/misc/attributes/src/attribute.ml
+++ b/test-suite/misc/attributes/src/attribute.ml
@@ -1,0 +1,31 @@
+open Names
+
+let print_hook =
+  let attr : Declare.Hook.t list Attributes.attribute =
+    let hook = Declare.Hook.make @@ fun data ->
+      Feedback.msg_info Pp.(str "generated " ++ GlobRef.print data.dref ++ str "\n")
+    in
+    let open Attributes in
+    let open Attributes.Notations in
+    map (Option.default []) @@ attribute_of_list [("print", fun ?loc _ _ -> [hook])]
+  in
+  Vernacentries.DefAttributes.Observer.register ~name:"print-afterwards" attr
+
+
+let error_hook =
+  let attr : Declare.Hook.t list Attributes.attribute =
+    let hook loc = Declare.Hook.make @@ fun data ->
+      Feedback.msg_info Pp.(str "failing attribute") ;
+      CErrors.user_err ?loc Pp.(str "attribute error!")
+    in
+    let open Attributes in
+    let open Attributes.Notations in
+    map (Option.default []) @@ attribute_of_list [("error", fun ?loc _ _ -> [hook loc])]
+  in
+  Vernacentries.DefAttributes.Observer.register ~name:"error" attr
+
+let () =
+  Mltop.(declare_cache_obj_full @@ interp_only_obj @@ fun () ->
+         Vernacentries.DefAttributes.Observer.activate print_hook;
+         Vernacentries.DefAttributes.Observer.activate error_hook)
+    "rocq-test-suite.attribute"

--- a/test-suite/misc/attributes/src/attribute_plugin.mlpack
+++ b/test-suite/misc/attributes/src/attribute_plugin.mlpack
@@ -1,0 +1,1 @@
+Attribute

--- a/test-suite/misc/attributes/theories/attr.v
+++ b/test-suite/misc/attributes/theories/attr.v
@@ -1,0 +1,17 @@
+Declare ML Module "rocq-test-suite.attribute".
+
+#[print]
+Definition foo : True := I.
+
+#[print]
+Definition bar : False -> False := fun x => x.
+
+Fail #[error]
+Definition baz : False -> False := fun x => x.
+
+(* par marshals th summary, enforcing that it doesn't contain closures *)
+Lemma parfoo : True /\ True.
+Proof.
+  split.
+  par: exact I.
+Defined.

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -352,7 +352,7 @@ let try_add_new_identity_coercion {CAst.v=id; loc} ~local ~poly ~source ~target 
 let try_add_new_coercion_with_source ref ~local ~reversible ~source =
   try_add_new_coercion_core ref ~local ~reversible (Some source) None false
 
-let add_coercion_hook reversible { Declare.Hook.S.scope; dref; _ } =
+let coercion_hook ~reversible = Declare.Hook.make @@ fun { scope; dref; _ } ->
   let open Locality in
   let local = match scope with
   | Discharge -> assert false (* Local Coercion in section behaves like Local Definition *)
@@ -363,10 +363,7 @@ let add_coercion_hook reversible { Declare.Hook.S.scope; dref; _ } =
   let msg = Nametab.pr_global_env Id.Set.empty dref ++ str " is now a coercion" in
   Flags.if_verbose Feedback.msg_info msg
 
-let add_coercion_hook ~reversible =
-  Declare.Hook.make (add_coercion_hook reversible)
-
-let add_subclass_hook ~poly { Declare.Hook.S.scope; dref; _ } =
+let subclass_hook ~poly ~reversible = Declare.Hook.make @@ fun { scope; dref; _ } ->
   let open Locality in
   let stre = match scope with
   | Discharge -> assert false (* Local Subclass in section behaves like Local Definition *)
@@ -375,12 +372,9 @@ let add_subclass_hook ~poly { Declare.Hook.S.scope; dref; _ } =
   in
   let cl = class_of_global dref in
   let loc = Nametab.cci_src_loc (TrueGlobal dref) in
-  try_add_new_coercion_subclass ?loc cl ~local:stre ~poly
+  try_add_new_coercion_subclass ?loc cl ~local:stre ~poly ~reversible
 
 let nonuniform = Attributes.bool_attribute ~name:"nonuniform"
-
-let add_subclass_hook ~poly ~reversible =
-  Declare.Hook.make (add_subclass_hook ~poly ~reversible)
 
 let warn_reverse_no_change =
   CWarnings.create ~name:"reversible-no-change" ~category:CWarnings.CoreCategories.coercions

--- a/vernac/comCoercion.mli
+++ b/vernac/comCoercion.mli
@@ -48,9 +48,9 @@ val try_add_new_identity_coercion
   -> local:bool
   -> poly:PolyFlags.t -> source:cl_typ -> target:cl_typ -> unit
 
-val add_coercion_hook : reversible:bool -> Declare.Hook.t
+val coercion_hook : reversible:bool -> Declare.Hook.t
 
-val add_subclass_hook : poly:PolyFlags.t -> reversible:bool -> Declare.Hook.t
+val subclass_hook : poly:PolyFlags.t -> reversible:bool -> Declare.Hook.t
 
 val class_of_global : GlobRef.t -> cl_typ
 

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -73,6 +73,7 @@ val preprocess_inductive_decl
 module DefAttributes : sig
 
 type t = {
+  hooks : Declare.Hook.t list ;
   scope : Locality.definition_scope;
   locality : bool option;
   poly : PolyFlags.t;
@@ -84,6 +85,9 @@ type t = {
   reversible : bool;
   clearbody: bool option;
 }
+
+module Observer : Summary.OBSERVABLE
+  with type value = unit Declare.Hook.g list Attributes.attribute
 
 val def_attributes : t Attributes.attribute
 


### PR DESCRIPTION
<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
This enables extensible attributes on `Definition` commands. Extensions can be implemented using Rocq plugins, potentially using elpi in the future. This overcomes two current limitations of elpi.
1. Elpi must write its own vernacular commands in order to support custom attributes. This risks a divergence between core Rocq commands and their Elpi clones.
2. Elpi vernacular commands can not open goals.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

Overlays:
- https://github.com/Mtac2/Mtac2/pull/422