### PR TITLE
ci-common don't use ci_dir

### DIFF
--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -79,10 +79,9 @@ function overlay()
 }
 
 set +x
-# shellcheck source=ci-basic-overlay.sh
-. "${ci_dir}/../ci-basic-overlay.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../ci-basic-overlay.sh"
 
-for overlay in "${ci_dir}"/../user-overlays/*.sh; do
+for overlay in "$(dirname "${BASH_SOURCE[0]}")"/../user-overlays/*.sh; do
     # shellcheck source=/dev/null
     # the directoy can be empty
     if [ -e "${overlay}" ]; then . "${overlay}"; fi


### PR DESCRIPTION
This makes it possible to do `source dev/ci/scripts/ci-common.sh` in a user shell (NB do `set +ex` afterwards for interactive use)