### PR TITLE
Abbreviations don't add printing rule when still qualified

### DIFF
--- a/dev/ci/user-overlays/20816-SkySkimmer-abbrev-mode.sh
+++ b/dev/ci/user-overlays/20816-SkySkimmer-abbrev-mode.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/proux01/coq-elpi rocq20816 20816

--- a/doc/changelog/03-notations/20816-abbrev-mod-Changed.rst
+++ b/doc/changelog/03-notations/20816-abbrev-mod-Changed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :cmd:`Abbreviation` no longer adds a printing rule when a surrounding module is imported
+  (i.e. when it would need to print a qualified name). :attr:`global` can be used
+  to retrieve the previous behavior
+  (`#20816 <https://github.com/rocq-prover/rocq/pull/20816>`_,
+  fixes `#20668 <https://github.com/rocq-prover/rocq/issues/20668>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1899,14 +1899,6 @@ Abbreviations
 
    Defines an abbreviation :token:`ident` with the parameters :n:`@ident__parm`.
 
-   This command supports the :attr:`local` attribute, which limits the notation to the
-   current module.
-
-   Unlike a :cmd:`Notation`, an abbreviation defined with the default locality
-   is available (with a fully qualified name) outside the current module even
-   when :cmd:`Import` (or one of its variants) has not been used on the current
-   :cmd:`Module`.
-
    An *abbreviation* is a name, possibly applied to arguments, that
    denotes a (presumably) more complex expression. Here are examples:
 
@@ -1940,6 +1932,20 @@ Abbreviations
 
       Compute (Plus1 3).
 
+   This command supports the :attr:`local`, :attr:`export` and
+   :attr:`global` attributes. :attr:`local` limits the notation to the
+   current module or section. With :attr:`export` the abbreviation is
+   only used for printing when it is imported (but it can still be
+   accessed by its qualified name when not imported). With
+   :attr:`global` requiring the module containing the abbreviation is
+   enough to make it used by printing (NB: for "only parsing"
+   abbreviations there is no difference between :attr:`export` and
+   :attr:`global`).
+
+   The default is :attr:`export` outside sections and :attr:`local` in
+   sections, and :attr:`local` is the only supported locality in
+   sections.
+
    An abbreviation expects no precedence nor associativity, since it
    is parsed as an usual application. Abbreviations are used as
    much as possible by the Rocq printers unless the modifier ``(only
@@ -1970,9 +1976,9 @@ Abbreviations
 
       Check (id 0).
 
-   Abbreviations disappear when a section is closed. No typing of the
-   denoted expression is performed at definition time. Type checking is
-   done only at the time of use of the abbreviation.
+   No typing of the denoted expression is performed at definition
+   time. Type checking is done only at the time of use of the
+   abbreviation.
 
    Like for notations, if the right-hand side of an abbreviation is a
    partially applied constant, the abbreviation inherits the implicit

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -15,7 +15,7 @@ open Globnames
 
 (** Abbreviations. *)
 
-val declare_abbreviation : local:bool -> Globnames.extended_global_reference UserWarn.with_qf option -> Id.t ->
+val declare_abbreviation : local:Libobject.locality -> Globnames.extended_global_reference UserWarn.with_qf option -> Id.t ->
   onlyparsing:bool -> interpretation -> unit
 
 val search_abbreviation : abbreviation -> interpretation

--- a/test-suite/output/bug_20668.out
+++ b/test-suite/output/bug_20668.out
@@ -1,0 +1,10 @@
+tt
+     : unit
+A'.B'.x
+     : unit
+x
+     : unit
+B.x
+     : unit
+x
+     : unit

--- a/test-suite/output/bug_20668.v
+++ b/test-suite/output/bug_20668.v
@@ -1,0 +1,27 @@
+Module Import A.
+  Module B.
+    Abbreviation x := tt.
+  End B.
+End A.
+Check B.x. (* should say tt *)
+
+Module A'.
+  Module B'.
+    #[global] Abbreviation x := tt.
+  End B'.
+End A'.
+Check tt. (* should say A'.B'.x *)
+
+Import B.
+Check tt. (* should say x *)
+
+Import A'.B'.
+Check tt.
+(* should say B.x (qualified because "x" is short name for B'.x, but
+   B'.x not used for printing because the printing rule didn't get
+   replayed by Import so is still shadowed by B.x) *)
+
+Disable Notation B.x.
+
+Check tt.
+(* should say x *)

--- a/test-suite/success/locality_attributes_modules.v
+++ b/test-suite/success/locality_attributes_modules.v
@@ -242,7 +242,7 @@ Module Bar.
   Fail #[export]
   Ltac find_secret := reflexivity.
   (* An abbreviation: *)
-  Fail #[export]
+  #[export]
   Notation add_42 := (Nat.add 42).
   (* A tactic notation: *)
   Fail #[export]

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -253,6 +253,15 @@ let hint_locality = explicit_hint_locality >>= function
   | Some v -> return v
   | None -> return (default_hint_locality())
 
+let hint_locality_no_sections =
+  explicit_hint_locality >>= function
+  | Some v ->
+    let () = if v <> Local && Lib.sections_are_opened() then
+        CErrors.user_err Pp.(str "This command does not support this locality in sections.")
+    in
+    return v
+  | None -> return (default_hint_locality())
+
 let hint_locality_default_superglobal = explicit_hint_locality >>= function
   | Some v -> return v
   | None -> return Hints.SuperGlobal

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -81,6 +81,9 @@ val user_warns_with_use_globref_instead : Globnames.extended_global_reference Us
 *)
 val hint_locality : Hints.hint_locality attribute
 
+(** Like [hint_locality], but errors on explicit non-Local in sections. *)
+val hint_locality_no_sections : Hints.hint_locality attribute
+
 (** Like [hint_locality] but the default in and out of sections is [SuperGlobal]. *)
 val hint_locality_default_superglobal : Hints.hint_locality attribute
 

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -63,7 +63,7 @@ val add_reserved_notation :
 
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
-val add_abbreviation : local:bool -> Globnames.extended_global_reference UserWarn.with_qf option -> env ->
+val add_abbreviation : local:Libobject.locality -> Globnames.extended_global_reference UserWarn.with_qf option -> env ->
   Id.t -> Id.t list * constr_expr -> syntax_modifier CAst.t list -> unit
 
 (** Print the Camlp5 state of a grammar *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1833,9 +1833,9 @@ let warn_deprecated_notation_for_abbreviation =
 let vernac_abbreviation ~warn_old_notation ~atts lid x only_parsing =
   Option.iter (fun loc -> warn_deprecated_notation_for_abbreviation ~loc ())
     warn_old_notation;
-  let module_local, user_warns = Attributes.(parse Notations.(module_locality ++ user_warns_with_use_globref_instead) atts) in
+  let local, user_warns = Attributes.(parse Notations.(hint_locality_no_sections ++ user_warns_with_use_globref_instead) atts) in
   Dumpglob.dump_definition lid false "abbrev";
-  Metasyntax.add_abbreviation ~local:module_local user_warns (Global.env()) lid.v x only_parsing
+  Metasyntax.add_abbreviation ~local user_warns (Global.env()) lid.v x only_parsing
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;


### PR DESCRIPTION
Fix #20668 , #14105 , #14587

#### Overlays (to be merged before the current PR)

- [x] https://github.com/rocq-prover/stdlib/pull/208
- [x] https://github.com/mit-plv/rewriter/pull/177
- [x] https://github.com/mit-plv/fiat-crypto/pull/2155

#### Overlay (to be merged in sync with the current PR)

- [ ] https://github.com/LPCIC/coq-elpi/pull/883
