### PR TITLE
Set firstorder solver explicitly to auto with core in prelude

### DIFF
--- a/theories/Corelib/Init/Prelude.v
+++ b/theories/Corelib/Init/Prelude.v
@@ -32,7 +32,7 @@ Declare ML Module "rocq-runtime.plugins.cc".
 Declare ML Module "rocq-runtime.plugins.firstorder_core".
 Declare ML Module "rocq-runtime.plugins.firstorder".
 
-Global Set Firstorder Solver auto.
+Global Set Firstorder Solver auto with core.
 
 (* Parsing / printing of hexadecimal numbers *)
 Arguments Nat.of_hex_uint d%_hex_uint_scope.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR proposes to `Set Firstorder Solver auto with core.` in the prelude so that
```
Print Firstorder Solver.
```
outputs
```
Firstorder solver tactic is auto with core
```
instead of the current
```
Firstorder solver tactic is <rocq-runtime.plugins.firstorder::auto_with@0>
```
which is arguably much less informative / confusing.