### PR TITLE
Correctly deambiguate constructor names when printing pattern matchings.

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -416,7 +416,7 @@ let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as
             match extern_record_pattern cstrsp args with
             | Some l -> CPatRecord l
             | None ->
-                  let c = extern_reference Id.Set.empty (GlobRef.ConstructRef cstrsp) in
+                  let c = extern_reference vars (GlobRef.ConstructRef cstrsp) in
                   if Constrintern.get_asymmetric_patterns () then
                     if pattern_printable_in_both_syntax cstrsp
                     then CPatCstr (c, None, args)

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -46,3 +46,12 @@ end
      : forall [A : Type] [x y : A], x = y -> y = x
 
 Arguments eq_sym [A]%_type_scope [x y] _
+test =
+fun (O : unit) (S : nat -> unit) (n : nat) =>
+match n with
+| 0 => O
+| Datatypes.S n0 => S n0
+end
+     : unit -> (nat -> unit) -> nat -> unit
+
+Arguments test O S%_function_scope n%_nat_scope

--- a/test-suite/output/PrintMatch.v
+++ b/test-suite/output/PrintMatch.v
@@ -27,3 +27,15 @@ Set Asymmetric Patterns.
 Print eq_sym.
 
 End Bug18163.
+
+Module AvoidName.
+
+Definition test (O : unit) (S : nat -> unit) (n : nat) :=
+match n with
+| Datatypes.O => O
+| Datatypes.S n => S n
+end.
+
+Print test.
+
+End AvoidName.


### PR DESCRIPTION
Given the way the code was written it was probably an oversight.