### PR TITLE
Retain original variable names for patterns in Print HintDb

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/20827-print_hintdb_patterns-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/20827-print_hintdb_patterns-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Default patterns displayed by :cmd:`Print HintDb` now show
+  pattern holes using the name from the original theorem
+  (e.g. :n:`?n` instead of :n:`?M3135`)
+  (`#20827 <https://github.com/rocq-prover/rocq/pull/20827>`_,
+  by Jim Fehrle).

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1662,11 +1662,42 @@ let pr_hint env sigma h = match h.obj with
   | Extern (_, tac) ->
     str "(*external*) " ++ Gentactic.print_glob env sigma ~level:(LevelLe 0) tac
 
+let rec subst_meta sigma s c =
+  match kind sigma c with
+    | Meta i -> (try Int.Map.find i s with Not_found -> c)
+    | _ -> EConstr.map sigma (subst_meta sigma s) c
+
+let replace_clenv_type_metas env sigma clnv =
+  let module Metas = Unification.Meta in
+  let metam = Clenv.clenv_meta_list clnv in
+  let sigma, metamap = List.fold_left (fun (sigma, metamap) mv ->
+    let tymeta = Metas.meta_ftype metam mv in
+    let ty = subst_meta sigma metamap tymeta.rebus in
+    let naming = match Metas.meta_name metam mv with
+      | Name na -> IntroIdentifier na
+      | Anonymous -> IntroAnonymous
+    in
+    let sigma, ev = Evarutil.new_evar ~naming env sigma ty in
+    sigma, Int.Map.add mv ev metamap)
+    (sigma, Int.Map.empty) (Clenv.clenv_arguments clnv)
+  in
+  sigma, subst_meta sigma metamap (Clenv.clenv_type clnv)
+
+let pr_default_pattern env sigma = function
+| Give_exact h ->
+  pr_leconstr_env env sigma h.hint_type
+| Res_pf h | ERes_pf h | Res_pf_THEN_trivial_fail h ->
+  let sigma, c = replace_clenv_type_metas env sigma h.hint_clnv in
+  pr_leconstr_env env sigma c
+| Unfold_nth _ | Extern _ ->
+  (* These hints cannot contain DefaultPattern *)
+  assert false
+
 let pr_id_hint env sigma (id, v) =
   let pr_pat p = match p.pat with
   | None -> mt ()
   | Some (ConstrPattern p | SyntacticPattern p) -> str", pattern " ++ pr_lconstr_pattern_env env sigma p
-  | Some DefaultPattern -> str", pattern " ++ pr_leconstr_env env sigma (get_default_pattern v.code.obj)
+  | Some DefaultPattern -> str", pattern " ++ (pr_default_pattern env sigma v.code.obj)
   in
   (pr_hint env sigma v.code ++ str" (cost " ++ int v.pri ++ pr_pat v
    ++ str", id " ++ int id ++ str ")")

--- a/test-suite/output/print_hintdb_metas.out
+++ b/test-suite/output/print_hintdb_metas.out
@@ -1,0 +1,9 @@
+Non-discriminated database
+Unfoldable variable definitions: all
+Unfoldable constant definitions: all
+Unfoldable projection definitions: all
+Cut: emp
+For any goal ->   
+For and ->   simple apply x (cost 0, pattern ?n = 1 /\
+                                             (forall n : nat, n = ?m), id 0)
+

--- a/test-suite/output/print_hintdb_metas.v
+++ b/test-suite/output/print_hintdb_metas.v
@@ -1,0 +1,8 @@
+Theorem x : forall n m:nat, n = 1 /\ forall n : nat, n = m.
+Admitted.
+Create HintDb foo.
+Hint Resolve x : foo.
+(* Note that the pattern doesn't have a metavariable for
+  the inner forall n
+  ie pattern is ?n = 1 /\ (forall n : nat, n = ?m) *)
+Print HintDb foo.


### PR DESCRIPTION
Currently, Print HintDb shows metavariables in patterns in the form `?M172`, which is hard to read; the metavariables tend to differ only in the last digit.  This change would preserve the variable name used in the forall, e.g. `?n` for easier understanding.

For example:

```coq
Hint Resolve plus_Sn_m : foo.
Print plus_Sn_m.
(*
plus_Sn_m =
fun n m : nat => eq_refl
     : forall n m : nat, S n + m = S (n + m)
*)     
Print HintDb foo.
(*
BEFORE THIS PR:
For eq ->   simple apply plus_Sn_m (cost 0, pattern 
            S ?M172 + ?M173 = S (?M172 + ?M173), id 0)

WITH THIS PR:
For eq ->   simple apply plus_Sn_m (cost 0, pattern 
            S ?n + ?m = S (?n + ?m), id 0)
*)
```

The change is to optionally preserve the original variable name in the `Meta` constructor in `Clenv.clenv_environments` and then recover the name in `Detyping.detype_r`.  If desired, I can tweak `Clenv.clenv_environments` to save the name only when it's called from `Hints.make_apply_entry`.

I may be unaware of some subtleties; please advise.

BTW, the Clenv code doesn't create metavariables for nested use of binders (e.g. `n` below)

```coq
Theorem x : forall n m:nat, n = 1 /\ forall n : nat, n = m.  Admitted.
Hint Resolve x : foo.
Print HintDb foo.
(* For and ->   simple apply x (cost 0, pattern ?n = 1 /\ (forall n : nat, n = ?m), id 0) *)
```

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
