### PR TITLE
Ltac2: Add a basic ability to declare definitions using ltac2 tactics

### DIFF
--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1030,7 +1030,10 @@ VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
     Tac2entries.register_notation_interpretation synterpv
   }
 | ![proof_opt_query] [ "Ltac2" "Eval" ltac2_expr(e) ] => { Vernacextend.classify_as_query } -> {
-  fun ~pstate -> Tac2entries.perform_eval ~pstate e
+    fun ~pstate -> Tac2entries.perform_eval ~pstate e
+  }
+| [ "Ltac2" "Declare" ltac2_expr(defn) ] => { Vernacextend.classify_as_query } -> {
+    Tac2entries.declare defn
   }
 END
 

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -36,6 +36,8 @@ val register_notation_interpretation : notation_interpretation_data -> unit
 
 val perform_eval : pstate:Declare.Proof.t option -> raw_tacexpr -> unit
 
+val declare : raw_tacexpr -> unit
+
 (** {5 Notations} *)
 
 type syntax_class_rule =

--- a/test-suite/ltac2/declare.v
+++ b/test-suite/ltac2/declare.v
@@ -1,0 +1,22 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Definition.
+
+Ltac2 get_name () : ident :=
+  Option.get (Ident.of_string "some_name").
+
+Ltac2 tp () : constr option :=
+  Some constr:(nat).
+
+Ltac2 body () : constr :=
+  constr:(1 + 1).
+
+Ltac2 d () : definition list :=
+  [Defn false (get_name ()) (tp ()) (body ())].
+
+Ltac2 Declare d ().
+
+Definition y : nat := some_name.
+
+Ltac2 Declare [Defn true (Option.get (Ident.of_string "some_other_name")) (tp ()) (body ())].
+
+Definition z : nat := some_other_name.

--- a/theories/Ltac2/Definition.v
+++ b/theories/Ltac2/Definition.v
@@ -1,0 +1,18 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import Ltac2.Init.
+Require Ltac2.Int.
+
+(** Data needed to declare a definition. The meanings of the arguments in order
+  are: opaqueness, name, type, body *)
+Ltac2 Type definition := [
+  Defn (bool, ident, constr option, constr)
+].


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Partial implemenattion of #20380 (definitions only)


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
