### PR TITLE
Names: move set/map modules `KNset` -> `KerName.Set` etc

### DIFF
--- a/dev/ci/user-overlays/20836-SkySkimmer-knset.sh
+++ b/dev/ci/user-overlays/20836-SkySkimmer-knset.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp knset 20836
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician knset 20836
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof knset 20836

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -129,12 +129,12 @@ let ppintmapgen l = pp (printmapgen l)
 let ppmpmapgen l =
   pp (prmapgen
         (fun mp -> str (ModPath.debug_to_string mp))
-        (MPset.elements (MPmap.domain l)))
+        (ModPath.Set.elements (ModPath.Map.domain l)))
 
 let ppdpmapgen l =
   pp (prmapgen
         (fun mp -> str (DirPath.to_string mp))
-        (DPset.elements (DPmap.domain l)))
+        (DirPath.Set.elements (DirPath.Map.domain l)))
 
 let ppconmapenvgen l =
   pp (prmapgen

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -77,8 +77,8 @@ val ppidmapgen : 'a Names.Id.Map.t -> unit
 val printmapgen : 'a Int.Map.t -> Pp.t
 val ppintmapgen : 'a Int.Map.t -> unit
 
-val ppmpmapgen : 'a Names.MPmap.t -> unit
-val ppdpmapgen : 'a Names.DPmap.t -> unit
+val ppmpmapgen : 'a Names.ModPath.Map.t -> unit
+val ppdpmapgen : 'a Names.DirPath.Map.t -> unit
 val ppconmapenvgen : 'a Names.Cmap_env.t -> unit
 val ppmindmapenvgen : 'a Names.Mindmap_env.t -> unit
 

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -28,17 +28,17 @@ type abbreviation =
   }
 
 let abbrev_table =
-  Summary.ref (KNmap.empty : (full_path * abbreviation) KNmap.t)
+  Summary.ref (KerName.Map.empty : (full_path * abbreviation) KerName.Map.t)
     ~name:"ABBREVIATIONS"
 
 let add_abbreviation kn sp abbrev =
-  abbrev_table := KNmap.add kn (sp,abbrev) !abbrev_table
+  abbrev_table := KerName.Map.add kn (sp,abbrev) !abbrev_table
 
 let toggle_abbreviation ~on ~use kn =
-  let sp, data = KNmap.find kn !abbrev_table in
+  let sp, data = KerName.Map.find kn !abbrev_table in
   if data.abbrev_activated != on then
     begin
-      abbrev_table := KNmap.add kn (sp, {data with abbrev_activated = on}) !abbrev_table;
+      abbrev_table := KerName.Map.add kn (sp, {data with abbrev_activated = on}) !abbrev_table;
       match use with
       | OnlyPrinting -> ()
       | OnlyParsing | ParsingAndPrinting ->
@@ -52,7 +52,7 @@ let toggle_abbreviation ~on ~use kn =
     end
 
 let toggle_abbreviations ~on ~use filter =
-  KNmap.fold (fun kn (sp,abbrev) () ->
+  KerName.Map.fold (fun kn (sp,abbrev) () ->
       if abbrev.abbrev_activated != on && filter sp abbrev.abbrev_pattern then toggle_abbreviation ~on ~use kn)
   !abbrev_table ()
 
@@ -82,7 +82,7 @@ let open_abbreviation i ((sp,kn),(_local,abbrev)) =
   end
 
 let import_abbreviation i sp kn =
-  let _,abbrev = KNmap.get kn !abbrev_table in
+  let _,abbrev = KerName.Map.get kn !abbrev_table in
   open_abbreviation i ((sp,kn),(false,abbrev))
 
 let cache_abbreviation d =
@@ -117,10 +117,10 @@ let declare_abbreviation ~local user_warns id ~onlyparsing pat =
 
 (* Remark: do not check for activation (if not activated, it is already not supposed to be located) *)
 let search_abbreviation kn =
-  let _,abbrev = KNmap.find kn !abbrev_table in
+  let _,abbrev = KerName.Map.find kn !abbrev_table in
   abbrev.abbrev_pattern
 
 let search_filtered_abbreviation filter kn =
-  let _,abbrev = KNmap.find kn !abbrev_table in
+  let _,abbrev = KerName.Map.find kn !abbrev_table in
   let res = filter abbrev.abbrev_pattern in
   res

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -64,8 +64,8 @@ type rel_context_val = {
 type env = {
   env_constants : constant_key Cmap_env.t;
   env_inductives : mind_key Mindmap_env.t;
-  env_modules : module_body MPmap.t;
-  env_modtypes : module_type_body MPmap.t;
+  env_modules : module_body ModPath.Map.t;
+  env_modtypes : module_type_body ModPath.Map.t;
   env_named_context : named_context_val; (* section variables *)
   env_rel_context   : rel_context_val;
   env_universes : UGraph.t;
@@ -101,8 +101,8 @@ let empty_rel_context_val = {
 let empty_env = {
   env_constants = Cmap_env.empty;
   env_inductives = Mindmap_env.empty;
-  env_modules = MPmap.empty;
-  env_modtypes = MPmap.empty;
+  env_modules = ModPath.Map.empty;
+  env_modtypes = ModPath.Map.empty;
   constant_hyps = Cmap_env.empty;
   inductive_hyps = Mindmap_env.empty;
   env_named_context = empty_named_context_val;
@@ -850,19 +850,19 @@ let keep_hyps env needed =
 (* Modules *)
 
 let add_modtype mp mtb env =
-  let new_modtypes = MPmap.add mp mtb env.env_modtypes in
+  let new_modtypes = ModPath.Map.add mp mtb env.env_modtypes in
   { env with env_modtypes = new_modtypes }
 
 let shallow_add_module mp mb env =
-  let new_mods = MPmap.add mp mb env.env_modules in
+  let new_mods = ModPath.Map.add mp mb env.env_modules in
   { env with env_modules = new_mods }
 
 let lookup_module mp env =
-    MPmap.find mp env.env_modules
+    ModPath.Map.find mp env.env_modules
 
 
 let lookup_modtype mp env =
-  MPmap.find mp env.env_modtypes
+  ModPath.Map.find mp env.env_modtypes
 
 (*s Judgments. *)
 
@@ -1052,8 +1052,8 @@ module Internal = struct
     type t = {
       env_constants : constant_key Cmap_env.t;
       env_inductives : mind_key Mindmap_env.t;
-      env_modules : module_body MPmap.t;
-      env_modtypes : module_type_body MPmap.t;
+      env_modules : module_body ModPath.Map.t;
+      env_modtypes : module_type_body ModPath.Map.t;
       env_named_context : named_context_val;
       env_rel_context   : rel_context_val;
       env_universes : UGraph.t;

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -453,8 +453,8 @@ module Internal : sig
     type t = {
       env_constants : constant_key Cmap_env.t;
       env_inductives : mind_key Mindmap_env.t;
-      env_modules : module_body MPmap.t;
-      env_modtypes : module_type_body MPmap.t;
+      env_modules : module_body ModPath.Map.t;
+      env_modtypes : module_type_body ModPath.Map.t;
       env_named_context : named_context_val;
       env_rel_context   : rel_context_val;
       env_universes : UGraph.t;

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -396,7 +396,7 @@ and subst_signature skind subst mp =
 type 'a mod_expr = ('a, module_implementation) when_mod_body
 
 let rec is_bounded_expr l = function
-  | MEident (MPbound mbid) -> MBIset.mem mbid l
+  | MEident (MPbound mbid) -> MBId.Set.mem mbid l
   | MEapply (fexpr,mp) ->
       is_bounded_expr l (MEident mp) || is_bounded_expr l fexpr
   | _ -> false

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -127,4 +127,4 @@ val hcons_module_type : module_type_body -> module_type_body
        functor(X:T)->struct module M:=<content of T> end)
 *)
 
-val clean_structure : Names.MBIset.t -> structure_body -> structure_body
+val clean_structure : Names.MBId.Set.t -> structure_body -> structure_body

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -398,14 +398,14 @@ let subst_modtype_signature_and_resolver mp_from mp_to sign reso =
 
 let rec collect_mbid l sign =  match sign with
   | MoreFunctor (mbid,ty,m) ->
-    let m' = collect_mbid (MBIset.add mbid l) m in
+    let m' = collect_mbid (MBId.Set.add mbid l) m in
     if m==m' then sign else MoreFunctor (mbid,ty,m')
   | NoFunctor struc ->
     let struc' = clean_structure l struc in
     if struc==struc' then sign else NoFunctor struc'
 
 let clean_bounded_mod_expr sign =
-  if is_functor sign then collect_mbid MBIset.empty sign else sign
+  if is_functor sign then collect_mbid MBId.Set.empty sign else sign
 
 (** {6 Building map of constants to inline } *)
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -149,10 +149,13 @@ let dummy_module_name = "If you see this, it's a bug"
 
 module DirPath =
 struct
+  module Self = struct
   type t = Id.t list
 
   let compare = List.compare Id.compare
   let equal = List.equal Id.equal
+  end
+  include Self
 
   let rec hash accu = function
   | [] -> accu
@@ -181,7 +184,13 @@ struct
 
   let hcons = Hashcons.simple_hcons Hdir.generate Hdir.hcons ()
 
+  module Set = Set.Make(Self)
+  module Map = Map.Make(Self)
+
 end
+
+module DPset = DirPath.Set
+module DPmap = DirPath.Map
 
 (** {6 Unique names for bound modules } *)
 
@@ -245,10 +254,18 @@ struct
 
   let hcons = Hashcons.simple_hcons HashMBId.generate HashMBId.hcons ()
 
+  module Self = struct
+    type nonrec t = t
+    let compare = compare
+  end
+
+  module Set = Set.Make(Self)
+  module Map = CMap.Make(Self)
+
 end
 
-module MBImap = CMap.Make(MBId)
-module MBIset = Set.Make(MBId)
+module MBImap = MBId.Map
+module MBIset = MBId.Set
 
 (** {6 Names of structure elements } *)
 
@@ -358,13 +375,18 @@ module ModPath = struct
 
   let hcons = Hashcons.simple_hcons HashMP.generate HashMP.hcons ()
 
+  module Self = struct
+    type nonrec t = t
+    let compare = compare
+  end
+
+  module Set = Set.Make(Self)
+  module Map = CMap.Make(Self)
+
 end
 
-module DPset = Set.Make(DirPath)
-module DPmap = Map.Make(DirPath)
-
-module MPset = Set.Make(ModPath)
-module MPmap = CMap.Make(ModPath)
+module MPset = ModPath.Set
+module MPmap = ModPath.Map
 
 (** {6 Kernel names } *)
 
@@ -434,11 +456,22 @@ module KerName = struct
   module HashKN = Hashcons.Make(Self_Hashcons)
 
   let hcons = Hashcons.simple_hcons HashKN.generate HashKN.hcons ()
+
+  module Self = struct
+    type nonrec t = t
+    let compare = compare
+    let hash = hash
+  end
+
+  module Map = HMap.Make(Self)
+  module Set = Map.Set
+  module Pred = Predicate.Make(Self)
+
 end
 
-module KNmap = HMap.Make(KerName)
-module KNpred = Predicate.Make(KerName)
-module KNset = KNmap.Set
+module KNmap = KerName.Map
+module KNpred = KerName.Pred
+module KNset = KerName.Set
 
 (** {6 Kernel pairs } *)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -158,10 +158,13 @@ sig
   (** Print non-empty directory paths as ["root.module.submodule"] *)
 
   val print : t -> Pp.t
+
+  module Set : Set.ExtS with type elt = t
+  module Map : Map.ExtS with type key = t and module Set := Set
 end
 
-module DPset : Set.ExtS with type elt = DirPath.t
-module DPmap : Map.ExtS with type key = DirPath.t and module Set := DPset
+module DPset = DirPath.Set [@@deprecated "Use DirPath.Set"]
+module DPmap = DirPath.Map [@@deprecated "Use DirPath.Map"]
 
 (** {6 Names of structure elements } *)
 
@@ -234,10 +237,13 @@ sig
   val debug_to_string : t -> string
   (** Same as [to_string], but outputs extra information related to debug. *)
 
+  module Set : Set.ExtS with type elt = t
+  module Map : Map.ExtS with type key = t and module Set := Set
+
 end
 
-module MBIset : Set.ExtS with type elt = MBId.t
-module MBImap : Map.ExtS with type key = MBId.t and module Set := MBIset
+module MBIset = MBId.Set [@@deprecated "Use MBId.Set"]
+module MBImap = MBId.Map [@@deprecated "Use MBId.Map"]
 
 (** {6 The module part of the kernel name } *)
 
@@ -271,10 +277,13 @@ sig
   val debug_to_string : t -> string
   (** Same as [to_string], but outputs extra information related to debug. *)
 
+  module Set : Set.ExtS with type elt = t
+  module Map : Map.ExtS with type key = t and module Set := Set
+
 end
 
-module MPset : Set.ExtS with type elt = ModPath.t
-module MPmap : Map.ExtS with type key = ModPath.t and module Set := MPset
+module MPset = ModPath.Set [@@deprecated "Use ModPath.Set"]
+module MPmap = ModPath.Map [@@deprecated "Use ModPath.Map"]
 
 (** {6 The absolute names of objects seen by kernel } *)
 
@@ -306,11 +315,16 @@ sig
   val compare : t -> t -> int
   val equal : t -> t -> bool
   val hash : t -> int
+
+  module Set : CSig.USetS with type elt = t
+  module Map : Map.UExtS with type key = t and module Set := Set
+  module Pred : Predicate.S with type elt = t
+
 end
 
-module KNset  : CSig.USetS with type elt = KerName.t
-module KNpred : Predicate.S with type elt = KerName.t
-module KNmap  : Map.UExtS with type key = KerName.t and module Set := KNset
+module KNset = KerName.Set [@@deprecated "Use KerName.Set"]
+module KNpred = KerName.Pred [@@deprecated "Use KerName.Pred"]
+module KNmap = KerName.Map [@@deprecated "Use KerName.Map"]
 
 (** {6 Signature for quotiented names} *)
 

--- a/kernel/vmlibrary.ml
+++ b/kernel/vmlibrary.ml
@@ -117,7 +117,7 @@ let inject lib =
 
 type t = {
   local : VmTable.t;
-  foreign : compiled_library Delayed.t DPmap.t;
+  foreign : compiled_library Delayed.t DirPath.Map.t;
 }
 
 type index = VmTable.index
@@ -126,7 +126,7 @@ type indirect_code = VmTable.index pbody_code
 
 let empty = {
   local = VmTable.empty;
-  foreign = DPmap.empty;
+  foreign = DirPath.Map.empty;
 }
 
 let set_path dp lib =
@@ -144,8 +144,8 @@ let load dp ~file ch =
   (dp, Delayed.make ~file ~segment:vm_segment ch : on_disk)
 
 let link (dp, m) libs =
-  let () = assert (not @@ DPmap.mem dp libs.foreign) in
-  { libs with foreign = DPmap.add dp m libs.foreign }
+  let () = assert (not @@ DirPath.Map.mem dp libs.foreign) in
+  { libs with foreign = DirPath.Map.add dp m libs.foreign }
 
 let missing_index dp i =
   CErrors.anomaly Pp.(str "Missing VM index " ++ int i ++
@@ -156,7 +156,7 @@ let resolve (dp, i) libs =
     match Int.Map.find i libs.local.VmTable.table_val with
     | v -> v
     | exception Not_found -> missing_index dp i
-  else match DPmap.find dp libs.foreign with
+  else match DirPath.Map.find dp libs.foreign with
   | tab ->
     let tab = Delayed.eval tab in
     tab.lib_data.(i)

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -688,7 +688,7 @@ module Quality = EasyNoWarn(QualityV)()
 module ModTypeV = struct
   include ModPath
   let is_var _ = None
-  module Map = MPmap
+  module Map = ModPath.Map
   let stage = Summary.Stage.Synterp
   let summary_name = "modtypetab"
 end
@@ -697,7 +697,7 @@ module ModTypes = EasyNoWarn(ModTypeV)()
 module ModuleV = struct
   include ModPath
   let is_var _ = None
-  module Map = MPmap
+  module Map = ModPath.Map
   let stage = Summary.Stage.Synterp
   let summary_name = "moduletab"
 end

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -84,25 +84,25 @@ module Visit : VISIT = struct
 
   type t =
       { mutable kn : KNset.t;
-        mutable mp : MPset.t;
-        mutable mp_all : MPset.t }
+        mutable mp : ModPath.Set.t;
+        mutable mp_all : ModPath.Set.t }
   (* the imperative internal visit lists *)
   let make () = {
     kn = KNset.empty;
-    mp = MPset.empty;
-    mp_all = MPset.empty;
+    mp = ModPath.Set.empty;
+    mp_all = ModPath.Set.empty;
   }
   (* the accessor functions *)
   let needed_ind v i inst = KNset.mem (MutInd.user i, inst) v.kn
   let needed_cst v c inst = KNset.mem (Constant.user c, inst) v.kn
-  let needed_mp v mp = MPset.mem mp v.mp || MPset.mem mp v.mp_all
-  let needed_mp_all v mp = MPset.mem mp v.mp_all
+  let needed_mp v mp = ModPath.Set.mem mp v.mp || ModPath.Set.mem mp v.mp_all
+  let needed_mp_all v mp = ModPath.Set.mem mp v.mp_all
   let add_mp v mp =
-    check_loaded_modfile mp; v.mp <- MPset.union (prefixes_mp mp) v.mp
+    check_loaded_modfile mp; v.mp <- ModPath.Set.union (prefixes_mp mp) v.mp
   let add_mp_all v mp =
     check_loaded_modfile mp;
-    v.mp <- MPset.union (prefixes_mp mp) v.mp;
-    v.mp_all <- MPset.add mp v.mp_all
+    v.mp <- ModPath.Set.union (prefixes_mp mp) v.mp;
+    v.mp_all <- ModPath.Set.add mp v.mp_all
   let add_kn v kn inst = v.kn <- KNset.add (kn, inst) v.kn; add_mp v (KerName.modpath kn)
   let add_ref v r = let open GlobRef in match r.glob with
     | ConstRef c -> add_kn v (Constant.user c) r.inst

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -321,7 +321,7 @@ let base_r r = let open GlobRef in match r.glob with
   | _ -> assert false
 
 type needed = {
-  needed_mp : MPset.t;
+  needed_mp : ModPath.Set.t;
   needed_rf : Refset'.t;
 }
 
@@ -329,14 +329,14 @@ let add_needed nd r =
   nd := { !nd with needed_rf = Refset'.add (base_r r) !nd.needed_rf }
 
 let add_needed_mp nd mp =
-  nd := { !nd with needed_mp = MPset.add mp !nd.needed_mp }
+  nd := { !nd with needed_mp = ModPath.Set.add mp !nd.needed_mp }
 
 let found_needed nd r =
   nd := { !nd with needed_rf = Refset'.remove (base_r r) !nd.needed_rf }
 
 let is_needed nd r =
   let r = base_r r in
-  Refset'.mem r nd.needed_rf || MPset.mem (modpath_of_r r) nd.needed_mp
+  Refset'.mem r nd.needed_rf || ModPath.Set.mem (modpath_of_r r) nd.needed_mp
 
 let declared_refs = function
   | Dind p -> [p.ind_packets.(0).ip_typename_ref]
@@ -429,7 +429,7 @@ let optimize_struct table to_appear struc =
     if Common.State.get_library table then
       List.filter (fun (_,lse) -> not (List.is_empty lse)) opt_struc
     else
-      let nd = ref { needed_mp = MPset.empty; needed_rf = Refset'.empty } in
+      let nd = ref { needed_mp = ModPath.Set.empty; needed_rf = Refset'.empty } in
       let () = List.iter (fun r -> add_needed nd r) (fst to_appear) in
       let () = List.iter (fun mp -> add_needed_mp nd mp) (snd to_appear) in
       depcheck_struct (Common.State.get_table table) nd opt_struc

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -59,7 +59,7 @@ val file_of_modfile : t -> ModPath.t -> string
 val is_toplevel : ModPath.t -> bool
 val at_toplevel : ModPath.t -> bool
 val mp_length : ModPath.t -> int
-val prefixes_mp : ModPath.t -> MPset.t
+val prefixes_mp : ModPath.t -> ModPath.Set.t
 val common_prefix_from_list :
   ModPath.t -> ModPath.t list -> ModPath.t option
 val get_nth_label_mp : int -> ModPath.t -> Label.t

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -62,10 +62,10 @@ type pp_tactic = {
 }
 
 (* Tactic notations *)
-let prnotation_tab = Summary.ref ~name:"pptactic-notation" KNmap.empty
+let prnotation_tab = Summary.ref ~name:"pptactic-notation" KerName.Map.empty
 
 let declare_notation_tactic_pprule kn pt =
-  prnotation_tab := KNmap.add kn pt !prnotation_tab
+  prnotation_tab := KerName.Map.add kn pt !prnotation_tab
 
 type 'a raw_extra_genarg_printer =
   Environ.env -> Evd.evar_map ->
@@ -259,7 +259,7 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_alias_key key =
     try
-      let prods = (KNmap.find key !prnotation_tab).pptac_prods in
+      let prods = (KerName.Map.find key !prnotation_tab).pptac_prods in
       let pr = function
       | TacTerm s -> primitive s
       | TacNonTerm (_, (symb, _)) -> str (Printf.sprintf "(%s)" (pr_user_symbol symb))
@@ -272,7 +272,7 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_alias_gen pr_gen lev key l =
     try
-      let pp = KNmap.find key !prnotation_tab in
+      let pp = KerName.Map.find key !prnotation_tab in
       let rec pack prods args = match prods, args with
       | [], [] -> []
       | TacTerm s :: prods, args -> TacTerm s :: pack prods args

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -528,7 +528,7 @@ let register_ltac atts = function
 (** Queries *)
 
 let print_ltacs () =
-  let entries = KNmap.bindings (Tacenv.ltac_entries ()) in
+  let entries = KerName.Map.bindings (Tacenv.ltac_entries ()) in
   let sort (kn1, _) (kn2, _) = KerName.compare kn1 kn2 in
   let entries = List.sort sort entries in
   let map (kn, entry) =
@@ -588,7 +588,7 @@ let () =
   let name (qid,kn) = str "Ltac" ++ spc () ++ pr_path (Tacenv.path_of_tactic kn) in
   let print (qid,kn) =
     let entries = Tacenv.ltac_entries () in
-    let tac = KNmap.find kn entries in
+    let tac = KerName.Map.find kn entries in
     print_ltac_body qid tac in
   let about = name in
   register_locatable locatable_ltac {
@@ -607,7 +607,7 @@ let print_ltac id =
  try
   let kn = Tacenv.locate_tactic id in
   let entries = Tacenv.ltac_entries () in
-  let tac = KNmap.find kn entries in
+  let tac = KerName.Map.find kn entries in
   print_ltac_body id tac
  with
   Not_found ->

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -18,7 +18,7 @@ open Tacexpr
 module TacticV = struct
   include KerName
   let is_var _ = None
-  module Map = KNmap
+  module Map = KerName.Map
   let stage = Summary.Stage.Interp
   let summary_name = "ltac1tab"
 end
@@ -46,16 +46,16 @@ type alias_tactic =
   }
 
 let alias_map = Summary.ref ~name:"tactic-alias"
-  (KNmap.empty : alias_tactic KNmap.t)
+  (KerName.Map.empty : alias_tactic KerName.Map.t)
 
 let register_alias key tac =
-  alias_map := KNmap.add key tac !alias_map
+  alias_map := KerName.Map.add key tac !alias_map
 
 let interp_alias key =
-  try KNmap.find key !alias_map
+  try KerName.Map.find key !alias_map
   with Not_found -> CErrors.anomaly (str "Unknown tactic alias: " ++ KerName.print key ++ str ".")
 
-let check_alias key = KNmap.mem key !alias_map
+let check_alias key = KerName.Map.mem key !alias_map
 
 (** ML tactic extensions (TacML) *)
 
@@ -112,14 +112,14 @@ type ltac_entry = {
 }
 
 let mactab =
-  Summary.ref (KNmap.empty : ltac_entry KNmap.t)
+  Summary.ref (KerName.Map.empty : ltac_entry KerName.Map.t)
     ~name:"tactic-definition"
 
 let ltac_entries () = !mactab
 
-let interp_ltac r = (KNmap.find r !mactab).tac_body
+let interp_ltac r = (KerName.Map.find r !mactab).tac_body
 
-let is_ltac_for_ml_tactic r = (KNmap.find r !mactab).tac_for_ml
+let is_ltac_for_ml_tactic r = (KerName.Map.find r !mactab).tac_for_ml
 
 let add ~depr kn b t =
   let entry = {
@@ -129,14 +129,14 @@ let add ~depr kn b t =
     tac_deprecation = depr;
   }
   in
-  mactab := KNmap.add kn entry !mactab
+  mactab := KerName.Map.add kn entry !mactab
 
 let replace kn path t =
   let entry _ e = { e with tac_body = t; tac_redef = path :: e.tac_redef } in
-  mactab := KNmap.modify kn entry !mactab
+  mactab := KerName.Map.modify kn entry !mactab
 
 let tac_deprecation kn =
-  try (KNmap.find kn !mactab).tac_deprecation with Not_found -> None
+  try (KerName.Map.find kn !mactab).tac_deprecation with Not_found -> None
 
 type tacdef = {
   local : bool;

--- a/plugins/ltac/tacenv.mli
+++ b/plugins/ltac/tacenv.mli
@@ -79,7 +79,7 @@ type ltac_entry = {
   (** Deprecation notice to be printed when the tactic is used *)
 }
 
-val ltac_entries : unit -> ltac_entry KNmap.t
+val ltac_entries : unit -> ltac_entry KerName.Map.t
 (** Low-level access to all Ltac entries currently defined. *)
 
 (** {5 ML tactic extensions} *)

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1078,7 +1078,7 @@ let print_type ~print_def qid kn =
         in
         hv 2 (str "{ " ++ prlist_with_sep spc pr_field fields ++ str " }")
       | GTydOpn ->
-        let ctors = KNmap.bindings (Tac2env.find_all_constructors_in_type kn) in
+        let ctors = KerName.Map.bindings (Tac2env.find_all_constructors_in_type kn) in
         if CList.is_empty ctors then str "[ .. ]"
         else
           let pr_ctor (ckn, cdata) =
@@ -1194,7 +1194,7 @@ let print_ltac2_type qid =
     Feedback.msg_notice (print_type ~print_def:true qid kn)
 
 let print_signatures () =
-  let entries = KNmap.bindings (Tac2env.globals ()) in
+  let entries = KerName.Map.bindings (Tac2env.globals ()) in
   let sort (kn1, _) (kn2, _) = KerName.compare kn1 kn2 in
   let entries = List.sort sort entries in
   let map (kn, entry) =

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -37,7 +37,7 @@ type compile_info = {
 val set_compiled_global : ltac_constant -> compile_info -> valexpr -> unit
 val get_compiled_global : ltac_constant -> (compile_info * valexpr) option
 
-val globals : unit -> global_data KNmap.t
+val globals : unit -> global_data KerName.Map.t
 
 (** {5 Toplevel definition of types} *)
 
@@ -63,7 +63,7 @@ type constructor_data = {
 val define_constructor : ltac_constructor -> constructor_data -> unit
 val interp_constructor : ltac_constructor -> constructor_data
 
-val find_all_constructors_in_type : type_constant -> constructor_data KNmap.t
+val find_all_constructors_in_type : type_constant -> constructor_data KerName.Map.t
 (** Useful for printing info about currently defined constructors of open types. *)
 
 (** {5 Toplevel definition of projections} *)

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -123,7 +123,7 @@ type case_info = type_constant or_tuple
 
 type 'a open_match = {
   opn_match : 'a;
-  opn_branch : (Name.t * Name.t array * 'a) KNmap.t;
+  opn_branch : (Name.t * Name.t array * 'a) KerName.Map.t;
   (** Invariant: should not be empty *)
   opn_default : Name.t * 'a;
 }

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1042,14 +1042,14 @@ let to_simple_case env ?loc (e,t) pl =
         in
         let ids = List.map get args in
         let map =
-          if KNmap.mem knc map then
+          if KerName.Map.mem knc map then
             map
           else
-            KNmap.add knc (Anonymous, Array.of_list ids, br) map
+            KerName.Map.add knc (Anonymous, Array.of_list ids, br) map
         in
         intern_branch map rem
     in
-    let (map, def) = intern_branch KNmap.empty pl in
+    let (map, def) = intern_branch KerName.Map.empty pl in
     GTacWth { opn_match = e; opn_branch = map; opn_default = def }
 
 let check ?loc env tycon (e,t as et) =
@@ -1872,9 +1872,9 @@ let rec subst_expr subst e = match e with
     let kn' = subst_kn subst kn in
     let p' = subst_expr subst p in
     if kn' == kn && p' == p then accu
-    else KNmap.add kn' (self, vars, p') (KNmap.remove kn accu)
+    else KerName.Map.add kn' (self, vars, p') (KerName.Map.remove kn accu)
   in
-  let br' = KNmap.fold fold br br in
+  let br' = KerName.Map.fold fold br br in
   if e' == e && br' == br && def' == def then e0
   else GTacWth { opn_match = e'; opn_default = (na, def'); opn_branch = br' }
 | GTacFullMatch (e,brs) as e0 ->

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -185,7 +185,7 @@ and interp_case ist e cse0 cse1 =
 
 and interp_with ist e cse def =
   let (kn, args) = Tac2ffi.to_open e in
-  let br = try Some (KNmap.find kn cse) with Not_found -> None in
+  let br = try Some (KerName.Map.find kn cse) with Not_found -> None in
   begin match br with
   | None ->
     let (self, def) = def in

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -314,13 +314,13 @@ end
 
 type rewrite_db = {
   rdb_hintdn : HintDN.t;
-  rdb_order : int KNmap.t;
+  rdb_order : int KerName.Map.t;
   rdb_maxuid : int;
 }
 
 let empty_rewrite_db = {
   rdb_hintdn = HintDN.empty;
-  rdb_order = KNmap.empty;
+  rdb_order = KerName.Map.empty;
   rdb_maxuid = 0;
 }
 
@@ -338,13 +338,13 @@ let find_base bas =
 
 let find_rewrites bas =
   let db = find_base bas in
-  let sort r1 r2 = Int.compare (KNmap.find r2.rew_id db.rdb_order) (KNmap.find r1.rew_id db.rdb_order) in
+  let sort r1 r2 = Int.compare (KerName.Map.find r2.rew_id db.rdb_order) (KerName.Map.find r1.rew_id db.rdb_order) in
   List.sort sort (HintDN.find_all db.rdb_hintdn)
 
 let find_matches env bas pat =
   let base = find_base bas in
   let res = HintDN.search_pattern env base.rdb_hintdn pat in
-  let sort r1 r2 = Int.compare (KNmap.find r2.rew_id base.rdb_order) (KNmap.find r1.rew_id base.rdb_order) in
+  let sort r1 r2 = Int.compare (KerName.Map.find r2.rew_id base.rdb_order) (KerName.Map.find r1.rew_id base.rdb_order) in
   List.sort sort res
 
 let print_rewrite_hintdb bas =
@@ -469,7 +469,7 @@ let cache_hintrewrite (rbase,lrl) =
   let base = try raw_find_base rbase with Not_found -> empty_rewrite_db in
   let fold accu r = {
     rdb_hintdn = HintDN.add (Global.env ()) r.rew_pat r accu.rdb_hintdn;
-    rdb_order = KNmap.add r.rew_id accu.rdb_maxuid accu.rdb_order;
+    rdb_order = KerName.Map.add r.rew_id accu.rdb_maxuid accu.rdb_order;
     rdb_maxuid = accu.rdb_maxuid + 1;
   } in
   let base = List.fold_left fold base lrl in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -28,7 +28,7 @@ module NamedDecl = Context.Named.Declaration
     without body. We fix this by looking in the implementation
     of the module *)
 
-let modcache = ref (MPmap.empty : structure_body MPmap.t)
+let modcache = ref (ModPath.Map.empty : structure_body ModPath.Map.t)
 
 let rec search_mod_label lab = function
   | [] -> raise Not_found
@@ -75,10 +75,10 @@ let rec lookup_module_in_impl mp =
          search_mod_label lab' fields
 
 and memoize_fields_of_mp mp =
-  try MPmap.find mp !modcache
+  try ModPath.Map.find mp !modcache
   with Not_found ->
     let l = fields_of_mp mp in
-    modcache := MPmap.add mp l !modcache;
+    modcache := ModPath.Map.add mp l !modcache;
     l
 
 and fields_of_mp mp =
@@ -333,7 +333,7 @@ and traverse_context access current ctx accu ctxt =
            ctx, accu) ctxt ~init:(ctx, accu))
 
 let traverse access current t =
-  let () = modcache := MPmap.empty in
+  let () = modcache := ModPath.Map.empty in
   traverse access current Context.Rel.empty (GlobRef.Set_env.empty, GlobRef.Map_env.empty, GlobRef.Map_env.empty) t
 
 (** Hopefully bullet-proof function to recover the type of a constant. It just


### PR DESCRIPTION
only for types below KerPair to avoid dealing with the canonical vs user split

Overlays:
- https://github.com/impermeable/coq-waterproof/pull/162
- https://github.com/coq-tactician/coq-tactician/pull/104
- https://github.com/ejgallego/coq-lsp/pull/989