### PR TITLE
Ltac2 type ltac_constant <> KerName.t

### DIFF
--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -113,7 +113,7 @@ let classify_abbreviation abbrev =
   if abbrev.abbrev_local = Local then Dispose else Substitute
 
 let inAbbreviation : Id.t -> abbreviation -> obj =
-  declare_named_object {(default_object "ABBREVIATION") with
+  declare_named_object make_oname {(default_object "ABBREVIATION") with
     cache_function = cache_abbreviation;
     load_function = load_abbreviation;
     open_function = filtered_open open_abbreviation;

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -170,9 +170,8 @@ let declare_object_gen odecl =
 let make_oname { obj_path; obj_mp } id =
   Libnames.add_path_suffix obj_path id, Names.KerName.make obj_mp id
 
-let declare_named_object_full odecl =
+let declare_named_object_full oname odecl =
   let odecl =
-    let oname = make_oname in
     { object_name = odecl.object_name;
       object_stage = odecl.object_stage;
       cache_function = (fun (p, (id, o)) -> odecl.cache_function (oname p id, o));
@@ -186,10 +185,12 @@ let declare_named_object_full odecl =
   in
   declare_object_gen odecl
 
-let declare_named_object odecl =
-  let tag = declare_named_object_full odecl in
+let declare_named_object oname odecl =
+  let tag = declare_named_object_full oname odecl in
   let infun id v = Dyn.Dyn (tag, (id, v)) in
   infun
+
+let declare_named_object_gen_full odecl = declare_object_gen odecl
 
 let declare_named_object_gen odecl =
   let tag = declare_object_gen odecl in

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -204,12 +204,6 @@ val declare_object :
 val declare_object_full :
   ('a, 'a, _) object_declaration -> 'a Dyn.tag
 
-val declare_named_object_full :
-  ('a, object_name * 'a, _) object_declaration -> (Id.t * 'a) Dyn.tag
-
-val declare_named_object :
-  ('a, object_name * 'a, _) object_declaration -> (Id.t -> 'a -> obj)
-
 (** Object prefix morally contains the "prefix" naming of an object to
    be stored by [library], where [obj_path] is the "absolute" path and
    [obj_mp] is the current "module" prefix.
@@ -228,7 +222,20 @@ type object_prefix = {
   obj_mp  : ModPath.t;
 }
 
+val make_oname : object_prefix -> Id.t -> object_name
+
+val declare_named_object_full :
+  (object_prefix -> Id.t -> 'name) ->
+  ('a, 'name * 'a, _) object_declaration -> (Id.t * 'a) Dyn.tag
+
+val declare_named_object :
+  (object_prefix -> Id.t -> 'name) ->
+  ('a, 'name * 'a, _) object_declaration -> (Id.t -> 'a -> obj)
+
 val eq_object_prefix : object_prefix -> object_prefix -> bool
+
+val declare_named_object_gen_full :
+  ('a, object_prefix * 'a, _) object_declaration -> 'a Dyn.tag
 
 val declare_named_object_gen :
   ('a, object_prefix * 'a, _) object_declaration -> ('a -> obj)

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -101,7 +101,7 @@ let subst_tacdef (subst, def) =
 let classify_tacdef o = Substitute
 
 let inTacDef : Id.t -> tacdef -> obj =
-  declare_named_object make_oname {(default_object "TAC2-DEFINITION") with
+  declare_named_object TacConstant.make_oname {(default_object "TAC2-DEFINITION") with
      cache_function  = cache_tacdef;
      load_function   = load_tacdef;
      open_function   = filtered_open open_tacdef;
@@ -330,7 +330,7 @@ let check_value ?loc e =
        str "Consider using a thunk.")
 
 let check_ltac_exists {loc;v=id} =
-  let kn = Lib.make_kn id in
+  let kn = TacConstant.make (Lib.current_mp()) id in
   let exists =
     try let _ = Tac2env.interp_global kn in true with Not_found -> false
   in
@@ -927,7 +927,7 @@ let subst_abbreviation (subst, abbr) =
 let classify_abbreviation o = Substitute
 
 let inTac2Abbreviation : Id.t -> abbreviation -> obj =
-  declare_named_object make_oname {(default_object "TAC2-ABBREVIATION") with
+  declare_named_object TacAlias.make_oname {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
      open_function   = filtered_open ~cat:ltac2_notation_cat open_abbreviation;
@@ -1080,7 +1080,7 @@ let perform_redefinition (prefix,redef) =
   Tac2env.define_global kn data
 
 let subst_redefinition (subst, redef) =
-  let kn = Mod_subst.subst_kn subst redef.redef_kn in
+  let kn = TacConstant.subst subst redef.redef_kn in
   let body = Tac2intern.subst_expr subst redef.redef_body in
   if kn == redef.redef_kn && body == redef.redef_body then redef
   else { redef_local = redef.redef_local;
@@ -1414,8 +1414,8 @@ let print_ltac2_type qid =
     Feedback.msg_notice (print_type ~print_def:true qid kn)
 
 let print_signatures () =
-  let entries = KerName.Map.bindings (Tac2env.globals ()) in
-  let sort (kn1, _) (kn2, _) = KerName.compare kn1 kn2 in
+  let entries = TacConstant.Map.bindings (Tac2env.globals ()) in
+  let sort (kn1, _) (kn2, _) = TacConstant.compare kn1 kn2 in
   let entries = List.sort sort entries in
   let map (kn, entry) =
     let qid =

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -101,7 +101,7 @@ let subst_tacdef (subst, def) =
 let classify_tacdef o = Substitute
 
 let inTacDef : Id.t -> tacdef -> obj =
-  declare_named_object {(default_object "TAC2-DEFINITION") with
+  declare_named_object make_oname {(default_object "TAC2-DEFINITION") with
      cache_function  = cache_tacdef;
      load_function   = load_tacdef;
      open_function   = filtered_open open_tacdef;
@@ -211,7 +211,7 @@ let subst_typdef (subst, def) =
 let classify_typdef o = Substitute
 
 let inTypDef : Id.t -> typdef -> obj =
-  declare_named_object {(default_object "TAC2-TYPE-DEFINITION") with
+  declare_named_object make_oname {(default_object "TAC2-TYPE-DEFINITION") with
      cache_function  = cache_typdef;
      load_function   = load_typdef;
      open_function   = filtered_open open_typdef;
@@ -625,7 +625,7 @@ let cache_custom_entry o =
   import_custom_entry 1 o
 
 let inCustomEntry : Id.t -> bool -> Libobject.obj =
-  declare_named_object {
+  declare_named_object Lib.make_oname {
     (default_object "Ltac2 custom entry") with
     object_stage = Synterp;
     cache_function = cache_custom_entry;
@@ -927,7 +927,7 @@ let subst_abbreviation (subst, abbr) =
 let classify_abbreviation o = Substitute
 
 let inTac2Abbreviation : Id.t -> abbreviation -> obj =
-  declare_named_object {(default_object "TAC2-ABBREVIATION") with
+  declare_named_object make_oname {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
      open_function   = filtered_open ~cat:ltac2_notation_cat open_abbreviation;

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -37,7 +37,7 @@ type compile_info = {
 val set_compiled_global : ltac_constant -> compile_info -> valexpr -> unit
 val get_compiled_global : ltac_constant -> (compile_info * valexpr) option
 
-val globals : unit -> global_data KerName.Map.t
+val globals : unit -> global_data TacConstant.Map.t
 
 (** {5 Toplevel definition of types} *)
 
@@ -91,8 +91,8 @@ type alias_data = {
   alias_depr : Deprecation.t option;
 }
 
-val define_alias : ?deprecation:Deprecation.t -> ltac_constant -> raw_tacexpr -> unit
-val interp_alias : ltac_constant -> alias_data
+val define_alias : ?deprecation:Deprecation.t -> ltac_alias -> raw_tacexpr -> unit
+val interp_alias : ltac_alias -> alias_data
 
 (** {5 Toplevel definition of notations} *)
 

--- a/plugins/ltac2/tac2expr.mli
+++ b/plugins/ltac2/tac2expr.mli
@@ -17,8 +17,11 @@ type redef_flag = bool
 type lid = Id.t
 type uid = Id.t
 
-type ltac_constant = KerName.t
-type ltac_alias = KerName.t
+module TacConstant : module type of Tac2names
+module TacAlias : module type of Tac2names
+type ltac_constant = TacConstant.t
+type ltac_alias = TacAlias.t
+
 type ltac_notation = KerName.t
 type ltac_constructor = KerName.t
 type ltac_projection = KerName.t

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -1169,7 +1169,7 @@ let rec intern_rec env tycon {loc;v=e} =
     let { Tac2env.gdata_type = sch; gdata_deprecation = depr } =
       try Tac2env.interp_global kn
       with Not_found ->
-        CErrors.anomaly (str "Missing hardwired primitive " ++ KerName.print kn)
+        CErrors.anomaly (str "Missing hardwired primitive " ++ TacConstant.print kn)
     in
     let () = check_deprecated_ltac2 ?loc qid (TacConstant kn) in
     check (GTacRef kn, fresh_type_scheme env sch)
@@ -1177,7 +1177,7 @@ let rec intern_rec env tycon {loc;v=e} =
     let e =
       try Tac2env.interp_alias kn
       with Not_found ->
-        CErrors.anomaly (str "Missing hardwired alias " ++ KerName.print kn)
+        CErrors.anomaly (str "Missing hardwired alias " ++ TacAlias.print kn)
     in
     let () = check_deprecated_ltac2 ?loc qid (TacAlias kn) in
     intern_rec env tycon e.alias_body
@@ -1856,7 +1856,7 @@ let rec subst_glb_pat subst = function
 
 let rec subst_expr subst e = match e with
 | GTacAtm _ | GTacVar _ | GTacPrm _ -> e
-| GTacRef kn -> GTacRef (subst_kn subst kn)
+| GTacRef kn -> GTacRef (TacConstant.subst subst kn)
 | GTacFun (ids, e) -> GTacFun (ids, subst_expr subst e)
 | GTacApp (f, args) ->
   GTacApp (subst_expr subst f, List.map (fun e -> subst_expr subst e) args)
@@ -1962,10 +1962,10 @@ let rec subst_rawtype subst ({loc;v=tr} as t) = match tr with
 let subst_tacref subst ref = match ref with
 | RelId _ -> ref
 | AbsKn (TacConstant kn) ->
-  let kn' = subst_kn subst kn in
+  let kn' = TacConstant.subst subst kn in
   if kn' == kn then ref else AbsKn (TacConstant kn')
 | AbsKn (TacAlias kn) ->
-  let kn' = subst_kn subst kn in
+  let kn' = TacAlias.subst subst kn in
   if kn' == kn then ref else AbsKn (TacAlias kn')
 
 let subst_projection subst prj = match prj with

--- a/plugins/ltac2/tac2interp.ml
+++ b/plugins/ltac2/tac2interp.ml
@@ -216,7 +216,7 @@ and eval_global kn =
   match Tac2env.get_compiled_global kn with
   | Some (_info,v) -> v
   | None -> match Tac2env.interp_global kn with
-    | exception Not_found -> anomaly (str "Unbound reference" ++ KerName.print kn)
+    | exception Not_found -> anomaly (str "Unbound reference" ++ TacConstant.print kn)
     | { gdata_expr = e } -> eval_pure Id.Map.empty (Some kn) e
 
 and eval_pure bnd kn = function

--- a/plugins/ltac2/tac2names.ml
+++ b/plugins/ltac2/tac2names.ml
@@ -1,0 +1,17 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+include Names.KerName
+
+let of_kn x = x
+
+let subst = Mod_subst.subst_kn
+
+let make_oname = Libobject.make_oname

--- a/plugins/ltac2/tac2names.mli
+++ b/plugins/ltac2/tac2names.mli
@@ -1,0 +1,17 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+include module type of Names.KerName
+
+val of_kn : Names.KerName.t -> t
+
+val subst : Mod_subst.substitution -> t -> t
+
+val make_oname : Libobject.object_prefix -> Names.Id.t -> Libnames.full_path * t

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -17,9 +17,9 @@ open Pputils
 
 let pr_tacref avoid kn =
   try Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac avoid (TacConstant kn))
-  with Not_found when !Flags.in_debugger || KerName.Map.mem kn (Tac2env.globals()) ->
-    str (ModPath.to_string (KerName.modpath kn))
-    ++ str"." ++ Id.print (KerName.label kn)
+  with Not_found when !Flags.in_debugger || TacConstant.Map.mem kn (Tac2env.globals()) ->
+    str (ModPath.to_string (TacConstant.modpath kn))
+    ++ str"." ++ Id.print (TacConstant.label kn)
     ++ if !Flags.in_debugger then mt() else str " (* local *)"
 
 (** Utils *)

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -81,7 +81,7 @@ let in_constr mods n =
   kername mp n
 
 let global_ref ?loc kn =
-  CAst.make ?loc @@ CTacRef (AbsKn (TacConstant kn))
+  CAst.make ?loc @@ CTacRef (AbsKn (TacConstant (TacConstant.of_kn kn)))
 
 let constructor ?loc kn args =
   let cst = CAst.make ?loc @@ CTacCst (AbsKn (Other kn)) in

--- a/plugins/ltac2_ltac1/tac2core_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2core_ltac1.ml
@@ -123,7 +123,7 @@ open Tac2quote.Refs
 let core_prefix path n = KerName.make path (Id.of_string_soft n)
 let ltac1_core n = core_prefix Tac2env.ltac1_prefix n
 let t_ltac1 = ltac1_core "t"
-let ltac1_lambda = ltac1_core "lambda"
+let ltac1_lambda = TacConstant.of_kn @@ ltac1_core "lambda"
 
 let () =
   let intern ist (ids, tac) =

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -441,7 +441,7 @@ let classify_constant cst = Libobject.Substitute
 
 let (objConstant : (Id.t * constant_obj) Libobject.Dyn.tag) =
   let open Libobject in
-  declare_named_object_full { (default_object "CONSTANT") with
+  declare_named_object_full make_oname { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
     open_function = filtered_open open_constant;

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -65,7 +65,7 @@ let discharge_inductive names =
 
 let objInductive : (Id.t * inductive_obj) Libobject.Dyn.tag =
   let open Libobject in
-  declare_named_object_full {(default_object "INDUCTIVE") with
+  declare_named_object_full make_oname {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
     open_function = filtered_open open_inductive;

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -2150,7 +2150,7 @@ let classify_custom_entry local =
   if local then Dispose else Substitute
 
 let inCustomEntry : Id.t -> locality_flag -> obj =
-  declare_named_object {(default_object "CUSTOM-ENTRIES") with
+  declare_named_object Lib.make_oname {(default_object "CUSTOM-ENTRIES") with
       object_stage = Summary.Stage.Synterp;
       cache_function = cache_custom_entry;
       load_function = load_custom_entry;


### PR DESCRIPTION
also type ltac_alias

If this experiment seems useful I can do the others (constructor, type
constant etc) in a followup PR.

The new Tac2names module wrapping KerName with a few extra functions
may be better placed outside the ltac2 plugin (it's not ltac2
specific) (and therefore named something else).

Depends:
- https://github.com/rocq-prover/rocq/pull/20836