### PR TITLE
Congruence: naive support for primitive arrays

### DIFF
--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -21,6 +21,7 @@ type constructor =
 | Int of Uint63.t
 | Float of Float64.t
 | String of Pstring.t
+| Array of {uvars: UVars.Instance.t; length: int}
 
 type cinfo =
     {ci_constr: constructor; (* inductive type *)

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -24,6 +24,11 @@ type rule =
 | Inject of proof * Constr.pconstructor * int * int
   (** ⊢ ci v = ci w :: Ind(args) -> ⊢ v = w :: T
       where T is the type of the n-th argument of ci, assuming they coincide *)
+| InjectArray of proof * int * int
+  (** ⊢ v = w :: array -> ⊢ v.[n] = w.[n] :: T
+      where T is the type of the n-th argument of ci, assuming they coincide.
+      NOTE:
+  *)
 and proof =
     private {p_lhs:ATerm.t;p_rhs:ATerm.t;p_rule:rule}
 

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -93,6 +93,16 @@ let rec decompose_term env sigma t =
         ATerm.mkConstructor env { ci_constr = Int i; ci_arity = 0; ci_nhyps = 0 }
     | Float f ->
         ATerm.mkConstructor env { ci_constr = Float f; ci_arity = 0; ci_nhyps = 0 }
+    | Array (uvars, vals, def, ty) ->
+        let length = Array.length vals in
+        let uvars = EInstance.kind sigma uvars in
+        let head =
+          ATerm.mkConstructor env
+            { ci_constr = Array {uvars; length}; ci_arity = length + 2; ci_nhyps = length + 1 }
+        in
+        let head = ATerm.mkAppli (head, decompose_term env sigma ty) in
+        let head = ATerm.mkAppli (head, decompose_term env sigma def) in
+        Array.fold_left (fun s t-> ATerm.mkAppli (s,decompose_term env sigma t)) head vals
     | _ ->
        let t = Termops.strip_outer_cast sigma t in
        if closed0 sigma t then ATerm.mkSymb (EConstr.to_constr ~abort_on_undefined_evars:false sigma t) else raise Not_found
@@ -323,6 +333,18 @@ let rec proof_term env sigma (typ, lhs, rhs) p = match p.p_rule with
   let g = constr_of_term p1.p_rhs in
   let t = constr_of_term p2.p_lhs in
   let u = constr_of_term p2.p_rhs in
+  debug_congruence Pp.(fun () ->
+      str "Congr" ++ spc () ++ str "f" ++ spc () ++ str "=" ++ spc () ++
+      Printer.pr_econstr_env env sigma f);
+  debug_congruence Pp.(fun () ->
+      str "Congr" ++ spc () ++ str "g" ++ spc () ++ str "=" ++ spc () ++
+      Printer.pr_econstr_env env sigma g);
+  debug_congruence Pp.(fun () ->
+      str "Congr" ++ spc () ++ str "t" ++ spc () ++ str "=" ++ spc () ++
+      Printer.pr_econstr_env env sigma t);
+  debug_congruence Pp.(fun () ->
+      str "Congr" ++ spc () ++ str "u" ++ spc () ++ str "=" ++ spc () ++
+      Printer.pr_econstr_env env sigma u);
   let sigma, funty = type_and_refresh_ env sigma f in
   let sigma, argty = type_and_refresh_ env sigma t in
   let id = fresh_id env (Id.of_string "f") in
@@ -354,6 +376,41 @@ let rec proof_term env sigma (typ, lhs, rhs) p = match p.p_rule with
   let sigma, proj = Ccprojectability.build_projection env sigma cstr argind typ default special argty in
   let sigma, prf = proof_term env sigma (argty, ti, tj) prf in
   app_global_ env sigma _f_equal [|argty; typ; proj; ti; tj; prf|]
+| InjectArray (prf, nargs, argind) ->
+  (* prf : ⊢ v = w : Ind(args) *)
+  let ti = constr_of_term prf.p_lhs in
+  let tj = constr_of_term prf.p_rhs in
+  let real_index =
+    (* The default element is encoded as the first argument. *)
+    if Int.equal argind 1 then
+      (* Projecting out the default element is achieved by an out of bound
+         access via [get]. *)
+      nargs + 1
+    else
+      argind - 2
+  in
+  let sigma, array_ty = type_and_refresh_ env sigma ti in
+  let uvars, elem_ty =
+    let ty = Reductionops.whd_all env sigma array_ty in
+    let c, args = decompose_app sigma ty in
+    let uvars = match kind sigma c with
+    | Const (_, u) -> u
+    | _ -> assert false
+    in
+    uvars, args.(0)
+  in
+  let array_get =
+    mkRef (Rocqlib.lib_ref "prim.array.get", uvars)
+  in
+  let proj =
+    mkLambda (
+      Context.make_annot Name.Anonymous EConstr.ERelevance.relevant,
+      array_ty,
+      mkApp (array_get, [|elem_ty; mkRel 1; mkInt (Uint63.of_int real_index)|])
+    )
+  in
+  let sigma, prf = proof_term env sigma (array_ty, ti, tj) prf in
+  app_global_ env sigma _f_equal [|array_ty; elem_ty; proj; ti; tj; prf|]
 
 let proof_tac (typ, lhs, rhs) p : unit Proofview.tactic =
   Proofview.Goal.enter begin fun gl ->
@@ -474,6 +531,8 @@ let cc_tactic depth additional_terms b =
         | Goal ->
           let lhs = constr_of_term ta in
           let rhs = constr_of_term tb in
+          debug_congruence Pp.(fun () -> str "lhs" ++ spc () ++ str "=" ++ spc () ++ Printer.pr_econstr_env env sigma lhs);
+          debug_congruence Pp.(fun () -> str "rhs" ++ spc () ++ str "=" ++ spc () ++ Printer.pr_econstr_env env sigma rhs);
           let sigma, typ = type_and_refresh_ env sigma lhs in
           Proofview.Unsafe.tclEVARS sigma <*> proof_tac (typ, lhs, rhs) p
         | Hyp id -> refute_tac (EConstr.of_constr id) ta tb p

--- a/test-suite/success/congruence_prim.v
+++ b/test-suite/success/congruence_prim.v
@@ -1,6 +1,7 @@
 Require Import Corelib.Numbers.Cyclic.Int63.PrimInt63.
 Require Import Corelib.Strings.PrimString.
 Require Import Corelib.Floats.PrimFloat.
+Require Import Corelib.Array.PrimArray.
 
 Inductive Box (A : Type) := box : A -> Box A.
 
@@ -20,3 +21,91 @@ Goal box 1.0%float = box 2.0%float -> False.
 Proof.
 congruence.
 Qed.
+
+(* Arrays *)
+
+(* TODO: array length *)
+Goal forall x : bool, [| x | x |] = [| | x |] -> False.
+Proof.
+  Fail congruence.
+Abort.
+
+(* (dis)equality in the array contents *)
+Goal forall x y:bool, x = y -> [| x | x|] = [| y |x|].
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y:bool, [| x | x|] = [| y |x|] -> x = y.
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y:bool, [| true | x|] = [| false |x|] -> False.
+Proof.
+  intros.
+  congruence.
+Qed.
+
+(* same tests with more items to test index computations *)
+Goal forall x y t:bool, x = y -> [| t; x; t | x|] = [| t; y; t |x|].
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y t:bool, [| t; true; t | x|] = [| t; false; t |x|] -> False.
+Proof.
+  intros.
+  congruence.
+Qed.
+
+Goal forall x y t:bool, x = y -> [| x; t; x | x|] = [| y; t; y |x|].
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y t:bool, [| true; t; true | x|] = [| false; t; true |x|] -> False.
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y t:bool, [| true; t; true | x|] = [| true; t; false |x|] -> False.
+Proof.
+  intros.
+  congruence.
+Qed.
+
+(* equality in the default element *)
+Goal forall x y t:bool, x = y -> [| | x|] = [| | y|].
+Proof.
+  intros.
+  congruence.
+Qed.
+Goal forall x y t:bool, [| | true|] = [| | false|] -> False.
+Proof.
+  intros.
+  congruence.
+Qed.
+
+
+(* equality in both default element and contents *)
+Goal forall x y a b:bool, a = b -> x = y -> [|a | x|] = [|b | y|].
+Proof.
+  intros.
+  congruence.
+Qed.
+
+(* equality in the type; not expected to make progress but must not raise anomalies *)
+Goal forall x y t:bool, bool = bool -> [|t | x|] = [|t | y|].
+Proof.
+  intros.
+  Fail congruence.
+Abort.
+
+(* TODO: Performance test for big arrays. *)
+Goal forall x y : bool, make 12 x = make 12 y -> x = y.
+Proof.
+  lazy.
+  intros.
+  Timeout 1 congruence.
+Abort.

--- a/theories/Corelib/Array/PrimArray.v
+++ b/theories/Corelib/Array/PrimArray.v
@@ -9,6 +9,7 @@ Arguments make {_} _ _.
 
 Primitive get : forall A, array A -> int -> A := #array_get.
 Arguments get {_} _ _.
+Register get as prim.array.get.
 
 Primitive default : forall A, array A -> A:= #array_default.
 Arguments default {_} _.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

TODO:
- [ ] The current implementation pretends that partially-applied arrays exists and wraps them in enough `fun`s to make the types match. This is horrible for performance.
- [ ] Discrimination based on array length is not implemented

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/coq/coq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/coq/coq/blob/master/test-suite/README.md

Changelog: https://github.com/coq/coq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/coq/coq/blob/master/doc/README.md
Sphinx: https://github.com/coq/coq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/coq/coq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/coq/coq/blob/master/dev/ci/user-overlays/README.md
