### PR TITLE
Fix dependency analysis in non-OCaml extraction

### DIFF
--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -117,15 +117,17 @@ let ind_iter_references do_term do_cons do_type ind =
   let cons_iter cp l = do_cons cp; List.iter type_iter l in
   let packet_iter i p =
     let () = do_type p.ip_typename_ref in
-    if lang () == Ocaml then
-      let inst = ind.ind_packets.(0).ip_typename_ref.inst in
-      (match ind.ind_equiv with
+    let () = if lang () == Ocaml then begin
+        let inst = ind.ind_packets.(0).ip_typename_ref.inst in
+        (match ind.ind_equiv with
          | Miniml.Equiv kne -> do_type { glob = (GlobRef.IndRef (MutInd.make1 kne, i)); inst };
-         | _ -> ());
+         | _ -> ())
+      end
+    in
     Array.iteri (fun j -> cons_iter p.ip_consnames_ref.(j)) p.ip_types
   in
-  if lang () == Ocaml then record_iter_references do_term ind.ind_kind;
-    Array.iteri (fun i p -> packet_iter i p) ind.ind_packets
+  let () = if lang () == Ocaml then record_iter_references do_term ind.ind_kind in
+  Array.iteri (fun i p -> packet_iter i p) ind.ind_packets
 
 let decl_iter_references do_term do_cons do_type =
   let type_iter = type_iter_references do_type

--- a/test-suite/output/bug_20711.out
+++ b/test-suite/output/bug_20711.out
@@ -1,0 +1,14 @@
+module Main where
+
+import qualified Prelude
+
+data Bool =
+   True
+ | False
+
+type Foo = Bool
+
+type Wrapper = Foo
+  -- singleton inductive, whose constructor was Build_Wrapper
+  
+

--- a/test-suite/output/bug_20711.v
+++ b/test-suite/output/bug_20711.v
@@ -1,0 +1,9 @@
+Require Extraction.
+
+Extraction Language Haskell.
+
+Definition foo := bool.
+
+Record Wrapper := { v1 : foo; }.
+
+Recursive Extraction Wrapper.


### PR DESCRIPTION
a `if lang() == OCaml then bar; baz` got turned into `if lang() == OCaml then let x = bar1 in bar2; bar` in https://github.com/rocq-prover/rocq/pull/20651

Fix #20711
