### PR TITLE
Remove Mltop.module_is_known, now fully handled by Findlib

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -708,7 +708,6 @@ let print_ast fmt arg =
 end
 
 let declare_plugin fmt name =
-  Option.iter (fprintf fmt "let _ = Mltop.add_known_module \"%s\"@\n") name;
   let () = match !plugin_name with
     | None -> plugin_name := Some name
     | Some _ -> fatal "Multiple DECLARE PLUGIN not allowed";

--- a/dev/ci/user-overlays/20853-SkySkimmer-module-is-known.sh
+++ b/dev/ci/user-overlays/20853-SkySkimmer-module-is-known.sh
@@ -1,0 +1,3 @@
+overlay bignums https://github.com/SkySkimmer/bignums module-is-known 20853
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician module-is-known 20853

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -23,7 +23,6 @@ open Proofview.Notations
 module NamedDecl = Context.Named.Declaration
 
 let tauto_plugin = "rocq-runtime.plugins.tauto"
-let () = Mltop.add_known_module tauto_plugin
 
 let assoc_var s ist =
   let v = Id.Map.find (Names.Id.of_string s) ist.lfun in

--- a/vernac/mltop.mli
+++ b/vernac/mltop.mli
@@ -59,20 +59,7 @@ val add_ml_dir : string -> unit
 (** Tests if we can load ML files *)
 val has_dynlink : bool
 
-val module_is_known : string -> bool
-
 (** {5 Initialization functions} *)
-
-(** Declare a plugin which has been linked.  A plugin is
-    a findlib library name. Usually, this will be called automatically
-    when use do [DECLARE PLUGIN "pkg.lib"] in the .mlg file.
-
-    The main effect is that dynlink will not be attempted for this
-    plugin, so eg if it was statically linked Coq will not try and
-    fail to find the cmxs.
-*)
-val add_known_module : string -> unit
-(* EJGA: Todo, this could take a PluginSpec.t at some point *)
 
 (** Declare a initialization function. The initialization function is
     called in Declare ML Module, including reruns after backtracking


### PR DESCRIPTION
Since the findlib switch this has been uselessly duplicating the findlib "recorded packages" API.

Notably since dune automatically generates `Findlib.record_package` calls when statically linking a plugin we can just delete the `add_known_module` in tauto and in coqpp DECLARE PLUGIN.

DECLARE PLUGIN is now used only for coqpp to generate various unique strings for grammar extensions.

Overlays:
- https://github.com/rocq-community/bignums/pull/99
- https://github.com/coq-tactician/coq-tactician/pull/105