### PR TITLE
Replace keyword "Notation" by "Abbreviation" for abbreviations

### DIFF
--- a/dev/ci/user-overlays/20855-proux01-abbreviation.sh
+++ b/dev/ci/user-overlays/20855-proux01-abbreviation.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/proux01/stdlib coq_20855 20855

--- a/doc/changelog/03-notations/20855-abbreviation-Deprecated.rst
+++ b/doc/changelog/03-notations/20855-abbreviation-Deprecated.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  use of "Notation" keyword for :cmd:`abbreviations <Abbreviation>`,
+  use "Abbreviation" instead
+  (`#20855 <https://github.com/rocq-prover/rocq/pull/20855>`_,
+  by Pierre Roux).

--- a/doc/changelog/06-Ltac2-language/20855-abbreviation-Deprecated.rst
+++ b/doc/changelog/06-Ltac2-language/20855-abbreviation-Deprecated.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  use of "Notation" keyword for :cmd:`abbreviations <Ltac2 Abbreviation>`,
+  use "Abbreviation" instead
+  (`#20855 <https://github.com/rocq-prover/rocq/pull/20855>`_,
+  by Pierre Roux).

--- a/doc/sphinx/language/core/modules.rst
+++ b/doc/sphinx/language/core/modules.rst
@@ -740,7 +740,7 @@ A similar table for :cmd:`Section` can be found
 
       when imported
 
-  * - :cmd:`Notation (abbreviation)`
+  * - :cmd:`Abbreviation`
     - :attr:`global`
     - not available
     - ❌

--- a/doc/sphinx/language/core/sections.rst
+++ b/doc/sphinx/language/core/sections.rst
@@ -188,7 +188,7 @@ A similar table for :cmd:`Module` can be found
     - ❌
     - ❌
 
-  * - :cmd:`Notation (abbreviation)`
+  * - :cmd:`Abbreviation`
     - :attr:`local`
     - not available
     - ❌

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -572,7 +572,7 @@ instances of the ``LEQ`` class.
     [find m | m ~ m0 | Is_not_the_right_mixin ]
     LEQ._Pack T (LEQ.Class ce co m).
 
-   Notation Pack T m := (packager T _ _ m _ id _ id _ id _ id _ id).
+   Abbreviation Pack T m := (packager T _ _ m _ id _ id _ id _ id _ id).
 
 The object ``Pack`` takes a type ``T`` (the key) and a mixin ``m``. It infers all
 the other pieces of the class ``LEQ`` and declares them as canonical

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -2504,7 +2504,7 @@ The following example requires the Stdlib library to use the :tacn:`lia` tactic.
    Ltac mytauto := tauto.
    Ltac tac := intros; repeat split; lia || mytauto.
 
-   Notation max x y := (x + (y - x)) (only parsing).
+   Abbreviation max x y := (x + (y - x)) (only parsing).
 
    Goal forall x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z,
        max x (max y z) = max (max x y) z /\ max x (max y z) = max (max x y) z

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1282,7 +1282,7 @@ Notations
    into the right-hand side.  In the following example, `x` is the formal parameter name and
    `constr` is its :ref:`syntactic class<syntactic_classes>`.  `print` and `of_constr` are
    functions provided by Rocq through `Message.v`.
-   (Also see :cmd:`Ltac2 Notation (abbreviation)`.)
+   (Also see :cmd:`Ltac2 Abbreviation`.)
 
    .. flag:: Ltac2 Typed Notations
 
@@ -1374,8 +1374,7 @@ Notations
 Abbreviations
 ~~~~~~~~~~~~~
 
-.. cmd:: Ltac2 Notation @ident := @ltac2_expr
-   :name: Ltac2 Notation (abbreviation)
+.. cmd:: Ltac2 Abbreviation @ident := @ltac2_expr
 
    Introduces a special kind of notation, called an abbreviation,
    that does not add any parsing rules. It is similar in
@@ -1395,7 +1394,7 @@ Abbreviations
 
    .. rocqdoc::
 
-      Ltac2 Notation foo := fun x => x ().
+      Ltac2 Abbreviation foo := fun x => x ().
 
    Then we have the following expansion at internalization time.
 

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1379,7 +1379,7 @@ Abbreviations
 
    Introduces a special kind of notation, called an abbreviation,
    that does not add any parsing rules. It is similar in
-   spirit to Rocq abbreviations (see :cmd:`Notation (abbreviation)`),
+   spirit to Rocq abbreviations (see :cmd:`Abbreviation`),
    insofar as its main purpose is to give an
    absolute name to a piece of pure syntax, which can be transparently referred to
    by this name as if it were a proper definition.

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -3915,8 +3915,8 @@ Notes:
       Notation "\sum_ ( m <= i < n | P ) F" :=
         (\big[plus/O]_(m <= i < n | P%bool) F%nat).
 
-      Notation eq_bigr := (fun n m => eq_bigr_ 0 plus (index_iota n m)).
-      Notation eq_big := (fun n m => eq_big_ 0 plus (index_iota n m)).
+      Abbreviation eq_bigr := (fun n m => eq_bigr_ 0 plus (index_iota n m)).
+      Abbreviation eq_big := (fun n m => eq_big_ 0 plus (index_iota n m)).
 
       Parameter odd : nat -> bool.
       Parameter prime : nat -> bool.
@@ -4487,8 +4487,8 @@ The following example is taken from ``ssreflect.v``, where the
 
 .. rocqdoc::
 
-   Notation RHS := (X in _ = X)%pattern.
-   Notation LHS := (X in X = _)%pattern.
+   Abbreviation RHS := (X in _ = X)%pattern.
+   Abbreviation LHS := (X in X = _)%pattern.
 
 Shortcuts defined this way can be freely used in place of the trailing
 ``ident in term`` part of any contextual pattern. Some examples follow:

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -524,7 +524,7 @@ Enabling and disabling notations
       | in constr
 
    Enables or disables notations previously defined with
-   :cmd:`Notation` or :cmd:`Notation (abbreviation)`.
+   :cmd:`Notation` or :cmd:`Abbreviation`.
    Disabling a notation doesn't remove parsing rules or tokens defined by the notation.
    The command has no effect on notations reserved with :cmd:`Reserved Notation`.
    At least one of
@@ -1889,8 +1889,10 @@ Displaying information about scopes
 Abbreviations
 --------------
 
-.. cmd:: Notation @ident {* @ident__parm } := @one_term {? ( {+, @syntax_modifier } ) }
-   :name: Notation (abbreviation)
+.. cmd:: Abbreviation @ident {* @ident__parm } := @one_term {? ( {+, @syntax_modifier } ) }
+
+   .. deprecated
+      .. cmd:: Notation @ident {* @ident__parm } := @one_term {? ( {+, @syntax_modifier } ) }
 
    .. todo: for some reason, Sphinx doesn't complain about a duplicate name if
       :name: is omitted
@@ -1915,7 +1917,7 @@ Abbreviations
 
    .. rocqtop:: in
 
-      Notation Nlist := (list nat).
+      Abbreviation Nlist := (list nat).
 
    .. rocqtop:: all
 
@@ -1923,7 +1925,7 @@ Abbreviations
 
    .. rocqtop:: in
 
-      Notation reflexive R := (forall x, R x x).
+      Abbreviation reflexive R := (forall x, R x x).
 
    .. rocqtop:: all
 
@@ -1932,7 +1934,7 @@ Abbreviations
 
    .. rocqtop:: in
 
-      Notation Plus1 B := (Nat.add B 1).
+      Abbreviation Plus1 B := (Nat.add B 1).
 
    .. rocqtop:: all
 
@@ -1962,7 +1964,7 @@ Abbreviations
 
    .. rocqtop:: in
 
-      Notation id := (explicit_id _).
+      Abbreviation id := (explicit_id _).
 
    .. rocqtop:: all
 
@@ -1986,7 +1988,7 @@ Abbreviations
       Definition force2 q (P:nat*nat -> Prop) :=
         (forall n', n' >= fst q -> forall p', p' >= snd q -> P (n', p')).
 
-      Notation F p P := (force2 p (fun p => P)).
+      Abbreviation F p P := (force2 p (fun p => P)).
       Check exists x y, F (x,y) (x >= 1 /\ y >= 2).
 
 .. extracted from Gallina chapter
@@ -2463,7 +2465,7 @@ The following errors apply to both string and number notations:
 
    .. rocqtop:: in
 
-      Notation nSet := Set (only parsing).
+      Abbreviation nSet := Set (only parsing).
       Number Notation nSet of_uint to_uint (via I
         mapping [Empty_set => Iempty, unit => Iunit, sum => Isum]) : type_scope.
 
@@ -2545,7 +2547,7 @@ The following errors apply to both string and number notations:
 
    .. rocqtop:: in reset
 
-      Notation string := (list Byte.byte) (only parsing).
+      Abbreviation string := (list Byte.byte) (only parsing).
       Definition id_string := @id string.
 
       String Notation string id_string id_string : list_scope.

--- a/doc/sphinx/using/libraries/writing.rst
+++ b/doc/sphinx/using/libraries/writing.rst
@@ -11,7 +11,7 @@ Deprecating library objects, tactics or library files
 
 You may use the following :term:`attribute` to deprecate a notation,
 tactic, definition, axiom, theorem or file.  When renaming a definition or theorem, you can introduce a
-deprecated compatibility alias using :cmd:`Notation (abbreviation)`
+deprecated compatibility alias using :cmd:`Abbreviation`
 (see :ref:`the example below <compatibility-alias>`).
 
 .. attr:: deprecated ( {? since = @string , } {? note = @string , } {? use = @qualid } )
@@ -138,7 +138,7 @@ notation, definition, axiom, theorem or file.
 
       Definition bar x := S x.
       #[deprecated(since="mylib 1.2", note="Use bar instead.")]
-      Notation foo := bar (only parsing).
+      Abbreviation foo := bar (only parsing).
 
    Then, the following code still works, but emits a warning:
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2432,6 +2432,7 @@ SPLICE: [
 | enable_notation_interpretation
 | enable_notation_flags
 | opt_scope
+| located_notation
 ] (* end SPLICE *)
 
 RENAME: [

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -118,6 +118,7 @@ RENAME: [
 | Constr.cpattern cpattern
 | G_vernac.section_subset_expr section_var_expr
 | Prim.ident ident
+| Prim.identref identref
 | Prim.reference reference
 | Prim.string string
 | Prim.integer integer
@@ -2041,7 +2042,6 @@ ltac2_entry: [
 | WITH "Ltac2" tac2def_val
 | REPLACE tac2def_ext     (* Ltac2 plugin *)
 | WITH "Ltac2" tac2def_ext
-| "Ltac2" "Notation" ident ":=" ltac2_expr6 TAG Ltac2  (* variant *)
 | MOVEALLBUT command
 (* todo: MOVEALLBUT should ignore tag on "but" prodns *)
 ]
@@ -2068,7 +2068,9 @@ SPLICE: [
 | tac2def_typ
 | tac2def_ext
 | tac2def_syn
+| tac2abbrev_syn
 | ltac2def_syn
+| ltac2abbrev_syn
 | tac2def_mut
 | rec_flag
 | tac2alg_constructors

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1552,11 +1552,16 @@ syntax: [
 | "Undelimit" "Scope" IDENT
 | "Bind" "Scope" IDENT; "with" LIST1 coercion_class
 | "Infix" notation_declaration
-| "Notation" identref LIST0 ident ":=" constr syntax_modifiers
-| "Notation" notation_declaration
+| located_notation identref LIST0 ident ":=" constr syntax_modifiers
+| "Abbreviation" identref LIST0 ident ":=" constr syntax_modifiers
+| located_notation notation_declaration
 | "Reserved" "Infix" ne_lstring syntax_modifiers
 | "Reserved" "Notation" ne_lstring syntax_modifiers
 | enable_enable_disable "Notation" enable_notation_rule enable_notation_interpretation enable_notation_flags opt_scope
+]
+
+located_notation: [
+| "Notation"
 ]
 
 enable_enable_disable: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -697,6 +697,7 @@ command: [
 | "Ltac2" ltac2_entry      (* ltac2 plugin *)
 | "Ltac2" "Custom" "Entry" identref      (* ltac2 plugin *)
 | "Ltac2" "Notation" ltac2def_syn      (* ltac2 plugin *)
+| "Ltac2" "Abbreviation" ltac2abbrev_syn      (* ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr6      (* ltac2 plugin *)
 | "Print" test_ltac2_ident "Ltac2" reference      (* ltac2 plugin *)
 | "Print" "Ltac2" "Type" reference      (* ltac2 plugin *)
@@ -2947,6 +2948,10 @@ tac2def_syn: [
 | LIST1 ltac2_syntax_class syn_level ":=" ltac2_expr6      (* ltac2 plugin *)
 ]
 
+tac2abbrev_syn: [
+| Prim.identref ":=" ltac2_expr6      (* ltac2 plugin *)
+]
+
 globref: [
 | "&" Prim.ident      (* ltac2 plugin *)
 | Prim.qualid      (* ltac2 plugin *)
@@ -3322,6 +3327,10 @@ ltac2_entry: [
 
 ltac2def_syn: [
 | tac2def_syn      (* ltac2 plugin *)
+]
+
+ltac2abbrev_syn: [
+| tac2abbrev_syn      (* ltac2 plugin *)
 ]
 
 ltac2_expr: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -977,6 +977,7 @@ command: [
 | "Bind" "Scope" scope_name "with" LIST1 coercion_class
 | "Infix" notation_declaration
 | "Notation" ident LIST0 ident ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
+| "Abbreviation" ident LIST0 ident ":=" one_term OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Notation" notation_declaration
 | "Reserved" "Infix" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )
 | "Reserved" "Notation" string OPT ( "(" LIST1 syntax_modifier SEP "," ")" )

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -992,8 +992,8 @@ command: [
 | "Ltac2" OPT "mutable" OPT "rec" tac2def_body LIST0 ( "with" tac2def_body )
 | "Ltac2" "Type" OPT "rec" tac2typ_def LIST0 ( "with" tac2typ_def )
 | "Ltac2" "@" "external" ident ":" ltac2_type ":=" string string
+| "Ltac2" "Abbreviation" ident ":=" ltac2_expr      (* ltac2 plugin *)
 | "Ltac2" "Set" qualid OPT [ "as" ident ] ":=" ltac2_expr
-| "Ltac2" "Notation" ident ":=" ltac2_expr      (* Ltac2 plugin *)
 | "Ltac2" "Eval" ltac2_expr      (* ltac2 plugin *)
 | "Print" "Ltac2" qualid      (* ltac2 plugin *)
 | "Print" "Ltac2" "Type" qualid      (* ltac2 plugin *)

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -109,6 +109,7 @@ let tac2def_val = Entry.make "tac2def_val"
 let tac2def_typ = Entry.make "tac2def_typ"
 let tac2def_ext = Entry.make "tac2def_ext"
 let tac2def_syn = Entry.make "tac2def_syn"
+let tac2abbrev_syn = Entry.make "tac2abbrev_syn"
 let tac2def_mut = Entry.make "tac2def_mut"
 let tac2mode = Entry.make "ltac2_command"
 let ltac2_atom = Entry.make "ltac2_atom"
@@ -142,7 +143,7 @@ let opt_fun ?loc args ty e =
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: ltac2_expr ltac2_type tac2def_val tac2def_typ tac2def_ext tac2def_syn
+  GLOBAL: ltac2_expr ltac2_type tac2def_val tac2def_typ tac2def_ext tac2def_syn tac2abbrev_syn
           tac2def_mut tac2expr_in_env ltac2_atom;
   tac2pat:
     [ "1" LEFTA
@@ -465,6 +466,10 @@ GRAMMAR EXTEND Gram
     [ [ toks = LIST1 ltac2_syntax_class; n = syn_level; ":=";
         e = ltac2_expr ->
         { (toks, n, e) }
+    ] ]
+  ;
+  tac2abbrev_syn:
+    [ [ id = Prim.identref; ":="; e = ltac2_expr -> { (id, e) }
     ] ]
   ;
   globref:
@@ -985,6 +990,7 @@ let rules = [
 let pr_ltac2entry = Tac2print.pr_strexpr
 let pr_ltac2expr e = Tac2print.pr_rawexpr_gen E5 ~avoid:Id.Set.empty e
 let pr_ltac2def_syn (a,b,c) = Tac2entries.pr_register_notation a b c
+let pr_ltac2abbrev_syn (a,c) = Tac2entries.pr_register_abbreviation a c
 
 }
 
@@ -999,6 +1005,11 @@ END
 VERNAC ARGUMENT EXTEND ltac2def_syn
 PRINTED BY { pr_ltac2def_syn }
 | [ tac2def_syn(e) ] -> { e }
+END
+
+VERNAC ARGUMENT EXTEND ltac2abbrev_syn
+PRINTED BY { pr_ltac2abbrev_syn }
+| [ tac2abbrev_syn(e) ] -> { e }
 END
 
 VERNAC ARGUMENT EXTEND ltac2_expr
@@ -1031,6 +1042,13 @@ VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
 | #[ raw_attributes ] [ "Ltac2" "Notation" ltac2def_syn(e) ] => { Vernacextend.(VtSideff ([], VtNow)) } SYNTERP AS synterpv {
     let (toks, n, body) = e in
     Tac2entries.register_notation raw_attributes toks n body
+  } ->
+  {
+    Tac2entries.register_notation_interpretation synterpv
+  }
+| #[ raw_attributes ] [ "Ltac2" "Abbreviation" ltac2abbrev_syn(e) ] => { Vernacextend.(VtSideff ([], VtNow)) } SYNTERP AS synterpv {
+    let (id, body) = e in
+    Tac2entries.register_abbreviation raw_attributes id body
   } ->
   {
     Tac2entries.register_notation_interpretation synterpv

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -31,8 +31,13 @@ type notation_target = qualid option * int option
 
 val pr_register_notation : sexpr list -> notation_target -> raw_tacexpr -> Pp.t
 
+val pr_register_abbreviation : Id.t CAst.t -> raw_tacexpr -> Pp.t
+
 val register_notation : Attributes.vernac_flags -> sexpr list ->
   notation_target -> raw_tacexpr -> notation_interpretation_data
+
+val register_abbreviation : Attributes.vernac_flags -> Id.t CAst.t ->
+  raw_tacexpr -> notation_interpretation_data
 
 val register_notation_interpretation : notation_interpretation_data -> unit
 

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -297,8 +297,8 @@ let is_user_name qid = match qid with
 
 let deprecated_ltac2_alias =
   Deprecation.create_warning
-    ~object_name:"Ltac2 alias"
-    ~warning_name_if_no_since:"deprecated-ltac2-alias"
+    ~object_name:"Ltac2 abbreviation"
+    ~warning_name_if_no_since:"deprecated-ltac2-abbreviation"
     (fun kn -> pr_qualid (Tac2env.shortest_qualid_of_ltac Id.Set.empty (TacAlias kn)))
 
 let deprecated_ltac2_def =

--- a/test-suite/bugs/bug_18133.v
+++ b/test-suite/bugs/bug_18133.v
@@ -1,5 +1,5 @@
 Set Warnings "+all".
-#[deprecated(since="1")] Notation a := id.
+#[deprecated(since="1")] Abbreviation a := id.
 
 Goal False.
 Proof.

--- a/test-suite/bugs/bug_9166.v
+++ b/test-suite/bugs/bug_9166.v
@@ -1,7 +1,7 @@
 Set Warnings "+deprecated".
 
 #[deprecated(since = "X", note = "Y")]
-Notation bar := option.
+Abbreviation bar := option.
 
 Definition foo (x: nat) : nat :=
   match x with

--- a/test-suite/ltac2/deprecation.v
+++ b/test-suite/ltac2/deprecation.v
@@ -43,7 +43,7 @@ Ltac2 match_warn_bar_disabled x :=
   end.
 
 (* the warning is at intern time *)
-Ltac2 Notation bar_nota := Bar.
+Ltac2 Abbreviation bar_nota := Bar.
 
 Ltac2 Notation "isBar_nota" x(tactic) := match x with Bar => true | _ => false end.
 

--- a/test-suite/output/Cases.v
+++ b/test-suite/output/Cases.v
@@ -298,7 +298,7 @@ Axiom admit : forall {T}, T.
 Section with_base.
   Context {base_type : Type}
           {base_interp : base_type -> Type}.
-  Local Notation type := (@type base_type).
+  Local Abbreviation type := (@type base_type).
 
   Fixpoint default {t} : interp base_interp t
     := match t with

--- a/test-suite/output/ErrorLocation_tac_in_term.v
+++ b/test-suite/output/ErrorLocation_tac_in_term.v
@@ -1,13 +1,13 @@
-Notation foo := (I I).
+Abbreviation foo := (I I).
 
 Fail Check foo.
 
-Notation bar := (ltac:(exact (I I))) (only parsing).
+Abbreviation bar := (ltac:(exact (I I))) (only parsing).
 
 (* whole command: it would be nice to be more precise *)
 Fail Check bar.
 
-Notation baz x := (ltac:(exact x)) (only parsing).
+Abbreviation baz x := (ltac:(exact x)) (only parsing).
 
 Fail Check baz (I I).
 

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -1,7 +1,7 @@
 (* Bug 5568, don't warn for notations in repeated module import *)
 
 Module foo.
-Notation compose := (fun g f => g f).
+Abbreviation compose := (fun g f => g f).
 Notation "g & f" := (compose g f) (at level 10).
 End foo.
 
@@ -126,23 +126,23 @@ Fail Notation "( x , y , .. , z )" := (pair .. (pair (pair y z) x) .. x).
 (**********************************************************************)
 (* Check preservation of scopes at printing time *)
 
-Notation SUM := sum.
+Abbreviation SUM := sum.
 Check SUM (nat*nat) nat.
 
 (**********************************************************************)
 (* Check preservation of implicit arguments at printing time *)
 
-Notation FST := fst.
+Abbreviation FST := fst.
 Check FST (0;1).
 
 (**********************************************************************)
 (* Check notations for references with activated or deactivated       *)
 (* implicit arguments                                                 *)
 
-Notation Nil := @nil.
+Abbreviation Nil := @nil.
 Check Nil.
 
-Notation NIL := nil.
+Abbreviation NIL := nil.
 Check NIL : list nat.
 
 
@@ -200,16 +200,16 @@ End Application.
 
 (* Check notations in cases patterns *)
 
-Notation SOME := Some.
-Notation NONE := None.
+Abbreviation SOME := Some.
+Abbreviation NONE := None.
 Check (fun x => match x with SOME x => x | NONE => 0 end).
 
-Notation NONE2 := (@None _).
-Notation SOME2 := (@Some _).
+Abbreviation NONE2 := (@None _).
+Abbreviation SOME2 := (@Some _).
 Check (fun x => match x with SOME2 x => x | NONE2 => 0 end).
 
-Notation NONE3 := @None.
-Notation SOME3 := @Some.
+Abbreviation NONE3 := @None.
+Abbreviation SOME3 := @Some.
 Check (fun x => match x with SOME3 _ x => x | NONE3 _ => 0 end).
 
 Notation "a :'" := (cons a) (at level 10).
@@ -221,7 +221,7 @@ Check (fun x => match x with | nil => NONE | h :' t => SOME3 _ t end).
    universe than the actual one; but it would be the same anyway
    without a notation *)
 
-Notation s := Type.
+Abbreviation s := Type.
 Check s.
 
 (* Test bug #2835: notations were not uniformly managed under prod and lambda *)

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -75,8 +75,8 @@ Notation "f ( x )" := (f x) (at level 10, format "f ( x )").
 Check fun f x => f x + S x.
 
 Open Scope list_scope.
-Notation list1 := (1::nil)%list.
-Notation plus2 n := (S (S n)).
+Abbreviation list1 := (1::nil)%list.
+Abbreviation plus2 n := (S (S n)).
 (* plus2 was not correctly printed in the two following tests in 8.3pl1 *)
 Print plus2.
 Check fun n => match n with list1 => 0 | _ => 2 end.

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -156,7 +156,7 @@ Check [ fun x => x+0 ;; fun x => x+1 ;; fun x => x+2 ].
 
 Section Bug4765.
 
-Notation foo5 x T y := (fun x : T => y).
+Abbreviation foo5 x T y := (fun x : T => y).
 Check foo5 x nat x.
 
 End Bug4765.
@@ -405,8 +405,8 @@ End Issue7731.
 Module Issue8126.
 
 Definition myfoo (x : nat) (y : nat) (z : unit) := y.
-Notation myfoo0 := (@myfoo 0).
-Notation myfoo01 := (@myfoo0 1).
+Abbreviation myfoo0 := (@myfoo 0).
+Abbreviation myfoo01 := (@myfoo0 1).
 Check myfoo 0 1 tt. (* was printing [myfoo0 1 HI], but should print [myfoo01 HI]  *)
 Check myfoo0 1 tt. (* was printing [myfoo0 1 HI], but should print [myfoo01 HI]  *)
 Check myfoo01 tt. (* was printing [myfoo0 1 HI], but should print [myfoo01 HI]  *)

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -12,7 +12,7 @@ Check [ < 0 > + < 1 > * < 2 >].
 Print Custom Grammar myconstr.
 
 Axiom a : nat.
-Notation b := a.
+Abbreviation b := a.
 Check [ < b > + < a > * < 2 >].
 
 Declare Custom Entry anotherconstr.
@@ -91,7 +91,7 @@ End C.
 Module I.
 
 Definition myAnd A B := A /\ B.
-Notation myAnd1 A := (myAnd A).
+Abbreviation myAnd1 A := (myAnd A).
 Check myAnd1 True True.
 
 Set Warnings "-auto-template".
@@ -250,9 +250,9 @@ End N.
 
 Module O.
 
-Notation U t := (match t with 0 => 0 | S t => t | _ => 0 end).
+Abbreviation U t := (match t with 0 => 0 | S t => t | _ => 0 end).
 Check fun x => U (S x).
-Notation V t := (t,fun t => t).
+Abbreviation V t := (t,fun t => t).
 Check V tt.
 Check fun x : nat => V x.
 
@@ -372,7 +372,7 @@ Module P.
 
   Module AbbreviationMixedTermBinderAsStrictPattern.
 
-  Notation myforce n P := (pseudo_force n (fun n => P)).
+  Abbreviation myforce n P := (pseudo_force n (fun n => P)).
   Check exists x y, myforce (x,y) (x >= 1 /\ y >= 2).
   Section S.
   Variable n:nat.
@@ -387,10 +387,10 @@ Module P.
 
   Module Bug4765Part.
 
-  Notation id x := ((fun y => y) x).
+  Abbreviation id x := ((fun y => y) x).
   Check id nat.
 
-  Notation id' x := ((fun x => x) x).
+  Abbreviation id' x := ((fun x => x) x).
   Check fun a : bool => id' a.
   Check fun nat : bool => id' nat.
   Fail Check id' nat.

--- a/test-suite/output/Notations5.v
+++ b/test-suite/output/Notations5.v
@@ -112,7 +112,7 @@ Module AppliedTermsPrinting.
 
   Axiom p : forall {A} (a1 a2:A) {B} (b:B), a1 = a2 /\ b = b.
 
-  Notation u := @p.
+  Abbreviation u := @p.
 
   Check u _.
   (* u ?A *)
@@ -140,7 +140,7 @@ Module AppliedTermsPrinting.
 
   Axiom p : forall A (a1 a2:A) B (b:B), a1 = a2 /\ b = b.
 
-  Notation u := p.
+  Abbreviation u := p.
 
   Check p.
   (* u *)
@@ -172,7 +172,7 @@ Module AppliedTermsPrinting.
 
   Axiom p : forall A (a1 a2:A) B (b:B), a1 = a2 /\ b = b.
 
-  Notation v := (@p _ 0).
+  Abbreviation v := (@p _ 0).
 
   Check v.
   (* v *)
@@ -202,7 +202,7 @@ Module AppliedTermsPrinting.
 
   Axiom p : forall A (a1 a2:A) B (b:B), a1 = a2 /\ b = b.
 
-  Notation v := (p 0).
+  Abbreviation v := (p 0).
 
   Check v.
   (* v *)
@@ -382,25 +382,25 @@ Module AppliedPatternsPrinting.
   End D.
 
   Module E.
-  Notation P := @ p.
+  Abbreviation P := @ p.
   Check P 0 0 _ true.
   Check fun a => match a with P 0 0 _ _ => 1 | _ => 2 end.
   End E.
 
   Module F.
-  Notation P' := p.
+  Abbreviation P' := p.
   Check P' 0 0 true.
   Check fun a => match a with P' 0 0 _ => 1 | _ => 2 end.
   End F.
 
   Module G.
-  Notation Q q := (@p q).
+  Abbreviation Q q := (@p q).
   Check Q 0 0 true.
   Check fun a => match a with Q 0 0 _ => 1 | _ => 2 end.
   End G.
 
   Module H.
-  Notation Q' q := (p q).
+  Abbreviation Q' q := (p q).
   Check Q' 0 0 true.
   Check fun a => match a with Q' 0 0 _ => 1 | _ => 2 end.
   End H.
@@ -417,7 +417,7 @@ Module Activation.
   Disable Notation "_ + _" : type_scope.
   Fail Check 0 + 0.
 
-  Notation f x := (Some x).
+  Abbreviation f x := (Some x).
 
   Disable Notation f.
 

--- a/test-suite/output/NotationsCoercions.v
+++ b/test-suite/output/NotationsCoercions.v
@@ -9,7 +9,7 @@ Section Test.
 Variables (A B : Type) (a : A) (b : B).
 Variable c : A -> B.
 Coercion c : A >-> B.
-Notation COERCION := (c).
+Abbreviation COERCION := (c).
 Check b = a. (* printed the same except in 8.10 *)
 End Test.
 

--- a/test-suite/output/NumberNotations.v
+++ b/test-suite/output/NumberNotations.v
@@ -164,8 +164,8 @@ Module Test8.
   Fail Check let v := 0%wuint8 in v : wuint.
   Compute wrap (Nat.to_num_uint 0).
 
-  Notation wrap'' := wrap.
-  Notation unwrap'' := unwrap.
+  Abbreviation wrap'' := wrap.
+  Abbreviation unwrap'' := unwrap.
   Number Notation wuint wrap'' unwrap'' : wuint8'_scope.
   Check let v := 0%wuint8' in v : wuint.
 End Test8.
@@ -180,8 +180,8 @@ Module Test9.
     Record wuint := wrap { unwrap : Number.uint }.
     Let wrap' := wrap.
     Let unwrap' := unwrap.
-    Local Notation wrap'' := wrap.
-    Local Notation unwrap'' := unwrap.
+    Local Abbreviation wrap'' := wrap.
+    Local Abbreviation unwrap'' := unwrap.
     Number Notation wuint wrap' unwrap' : wuint9_scope.
     Check let v := 0%wuint9 in v : wuint.
     Number Notation wuint wrap'' unwrap'' : wuint9'_scope.
@@ -231,8 +231,8 @@ Module Test13.
   Definition to_uint (x y : unit) : Number.uint := Nat.to_num_uint O.
   Definition of_uint (x : Number.uint) : unit := tt.
   Definition to_uint_good := to_uint tt.
-  Notation to_uint' := (to_uint tt).
-  Notation to_uint'' := (to_uint _).
+  Abbreviation to_uint' := (to_uint tt).
+  Abbreviation to_uint'' := (to_uint _).
   Number Notation unit of_uint to_uint_good : test13_scope.
   Check let v := 0%test13 in v : unit.
   Fail Number Notation unit of_uint to_uint' : test13'_scope.
@@ -534,7 +534,7 @@ Definition to_uint (x : I) : Number.uint :=
       end in
   Nat.to_num_uint (f x).
 
-Notation nSet := (Set) (only parsing).  (* needed as a reference is expected in Number Notation and Set is syntactically not a reference *)
+Abbreviation nSet := (Set) (only parsing).  (* needed as a reference is expected in Number Notation and Set is syntactically not a reference *)
 Number Notation nSet of_uint to_uint (via I
   mapping [Empty_set => Iempty, unit => Iunit, sum => Isum])
   : type_scope.
@@ -726,7 +726,7 @@ Definition to_uint (l : list unit) : Number.uint :=
     end in
   Nat.to_num_uint (f l).
 
-Notation listunit := (list unit) (only parsing).
+Abbreviation listunit := (list unit) (only parsing).
 Number Notation listunit of_uint to_uint : nat_scope.
 
 Check 0.
@@ -765,7 +765,7 @@ Definition Ip_to_uint (l : Ip nat bool) : Number.uint :=
     end in
   Nat.to_num_uint (f l).
 
-Notation Ip_nat_bool := (Ip nat bool) (only parsing).
+Abbreviation Ip_nat_bool := (Ip nat bool) (only parsing).
 Number Notation Ip_nat_bool Ip_of_uint Ip_to_uint : nat_scope.
 
 Check 0.
@@ -787,7 +787,7 @@ Check 2.
 Check 3.
 Unset Printing All.
 
-Notation eqO := (eq _ O) (only parsing).
+Abbreviation eqO := (eq _ O) (only parsing).
 Definition eqO_of_uint (x : Number.uint) : eqO := eq_refl O.
 Definition eqO_to_uint (x : O = O) : Number.uint :=
   match x with
@@ -800,7 +800,7 @@ Check eq_refl (S O).  (* doesn't match eq _ O, printer not called *)
 Check eq_refl O. (* matches eq _ O, printer called *)
 Check eq_refl (id O). (* doesn't match eq _ O, printer not called *)
 
-Notation eq_ := (eq _ _) (only parsing).
+Abbreviation eq_ := (eq _ _) (only parsing).
 Number Notation eq_ eqO_of_uint eqO_to_uint : nat_scope.
 
 Check eq_refl (S O).  (* matches eq _ _, printer called, but type incorrect *)
@@ -827,7 +827,7 @@ Definition extra_list_unit_to_uint (x : extra_list unit) : Number.uint :=
       end in
   Nat.to_num_uint (f unit x).
 
-Notation extra_list_unit := (extra_list unit).
+Abbreviation extra_list_unit := (extra_list unit).
 Number Notation extra_list_unit
         extra_list_unit_of_uint extra_list_unit_to_uint : nat_scope.
 
@@ -866,7 +866,7 @@ Definition to_uint (x : (fun x => let v := x in v) I) : match O with O => Number
       end in
   Nat.to_num_uint (f x).
 
-Notation nSet := (Set) (only parsing).  (* needed as a reference is expected in Number Notation and Set is syntactically not a reference *)
+Abbreviation nSet := (Set) (only parsing).  (* needed as a reference is expected in Number Notation and Set is syntactically not a reference *)
 Number Notation nSet of_uint to_uint (via I
   mapping [Empty_set => Iempty, unit => Iunit, sum => Isum])
   : type_scope.
@@ -1027,7 +1027,7 @@ Definition printer2 (x : nunit 2) : Number.uint :=
 
 Definition parser2 (_ : Number.uint) : nunit 2 := NUnit 2.
 
-Notation nunit2 := (nunit 2).
+Abbreviation nunit2 := (nunit 2).
 Number Notation nunit2 parser2 printer2 : nat_scope.
 
 Check 2.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -84,7 +84,7 @@ Arguments bar {x}
 Module Corelib.Init.Peano
 Notation sym_eq := eq_sym
 Expands to: Notation Corelib.Init.Logic.sym_eq
-Declared in library Corelib.Init.Logic, line 757, characters 0-41
+Declared in library Corelib.Init.Logic, line 757, characters 0-45
 
 eq_sym : forall [A : Type] [x y : A], x = y -> y = x
 

--- a/test-suite/output/Qf_deprecated.out
+++ b/test-suite/output/Qf_deprecated.out
@@ -3,11 +3,11 @@ Warning: Reference x is deprecated. Use M.y instead.
 [deprecated-reference,deprecated,default]
 Quickfix:
 Replace File "./output/Qf_deprecated.v", line 10, characters 17-18 with M.y
-File "./output/Qf_deprecated.v", line 13, characters 14-15:
+File "./output/Qf_deprecated.v", line 13, characters 18-19:
 Warning: Reference x is deprecated. Use M.y instead.
 [deprecated-reference,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_deprecated.v", line 13, characters 14-15 with M.y
+Replace File "./output/Qf_deprecated.v", line 13, characters 18-19 with M.y
 File "./output/Qf_deprecated.v", line 25, characters 17-18:
 Warning: Notation v is deprecated. Use M1.w instead.
 [deprecated-syntactic-definition,deprecated,default]

--- a/test-suite/output/Qf_deprecated.v
+++ b/test-suite/output/Qf_deprecated.v
@@ -10,15 +10,15 @@ Import N.
 Definition d1 := x = 3.
 
 Module M1.
-Notation w := x.
+Abbreviation w := x.
 End M1.
 Import M1.
 
 #[deprecated(use=w)]
-Notation v := 3.
+Abbreviation v := 3.
 
 Module M2.
-Notation w := 5.
+Abbreviation w := 5.
 End M2.
 Import M2.
 

--- a/test-suite/output/UselessSyndef.v
+++ b/test-suite/output/UselessSyndef.v
@@ -2,7 +2,7 @@ Module M.
   Definition a := 0.
 End M.
 Module N.
-  Notation a := M.a (only parsing).
+  Abbreviation a := M.a (only parsing).
 End N.
 
 Import M. Import N.

--- a/test-suite/output/activation.v
+++ b/test-suite/output/activation.v
@@ -15,11 +15,11 @@ Module Abbrev.
 Set Warnings "+no-notation-to-enable-or-disable".
 Fail Disable Notation f. (* no abbreviation with such suffix *)
 Set Warnings "no-notation-to-enable-or-disable".
-Notation f w := (S w).
+Abbreviation f w := (S w).
 Disable Notation f w := (S w).
 Enable Notation := (S _).
 
-Module A. Notation a := Prop. End A. Include A.
+Module A. Abbreviation a := Prop. End A. Include A.
 Disable Notation A.a.
 Check a.
 Disable Notation a.
@@ -29,9 +29,9 @@ Enable Notation a (all). (* Note: reactivation is not necessarily in the same or
 Check a.
 Check Prop.
 
-Module Shadowed. Notation x := true. End Shadowed.
+Module Shadowed. Abbreviation x := true. End Shadowed.
 Import Shadowed.
-Notation x := 0.
+Abbreviation x := 0.
 Check x.
 Disable Notation Abbrev.x.
 Check x.

--- a/test-suite/output/bug_10803.v
+++ b/test-suite/output/bug_10803.v
@@ -4,8 +4,8 @@ Delimit Scope foo_scope with foo.
 Bind Scope foo_scope with Foo.
 Notation "'!'" := foo : foo_scope.
 Definition of_foo {x : nat} {y : nat} (f : Foo) := f.
-Notation a := (@of_foo O).
-Notation b := (@a).
+Abbreviation a := (@of_foo O).
+Abbreviation b := (@a).
 Check a !.
 Check @a O !.
 Check @b O.

--- a/test-suite/output/bug_10824.v
+++ b/test-suite/output/bug_10824.v
@@ -1,12 +1,12 @@
 Module A.
-Notation F := False.
+Abbreviation F := False.
 Notation "!!" := False (at level 100).
 Check False.
 End A.
 
 Module B.
 Notation "!!" := False (at level 100).
-Notation F := False.
+Abbreviation F := False.
 Notation "!!" := False (at level 100).
 Check False.
 End B.

--- a/test-suite/output/bug_12777.v
+++ b/test-suite/output/bug_12777.v
@@ -1,6 +1,6 @@
 Module Import M1.
 Module Export M2.
-Notation tt' := tt.
+Abbreviation tt' := tt.
 End M2.
 End M1.
 

--- a/test-suite/output/bug_17708.out
+++ b/test-suite/output/bug_17708.out
@@ -1,4 +1,4 @@
-File "./output/bug_17708.v", line 1, characters 0-35:
+File "./output/bug_17708.v", line 1, characters 0-39:
 Warning: This notation contains Ltac expressions:
 it will not be used for printing. [non-reversible-notation,parsing,default]
 Ltac foo := exact ltac:(exact 0)

--- a/test-suite/output/bug_17708.v
+++ b/test-suite/output/bug_17708.v
@@ -1,3 +1,3 @@
-Notation zero := (ltac: (exact 0)).
+Abbreviation zero := (ltac: (exact 0)).
 Ltac foo := exact zero.
 Print foo.

--- a/test-suite/output/bug_7443.v
+++ b/test-suite/output/bug_7443.v
@@ -9,8 +9,8 @@ Ltac reify t :=
   | Datatypes.nat => nat
   | Datatypes.bool => bool
   end.
-Notation reify t := (ltac:(let rt := reify t in exact rt)) (only parsing).
-Notation reify_type_of e := (reify ((fun t (_ : t) => t) _ e)) (only parsing).
+Abbreviation reify t := (ltac:(let rt := reify t in exact rt)) (only parsing).
+Abbreviation reify_type_of e := (reify ((fun t (_ : t) => t) _ e)) (only parsing).
 Axiom Literal : forall {t}, denote t -> Type.
 Declare Scope foo_scope.
 Delimit Scope foo_scope with foo.

--- a/test-suite/output/bug_9180.v
+++ b/test-suite/output/bug_9180.v
@@ -1,4 +1,4 @@
-Notation succn := (Datatypes.S).
+Abbreviation succn := (Datatypes.S).
 
 Notation "n .+1" := (succn n) (at level 2, left associativity,
   format "n .+1") : nat_scope.

--- a/test-suite/output/bug_9569.v
+++ b/test-suite/output/bug_9569.v
@@ -2,7 +2,7 @@ Goal exists I, I = Logic.I.
 Show.
 Abort.
 
-Notation f x y p q r := ((forall x, p /\ r) /\ forall y, q /\ r).
+Abbreviation f x y p q r := ((forall x, p /\ r) /\ forall y, q /\ r).
 Goal f True False True False (Logic.True /\ Logic.False).
 Show.
 Abort.

--- a/test-suite/output/ltac2_deprecated.out
+++ b/test-suite/output/ltac2_deprecated.out
@@ -3,8 +3,8 @@ Warning: Ltac2 definition foo is deprecated. test_definition
 [deprecated-ltac2-definition,deprecated,default]
 - : unit = ()
 File "./output/ltac2_deprecated.v", line 14, characters 11-14:
-Warning: Ltac2 alias bar is deprecated. test_notation
-[deprecated-ltac2-alias,deprecated,default]
+Warning: Ltac2 abbreviation bar is deprecated. test_notation
+[deprecated-ltac2-abbreviation,deprecated,default]
 - : unit = ()
 File "./output/ltac2_deprecated.v", line 15, characters 11-14:
 Warning: Ltac2 definition qux is deprecated. test_external

--- a/test-suite/output/ltac2_deprecated.v
+++ b/test-suite/output/ltac2_deprecated.v
@@ -4,7 +4,7 @@ Require Import Ltac2.Ltac2.
 Ltac2 foo := ().
 
 #[deprecated(note="test_notation")]
-Ltac2 Notation bar := ().
+Ltac2 Abbreviation bar := ().
 
 #[deprecated(note="test_external")]
 Ltac2 @ external qux : 'a array -> int := "rocq-runtime.plugins.ltac2" "array_length".

--- a/test-suite/output/ltac2_printabout.v
+++ b/test-suite/output/ltac2_printabout.v
@@ -31,7 +31,7 @@ Print Ltac2 Out_of_bounds.
 
 (* alias *)
 
-Ltac2 Notation nota := () ().
+Ltac2 Abbreviation nota := () ().
 
 Print nota.
 

--- a/test-suite/output/ltac2_unused_var.v
+++ b/test-suite/output/ltac2_unused_var.v
@@ -43,7 +43,7 @@ Ltac2 foo16 () := ltac1:(ltac2:(x |- ())).
 
 (* no warning for y even though it's bound in the ltac2 context
    (ltac2 can't tell that the notation isn't eg "ltac2:(...) + y") *)
-Notation foo17 x y := ltac2:(exact $preterm:x) (only parsing).
+Abbreviation foo17 x y := ltac2:(exact $preterm:x) (only parsing).
 
 (* the usage of the second "a" binder should not prevent warning for the first "a" *)
 Ltac2 foo18 a a := a.

--- a/test-suite/output/non_reversible_notation.out
+++ b/test-suite/output/non_reversible_notation.out
@@ -1,7 +1,7 @@
-File "./output/non_reversible_notation.v", line 2, characters 0-31:
+File "./output/non_reversible_notation.v", line 2, characters 0-35:
 Warning: This notation contains Ltac expressions:
 it will not be used for printing. [non-reversible-notation,parsing,default]
-File "./output/non_reversible_notation.v", line 4, characters 0-27:
+File "./output/non_reversible_notation.v", line 4, characters 0-31:
 Warning: This notation contains volatile casts:
 it will not be used for printing. [non-reversible-notation,parsing,default]
 1

--- a/test-suite/output/non_reversible_notation.v
+++ b/test-suite/output/non_reversible_notation.v
@@ -1,9 +1,9 @@
 
-Notation foo := ltac:(exact 1).
+Abbreviation foo := ltac:(exact 1).
 
-Notation bar := (2 :> nat).
+Abbreviation bar := (2 :> nat).
 
-Notation baz := (3 <: nat).
+Abbreviation baz := (3 <: nat).
 
 Check foo.
 Check bar.

--- a/test-suite/output/notation_principal_scope.out
+++ b/test-suite/output/notation_principal_scope.out
@@ -1,16 +1,16 @@
-File "./output/notation_principal_scope.v", line 4, characters 28-29:
+File "./output/notation_principal_scope.v", line 4, characters 32-33:
 The command has indeed failed with message:
 Argument X was previously inferred to be in scope function_scope but is here
 used in the empty scope stack. Scope function_scope will be used at parsing
 time unless you override it by annotating the argument with an explicit scope
 of choice. [inconsistent-scopes,syntax,default]
-File "./output/notation_principal_scope.v", line 6, characters 23-36:
+File "./output/notation_principal_scope.v", line 6, characters 27-40:
 The command has indeed failed with message:
 Abbreviations don't support only printing
-File "./output/notation_principal_scope.v", line 8, characters 22-33:
+File "./output/notation_principal_scope.v", line 8, characters 26-37:
 The command has indeed failed with message:
 The reference nonexisting was not found in the current environment.
-File "./output/notation_principal_scope.v", line 10, characters 34-57:
+File "./output/notation_principal_scope.v", line 10, characters 38-61:
 The command has indeed failed with message:
 Notation scope for argument X can be specified only once.
 pp I
@@ -20,6 +20,6 @@ The command has indeed failed with message:
 Illegal application (Non-functional construction): 
 The expression "I" of type "True" cannot be applied to the term
  "I" : "True"
-File "./output/notation_principal_scope.v", line 21, characters 0-50:
+File "./output/notation_principal_scope.v", line 21, characters 0-54:
 Warning: This notation will not be used for printing as it is bound to a
 single variable. [notation-bound-to-variable,parsing,default]

--- a/test-suite/output/notation_principal_scope.v
+++ b/test-suite/output/notation_principal_scope.v
@@ -1,15 +1,15 @@
 Arguments conj {_ _} _ _%_function.
 
 Set Warnings "+inconsistent-scopes".
-Fail Notation pp X := (conj X X).
+Fail Abbreviation pp X := (conj X X).
 
-Fail Notation pp := 1 (only printing).
+Fail Abbreviation pp := 1 (only printing).
 
-Fail Notation pp X := nonexisting.
+Fail Abbreviation pp X := nonexisting.
 
-Fail Notation pp X := (conj X X) (X, X in scope nat_scope).
+Fail Abbreviation pp X := (conj X X) (X, X in scope nat_scope).
 
-Notation pp X := (conj X X) (X in scope nat_scope).
+Abbreviation pp X := (conj X X) (X in scope nat_scope).
 
 Notation "$" := I (only parsing) : nat_scope.
 Notation "$" := (I I) (only parsing) : bool_scope.
@@ -18,6 +18,6 @@ Open Scope bool_scope.
 Check pp $.
 Fail Check pp (id $).
 
-Notation pp1 X := (X%nat) (X in scope bool_scope).
-Notation pp2 X := ((X + X)%type) (X in scope bool_scope).
-Notation pp3 X := (((X, X)%type, X)%nat) (X in scope bool_scope).
+Abbreviation pp1 X := (X%nat) (X in scope bool_scope).
+Abbreviation pp2 X := ((X + X)%type) (X in scope bool_scope).
+Abbreviation pp3 X := (((X, X)%type, X)%nat) (X in scope bool_scope).

--- a/test-suite/output/print_ltac.v
+++ b/test-suite/output/print_ltac.v
@@ -11,9 +11,9 @@ Print Ltac t3.
 Ltac t4 x := match x with ?A => constr:((A, A)) end.
 Print Ltac t4.
 
-Notation idnat := (@id nat).
-Notation idn := id.
-Notation idan := (@id).
+Abbreviation idnat := (@id nat).
+Abbreviation idn := id.
+Abbreviation idan := (@id).
 Fail Strategy transparent [idnat].
 Strategy transparent [idn].
 Strategy transparent [idan].
@@ -46,9 +46,9 @@ Module Type Empty. End Empty.
 Module E. End E.
 Module F (E : Empty).
   Definition id {T} := @id T.
-  Notation idnat := (@id nat).
-  Notation idn := id.
-  Notation idan := (@id).
+  Abbreviation idnat := (@id nat).
+  Abbreviation idn := id.
+  Abbreviation idan := (@id).
   Fail Strategy transparent [idnat].
   Strategy transparent [idn].
   Strategy transparent [idan].

--- a/test-suite/output/subst.v
+++ b/test-suite/output/subst.v
@@ -1,6 +1,6 @@
 (* Ensure order of hypotheses is respected after "subst" *)
 
-Notation goal :=
+Abbreviation goal :=
   (forall x y z, x = 0 -> y = 0 -> z = 0 -> x = 1 -> True -> x = 2 -> y = 3 -> True -> z = 4 -> True)
     (only parsing).
 

--- a/test-suite/output/wish_18097.out
+++ b/test-suite/output/wish_18097.out
@@ -11,7 +11,7 @@ fix pow (n m : nat) {struct m} : nat :=
 Arguments Nat.pow (n m)%_nat_scope
 Notation pow := Nat.pow
 Expands to: Notation wish_18097.pow
-Declared in library wish_18097, line 1, characters 0-24
+Declared in library wish_18097, line 1, characters 0-28
 
 Nat.pow : nat -> nat -> nat
 

--- a/test-suite/output/wish_18097.v
+++ b/test-suite/output/wish_18097.v
@@ -1,3 +1,3 @@
-Notation pow := Nat.pow.
+Abbreviation pow := Nat.pow.
 Print pow.
 About pow.

--- a/theories/Corelib/Array/ArrayAxioms.v
+++ b/theories/Corelib/Array/ArrayAxioms.v
@@ -1,6 +1,6 @@
 From Corelib Require Import PrimArray.
 
-Local Notation in_bounds i t := (PrimInt63.ltb i (length t)).
+Local Abbreviation in_bounds i t := (PrimInt63.ltb i (length t)).
 
 Axiom get_out_of_bounds : forall A (t:array A) i,
   in_bounds i t = false -> t.[i] = default t.

--- a/theories/Corelib/Classes/RelationClasses.v
+++ b/theories/Corelib/Classes/RelationClasses.v
@@ -338,7 +338,7 @@ Definition ternary_operation A := arrows (A::A::A::Tnil) A.
 
 (** We define n-ary [predicate]s as functions into [Prop]. *)
 
-Notation predicate l := (arrows l Prop).
+Abbreviation predicate l := (arrows l Prop).
 
 (** Unary predicates, or sets. *)
 

--- a/theories/Corelib/Compat/Coq820.v
+++ b/theories/Corelib/Compat/Coq820.v
@@ -13,4 +13,6 @@
 (** When removing this file, please cleanup the "-compat" option code
     in sysinit/coqargs.ml *)
 
+Require Export Corelib.Compat.Rocq90.
+
 #[export] Set Warnings "-deprecated-since-9.0".

--- a/theories/Corelib/Compat/Rocq90.v
+++ b/theories/Corelib/Compat/Rocq90.v
@@ -10,4 +10,6 @@
 
 (** Compatibility file for making Rocq act similar to Coq v9.0 *)
 
+Require Export Corelib.Compat.Rocq91.
+
 #[export] Set Warnings "-deprecated-since-9.1".

--- a/theories/Corelib/Compat/Rocq91.v
+++ b/theories/Corelib/Compat/Rocq91.v
@@ -10,4 +10,7 @@
 
 (** Compatibility file for making Rocq act similar to Coq v9.1 *)
 
+(* When adding Rocq92.v, uncomment the following line *)
+(* Require Export Corelib.Compat.Rocq92. *)
+
 #[export] Set Warnings "-deprecated-since-9.2".

--- a/theories/Corelib/Floats/FloatAxioms.v
+++ b/theories/Corelib/Floats/FloatAxioms.v
@@ -13,7 +13,7 @@ From Corelib Require Import SpecFloat PrimFloat FloatOps.
 
 (** * Properties of the primitive operators for the Binary64 format *)
 
-Notation valid_binary := (valid_binary prec emax).
+Abbreviation valid_binary := (valid_binary prec emax).
 
 Definition SF64classify := SFclassify prec.
 Definition SF64mul := SFmul prec emax.

--- a/theories/Corelib/Floats/FloatOps.v
+++ b/theories/Corelib/Floats/FloatOps.v
@@ -15,7 +15,7 @@ From Corelib Require Import FloatClass SpecFloat PrimFloat.
 
 Definition prec := Eval compute in Z.of_nat 53.
 Definition emax := Eval compute in Z.of_nat 1024.
-Notation emin := (emin prec emax).
+Abbreviation emin := (emin prec emax).
 
 Definition shift := Eval compute in Z.of_nat 2101. (** [= 2*emax + prec] *)
 

--- a/theories/Corelib/Init/Datatypes.v
+++ b/theories/Corelib/Init/Datatypes.v
@@ -457,29 +457,29 @@ Proof. intros. apply CompareSpec2Type; assumption. Defined.
     sole inhabitant is denoted [identity_refl A a] *)
 
 #[deprecated(since="8.16",note="Use eq instead")]
-Notation identity := eq (only parsing).
+Abbreviation identity := eq (only parsing).
 #[deprecated(since="8.16",note="Use eq_refl instead")]
-Notation identity_refl := eq_refl (only parsing).
+Abbreviation identity_refl := eq_refl (only parsing).
 #[deprecated(since="8.16",note="Use eq_ind instead")]
-Notation identity_ind := eq_ind (only parsing).
+Abbreviation identity_ind := eq_ind (only parsing).
 #[deprecated(since="8.16",note="Use eq_rec instead")]
-Notation identity_rec := eq_rec (only parsing).
+Abbreviation identity_rec := eq_rec (only parsing).
 #[deprecated(since="8.16",note="Use eq_rect instead")]
-Notation identity_rect := eq_rect (only parsing).
+Abbreviation identity_rect := eq_rect (only parsing).
 #[deprecated(since="8.16",note="Use eq_sym instead")]
-Notation identity_sym := eq_sym (only parsing).
+Abbreviation identity_sym := eq_sym (only parsing).
 #[deprecated(since="8.16",note="Use eq_trans instead")]
-Notation identity_trans := eq_trans (only parsing).
+Abbreviation identity_trans := eq_trans (only parsing).
 #[deprecated(since="8.16",note="Use f_equal instead")]
-Notation identity_congr := f_equal (only parsing).
+Abbreviation identity_congr := f_equal (only parsing).
 #[deprecated(since="8.16",note="Use not_eq_sym instead")]
-Notation not_identity_sym := not_eq_sym (only parsing).
+Abbreviation not_identity_sym := not_eq_sym (only parsing).
 #[deprecated(since="8.16",note="Use eq_ind_r instead")]
-Notation identity_ind_r := eq_ind_r (only parsing).
+Abbreviation identity_ind_r := eq_ind_r (only parsing).
 #[deprecated(since="8.16",note="Use eq_rec_r instead")]
-Notation identity_rec_r := eq_rec_r (only parsing).
+Abbreviation identity_rec_r := eq_rec_r (only parsing).
 #[deprecated(since="8.16",note="Use eq_rect_r instead")]
-Notation identity_rect_r := eq_rect_r (only parsing).
+Abbreviation identity_rect_r := eq_rect_r (only parsing).
 
 Register eq as core.identity.type.
 Register eq_refl as core.identity.refl.
@@ -489,13 +489,13 @@ Register eq_trans as core.identity.trans.
 Register f_equal as core.identity.congr.
 
 #[deprecated(since="8.16",note="Use eq_refl instead")]
-Notation refl_id := eq_refl (only parsing).
+Abbreviation refl_id := eq_refl (only parsing).
 #[deprecated(since="8.16",note="Use eq_sym instead")]
-Notation sym_id := eq_sym (only parsing).
+Abbreviation sym_id := eq_sym (only parsing).
 #[deprecated(since="8.16",note="Use eq_trans instead")]
-Notation trans_id := eq_trans (only parsing).
+Abbreviation trans_id := eq_trans (only parsing).
 #[deprecated(since="8.16",note="Use not_eq_sym instead")]
-Notation sym_not_id := not_eq_sym (only parsing).
+Abbreviation sym_not_id := not_eq_sym (only parsing).
 
 (** Identity type *)
 
@@ -511,12 +511,12 @@ Register idProp as core.IDProp.idProp.
 
 (* Compatibility *)
 
-Notation prodT := prod (only parsing).
-Notation pairT := pair (only parsing).
-Notation prodT_rect := prod_rect (only parsing).
-Notation prodT_rec := prod_rec (only parsing).
-Notation prodT_ind := prod_ind (only parsing).
-Notation fstT := fst (only parsing).
-Notation sndT := snd (only parsing).
+Abbreviation prodT := prod (only parsing).
+Abbreviation pairT := pair (only parsing).
+Abbreviation prodT_rect := prod_rect (only parsing).
+Abbreviation prodT_rec := prod_rec (only parsing).
+Abbreviation prodT_ind := prod_ind (only parsing).
+Abbreviation fstT := fst (only parsing).
+Abbreviation sndT := snd (only parsing).
 
 (* end hide *)

--- a/theories/Corelib/Init/Decimal.v
+++ b/theories/Corelib/Init/Decimal.v
@@ -38,12 +38,12 @@ Inductive uint :=
     but rather use [D0 Nil] instead, since this form will be denoted
     as [0], while [Nil] will be printed as [Nil]. *)
 
-Notation zero := (D0 Nil).
+Abbreviation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
 Variant signed_int := Pos (d:uint) | Neg (d:uint).
-Notation int := signed_int.
+Abbreviation int := signed_int.
 
 (** For decimal numbers, we use two constructors [Decimal] and
     [DecimalExp], depending on whether or not they are given with an
@@ -57,10 +57,10 @@ Variant decimal :=
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for decimal.
-Notation int_eq_dec := signed_int_eq_dec.
-Notation int_beq := signed_int_beq.
-Notation internal_int_dec_lb := internal_signed_int_dec_lb.
-Notation internal_int_dec_bl := internal_signed_int_dec_bl.
+Abbreviation int_eq_dec := signed_int_eq_dec.
+Abbreviation int_beq := signed_int_beq.
+Abbreviation internal_int_dec_lb := internal_signed_int_dec_lb.
+Abbreviation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Declare Scope dec_uint_scope.
 Delimit Scope dec_uint_scope with uint.

--- a/theories/Corelib/Init/Hexadecimal.v
+++ b/theories/Corelib/Init/Hexadecimal.v
@@ -44,12 +44,12 @@ Inductive uint :=
     but rather use [D0 Nil] instead, since this form will be denoted
     as [0], while [Nil] will be printed as [Nil]. *)
 
-Notation zero := (D0 Nil).
+Abbreviation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
 Variant signed_int := Pos (d:uint) | Neg (d:uint).
-Notation int := signed_int.
+Abbreviation int := signed_int.
 
 (** For decimal numbers, we use two constructors [Hexadecimal] and
     [HexadecimalExp], depending on whether or not they are given with an
@@ -63,10 +63,10 @@ Variant hexadecimal :=
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for hexadecimal.
-Notation int_eq_dec := signed_int_eq_dec.
-Notation int_beq := signed_int_beq.
-Notation internal_int_dec_lb := internal_signed_int_dec_lb.
-Notation internal_int_dec_bl := internal_signed_int_dec_bl.
+Abbreviation int_eq_dec := signed_int_eq_dec.
+Abbreviation int_beq := signed_int_beq.
+Abbreviation internal_int_dec_lb := internal_signed_int_dec_lb.
+Abbreviation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Declare Scope hex_uint_scope.
 Delimit Scope hex_uint_scope with huint.

--- a/theories/Corelib/Init/Logic.v
+++ b/theories/Corelib/Init/Logic.v
@@ -754,14 +754,14 @@ Qed.
 
 (* Aliases *)
 
-Notation sym_eq := eq_sym (only parsing).
-Notation trans_eq := eq_trans (only parsing).
-Notation sym_not_eq := not_eq_sym (only parsing).
+Abbreviation sym_eq := eq_sym (only parsing).
+Abbreviation trans_eq := eq_trans (only parsing).
+Abbreviation sym_not_eq := not_eq_sym (only parsing).
 
-Notation refl_equal := eq_refl (only parsing).
-Notation sym_equal := eq_sym (only parsing).
-Notation trans_equal := eq_trans (only parsing).
-Notation sym_not_equal := not_eq_sym (only parsing).
+Abbreviation refl_equal := eq_refl (only parsing).
+Abbreviation sym_equal := eq_sym (only parsing).
+Abbreviation trans_equal := eq_trans (only parsing).
+Abbreviation sym_not_equal := not_eq_sym (only parsing).
 
 #[global]
 Hint Immediate eq_sym not_eq_sym: core.

--- a/theories/Corelib/Init/Nat.v
+++ b/theories/Corelib/Init/Nat.v
@@ -168,7 +168,7 @@ Definition tail_mul n m := tail_addmul 0 n m.
 
 (** ** Conversion with a decimal representation for printing/parsing *)
 
-Local Notation ten := (S (S (S (S (S (S (S (S (S (S O)))))))))).
+Local Abbreviation ten := (S (S (S (S (S (S (S (S (S (S O)))))))))).
 
 Fixpoint of_uint_acc (d:Decimal.uint)(acc:nat) :=
   match d with
@@ -187,7 +187,7 @@ Fixpoint of_uint_acc (d:Decimal.uint)(acc:nat) :=
 
 Definition of_uint (d:Decimal.uint) := of_uint_acc d O.
 
-Local Notation sixteen := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))).
+Local Abbreviation sixteen := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))).
 
 Fixpoint of_hex_uint_acc (d:Hexadecimal.uint)(acc:nat) :=
   match d with

--- a/theories/Corelib/Init/Number.v
+++ b/theories/Corelib/Init/Number.v
@@ -15,17 +15,17 @@ Require Import Decimal Hexadecimal.
 Variant uint := UIntDecimal (u:Decimal.uint) | UIntHexadecimal (u:Hexadecimal.uint).
 
 Variant signed_int := IntDecimal (i:Decimal.int) | IntHexadecimal (i:Hexadecimal.int).
-Notation int := signed_int.
+Abbreviation int := signed_int.
 
 Variant number := Decimal (d:Decimal.decimal) | Hexadecimal (h:Hexadecimal.hexadecimal).
 
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for number.
-Notation int_eq_dec := signed_int_eq_dec.
-Notation int_beq := signed_int_beq.
-Notation internal_int_dec_lb := internal_signed_int_dec_lb.
-Notation internal_int_dec_bl := internal_signed_int_dec_bl.
+Abbreviation int_eq_dec := signed_int_eq_dec.
+Abbreviation int_beq := signed_int_beq.
+Abbreviation internal_int_dec_lb := internal_signed_int_dec_lb.
+Abbreviation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Register uint as num.num_uint.type.
 Register int as num.num_int.type.

--- a/theories/Corelib/Init/Peano.v
+++ b/theories/Corelib/Init/Peano.v
@@ -42,7 +42,7 @@ Hint Resolve f_equal_nat: core.
 
 (** The predecessor function *)
 
-Notation pred := Nat.pred (only parsing).
+Abbreviation pred := Nat.pred (only parsing).
 
 Definition f_equal_pred := f_equal pred.
 
@@ -88,7 +88,7 @@ Hint Resolve n_Sn: core.
 
 (** Addition *)
 
-Notation plus := Nat.add (only parsing).
+Abbreviation plus := Nat.add (only parsing).
 Infix "+" := Nat.add : nat_scope.
 
 Definition f_equal2_plus := f_equal2 plus.
@@ -125,12 +125,12 @@ Qed.
 
 (** Standard associated names *)
 
-Notation plus_0_r_reverse := plus_n_O (only parsing).
-Notation plus_succ_r_reverse := plus_n_Sm (only parsing).
+Abbreviation plus_0_r_reverse := plus_n_O (only parsing).
+Abbreviation plus_succ_r_reverse := plus_n_Sm (only parsing).
 
 (** Multiplication *)
 
-Notation mult := Nat.mul (only parsing).
+Abbreviation mult := Nat.mul (only parsing).
 Infix "*" := Nat.mul : nat_scope.
 
 Definition f_equal2_mult := f_equal2 mult.
@@ -155,12 +155,12 @@ Hint Resolve mult_n_Sm: core.
 
 (** Standard associated names *)
 
-Notation mult_0_r_reverse := mult_n_O (only parsing).
-Notation mult_succ_r_reverse := mult_n_Sm (only parsing).
+Abbreviation mult_0_r_reverse := mult_n_O (only parsing).
+Abbreviation mult_succ_r_reverse := mult_n_Sm (only parsing).
 
 (** Truncated subtraction: [m-n] is [0] if [n>=m] *)
 
-Notation minus := Nat.sub (only parsing).
+Abbreviation minus := Nat.sub (only parsing).
 Infix "-" := Nat.sub : nat_scope.
 
 (** Definition of the usual orders, the basic properties of [le] and [lt]
@@ -249,8 +249,8 @@ Qed.
 
 (** Maximum and minimum : definitions and specifications *)
 
-Notation max := Nat.max (only parsing).
-Notation min := Nat.min (only parsing).
+Abbreviation max := Nat.max (only parsing).
+Abbreviation min := Nat.min (only parsing).
 
 Lemma max_l n m : m <= n -> Nat.max n m = n.
 Proof.

--- a/theories/Corelib/Init/Wf.v
+++ b/theories/Corelib/Init/Wf.v
@@ -172,8 +172,8 @@ Section Well_founded_2.
 
 End Well_founded_2.
 
-Notation Acc_iter   := Fix_F   (only parsing). (* compatibility *)
-Notation Acc_iter_2 := Fix_F_2 (only parsing). (* compatibility *)
+Abbreviation Acc_iter   := Fix_F   (only parsing). (* compatibility *)
+Abbreviation Acc_iter_2 := Fix_F_2 (only parsing). (* compatibility *)
 
 
 

--- a/theories/Corelib/Program/Utils.v
+++ b/theories/Corelib/Program/Utils.v
@@ -35,14 +35,14 @@ Notation " `  t " := (proj1_sig t) (at level 10, t at next level) : program_scop
 
 (** Construct a dependent disjunction from a boolean. *)
 
-Notation dec := sumbool_of_bool.
+Abbreviation dec := sumbool_of_bool.
 
 (** The notations [in_right] and [in_left] construct objects of a dependent disjunction. *)
 
 (** Hide proofs and generates obligations when put in a term. *)
 
-Notation in_left := (@left _ _ _).
-Notation in_right := (@right _ _ _).
+Abbreviation in_left := (@left _ _ _).
+Abbreviation in_right := (@right _ _ _).
 
 (** Extraction directives *)
 (*

--- a/theories/Corelib/Program/Wf.v
+++ b/theories/Corelib/Program/Wf.v
@@ -32,7 +32,7 @@ Section Well_founded.
 
   Register Fix_sub as program.wf.fix_sub.
 
-  (* Notation Fix_F := (Fix_F_sub P F_sub) (only parsing). (* alias *) *)
+  (* Abbreviation Fix_F := (Fix_F_sub P F_sub) (only parsing). (* alias *) *)
   (* Definition Fix (x:A) := Fix_F_sub P F_sub x (Rwf x). *)
 
   Hypothesis F_ext :

--- a/theories/Corelib/Strings/PrimStringAxioms.v
+++ b/theories/Corelib/Strings/PrimStringAxioms.v
@@ -7,8 +7,8 @@ Definition char63_valid (c : char63) :=
 
 (** * Conversion to / from lists *)
 
-Notation of_nat n := (of_Z (Z.of_nat n)).
-Notation to_nat i := (Z.to_nat (to_Z i)).
+Abbreviation of_nat n := (of_Z (Z.of_nat n)).
+Abbreviation to_nat i := (Z.to_nat (to_Z i)).
 
 Definition to_list (s : string) : list char63 :=
   ListDef.map (fun i => get s (of_nat i)) (ListDef.seq 0 (to_nat (length s))).
@@ -57,7 +57,7 @@ Axiom cat_spec :
     to_list (cat s1 s2) =
       ListDef.firstn (to_nat max_length) (to_list s1 ++ to_list s2).
 
-Notation char63_compare := PrimInt63.compare (only parsing).
+Abbreviation char63_compare := PrimInt63.compare (only parsing).
 
 Axiom compare_spec :
   forall (s1 s2 : string),

--- a/theories/Corelib/ssr/ssrbool.v
+++ b/theories/Corelib/ssr/ssrbool.v
@@ -299,9 +299,9 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Notation reflect := Datatypes.reflect.
-Notation ReflectT := Datatypes.ReflectT.
-Notation ReflectF := Datatypes.ReflectF.
+Abbreviation reflect := Datatypes.reflect.
+Abbreviation ReflectT := Datatypes.ReflectT.
+Abbreviation ReflectF := Datatypes.ReflectF.
 
 Reserved Notation "~~ b" (at level 35, right associativity).
 Reserved Notation "b ==> c" (at level 55, right associativity).
@@ -429,7 +429,7 @@ Reserved Notation "{ 'on' cd , 'bijective' f }" (at level 0, f at level 8,
  our default is &, but we try to match the intended meaning of op. The
  separator is a workaround for limitations of the parsing engine; the same
  limitations mean the separator cannot be omitted even when last_arg can.
-   The Notation declarations are complicated by the separate treatment for
+   The Abbreviation declarations are complicated by the separate treatment for
  some fixed arities (binary for bool operators, and all arities for Prop
  operators).
    We also use the square brackets in comprehension-style notations
@@ -471,7 +471,7 @@ Open Scope bool_scope.
 (**  An alternative to xorb that behaves somewhat better wrt simplification. **)
 Definition addb b := if b then negb else id.
 
-(**  Notation for && and || is declared in Init.Datatypes.  **)
+(**  Abbreviation for && and || is declared in Init.Datatypes.  **)
 Notation "~~ b" := (negb b) : bool_scope.
 Notation "b ==> c" := (implb b c) : bool_scope.
 Notation "b1 (+) b2" := (addb b1 b2) : bool_scope.
@@ -885,7 +885,7 @@ Notation "[ ==> b1 => c ]" := (b1 ==> c) (only parsing) : bool_scope.
 Section AllAnd.
 
 Variables (T : Type) (P1 P2 P3 P4 P5 : T -> Prop).
-Local Notation a P := (forall x, P x).
+Local Abbreviation a P := (forall x, P x).
 
 Lemma all_and2 : implies (forall x, [/\ P1 x & P2 x]) [/\ a P1 & a P2].
 Proof. by split=> haveP; split=> x; case: (haveP x). Qed.
@@ -1254,15 +1254,15 @@ Identity Coercion fun_of_pred : pred >-> Funclass.
 
 Definition subpred T (p1 p2 : pred T) := forall x : T, p1 x -> p2 x.
 
-(* Notation for some manifest predicates. *)
+(* Abbreviation for some manifest predicates. *)
 
-Notation xpred0 := (fun=> false).
-Notation xpredT := (fun=> true).
-Notation xpredI := (fun (p1 p2 : pred _) x => p1 x && p2 x).
-Notation xpredU := (fun (p1 p2 : pred _) x => p1 x || p2 x).
-Notation xpredC := (fun (p : pred _) x => ~~ p x).
-Notation xpredD := (fun (p1 p2 : pred _) x => ~~ p2 x && p1 x).
-Notation xpreim := (fun f (p : pred _) x => p (f x)).
+Abbreviation xpred0 := (fun=> false).
+Abbreviation xpredT := (fun=> true).
+Abbreviation xpredI := (fun (p1 p2 : pred _) x => p1 x && p2 x).
+Abbreviation xpredU := (fun (p1 p2 : pred _) x => p1 x || p2 x).
+Abbreviation xpredC := (fun (p : pred _) x => ~~ p x).
+Abbreviation xpredD := (fun (p1 p2 : pred _) x => ~~ p2 x && p1 x).
+Abbreviation xpreim := (fun f (p : pred _) x => p (f x)).
 
 (** The packed class interface for pred-like types. **)
 
@@ -1343,7 +1343,7 @@ Notation "[ 'pred' x : T | E1 & E2 ]" :=
 Module PredOfSimpl.
 Definition coerce T (sp : simpl_pred T) : pred T := fun_of_simpl sp.
 End PredOfSimpl.
-Notation pred_of_simpl := PredOfSimpl.coerce.
+Abbreviation pred_of_simpl := PredOfSimpl.coerce.
 Coercion pred_of_simpl : simpl_pred >-> pred.
 Canonical simplPredType T := PredType (@pred_of_simpl T).
 
@@ -1388,8 +1388,8 @@ Definition simpl_rel T := T -> simpl_pred T.
 Coercion rel_of_simpl T (sr : simpl_rel T) : rel T := fun x : T => sr x.
 Arguments rel_of_simpl {T} sr x /.
 
-Notation xrelU := (fun (r1 r2 : rel _) x y => r1 x y || r2 x y).
-Notation xrelpre := (fun f (r : rel _) x y => r (f x) (f y)).
+Abbreviation xrelU := (fun (r1 r2 : rel _) x y => r1 x y || r2 x y).
+Abbreviation xrelpre := (fun f (r : rel _) x y => r (f x) (f y)).
 
 Definition SimplRel {T} (r : rel T) : simpl_rel T := fun x => SimplPred (r x).
 Definition relU {T} (r1 r2 : rel T) := SimplRel (xrelU r1 r2).
@@ -1681,7 +1681,7 @@ Canonical keyed_mem_simpl :=
 
 End KeyPred.
 
-Local Notation in_unkey x S := (x \in @unkey_pred _ S _ _) (only parsing).
+Local Abbreviation in_unkey x S := (x \in @unkey_pred _ S _ _) (only parsing).
 Notation "x \in S" := (in_unkey x S) (only printing) : bool_scope.
 
 Section KeyedQualifier.
@@ -1805,14 +1805,14 @@ Proof. by move=> trR x y z Ryx Rzy; apply: trR Rzy Ryx. Qed.
 Local Notation "{ 'all1' P }" := (forall x, P x : Prop) (at level 0).
 Local Notation "{ 'all2' P }" := (forall x y, P x y : Prop) (at level 0).
 Local Notation "{ 'all3' P }" := (forall x y z, P x y z: Prop) (at level 0).
-Local Notation ph := (phantom _).
+Local Abbreviation ph := (phantom _).
 
 Section LocalProperties.
 
 Variables T1 T2 T3 : Type.
 
 Variables (d1 : mem_pred T1) (d2 : mem_pred T2) (d3 : mem_pred T3).
-Local Notation ph := (phantom Prop).
+Local Abbreviation ph := (phantom Prop).
 
 Definition prop_for (x : T1) P & ph {all1 P} := P x.
 
@@ -2245,7 +2245,7 @@ Lemma mono1W_in :
   {in aD, {homo f : x / aP x >-> rP x}}.
 Proof. by move=> hf x hx ax; rewrite hf. Qed.
 #[deprecated(since="Coq 8.16", note="Use mono1W_in instead.")]
-Notation mono2W_in := mono1W_in.
+Abbreviation mono2W_in := mono1W_in.
 
 Lemma monoW_in :
     {in aD &, {mono f : x y / aR x y >-> rR x y}} ->

--- a/theories/Corelib/ssr/ssreflect.v
+++ b/theories/Corelib/ssr/ssreflect.v
@@ -100,8 +100,8 @@ Export SsrMatchingSyntax.
 Export SsrSyntax.
 
 (** Save primitive notation that will be overloaded. **)
-Local Notation RocqGenericIf c vT vF := (if c then vT else vF) (only parsing).
-Local Notation RocqGenericDependentIf c x R vT vF :=
+Local Abbreviation RocqGenericIf c vT vF := (if c then vT else vF) (only parsing).
+Local Abbreviation RocqGenericDependentIf c x R vT vF :=
   (if c as x return R then vT else vF) (only parsing).
 
 (** Reserve notation that introduced in this file. **)
@@ -341,7 +341,7 @@ Register protect_term as plugins.ssreflect.protect_term.
   - unkeyed x where x is a variable will match any subterm with the same
     type as x (when x would raise the 'indeterminate pattern' error).        **)
 
-Notation unkeyed x := (let flex := x in flex).
+Abbreviation unkeyed x := (let flex := x in flex).
 
 (**  Ssreflect converse rewrite rule rule idiom.  **)
 Definition ssr_converse R (r : R) := (Logic.I, r).
@@ -377,7 +377,7 @@ Notation "=^~ r" := (ssr_converse r) : form_scope.
     constants can be expanded generically with the unlock rewrite rule.
     See the definition of card and subset in fintype for examples of this.   **)
 
-Notation nosimpl t := (let: tt := tt in t).
+Abbreviation nosimpl t := (let: tt := tt in t).
 
 Lemma master_key : unit. Proof. exact tt. Qed.
 Definition locked A := let: tt := master_key in fun x : A => x.
@@ -431,7 +431,7 @@ Canonical locked_with_unlockable T k x :=
 Lemma unlock_with T k x : unlocked (locked_with_unlockable k x) = x :> T.
 Proof. exact: unlock. Qed.
 
-(**  Notation to trigger Rocq elaboration to fill the holes **)
+(**  Abbreviation to trigger Rocq elaboration to fill the holes **)
 Notation "[ 'elaborate' x ]" := (ltac:(refine x)) (only parsing).
 
 (**  The internal lemmas for the have tactics.  **)
@@ -627,10 +627,10 @@ Canonical call.
 Canonical test_Prop.
 Canonical test_negative.
 Canonical check.
-Notation nonPropType := type.
+Abbreviation nonPropType := type.
 Coercion callee : call_of >-> Sortclass.
 Coercion frame : type >-> call_of.
-Notation notProp T := (@check false test_negative (call T)).
+Abbreviation notProp T := (@check false test_negative (call T)).
 End Exports.
 
 End NonPropType.

--- a/theories/Corelib/ssr/ssrfun.v
+++ b/theories/Corelib/ssr/ssrfun.v
@@ -356,17 +356,17 @@ Definition lift aT rT (f : aT -> rT) := fun x => Some (f x).
 
 End Option.
 
-Notation oapp := Option.apply.
-Notation odflt := Option.default.
-Notation obind := Option.bind.
-Notation omap := Option.map.
-Notation olift := Option.lift.
-Notation some := (@Some _) (only parsing).
+Abbreviation oapp := Option.apply.
+Abbreviation odflt := Option.default.
+Abbreviation obind := Option.bind.
+Abbreviation omap := Option.map.
+Abbreviation olift := Option.lift.
+Abbreviation some := (@Some _) (only parsing).
 
 (**  Shorthand for some basic equality lemmas.  **)
 
-Notation erefl := refl_equal.
-Notation ecast i T e x := (let: erefl in _ = i := e return T in x).
+Abbreviation erefl := refl_equal.
+Abbreviation ecast i T e x := (let: erefl in _ = i := e return T in x).
 Definition esym := sym_eq.
 Definition nesym := sym_not_eq.
 Definition etrans := trans_eq.
@@ -487,7 +487,7 @@ Notation "[ 'eta' f ]" := (fun x => f x) : function_scope.
 
 Notation "'fun' => E" := (fun _ => E) : function_scope.
 
-Notation id := (fun x => x).
+Abbreviation id := (fun x => x).
 
 Notation "@ 'id' T" := (fun x : T => x) (only parsing) : function_scope.
 
@@ -533,7 +533,7 @@ End OptionTheory.
 
 (** The empty type. **)
 
-Notation void := Empty_set.
+Abbreviation void := Empty_set.
 
 Definition of_void T (x : void) : T := match x with end.
 
@@ -574,7 +574,7 @@ Proof. by case/all_tag=> f /all_pair[]; exists f. Qed.
 (**  Refinement types.  **)
 
 (**  Prenex Implicits and renaming.  **)
-Notation sval := (@proj1_sig _ _).
+Abbreviation sval := (@proj1_sig _ _).
 Notation "@ 'sval'" := (@proj1_sig) (only parsing) : function_scope.
 
 Section Sig.
@@ -867,7 +867,7 @@ End SopSisS.
 End OperationProperties.
 
 #[deprecated(since="9.1", use=idempotent_op)]
-Notation idempotent:= idempotent_op (only parsing).
+Abbreviation idempotent:= idempotent_op (only parsing).
 
 Definition idempotent_fun (U : Type) (f : U -> U) := f \o f =1 f.
 

--- a/theories/Corelib/ssrmatching/ssrmatching.v
+++ b/theories/Corelib/ssrmatching/ssrmatching.v
@@ -24,12 +24,12 @@ Reserved Notation "( a 'as' b 'in' c )" (at level 0).
 Declare Scope ssrpatternscope.
 Delimit Scope ssrpatternscope with pattern.
 
-(* Notation to define shortcuts for the "X in t" part of a pattern.           *)
+(* Abbreviation to define shortcuts for the "X in t" part of a pattern.           *)
 Notation "( X 'in' t )" := (_ : fun X => t) (only parsing) : ssrpatternscope.
 
 (* Some shortcuts for recurrent "X in t" parts.                               *)
-Notation RHS := (X in _ = X)%pattern.
-Notation LHS := (X in X = _)%pattern.
+Abbreviation RHS := (X in _ = X)%pattern.
+Abbreviation LHS := (X in X = _)%pattern.
 
 End SsrMatchingSyntax.
 

--- a/theories/Ltac2/Constr.v
+++ b/theories/Ltac2/Constr.v
@@ -453,18 +453,18 @@ Module Pretype.
         anything other than performance.
         [true] in [constr_flags]. *)
 
-    Ltac2 Notation open_constr_flags_with_tc :=
+    Ltac2 Abbreviation open_constr_flags_with_tc :=
       set_nf_evars false (set_allow_evars true constr_flags).
 
     Local Ltac2 open_constr_flags_with_tc_kn () := open_constr_flags_with_tc.
     (** Code generation uses this as using the notation is not convenient. *)
 
-    Ltac2 Notation open_constr_flags_no_tc :=
+    Ltac2 Abbreviation open_constr_flags_no_tc :=
       set_use_typeclasses false open_constr_flags_with_tc.
     (** The flags used by open_constr:() and its alias [']. *)
 
     #[deprecated(since="8.20", note="use open_constr_flags_with_tc (or open_constr_flags_no_tc as desired)")]
-    Ltac2 Notation open_constr_flags := open_constr_flags_with_tc.
+    Ltac2 Abbreviation open_constr_flags := open_constr_flags_with_tc.
   End Flags.
 
   Ltac2 Type expected_type.

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -63,18 +63,18 @@ end.
 
 Ltac2 fail0 (_ : unit) := Control.enter (fun _ => Control.zero (Tactic_failure None)).
 
-Ltac2 Notation fail := fail0 ().
+Ltac2 Abbreviation fail := fail0 ().
 
 Ltac2 try0 t := Control.enter (fun _ => orelse t (fun _ => ())).
 
-Ltac2 Notation try := try0.
+Ltac2 Abbreviation try := try0.
 
 Ltac2 rec repeat0 (t : unit -> unit) :=
   Control.enter (fun () =>
     ifcatch (fun _ => Control.progress t)
       (fun _ => Control.check_interrupt (); repeat0 t) (fun _ => ())).
 
-Ltac2 Notation repeat := repeat0.
+Ltac2 Abbreviation repeat := repeat0.
 
 Ltac2 dispatch0 t (head, tail) :=
   match tail with
@@ -93,17 +93,17 @@ Ltac2 do0 n t :=
   end in
   aux (n ()) t.
 
-Ltac2 Notation do := do0.
+Ltac2 Abbreviation do := do0.
 
-Ltac2 Notation once := Control.once.
+Ltac2 Abbreviation once := Control.once.
 
-Ltac2 Notation unshelve := Control.unshelve.
+Ltac2 Abbreviation unshelve := Control.unshelve.
 
 Ltac2 cycle := Control.cycle.
 
 Ltac2 progress0 tac := Control.enter (fun _ => Control.progress tac).
 
-Ltac2 Notation progress := progress0.
+Ltac2 Abbreviation progress := progress0.
 
 Ltac2 rec first0 tacs :=
 match tacs with
@@ -129,11 +129,11 @@ Ltac2 Notation "solve" "[" tacs(list0(thunk(tactic(6)), "|")) "]" := solve0 tacs
 
 Ltac2 time0 tac := Control.time None tac.
 
-Ltac2 Notation time := time0.
+Ltac2 Abbreviation time := time0.
 
 Ltac2 abstract0 tac := Control.abstract None tac.
 
-Ltac2 Notation abstract := abstract0.
+Ltac2 Abbreviation abstract := abstract0.
 
 (** Base tactics *)
 
@@ -154,19 +154,19 @@ Ltac2 intros0 ev p :=
   Control.enter (fun () => Std.intros ev p).
 
 Ltac2 Notation "intros" p(intropatterns) := intros0 false p.
-Ltac2 Notation intros := intros.
+Ltac2 Abbreviation intros := intros.
 
 Ltac2 Notation "eintros" p(intropatterns) := intros0 true p.
-Ltac2 Notation eintros := eintros.
+Ltac2 Abbreviation eintros := eintros.
 
 Ltac2 split0 ev bnd :=
   enter_h ev Std.split bnd.
 
 Ltac2 Notation "split" bnd(thunk(with_bindings)) := split0 false bnd.
-Ltac2 Notation split := split.
+Ltac2 Abbreviation split := split.
 
 Ltac2 Notation "esplit" bnd(thunk(with_bindings)) := split0 true bnd.
-Ltac2 Notation esplit := esplit.
+Ltac2 Abbreviation esplit := esplit.
 
 Ltac2 exists0 ev bnds := match bnds with
 | [] => split0 ev (fun () => Std.NoBindings)
@@ -179,26 +179,26 @@ Ltac2 exists0 ev bnds := match bnds with
 end.
 
 Ltac2 Notation "exists" bnd(list0(thunk(bindings), ",")) := exists0 false bnd.
-(* Ltac2 Notation exists := exists. *)
+(* Ltac2 Abbreviation exists := exists. *)
 
 Ltac2 Notation "eexists" bnd(list0(thunk(bindings), ",")) := exists0 true bnd.
-Ltac2 Notation eexists := eexists.
+Ltac2 Abbreviation eexists := eexists.
 
 Ltac2 left0 ev bnd := enter_h ev Std.left bnd.
 
 Ltac2 Notation "left" bnd(thunk(with_bindings)) := left0 false bnd.
-Ltac2 Notation left := left.
+Ltac2 Abbreviation left := left.
 
 Ltac2 Notation "eleft" bnd(thunk(with_bindings)) := left0 true bnd.
-Ltac2 Notation eleft := eleft.
+Ltac2 Abbreviation eleft := eleft.
 
 Ltac2 right0 ev bnd := enter_h ev Std.right bnd.
 
 Ltac2 Notation "right" bnd(thunk(with_bindings)) := right0 false bnd.
-Ltac2 Notation right := right.
+Ltac2 Abbreviation right := right.
 
 Ltac2 Notation "eright" bnd(thunk(with_bindings)) := right0 true bnd.
-Ltac2 Notation eright := eright.
+Ltac2 Abbreviation eright := eright.
 
 Ltac2 constructor0 ev n bnd :=
   enter_h ev (fun ev bnd => Std.constructor_n ev n bnd) bnd.
@@ -209,10 +209,10 @@ Local Ltac2 constructor1 ev x :=
   | Some (tac, bnd) => constructor0 ev tac bnd
   end.
 
-Ltac2 Notation constructor := constructor1 false None.
+Ltac2 Abbreviation constructor := constructor1 false None.
 Ltac2 Notation "constructor" x(opt(seq(tactic,thunk(with_bindings)))) := constructor1 false x.
 
-Ltac2 Notation econstructor := constructor1 true None.
+Ltac2 Abbreviation econstructor := constructor1 true None.
 Ltac2 Notation "econstructor" x(opt(seq(tactic,thunk(with_bindings)))) := constructor1 true x.
 
 Ltac2 specialize0 c pat :=
@@ -360,31 +360,31 @@ Ltac2 Notation "inversion_clear"
   ids(opt(seq("in", list1(ident)))) :=
   Std.inversion Std.FullInversionClear arg pat ids.
 
-Ltac2 Notation exfalso := Std.exfalso ().
+Ltac2 Abbreviation exfalso := Std.exfalso ().
 
 Ltac2 Notation "red" cl(opt(clause)) :=
   Std.red (default_on_concl cl).
-Ltac2 Notation red := red.
+Ltac2 Abbreviation red := red.
 
 Ltac2 Notation "hnf" cl(opt(clause)) :=
   Std.hnf (default_on_concl cl).
-Ltac2 Notation hnf := hnf.
+Ltac2 Abbreviation hnf := hnf.
 
 Ltac2 Notation "simpl" s(strategy) pl(opt(seq(pattern, occurrences))) cl(opt(clause)) :=
   Std.simpl s pl (default_on_concl cl).
-Ltac2 Notation simpl := simpl.
+Ltac2 Abbreviation simpl := simpl.
 
 Ltac2 Notation "cbv" s(strategy) cl(opt(clause)) :=
   Std.cbv s (default_on_concl cl).
-Ltac2 Notation cbv := cbv.
+Ltac2 Abbreviation cbv := cbv.
 
 Ltac2 Notation "cbn" s(strategy) cl(opt(clause)) :=
   Std.cbn s (default_on_concl cl).
-Ltac2 Notation cbn := cbn.
+Ltac2 Abbreviation cbn := cbn.
 
 Ltac2 Notation "lazy" s(strategy) cl(opt(clause)) :=
   Std.lazy s (default_on_concl cl).
-Ltac2 Notation lazy := lazy.
+Ltac2 Abbreviation lazy := lazy.
 
 Ltac2 Notation "unfold" pl(list1(seq(reference, occurrences), ",")) cl(opt(clause)) :=
   Std.unfold pl (default_on_concl cl).
@@ -401,11 +401,11 @@ Ltac2 Notation "pattern" pl(list1(seq(constr, occurrences), ",")) cl(opt(clause)
 
 Ltac2 Notation "vm_compute" pl(opt(seq(pattern, occurrences))) cl(opt(clause)) :=
   Std.vm pl (default_on_concl cl).
-Ltac2 Notation vm_compute := vm_compute.
+Ltac2 Abbreviation vm_compute := vm_compute.
 
 Ltac2 Notation "native_compute" pl(opt(seq(pattern, occurrences))) cl(opt(clause)) :=
   Std.native pl (default_on_concl cl).
-Ltac2 Notation native_compute := native_compute.
+Ltac2 Abbreviation native_compute := native_compute.
 
 Ltac2 Notation "eval" "red" "in" c(constr) :=
   Std.eval_red c.
@@ -500,27 +500,27 @@ Ltac2 Notation "eexact" c(preterm) := exact1 true c.
 (** Like [refine] but new evars are shelved instead of becoming subgoals. *)
 
 Ltac2 Notation "intro" id(opt(ident)) mv(opt(move_location)) := Std.intro id mv.
-Ltac2 Notation intro := intro.
+Ltac2 Abbreviation intro := intro.
 
 Ltac2 Notation "move" id(ident) mv(move_location) := Std.move id mv.
 
-Ltac2 Notation reflexivity := Std.reflexivity ().
+Ltac2 Abbreviation reflexivity := Std.reflexivity ().
 
 Ltac2 symmetry0 cl :=
   Std.symmetry (default_on_concl cl).
 
 Ltac2 Notation "symmetry" cl(opt(clause)) := symmetry0 cl.
-Ltac2 Notation symmetry := symmetry.
+Ltac2 Abbreviation symmetry := symmetry.
 
 Ltac2 Notation "revert" ids(list1(ident)) := Std.revert ids.
 
-Ltac2 Notation assumption := Std.assumption ().
+Ltac2 Abbreviation assumption := Std.assumption ().
 
-Ltac2 Notation eassumption := Std.eassumption ().
+Ltac2 Abbreviation eassumption := Std.eassumption ().
 
-Ltac2 Notation etransitivity := Std.etransitivity ().
+Ltac2 Abbreviation etransitivity := Std.etransitivity ().
 
-Ltac2 Notation admit := Std.admit ().
+Ltac2 Abbreviation admit := Std.admit ().
 
 Ltac2 clear0 ids := match ids with
 | [] => Std.keep []
@@ -529,9 +529,9 @@ end.
 
 Ltac2 Notation "clear" ids(list0(ident)) := clear0 ids.
 Ltac2 Notation "clear" "-" ids(list1(ident)) := Std.keep ids.
-Ltac2 Notation clear := clear.
+Ltac2 Abbreviation clear := clear.
 
-Ltac2 Notation refine := Control.refine.
+Ltac2 Abbreviation refine := Control.refine.
 
 (** extratactics *)
 
@@ -545,15 +545,15 @@ Ltac2 subst0 ids := match ids with
 end.
 
 Ltac2 Notation "subst" ids(list0(ident)) := subst0 ids.
-Ltac2 Notation subst := subst.
+Ltac2 Abbreviation subst := subst.
 
 Ltac2 Notation "discriminate" arg(opt(destruction_arg)) :=
   Std.discriminate false arg.
-Ltac2 Notation discriminate := discriminate.
+Ltac2 Abbreviation discriminate := discriminate.
 
 Ltac2 Notation "ediscriminate" arg(opt(destruction_arg)) :=
   Std.discriminate true arg.
-Ltac2 Notation ediscriminate := ediscriminate.
+Ltac2 Abbreviation ediscriminate := ediscriminate.
 
 Ltac2 Notation "injection" arg(opt(destruction_arg)) ipat(opt(seq("as", intropatterns))):=
   Std.injection false ipat arg.
@@ -586,7 +586,7 @@ Ltac2 Notation "trivial"
   use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := trivial0 use dbs.
 
-Ltac2 Notation trivial := trivial.
+Ltac2 Abbreviation trivial := trivial.
 
 Ltac2 auto0 n use dbs :=
   let dbs := default_db dbs in
@@ -597,7 +597,7 @@ Ltac2 Notation "auto" n(opt(tactic(0)))
   use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := auto0 n use dbs.
 
-Ltac2 Notation auto := auto.
+Ltac2 Abbreviation auto := auto.
 
 Ltac2 eauto0 n use dbs :=
   let dbs := default_db dbs in
@@ -608,7 +608,7 @@ Ltac2 Notation "eauto" n(opt(tactic(0)))
   use(opt(seq("using", list1(reference, ","))))
   dbs(opt(seq("with", hintdb))) := eauto0 n use dbs.
 
-Ltac2 Notation eauto := eauto.
+Ltac2 Abbreviation eauto := eauto.
 
 Ltac2 Notation "typeclasses_eauto" n(opt(tactic(0)))
   dbs(opt(seq("with", list1(ident)))) := Std.typeclasses_eauto None n dbs.
@@ -616,7 +616,7 @@ Ltac2 Notation "typeclasses_eauto" n(opt(tactic(0)))
 Ltac2 Notation "typeclasses_eauto" "bfs" n(opt(tactic(0)))
   dbs(opt(seq("with", list1(ident)))) := Std.typeclasses_eauto (Some Std.BFS) n dbs.
 
-Ltac2 Notation typeclasses_eauto := typeclasses_eauto.
+Ltac2 Abbreviation typeclasses_eauto := typeclasses_eauto.
 
 Ltac2 Notation "unify" x(constr) y(constr) := Std.unify x y.
 
@@ -628,7 +628,7 @@ Ltac2 Notation "simple" "congruence" n(opt(tactic(0))) l(opt(seq("with", list1(c
 
 #[deprecated(since="9.1", note="Use Std.f_equal instead.")]
 Ltac2 f_equal0 := Std.f_equal.
-Ltac2 Notation f_equal := Std.f_equal ().
+Ltac2 Abbreviation f_equal := Std.f_equal ().
 
 (** now *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1349,10 +1349,13 @@ GRAMMAR EXTEND Gram
 
      | IDENT "Infix"; ntn_decl = notation_declaration ->
          { VernacSynterp (VernacNotation (true,ntn_decl)) }
-     | IDENT "Notation"; id = identref; idl = LIST0 ident;
+     | lnot = located_notation; id = identref; idl = LIST0 ident;
          ":="; c = constr; modl = syntax_modifiers ->
-           { VernacSynPure (VernacAbbreviation (id,(idl,c), modl)) }
-     | IDENT "Notation"; ntn_decl = notation_declaration ->
+           { VernacSynPure (VernacAbbreviation (id,(idl,c), modl, Some lnot)) }
+     | IDENT "Abbreviation"; id = identref; idl = LIST0 ident;
+         ":="; c = constr; modl = syntax_modifiers ->
+           { VernacSynPure (VernacAbbreviation (id,(idl,c), modl, None)) }
+     | located_notation; ntn_decl = notation_declaration ->
            { VernacSynterp (VernacNotation (false,ntn_decl)) }
 
      | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring; l = syntax_modifiers ->
@@ -1368,6 +1371,9 @@ GRAMMAR EXTEND Gram
      (* "Print" "Grammar" and "Declare" "Scope" should be here but are in "command" entry in order
         to factorize with other "Print"-based or "Declare"-based vernac entries *)
   ] ]
+  ;
+  located_notation:
+    [ [ IDENT "Notation" -> { loc } ] ]
   ;
   enable_enable_disable:
     [ [ IDENT "Enable" -> { true }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1351,7 +1351,7 @@ GRAMMAR EXTEND Gram
          { VernacSynterp (VernacNotation (true,ntn_decl)) }
      | IDENT "Notation"; id = identref; idl = LIST0 ident;
          ":="; c = constr; modl = syntax_modifiers ->
-           { VernacSynPure (VernacSyntacticDefinition (id,(idl,c), modl)) }
+           { VernacSynPure (VernacAbbreviation (id,(idl,c), modl)) }
      | IDENT "Notation"; ntn_decl = notation_declaration ->
            { VernacSynterp (VernacNotation (false,ntn_decl)) }
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1083,10 +1083,10 @@ let pr_synpure_vernac_expr v =
     )
   | VernacHints (dbnames,h) ->
     return (pr_hints dbnames h pr_constr pr_constr_pattern_expr)
-  | VernacAbbreviation (id,(ids,c),l) ->
+  | VernacAbbreviation (id,(ids,c),l,_) ->
     return (
       hov 2
-        (keyword "Notation" ++ spc () ++ pr_abbreviation pr_lident (ids,id) ++ str":=" ++ pr_constrarg c ++
+        (keyword "Abbreviation" ++ spc () ++ pr_abbreviation pr_lident (ids,id) ++ str":=" ++ pr_constrarg c ++
          pr_syntax_modifiers l)
     )
   | VernacArguments (q, args, more_implicits, mods) ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1083,7 +1083,7 @@ let pr_synpure_vernac_expr v =
     )
   | VernacHints (dbnames,h) ->
     return (pr_hints dbnames h pr_constr pr_constr_pattern_expr)
-  | VernacSyntacticDefinition (id,(ids,c),l) ->
+  | VernacAbbreviation (id,(ids,c),l) ->
     return (
       hov 2
         (keyword "Notation" ++ spc () ++ pr_abbreviation pr_lident (ids,id) ++ str":=" ++ pr_constrarg c ++

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -193,7 +193,7 @@ let classify_vernac e =
     | VernacOpenCloseScope _ | VernacDeclareScope _
     | VernacDelimiters _ | VernacBindScope _
     | VernacEnableNotation _
-    | VernacSyntacticDefinition _
+    | VernacAbbreviation _
     | VernacContext _ (* TASSI: unsure *) -> VtSideff ([], VtNow)
     | VernacInstance ((name,_),_,_,props,_) ->
       let program, refine =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2842,7 +2842,7 @@ let translate_pure_vernac ?loc ~atts v = let open Vernactypes in match v with
     vtdefault(fun () ->
         vernac_hints ~atts dbnames hints)
 
-  | VernacSyntacticDefinition (id,c,b) ->
+  | VernacAbbreviation (id,c,b) ->
      vtdefault(fun () -> vernac_abbreviation ~atts id c b)
 
   | VernacArguments (qid, args, more_implicits, flags) ->

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -467,6 +467,7 @@ type nonrec synpure_vernac_expr =
   | VernacHints of string list * hints_expr
   | VernacAbbreviation of
       lident * (Id.t list * constr_expr) * syntax_modifier CAst.t list
+      * Loc.t option (* warn about old deprecated "Notation" keyword, to remove when removing it *)
   | VernacArguments of
       qualid or_by_notation *
       vernac_argument_status list (* Main arguments status list *) *

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -465,7 +465,7 @@ type nonrec synpure_vernac_expr =
   | VernacCreateHintDb of string * bool
   | VernacRemoveHints of string list * qualid list
   | VernacHints of string list * hints_expr
-  | VernacSyntacticDefinition of
+  | VernacAbbreviation of
       lident * (Id.t list * constr_expr) * syntax_modifier CAst.t list
   | VernacArguments of
       qualid or_by_notation *


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Following what was decided at yesterday's call: https://github.com/rocq-prover/rocq/wiki/Rocq-Call-2025-07-01

<!-- If this is a bug fix, make sure the bug was reported beforehand.
Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~~Added / updated **test-suite**.~~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~~Documented any new / changed **user messages**.~~
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md -->

#### Overlays (to be merged in sync with the current PR)

- [ ] https://github.com/rocq-prover/stdlib/pull/180
