### PR TITLE
Remove incorrect comment in 9.0 compat file

### DIFF
--- a/theories/Corelib/Compat/Rocq90.v
+++ b/theories/Corelib/Compat/Rocq90.v
@@ -10,7 +10,4 @@
 
 (** Compatibility file for making Rocq act similar to Coq v9.0 *)
 
-(** When removing this file, please cleanup the "-compat" option code
-    in sysinit/coqargs.ml *)
-
 #[export] Set Warnings "-deprecated-since-9.1".


### PR DESCRIPTION
The comment is specific to the 8.20 compat file, I guess it was inadvertently copied.
