### PR TITLE
Do not keep readding modules when computing self inclusions.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1427,7 +1427,8 @@ let add_include me is_module inl senv =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
       let state = check_state senv in
-      let env = Modops.add_module mp_sup (module_body_of_type mb) senv.env in
+      (* Module subcomponents are already part of senv.env at this point *)
+      let env = Environ.shallow_add_module mp_sup (module_body_of_type mb) senv.env in
       let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1430,7 +1430,8 @@ let declare_one_include_core (me,base,kind,inl) =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
       let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
-      let env = Modops.add_module cur_mp (module_body_of_type mb) (Global.env ()) in
+      (* Module subcomponents are already part of env at this point *)
+      let env = Environ.shallow_add_module cur_mp (module_body_of_type mb) (Global.env ()) in
       let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) mtb in
       let () = Global.add_constraints cst in
       let mpsup_delta = match mod_global_delta mb with


### PR DESCRIPTION
We only care about the current prefix of the module being registered as a module in the environment, because at the call point the module is still open and thus its subcomponents are part of the environment. Given that the code was basically copy-pasted, both the kernel and Declaremods must be fixed the same way.