### PR TITLE
Prevent module redeclaration in module type subtyping.

### DIFF
--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -267,7 +267,7 @@ let check_constant (cst, ustate) trace env l info1 cb2 subst1 subst2 =
 let rec check_modules state trace env mp1 msb1 mp2 msb2 subst1 subst2 =
   let mty1 = module_type_of_module msb1 in
   let mty2 = module_type_of_module msb2 in
-  check_modtypes state trace env mp1 mty1 mp2 mty2 subst1 subst2 false
+  check_modtypes state trace env mp1 mty1 mp2 mty2 subst1 subst2
 
 and check_signatures (cst, ustate) trace env mp1 sig1 mp2 sig2 subst1 subst2 reso1 reso2 =
   let map1 = make_labmap mp1 sig1 in
@@ -295,15 +295,20 @@ and check_signatures (cst, ustate) trace env mp1 sig1 mp2 sig2 subst1 subst2 res
             in
             let mp1' = MPdot (mp1, l) in
             let mp2' = MPdot (mp2, l) in
-            let env = add_module mp2' (module_body_of_type mtb2) (add_module mp1' (module_body_of_type mtb1) env) in
-            check_modtypes (cst, ustate) (Submodule l :: trace) env mp1' mtb1 mp2' mtb2 subst1 subst2 true
+            (* Check for equivalence via subtyping in both directions *)
+            let cst =
+              let env = add_module mp1' (module_body_of_type mtb1) env in
+              check_modtypes (cst, ustate) (Submodule l :: trace) env mp1' mtb1 mp2' mtb2 subst1 subst2
+            in
+            let env = add_module mp2' (module_body_of_type mtb2) env in
+            check_modtypes (cst, ustate) (Submodule l :: trace) env mp2' mtb2 mp1' mtb1 subst2 subst1
   in
     List.fold_left check_one_body cst sig2
 
-and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 equiv =
+and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 =
   if mtb1==mtb2 || mod_type mtb1 == mod_type mtb2 then cst
   else
-    let rec check_structure cst ~nargs env struc1 struc2 equiv subst1 subst2 =
+    let rec check_structure cst ~nargs env struc1 struc2 subst1 subst2 =
       match struc1,struc2 with
       | NoFunctor list1,
         NoFunctor list2 ->
@@ -320,33 +325,21 @@ and check_modtypes (cst, ustate) trace env mp1 mtb1 mp2 mtb2 subst1 subst2 equiv
         in
         let delta_mtb1 = mod_delta mtb1 in
         let delta_mtb2 = mod_delta mtb2 in
-        if equiv then
-          let subst2 = add_mp mp2 mp1 delta_mtb1 subst2 in
-          let cst = check_signatures (cst, ustate) trace env
-            mp1 list1 mp2 list2 subst1 subst2
-            delta_mtb1 delta_mtb2
-          in
-          let cst = check_signatures (cst, ustate) trace env
-            mp2 list2 mp1 list1 subst2 subst1
-            delta_mtb2 delta_mtb1
-          in
-          cst
-        else
-          check_signatures (cst, ustate) trace env
-            mp1 list1 mp2 list2 subst1 subst2
-            delta_mtb1 delta_mtb2
+        check_signatures (cst, ustate) trace env
+          mp1 list1 mp2 list2 subst1 subst2
+          delta_mtb1 delta_mtb2
       | MoreFunctor (arg_id1,arg_t1,body_t1),
         MoreFunctor (arg_id2,arg_t2,body_t2) ->
         let mparg1 = MPbound arg_id1 in
         let mparg2 = MPbound arg_id2 in
         let subst1 = join (map_mbid arg_id1 mparg2 (mod_delta arg_t2)) subst1 in
         let env = add_module_parameter arg_id2 arg_t2 env in
-        let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 arg_t2 mparg1 arg_t1 subst2 subst1 equiv in
+        let cst = check_modtypes (cst, ustate) (FunctorArgument (nargs+1) :: trace) env mparg2 arg_t2 mparg1 arg_t1 subst2 subst1 in
         (* contravariant *)
-        check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 equiv subst1 subst2
+        check_structure cst ~nargs:(nargs + 1) env body_t1 body_t2 subst1 subst2
       | _ , _ -> error_incompatible_modtypes mtb1 mtb2
     in
-    check_structure cst ~nargs:0 env (mod_type mtb1) (mod_type mtb2) equiv subst1 subst2
+    check_structure cst ~nargs:0 env (mod_type mtb1) (mod_type mtb2) subst1 subst2
 
 let check_subtypes state env mp_sup mp_super super =
   let sup = match Environ.lookup_module mp_sup env with
@@ -355,4 +348,4 @@ let check_subtypes state env mp_sup mp_super super =
   in
   check_modtypes state [] env
     mp_sup (strengthen sup mp_sup) mp_super super empty_subst
-    (map_mp mp_super mp_sup (mod_delta sup)) false
+    (map_mp mp_super mp_sup (mod_delta sup))


### PR DESCRIPTION
The rule to check field subtyping when the field is a module type boils down to checking that the two modules types are equivalent. The previous code had an ad-hoc check for this, but to satisfy that the module contents are part of the current environment, when checking mp₁ : M₁ ≅ mp₂ : M₂, it was adding both module paths to the environment. Unfortunately, there is no requirement that the two pathes are distinct, and in practice some callers do pass the same path on both sides. The net result is that one implementation took precedence over the other.

I am not sure this can be weaponized into an unsoundness proof, but it clearly messes with some other expected invariants. To fix this, we remove the ad-hoc check for module equivalence and replace it with a subtyping check in both directions. This is not really worse algorithmically-wise, because the previous check also ended up performing a two-way check when it reached non-functor modules. Hence both implementations are exponential in the depth of nested module types. The only difference is that the previous code was a bit more efficient with module parameters, but in practice it should not matter that much, and it is also unclear to me that code in the wild stores functor types (!) in modules, let alone deeply nested.
