### PR TITLE
`Capture Output` control and `Test Output` command for asserting outputs of vernac commands.

### DIFF
--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -103,6 +103,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Timeout"; n = natural -> { CAst.make ~loc (ControlTimeout n) }
       | IDENT "Fail" -> { CAst.make ~loc ControlFail }
       | IDENT "Succeed" -> { CAst.make ~loc ControlSucceed }
+      | IDENT "Capture"; IDENT "Output" -> { CAst.make ~loc ControlCaptureOutput }
     ] ]
   ;
   decorated_vernac:
@@ -1105,11 +1106,17 @@ GRAMMAR EXTEND Gram
         -> { VernacSynPure (VernacMemOption (table, v)) }
       | IDENT "Test"; table = setting_name ->
           { VernacSynPure (VernacPrintOption table) }
+      | IDENT "Test"; IDENT "Output"; s = string ->
+          { VernacSynPure (VernacTestOutput(s)) }
 
       | IDENT "Remove"; table = IDENT; field = IDENT; v= LIST1 table_value
         -> { VernacSynPure (VernacRemoveOption ([table;field], v)) }
       | IDENT "Remove"; table = IDENT; v = LIST1 table_value ->
-          { VernacSynPure (VernacRemoveOption ([table], v)) } ]]
+          { VernacSynPure (VernacRemoveOption ([table], v)) }
+
+      | IDENT "Drop"; IDENT "Output" ->
+          { VernacSynPure (VernacDropOutput) }
+      ] ]
   ;
   query_command:
     [ [ IDENT "Eval"; r = red_expr; "in"; c = lconstr; "." ->
@@ -1188,6 +1195,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Strategies" -> { PrintStrategy None }
       | IDENT "Registered" -> { PrintRegistered }
       | IDENT "Registered"; IDENT "Schemes" -> { PrintRegisteredSchemes }
+      | IDENT "Output" -> { PrintOutput }
     ] ]
   ;
   debug_univ_name:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -703,6 +703,8 @@ let pr_printable = function
     keyword "Print Notation" ++ spc() ++ str ntn_key
   | PrintNotation (Constrexpr.InCustomEntry ent, ntn_key) ->
     keyword "Print Notation" ++ spc() ++ pr_qualid ent ++ str ntn_key
+  | PrintOutput ->
+    keyword "Print Output"
 
 let pr_using e =
   let rec aux = function
@@ -1317,6 +1319,10 @@ let pr_synpure_vernac_expr v =
             prlist_with_sep (fun _ -> fnl () ++ keyword "with"
                                       ++ spc ()) pr_rew_rule l)
     )
+  | VernacDropOutput ->
+    keyword "Drop Output"
+  | VernacTestOutput (s) ->
+    keyword "Test Output" ++ spc () ++ quote (str s) (* TODO @radrow is this ok? *)
 
 let pr_synterp_vernac_expr v =
   let return = tag_vernac v in
@@ -1433,6 +1439,7 @@ let pr_control_flag (p : control_flag) =
     | ControlTimeout n -> keyword "Timeout " ++ int n
     | ControlFail -> keyword "Fail"
     | ControlSucceed -> keyword "Succeed"
+    | ControlCaptureOutput -> keyword "Capture" ++ spc() ++ keyword "Output"
   in
   w ++ spc ()
 

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -73,4 +73,6 @@ val print_err_exn : exn -> unit
     [truncate:true], otherwise appending if it already exists). *)
 val with_output_to_file : truncate:bool -> string -> ('a -> 'b) -> 'a -> 'b
 
+val with_output_to_buffer : Buffer.t -> ('a -> 'b) -> 'a -> 'b
+
 val pr_cmd_header : Vernacexpr.vernac_control -> Pp.t

--- a/vernac/vernacControl.mli
+++ b/vernac/vernacControl.mli
@@ -43,3 +43,8 @@ val under_control : loc:Loc.t option ->
     command failed or [Succeed] where it succeeded).
 *)
 val after_last_phase : loc:Loc.t option -> _ control_entries -> bool
+
+
+(** Retrieves captured output and flushes the buffer. TODO @radrow this sucks atm
+*)
+val flush_captured_output : unit -> string

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -210,6 +210,7 @@ let classify_vernac e =
     | VernacUndoTo _ | VernacUndo _
     | VernacResetName _ | VernacResetInitial
     | VernacRestart -> VtMeta
+    | VernacDropOutput | VernacTestOutput _ -> VtSideff  ([], VtLater) (* TODO @radrow check dis *)
   in
   let static_classifier ~atts e = match e with
     | VernacSynPure e -> static_pure_classifier ~atts e

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -77,6 +77,7 @@ type printable =
   | PrintRegistered
   | PrintRegisteredSchemes
   | PrintNotation of qualid Constrexpr.notation_entry_gen * string
+  | PrintOutput
 
 type glob_search_where = InHyp | InConcl | Anywhere
 
@@ -489,6 +490,8 @@ type nonrec synpure_vernac_expr =
   | VernacPrimitive of ident_decl * CPrimitives.op_or_type * constr_expr option
   | VernacComments of comment list
   | VernacAttributes of Attributes.vernac_flags
+  | VernacTestOutput of string
+  | VernacDropOutput
 
   (* Proof management *)
   | VernacAbort
@@ -527,6 +530,7 @@ type control_flag_r =
   | ControlTimeout of int
   | ControlFail
   | ControlSucceed
+  | ControlCaptureOutput
 
 type control_flag = control_flag_r CAst.t
 


### PR DESCRIPTION
This is a very early draft/POC. Some stuff might be (is) totally wrong. Publishing it to get some preliminary feedback and how-tos.

Design discussion there: https://github.com/rocq-prover/rfcs/pull/107

-----

Example:

```coq
Capture Output Check 2 = 2.
Test Output "2 = 2 : Prop".

Capture Output Check 2 = 2.
Test Output "2 = 21 : Prop".
```
output:
```
File "./Test.v", line 5, characters 0-28:
Error: Outputs do not match.
Expected:
2 = 21 : Prop

Got:
2 = 2
     : Prop
```