### PR TITLE
rocq dep: don't bind plugins dir as Corelib

### DIFF
--- a/tools/coqdep/lib/rocqdep_main.ml
+++ b/tools/coqdep/lib/rocqdep_main.ml
@@ -39,10 +39,8 @@ let coqdep args =
     | Boot -> ()
     | Env env ->
     let corelib = Boot.Env.(corelib env |> Path.to_string) in
-    let plugins = Boot.Env.(plugins env |> Path.to_string) in
     let user_contrib = Boot.Env.(user_contrib env |> Path.to_string) in
     Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) corelib ["Corelib"];
-    Loadpath.add_rec_dir_import (Loadpath.add_coqlib_known lst) plugins ["Corelib"];
     if Sys.file_exists user_contrib then
       Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) user_contrib [];
     let add_dir s = Loadpath.add_rec_dir_no_import (Loadpath.add_coqlib_known lst) s [] in


### PR DESCRIPTION
I guess this is a remnant of when we add .v files in plugins/
