### PR TITLE
Assert that modules are not redeclared in Environ API.

### DIFF
--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -854,6 +854,7 @@ let add_modtype mp mtb env =
   { env with env_modtypes = new_modtypes }
 
 let shallow_add_module mp mb env =
+  let () = assert (not @@ ModPath.Map.mem mp env.env_modules) in
   let new_mods = ModPath.Map.add mp mb env.env_modules in
   { env with env_modules = new_mods }
 


### PR DESCRIPTION
This is a good way to catch extremely dubious implementations, and it has helped sanitize the implementation in several parts already. Unfortunately, extraction could not care less about trying to maintain sane invariants in the module layer, so I had to patch it to specifically ignore the assertion. Maybe we can try to fix it by reimplementing it, but first I have to sanitize delta resolvers and this PR is a small step towards this dream.

The CI may help to uncover other places where we play fast and loose with modules. At least the test-suite goes through.