### PR TITLE
Fix incorrect use of non-evar-aware `interp_casted_constr` in `exact_proof`

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2760,16 +2760,16 @@ let interp_type_evars_impls ?(flags=Pretyping.all_no_fail_flags) env sigma ?(imp
 
 (* Not all evars expected to be resolved, with side-effect on evars *)
 
-let interp_constr_evars_gen ?(program_mode=false) env sigma ?(impls=empty_internalization_env) expected_type c =
+let interp_constr_evars_gen ?flags ?(program_mode=false) env sigma ?(impls=empty_internalization_env) expected_type c =
   let c = intern_gen expected_type ~impls env sigma c in
-  let flags = { Pretyping.all_no_fail_flags with program_mode } in
+  let flags = Option.default { Pretyping.all_no_fail_flags with program_mode } flags in
   understand_tcc ~flags env sigma ~expected_type c
 
 let interp_constr_evars ?program_mode env evdref ?(impls=empty_internalization_env) c =
   interp_constr_evars_gen ?program_mode env evdref WithoutTypeConstraint ~impls c
 
-let interp_casted_constr_evars ?program_mode env sigma ?(impls=empty_internalization_env) c typ =
-  interp_constr_evars_gen ?program_mode env sigma ~impls (OfType typ) c
+let interp_casted_constr_evars ?flags ?program_mode env sigma ?(impls=empty_internalization_env) c typ =
+  interp_constr_evars_gen ?flags ?program_mode env sigma ~impls (OfType typ) c
 
 let interp_type_evars ?program_mode env sigma ?(impls=empty_internalization_env) c =
   interp_constr_evars_gen ?program_mode env sigma IsType ~impls c

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -117,7 +117,7 @@ val interp_open_constr : ?expected_type:typing_constraint -> env -> evar_map -> 
 val interp_constr_evars : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr -> evar_map * constr
 
-val interp_casted_constr_evars : ?program_mode:bool -> env -> evar_map ->
+val interp_casted_constr_evars : ?flags:Pretyping.inference_flags -> ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr -> types -> evar_map * constr
 
 val interp_type_evars : ?program_mode:bool -> env -> evar_map ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2137,9 +2137,7 @@ let exact_proof c =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   Refine.refine ~typecheck:false begin fun sigma ->
-    let (c, ctx) = Constrintern.interp_casted_constr (pf_env gl) sigma c (pf_concl gl) in
-    let sigma = Evd.set_universe_context sigma ctx in
-    (sigma, c)
+    Constrintern.interp_casted_constr_evars ~flags:Pretyping.all_and_fail_flags (pf_env gl) sigma c (pf_concl gl)
   end
   end
 

--- a/test-suite/bugs/bug_20890.v
+++ b/test-suite/bugs/bug_20890.v
@@ -1,0 +1,4 @@
+Require Derive.
+
+Derive (f : _) in (f = f) as H.
+Proof (eq_refl 0).


### PR DESCRIPTION

Fix #20890
