### PR TITLE
Cleanup pretyping API

### DIFF
--- a/dev/ml_toplevel/include_utilities
+++ b/dev/ml_toplevel/include_utilities
@@ -20,7 +20,7 @@ let e s =
 let constr_of_string s = 
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  Constrintern.interp_constr env sigma (parse_constr s)
+  Constrintern.interp_constr_evars env sigma (parse_constr s)
 
 (* get the body of a constant *)
 
@@ -37,4 +37,4 @@ let current_goal () = get_nth_goal 1;;
 *)
 
 let pf_e gl s = 
-  Constrintern.interp_constr (Tacmach.pf_env gl) (Tacmach.project gl) (parse_constr s)
+  Constrintern.interp_constr_evars (Tacmach.pf_env gl) (Tacmach.project gl) (parse_constr s)

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -647,7 +647,8 @@ let ppist ist =
 
 let in_current_context f c =
   let (evmap,sign) = get_current_context () in
-  f (fst (Constrintern.interp_constr sign evmap c))(*FIXME*)
+  (* FIXME dropping evar map *)
+  f (snd (Constrintern.interp_constr_evars sign evmap c)).uj_val
 
 (* We expand the result of preprocessing to be independent of camlp5
 

--- a/doc/plugin_tutorial/tuto1/src/g_tuto1.mlg
+++ b/doc/plugin_tutorial/tuto1/src/g_tuto1.mlg
@@ -120,7 +120,7 @@ VERNAC COMMAND EXTEND Intern CLASSIFIED AS QUERY
      let sigma = Evd.from_env env in (* use this; never use empty *)
      let debug sigma = Termops.pr_evar_map ~with_univs:true None env sigma in
      Feedback.msg_notice (strbrk "State before intern: " ++ debug sigma);
-     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let (sigma, { Environ.uj_val = t }) = Constrintern.interp_constr_evars env sigma e in
      Feedback.msg_notice (strbrk "State after intern: " ++ debug sigma);
      let print t = Printer.pr_econstr_env env sigma t in
      Feedback.msg_notice (strbrk "Interned: " ++ print t)
@@ -153,7 +153,7 @@ VERNAC COMMAND EXTEND MyDefine CLASSIFIED AS SIDEFF
    {
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let (sigma, { Environ.uj_val = t }) = Constrintern.interp_constr_evars env sigma e in
      let r = Simple_declare.declare_definition ~poly i sigma t in
      let print r = strbrk "Defined " ++ Printer.pr_global r ++ strbrk "." in
      Feedback.msg_notice (print r)
@@ -207,7 +207,7 @@ VERNAC COMMAND EXTEND DefineLookup CLASSIFIED AS SIDEFF
    { fun ~opaque_access ->
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let (sigma, { Environ.uj_val = t }) = Constrintern.interp_constr_evars env sigma e in
      let r = Simple_declare.declare_definition ~poly i sigma t in
      let print r = strbrk "Defined " ++ Printer.pr_global r ++ strbrk "." in
      Feedback.msg_notice (print r);
@@ -231,7 +231,7 @@ VERNAC COMMAND EXTEND Check1 CLASSIFIED AS QUERY
    {
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let (sigma, { Environ.uj_val = t }) = Constrintern.interp_constr_evars env sigma e in
      let (sigma, typ) = Simple_check.simple_check1 env sigma t in
      Feedback.msg_notice (Printer.pr_econstr_env env sigma typ)
    }
@@ -242,7 +242,7 @@ VERNAC COMMAND EXTEND Check2 CLASSIFIED AS QUERY
    {
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let (sigma, { Environ.uj_val = t }) = Constrintern.interp_constr_evars env sigma e in
      let typ = Simple_check.simple_check2 env sigma t in
      Feedback.msg_notice (Printer.pr_econstr_env env sigma typ)
    }
@@ -260,8 +260,8 @@ VERNAC COMMAND EXTEND Convertible CLASSIFIED AS QUERY
    {
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let (sigma, t1) = Constrintern.interp_constr_evars env sigma e1 in
-     let (sigma, t2) = Constrintern.interp_constr_evars env sigma e2 in
+     let (sigma, { Environ.uj_val = t1 }) = Constrintern.interp_constr_evars env sigma e1 in
+     let (sigma, { Environ.uj_val = t2 }) = Constrintern.interp_constr_evars env sigma e2 in
      match Reductionops.infer_conv env sigma t1 t2 with
      | Some _ ->
         Feedback.msg_notice (strbrk "Yes :)")

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -98,44 +98,44 @@ val intern_context : env -> bound_univs:UnivNames.universe_binders ->
 (** Main interpretation functions, using type class inference,
     expecting evars and pending problems to be all resolved *)
 
-val interp_constr : ?flags:inference_flags -> ?expected_type:typing_constraint -> env -> evar_map -> ?impls:internalization_env ->
+val interp_constr : ?flags:inference_flags -> ?expected_type:typing_constraint -> env -> UState.t -> ?impls:internalization_env ->
   constr_expr -> constr Evd.in_ustate
 
-val interp_casted_constr : ?flags:inference_flags -> env -> evar_map -> ?impls:internalization_env ->
+val interp_casted_constr : ?flags:inference_flags -> env -> UState.t -> ?impls:internalization_env ->
   constr_expr -> types -> constr Evd.in_ustate
 
-val interp_type : ?flags:inference_flags -> env -> evar_map -> ?impls:internalization_env ->
+val interp_type : ?flags:inference_flags -> env -> UState.t -> ?impls:internalization_env ->
   constr_expr -> types Evd.in_ustate
 
 (** Main interpretation function expecting all postponed problems to
     be resolved, but possibly leaving evars. *)
 
-val interp_open_constr : ?expected_type:typing_constraint -> env -> evar_map -> constr_expr -> evar_map * constr
+val interp_open_constr : ?expected_type:typing_constraint -> env -> evar_map -> constr_expr -> evar_map * unsafe_judgment
 
 (** Accepting unresolved evars *)
 
-val interp_constr_evars : ?program_mode:bool -> env -> evar_map ->
-  ?impls:internalization_env -> constr_expr -> evar_map * constr
+val interp_constr_evars : ?flags:Pretyping.inference_flags -> ?program_mode:bool -> env -> evar_map ->
+  ?impls:internalization_env -> constr_expr -> evar_map * unsafe_judgment
 
 val interp_casted_constr_evars : ?flags:Pretyping.inference_flags -> ?program_mode:bool -> env -> evar_map ->
-  ?impls:internalization_env -> constr_expr -> types -> evar_map * constr
+  ?impls:internalization_env -> constr_expr -> types -> evar_map * unsafe_judgment
 
 val interp_type_evars : ?program_mode:bool -> env -> evar_map ->
-  ?impls:internalization_env -> constr_expr -> evar_map * types
+  ?impls:internalization_env -> constr_expr -> evar_map * unsafe_type_judgment
 
 (** Accepting unresolved evars and giving back the manual implicit arguments *)
 
 val interp_constr_evars_impls : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr ->
-  evar_map * (constr * Impargs.manual_implicits)
+  evar_map * (unsafe_judgment * Impargs.manual_implicits)
 
 val interp_casted_constr_evars_impls : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr -> types ->
-  evar_map * (constr * Impargs.manual_implicits)
+  evar_map * (unsafe_judgment * Impargs.manual_implicits)
 
 val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr ->
-  evar_map * (types * Impargs.manual_implicits)
+  evar_map * (unsafe_type_judgment * Impargs.manual_implicits)
 
 (** Interprets constr patterns *)
 
@@ -161,10 +161,10 @@ val interp_reference : ltac_sign -> qualid -> glob_constr
 
 (** Interpret binders *)
 
-val interp_binder  : env -> evar_map -> Name.t -> constr_expr ->
+val interp_binder  : env -> UState.t -> Name.t -> constr_expr ->
   types Evd.in_ustate
 
-val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map * types
+val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map * unsafe_type_judgment
 
 (** Interpret contexts: returns extended env and context.
 
@@ -220,17 +220,17 @@ val interp_univ_constraint
 
 (** Local universe and constraint declarations. *)
 val interp_univ_decl : Environ.env -> universe_decl_expr ->
-                       Evd.evar_map * UState.universe_decl
+  UState.t * UState.universe_decl
 
 val interp_univ_decl_opt : Environ.env -> universe_decl_expr option ->
-                       Evd.evar_map * UState.universe_decl
+  UState.t * UState.universe_decl
 
 val interp_cumul_univ_decl_opt : Environ.env -> cumul_univ_decl_expr option ->
-  Evd.evar_map * UState.universe_decl * Entries.variance_entry
+  UState.t * UState.universe_decl * Entries.variance_entry
 (** BEWARE the variance entry needs to be adjusted by
    [ComInductive.variance_of_entry] if the instance is extensible. *)
 
 val interp_mutual_univ_decl_opt : Environ.env -> universe_decl_expr option list ->
-  Evd.evar_map * UState.universe_decl
+  UState.t * UState.universe_decl
 (** Check that all defined udecls of a list of udecls associated to a mutual definition
     are the same and interpret this common udecl *)

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -50,7 +50,9 @@ let start_deriving ~atts bl suchthat name : Declare.Proof.t =
   let sigma, (impls_env, ((env', ctx'), _, locs)) = Constrintern.interp_named_context_evars env sigma bl in
   let sigma, env', ctx' = fill_assumptions env sigma ctx' in
   let sigma = Evd.shelve sigma (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma))) in
-  let sigma, (suchthat, impargs) = Constrintern.interp_type_evars_impls env' sigma ~impls:impls_env suchthat in
+  let sigma, ({Environ.utj_val = suchthat}, impargs) =
+    Constrintern.interp_type_evars_impls env' sigma ~impls:impls_env suchthat
+  in
   (* create the initial goals for the proof: |- Type ; |- ?1 ; f:=?2 |- suchthat *)
   let goals =
     let open Proofview in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -37,12 +37,12 @@ let interp_casted_constr_with_implicits env sigma impls c =
 
 let build_newrecursive lnameargsardef =
   let env0 = Global.env () in
-  let sigma = Evd.from_env env0 in
+  let uctx = UState.from_env env0 in
   let rec_sign, rec_impls =
     List.fold_left
       (fun (env, impls) {Vernacexpr.fname = {CAst.v = recname}; binders; rtype} ->
         let arityc = Constrexpr_ops.mkCProdN binders rtype in
-        let arity, _ctx = Constrintern.interp_type env0 sigma arityc in
+        let arity, _ctx = Constrintern.interp_type env0 uctx arityc in
         let evd = Evd.from_env env0 in
         let evd, (_, (_, impls', _locs)) =
           Constrintern.interp_context_evars ~program_mode:false env evd binders
@@ -67,7 +67,7 @@ let build_newrecursive lnameargsardef =
       match body_def with
       | Some body_def ->
         let def = abstract_glob_constr body_def binders in
-        interp_casted_constr_with_implicits rec_sign sigma rec_impls def
+        interp_casted_constr_with_implicits rec_sign (Evd.from_ctx uctx) rec_impls def
       | None ->
         CErrors.user_err
           (Pp.str "Body of Function must be given.")

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -195,11 +195,10 @@ let add_morphism_as_parameter atts m n : unit =
   init_setoid ();
   let instance_id = add_suffix n "_Proper" in
   let env = Global.env () in
-  let evd = Evd.from_env env in
   let poly = atts.polymorphic in
   let kind = Decls.(IsAssumption Logical) in
   let impargs, udecl = [], UState.default_univ_decl in
-  let evd, types = Rewrite.Internal.build_morphism_signature env evd m in
+  let evd, types = Rewrite.Internal.build_morphism_signature env (UState.from_env env) m in
   let evd, pe = Declare.prepare_parameter ~poly ~udecl ~types evd in
   let cst = Declare.declare_constant ?loc:instance_id.loc ~name:instance_id.v ~kind (Declare.ParameterEntry pe) in
   let cst = GlobRef.ConstRef cst in
@@ -211,8 +210,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
   init_setoid ();
   let instance_id = add_suffix n "_Proper" in
   let env = Global.env () in
-  let evd = Evd.from_env env in
-  let evd, morph = Rewrite.Internal.build_morphism_signature env evd m in
+  let evd, morph = Rewrite.Internal.build_morphism_signature env (UState.from_env env) m in
   let poly = atts.polymorphic in
   let kind = Decls.(IsDefinition Instance) in
   let hook { Declare.Hook.S.dref; _ } = dref |> function

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -405,9 +405,8 @@ let inTransitivity : bool * Constr.t -> obj =
 
 let add_transitivity_lemma left lem =
   let env = Global.env () in
-  let sigma = Evd.from_env env in
-  let lem',ctx (*FIXME*) = Constrintern.interp_constr env sigma lem in
-  let lem' = EConstr.to_constr sigma lem' in
+  let lem',ctx = Constrintern.interp_constr env (UState.from_env env) lem in
+  let lem' = EConstr.to_constr (Evd.from_ctx ctx) lem' in
   Lib.add_leaf (inTransitivity (left,lem'))
 
 }

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -347,7 +347,7 @@ let declare_equivalent_keys c c' =
   let get_key c =
     let env = Global.env () in
     let evd = Evd.from_env env in
-    let (evd, c) = Constrintern.interp_open_constr env evd c in
+    let (evd, { Environ.uj_val = c }) = Constrintern.interp_open_constr env evd c in
     let kind c = EConstr.kind evd c in
     Keys.constr_key env kind c
   in

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -243,8 +243,8 @@ let add_inversion_lemma ~poly (name:lident) env sigma t sort dep inv_op =
 
 let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let env = Global.env () in
-  let sigma = Evd.from_env env in
-  let c, uctx = Constrintern.interp_type env sigma com in
+  let uctx = UState.from_env env in
+  let c, uctx = Constrintern.interp_type env uctx com in
   let sigma = Evd.from_ctx uctx in
   let sigma, sort = Evd.fresh_sort_in_quality ~rigid:univ_rigid sigma comsort in
   add_inversion_lemma ~poly na env sigma c sort bool tac

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -601,7 +601,7 @@ let interp_gen kind ist pattern_mode flags env sigma c =
      with an empty trace *)
   Tactic_debug.push_chunk trace;
   try
-    let (evd,c) =
+    let (evd,{ Environ.uj_val = c }) =
       catch_error_with_trace_loc loc stack (understand_ltac flags env sigma vars kind) term
     in
     (* spiwack: to avoid unnecessary modifications of tacinterp, as this
@@ -1070,7 +1070,8 @@ let type_uconstr ?(flags = (constr_flags ()))
   ?(expected_type = WithoutTypeConstraint) ist c =
   let flags = { flags with polymorphic = ist.Geninterp.poly } in
   begin fun env sigma ->
-    Pretyping.understand_uconstr ~flags ~expected_type env sigma c
+    let sigma, j = Pretyping.understand_uconstr ~flags ~expected_type env sigma c in
+    sigma, j.uj_val
   end
 
 (* Interprets an l-tac expression into a value *)

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -780,7 +780,9 @@ let () = define "expected_without_type_constraint" (ret expected_type)
 let () =
   define "constr_pretype" (pretype_flags @-> expected_type @-> preterm @-> tac constr) @@ fun flags expected_type c ->
   let pretype env sigma =
-    let sigma, t = Pretyping.understand_uconstr ~flags ~expected_type env sigma c in
+    let sigma, { Environ.uj_val = t } =
+      Pretyping.understand_uconstr ~flags ~expected_type env sigma c
+    in
     Proofview.Unsafe.tclEVARS sigma <*> Proofview.tclUNIT t
   in
   pf_apply ~catch_exceptions:true pretype

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -65,8 +65,8 @@ let interp_constr flags ist c =
   let open Pretyping in
   let ist = to_lvar ist in
   Tac2core.pf_apply ~catch_exceptions:true begin fun env sigma ->
-    let (sigma, c) = understand_ltac flags env sigma ist WithoutTypeConstraint c in
-    let c = Tac2ffi.of_constr c in
+    let (sigma, j) = understand_ltac flags env sigma ist WithoutTypeConstraint c in
+    let c = Tac2ffi.of_constr j.uj_val in
     Proofview.Unsafe.tclEVARS sigma >>= fun () ->
     Proofview.tclUNIT c
   end
@@ -275,8 +275,8 @@ let interp_preterm_var_as_constr ?loc env sigma tycon id =
     | Some ty -> OfType ty
     | None -> WithoutTypeConstraint
   in
-  let sigma, t, ty = Pretyping.understand_ltac_ty flags env sigma vars tycon term in
-  Environ.make_judge t ty, sigma
+  let sigma, j = Pretyping.understand_ltac flags env sigma vars tycon term in
+  j, sigma
 
 exception NotFoundHypVar of Id.t * Id.t
 

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -205,11 +205,14 @@ struct
     Rewrite.Strategies.old_hints (Id.to_string i)
 
   let one_lemma c l2r =
-    let c env sigma = Pretyping.understand_uconstr env sigma c in
+    let c env sigma = Pretyping.understand_uconstr env sigma c |> Util.on_snd Environ.j_val in
     Rewrite.Strategies.one_lemma c l2r None AllOccurrences
 
   let lemmas cs =
-    let mk_c c = (); fun env sigma -> Pretyping.understand_uconstr env sigma c in
+    let mk_c c = (); fun env sigma ->
+        Pretyping.understand_uconstr env sigma c
+        |> Util.on_snd Environ.j_val
+    in
     let mk_c c = (mk_c c, true, None) in
     let cs = List.map mk_c cs in
     Rewrite.Strategies.lemmas cs

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -170,11 +170,11 @@ let _ = add_tacdef false ((Loc.ghost,Id.of_string"ring_closed_term"
 (****************************************************************************)
 
 let ic env sigma c =
-  let c, uctx = Constrintern.interp_constr env sigma c in
-  (Evd.from_ctx uctx, c)
+  let sigma, j = Constrintern.interp_constr_evars ~flags:Pretyping.all_and_fail_flags env sigma c in
+  sigma, j.uj_val
 
 let ic_unsafe env sigma c = (*FIXME remove *)
-  fst (Constrintern.interp_constr env sigma c)
+  fst (Constrintern.interp_constr env (Evd.ustate sigma) c)
 
 let decl_constant name univs c =
   let open Constr in
@@ -647,8 +647,7 @@ let process_ring_mods env sigma l =
 
 let add_theory id rth l =
   let env = Global.env () in
-  let sigma = Evd.from_env env in
-  let sigma, rth = ic env sigma rth in
+  let sigma, rth = ic env (Evd.from_env env) rth in
   let (k,set,cst,pre,post,power,sign, div) = process_ring_mods env sigma l in
   add_theory0 env sigma id rth set k cst (pre,post) power sign div
 

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -83,7 +83,8 @@ let apply_rconstr ?ist t =
       errorstrm Pp.(str"Cannot apply lemma "++pr_glob_constr_env env sigma t)
     else try understand_tcc env sigma ~expected_type:(OfType cl) (mkRlemma i)
       with e when CErrors.noncritical e -> loop (i + 1) in
-  refine_with (loop 0)
+  let sigma, j = loop 0 in
+  refine_with (sigma, j.uj_val)
   end
 
 let mkRAppView ist env sigma rv gv =

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -178,7 +178,7 @@ let interp_refine env sigma ist ~concl rc =
     unconstrained_sorts = false;
   }
   in
-  let sigma, c = Pretyping.understand_ltac flags env sigma vars kind rc in
+  let sigma, { Environ.uj_val = c } = Pretyping.understand_ltac flags env sigma vars kind rc in
 (*   ppdebug(lazy(str"sigma@interp_refine=" ++ pr_evar_map None sigma)); *)
   debug_ssr (fun () -> str"c@interp_refine=" ++ Printer.pr_econstr_env env sigma c);
   (sigma, c)

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -117,7 +117,7 @@ let locate_float () =
 let has_type env sigma f ty =
   let c = DAst.make @@ GCast (f, Some Constr.DEFAULTcast, ty) in
   let flags = Pretyping.{ all_and_fail_flags with use_coercions = false } in
-  try let _ = Pretyping.understand ~flags env sigma c in true
+  try let _, _ = Pretyping.understand ~flags env (Evd.ustate sigma) c in true
   with Pretype_errors.PretypeError _ -> false
 
 let q_option () = Rocqlib.lib_ref_opt "core.option.type"
@@ -440,8 +440,7 @@ let locate_global_inductive_with_params allow_params qid =
               let g = Notation_ops.glob_constr_of_notation_constr n in
               let c, _ =
                 let env = Global.env () in
-                let sigma = Evd.from_env env in
-                Pretyping.understand env sigma g in
+                Pretyping.understand env (UState.from_env env) g in
               Some (EConstr.Unsafe.to_constr c)) l
     | _ -> raise Not_found
 

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -98,15 +98,13 @@ val all_and_fail_flags : inference_flags
     heuristics (but no external tactic solver hooks), as well as to
     ensure that conversion problems are all solved and expand evars,
     but unresolved evars can remain. The difference is in whether the
-    evar_map is modified explicitly or by side-effect. *)
+    evar_map is modified explicitly or by side-effect.
+
+    The [expand_evars] flag is not applied to the type (only to the term).
+*)
 
 val understand_tcc : ?flags:inference_flags -> env -> evar_map ->
-  ?expected_type:typing_constraint -> glob_constr -> evar_map * constr
-
-(** As [understand_tcc] but also returns the type of the elaborated term.
-    The [expand_evars] flag is not applied to the type (only to the term). *)
-val understand_tcc_ty : ?flags:inference_flags -> env -> evar_map ->
-  ?expected_type:typing_constraint -> glob_constr -> evar_map * constr * types
+  ?expected_type:typing_constraint -> glob_constr -> evar_map * unsafe_judgment
 
 (** More general entry point with evars from ltac *)
 
@@ -122,24 +120,24 @@ val understand_tcc_ty : ?flags:inference_flags -> env -> evar_map ->
 
 val understand_ltac : inference_flags ->
   env -> evar_map -> ltac_var_map ->
-  typing_constraint -> glob_constr -> evar_map * EConstr.t
-
-val understand_ltac_ty : inference_flags ->
-  env -> evar_map -> ltac_var_map ->
-  typing_constraint -> glob_constr -> evar_map * EConstr.t * EConstr.types
+  typing_constraint -> glob_constr -> evar_map * unsafe_judgment
 
 (** Standard call to get a constr from a glob_constr, resolving
     implicit arguments and coercions, and compiling pattern-matching;
     the default inference_flags tells to use type classes and
     heuristics (but no external tactic solver hook), as well as to
     ensure that conversion problems are all solved and that no
-    unresolved evar remains, expanding evars. *)
+    unresolved evar remains, expanding evars.
+
+    Because we don't return an updated evar map but only the ustate,
+    we also take as argument just the ustate to avoid forgetting an
+    instantiation of preexisting evar. *)
 val understand : ?flags:inference_flags -> ?expected_type:typing_constraint ->
-  env -> evar_map -> glob_constr -> constr Evd.in_ustate
+  env -> UState.t -> glob_constr -> constr Evd.in_ustate
 
 val understand_uconstr :
   ?flags:inference_flags -> ?expected_type:typing_constraint ->
-  env -> evar_map -> Ltac_pretype.closed_glob_constr -> evar_map * EConstr.t
+  env -> evar_map -> Ltac_pretype.closed_glob_constr -> evar_map * unsafe_judgment
 
 (** [hook env sigma ev] returns [Some (sigma', term)] if [ev] can be
    instantiated with a solution, [None] otherwise. Used to extend
@@ -170,7 +168,7 @@ val check_evars : env -> ?initial:evar_map -> evar_map -> constr -> unit
 (** Internal of Pretyping... *)
 val ise_pretype_gen :
   inference_flags -> env -> evar_map ->
-  ltac_var_map -> typing_constraint -> glob_constr -> evar_map * constr * types
+  ltac_var_map -> typing_constraint -> glob_constr -> evar_map * unsafe_judgment
 
 (** {6 Open-recursion style pretyper} *)
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -559,12 +559,12 @@ let add_rew_rules ~locality base (lrul:raw_rew_rule list) =
 
 let add_rewrite_hint ~locality ~poly bases ort t lcsr =
   let env = Global.env() in
-  let sigma = Evd.from_env env in
+  let uctx = UState.from_env env in
   let f ce =
-    let c, ctx = Constrintern.interp_constr env sigma ce in
-    let c = EConstr.to_constr sigma c in
+    let c, uctx = Constrintern.interp_constr env uctx ce in
+    let c = EConstr.to_constr (Evd.from_ctx uctx) c in
     let ctx =
-      let ctx = UState.context_set ctx in
+      let ctx = UState.context_set uctx in
       if poly then ctx
       else (* This is a global universe context that shouldn't be
               refreshed at every use of the hint, declare it globally. *)

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -48,7 +48,7 @@ let w_refine evk rawc env sigma =
       user_err Pp.(str "Instantiate called on already-defined evar")
   in
   let env = Evd.evar_filtered_env env evi in
-  let sigma',typed_c =
+  let sigma', { Environ.uj_val = typed_c } =
     let flags = Pretyping.{
       use_coercions = true;
       use_typeclasses = UseTC;

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -586,7 +586,8 @@ module Interp = struct
 
   let interp_constr env sigma c =
     let flags = Pretyping.all_and_fail_flags in
-    Pretyping.understand_ltac flags env sigma Glob_ops.empty_lvar WithoutTypeConstraint c
+    let sigma, j = Pretyping.understand_ltac flags env sigma Glob_ops.empty_lvar WithoutTypeConstraint c in
+    sigma, j.uj_val
 
   let interp_constr_list env sigma c =
     let sigma, c = interp_constr env sigma c in
@@ -594,7 +595,7 @@ module Interp = struct
 
   let interp_pattern env sigma c =
     let flags = { Pretyping.no_classes_no_fail_inference_flags with expand_evars = false } in
-    let sigma, c = Pretyping.understand_ltac flags env sigma Glob_ops.empty_lvar WithoutTypeConstraint c in
+    let sigma, { Environ.uj_val = c } = Pretyping.understand_ltac flags env sigma Glob_ops.empty_lvar WithoutTypeConstraint c in
     Patternops.legacy_bad_pattern_of_constr env sigma c
 
   let without_ltac = {

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1480,7 +1480,7 @@ module Strategies =
 
     let fold_glob c : 'a pure_strategy =
       { strategy = fun { state ; env ; term1 = t ; ty1 = ty ; cstr ; evars } ->
-            let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
+            let sigma, { uj_val = c } = Pretyping.understand_tcc env (goalevars evars) c in
             state, run_fold_in env (sigma, cstrevars evars) c t ty
       }
 end
@@ -1835,8 +1835,8 @@ let proper_projection env sigma r ty =
                   Array.append args [| instarg |]) in
   sigma, it_mkLambda_or_LetIn app ctx
 
-let build_morphism_signature env sigma m =
-  let m,ctx = Constrintern.interp_constr env sigma m in
+let build_morphism_signature env ctx m =
+  let m,ctx = Constrintern.interp_constr env ctx m in
   let sigma = Evd.from_ctx ctx in
   let t = Retyping.get_type_of env sigma m in
   let cstrs =

--- a/tactics/rewrite.mli
+++ b/tactics/rewrite.mli
@@ -146,7 +146,7 @@ val build_signature :
   (types * types option) option list ->
   (types * types option) option ->
   Evd.evar_map * constr * (constr * t option) list
-val build_morphism_signature : Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> Evd.evar_map * t
+val build_morphism_signature : Environ.env -> UState.t -> Constrexpr.constr_expr -> Evd.evar_map * t
 val default_morphism : Environ.env -> Evd.evar_map ->
   (types * types option) option list *
   (types * types option) option ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2136,7 +2136,10 @@ let exact_proof c =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   Refine.refine ~typecheck:false begin fun sigma ->
-    Constrintern.interp_casted_constr_evars ~flags:Pretyping.all_and_fail_flags (pf_env gl) sigma c (pf_concl gl)
+    let sigma, j =
+      Constrintern.interp_casted_constr_evars ~flags:Pretyping.all_and_fail_flags (pf_env gl) sigma c (pf_concl gl)
+    in
+    sigma, j.uj_val
   end
   end
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -288,7 +288,7 @@ let type_ctx_instance ~program_mode env sigma ctx inst subst =
     | LocalAssum _ :: _, [] | [], _ :: _ -> assert false
     | LocalAssum (_,t) :: ctx, c :: l ->
       let t' = substl subst t in
-      let (sigma, c') =
+      let (sigma, { Environ.uj_val = c' }) =
         interp_casted_constr_evars ~program_mode env sigma c t'
       in
       aux (sigma, c' :: subst) l ctx
@@ -462,7 +462,7 @@ let interp_props ~program_mode env' cty k ctx ctx' subst sigma = function
       do_instance_subst_constructor_and_ty subst k (ctx' @ ctx) in
     term, termtype, sigma
   | (_, term) ->
-    let sigma, def =
+    let sigma, { Environ.uj_val = def } =
       interp_casted_constr_evars ~program_mode env' sigma term cty in
     let termtype = it_mkProd_or_LetIn cty ctx in
     let term = it_mkLambda_or_LetIn def ctx in
@@ -536,10 +536,10 @@ let typeclass_univ_instance (cl, u) =
   }
 
 let interp_instance_context ~program_mode env ctx pl tclass =
-  let sigma, decl = interp_univ_decl_opt env pl in
+  let sigma, decl = interp_univ_decl_opt env pl |> Util.on_fst Evd.from_ctx in
   let sigma, (impls, ((env', ctx), imps, _locs)) = interp_context_evars ~program_mode env sigma ctx in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
-  let sigma, (c', imps') = interp_type_evars_impls ~flags ~impls env' sigma tclass in
+  let sigma, ({ Environ.utj_val = c' }, imps') = interp_type_evars_impls ~flags ~impls env' sigma tclass in
   let imps = imps @ imps' in
   let ctx', c = decompose_prod_decls sigma c' in
   let ctx'' = ctx' @ ctx in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -96,7 +96,7 @@ let declare_axiom ~coe ~local ~kind ?user_warns ~univs ~impargs ~inline ~name ty
 let interp_assumption ~program_mode env sigma impl_env bl c =
   let flags = { Pretyping.all_no_fail_flags with program_mode } in
   let sigma, (impls, ((env_bl, ctx), impls1, _locs)) = interp_context_evars ~program_mode ~impl_env env sigma bl in
-  let sigma, (ty, impls2) = interp_type_evars_impls ~flags env_bl sigma ~impls c in
+  let sigma, ({ Environ.utj_val = ty }, impls2) = interp_type_evars_impls ~flags env_bl sigma ~impls c in
   let ty = EConstr.it_mkProd_or_LetIn ty ctx in
   sigma, ty, impls1@impls2
 
@@ -217,7 +217,7 @@ let do_assumptions ~program_mode ~poly ~scope ~kind ?user_warns ~inline l =
   let udecl, l = match scope with
     | Locality.Global import_behavior -> process_assumptions_udecls l
     | Locality.Discharge -> None, process_assumptions_no_udecls l in
-  let sigma, udecl = interp_univ_decl_opt env udecl in
+  let sigma, udecl = interp_univ_decl_opt env udecl |> Util.on_fst Evd.from_ctx in
   let coercions, ctx = local_binders_of_decls ~poly l in
   let sigma, ctx = interp_context_gen ~program_mode ~kind ~autoimp_enable:true ~coercions env sigma ctx in
   let univs = Evd.check_univ_decl ~poly sigma udecl in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -146,7 +146,7 @@ let intern_ind_arity env sigma ind =
 
 let pretype_ind_arity ~unconstrained_sorts env sigma (loc, c, impls, template_syntax) =
   let flags = { Pretyping.all_no_fail_flags with unconstrained_sorts } in
-  let sigma,t = understand_tcc ~flags env sigma ~expected_type:IsType c in
+  let sigma,{ uj_val = t } = understand_tcc ~flags env sigma ~expected_type:IsType c in
   match Reductionops.sort_of_arity env sigma t with
   | exception Reduction.NotArity ->
     user_err ?loc (str "Not an arity")
@@ -178,7 +178,7 @@ let interp_cstrs env (sigma, ind_rel) impls params ind arity =
                   use_typeclasses = UseTCForConv;
                   solve_unification_constraints = false }
     in
-    let sigma, (ctyp, cimpl) = interp_type_evars_impls ~flags env sigma ~impls ctyp in
+    let sigma, ({utj_val = ctyp}, cimpl) = interp_type_evars_impls ~flags env sigma ~impls ctyp in
     let ctx, concl = Reductionops.whd_decompose_prod_decls env sigma ctyp in
     let concl_env = EConstr.push_rel_context ctx env in
     let sigma_with_model_evars, model =
@@ -682,7 +682,7 @@ let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~
   default_dep_elim, mind_ent, ubinders, global_univs
 
 let interp_params ~unconstrained_sorts env udecl uparamsl paramsl =
-  let sigma, udecl, variances = interp_cumul_univ_decl_opt env udecl in
+  let sigma, udecl, variances = interp_cumul_univ_decl_opt env udecl |> Util.on_pi1 Evd.from_ctx in
   let sigma, (uimpls, ((env_uparams, ctx_uparams), useruimpls, _locs)) =
     interp_context_evars ~program_mode:false ~unconstrained_sorts env sigma uparamsl in
   let sigma, (impls, ((env_params, ctx_params), userimpls, _locs)) =

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -31,11 +31,11 @@ let do_primitive id udecl prim typopt =
     declare ?loc id e
   | Some typ ->
     let env = Global.env () in
-    let evd, udecl = Constrintern.interp_univ_decl_opt env udecl in
+    let evd, udecl = Constrintern.interp_univ_decl_opt env udecl |> Util.on_fst Evd.from_ctx in
     let auctx = CPrimitives.op_or_type_univs prim in
     let evd, u = Evd.with_sort_context_set UState.univ_flexible evd (UnivGen.fresh_instance auctx) in
     let expected_typ = EConstr.of_constr @@ Typeops.type_of_prim_or_type env u prim in
-    let evd, (typ,impls) =
+    let evd, ({Environ.utj_val = typ},impls) =
       Constrintern.(interp_type_evars_impls ~impls:empty_internalization_env)
         env evd typ
     in

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -71,7 +71,7 @@ let kind_searcher env = Decls.(function
 let interp_constr_pattern env sigma ?(expected_type=Pretyping.WithoutTypeConstraint) c =
   let c = Constrintern.intern_gen expected_type ~pattern_mode:true env sigma c in
   let flags = { Pretyping.no_classes_no_fail_inference_flags with expand_evars = false } in
-  let sigma, c = Pretyping.understand_tcc ~flags env sigma ~expected_type c in
+  let sigma, { Environ.uj_val = c } = Pretyping.understand_tcc ~flags env sigma ~expected_type c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
   Patternops.legacy_bad_pattern_of_constr env sigma c

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1835,8 +1835,7 @@ let default_env () = {
 let vernac_reserve bl =
   let sb_decl = (fun (idl,c) ->
     let env = Global.env() in
-    let sigma = Evd.from_env env in
-    let t,ctx = Constrintern.interp_type env sigma c in
+    let t,ctx = Constrintern.interp_type env (UState.from_env env) c in
     let t = Flags.without_option Detyping.print_universes (fun () ->
         Detyping.detype Detyping.Now env (Evd.from_ctx ctx) t)
         ()
@@ -2163,7 +2162,7 @@ let query_command_selector ?loc = function
 
 let check_may_eval env sigma redexp rc =
   let gc = Constrintern.intern_unknown_if_term_or_type env sigma rc in
-  let sigma, c = Pretyping.understand_tcc env sigma gc in
+  let sigma, { Environ.uj_val = c } = Pretyping.understand_tcc env sigma gc in
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
   Evarconv.check_problems_are_solved env sigma;
   let sigma = Evd.minimize_universes sigma in
@@ -2216,7 +2215,7 @@ let vernac_global_check c =
   let env = Global.env() in
   let sigma = Evd.from_env env in
   let c = Constrintern.intern_constr env sigma c in
-  let sigma, c = Pretyping.understand_tcc ~flags:Pretyping.all_and_fail_flags env sigma c in
+  let sigma, { Environ.uj_val = c } = Pretyping.understand_tcc ~flags:Pretyping.all_and_fail_flags env sigma c in
   let sigma = Evd.collapse_sort_variables sigma in
   let senv = Global.safe_env() in
   let uctx = Evd.universe_context_set sigma in


### PR DESCRIPTION

- merge _ty and non-ty variants into a single function returning
 unsafe_judgment

- evar_map-dropping `understand` now takes just a ustate as argument
  instead of an evar map, hopefully preventing bugs like #20890 in the future


Depends:
- https://github.com/rocq-prover/rocq/pull/20891