### PR TITLE
Deprecate "Proof term" command

### DIFF
--- a/test-suite/output/SuggestProofUsing.out
+++ b/test-suite/output/SuggestProofUsing.out
@@ -1,3 +1,6 @@
+File "./output/SuggestProofUsing.v", line 8, characters 31-43:
+Warning: "Proof term." is deprecated. Use "Proof. exact term. Qed." instead.
+[deprecated-exact-proof,deprecated-since-9.2,deprecated,default]
 The proof of Nat should start with one of the following commands:
 Proof using . 
 Proof using Type*. 
@@ -5,6 +8,9 @@ Proof using Type.
 The proof of foo should start with one of the following commands:
 Proof using A B. 
 Proof using All. 
+File "./output/SuggestProofUsing.v", line 53, characters 31-42:
+Warning: "Proof term." is deprecated. Use "Proof. exact term. Qed." instead.
+[deprecated-exact-proof,deprecated-since-9.2,deprecated,default]
 The proof of sec_exactproof should start with one of the following commands:
 Proof using . 
 Proof using Type*. 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -923,7 +923,11 @@ let vernac_end_proof ~lemma ~pm = let open Vernacexpr in function
 
 let vernac_abort ~lemma:_ ~pm = pm
 
+let deprecated_exact_proof = CWarnings.create ~name:"deprecated-exact-proof" ~category:Deprecation.Version.v9_2
+    Pp.(fun () -> str "\"Proof term.\" is deprecated. Use \"Proof. exact term. Qed.\" instead.")
+
 let vernac_exact_proof ~lemma ~pm c =
+  deprecated_exact_proof ();
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the beginning of a proof. *)
   let lemma, status = Declare.Proof.by (Tactics.exact_proof c) lemma in


### PR DESCRIPTION
It's buggy and not particularly useful over `exact term. Qed.`
