### PR TITLE
Ignore module redeclaration in extraction.

### DIFF
--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -467,4 +467,18 @@ module Internal : sig
   end
   (** View type only used by Serlib. Do not use otherwise. *)
 
+  val shallow_overwrite_module : ModPath.t -> module_body -> env -> env
+  (** Same as [shallow_add_module] but tolerates that the module is already
+      in the environment. Only used to bypass a dubious implementation in
+      extraction, do not use. *)
+
+  val overwrite_module : ModPath.t -> module_body -> env -> env
+  (** Overwriting variant of Modops.add_module, see above. *)
+
+  val overwrite_module_parameter : MBId.t -> module_type_body -> env -> env
+  (** Overwriting variant of Modops.add_module_parameter, see above. *)
+
+  val overwrite_structure : ModPath.t -> structure_body -> Mod_subst.delta_resolver -> env -> env
+  (** Overwriting variant of Modops.add_structure, see above. *)
+
 end

--- a/test-suite/bugs/bug_20894.v
+++ b/test-suite/bugs/bug_20894.v
@@ -1,0 +1,22 @@
+Require Corelib.extraction.Extraction.
+
+Module Type S.
+  Parameter t : Type.
+  Parameter fold : t.
+End S.
+
+Module M : S.
+  Definition t := list unit -> unit.
+  Fixpoint fold (l : list unit) : unit :=
+    match l with
+    | nil => tt
+    | cons b l =>
+      match b with
+      | tt => fold l
+      end
+    end.
+End M.
+
+Axiom bug : M.t.
+
+Extraction bug.


### PR DESCRIPTION
Extraction has a strong tendency to overwrite modules by their signatures, which is breaking a lot of implicit invariants. It is not easy to fix without reimplementing the module extraction from scratch. All bets are off in this case, so we introduce a new internal API in Environ to cover this extremely dubious behaviour.