### PR TITLE
CI: Make fiat-crypto legacy depend on coqprime

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -777,6 +777,8 @@ library:ci-fiat_crypto_legacy:
   needs:
   - build:edge+flambda
   - library:ci-stdlib+flambda
+  - library:ci-coqprime
+  stage: build-3+
   timeout: 1h 30min
 
 # We cannot use flambda due to

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -167,7 +167,7 @@ ci-bedrock2: ci-coqutil ci-riscv_coq ci-kami
 ci-bedrock2_examples: ci-bedrock2
 ci-rupicola: ci-bedrock2 ci-coqutil
 ci-fiat_crypto: ci-coqprime ci-rewriter ci-bedrock2 ci-coqutil ci-rupicola
-ci-fiat_crypto_legacy: ci-stdlib
+ci-fiat_crypto_legacy: ci-coqprime
 ci-fiat_crypto_ocaml: ci-fiat_crypto
 ci-fiat_parsers: ci-stdlib
 

--- a/dev/ci/scripts/ci-fiat_crypto_legacy.sh
+++ b/dev/ci/scripts/ci-fiat_crypto_legacy.sh
@@ -24,8 +24,11 @@ targets2=(
     selected-specific-display
 )
 
+# Use external dependencies to avoid building coqprime from scratch
+make_args=(EXTERNAL_DEPENDENCIES=1)
+
 export COQEXTRAFLAGS='-native-compiler no'
 ( cd "${CI_BUILD_DIR}/fiat_crypto_legacy"
-  make "${targets1[@]}"
-  make -j 1 "${targets2[@]}"
+  make "${make_args[@]}" "${targets1[@]}"
+  make -j 1 "${make_args[@]}" "${targets2[@]}"
 )


### PR DESCRIPTION
This change makes the fiat-crypto legacy CI job depend on coqprime to avoid building it from scratch, and passes EXTERNAL_DEPENDENCIES=1 to use the external coqprime installation.

Fixes #20886
