### PR TITLE
Ignore module redeclaration in Print Module commands.

### DIFF
--- a/test-suite/bugs/bug_20903.v
+++ b/test-suite/bugs/bug_20903.v
@@ -1,0 +1,7 @@
+Module A.
+Module B.
+Definition t := nat.
+End B.
+End A.
+
+Print Module A.

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -302,7 +302,8 @@ let print_struct is_impl extent env mp struc =
   prlist_with_sep spc (print_body is_impl extent env mp) struc
 
 let print_structure is_type extent env mp locals struc =
-  let env' = Modops.add_structure mp struc (Mod_subst.empty_delta_resolver mp) env in
+  (* XXX: when printing signatures we overwrite already defined modules *)
+  let env' = Environ.Internal.overwrite_structure mp struc (Mod_subst.empty_delta_resolver mp) env in
   nametab_register_module_body mp struc;
   let kwd = if is_type then "Sig" else "Struct" in
   hv 2 (keyword kwd ++ spc () ++ print_struct false extent env' mp struc ++


### PR DESCRIPTION
This code is definitely buggy, but like all module-related issues, fixing it would require a full rewriting. For simplicity we just rely on the explicitly broken API.