### PR TITLE
Fix link in corelib doc header

### DIFF
--- a/doc/common/styles/html/coqremote/header.html
+++ b/doc/common/styles/html/coqremote/header.html
@@ -218,7 +218,7 @@
     <nav aria-label="breadcrumbs" class="px-4 flex bg-title dark:bg-[#111827] text-white dark:text-dark-title md:hidden">
       <ul>
         <li class="inline-block">
-          <a href="http://rocq-prover.org/stdlib" class="flex items-center px-2 py-2 border-transparent border-2 border-b-4"> Core Library
+          <a href="http://rocq-prover.org/corelib" class="flex items-center px-2 py-2 border-transparent border-2 border-b-4"> Core Library
             <span> <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 ml-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"></path>
               </svg>


### PR DESCRIPTION
This link is hidden on the website (the surrounding <nav> has class md:hidden) but we may as well fix this.

