### PR TITLE
Documentation wording fix + Code formatting.

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -436,7 +436,8 @@ As an example of translation to a non-inductive datatype, let's turn
 
 .. rocqtop:: in
 
-   Extract Inductive nat => int [ "0" "succ" ] "(fun fO fS n -> if n=0 then fO () else fS (n-1))".
+   Extract Inductive nat => int [ "0" "succ" ]
+      "(fun fO fS n -> if n=0 then fO () else fS (n-1))".
 
 Generating FFI Code
 ~~~~~~~~~~~~~~~~~~~
@@ -549,7 +550,7 @@ Avoiding conflicts with existing filenames
 
 When using :cmd:`Extraction Library`, the names of the extracted files
 directly depend on the names of the Rocq files. It may happen that
-these filenames are in conflict with already existing files, 
+these filenames conflict with already existing files,
 either in the standard library of the target language or in other
 code that is meant to be linked with the extracted code. 
 For instance the module ``List`` exists both in Rocq and in OCaml.
@@ -670,7 +671,7 @@ In OCaml, we must cast any argument of the constructor dummy
 
 Even with those unsafe castings, you should never get error like
 ``segmentation fault``. In fact even if your program may seem
-ill-typed to the OCaml type checker, it can't go wrong : it comes
+ill-typed to the OCaml type checker, it can't go wrong: it comes
 from a Rocq well-typed terms, so for example inductive types will always
 have the correct number of arguments, etc. Of course, when launching
 manually some extracted function, you should apply it to arguments
@@ -755,18 +756,18 @@ Note that these ``nat_of_int`` and ``int_of_nat`` are now
 available via a mere ``From Stdlib Require Import ExtrOcamlIntConv`` and then
 adding these functions to the list of functions to extract. This file
 ``ExtrOcamlIntConv.v`` and some others in ``plugins/extraction/``
-are meant to help building concrete program via extraction.
+are meant to help build concrete programs via extraction.
 
 Extraction's horror museum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some pathological examples of extraction are grouped in the file
-``test-suite/success/extraction.v`` of the sources of Rocq.
+``test-suite/success/extraction_*.v`` of the sources of Rocq.
 
 Users' Contributions
 ~~~~~~~~~~~~~~~~~~~~
 
-Several of user contributions use extraction to produce
+Several user contributions use extraction to produce
 certified programs. In particular the following ones have an automatic
 extraction test:
 

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -151,7 +151,7 @@ Coercion Classes
   The first form declares the construction denoted by :token:`reference` as a coercion between
   the two given classes.  The second form defines :token:`ident_decl`
   just like :cmd:`Definition` :n:`@ident_decl @def_body`
-  and then declares :token:`ident_decl` as a coercion between it source and its target.
+  and then declares :token:`ident_decl` as a coercion between its source and its target.
   Both forms support the :attr:`local` attribute, which makes the coercion local to the current section.
 
   :n:`{? : @coercion_class >-> @coercion_class }`


### PR DESCRIPTION
Mostly non-functional changes, so I did not build and review the documentation. The most dangerous change is adding a new-line in inlined code in extraction.rst. I added it because it clips off my firefox browser window when I read the refman. Screenshot attached.

<img width="1920" height="1200" alt="Screenshot from 2025-07-11 12-39-28" src="https://github.com/user-attachments/assets/8ab37e7d-6cd0-4406-99d0-769c4674b3f8" />
