### PR TITLE
Slightly more type safe native mk_cofix_accu

### DIFF
--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -213,7 +213,6 @@ let mk_fix_accu rec_pos pos types bodies =
   mk_accu (Afix(types,bodies,rec_pos, pos))
 
 let mk_cofix_accu pos types norm cofix args =
-  let cofix = Obj.magic (cofix : t) in
   mk_accu (Acofix (types, norm, pos, args, Lazy.from_fun cofix))
 
 let force_cofix (cofix : t) =

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -89,7 +89,7 @@ val mk_sort_accu : Sorts.t -> UVars.Instance.t -> t
 val mk_var_accu : Id.t -> t
 val mk_sw_accu : annot_sw -> accumulator -> t -> (t -> t)
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t
-val mk_cofix_accu : int -> t array -> t array -> t -> t array -> t
+val mk_cofix_accu : int -> t array -> t array -> (unit -> t) -> t array -> t
 val mk_evar_accu : Evar.t -> t array -> t
 val mk_proj_accu : (inductive * int) -> accumulator -> t
 val force_cofix : t -> t


### PR DESCRIPTION
This Obj.magic bugs me, IDK if this is the best way to get rid of it but it works.