### PR TITLE
Deprecate "end tac" ("...")

### DIFF
--- a/dev/ci/user-overlays/20917-SkySkimmer-depr-dots.sh
+++ b/dev/ci/user-overlays/20917-SkySkimmer-depr-dots.sh
@@ -1,0 +1,5 @@
+overlay tactician https://github.com/SkySkimmer/coq-tactician depr-dots 20917
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp depr-dots 20917
+
+overlay vsrocq https://github.com/SkySkimmer/vsrocq depr-dots 20917

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1743,7 +1743,7 @@ tactic_mode: [
 (* todo: make sure to document this production! *)
 (* deleting to allow splicing query_command into command *)
 | DELETE OPT ltac_selector OPT ltac_info tactic ltac_use_default
-| DELETE "par" ":" OPT ltac_info tactic ltac_use_default
+| DELETE "par" ":" OPT ltac_info tactic "."
 (* Ignore attributes (none apply) and "...". *)
 | ltac_info tactic
 | MOVETO command ltac_info tactic

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2311,7 +2311,7 @@ tactic_mode: [
 | subprf
 | OPT toplevel_selector subprf_with_selector
 | OPT ltac_selector OPT ltac_info tactic ltac_use_default
-| "par" ":" OPT ltac_info tactic ltac_use_default
+| "par" ":" OPT ltac_info tactic "."
 ]
 
 ltac_selector: [
@@ -3332,7 +3332,7 @@ ltac2_use_default: [
 
 tac2mode: [
 | OPT ltac2_selector ltac2_expr6 ltac2_use_default      (* ltac2 plugin *)
-| "par" ":" ltac2_expr6 ltac2_use_default      (* ltac2 plugin *)
+| "par" ":" ltac2_expr6 "."      (* ltac2 plugin *)
 | subprf      (* ltac2 plugin *)
 | OPT toplevel_selector subprf_with_selector      (* ltac2 plugin *)
 ]

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -323,13 +323,13 @@ END
 {
 
 let pr_ltac_use_default b =
-  if b then (* Bug: a space is inserted before "..." *) str ".." else mt ()
+  if b.CAst.v then (* Bug: a space is inserted before "..." *) str ".." else mt ()
 
 }
 
 VERNAC ARGUMENT EXTEND ltac_use_default PRINTED BY { pr_ltac_use_default }
-| [ "." ] -> { false }
-| [ "..." ] -> { true }
+| [ "." ] -> { CAst.make ~loc false }
+| [ "..." ] -> { CAst.make ~loc true }
 END
 
 {
@@ -364,7 +364,7 @@ VERNAC { tactic_mode } EXTEND VernacSolve STATE proof
 END
 
 VERNAC { tactic_mode } EXTEND VernacSolveParallel STATE proof
-| [ "par" ":" ltac_info_opt(info) tactic(t) ltac_use_default(with_end_tac) ] =>
+| [ "par" ":" ltac_info_opt(info) tactic(t) "." ] =>
     {
       let solving_tac = is_explicit_terminator t in
       let pbr = if solving_tac then Some "par" else None in
@@ -372,7 +372,7 @@ VERNAC { tactic_mode } EXTEND VernacSolveParallel STATE proof
     } -> {
       let t, abstract = rm_abstract t in
       let t = Tacinterp.hide_interp { Tacinterp.global = true; ast = t; } in
-      ComTactic.solve_parallel ~info t ~abstract ~with_end_tac
+      ComTactic.solve_parallel ~info t ~abstract
     }
 END
 

--- a/plugins/ltac/g_ltac.mli
+++ b/plugins/ltac/g_ltac.mli
@@ -35,9 +35,9 @@ val wit_ltac_info : int Genarg.vernac_genarg_type
 
 val ltac_info : int Procq.Entry.t
 
-val wit_ltac_use_default : bool Genarg.vernac_genarg_type
+val wit_ltac_use_default : bool CAst.t Genarg.vernac_genarg_type
 
-val ltac_use_default : bool Procq.Entry.t
+val ltac_use_default : bool CAst.t Procq.Entry.t
 
 val wit_ltac_tactic_level : int Genarg.vernac_genarg_type
 

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1049,7 +1049,7 @@ let toplevel_selector = G_vernac.toplevel_selector
 let pr_ltac2_selector s = Pp.(Goal_select.pr_goal_selector s ++ str ":")
 
 let pr_ltac2_use_default b =
-  if b then (* Bug: a space is inserted before "..." *) str ".." else mt ()
+  if b.CAst.v then (* Bug: a space is inserted before "..." *) str ".." else mt ()
 
 let subprf = G_vernac.subprf
 let subprf_with_selector = G_vernac.subprf_with_selector
@@ -1061,8 +1061,8 @@ VERNAC ARGUMENT EXTEND ltac2_selector PRINTED BY { pr_ltac2_selector }
 END
 
 VERNAC ARGUMENT EXTEND ltac2_use_default PRINTED BY { pr_ltac2_use_default }
-| [ "." ] -> { false }
-| [ "..." ] -> { true }
+| [ "." ] -> { CAst.make ~loc false }
+| [ "..." ] -> { CAst.make ~loc true }
 END
 
 VERNAC { tac2mode } EXTEND VernacLtac2
@@ -1070,9 +1070,9 @@ VERNAC { tac2mode } EXTEND VernacLtac2
   { classify_as_proofstep } -> { fun ~pstate ->
     Tac2entries.call ~pstate g ~with_end_tac t
   }
-| ![proof] [ "par" ":" ltac2_expr(t) ltac2_use_default(with_end_tac) ] =>
+| ![proof] [ "par" ":" ltac2_expr(t) "." ] =>
   { classify_as_proofstep } -> { fun ~pstate ->
-    Tac2entries.call_par ~pstate ~with_end_tac t
+    Tac2entries.call_par ~pstate t
   }
 END
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1256,8 +1256,8 @@ let call ~pstate g ~with_end_tac tac =
   let g = Option.default (Goal_select.get_default_goal_selector()) g in
   ComTactic.solve ~pstate ~with_end_tac g ~info:None (ltac2_interp tac)
 
-let call_par ~pstate ~with_end_tac tac =
-  ComTactic.solve_parallel ~pstate ~info:None (ltac2_interp tac) ~abstract:false ~with_end_tac
+let call_par ~pstate tac =
+  ComTactic.solve_parallel ~pstate ~info:None (ltac2_interp tac) ~abstract:false
 
 (** Primitive algebraic types than can't be defined Rocq-side *)
 

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -70,11 +70,10 @@ val globalize_expr : raw_tacexpr -> unit
 (** {5 Eval loop} *)
 
 (** Evaluate a tactic expression in the current environment *)
-val call : pstate:Declare.Proof.t -> Goal_select.t option -> with_end_tac:bool -> raw_tacexpr
+val call : pstate:Declare.Proof.t -> Goal_select.t option -> with_end_tac:bool CAst.t -> raw_tacexpr
   -> Declare.Proof.t
 
-val call_par : pstate:Declare.Proof.t -> with_end_tac:bool -> raw_tacexpr
-  -> Declare.Proof.t
+val call_par : pstate:Declare.Proof.t -> raw_tacexpr -> Declare.Proof.t
 
 (** {5 Parsing entries} *)
 

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -114,7 +114,7 @@ end = struct (* {{{ *)
             Declare.Proof.map pstate ~f:(Proof.focus focus_cond () r_goalno) in
           let pstate =
             ComTactic.solve ~pstate
-              Goal_select.SelectAll ~info:None tactic ~with_end_tac:false in
+              Goal_select.SelectAll ~info:None tactic ~with_end_tac:(CAst.make false) in
           let { Proof.sigma } = Declare.Proof.fold pstate ~f:Proof.data in
           let EvarInfo evi = Evd.find sigma r_goal in
           match Evd.(evar_body evi) with
@@ -190,7 +190,7 @@ let get_results res =
        spc () ++ prlist_with_sep spc int missing ++ str ")")
 
 let enable_par ~spawn_args ~nworkers = ComTactic.set_par_implementation
-  (fun ~pstate ~info t_ast ~abstract ~with_end_tac ->
+  (fun ~pstate ~info t_ast ~abstract ->
     let t_state = Vernacstate.freeze_full_state () in
     let t_state = Vernacstate.Stm.make_shallow t_state in
     TaskQueue.with_n_workers ~spawn_args nworkers CoqworkmgrApi.High (fun queue ->

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1934,7 +1934,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
            match (VCS.get_info base_state).state with
            | FullState { Vernacstate.interp = { lemmas } } ->
                Option.iter PG_compat.unfreeze lemmas;
-               PG_compat.with_current_proof (fun _ p ->
+               PG_compat.with_current_proof (fun p ->
                  feedback ~id:id Feedback.AddedAxiom;
                  fst (Proof.solve Goal_select.SelectAll None tac p), ());
                (* STATE SPEC:

--- a/theories/Corelib/Classes/CMorphisms.v
+++ b/theories/Corelib/Classes/CMorphisms.v
@@ -280,11 +280,11 @@ Section GenericInstances.
   Program Instance respectful_per `(PER A R, PER B R') : PER (R ==> R').
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H B R' H0 x y z X X0 x0 y0 X1.
     assert(R x0 x0).
-    - eapply transitivity with y0... now apply symmetry.
-    - eapply transitivity with (y x0)...
+    - eapply transitivity with y0; auto. now apply symmetry.
+    - eapply transitivity with (y x0); auto.
   Qed.
 
   Unset Strict Universe Declaration.
@@ -311,10 +311,10 @@ Section GenericInstances.
     `(Transitive A R) : Proper (R --> R ++> arrow) R.
   
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x y X x0 y0 X0 X1.
-    apply transitivity with x...
-    apply transitivity with x0...
+    apply transitivity with x; auto.
+    apply transitivity with x0; auto.
   Qed.
 
   (** Proper declarations for partial applications. *)
@@ -324,9 +324,9 @@ Section GenericInstances.
   `(Transitive A R) {x} : Proper (R --> flip arrow) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x x0 y X X0.
-    apply transitivity with y...
+    apply transitivity with y; auto.
   Qed.
 
   Global Program 
@@ -334,9 +334,9 @@ Section GenericInstances.
     `(Transitive A R) {x} : Proper (R ++> arrow) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x x0 y X X0.
-    apply transitivity with x0...
+    apply transitivity with x0; auto.
   Qed.
 
   Global Program 
@@ -344,31 +344,31 @@ Section GenericInstances.
     `(PER A R) {x} : Proper (R ++> flip arrow) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x x0 y X X0.
-    apply transitivity with y... apply symmetry...
+    apply transitivity with y; auto. apply symmetry; auto.
   Qed.
 
   Global Program Instance trans_sym_contra_arrow_morphism
     `(PER A R) {x} : Proper (R --> arrow) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x x0 y X X0.
-    apply transitivity with x0... apply symmetry...
+    apply transitivity with x0; auto. apply symmetry; auto.
   Qed.
 
   Global Program Instance per_partial_app_type_morphism
   `(PER A R) {x} : Proper (R ==> iffT) (R x) | 2.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x x0 y X.
     split.
-    - intros ; apply transitivity with x0...
+    - intros ; apply transitivity with x0; auto.
     - intros.
-      apply transitivity with y...
-      apply symmetry...
+      apply transitivity with y; auto.
+      apply symmetry; auto.
   Qed.
 
   (** Every Transitive crelation induces a morphism by "pushing" an [R x y] on the left of an [R x z] proof to get an [R y z] goal. *)
@@ -378,9 +378,9 @@ Section GenericInstances.
   `(Transitive A R) : Proper (R ==> (@eq A) ==> flip arrow) R | 2.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x y X y0 y1 e X0; destruct e.
-    apply transitivity with y...
+    apply transitivity with y; auto.
   Qed.
 
   (** Every Symmetric and Transitive crelation gives rise to an equivariant morphism. *)
@@ -389,14 +389,14 @@ Section GenericInstances.
   Instance PER_type_morphism `(PER A R) : Proper (R ==> R ==> iffT) R | 1.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros A R H x y X x0 y0 X0.
     split ; intros.
-    - apply transitivity with x0...
-      apply transitivity with x... apply symmetry...
+    - apply transitivity with x0; auto.
+      apply transitivity with x; auto. apply symmetry; auto.
 
-    - apply transitivity with y... apply transitivity with y0...
-      apply symmetry...
+    - apply transitivity with y; auto. apply transitivity with y0; auto.
+      apply symmetry; auto.
   Qed.
 
   Lemma symmetric_equiv_flip `(Symmetric A R) : relation_equivalence R (flip R).

--- a/theories/Corelib/Classes/Morphisms.v
+++ b/theories/Corelib/Classes/Morphisms.v
@@ -340,11 +340,11 @@ Section GenericInstances.
   Program Instance respectful_per `(PER A R, PER B R') : PER (R ==> R').
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H R' H0 x y z H1 H2 x0 y0 H3.
     assert(R x0 x0).
-    - transitivity y0... symmetry...
-    - transitivity (y x0)...
+    - transitivity y0; auto. symmetry; auto.
+    - transitivity (y x0); auto.
   Qed.
 
   (** The complement of a relation conserves its proper elements. *)
@@ -381,10 +381,10 @@ Section GenericInstances.
     `(Transitive A R) : Proper (R --> R ++> impl) R.
   
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x y H0 x0 y0 H1 H2.
-    transitivity x...
-    transitivity x0...
+    transitivity x; auto.
+    transitivity x0; auto.
   Qed.
 
   (** Proper declarations for partial applications. *)
@@ -394,9 +394,9 @@ Section GenericInstances.
   `(Transitive A R) {x} : Proper (R --> flip impl) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x x0 y H0 H1.
-    transitivity y...
+    transitivity y; auto.
   Qed.
 
   Global Program 
@@ -404,9 +404,9 @@ Section GenericInstances.
     `(Transitive A R) {x} : Proper (R ++> impl) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x x0 y H0 H1.
-    transitivity x0...
+    transitivity x0; auto.
   Qed.
 
   Global Program 
@@ -414,31 +414,31 @@ Section GenericInstances.
     `(PER A R) {x} : Proper (R ++> flip impl) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x x0 y H0 H1.
-    transitivity y... symmetry...
+    transitivity y; auto. symmetry; auto.
   Qed.
 
   Global Program Instance trans_sym_contra_impl_morphism
     `(PER A R) {x} : Proper (R --> impl) (R x) | 3.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x x0 y H0 H1.
-    transitivity x0... symmetry...
+    transitivity x0; auto. symmetry; auto.
   Qed.
 
   Global Program Instance per_partial_app_morphism
   `(PER A R) {x} : Proper (R ==> iff) (R x) | 2.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x x0 y H0.
     split.
-    - intros ; transitivity x0...
+    - intros ; transitivity x0; auto.
     - intros.
-      transitivity y...
-      symmetry...
+      transitivity y; auto.
+      symmetry; auto.
   Qed.
 
   (** Every Transitive relation induces a morphism by "pushing" an [R x y] on the left of an [R x z] proof to get an [R y z] goal. *)
@@ -448,9 +448,9 @@ Section GenericInstances.
   `(Transitive A R) : Proper (R ==> (@eq A) ==> flip impl) R | 2.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x y H0 y0 y1 e H2; destruct e.
-    transitivity y...
+    transitivity y; auto.
   Qed.
 
   (** Every Symmetric and Transitive relation gives rise to an equivariant morphism. *)
@@ -459,12 +459,11 @@ Section GenericInstances.
   Instance PER_morphism `(PER A R) : Proper (R ==> R ==> iff) R | 1.
 
   Next Obligation.
-  Proof with auto.
+  Proof.
     intros R H x y H0 x0 y0 H1.
     split ; intros.
-    - transitivity x0... transitivity x... symmetry...
-
-    - transitivity y... transitivity y0... symmetry...
+    - transitivity x0; auto. transitivity x; auto. symmetry; auto.
+    - transitivity y; auto. transitivity y0; auto. symmetry; auto.
   Qed.
 
   Lemma symmetric_equiv_flip `(Symmetric A R) : relation_equivalence R (flip R).

--- a/theories/Corelib/Init/Datatypes.v
+++ b/theories/Corelib/Init/Datatypes.v
@@ -288,14 +288,14 @@ Qed.
 
 Lemma pair_equal_spec (A B : Type) (a1 a2 : A) (b1 b2 : B) :
     (a1, b1) = (a2, b2) <-> a1 = a2 /\ b1 = b2.
-Proof with auto.
+Proof.
   split; intro H.
   - split.
-    + replace a1 with (fst (a1, b1)); replace a2 with (fst (a2, b2))...
-      rewrite H...
-    + replace b1 with (snd (a1, b1)); replace b2 with (snd (a2, b2))...
-      rewrite H...
-  - destruct H; subst...
+    + replace a1 with (fst (a1, b1)); replace a2 with (fst (a2, b2)); auto.
+      rewrite H; auto.
+    + replace b1 with (snd (a1, b1)); replace b2 with (snd (a2, b2)); auto.
+      rewrite H; auto.
+  - destruct H; subst; auto.
 Qed.
 
 Definition curry {A B C:Type} (f:A * B -> C)

--- a/theories/Corelib/Program/Wf.v
+++ b/theories/Corelib/Program/Wf.v
@@ -89,18 +89,18 @@ Section Measure_well_founded.
   Register MR as program.wf.mr.
 
   Lemma measure_wf: well_founded MR.
-  Proof with auto.
+  Proof.
     unfold well_founded.
     cut (forall (a: M) (a0: T), m a0 = a -> Acc MR a0).
     + intros H a.
-      apply (H (m a))...
+      apply (H (m a)); auto.
     + apply (@well_founded_ind M R wf (fun mm => forall a, m a = mm -> Acc MR a)).
       intros ? H ? H0.
       apply Acc_intro.
       intros y H1.
       unfold MR in H1.
       rewrite H0 in H1.
-      apply (H (m y))...
+      apply (H (m y)); auto.
   Defined.
 
 End Measure_well_founded.
@@ -135,14 +135,14 @@ Section Fix_rects.
           Q x (f (fun y: {y: A | R y x} =>
             Fix_F_sub A R P f (proj1_sig y) (Acc_inv a (proj2_sig y)))))
     : forall x a, Q _ (Fix_F_sub A R P f x a).
-  Proof with auto.
+  Proof.
     set (R' := fun (x: A) => forall a, Q _ (Fix_F_sub A R P f x a)).
-    cut (forall x, R' x)...
+    cut (forall x, R' x); auto.
     apply (well_founded_induction_type Rwf).
     subst R'.
     simpl.
     intros.
-    rewrite F_unfold...
+    rewrite F_unfold; auto.
   Qed.
 
   (* Let's call f's second parameter its "lowers" function, since it
@@ -192,16 +192,16 @@ Section Fix_rects.
       (a: Acc R x),
         Q x (f (fun y: {y: A | R y x} => Fix_sub A R Rwf P f (proj1_sig y))))
     : forall x, Q _ (Fix_sub A R Rwf P f x).
-  Proof with auto.
+  Proof.
     unfold Fix_sub.
     intros x.
     apply Fix_F_sub_rect.
     intros x0 H a.
-    assert (forall y: A, R y x0 -> Q y (Fix_F_sub A R P f y (Rwf y))) as X0...
+    assert (forall y: A, R y x0 -> Q y (Fix_F_sub A R P f y (Rwf y))) as X0; auto.
     set (q := inv x0 X0 a). clearbody q.
     rewrite <- (equiv_lowers (fun y: {y: A | R y x0} =>
       Fix_F_sub A R P f (proj1_sig y) (Rwf (proj1_sig y)))
-    (fun y: {y: A | R y x0} => Fix_F_sub A R P f (proj1_sig y) (Acc_inv a (proj2_sig y))))...
+    (fun y: {y: A | R y x0} => Fix_F_sub A R P f (proj1_sig y) (Acc_inv a (proj2_sig y)))); auto.
     intros.
     apply eq_Fix_F_sub.
   Qed.

--- a/vernac/comTactic.mli
+++ b/vernac/comTactic.mli
@@ -26,8 +26,8 @@ val solve :
   pstate:Declare.Proof.t ->
   Goal_select.t ->
   info:int option ->
+  ?with_end_tac:bool CAst.t ->
   interpretable ->
-  with_end_tac:bool ->
   Declare.Proof.t
 
 (** [par: tac] runs tac on all goals, possibly in parallel using a worker pool.
@@ -39,7 +39,6 @@ type parallel_solver =
   info:int option ->
   interpretable ->
   abstract:bool -> (* the tactic result has to be opacified as per abstract *)
-  with_end_tac:bool ->
   Declare.Proof.t
 
 (** Entry point when the goal selector is par: *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1777,12 +1777,7 @@ let map ~f p = { p with proof = f p.proof }
 let map_fold ~f p = let proof, res = f p.proof in { p with proof }, res
 
 let map_fold_endline ~f ps =
-  let et =
-    match ps.endline_tactic with
-    | None -> Proofview.tclUNIT ()
-    | Some tac -> Gentactic.interp tac
-  in
-  let (newpr,ret) = f et ps.proof in
+  let (newpr,ret) = f ps.endline_tactic ps.proof in
   let ps = { ps with proof = newpr } in
   ps, ret
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -263,7 +263,7 @@ module Proof : sig
   val fold : f:(Proof.t -> 'a) -> t -> 'a
   val map : f:(Proof.t -> Proof.t) -> t -> t
   val map_fold : f:(Proof.t -> Proof.t * 'a) -> t -> t * 'a
-  val map_fold_endline : f:(unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> t -> t * 'a
+  val map_fold_endline : f:(Gentactic.glob_generic_tactic option -> Proof.t -> Proof.t * 'a) -> t -> t * 'a
 
   (** Sets the tactic to be used when a tactic line is closed with [...] *)
   val set_endline_tactic : Gentactic.glob_generic_tactic -> t -> t

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -217,7 +217,7 @@ module Declare_ = struct
     match !s_lemmas with
     | None -> raise NoCurrentProof
     | Some stack ->
-      let pf, res = LemmaStack.with_top stack ~f:(Declare.Proof.map_fold_endline ~f) in
+      let pf, res = LemmaStack.with_top stack ~f:(Declare.Proof.map_fold ~f) in
       let stack = LemmaStack.map_top stack ~f:(fun _ -> pf) in
       s_lemmas := Some stack;
       res

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -108,8 +108,7 @@ module Declare : sig
   val get_current_proof_name : unit -> Names.Id.t
 
   val map_proof : (Proof.t -> Proof.t) -> unit
-  val with_current_proof :
-      (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> 'a
+  val with_current_proof : (Proof.t -> Proof.t * 'a) -> 'a
 
   val return_proof : unit -> Declare.Proof.closed_proof_output
 


### PR DESCRIPTION
Close #12059

Overlays (backwards compatible):
- https://gitlab.inria.fr/flocq/flocq/-/merge_requests/25 (merged)
- https://github.com/rocq-prover/stdlib/pull/196
- https://github.com/thery/coqprime/pull/85
- https://github.com/rocq-community/math-classes/pull/137
- https://github.com/rocq-community/corn/pull/216

Overlays (synch):
- https://github.com/rocq-prover/vsrocq/pull/1135
- https://github.com/ejgallego/coq-lsp/pull/997
- https://github.com/coq-tactician/coq-tactician/pull/107