### PR TITLE
Taccoerce.coerce_to_hyp check that variable is still bound in the current context

### DIFF
--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -392,7 +392,9 @@ let coerce_to_hyp env sigma v =
     let id = out_gen (topwit wit_hyp) v in
     if is_variable env id then id else fail ()
   else match Value.to_constr v with
-  | Some c when isVar sigma c -> destVar sigma c
+  | Some c when isVar sigma c ->
+    let id = destVar sigma c in
+    if is_variable env id then id else fail ()
   | _ -> fail ()
 
 let coerce_to_hyp_list env sigma v =

--- a/test-suite/bugs/bug_20919.v
+++ b/test-suite/bugs/bug_20919.v
@@ -1,0 +1,6 @@
+Goal forall n: nat, True.
+  intros n.
+  let x := n in
+  clear x;
+  assert_fails clearbody x.
+Abort.


### PR DESCRIPTION

Fix #20919
