### PR TITLE
Update the behaviour of mutual_fix and mutual_cofix

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1156,7 +1156,7 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
                 (fix this_fix_info.name (this_fix_info.idx + 1))
           else
             Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
-              other_fix_infos 0
+              other_fix_infos
       in
       let first_tac : unit Proofview.tactic =
         (* every operations until fix creations *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1720,7 +1720,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_fix (interp_ident ist env sigma id) n l_interp 0)
+        (Tactics.mutual_fix (interp_ident ist env sigma id) n l_interp)
       end
       end
   | TacMutualCofix (id,l) ->
@@ -1735,7 +1735,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_cofix (interp_ident ist env sigma id) l_interp 0)
+        (Tactics.mutual_cofix (interp_ident ist env sigma id) l_interp)
       end
       end
   | TacAssert (ev,b,t,ipat,c) ->

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -37,9 +37,9 @@ val introduction    : Id.t -> unit Proofview.tactic
 val convert_concl   : cast:bool -> check:bool -> types -> cast_kind -> unit Proofview.tactic
 val convert_hyp     : check:bool -> reorder:bool -> named_declaration -> unit Proofview.tactic
 val mutual_fix      :
-  Id.t -> int -> (Id.t * int * constr) list -> int -> unit Proofview.tactic
+  Id.t -> int -> (Id.t * int * constr) list -> unit Proofview.tactic
 val fix             : Id.t -> int -> unit Proofview.tactic
-val mutual_cofix    : Id.t -> (Id.t * constr) list -> int -> unit Proofview.tactic
+val mutual_cofix    : Id.t -> (Id.t * constr) list -> unit Proofview.tactic
 val cofix           : Id.t -> unit Proofview.tactic
 
 val convert         : constr -> constr -> unit Proofview.tactic


### PR DESCRIPTION
I noticed [on zulip](https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/bug.20in.20.60mutual_fix.60.20tactic.20.3F) that the `mutual_fix` and `mutual_cofix` tactics in `tactics.ml` are probably bugged. Since the buggy behaviour does not seem to be actually used by anyone, I propose to simplify these tactics by removing their last argument (which is set to `0` by everyone AFAIK). 