### PR TITLE
Fixes #20940: anomaly List.chop in the presence of projections with not enough argument scopes

### DIFF
--- a/doc/changelog/02-specification-language/20945-master+fix-arguments-too-little-scopes-proj-Fixed.rst
+++ b/doc/changelog/02-specification-language/20945-master+fix-arguments-too-little-scopes-proj-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Anomaly `List.chop` in the presence of projections with not
+  enough argument scopes (`#20945
+  <https://github.com/rocq-prover/rocq/pull/20945>`_, fixes `#20940
+  <https://github.com/rocq-prover/rocq/issues/20940>`_, by Hugo
+  Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2590,7 +2590,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
             user_err ?loc:qid.CAst.loc (str "Projection " ++ pr_qualid qid ++ str " expected " ++ pr_choice int l ++
                            str (String.plural n " explicit parameter") ++ str ".")
       in
-      let subscopes1, subscopes2 = List.chop (nexpectedparams + 1) subscopes in
+      let subscopes1, subscopes2 = try List.chop (nexpectedparams + 1) subscopes with Failure _ -> subscopes, [] in
       let c,args1 = List.sep_last (intern_impargs head env imps1 subscopes1 (args1@[c,None])) in
       let p = DAst.make ?loc (GProj ((p,us),args0@args1,c)) in
       let args2 = intern_impargs head env imps2 subscopes2 args2 in

--- a/test-suite/bugs/bug_20940.v
+++ b/test-suite/bugs/bug_20940.v
@@ -1,0 +1,4 @@
+(* Was an anomaly List.chop in the presence of projections with not enough argument scopes *)
+Record R (n:nat) (p: unit) (q : unit) := { field : unit }.
+Arguments field n%_nat {p} {q}.
+Check fun C => C.(field _).


### PR DESCRIPTION
Fixes / closes #20940

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
