### PR TITLE
gramlib remove unused "OPT_SEP" support on LIST0 SEP / LIST1 SEP

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -289,11 +289,11 @@ and print_symbol fmt tkn = match tkn with
 | SymbList0 (s, None) ->
   fprintf fmt "(Procq.Symbol.list0 %a)" print_symbol s
 | SymbList0 (s, Some sep) ->
-  fprintf fmt "(Procq.Symbol.list0sep (%a) (%a) false)" print_symbol s print_anonymized_symbol sep
+  fprintf fmt "(Procq.Symbol.list0sep (%a) (%a))" print_symbol s print_anonymized_symbol sep
 | SymbList1 (s, None) ->
   fprintf fmt "(Procq.Symbol.list1 (%a))" print_symbol s
 | SymbList1 (s, Some sep) ->
-  fprintf fmt "(Procq.Symbol.list1sep (%a) (%a) false)" print_symbol s print_anonymized_symbol sep
+  fprintf fmt "(Procq.Symbol.list1sep (%a) (%a))" print_symbol s print_anonymized_symbol sep
 | SymbOpt s ->
   fprintf fmt "(Procq.Symbol.opt %a)" print_symbol s
 | SymbRules rules ->

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -77,11 +77,11 @@ module type S = sig
     val nterml : 'a Entry.t -> string -> ('self, norec, 'a) t
     val list0 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list0sep :
-      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t ->
       ('self, 'trec, 'a list) t
     val list1 : ('self, 'trec, 'a) t -> ('self, 'trec, 'a list) t
     val list1sep :
-      ('self, 'trec, 'a) t -> ('self, norec, unit) t -> bool ->
+      ('self, 'trec, 'a) t -> ('self, norec, unit) t ->
       ('self, 'trec, 'a list) t
     val opt : ('self, 'trec, 'a) t -> ('self, 'trec, 'a option) t
     val self : ('self, mayrec, 'self) t

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -139,10 +139,10 @@ let rec prod_item_of_symbol lev = function
   EntryName (Rawwit (ListArg typ), Procq.Symbol.list0 e)
 | Extend.Ulist1sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Procq.Symbol.list1sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]) false)
+  EntryName (Rawwit (ListArg typ), Procq.Symbol.list1sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]))
 | Extend.Ulist0sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Procq.Symbol.list0sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]) false)
+  EntryName (Rawwit (ListArg typ), Procq.Symbol.list0sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]))
 | Extend.Uopt s ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
   EntryName (Rawwit (OptArg typ), Procq.Symbol.opt e)

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -453,7 +453,7 @@ let () = add_syntax_class "list0" begin function
 | [tok; SexprStr {v=str}] ->
   let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
   let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
-  let syntax_class = Procq.Symbol.list0sep syntax_class sep false in
+  let syntax_class = Procq.Symbol.list0sep syntax_class sep in
   let act l = Tac2quote.of_list act l in
   Tac2entries.SyntaxRule (syntax_class, act)
 | arg -> syntax_class_fail "list0" arg
@@ -468,7 +468,7 @@ let () = add_syntax_class "list1" begin function
 | [tok; SexprStr {v=str}] ->
   let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.parse_syntax_class tok in
   let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
-  let syntax_class = Procq.Symbol.list1sep syntax_class sep false in
+  let syntax_class = Procq.Symbol.list1sep syntax_class sep in
   let act l = Tac2quote.of_list act l in
   Tac2entries.SyntaxRule (syntax_class, act)
 | arg -> syntax_class_fail "list1" arg

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -381,20 +381,20 @@ let rec symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) mayrec_symb
   | MayRecMay s -> MayRecMay (Procq.Symbol.list1 s) end
 | TTConstrList (s, typ', tkl, forpat) ->
   begin match symbol_of_target s typ' assoc from forpat with
-  | MayRecNo s -> MayRecNo (Procq.Symbol.list1sep s (make_sep_rules tkl) false)
-  | MayRecMay s -> MayRecMay (Procq.Symbol.list1sep s (make_sep_rules tkl) false) end
+  | MayRecNo s -> MayRecNo (Procq.Symbol.list1sep s (make_sep_rules tkl))
+  | MayRecMay s -> MayRecMay (Procq.Symbol.list1sep s (make_sep_rules tkl)) end
 | TTPattern p -> MayRecNo (Procq.Symbol.nterml Constr.pattern (string_of_int p))
 | TTOpenBinderList -> MayRecNo (Procq.Symbol.nterm Constr.open_binders)
 | TTClosedBinderListPure [] -> MayRecNo (Procq.Symbol.list1 (Procq.Symbol.nterm Constr.binder))
-| TTClosedBinderListPure tkl -> MayRecNo (Procq.Symbol.list1sep (Procq.Symbol.nterm Constr.binder) (make_sep_rules tkl) false)
+| TTClosedBinderListPure tkl -> MayRecNo (Procq.Symbol.list1sep (Procq.Symbol.nterm Constr.binder) (make_sep_rules tkl))
 | TTClosedBinderListOther (typ,[]) ->
   begin match symbol_of_entry assoc from typ with
   | MayRecNo s -> MayRecNo (Procq.Symbol.list1 s)
   | MayRecMay s -> MayRecMay (Procq.Symbol.list1 s) end
 | TTClosedBinderListOther (typ,tkl) ->
   begin match symbol_of_entry assoc from typ with
-  | MayRecNo s -> MayRecNo (Procq.Symbol.list1sep s (make_sep_rules tkl) false)
-  | MayRecMay s -> MayRecMay (Procq.Symbol.list1sep s (make_sep_rules tkl) false) end
+  | MayRecNo s -> MayRecNo (Procq.Symbol.list1sep s (make_sep_rules tkl))
+  | MayRecMay s -> MayRecMay (Procq.Symbol.list1sep s (make_sep_rules tkl)) end
 | TTIdent -> MayRecNo (Procq.Symbol.nterm Prim.identref)
 | TTName -> MayRecNo (Procq.Symbol.nterm Prim.name)
 | TTBinder true -> MayRecNo (Procq.Symbol.nterm Constr.one_open_binder)

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -168,9 +168,9 @@ let rec untype_command : type r s. (r, s) ty_sig -> r -> plugin_args -> vernac_c
 let rec untype_user_symbol : type s a b c. (a, b, c) Extend.ty_user_symbol -> (s, Gramlib.Grammar.norec, a) Procq.Symbol.t =
   let open Extend in function
   | TUlist1 l -> Procq.Symbol.list1 (untype_user_symbol l)
-  | TUlist1sep (l, s) -> Procq.Symbol.list1sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)]) false
+  | TUlist1sep (l, s) -> Procq.Symbol.list1sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)])
   | TUlist0 l -> Procq.Symbol.list0 (untype_user_symbol l)
-  | TUlist0sep (l, s) -> Procq.Symbol.list0sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)]) false
+  | TUlist0sep (l, s) -> Procq.Symbol.list0sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)])
   | TUopt o -> Procq.Symbol.opt (untype_user_symbol o)
   | TUentry a -> Procq.Symbol.nterm (Procq.genarg_grammar (Genarg.ExtraArg a))
   | TUentryl (a, i) -> Procq.Symbol.nterml (Procq.genarg_grammar (Genarg.ExtraArg a)) (string_of_int i)


### PR DESCRIPTION
Not entirely sure what this would do, from the printing I guess make the separator optional, but we don't use it so may as well get rid of it.
