### PR TITLE
Match-printing

### DIFF
--- a/dev/ci/user-overlays/20957-Yann-Leray-match-printing.sh
+++ b/dev/ci/user-overlays/20957-Yann-Leray-match-printing.sh
@@ -1,1 +1,1 @@
-overlay stdlib https://github.com/Yann-Leray/stdlib match-printing 20957
+overlay stdlib https://github.com/Yann-Leray/rocq-stdlib match-printing 20957

--- a/dev/ci/user-overlays/20957-Yann-Leray-match-printing.sh
+++ b/dev/ci/user-overlays/20957-Yann-Leray-match-printing.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/Yann-Leray/stdlib match-printing 20957

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -261,35 +261,36 @@ let add_cpatt_for_params ind l =
   if !Flags.in_debugger then l else
     Util.List.addn  (Inductiveops.inductive_nparamdecls (Global.env()) ind) (DAst.make @@ PatVar Anonymous) l
 
-let drop_implicits_in_patt cst nb_expl args =
+let drop_implicits_in_patt cst nb_expl ?(tags=[]) args =
   let impl_st = implicits_of_global cst in
   let impl_data = extract_impargs_data impl_st in
   let rec impls_fit l = function
-    | [], t -> Some (List.rev_append l t)
-    | _, [] -> None
-    | h::t, { CAst.v = CPatAtom None }::tt when is_status_implicit h -> impls_fit l (t,tt)
-    | h::_, _ when is_status_implicit h -> None
-    | _::t, hh::tt -> impls_fit (hh::l) (t,tt)
+    | [], t, _ -> Some (List.rev_append l t)
+    | _, [], _ -> None
+    | t, hh :: tt, true :: tags -> impls_fit (hh :: l) (t, tt, tags)
+    | h::t, { CAst.v = CPatAtom None }::tt, ((false :: tags) | ([] as tags)) when is_status_implicit h -> impls_fit l (t,tt,tags)
+    | h::_, _, _ when is_status_implicit h -> None
+    | _::t, hh::tt, ((false :: tags) | ([] as tags)) -> impls_fit (hh::l) (t,tt,tags)
   in
-  let try_impls_fit (imps,args) =
+  let try_impls_fit (imps,args,tags) =
     if not !Constrintern.parsing_explicit &&
        ((!Flags.raw_print || !print_implicits) &&
         List.exists is_status_implicit imps)
        (* Note: !print_implicits_explicit_args=true not supported for patterns *)
     then None
-    else impls_fit [] (imps,args)
+    else impls_fit [] (imps,args,tags)
   in
   let rec select = function
     | [] -> None
     | (_,imps)::imps_list ->
-      match try_impls_fit (imps,args) with
+      match try_impls_fit (imps,args, tags) with
         | None -> select imps_list
         | x -> x
   in
   if Int.equal nb_expl 0 then select impl_data
   else
     let imps = List.skipn_at_best nb_expl (select_stronger_impargs impl_st) in
-    try_impls_fit (imps,args)
+    try_impls_fit (imps,args, tags)
 
 let destPrim = function { CAst.v = CPrim t } -> Some t | _ -> None
 let destPatPrim = function { CAst.v = CPatPrim t } -> Some t | _ -> None
@@ -423,7 +424,8 @@ let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as
                     else CPatCstr (c, Some (add_patt_for_params (fst cstrsp) args), [])
                   else
                     let full_args = add_patt_for_params (fst cstrsp) args in
-                    match drop_implicits_in_patt (GlobRef.ConstructRef cstrsp) 0 full_args with
+                    let tags = Inductiveops.constructor_alltags (Global.env()) cstrsp in
+                    match drop_implicits_in_patt (GlobRef.ConstructRef cstrsp) 0 ~tags full_args with
                       | Some true_args -> CPatCstr (c, None, true_args)
                       | None           -> CPatCstr (c, Some full_args, [])
           in
@@ -525,19 +527,21 @@ let rec extern_notation_ind_pattern allscopes vars ind args = function
 let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
   (* pboutill: There are letins in pat which is incompatible with notations and
      not explicit application. *)
-  if !Flags.in_debugger||Inductiveops.inductive_has_local_defs (Global.env()) ind then
+  if !Flags.in_debugger then
     let c = extern_reference vars (GlobRef.IndRef ind) in
     let args = List.map (extern_cases_pattern_in_scope allscopes vars) args in
-    CAst.make @@ CPatCstr (c, Some (add_patt_for_params ind args), [])
+    CAst.make @@ CPatCstr (c, Some args, [])
   else
     try
-      if !Flags.raw_print || !print_no_symbol then raise No_match;
+      if !Flags.raw_print || !print_no_symbol || Inductiveops.inductive_has_local_defs (Global.env()) ind
+        then raise No_match;
       extern_notation_ind_pattern allscopes vars ind args
           (uninterp_ind_pattern_notations ind)
     with No_match ->
       let c = extern_reference vars (GlobRef.IndRef ind) in
       let args = List.map (extern_cases_pattern_in_scope allscopes vars) args in
-      match drop_implicits_in_patt (GlobRef.IndRef ind) 0 args with
+      let tags = Inductiveops.inductive_alltags (Global.env()) ind in
+      match drop_implicits_in_patt (GlobRef.IndRef ind) 0 ~tags args with
       | Some true_args -> CAst.make @@ CPatCstr (c, None, true_args)
       | None           -> CAst.make @@ CPatCstr (c, Some args, [])
 

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -292,8 +292,8 @@ struct
         | Anonymous -> accu)
       Id.Set.empty l
 
-  (** Map a given rel-context to a list where each {e local assumption} is mapped to [true]
-      and each {e local definition} is mapped to [false]. *)
+  (** Map a given rel-context to a list where each {e local definition} is mapped to [true]
+      and each {e local assumption} is mapped to [false]. *)
   let to_tags l =
     let rec aux l = function
       | [] -> l

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -186,7 +186,7 @@ sig
   val to_vars : ('c, 't, 'r) pt -> Id.Set.t
 
   (** Map a given rel-context to a list where each {e local
-      assumption} is mapped to [true] and each {e local definition} is
+      definition} is mapped to [true] and each {e local assumption} is
       mapped to [false]. The resulting list is in reverse order
       compared to the order of declarations in the context. *)
   val to_tags : ('c, 't, 'r) pt -> bool list

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -118,7 +118,7 @@ val constructor_nrealargs : env -> constructor -> int
 (** @return args with letin *)
 val constructor_nrealdecls : env -> constructor -> int
 
-(** @return tags of all decls: true = assumption, false = letin *)
+(** @return tags of all decls: true = letin, false = assumption *)
 val inductive_alltags : env -> inductive -> bool list
 val constructor_alltags : env -> constructor -> bool list
 

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -66,6 +66,7 @@ let lnegint = 35 (* must be consistent with Notation "- x" *)
 let ltop = LevelLe 200
 let lproj = 1
 let ldelim = 1
+let lcase_type = LevelLe 100
 let lsimpleconstr = LevelLe 8
 let lsimplepatt = LevelLe 1
 let no_after = None
@@ -548,7 +549,7 @@ let pr_as_in pr na indnalopt =
    | None -> mt ()) ++
   (match indnalopt with
    | None -> mt ()
-   | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr no_after lsimplepatt t)
+   | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr no_after ltop t)
 
 let pr_case_item pr (tm,as_clause, in_clause) =
   hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in (pr no_after ltop) as_clause in_clause)
@@ -558,7 +559,7 @@ let pr_case_type pr po =
   | None -> mt ()
   | Some { CAst.v = CHole h } when is_anonymous_hole h -> mt()
   | Some p ->
-    spc() ++ hov 2 (keyword "return" ++ pr_sep_com spc (pr no_after lsimpleconstr) p)
+    spc() ++ hov 2 (keyword "return" ++ pr_sep_com spc (pr no_after lcase_type) p)
 
 let pr_simple_return_type pr na po =
   (match na with

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -1,7 +1,7 @@
 t_rect =
 fun (P : t -> Type) (k : let x := t in forall x0 : x, P x0 -> P (k x0)) =>
 fix F (t : t) : P t :=
-  match t as t0 return (P t0) with
+  match t as t0 return P t0 with
   | Cases.k _ x0 => k x0 (F x0)
   end
      : forall P : t -> Type,
@@ -19,7 +19,7 @@ Arguments t_rect (P k)%_function_scope t
 proj =
 fun (x y : nat) (P : nat -> Type) (def : P x) (prf : P y) =>
 match eq_nat_dec x y with
-| left eqprf => match eqprf in (_ = z) return (P z) with
+| left eqprf => match eqprf in _ = z return P z with
                 | eq_refl => def
                 end
 | right _ => prf
@@ -52,7 +52,7 @@ match H with
 | AC x =>
     (fun x0 : P b =>
      let b0 := b in
-     (if b0 as b return (P b -> True)
+     (if b0 as b return P b -> True
       then fun _ : P true => Logic.I
       else fun _ : P false => Logic.I) x0) x
 end
@@ -82,17 +82,17 @@ Once notations are expanded, the resulting constructor D (in type J) is
 expected to be applied to no arguments while it is actually applied to
 1 argument.
 lem1 =
-fun dd : nat * nat => let (bb, cc) as aa return (aa = aa) := dd in eq_refl
+fun dd : nat * nat => let (bb, cc) as aa return aa = aa := dd in eq_refl
      : forall k : nat * nat, k = k
 
 Arguments lem1 k
 lem2 =
-fun dd : bool => if dd as aa return (aa = aa) then eq_refl else eq_refl
+fun dd : bool => if dd as aa return aa = aa then eq_refl else eq_refl
      : forall k : bool, k = k
 
 Arguments lem2 k%_bool_scope
 lem3 =
-fun dd : nat * nat => let (bb, cc) as aa return (aa = aa) := dd in eq_refl
+fun dd : nat * nat => let (bb, cc) as aa return aa = aa := dd in eq_refl
      : forall k : nat * nat, k = k
 
 Arguments lem3 k
@@ -103,14 +103,14 @@ Arguments lem3 k
            | 0 | S _ => 0
            end : nat
   e, e0 :=
-    match x + 0 as y return (y = y) with
+    match x + 0 as y return y = y with
     | 0 => eq_refl
     | S n => eq_refl
     end : x + 0 = x + 0
   n1, n2 := match x with
             | 0 | S _ => 0
             end : nat
-  e1, e2 := match x return (x = x) with
+  e1, e2 := match x return x = x with
             | 0 => eq_refl
             | S n => eq_refl
             end
@@ -121,11 +121,11 @@ Arguments lem3 k
   
   p : nat
   a, a0 :=
-    match eq_refl as y in (_ = e) return (y = y /\ e = e) with
+    match eq_refl as y in _ = e return y = y /\ e = e with
     | eq_refl => conj eq_refl eq_refl
     end : eq_refl = eq_refl /\ p = p
   a1, a2 :=
-    match eq_refl in (_ = e) return (p = p /\ e = e) with
+    match eq_refl in _ = e return p = p /\ e = e with
     | eq_refl => conj eq_refl eq_refl
     end : p = p /\ p = p
   ============================

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -213,13 +213,12 @@ The constructor D' (in type J') is expected to be applied to 4 arguments (or
 actually applied to 5 arguments.
 fun x : J' bool (true, true) =>
 match x with
-| D' _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
+| @D' _ _ _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
 end
      : J' bool (true, true) -> {x : nat & x = x}
-fun x : J' bool (true, true) =>
-match x with
-| @D' _ _ _ _ n _ p _ => n + p
-end
+fun x : J' bool (true, true) => match x with
+                                | D' _ _ _ n p _ => n + p
+                                end
      : J' bool (true, true) -> nat
 File "./output/Cases.v", line 277, characters 33-40:
 The command has indeed failed with message:

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -1,6 +1,6 @@
 true ? 0; 1
      : nat
-if true as x return (x ? nat; bool) then 0 else true
+if true as x return x ? nat; bool then 0 else true
      : nat
 fun e : nat * nat => proj1 e
      : nat * nat -> nat
@@ -135,12 +135,12 @@ s
 fun _ : nat => 9
      : nat -> nat
 fun (x : nat) (p : x = x) =>
-match p in (_ = n) return (n = n) with
+match p in _ = n return n = n with
 | ONE => ONE
 end = p
      : forall x : nat, x = x -> Prop
 fun (x : nat) (p : x = x) =>
-match p in (_ = n) return (n = n) with
+match p in _ = n return n = n with
 | 1 => 1
 end = p
      : forall x : nat, x = x -> Prop

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -37,7 +37,7 @@ fun '(x, y) => (y, x)
 forall '(x, y), swap (x, y) = (y, x)
      : Prop
 both_z =
-fun pat : nat * nat => let '(n, p) as x := pat return (F x) in (Z n, Z p)
+fun pat : nat * nat => let '(n, p) as x := pat return F x in (Z n, Z p)
      : forall pat : nat * nat, F pat
 
 Arguments both_z pat

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -1,7 +1,7 @@
 eqT_rect@{u u0} =
 fun (A : Type@{u}) (a : A) (P : forall a0 : A, eqT@{u} a a0 -> Type@{u0})
   (reflT : P a (reflT@{u} a)) (a0 : A) (e : eqT@{u} a a0) =>
-match e :> eqT@{u} a _ as e0 in (eqT _ a1) return (P a1 e0) with
+match e :> eqT@{u} a _ as e0 in eqT _ a1 return P a1 e0 with
 | MatchAllSubterms.reflT _ => reflT
 end
      : forall (A : Type@{u}) (a : A)
@@ -14,7 +14,7 @@ seq_rect =
 fun (A : Type@{seq_rect.u1}) (a : A)
   (P : forall a0 : A, seq a a0 -> Type@{seq_rect.u0}) 
   (srefl : P a (srefl a)) (a0 : A) (s : seq a a0) =>
-match s :> seq a a0 as s0 in (seq _ a1) return (P a1 s0) with
+match s :> seq a a0 as s0 in seq _ a1 return P a1 s0 with
 | MatchAllSubterms.srefl _ => srefl
 end
      : forall (A : Type@{seq_rect.u1}) (a : A)
@@ -24,7 +24,7 @@ end
 Arguments seq_rect A%_type_scope a P%_function_scope srefl a0 s
 eq_sym =
 fun (A : Type) (x y : A) (H : @eq A x y) =>
-match H in (@eq _ _ a) return (@eq A a x) with
+match H in @eq _ _ a return @eq A a x with
 | @eq_refl _ _ => @eq_refl A x
 end
      : forall [A : Type] [x y : A] (_ : @eq A x y), @eq A y x
@@ -32,7 +32,7 @@ end
 Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym =
 fun (A : Type) (x y : A) (H : x = y) =>
-match H in (_ = a) return (a = x) with
+match H in _ = a return a = x with
 | @eq_refl _ _ => @eq_refl A x
 end
      : forall [A : Type] [x y : A], x = y -> y = x
@@ -40,7 +40,7 @@ end
 Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym =
 fun (A : Type) (x y : A) (H : x = y) =>
-match H in (_ = a) return (a = x) with
+match H in _ = a return a = x with
 | @eq_refl _ _ => @eq_refl A x
 end
      : forall [A : Type] [x y : A], x = y -> y = x

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -6,7 +6,7 @@ nat_ind (fun n0 : nat => ((n0 * m) + n0) = (n0 * (S m)))
   (eq_refl : ((0 * m) + 0) = (0 * (S m)))
   (fun (p : nat) (H : ((p * m) + p) = (p * (S m))) =>
    (let n0 := p * (S m) in
-    match H in (_ = n1) return (((m + (p * m)) + (S p)) = (S (m + n1))) with
+    match H in _ = n1 return ((m + (p * m)) + (S p)) = (S (m + n1)) with
     | eq_refl =>
         eq_ind (S ((m + (p * m)) + p))
           (fun n1 : nat => n1 = (S (m + ((p * m) + p))))

--- a/test-suite/output/bug_19227.out
+++ b/test-suite/output/bug_19227.out
@@ -1,5 +1,5 @@
 test =
-fun x : T 0 => match x in (T _ e) return (e = e) with
+fun x : T 0 => match x in T _ e return e = e with
                | C _ => eq_refl
                end
      : T 0 -> 0 = 0

--- a/test-suite/output/bug_19227.out
+++ b/test-suite/output/bug_19227.out
@@ -1,0 +1,7 @@
+test =
+fun x : T 0 => match x in (T _ e) return (e = e) with
+               | C _ => eq_refl
+               end
+     : T 0 -> 0 = 0
+
+Arguments test x

--- a/test-suite/output/bug_19227.v
+++ b/test-suite/output/bug_19227.v
@@ -1,0 +1,15 @@
+Inductive T (a := 0) : nat -> Set := C : T 0.
+
+Definition test (x : T 0) := match x in T e return e = e with C => eq_refl end.
+
+Print test.
+(* was
+test =
+fun x : T 0 =>
+match x in (@T _ _ e) return (e = e) with
+| C _ => eq_refl
+end
+     : T 0 -> 0 = 0
+
+Arguments test x
+*)

--- a/test-suite/output/bug_20968.out
+++ b/test-suite/output/bug_20968.out
@@ -1,0 +1,4 @@
+fun x : T => match x with
+             | C i => i
+             end
+     : T -> True

--- a/test-suite/output/bug_20968.v
+++ b/test-suite/output/bug_20968.v
@@ -1,0 +1,3 @@
+Inductive T := C (c := I) (n : nat).
+Arguments C {_}.
+Check fun x => match x return True with C i => i end.


### PR DESCRIPTION
Fixes / closes #19227
Fixes / closes #20968

Harmonise printing behaviour to current parsing behaviour, in patterns, when the constructor/inductive has both declared implicit arguments and local definitions in its type.

Removes unneeded parentheses in in-clauses and case_types by setting their printing priority level to align with their parsing priority level (this may be controversial, so it's in its own commit)

This fixes a test case which was not following the new behaviour.


- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.

Overlays:
- stdlib: https://github.com/rocq-prover/stdlib/pull/204