### PR TITLE
Fixes #20941: assert false anomaly in "evarsolve.ml" when "imitate" solves the evar on the fly

### DIFF
--- a/doc/changelog/02-specification-language/20960-master+fix-anomaly-imitate-solved-on-the-fly-Fixed.rst
+++ b/doc/changelog/02-specification-language/20960-master+fix-anomaly-imitate-solved-on-the-fly-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  type-checking anomaly in the presence of primitive projections (some
+  `assert false` in `evarsolve.ml`)
+  (`#20960 <https://github.com/rocq-prover/rocq/pull/20960>`_,
+  fixes `#20941 <https://github.com/rocq-prover/rocq/issues/20941>`_,
+  by Hugo Herbelin).

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1585,8 +1585,11 @@ let instantiate_evar unify flags env evd evk body =
      checking could involve the same evar definition problem again otherwise *)
   let allowed_evars = AllowedEvars.remove evk flags.allowed_evars in
   let flags = { flags with allowed_evars } in
-  let evd' = check_evar_instance unify flags env evd evk body in
-  Evd.define evk body evd'
+  if Evd.is_undefined evd evk then
+    let evd' = check_evar_instance unify flags env evd evk body in
+    Evd.define evk body evd'
+  else
+    evd
 
 (* We try to instantiate the evar assuming the body won't depend
  * on arguments that are not Rels or Vars, or appearing several times

--- a/test-suite/output/bug_20941.out
+++ b/test-suite/output/bug_20941.out
@@ -1,0 +1,36 @@
+File "./output/bug_20941.v", line 90, characters 58-64:
+The command has indeed failed with message:
+In environment
+n : nat
+p : nat
+Hp : p <= n
+frame'' : forall p : nat, p.+1 <= n.+1 -> Type
+painting'' : forall (p : nat) (Hp : p.+1 <= n.+1), frame'' p Hp -> Type
+restrFrames' : RestrFrameType'
+frame' :=
+  fun (p : nat) (Hp : p.+1 <= n.+1) =>
+  Frame' (take_head n.+1 p (leI_down Hp)) :
+  forall p : nat, p.+1 <= n.+1 -> Type
+restrFrame' :=
+  fun (p : nat) (Hp : p.+1 <= n.+1) => take_restrFrame' n.+1 p Hp :
+  forall (p : nat) (Hp : p.+1 <= n.+1), frame' p Hp -> frame'' p Hp
+E : frame' n (leI_refl n.+1) -> Type
+aux :
+  forall (p0 : nat) (Hp0 : p0 <= ?n0@{p0:=p; Hp0:=Hp}),
+  frame' p0 ?l@{p0:=p; Hp0:=Hp; p:=p0; Hp:=Hp0; y0:=p0; h0:=Hp0} ->
+  ?T@{y0:=p0} ?n@{y0:=p0} (leI_refl ?n@{y0:=p0}.+1) -> Type
+p0 : nat
+Hp0 : p0 <= ?n0@{p0:=p; Hp0:=Hp}
+p1 : nat
+Hp1 : p1.+1 <= ?n0@{p0:=p; Hp0:=Hp}
+d : frame' p1 ?l@{p0:=p; Hp0:=Hp; p:=p0; Hp:=Hp0; y0:=p1; h0:=leI_down Hp1}
+l :
+  painting'' p1 ?l@{p0:=p; Hp0:=Hp; p:=p0; Hp:=Hp0; y0:=p1; h0:=leI_down Hp1}
+    (restrFrame' p1
+       ?l@{p0:=p; Hp0:=Hp; p:=p0; Hp:=Hp0; y0:=p1; h0:=leI_down Hp1} d)
+The term "(d; l)" has type
+ "{x
+  : frame' p1 ?l@{p0:=p; Hp0:=Hp; p:=p0; Hp:=Hp0; y0:=p1; h0:=leI_down Hp1} &
+  ?P@{p0:=p; Hp0:=Hp; p1:=p0; Hp1:=Hp0; p:=p1; Hp:=Hp1} x}"
+while it is expected to have type
+ "frame' p1.+1 ?l@{p0:=p; Hp0:=Hp; p:=p1.+1; Hp:=Hp1; y0:=p1.+1; h0:=Hp1}".

--- a/test-suite/output/bug_20941.v
+++ b/test-suite/output/bug_20941.v
@@ -1,0 +1,91 @@
+(* Was a unification anomaly in the imitation phase with primitive
+   projections (assert false at line 913 of evarsolve.ml) while a regular
+   typing error is expected. *)
+
+Set Primitive Projections.
+Set Warnings "-notation-overridden".
+Notation "x .+1" := (S x) (at level 1, left associativity, format "x .+1").
+Notation "x .+2" := (S (S x)) (at level 1, left associativity, format "x .+2").
+Notation "x .+3" := (S (S (S x))) (at level 1, left associativity, format "x .+3").
+Notation "x .1" := (projT1 x) (at level 1, left associativity, format "x .1").
+Notation "x .2" := (projT2 x) (at level 1, left associativity, format "x .2").
+Notation "( x ; y )" := (existT _ x y) (at level 0, format "'[' ( x ;  '/ ' y ) ']'").
+
+Inductive leI n: nat -> Type :=
+| leI_refl: n <= n
+| leI_down p: p.+1 <= n -> p <= n
+where "p <= n" := (leI n p): nat_scope.
+Arguments leI_down {n p} H.
+Lemma leI_raise_both {n p}: p <= n -> p.+1 <= n.+1.
+  induction 1. now constructor. now constructor.
+Defined.
+
+Class RestrFrameTypeBlock' := {
+  RestrFrameType': Type;
+  Frame': RestrFrameType' -> Type;
+}.
+
+Definition mkRestrFrameTypeBlock' n
+  (frame'': forall p (Hp: p.+1 <= n), Type)
+  (painting'': forall p (Hp: p.+1 <= n), frame'' p Hp -> Type) :=
+  fix aux p: forall (Hp: p <= n), RestrFrameTypeBlock' :=
+  match p with
+  | O => fun (Hp: 0 <= n) =>
+    {| RestrFrameType' := unit; Frame' _ := unit |}
+  | S p => fun (Hp: p.+1 <= n) =>
+    {|
+      RestrFrameType' :=
+        { R : (aux p _).(RestrFrameType') &
+         (aux p (leI_down Hp)).(Frame') R -> frame'' p Hp };
+      Frame' R :=
+        { d: (aux p _).(Frame') R.1 & painting'' p Hp (R.2 d) }
+    |}
+  end.
+
+Class CohFrameTypeBlock n
+  (frame'': forall p (Hp: p.+2 <= n), Type)
+  (painting'': forall p (Hp: p.+2 <= n), frame'' p Hp -> Type)
+  (frame': forall p (Hp: p.+1 <= n), Type) p {Hp: p.+1 <= n} := {
+  CohFrameType: Type;
+  Frame: forall Q: CohFrameType, Type;
+  RestrFrame: forall Q: CohFrameType,
+   forall q {Hpq: p.+1 <= q.+1} {Hq: q.+1 <= n},
+   Frame Q -> frame' p Hp;
+}.
+
+Definition take_head n
+  {frame'': forall p {Hp: p.+1 <= n}, Type}
+  {painting'': forall p {Hp: p.+1 <= n}, frame'' p -> Type}
+  {restrFrames': (mkRestrFrameTypeBlock' n frame'' painting'' n (leI_refl _)).(RestrFrameType')}:
+  forall p (Hp: p <= n), (mkRestrFrameTypeBlock' n _ _ p Hp).(RestrFrameType') :=
+  fix aux p (Hp: p <= n) :=
+  match Hp in p <= _ return (mkRestrFrameTypeBlock' n _ _ p Hp).(RestrFrameType') with
+  | leI_refl _ => restrFrames'
+  | @leI_down _ p Hp => (aux p.+1 Hp).1
+  end.
+
+Definition take_restrFrame' n
+  {frame'': forall p {Hp: p.+1 <= n}, Type}
+  {painting'': forall p {Hp: p.+1 <= n}, frame'' p -> Type}
+  {restrFrames': (mkRestrFrameTypeBlock' n frame'' painting'' n (leI_refl _) ).(RestrFrameType')}
+  p (Hp: p.+1 <= n) := (take_head (restrFrames' := restrFrames') n p.+1 Hp).2:
+    (mkRestrFrameTypeBlock' n _ _ p (leI_down Hp)).(Frame')
+    (take_head (restrFrames' := restrFrames') n p.+1 Hp).1 ->
+    frame'' p.
+
+Fail Definition Painting' n p {Hp:p <= n}
+  {frame'': forall p {Hp: p.+1 <= n.+1}, Type}
+  {painting'': forall p {Hp: p.+1 <= n.+1}, frame'' p -> Type}
+  {restrFrames': (mkRestrFrameTypeBlock' n.+1 _ _ n.+1 (leI_refl _)).(RestrFrameType')}
+  (frame' := fun p (Hp: p.+1 <= n.+1) =>
+    (mkRestrFrameTypeBlock' n.+1 frame'' painting'' p (leI_down Hp)).(Frame')
+      (take_head (restrFrames' := restrFrames') n.+1 p (leI_down Hp)))
+ (restrFrame' : forall p {Hp:p.+1 <= n.+1} , frame' p Hp-> frame'' p
+   := fun p {Hp:p.+1 <= n.+1} => take_restrFrame' (restrFrames' := restrFrames') n.+1 p Hp)
+   {E: frame' n (leI_refl _) -> Type}: frame' p (leI_raise_both Hp) -> Type :=
+ (fix aux p Hp :=
+ match Hp with
+  | leI_refl _ => fun _ => E (* this is the typing bug: should be "E" *)
+  | @leI_down _ p Hp => fun d =>
+       {l: painting'' p (restrFrame' p d) & (aux p.+1 Hp) (d; l)}
+  end) p Hp.


### PR DESCRIPTION
Rather canonical fix: when the evar has already been defined on the fly, we don't instantiate it again.

Fixes / closes #20941

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
