### PR TITLE
Streams don't use Stream.Failure for control flow

### DIFF
--- a/dev/ci/user-overlays/20962-SkySkimmer-stream-fail.sh
+++ b/dev/ci/user-overlays/20962-SkySkimmer-stream-fail.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp stream-fail 20962
+
+overlay elpi https://github.com/proux01/coq-elpi stream-fail 20962
+
+overlay vsrocq https://github.com/SkySkimmer/vsrocq stream-fail 20962

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -31,6 +31,8 @@ module type S = sig
   type 'c pattern
   type ty_pattern = TPattern : 'a pattern -> ty_pattern
 
+  exception StreamFail
+
   (** Type combinators to factor the module type between explicit
       state passing in Grammar and global state in Procq *)
 

--- a/gramlib/lStream.ml
+++ b/gramlib/lStream.ml
@@ -65,14 +65,8 @@ let npeek e n strm =
   l
 
 let peek_nth e n strm =
-  let list = Stream.npeek e (n + 1) strm.strm in
-  let rec loop list p =
-    match list, p with
-      x :: _, 0 -> strm.max_peek <- Stream.count strm.strm + n + 1; x
-    | _ :: l, p -> loop l (p - 1)
-    | [], p -> strm.max_peek <- Stream.count strm.strm + (n - p); raise Stream.Failure
-  in
-  loop list n
+  let list = npeek e (n + 1) strm in
+  List.nth_opt list n
 
 let junk e strm = Stream.junk e strm.strm
 let njunk e len strm = Stream.njunk e len strm.strm

--- a/gramlib/lStream.mli
+++ b/gramlib/lStream.mli
@@ -47,13 +47,12 @@ val junk : 'e -> ('e,'a) t -> unit
 val njunk : 'e -> int -> ('e,'a) t -> unit
 (** [njunk e n strm] consumes [n] elements from [strm] *)
 
-val next : 'e -> ('e,'a) t -> 'a
+val next : 'e -> ('e,'a) t -> 'a option
   (** [next e strm] returns and consumes the next element;
-      raise [Stream.Failure] if the stream is empty *)
+      [None] if the stream is empty *)
 
 (** Other functions *)
 
-val peek_nth : 'e -> int -> ('e,'a) t -> 'a
+val peek_nth : 'e -> int -> ('e,'a) t -> 'a option
   (** [peek_nth e n strm] returns the nth element counting from 0 without
-      consuming the stream; raises [Stream.Failure] if not enough
-      elements *)
+      consuming the stream; [None] if not enough elements *)

--- a/gramlib/stream.ml
+++ b/gramlib/stream.ml
@@ -23,8 +23,6 @@ and ('e,'a) gen = { mutable curr : 'a option option; func : 'e -> 'a option }
 and buffio =
   { ic : in_channel; buff : bytes; mutable len : int; mutable ind : int }
 
-exception Failure
-
 let count { count } = count
 
 let fill_buff b =
@@ -74,16 +72,15 @@ let npeek e n s =
   al
 
 let nth e n st =
-  try List.nth (npeek e (n+1) st) n
-  with Stdlib.Failure _ -> raise Failure
+  List.nth_opt (npeek e (n+1) st) n
 
 let rec njunk e n st =
   if n <> 0 then (junk e st; njunk e (n-1) st)
 
 let next e s =
   match peek e s with
-    Some a -> junk e s; a
-  | None -> raise Failure
+  | Some _ as a -> junk e s; a
+  | None -> None
 
 
 let is_empty e s =

--- a/gramlib/stream.mli
+++ b/gramlib/stream.mli
@@ -19,9 +19,6 @@ type ('e,'a) t
 (** The type of streams holding values of type ['a].
     Producing a new value needs an environment ['e]. *)
 
-exception Failure
-(** Raised by streams when trying to access beyond their end. *)
-
 (** {1 Stream builders} *)
 
 val from : ?offset:int -> ('e -> 'a option) -> ('e,'a) t
@@ -46,10 +43,9 @@ val of_channel : in_channel -> (unit,char) t
 
 (** {1 Predefined parsers} *)
 
-val next : 'e -> ('e,'a) t -> 'a
+val next : 'e -> ('e,'a) t -> 'a option
 (** Return the first element of the stream and remove it from the
-   stream.
-   @raise Stream.Failure if the stream is empty. *)
+   stream. [None] if the stream is empty. *)
 
 val is_empty : 'e -> ('e,'a) t -> bool
 (** Return [true] if the stream is empty, else [false]. *)
@@ -74,7 +70,9 @@ val npeek : 'e -> int -> ('e,'a) t -> 'a list
    the stream, or all its remaining elements if less than [n]
    elements are available. *)
 
-val nth : 'e -> int -> ('e,'a) t -> 'a
+val nth : 'e -> int -> ('e,'a) t -> 'a option
+(** Returns the [n]th (0-indexed) element of the sream without
+    consuming, or [None] if less than [n+1] elements are available. *)
 
 val njunk : 'e -> int -> ('e,'a) t -> unit
 

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -35,7 +35,7 @@ let all_with ~head delta =
   let all = [FBeta;FMatch;FFix;FCofix;FZeta;delta] in
   Redops.make_red_flag (if head then FHead :: all else all)
 
-let err () = raise Gramlib.Stream.Failure
+let err () = raise Procq.StreamFail
 
 (* Hack to parse "(x:=t)" as an explicit argument without conflicts with the *)
 (* admissible notation "(x t)" *)
@@ -90,7 +90,7 @@ let check_for_coloneq =
         | KEYWORD ":=" -> ()
         | _ -> err () in
       match Gramlib.LStream.peek_nth kwstate 0 strm with
-      | KEYWORD "(" -> skip_binders 2
+      | Some (KEYWORD "(") -> skip_binders 2
       | _ -> err () })
 
 let lookup_at_as_comma =
@@ -442,7 +442,7 @@ GRAMMAR EXTEND Gram
         (* Condition for accepting "in" at the end by compatibility *)
         { match ic,el,cl_tolerance with
         | [c,pat,None],Some _,Some _ -> ([c,pat,cl_tolerance],el)
-        | _,_,Some _ -> err ()
+        | _,_,Some _ -> CErrors.user_err ~loc Pp.(str "Unsupported syntax.")
         | _,_,None -> (ic,el) } ] ]
   ;
   simple_tactic:

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -244,40 +244,41 @@ let pr_ssrsimpl _ _ _ = pr_simpl
 let wit_ssrsimplrep = add_genarg "ssrsimplrep" (fun env sigma -> pr_simpl)
 
 let test_ssrslashnum b1 b2 kwstate strm =
+  let err () = raise Procq.StreamFail in
   match LStream.peek_nth kwstate 0 strm with
-  | Tok.KEYWORD "/" ->
+  | Some (Tok.KEYWORD "/") ->
       (match LStream.peek_nth kwstate 1 strm with
-      | Tok.NUMBER _ when b1 ->
+      | Some (Tok.NUMBER _) when b1 ->
          (match LStream.peek_nth kwstate 2 strm with
-         | Tok.KEYWORD "=" | Tok.KEYWORD "/=" when not b2 -> ()
-         | Tok.KEYWORD "/" ->
+         | Some (Tok.KEYWORD ("=" | "/=")) when not b2 -> ()
+         | Some (Tok.KEYWORD "/") ->
              if not b2 then () else begin
                match LStream.peek_nth kwstate 3 strm with
-               | Tok.NUMBER _ -> ()
-               | _ -> raise Stream.Failure
+               | Some (Tok.NUMBER _) -> ()
+               | _ -> err  ()
              end
-         | _ -> raise Stream.Failure)
-      | Tok.KEYWORD "/" when not b1 ->
+         | _ -> err ())
+      | Some (Tok.KEYWORD "/") when not b1 ->
          (match LStream.peek_nth kwstate 2 strm with
-         | Tok.KEYWORD "=" when not b2 -> ()
-         | Tok.NUMBER _ when b2 ->
+         | Some (Tok.KEYWORD "=") when not b2 -> ()
+         | Some (Tok.NUMBER _) when b2 ->
            (match LStream.peek_nth kwstate 3 strm with
-           | Tok.KEYWORD "=" -> ()
-           | _ -> raise Stream.Failure)
+           | Some (Tok.KEYWORD "=") -> ()
+           | _ -> err ())
          | _ when not b2 -> ()
-         | _ -> raise Stream.Failure)
-      | Tok.KEYWORD "=" when not b1 && not b2 -> ()
-      | _ -> raise Stream.Failure)
-  | Tok.KEYWORD "//" when not b1 ->
+         | _ -> err ())
+      | Some (Tok.KEYWORD "=") when not b1 && not b2 -> ()
+      | _ -> err ())
+  | Some (Tok.KEYWORD "//") when not b1 ->
          (match LStream.peek_nth kwstate 1 strm with
-         | Tok.KEYWORD "=" when not b2 -> ()
-         | Tok.NUMBER _ when b2 ->
+         | Some (Tok.KEYWORD "=") when not b2 -> ()
+         | Some (Tok.NUMBER _) when b2 ->
            (match LStream.peek_nth kwstate 2 strm with
-           | Tok.KEYWORD "=" -> ()
-           | _ -> raise Stream.Failure)
+           | Some (Tok.KEYWORD "=") -> ()
+           | _ -> err ())
          | _ when not b2 -> ()
-         | _ -> raise Stream.Failure)
-  | _ -> raise Stream.Failure
+         | _ -> err ())
+  | _ -> err ()
 
 let test_ssrslashnum10 = test_ssrslashnum true false
 let test_ssrslashnum11 = test_ssrslashnum true true
@@ -285,10 +286,10 @@ let test_ssrslashnum01 = test_ssrslashnum false true
 let test_ssrslashnum00 = test_ssrslashnum false false
 
 let negate_parser f x y =
-  let rc = try Some (f x y) with Stream.Failure -> None in
+  let rc = try Some (f x y) with Procq.StreamFail -> None in
   match rc with
   | None -> ()
-  | Some _ -> raise Stream.Failure
+  | Some _ -> raise Procq.StreamFail
 
 let test_not_ssrslashnum =
   Procq.Entry.(of_parser
@@ -482,9 +483,10 @@ END
 (* Old kinds of terms *)
 
 let input_ssrtermkind kwstate strm = match LStream.peek_nth kwstate 0 strm with
-  | Tok.KEYWORD "(" -> InParens
-  | Tok.KEYWORD "@" -> WithAt
-  | _ -> NoFlag
+  | Some (Tok.KEYWORD "(") -> InParens
+  | Some (Tok.KEYWORD "@") -> WithAt
+  | Some _ -> NoFlag
+  | None -> raise Procq.StreamFail
 
 let ssrtermkind = Procq.Entry.(of_parser "ssrtermkind" { parser_fun = input_ssrtermkind })
 
@@ -839,25 +841,22 @@ let test_leftsquarebracket_equal =
 
 let reject_ssrhid kwstate strm =
   match LStream.peek_nth kwstate 0 strm with
-  | Tok.KEYWORD "[" ->
+  | Some (Tok.KEYWORD "[") ->
       (match LStream.peek_nth kwstate 1 strm with
-      | Tok.KEYWORD ":" -> raise Stream.Failure
+      | Some (Tok.KEYWORD ":") -> raise Procq.StreamFail
       | _ -> ())
   | _ -> ()
 
 let test_nohidden = Procq.Entry.(of_parser "test_ssrhid" { parser_fun = reject_ssrhid })
 
 let rec reject_binder crossed_paren k kwstate s =
-  match
-    try Some (LStream.peek_nth kwstate k s)
-    with Stream.Failure -> None
-  with
+  match LStream.peek_nth kwstate k s with
   | Some (Tok.KEYWORD "(") when not crossed_paren -> reject_binder true (k+1) kwstate s
   | Some (Tok.IDENT _) when crossed_paren -> reject_binder true (k+1) kwstate s
   | Some (Tok.KEYWORD ":" | Tok.KEYWORD ":=") when crossed_paren ->
-      raise Stream.Failure
-  | Some (Tok.KEYWORD ")") when crossed_paren -> raise Stream.Failure
-  | _ -> if crossed_paren then () else raise Stream.Failure
+      raise Procq.StreamFail
+  | Some (Tok.KEYWORD ")") when crossed_paren -> raise Procq.StreamFail
+  | _ -> if crossed_paren then () else raise Procq.StreamFail
 
 let _test_nobinder = Procq.Entry.(of_parser "test_nobinder" { parser_fun = reject_binder false 0 })
 

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -757,11 +757,11 @@ let lbrace = Char.chr 123
 
 let test_ssr_rw_syntax =
   let test kwstate strm =
-    if not !ssr_rw_syntax then raise Stream.Failure else
+    if not !ssr_rw_syntax then raise Procq.StreamFail else
     if is_ssr_loaded () then () else
     match LStream.peek_nth kwstate 0 strm with
-    | Tok.KEYWORD key when List.mem key.[0] [lbrace; '['; '/'] -> ()
-    | _ -> raise Stream.Failure in
+    | Some (Tok.KEYWORD key) when List.mem key.[0] [lbrace; '['; '/'] -> ()
+    | _ -> raise Procq.StreamFail in
   Procq.Entry.(of_parser "test_ssr_rw_syntax" { parser_fun = test })
 
 }

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -69,9 +69,10 @@ END
 {
 
 let input_ssrtermkind kwstate strm = match Gramlib.LStream.peek_nth kwstate 0 strm with
-  | Tok.KEYWORD "(" -> InParens
-  | Tok.KEYWORD "@" -> WithAt
-  | _ -> NoFlag
+  | Some (Tok.KEYWORD "(") -> InParens
+  | Some (Tok.KEYWORD "@") -> WithAt
+  | Some _ -> NoFlag
+  | None -> raise Procq.StreamFail
 let ssrtermkind = Procq.Entry.(of_parser "ssrtermkind" { parser_fun = input_ssrtermkind })
 
 }

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -94,8 +94,9 @@ let tokenize_string s =
   let rec stream_tok acc str =
     let e = Gramlib.LStream.next kwstate str in
     match e with
-    | Tok.EOI -> List.rev acc
-    | _ -> stream_tok ((Tok.extract_string true e) :: acc) str
+    | Some Tok.EOI -> List.rev acc
+    | Some e -> stream_tok ((Tok.extract_string true e) :: acc) str
+    | None -> raise Exit
   in
   let st = CLexer.Lexer.State.get () in
   Fun.protect ~finally:(fun () -> CLexer.Lexer.State.set st) @@ fun () ->

--- a/test-suite/output-coqtop/ltac2_var_quot.out
+++ b/test-suite/output-coqtop/ltac2_var_quot.out
@@ -10,19 +10,19 @@ Rocq < Rocq < Toplevel input, characters 16-17:
 >                ^
 Error: Unbound value x
 
-Rocq < Rocq < Toplevel input, characters 7-8:
+Rocq < Rocq < Toplevel input, characters 7-11:
 > Check $ x.
->       ^
+>       ^^^^
 Error: Syntax error: [lconstr] expected after 'Check' (in [query_command]).
 
-Rocq < Rocq < Toplevel input, characters 7-8:
+Rocq < Rocq < Toplevel input, characters 7-18:
 > Check $ preterm:x.
->       ^
+>       ^^^^^^^^^^^
 Error: Syntax error: [lconstr] expected after 'Check' (in [query_command]).
 
-Rocq < Rocq < Toplevel input, characters 7-8:
+Rocq < Rocq < Toplevel input, characters 7-20:
 > Check $ preterm : x.
->       ^
+>       ^^^^^^^^^^^^^
 Error: Syntax error: [lconstr] expected after 'Check' (in [query_command]).
 
 Rocq < Rocq < Toplevel input, characters 18-19:
@@ -45,9 +45,9 @@ Rocq < Rocq < Toplevel input, characters 16-24:
 >                ^^^^^^^^
 Error: Unbound value preterm
 
-Rocq < Rocq < Toplevel input, characters 7-8:
+Rocq < Rocq < Toplevel input, characters 7-19:
 > Check $ preterm :x.
->       ^
+>       ^^^^^^^^^^^^
 Error: Syntax error: [lconstr] expected after 'Check' (in [query_command]).
 
 Rocq < 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -264,9 +264,10 @@ let set_prompt prompt =
 (* Read the input stream until a dot is encountered *)
 let parse_to_dot =
   let rec dot kwstate st = match Gramlib.LStream.next kwstate st with
-    | Tok.KEYWORD ("."|"...") -> ()
-    | Tok.EOI -> ()
-    | _ -> dot kwstate st
+    | Some (Tok.KEYWORD ("."|"...")) -> ()
+    | Some Tok.EOI -> ()
+    | Some _ -> dot kwstate st
+    | None -> raise Procq.StreamFail
   in
   Procq.Entry.(of_parser "Coqtoplevel.dot" { parser_fun = dot })
 

--- a/toplevel/g_toplevel.mlg
+++ b/toplevel/g_toplevel.mlg
@@ -26,8 +26,6 @@ type vernac_toplevel =
 
 let vernac_toplevel = Entry.make "toplevel:vernac_toplevel"
 
-let err () = raise Gramlib.Stream.Failure
-
 let test_show_goal =
   let open Procq.Lookahead in
   to_entry "test_show_goal" begin

--- a/toplevel/g_toplevel.mli
+++ b/toplevel/g_toplevel.mli
@@ -7,8 +7,6 @@ type vernac_toplevel =
   | VernacShowGoal of { gid : int; sid : int; }
   | VernacShowProofDiffs of Proof_diffs.diffOpt
 
-val err : unit -> 'a
-
 val test_show_goal : unit Procq.Entry.t
 
 val vernac_toplevel :


### PR DESCRIPTION
Functions which raised it return option instead.

This change is pushed through CLexer but not Grammar. Consequently the exception is moved to Grammar.

Behaviour is a little changed:

- unterminated quotations produce new lexer error
  Unterminated_quotation instead of Stream.Failure (this was the only
  Stream.Failure which could be raised from lexing AFAICT)

- some compat syntax for `induction in` fails in a different way in
  rare cases (I don't fully understand this code, cf g_tactic change)

- location errors after a peek_nth changed a bit

Overlays:
- https://github.com/rocq-prover/vsrocq/pull/1136
- https://github.com/ejgallego/coq-lsp/pull/998
- https://github.com/LPCIC/coq-elpi/pull/858
