### PR TITLE
Add CSS to fix the display of description lists in recent versions of Sphinx.

### DIFF
--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -280,3 +280,8 @@ code span.error {
     padding-left: 2em; /* indent 2nd & subsequent lines */
     text-indent: -2em;
 }
+
+.rst-content dl:not(.docutils) dt {
+    padding: 6px;
+    display: table;
+}


### PR DESCRIPTION
Fix #16956.
Fix #20717.

This longs CSS selector comes from what I found in my web browser inspector. I didn't try to make sense of it or whether it could be simplified. I just tested that it fixed the issue.

@cpitclaudel Is putting this piece of CSS in `notations.css` OK?