### PR TITLE
Ltac2: move "rename" notation to Ltac1CompatNotations

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -160,7 +160,7 @@ Ltac2 language
   (`#20516 <https://github.com/rocq-prover/rocq/pull/20516>`_,
   by Gaëtan Gilbert).
 - **Added:**
-  `rename`, `eassumption`, `cycle`, and `exfalso` Ltac2 notations
+  `rename` (in `Ltac1CompatNotations`), `eassumption`, `cycle`, and `exfalso` Ltac2 notations
   (`#20197 <https://github.com/rocq-prover/rocq/pull/20197>`_,
   by Josselin Poiret).
 - **Added:**

--- a/test-suite/ltac2/compat_tactics.v
+++ b/test-suite/ltac2/compat_tactics.v
@@ -1,0 +1,9 @@
+From Ltac2 Require Import Ltac2 Ltac1CompatNotations.
+
+(* rename *)
+Goal forall (x : nat), x = x.
+Proof.
+  intro x.
+  rename x into y.
+  exact (@eq_refl _ y).
+Qed.

--- a/test-suite/ltac2/std_tactics.v
+++ b/test-suite/ltac2/std_tactics.v
@@ -144,14 +144,6 @@ Proof.
   Std.apply true false [fun () => Control.plus (fun () => 'I) (fun _ => '0), Std.NoBindings] None.
 Qed.
 
-(* rename *)
-Goal forall (x : nat), x = x.
-Proof.
-  intro x.
-  rename x into y.
-  exact (@eq_refl _ y).
-Qed.
-
 (* eassumption *)
 Goal forall (x : nat) y z, x = y -> y = z -> x = z.
 Proof.

--- a/theories/Ltac2/Ltac1CompatNotations.v
+++ b/theories/Ltac2/Ltac1CompatNotations.v
@@ -18,3 +18,6 @@
 Require Import Ltac2.Init Ltac2.Std.
 
 Ltac2 Notation "transitivity" c(constr) : 1 := Std.transitivity c.
+
+Ltac2 Notation "rename" renames(list1(seq(ident, "into", ident), ",")) :=
+  Std.rename renames.

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -512,9 +512,6 @@ Ltac2 symmetry0 cl :=
 Ltac2 Notation "symmetry" cl(opt(clause)) := symmetry0 cl.
 Ltac2 Notation symmetry := symmetry.
 
-Ltac2 Notation "rename" renames(list1(seq(ident, "into", ident), ",")) :=
-  Std.rename renames.
-
 Ltac2 Notation "revert" ids(list1(ident)) := Std.revert ids.
 
 Ltac2 Notation assumption := Std.assumption ().


### PR DESCRIPTION
It's new in 9.1, so we can do a rc2 with this change and not have a deprecation phase.
