### PR TITLE
Require a more recent version of Yojson.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -57,8 +57,8 @@ prelude, now living in the rocq-core package."))
  (name rocq-devtools)
  (depends
   (rocq-runtime (= :version))
-   yojson
-   camlzip)
+  (yojson (>= 2.0))
+  camlzip)
  (synopsis "Development tools for Rocq")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
 a formal language to write mathematical definitions, executable

--- a/rocq-devtools.opam
+++ b/rocq-devtools.opam
@@ -27,7 +27,7 @@ bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
   "rocq-runtime" {= version}
-  "yojson"
+  "yojson" {>= "2.0"}
   "camlzip"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
The type `Yojson.Basic.t` used by `dev/bench/profparser.ml` did not exist in Yojson 1.5.

The issue appeared when submitting the 9.1+rc1 packages to the main Opam repository.