### PR TITLE
Do not overwrite modules when extracting abstract subcomponents.

### DIFF
--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -190,9 +190,14 @@ let vm_state =
 
 let expand_mexpr env mp me =
   let inl = Some (Flags.get_inline_level()) in
+  (* hack: in order not to overwrite the module binding mp, we first give it a
+     name that should not be part of the env and then substitute it away *)
+  let mp0 = ModPath.dummy in
   let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
-  let mb, (_, cst), _ = Mod_typing.translate_module state vm_state env mp inl (MExpr ([], me, None)) in
-  mod_type mb, mod_delta mb
+  let mb, (_, cst), _ = Mod_typing.translate_module state vm_state env mp0 inl (MExpr ([], me, None)) in
+  let sign = mod_type mb in
+  let reso = mod_delta mb in
+  Modops.subst_modtype_signature_and_resolver mp0 mp sign reso
 
 let expand_modtype env mp me =
   let inl = Some (Flags.get_inline_level()) in

--- a/test-suite/bugs/bug_20989.v
+++ b/test-suite/bugs/bug_20989.v
@@ -1,0 +1,20 @@
+From Corelib Require Import Extraction.
+
+Extraction Language Haskell.
+
+Module Type S.
+Definition n := 0.
+End S.
+
+Module A.
+Definition n := 0.
+End A.
+
+Module M (X : S).
+Module In := X.
+Definition n := In.n.
+End M.
+
+Module N := M(A).
+
+Recursive Extraction N.


### PR DESCRIPTION
This code path is only taken when extraction is targetting another language than OCaml. It tries to expand away the contents of the module, but when facing abstract modules such as bound parameters, it had the unfortunate side-effect of overwriting the module binding. We fix this by expanding it to a dummy name that is substituted away right after.