### PR TITLE
Move Proof Mode and SSR chapter one level up.

### DIFF
--- a/doc/sphinx/index.html.rst
+++ b/doc/sphinx/index.html.rst
@@ -20,7 +20,9 @@ Contents
 .. toctree::
    :caption: Proofs
 
+   proofs/writing-proofs/proof-mode
    proofs/writing-proofs/index
+   proof-engine/ssreflect-proof-language
    proofs/automatic-tactics/index
    proofs/creating-tactics/index
 

--- a/doc/sphinx/index.latex.rst
+++ b/doc/sphinx/index.latex.rst
@@ -25,7 +25,9 @@ Proofs
 
 .. toctree::
 
+   proofs/writing-proofs/proof-mode
    proofs/writing-proofs/index
+   proof-engine/ssreflect-proof-language
    proofs/automatic-tactics/index
    proofs/creating-tactics/index
 

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -47,8 +47,9 @@ This manual is organized in three main parts, plus an appendix:
   "elaboration process".
 
 - **The second part presents proof mode**, the central
-  feature of the Rocq Prover.  :ref:`writing-proofs` introduces this interactive
-  mode and the available proof languages.
+  feature of the Rocq Prover.  :ref:`proofhandling` introduces this interactive
+  mode, then :ref:`tactics` introduces the standard Rocq tactics and
+  :ref:`thessreflectprooflanguage` presents the alternative SSReflect tactics.
   :ref:`automatic-tactics` presents some more advanced tactics, while
   :ref:`writing-tactics` is about the languages that allow a user to
   combine tactics together and develop new ones.

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -137,7 +137,7 @@ Assertions and proofs
 An assertion states a proposition (or a type) for which the proof (or an
 inhabitant of the type) is interactively built using :term:`tactics <tactic>`.
 Assertions cause Rocq to enter :term:`proof mode` (see :ref:`proofhandling`).
-Common tactics are described in the :ref:`writing-proofs` chapter.
+Common tactics are described in the :ref:`tactics` chapter.
 The basic assertion command is:
 
 .. cmd:: @thm_token @ident_decl {* @binder } : @type {* with @ident_decl {* @binder } : @type }
@@ -200,7 +200,7 @@ The basic assertion command is:
 
 Proofs start with the keyword :cmd:`Proof`. Then Rocq enters the proof mode
 until the proof is completed. In proof mode, the user primarily enters
-tactics (see :ref:`writing-proofs`). The user may also enter
+tactics (see :ref:`tactics`). The user may also enter
 commands to manage the proof mode (see :ref:`proofhandling`).
 
 When the proof is complete, use the :cmd:`Qed` command so the kernel verifies

--- a/doc/sphinx/language/core/index.rst
+++ b/doc/sphinx/language/core/index.rst
@@ -12,7 +12,7 @@ users have access to a language with many convenient features such as
 the core language (the Calculus of Inductive Constructions) that the
 kernel understands, which we present here.  Furthermore, while users
 can build proofs interactively using tactics (see Chapter
-:ref:`writing-proofs`), the role of these tactics is to incrementally
+:ref:`tactics`), the role of these tactics is to incrementally
 build a "proof term" which the kernel will verify.  More precisely, a
 proof term is a :term:`term` of the Calculus of Inductive
 Constructions whose :term:`type` corresponds to a theorem statement.
@@ -21,7 +21,7 @@ expected types.
 
 This separation between the kernel on one hand and the
 :ref:`elaboration engine <extensions>` and :ref:`tactics
-<writing-proofs>` on the other follows what is known as the :gdef:`de
+<tactics>` on the other follows what is known as the :gdef:`de
 Bruijn criterion` (keeping a small and well delimited trusted code
 base within a proof assistant which can be much more complex).  This
 separation makes it necessary to trust only a smaller, critical

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -16,19 +16,19 @@ proof methodology. Despite the original purpose, this set of tactics is
 of general interest and is available in Rocq starting from version 8.7.
 
 |SSR| was developed independently of the tactics described in
-Chapter :ref:`tactics`. Indeed the scope of the tactics part of |SSR| largely
+:ref:`tactics`. Indeed the scope of the tactics part of |SSR| largely
 overlaps with the standard set of tactics. Eventually the overlap will
 be reduced in future releases of Rocq.
 
 Proofs written in |SSR| typically look quite different from the
-ones written using only tactics as per Chapter :ref:`tactics`. We try to
+ones written using only tactics described in :ref:`tactics`. We try to
 summarise here the most “visible” ones in order to help the reader
-already accustomed to the tactics described in Chapter :ref:`tactics` to read
+already accustomed to the tactics in :ref:`tactics` to read
 this chapter.
 
 The first difference between the tactics described in this chapter and the
-tactics described in Chapter :ref:`tactics` is the way hypotheses are managed
-(we call this *bookkeeping*). In Chapter :ref:`tactics` the most common
+tactics described in :ref:`tactics` is the way hypotheses are managed
+(we call this *bookkeeping*). In :ref:`tactics` the most common
 approach is to avoid moving explicitly hypotheses back and forth between the
 context and the conclusion of the goal. On the contrary, in |SSR| all
 bookkeeping is performed on the conclusion of the goal, using for that
@@ -39,16 +39,16 @@ conclusion to the context, and ``in`` moves back and forth a hypothesis from the
 context to the conclusion for the time of applying an action to it.
 
 While naming hypotheses is commonly done by means of an ``as`` clause in the
-basic model of Chapter :ref:`tactics`, it is here to ``=>`` that this task is
+basic model of :ref:`tactics`, it is here to ``=>`` that this task is
 devoted. Tactics frequently leave new assumptions in the conclusion, and are
 often followed by ``=>`` to explicitly name them. While generalizing the
-goal is normally not explicitly needed in Chapter :ref:`tactics`, it is an
+goal is normally not explicitly needed in :ref:`tactics`, it is an
 explicit operation performed by ``:``.
 
 .. seealso:: :ref:`bookkeeping_ssr`
 
 Besides the difference of bookkeeping model, this chapter includes
-specific tactics that have no explicit counterpart in Chapter :ref:`tactics`
+specific tactics that have no explicit counterpart in :ref:`tactics`
 such as tactics to mix forward steps and generalizations as
 :tacn:`generally have` or :tacn:`without loss`.
 

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1,51 +1,6 @@
-.. _tactics:
-
-Tactics
-========
-
-Tactics specify how to transform the :term:`proof state` of an
-incomplete proof to eventually generate a complete proof.
-
-Proofs can be developed in two basic ways: In :gdef:`forward reasoning`,
-the proof begins by proving simple statements that are then combined to prove the
-theorem statement as the last step of the proof. With forward reasoning,
-for example,
-the proof of `A /\\ B` would begin with proofs of `A` and `B`, which are
-then used to prove `A /\\ B`.  Forward reasoning is probably the most common
-approach in human-generated proofs.
-
-In :gdef:`backward reasoning`, the proof begins with the theorem statement
-as the goal, which is then gradually transformed until every subgoal generated
-along the way has been proven.  In this case, the proof of `A /\\ B` begins
-with that formula as the goal.  This can be transformed into two subgoals,
-`A` and `B`, followed by the proofs of `A` and `B`.  Rocq and its tactics
-primarily use backward reasoning.
-
-A tactic may fully prove a goal, in which case the goal is removed
-from the proof state.
-More commonly, a tactic replaces a goal with one or more :term:`subgoals <subgoal>`.
-(We say that a tactic reduces a goal to its subgoals.)
-
-Most tactics require specific elements or preconditions to reduce a goal;
-they display error messages if they can't be applied to the goal.
-A few tactics, such as :tacn:`auto`, don't fail even if the proof state
-is unchanged.
-
-Goals are identified by number. The current goal is number
-1. Tactics are applied to the current goal by default.  (The
-default can be changed with the :opt:`Default Goal Selector`
-option.)  They can
-be applied to another goal or to multiple goals with a
-:ref:`goal selector <goal-selectors>` such as :n:`2: @tactic`.
-
-This chapter describes many of the most common built-in tactics.
-Built-in tactics can be combined to form tactic expressions, which are
-described in the :ref:`Ltac` chapter.  Since tactic expressions can
-be used anywhere that a built-in tactic can be used, "tactic" may
-refer to both built-in tactics and tactic expressions.
-
+==========================
 Common elements of tactics
---------------------------
+==========================
 
 Reserved keywords
 ~~~~~~~~~~~~~~~~~
@@ -610,8 +565,9 @@ Automatic clearing of hypotheses
 
 .. _applyingtheorems:
 
+=================
 Applying theorems
----------------------
+=================
 
 .. tacn:: exact @one_term
 
@@ -1110,8 +1066,9 @@ Applying theorems
 
 .. _managingthelocalcontext:
 
+==========================
 Managing the local context
-------------------------------
+==========================
 
 .. tacn:: intro {? @ident } {? @where }
 
@@ -1475,8 +1432,9 @@ Managing the local context
 
 .. _controllingtheproofflow:
 
+==========================
 Controlling the proof flow
-------------------------------
+==========================
 
 .. tacn:: assert ( @ident : @type ) {? by @ltac_expr3 }
           assert ( @ident := @term )
@@ -1859,8 +1817,9 @@ Controlling the proof flow
    then required to prove that False is indeed provable in the current
    context.
 
+=================
 Classical tactics
------------------
+=================
 
 In order to ease the proving process, when the ``Classical`` module is
 loaded, a few more tactics are available. Make sure to load the module
@@ -1876,8 +1835,9 @@ using the :cmd:`Require Import` command.
    Use :tacn:`classical_right` to prove the right part of the disjunction with
    the assumption that the negation of left part holds.
 
+====================================
 Performance-oriented tactic variants
-------------------------------------
+====================================
 
 .. todo: move the following adjacent to the `exact` tactic?
 

--- a/doc/sphinx/proofs/writing-proofs/index.rst
+++ b/doc/sphinx/proofs/writing-proofs/index.rst
@@ -1,29 +1,58 @@
-.. _writing-proofs:
+.. _tactics:
 
-===================
-Basic proof writing
-===================
+=============
+Basic tactics
+=============
 
-The Rocq Prover is a proof assistant (or interactive theorem prover), which means
-that proofs can be constructed interactively through a dialog between
-the user and the assistant.  The building blocks for this dialog are
-tactics which the user will use to represent steps in the proof of a
-theorem.
+:term:`Tactics <tactic>` specify how to transform the :term:`proof state` of an
+incomplete proof to eventually generate a complete proof.
 
-The first section presents the proof mode (the core mechanism of the
-dialog between the user and the proof assistant).  Then, several
-sections describe the available tactics.  The last section covers the
-SSReflect proof language, which provides a consistent alternative set
-of tactics to the standard basic tactics.
+This chapter introduces the basic tactics that are available in Rocq.
+An alternative set of tactics is provided by the SSReflect proof language,
+which is described in the :ref:`thessreflectprooflanguage` chapter.
+Additional tactics are documented in the :ref:`automatic-tactics` chapter.
 
-Additional tactics are documented in the next chapter
-:ref:`automatic-tactics`.
+Proofs can be developed in two basic ways: In :gdef:`forward reasoning`,
+the proof begins by proving simple statements that are then combined to prove the
+theorem statement as the last step of the proof. With forward reasoning,
+for example,
+the proof of `A /\\ B` would begin with proofs of `A` and `B`, which are
+then used to prove `A /\\ B`.  Forward reasoning is probably the most common
+approach in human-generated proofs.
+
+In :gdef:`backward reasoning`, the proof begins with the theorem statement
+as the goal, which is then gradually transformed until every subgoal generated
+along the way has been proven.  In this case, the proof of `A /\\ B` begins
+with that formula as the goal.  This can be transformed into two subgoals,
+`A` and `B`, followed by the proofs of `A` and `B`.  Rocq and its tactics
+primarily use backward reasoning.
+
+A tactic may fully prove a goal, in which case the goal is removed
+from the proof state.
+More commonly, a tactic replaces a goal with one or more :term:`subgoals <subgoal>`.
+(We say that a tactic reduces a goal to its subgoals.)
+
+Most tactics require specific elements or preconditions to reduce a goal;
+they display error messages if they can't be applied to the goal.
+A few tactics, such as :tacn:`auto`, don't fail even if the proof state
+is unchanged.
+
+Goals are identified by number (and optionally given names).  The current goal is number
+1. Tactics are applied to the current goal by default.  (The
+default can be changed with the :opt:`Default Goal Selector`
+option.)  They can
+be applied to another goal or to multiple goals with a
+:ref:`goal selector <goal-selectors>` such as :n:`2: @tactic`.
+
+This chapter describes many of the most common built-in tactics.
+Built-in tactics can be combined to form tactic expressions, which are
+described in the :ref:`Ltac` chapter.  Since tactic expressions can
+be used anywhere that a built-in tactic can be used, "tactic" may
+refer to both built-in tactics and tactic expressions.
 
 .. toctree::
    :maxdepth: 1
 
-   proof-mode
    ../../proof-engine/tactics
    equality
    reasoning-inductives
-   ../../proof-engine/ssreflect-proof-language

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -4,10 +4,15 @@
 Proof mode
 ----------
 
+The Rocq Prover is a proof assistant (or interactive theorem prover), which allows
+users to interactively construct proofs through a dialog with the assistant.  The assistant
+ensures the validity of each step of the proof.  :term:`Tactics <tactic>`, which represent
+steps in the proof of a theorem, are the building blocks for this dialog.
+
 :gdef:`Proof mode <proof mode>` is used to prove theorems.
 Rocq enters proof mode when you begin a proof,
 such as with the :cmd:`Theorem` command.  It exits proof mode when
-you complete a proof, such as with the :cmd:`Qed` command.  Tactics,
+you complete a proof, such as with the :cmd:`Qed` command.  :term:`Tactics <tactic>`,
 which are available only in proof mode, incrementally transform incomplete
 proofs to eventually generate a complete proof.
 

--- a/doc/sphinx/using/libraries/index.rst
+++ b/doc/sphinx/using/libraries/index.rst
@@ -10,7 +10,7 @@ plugins can add new tactics and commands written in OCaml.
 
 The Rocq Prover is distributed with a standard library and a set of internal
 plugins (most of which provide tactics that have already been
-presented in :ref:`writing-proofs`).  This chapter presents this
+presented in :ref:`tactics`).  This chapter presents this
 standard library and some of these internal plugins which provide
 features that are not tactics.
 


### PR DESCRIPTION
Transform writing proofs chapter in tactics chapter. Bring sections of former tactics chapter one level up.

I started experimenting with this after a discussion with Jim Fehrle in #20986 (more precisely https://github.com/rocq-prover/rocq/pull/20986#issuecomment-3145576965 and https://github.com/rocq-prover/rocq/pull/20986#issuecomment-3151060200) and I like the result. I feel in particular like it gets rid of the previous duality between the writing-proof index and the tactics chapter (former very long chapter of which some parts had been moved out).

I reuse the technic from #19759 of having several main titles at the same level in a rst file so that they are listed in the index of the above chapter.