### PR TITLE
Change the failing behaviour of Option.get to an assertion failure.

### DIFF
--- a/clib/option.ml
+++ b/clib/option.ml
@@ -41,13 +41,10 @@ let hash f = function
   | None -> 0
   | Some x -> f x
 
-exception IsNone
-
-(** [get x] returns [y] where [x] is [Some y].
-    @raise IsNone if [x] equals [None]. *)
+(** [get x] returns [y] where [x] is [Some y] and asserts false otherwise. *)
 let get = function
   | Some y -> y
-  | _ -> raise IsNone
+  | None -> assert false
 
 (** [make x] returns [Some x]. *)
 let make x = Some x

--- a/clib/option.mli
+++ b/clib/option.mli
@@ -15,8 +15,6 @@
    they actually are similar considering ['a option] as a type
    of lists with at most one element. *)
 
-exception IsNone
-
 (** [has_some x] is [true] if [x] is of the form [Some y] and [false]
     otherwise.  *)
 val has_some : 'a option -> bool
@@ -36,8 +34,7 @@ val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
 (** Lift a hash to option types. *)
 val hash : ('a -> int) -> 'a option -> int
 
-(** [get x] returns [y] where [x] is [Some y].
-    @raise IsNone if [x] equals [None]. *)
+(** [get x] returns [y] where [x] is [Some y], and asserts false otherwise. *)
 val get : 'a option -> 'a
 
 (** [make x] returns [Some x]. *)

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -274,14 +274,18 @@ let id_of_qvar uctx l =
 
 let is_rigid_qvar uctx q = QState.is_rigid uctx.sort_variables q
 
+let get_uname info = match info.uname with
+| None -> raise Not_found
+| Some id -> id
+
 let qualid_of_qvar_names (bind, (qrev,_)) l =
-  try Some (Libnames.qualid_of_ident (Option.get (QVar.Map.find l qrev).uname))
-  with Not_found | Option.IsNone ->
+  try Some (Libnames.qualid_of_ident (get_uname (QVar.Map.find l qrev)))
+  with Not_found ->
     UnivNames.qualid_of_quality bind l
 
 let qualid_of_level_names (bind, (_,urev)) l =
-  try Some (Libnames.qualid_of_ident (Option.get (Level.Map.find l urev).uname))
-  with Not_found | Option.IsNone ->
+  try Some (Libnames.qualid_of_ident (get_uname (Level.Map.find l urev)))
+  with Not_found ->
     UnivNames.qualid_of_level bind l
 
 let qualid_of_level uctx l = qualid_of_level_names uctx.names l
@@ -366,14 +370,14 @@ let compute_instance_binders uctx inst =
   let qinst, uinst = Instance.to_array inst in
   let qmap = function
     | QVar q ->
-      begin try Name (Option.get (QVar.Map.find q qrev).uname)
-      with Option.IsNone | Not_found -> Anonymous
+      begin try Name (get_uname (QVar.Map.find q qrev))
+      with Not_found -> Anonymous
       end
     | QConstant _ -> assert false
   in
   let umap lvl =
-    try Name (Option.get (Level.Map.find lvl urev).uname)
-    with Option.IsNone | Not_found -> Anonymous
+    try Name (get_uname (Level.Map.find lvl urev))
+    with Not_found -> Anonymous
   in
   {quals = Array.map qmap qinst; univs =  Array.map umap uinst}
 

--- a/ide/rocqide/document.ml
+++ b/ide/rocqide/document.ml
@@ -135,7 +135,10 @@ let is_empty = function
 
 let context d =
   let top, _, bot = to_lists d in
-  let pair _ x y = try Option.get x, y with Option.IsNone -> assert false in
+  let pair _ x y = match x with
+  | None -> assert false
+  | Some x -> x, y
+  in
   List.map (flat pair true) top, List.map (flat pair true) bot
 
 let stateid_opt_equal = Option.equal Stateid.equal

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1114,10 +1114,9 @@ let prove_fun_complete funcs graphs schemes lemmas_types_infos i :
               || Rtree.is_infinite Declareops.eq_recarg
                    graph_def.Declarations.mind_recargs
             then
-              let eq_lemma =
-                try Option.get infos.equation_lemma
-                with Option.IsNone ->
-                  CErrors.anomaly (Pp.str "Cannot find equation lemma.")
+              let eq_lemma = match infos.equation_lemma with
+              | None -> CErrors.anomaly (Pp.str "Cannot find equation lemma.")
+              | Some lemma -> lemma
               in
               tclTHENLIST
                 [ tclMAP Simple.intro ids

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -142,15 +142,19 @@ let invfun qhyp f =
       match EConstr.kind sigma hyp_typ with
       | App (eq, args) when EConstr.eq_constr sigma eq (make_eq ()) -> (
         let f1, _ = decompose_app sigma args.(1) in
+        let get_opt = function
+        | None -> raise NoFunction
+        | Some v -> v
+        in
         try
           if not (isConst sigma f1) then raise NoFunction;
           let finfos =
-            Option.get (find_Function_infos (fst (destConst sigma f1)))
+            get_opt (find_Function_infos (fst (destConst sigma f1)))
           in
-          let f_correct = mkConst (Option.get finfos.correctness_lemma)
-          and kn = fst finfos.graph_ind in
+          let f_correct = mkConst (get_opt finfos.correctness_lemma) in
+          let kn = fst finfos.graph_ind in
           functional_inversion kn hid f1 f_correct
-        with NoFunction | Option.IsNone ->
+        with NoFunction ->
           let f2, _ = decompose_app sigma args.(2) in
           if isConst sigma f2 then
             match find_Function_infos (fst (destConst sigma f2)) with

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -315,9 +315,7 @@ let unfoldintac occ rdx t (kt,_) =
         with e when CErrors.noncritical e -> errorstrm Pp.(str "The term " ++
           pr_econstr_env env sigma c ++spc()++ str "does not unify with " ++ pr_econstr_pat env sigma t)),
     ignore in
-  let concl =
-    try beta env0 (eval_pattern env0 sigma0 concl0 rdx occ unfold)
-    with Option.IsNone -> errorstrm Pp.(str"Failed to unfold " ++ pr_econstr_pat env0 sigma t) in
+  let concl = beta env0 (eval_pattern env0 sigma0 concl0 rdx occ unfold) in
   let () = conclude () in
   convert_concl ~check:true concl
   end

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -585,8 +585,8 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
       let possible_guard = (possible_guard, fixrs) in
       Some (Declare.Obls.add_mutual_definitions ~pm ~cinfo ~info ~opaque:false ~uctx ~bodies ~possible_guard ?using obls), None)
   | None ->
-    try
-      let bodies = List.map Option.get bodies in
+    match Option.List.map (fun x -> x) bodies with
+    | Some bodies ->
       let uctx = Evd.ustate sigma in
       (* All bodies are defined *)
       let possible_guard = (possible_guard, fixrs) in
@@ -594,7 +594,7 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
         Declare.declare_mutual_definitions ~cinfo ~info ~opaque:false ~uctx ~possible_guard ~bodies ?using ()
       in
       None, None
-    with Option.IsNone ->
+    | None ->
       (* At least one undefined body *)
       Evd.check_univ_decl_early ~poly ~with_obls:false sigma udecl (Option.List.flatten bodies @ fixtypes);
       let possible_guard = (possible_guard, fixrs) in

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -298,9 +298,12 @@ let create_custom_entry s =
 
 let find_custom_entry s =
   let state = gramstate() in
-  let find_aux field = CustomName.Map.find s (Option.get @@ GramState.get state field) in
+  let find_aux field = match GramState.get state field with
+  | None -> raise Not_found
+  | Some m -> CustomName.Map.find s m
+  in
   try (find_aux constr_custom_map, find_aux pattern_custom_map)
-  with Not_found | Option.IsNone ->
+  with Not_found ->
     anomaly Pp.(str "Undeclared custom entry: " ++ CustomName.print s ++ str ".")
 
 (** This computes the name of the level where to add a new rule *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -143,7 +143,7 @@ let with_section_locality ~atts f =
 let show_proof ~pstate =
   (* spiwack: this would probably be cooler with a bit of polishing. *)
   try
-    let pstate = Option.get pstate in
+    let pstate = match pstate with None -> raise Exit | Some s -> s in
     let p = Declare.Proof.get pstate in
     let sigma, _ = Declare.Proof.get_current_context pstate in
     let pprf = Proof.partial_proof p in
@@ -156,8 +156,7 @@ let show_proof ~pstate =
     Pp.prlist_with_sep Pp.fnl (Printer.pr_econstr_env env sigma) pprf
   (* We print nothing if there are no goals left *)
   with
-  | Proof.NoSuchGoal _
-  | Option.IsNone ->
+  | Proof.NoSuchGoal _ | Exit ->
     user_err (str "No goals to show.")
 
 let show_top_evars ~proof =


### PR DESCRIPTION
This is in line with all other APIs called get, and it removes a very dubious case of exception-raising for potential control flow. The very point of option types is to do a case analysis on a exception case, no need to introduce a dynamic exception for that.