### PR TITLE
Properly update resolvers of submodules when performing strengthening.

### DIFF
--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -273,7 +273,8 @@ let rec strengthen_and_subst_module mb subst mp_from mp_to =
         strengthen_and_subst_struct struc subst
           mp_from mp_to false false delta_mb
       in
-      let reso' = add_mp_delta_resolver mp_to mp_from reso' in
+      (* Don't forget to add the original resolver up to substitution *)
+      let reso' = add_delta_resolver (subst_dom_delta_resolver subst delta_mb) (add_mp_delta_resolver mp_to mp_from reso') in
       strengthen_module_body ~src:mp_from (NoFunctor struc') reso' mb
   | MoreFunctor _ ->
     let subst = add_mp mp_from mp_to (empty_delta_resolver mp_to) subst in


### PR DESCRIPTION
An implicit invariant of delta-resolvers is that when nesting non-functor modules, the resolver associated to an inner module is equal to one obtained by taking the resolver of the encompassing module and restricting it to the submodule modpath. Said otherwise, resolvers from inner modules are completely redundant.

The previous code was losing the original resolver from the inner module when performing aliasing calls like e.g. Module M := N, leading to a breakage of this implicit invariant. This was leading to further silent issues down the road but since the module code is not well-excercised, this flew under the radar.