### PR TITLE
Various cleanups of the global extraction state

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -211,7 +211,7 @@ module DupMap = CMap.Make(DupOrd)
 *)
 
 type visible_layer = { mp : ModPath.t;
-                       params : ModPath.t list;
+                       params : MBId.t list;
                        content : Label.t KMap.t; }
 
 module State =
@@ -505,10 +505,10 @@ let mpfiles_clash table mp0 ks =
 
 let rec params_lookup table mp0 ks = function
   | [] -> false
-  | param :: _ when ModPath.equal mp0 param -> true
+  | param :: _ when ModPath.equal mp0 (MPbound param) -> true
   | param :: params ->
       let () = match ks with
-      | (Mod, mp) when String.equal (List.hd (mp_renaming table param)) mp -> State.add_params_ren table param
+      | (Mod, mp) when String.equal (List.hd (mp_renaming table (MPbound param))) mp -> State.add_params_ren table (MPbound param)
       | _ -> ()
       in
       params_lookup table mp0 ks params

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -452,7 +452,7 @@ let rec mp_renaming_fun table mp = match mp with
       assert (State.get_phase table == Pre);
       let current_mpfile = (List.last (State.get_visible table)).mp in
       if not (ModPath.equal mp current_mpfile) then State.add_mpfiles table f;
-      [string_of_modfile (State.get_table table) mp]
+      [string_of_modfile (State.get_table table) f]
 
 (* ... and its version using a cache *)
 
@@ -551,7 +551,7 @@ let opened_libraries table =
   if not (State.get_modular table) then DirPath.Set.empty
   else
     let used_files = DirPath.Set.elements (State.get_mpfiles table) in
-    let used_ks = List.map (fun dp -> Mod, string_of_modfile (State.get_table table) (MPfile dp)) used_files in
+    let used_ks = List.map (fun dp -> Mod, string_of_modfile (State.get_table table) dp) used_files in
     (* By default, we open all used files. Ambiguities will be resolved later
        by using qualified names. Nonetheless, we don't open any file A that
        contains an immediate submodule A.B hiding another file B : otherwise,

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -220,8 +220,8 @@ struct
 type state = {
   global_ids : Id.Set.t;
   mod_index : int Id.Map.t;
-  ref_renaming : pp_tag list Refmap'.t;
-  mp_renaming : pp_tag list ModPath.Map.t;
+  ref_renaming : string list Refmap'.t;
+  mp_renaming : string list ModPath.Map.t;
   params_ren : MBId.Set.t; (* List of module parameters that we should alpha-rename *)
   mpfiles : ModPath.Set.t; (* List of external modules that will be opened initially *)
   duplicates : int * string DupMap.t; (* table of local module wrappers used to provide non-ambiguous names *)

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -58,7 +58,7 @@ sig
 
   (** Reader-like *)
 
-  val with_visibility : t -> ModPath.t -> ModPath.t list -> (t -> 'a) -> 'a
+  val with_visibility : t -> ModPath.t -> MBId.t list -> (t -> 'a) -> 'a
   (* the [module_path list] corresponds to module parameters, the innermost one
     coming first in the list *)
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -78,7 +78,7 @@ val rename_tvars: Id.Set.t -> Id.t list -> Id.t list
 val push_vars : Id.t list -> env -> Id.t list * env
 val get_db_name : int -> env -> Id.t
 
-val opened_libraries : State.t -> ModPath.t list
+val opened_libraries : State.t -> DirPath.Set.t
 
 type kind = Term | Type | Cons | Mod
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -656,7 +656,7 @@ let print_structure_to_file table (fn,si,mo) dry struc =
 (*s Part III: the actual extraction commands *)
 (*********************************************)
 
-let init ?(inner=false) modular library =
+let init ?(inner=false) ~modular ~library () =
   if not inner then check_inside_section ();
   let keywords = (descr ()).keywords in
   let state = State.make ~modular ~library ~keywords () in
@@ -697,7 +697,7 @@ let rec locate_ref = function
     \verb!Extraction "file"! [qualid1] ... [qualidn]. *)
 
 let full_extr opaque_access f (refs,mps) =
-  let table = init false false in
+  let table = init ~modular:false ~library:false () in
   List.iter (fun mp -> if is_modfile mp then error_MPfile_as_mod mp true) mps;
   let struc = optimize_struct table (refs,mps) (mono_environment table ~opaque_access refs mps) in
   let () = warns table in
@@ -710,7 +710,7 @@ let full_extraction ~opaque_access f lr =
    decomposed in many files, one per Rocq .v file *)
 
 let separate_extraction ~opaque_access lr =
-  let table = init true false in
+  let table = init ~modular:true ~library:false () in
   let refs,mps = locate_ref lr in
   let struc = optimize_struct table (refs,mps) (mono_environment table ~opaque_access refs mps) in
   let () = List.iter (function
@@ -735,7 +735,7 @@ let simple_extraction ~opaque_access r =
   match locate_ref [r] with
   | ([], [mp]) as p -> full_extr opaque_access None p
   | [r],[] ->
-      let table = init false false in
+      let table = init ~modular:false ~library:false () in
       let struc = optimize_struct table ([r],[]) (mono_environment table ~opaque_access [r] []) in
       let d = get_decl_in_structure r struc in
       let () = warns table in
@@ -752,7 +752,7 @@ let simple_extraction ~opaque_access r =
   \verb!(Recursive) Extraction Library! [M]. *)
 
 let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
-  let table = init true true in
+  let table = init ~modular:true ~library:true () in
   let dir_m =
     (* XXX WTF is going on here? *)
     let q = qualid_of_ident m in
@@ -819,7 +819,7 @@ let extract_and_compile ~opaque_access l =
 
 (* Show the extraction of the current ongoing proof *)
 let show_extraction ~pstate =
-  let table = init ~inner:true false false in
+  let table = init ~inner:true ~modular:false ~library:false () in
   let prf = Declare.Proof.get pstate in
   let sigma, env = Declare.Proof.get_current_context pstate in
   let trms = Proof.partial_proof prf in

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -721,8 +721,8 @@ let separate_extraction ~opaque_access lr =
   in
   let () = warns table in
   let print = function
-    | (MPfile dir as mp, sel) as e ->
-        print_structure_to_file table (module_filename table mp) false [e]
+    | (MPfile dir, sel) as e ->
+        print_structure_to_file table (module_filename table dir) false [e]
     | (MPdot _ | MPbound _), _ -> assert false
   in
   let () = List.iter print struc in
@@ -772,9 +772,9 @@ let extraction_library ~opaque_access is_rec CAst.{loc;v=m} =
   let struc = optimize_struct table ([],[]) struc in
   let () = warns table in
   let print = function
-    | (MPfile dir as mp, sel) as e ->
+    | (MPfile dir, sel) as e ->
         let dry = not is_rec && not (DirPath.equal dir dir_m) in
-        print_structure_to_file table (module_filename table mp) dry [e]
+        print_structure_to_file table (module_filename table dir) dry [e]
     | _ -> assert false
   in
   let () = List.iter print struc in

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -38,7 +38,7 @@ let pp_bracket_comment s = str"{- " ++ hov 0 s ++ str" -}"
    the '\n' character interacts badly with the Format boxing mechanism *)
 
 let preamble table mod_name comment used_modules usf =
-  let pp_import mp = str ("import qualified "^ string_of_modfile (State.get_table table) mp) ++ fnl ()
+  let pp_import dp = str ("import qualified "^ string_of_modfile (State.get_table table) (MPfile dp)) ++ fnl ()
   in
   (if not (usf.magic || usf.tunknown) then mt ()
    else
@@ -51,7 +51,7 @@ let preamble table mod_name comment used_modules usf =
   ++
   str "module " ++ pr_upper_id mod_name ++ str " where" ++ fnl2 () ++
   str "import qualified Prelude" ++ fnl () ++
-  prlist pp_import used_modules ++ fnl ()
+  prlist pp_import (DirPath.Set.elements used_modules) ++ fnl ()
   ++
   (if not (usf.magic || usf.tunknown) then mt ()
    else

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -38,7 +38,7 @@ let pp_bracket_comment s = str"{- " ++ hov 0 s ++ str" -}"
    the '\n' character interacts badly with the Format boxing mechanism *)
 
 let preamble table mod_name comment used_modules usf =
-  let pp_import dp = str ("import qualified "^ string_of_modfile (State.get_table table) (MPfile dp)) ++ fnl ()
+  let pp_import dp = str ("import qualified "^ string_of_modfile (State.get_table table) dp) ++ fnl ()
   in
   (if not (usf.magic || usf.tunknown) then mt ()
    else

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -56,7 +56,7 @@ let preamble table mod_name comment used_modules usf =
     ("need_magic", json_bool (usf.magic));
     ("need_dummy", json_bool (usf.mldummy));
     ("used_modules", json_list
-      (List.map (fun mf -> json_str (file_of_modfile (State.get_table table) (MPfile mf))) (DirPath.Set.elements used_modules)))
+      (List.map (fun mf -> json_str (file_of_modfile (State.get_table table) mf)) (DirPath.Set.elements used_modules)))
   ]
 
 

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -56,7 +56,7 @@ let preamble table mod_name comment used_modules usf =
     ("need_magic", json_bool (usf.magic));
     ("need_dummy", json_bool (usf.mldummy));
     ("used_modules", json_list
-      (List.map (fun mf -> json_str (file_of_modfile (State.get_table table) mf)) used_modules))
+      (List.map (fun mf -> json_str (file_of_modfile (State.get_table table) (MPfile mf))) (DirPath.Set.elements used_modules)))
   ]
 
 

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -268,7 +268,7 @@ type 's language_descr = {
   file_naming : 's -> ModPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
-    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->
     Pp.t;
   pp_struct : 's -> ml_structure -> Pp.t;
 
@@ -276,7 +276,7 @@ type 's language_descr = {
   sig_suffix : string option;
   (* the second argument is a comment to add to the preamble *)
   sig_preamble :
-    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->
     Pp.t;
   pp_sig : 's -> ml_signature -> Pp.t;
 

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -265,7 +265,7 @@ type 's language_descr = {
 
   (* Concerning the source file *)
   file_suffix : string;
-  file_naming : 's -> ModPath.t -> string;
+  file_naming : 's -> DirPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
     's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -239,7 +239,7 @@ type 's language_descr = {
   file_naming : 's -> ModPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
-    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->
     Pp.t;
   pp_struct : 's -> ml_structure -> Pp.t;
 
@@ -247,7 +247,7 @@ type 's language_descr = {
   sig_suffix : string option;
   (* the second argument is a comment to add to the preamble *)
   sig_preamble :
-    's -> Id.t -> Pp.t option -> ModPath.t list -> unsafe_needs ->
+    's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->
     Pp.t;
   pp_sig : 's -> ml_signature -> Pp.t;
 

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -236,7 +236,7 @@ type 's language_descr = {
 
   (* Concerning the source file *)
   file_suffix : string;
-  file_naming : 's -> ModPath.t -> string;
+  file_naming : 's -> DirPath.t -> string;
   (* the second argument is a comment to add to the preamble *)
   preamble :
     's -> Id.t -> Pp.t option -> DirPath.Set.t -> unsafe_needs ->

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -59,7 +59,7 @@ let keywords =
 (* Note: do not shorten [str "foo" ++ fnl ()] into [str "foo\n"],
    the '\n' character interacts badly with the Format boxing mechanism *)
 
-let pp_open table mp = str ("open "^ string_of_modfile (State.get_table table) mp) ++ fnl ()
+let pp_open table dp = str ("open "^ string_of_modfile (State.get_table table) (MPfile dp)) ++ fnl ()
 
 let pp_comment s = str "(* " ++ hov 0 s ++ str " *)"
 
@@ -79,12 +79,12 @@ let pp_mldummy usf =
 
 let preamble table _ comment used_modules usf =
   pp_header_comment comment ++
-  then_nl (prlist (fun o -> pp_open table o) used_modules) ++
+  then_nl (prlist (fun o -> pp_open table o) (DirPath.Set.elements used_modules)) ++
   then_nl (pp_tdummy usf ++ pp_mldummy usf)
 
 let sig_preamble table _ comment used_modules usf =
   pp_header_comment comment ++
-  then_nl (prlist (fun o -> pp_open table o) used_modules) ++
+  then_nl (prlist (fun o -> pp_open table o) (DirPath.Set.elements used_modules)) ++
   then_nl (pp_tdummy usf)
 
 (*s The pretty-printer for Ocaml syntax*)

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -688,7 +688,7 @@ and pp_module_type table params = function
   | MTfunsig (mbid, mt, mt') ->
       let typ = pp_module_type table [] mt in
       let name = pp_modname table (MPbound mbid) in
-      let def = pp_module_type table (MPbound mbid :: params) mt' in
+      let def = pp_module_type table (mbid :: params) mt' in
       str "functor (" ++ name ++ str ":" ++ typ ++ str ") ->" ++ fnl () ++ def
   | MTsig (mp, sign) ->
       let l = State.with_visibility table mp params begin fun table ->
@@ -766,7 +766,7 @@ and pp_module_expr table params = function
   | MEfunctor (mbid, mt, me) ->
       let name = pp_modname table (MPbound mbid) in
       let typ = pp_module_type table [] mt in
-      let def = pp_module_expr table (MPbound mbid :: params) me in
+      let def = pp_module_expr table (mbid :: params) me in
       str "functor (" ++ name ++ str ":" ++ typ ++ str ") ->" ++ fnl () ++ def
   | MEstruct (mp, sel) ->
       let l = State.with_visibility table mp params begin fun table ->

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -59,7 +59,7 @@ let keywords =
 (* Note: do not shorten [str "foo" ++ fnl ()] into [str "foo\n"],
    the '\n' character interacts badly with the Format boxing mechanism *)
 
-let pp_open table dp = str ("open "^ string_of_modfile (State.get_table table) (MPfile dp)) ++ fnl ()
+let pp_open table dp = str ("open "^ string_of_modfile (State.get_table table) dp) ++ fnl ()
 
 let pp_comment s = str "(* " ++ hov 0 s ++ str " *)"
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -136,7 +136,7 @@ type table = {
   symbols : Label.t list Refmap'.t;
   opaques:  Refset'.t;
   modfile_ids : Id.Set.t;
-  modfile_mps : string ModPath.Map.t;
+  modfile_mps : string DirPath.Map.t;
 }
 
 type t = table ref
@@ -153,7 +153,7 @@ let empty_table = {
   symbols = Refmap'.empty;
   opaques = Refset'.empty;
   modfile_ids = Id.Set.empty;
-  modfile_mps = ModPath.Map.empty;
+  modfile_mps = DirPath.Map.empty;
 }
 
 let make_table () = ref { empty_table with modfile_ids = !blacklist_table }
@@ -857,25 +857,22 @@ let extraction_implicit r l =
   List.iter (fun r -> Lib.add_leaf (implicit_extraction (r, l))) r
 
 let string_of_modfile table mp =
-  try ModPath.Map.find mp !table.modfile_mps
+  try DirPath.Map.find mp !table.modfile_mps
   with Not_found ->
-    let id = Id.of_string (raw_string_of_modfile mp) in
+    let id = Id.of_string (raw_string_of_modfile (MPfile mp)) in
     let id' = next_ident_away id !table.modfile_ids in
     let s' = Id.to_string id' in
     table := { !table with
       modfile_ids = Id.Set.add id' !table.modfile_ids;
-      modfile_mps = ModPath.Map.add mp s' !table.modfile_mps;
+      modfile_mps = DirPath.Map.add mp s' !table.modfile_mps;
     };
     s'
 
 (* same as [string_of_modfile], but preserves the capital/uncapital 1st char *)
 
-let file_of_modfile table mp =
-  let s0 = match mp with
-    | MPfile f -> Id.to_string (List.hd (DirPath.repr f))
-    | _ -> assert false
-  in
-  String.mapi (fun i c -> if i = 0 then s0.[0] else c) (string_of_modfile table mp)
+let file_of_modfile table dp =
+  let s0 = Id.to_string (List.hd (DirPath.repr dp)) in
+  String.mapi (fun i c -> if i = 0 then s0.[0] else c) (string_of_modfile table dp)
 
 let add_blacklist_entries l =
   blacklist_table :=

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -136,7 +136,7 @@ type table = {
   symbols : Label.t list Refmap'.t;
   opaques:  Refset'.t;
   modfile_ids : Id.Set.t;
-  modfile_mps : pp_tag ModPath.Map.t;
+  modfile_mps : string ModPath.Map.t;
 }
 
 type t = table ref

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -54,8 +54,8 @@ val modpath_of_r : global -> ModPath.t
 val label_of_r : global -> Label.t
 val base_mp : ModPath.t -> ModPath.t
 val is_modfile : ModPath.t -> bool
-val string_of_modfile : t -> ModPath.t -> string
-val file_of_modfile : t -> ModPath.t -> string
+val string_of_modfile : t -> DirPath.t -> string
+val file_of_modfile : t -> DirPath.t -> string
 val is_toplevel : ModPath.t -> bool
 val at_toplevel : ModPath.t -> bool
 val mp_length : ModPath.t -> int


### PR DESCRIPTION
We use more precise types and enforce static invariants in the API wherever possible. This should not change the semantics.