### PR TITLE
Repair refman detecting errors

### DIFF
--- a/doc/sphinx/addendum/rewrite-rules.rst
+++ b/doc/sphinx/addendum/rewrite-rules.rst
@@ -1,4 +1,4 @@
-:COQTOP_ARGS: -allow-rewrite-rules
+:ROCQTOP_ARGS: -allow-rewrite-rules
 
 .. _rewrite_rules:
 

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -29,7 +29,7 @@ There is also a byte-code toplevel `rocq repl-with-drop` based on an OCaml tople
 You can switch to the OCaml toplevel with the command ``Drop.``,
 and come back to the Rocq toplevel with the command ``#go;;``.
 
-.. flag:: Coqtop Exit On Error
+.. flag:: Rocqtop Exit On Error
 
    This :term:`flag`, off by default, causes `rocq top` to exit with status code
    ``1`` if a command produces an error instead of recovering from it.

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1684,11 +1684,11 @@ must help the automation by giving some arguments, using the
 
 .. rocqtop:: in extra-stdlib
 
-   destruct D... apply weak; apply ax. apply ax.
+   destruct D; simpl in * ; simpl_depind ; auto. apply weak; apply ax. apply ax.
 
 .. rocqtop:: in extra-stdlib
 
-   destruct D...
+   destruct D; simpl in * ; simpl_depind ; auto.
 
 .. rocqtop:: all extra-stdlib
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -420,7 +420,7 @@ let top_goal_print ~doc c oldp newp =
 let { Goptions.get = exit_on_error } =
   let open Goptions in
   declare_bool_option_and_ref
-    ~key:["Coqtop";"Exit";"On";"Error"]
+    ~key:["Rocqtop";"Exit";"On";"Error"]
     ~value:false
     ()
 


### PR DESCRIPTION
Fixes #21010.

Instead of reverting the problematic changes from #20744, I just renamed the (internal) option `Coqtop Exit On Error` to match the expectations from #20744. I didn't do a changelog entry given that this is an internal option. Let me know if I should do one.

As we can see from the two other commits, the absence of this check was responsible for letting several failing examples slip by, and another renaming in the same PR made the entirety of the examples from the rewrite rules chapter fail. Fortunately, this change was not released yet.