### PR TITLE
refactor tactic errors

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -482,7 +482,7 @@ let cc_tactic depth additional_terms b =
         | HeqnH (ida,idb) ->
           convert_to_hyp_tac ida ta idb tb p)
       begin function (e, info) -> match e with
-        | Tactics.NotConvertible ->
+        | TacticErrors.NotConvertible ->
           Tacticals.tclFAIL
             (str (if b then "simple congruence failed" else "congruence failed") ++
              str " (cannot build a well-typed proof)")

--- a/tactics/tacticErrors.ml
+++ b/tactics/tacticErrors.ml
@@ -1,0 +1,297 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+open Util
+open Names
+open Environ
+open EConstr
+open Evd
+open Tactypes
+
+(**********************************************************)
+(** {6 Exceptions.}                                       *)
+(**********************************************************)
+
+exception IntroAlreadyDeclared of Id.t
+exception ClearDependency of env * evar_map * Id.t option * Evarutil.clear_dependency_error * GlobRef.t option
+exception ReplacingDependency of env * evar_map * Id.t * Evarutil.clear_dependency_error * GlobRef.t option
+exception AlreadyUsed of Id.t
+exception UsedTwice of Id.t
+exception VariableHasNoValue of Id.t
+exception ConvertIncompatibleTypes of env * evar_map * constr * constr
+exception ConvertNotAType
+exception NotConvertible
+exception NotUnfoldable
+exception NoQuantifiedHypothesis of quantified_hypothesis * bool
+exception CannotFindInstance of Id.t
+exception NothingToRewrite of Id.t
+exception IllFormedEliminationType
+exception UnableToApplyLemma of env * evar_map * constr * constr
+exception DependsOnBody of Id.t list * Id.Set.t * Id.t option
+exception NotRightNumberConstructors of int
+exception NotEnoughConstructors
+exception ConstructorNumberedFromOne
+exception NoConstructors
+exception UnexpectedExtraPattern of int option * delayed_open_constr intro_pattern_expr
+exception CannotFindInductiveArgument
+exception OneIntroPatternExpected
+exception KeepAndClearModifierOnlyForHypotheses
+exception FixpointOnNonInductiveType
+exception NotEnoughProducts
+exception AllMethodsInCoinductiveType
+exception ReplacementIllTyped of exn
+exception NotEnoughPremises
+exception NeedDependentProduct
+
+(**********************************************************)
+(** {6 Printing exceptions.}                              *)
+(**********************************************************)
+
+let clear_in_global_msg = function
+  | None -> mt ()
+  | Some ref -> str " implicitly in " ++ Printer.pr_global ref
+
+let clear_dependency_msg env sigma id err inglobal =
+  let ppidupper = function Some id -> Id.print id | None -> str "This variable" in
+  let ppid = function Some id -> Id.print id | None -> str "this variable" in
+  let pp = clear_in_global_msg inglobal in
+  match err with
+  | Evarutil.OccurHypInSimpleClause None ->
+      ppidupper id ++ str " is used" ++ pp ++ str " in conclusion."
+  | Evarutil.OccurHypInSimpleClause (Some id') ->
+      ppidupper id ++ strbrk " is used" ++ pp ++ str " in hypothesis " ++ Id.print id' ++ str"."
+  | Evarutil.EvarTypingBreak ev ->
+      str "Cannot remove " ++ ppid id ++
+      strbrk " without breaking the typing of " ++
+      Printer.pr_leconstr_env env sigma (mkEvar ev) ++ str"."
+  | Evarutil.NoCandidatesLeft ev ->
+      str "Cannot remove " ++ ppid id ++ str " as it would leave the existential " ++
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
+
+let replacing_dependency_msg env sigma id err inglobal =
+  let pp = clear_in_global_msg inglobal in
+  match err with
+  | Evarutil.OccurHypInSimpleClause None ->
+      str "Cannot change " ++ Id.print id ++ str ", it is used" ++ pp ++ str " in conclusion."
+  | Evarutil.OccurHypInSimpleClause (Some id') ->
+      str "Cannot change " ++ Id.print id ++
+      strbrk ", it is used" ++ pp ++ str " in hypothesis " ++ Id.print id' ++ str"."
+  | Evarutil.EvarTypingBreak ev ->
+      str "Cannot change " ++ Id.print id ++
+      strbrk " without breaking the typing of " ++
+      Printer.pr_leconstr_env env sigma (mkEvar ev) ++ str"."
+  | Evarutil.NoCandidatesLeft ev ->
+      str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
+
+let msg_quantified_hypothesis = function
+  | NamedHyp id ->
+      str "quantified hypothesis named " ++ Id.print id.CAst.v
+  | AnonHyp n ->
+      pr_nth n ++
+      str " non dependent hypothesis"
+
+let explain_unexpected_extra_pattern bound pat =
+  let nb = Option.get bound in
+  let s1,s2,s3 = match pat with
+  | IntroNaming (IntroIdentifier _) ->
+      "name", (String.plural nb " introduction pattern"), "no"
+  | _ -> "introduction pattern", "", "none" in
+  str "Unexpected " ++ str s1 ++ str " (" ++
+  (if Int.equal nb 0 then (str s3 ++ str s2) else
+   (str "at most " ++ int nb ++ str s2)) ++ spc () ++
+  str (if Int.equal nb 1 then "was" else "were") ++
+  strbrk " expected in the branch)."
+
+(** Internal exception used by [tactic_interp_error_handler]. *)
+exception Unhandled
+
+(** Top-level exception handler (pretty-prints an exception). *)
+let tactic_interp_error_handler = function
+  | IntroAlreadyDeclared id ->
+      Id.print id ++ str " is already declared."
+  | ClearDependency (env,sigma,id,err,inglobal) ->
+      clear_dependency_msg env sigma id err inglobal
+  | ReplacingDependency (env,sigma,id,err,inglobal) ->
+      replacing_dependency_msg env sigma id err inglobal
+  | AlreadyUsed id ->
+      Id.print id ++ str " is already used."
+  | UsedTwice id ->
+      Id.print id ++ str" is used twice."
+  | VariableHasNoValue id ->
+      Id.print id ++ str" is not a defined hypothesis."
+  | ConvertIncompatibleTypes (env,sigma,t1,t2) ->
+      str "The first term has type" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t1) ++ spc () ++
+      strbrk "while the second term has incompatible type" ++ spc () ++
+      quote (Termops.Internal.print_constr_env env sigma t2) ++ str "."
+  | ConvertNotAType ->
+      str "Not a type."
+  | NotConvertible ->
+      str "Not convertible."
+  | NotUnfoldable ->
+     str "Cannot unfold a non-constant."
+  | NoQuantifiedHypothesis (id,red) ->
+      str "No " ++ msg_quantified_hypothesis id ++
+      strbrk " in current goal" ++
+      (if red then strbrk " even after head-reduction" else mt ()) ++ str"."
+  | CannotFindInstance id ->
+      str "Cannot find an instance for " ++ Id.print id ++ str"."
+  | NothingToRewrite id ->
+      str "Nothing to rewrite in " ++ Id.print id ++ str"."
+  | IllFormedEliminationType ->
+      str "The type of elimination clause is not well-formed."
+  | UnableToApplyLemma (env,sigma,thm,t) ->
+      str "Unable to apply lemma of type" ++ brk(1,1) ++
+      quote (Printer.pr_leconstr_env env sigma thm) ++ spc() ++
+      str "on hypothesis of type" ++ brk(1,1) ++
+      quote (Printer.pr_leconstr_env env sigma t) ++
+      str "."
+  | DependsOnBody (idl,ids,where) ->
+     let idl = List.filter (fun id -> Id.Set.mem id ids) idl in
+     let on_the_bodies = function
+       | [] -> assert false
+       | [id] -> str " depends on the body of " ++ Id.print id
+       | l -> str " depends on the bodies of " ++ pr_sequence Id.print l
+     in
+     (match where with
+     | None -> str "Conclusion" ++ on_the_bodies idl
+     | Some id -> str "Hypothesis " ++ Id.print id ++ on_the_bodies idl)
+  | NotRightNumberConstructors n ->
+      str "Not an inductive goal with " ++ int n ++ str (String.plural n " constructor") ++ str "."
+  | NotEnoughConstructors ->
+      str "Not enough constructors."
+  | ConstructorNumberedFromOne ->
+      str "The constructors are numbered starting from 1."
+  | NoConstructors ->
+      str "The type has no constructors."
+  | UnexpectedExtraPattern (bound,pat) ->
+      explain_unexpected_extra_pattern bound pat
+  | CannotFindInductiveArgument ->
+      str "Cannot find inductive argument of elimination scheme."
+  | OneIntroPatternExpected ->
+      str "Introduction pattern for one hypothesis expected."
+  | KeepAndClearModifierOnlyForHypotheses ->
+      str "keep/clear modifiers apply only to hypothesis names."
+  | FixpointOnNonInductiveType ->
+      str "Cannot do a fixpoint on a non inductive type."
+  | NotEnoughProducts ->
+      str "Not enough products."
+  | AllMethodsInCoinductiveType ->
+      str "All methods must construct elements in coinductive types."
+  | ReplacementIllTyped e ->
+      str "Replacement would lead to an ill-typed term:" ++ spc () ++ CErrors.print e
+  | NotEnoughPremises ->
+      str "Applied theorem does not have enough premises."
+  | NeedDependentProduct ->
+      str "Needs a non-dependent product."
+  | _ -> raise Unhandled
+
+let wrap_unhandled f e =
+  try Some (f e)
+  with Unhandled -> None
+
+(** Register the exception handler so that exceptions are nicely printed to the user. *)
+let _ = CErrors.register_handler (wrap_unhandled tactic_interp_error_handler)
+
+(**********************************************************)
+(** {6 Raising exceptions.}                               *)
+(**********************************************************)
+
+let intro_already_declared ?loc id =
+  Loc.raise ?loc (IntroAlreadyDeclared id)
+
+let clear_dependency ?loc env sigma id dep_err gref =
+  Loc.raise ?loc (ClearDependency (env, sigma, id, dep_err, gref))
+
+let replacing_dependency ?loc env sigma id dep_err gref =
+  Loc.raise ?loc (ReplacingDependency (env, sigma, id, dep_err, gref))
+
+let already_used ?loc id =
+  Loc.raise ?loc (AlreadyUsed id)
+
+let used_twice ?loc id =
+  Loc.raise ?loc (UsedTwice id)
+
+let variable_has_no_value ?loc id =
+  Loc.raise ?loc (VariableHasNoValue id)
+
+let convert_incompatible_types ?loc env sigma x y =
+  Loc.raise ?loc (ConvertIncompatibleTypes (env, sigma, x, y))
+
+let convert_not_a_type ?loc () =
+  Loc.raise ?loc ConvertNotAType
+
+let not_convertible ?loc () =
+  Loc.raise ?loc NotConvertible
+
+let not_unfoldable ?loc () =
+  Loc.raise ?loc NotUnfoldable
+
+let no_quantified_hypothesis ?loc hyp b =
+  Loc.raise ?loc (NoQuantifiedHypothesis (hyp, b))
+
+let cannot_find_instance ?loc id =
+  Loc.raise ?loc (CannotFindInstance id)
+
+let nothing_to_rewrite ?loc id =
+  Loc.raise ?loc (NothingToRewrite id)
+
+let ill_formed_elimination_type ?loc () =
+  Loc.raise ?loc IllFormedEliminationType
+
+let unable_to_apply_lemma ?loc env sigma x y =
+  Loc.raise ?loc (UnableToApplyLemma (env, sigma, x, y))
+
+let depends_on_body ?loc id ids id_opt =
+  Loc.raise ?loc (DependsOnBody (id, ids, id_opt))
+
+let not_right_number_constructors ?loc n =
+  Loc.raise ?loc (NotRightNumberConstructors n)
+
+let not_enough_constructors ?loc () =
+  Loc.raise ?loc NotEnoughConstructors
+
+let constructors_numbered_from_one ?loc () =
+  Loc.raise ?loc ConstructorNumberedFromOne
+
+let no_constructors ?loc () =
+  Loc.raise ?loc NoConstructors
+
+let unexpected_extra_pattern ?loc n patt =
+  Loc.raise ?loc (UnexpectedExtraPattern (n, patt))
+
+let cannot_find_inductive_argument ?loc () =
+  Loc.raise ?loc CannotFindInductiveArgument
+
+let one_intro_pattern_expected ?loc () =
+  Loc.raise ?loc OneIntroPatternExpected
+
+let keep_and_clear_modifier_only_for_hypotheses ?loc () =
+  Loc.raise ?loc KeepAndClearModifierOnlyForHypotheses
+
+let fixpoint_on_non_inductive_type ?loc () =
+  Loc.raise ?loc FixpointOnNonInductiveType
+
+let not_enough_products ?loc () =
+  Loc.raise ?loc NotEnoughProducts
+
+let all_methods_in_coinductive_type ?loc () =
+  Loc.raise ?loc AllMethodsInCoinductiveType
+
+let replacement_ill_typed ?loc exn =
+  Loc.raise ?loc (ReplacementIllTyped exn)
+
+let not_enough_premises ?loc () =
+  Loc.raise ?loc NotEnoughPremises
+
+let need_dependent_product ?loc () =
+  Loc.raise ?loc NeedDependentProduct

--- a/tactics/tacticErrors.mli
+++ b/tactics/tacticErrors.mli
@@ -1,0 +1,91 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open EConstr
+open Environ
+open Evd
+open Tactypes
+
+(** Common exceptions raised by tactics. These exceptions are catched at
+    toplevel and pretty-printed to the user. *)
+
+(** {6 Raising exceptions.} *)
+
+val intro_already_declared : ?loc:Loc.t -> Id.t -> 'a
+
+val clear_dependency : ?loc:Loc.t -> env -> evar_map -> Id.t option ->
+    Evarutil.clear_dependency_error -> GlobRef.t option -> 'a
+
+val replacing_dependency : ?loc:Loc.t -> env -> evar_map -> Id.t ->
+    Evarutil.clear_dependency_error -> GlobRef.t option -> 'a
+
+val already_used : ?loc:Loc.t -> Id.t -> 'a
+
+val used_twice : ?loc:Loc.t -> Id.t -> 'a
+
+val variable_has_no_value : ?loc:Loc.t -> Id.t -> 'a
+
+val convert_incompatible_types : ?loc:Loc.t -> env -> evar_map -> constr -> constr -> 'a
+
+val convert_not_a_type : ?loc:Loc.t -> unit -> 'a
+
+val not_convertible : ?loc:Loc.t -> unit -> 'a
+
+val not_unfoldable : ?loc:Loc.t -> unit -> 'a
+
+val no_quantified_hypothesis : ?loc:Loc.t -> quantified_hypothesis -> bool -> 'a
+
+val cannot_find_instance : ?loc:Loc.t -> Id.t -> 'a
+
+val nothing_to_rewrite : ?loc:Loc.t -> Id.t -> 'a
+
+val ill_formed_elimination_type : ?loc:Loc.t -> unit -> 'a
+
+val unable_to_apply_lemma : ?loc:Loc.t -> env -> evar_map -> constr -> constr -> 'a
+
+val depends_on_body : ?loc:Loc.t -> Id.t list -> Id.Set.t -> Id.t option -> 'a
+
+val not_right_number_constructors : ?loc:Loc.t -> int -> 'a
+
+val not_enough_constructors : ?loc:Loc.t -> unit -> 'a
+
+val constructors_numbered_from_one : ?loc:Loc.t -> unit -> 'a
+
+val no_constructors : ?loc:Loc.t -> unit -> 'a
+
+val unexpected_extra_pattern : ?loc:Loc.t -> int option ->
+    delayed_open_constr intro_pattern_expr -> 'a
+
+val cannot_find_inductive_argument : ?loc:Loc.t -> unit -> 'a
+
+val one_intro_pattern_expected : ?loc:Loc.t -> unit -> 'a
+
+val keep_and_clear_modifier_only_for_hypotheses : ?loc:Loc.t -> unit -> 'a
+
+val fixpoint_on_non_inductive_type : ?loc:Loc.t -> unit -> 'a
+
+val not_enough_products : ?loc:Loc.t -> unit -> 'a
+
+val all_methods_in_coinductive_type : ?loc:Loc.t -> unit -> 'a
+
+val replacement_ill_typed : ?loc:Loc.t -> exn -> 'a
+
+val not_enough_premises : ?loc:Loc.t -> unit -> 'a
+
+val need_dependent_product : ?loc:Loc.t -> unit -> 'a
+
+(** {6 Internal use only.} *)
+
+val clear_dependency_msg : env -> evar_map -> Names.Id.t option ->
+    Evarutil.clear_dependency_error -> GlobRef.t option -> Pp.t
+
+exception NotConvertible
+exception DependsOnBody of Names.Id.t list * Names.Id.Set.t * Names.Id.t option

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -67,193 +67,6 @@ let () =
       optread  = (fun () -> !clear_hyp_by_default) ;
       optwrite = (fun b -> clear_hyp_by_default := b) }
 
-(*********************************************)
-(*                 Errors                    *)
-(*********************************************)
-
-exception IntroAlreadyDeclared of Id.t
-exception ClearDependency of env * evar_map * Id.t option * Evarutil.clear_dependency_error * GlobRef.t option
-exception ReplacingDependency of env * evar_map * Id.t * Evarutil.clear_dependency_error * GlobRef.t option
-exception AlreadyUsed of Id.t
-exception UsedTwice of Id.t
-exception VariableHasNoValue of Id.t
-exception ConvertIncompatibleTypes of env * evar_map * constr * constr
-exception ConvertNotAType
-exception NotConvertible
-exception NotUnfoldable
-exception NoQuantifiedHypothesis of quantified_hypothesis * bool
-exception CannotFindInstance of Id.t
-exception NothingToRewrite of Id.t
-exception IllFormedEliminationType
-exception UnableToApplyLemma of env * evar_map * constr * constr
-exception DependsOnBody of Id.t list * Id.Set.t * Id.t option
-exception NotRightNumberConstructors of int
-exception NotEnoughConstructors
-exception ConstructorNumberedFromOne
-exception NoConstructors
-exception UnexpectedExtraPattern of int option * delayed_open_constr intro_pattern_expr
-exception CannotFindInductiveArgument
-exception OneIntroPatternExpected
-exception KeepAndClearModifierOnlyForHypotheses
-exception FixpointOnNonInductiveType
-exception NotEnoughProducts
-exception AllMethodsInCoinductiveType
-exception ReplacementIllTyped of exn
-exception NotEnoughPremises
-exception NeedDependentProduct
-
-let error ?loc e =
-  Loc.raise ?loc e
-
-let clear_in_global_msg = function
-  | None -> mt ()
-  | Some ref -> str " implicitly in " ++ Printer.pr_global ref
-
-let clear_dependency_msg env sigma id err inglobal =
-  let ppidupper = function Some id -> Id.print id | None -> str "This variable" in
-  let ppid = function Some id -> Id.print id | None -> str "this variable" in
-  let pp = clear_in_global_msg inglobal in
-  match err with
-  | Evarutil.OccurHypInSimpleClause None ->
-      ppidupper id ++ str " is used" ++ pp ++ str " in conclusion."
-  | Evarutil.OccurHypInSimpleClause (Some id') ->
-      ppidupper id ++ strbrk " is used" ++ pp ++ str " in hypothesis " ++ Id.print id' ++ str"."
-  | Evarutil.EvarTypingBreak ev ->
-      str "Cannot remove " ++ ppid id ++
-      strbrk " without breaking the typing of " ++
-      Printer.pr_leconstr_env env sigma (mkEvar ev) ++ str"."
-  | Evarutil.NoCandidatesLeft ev ->
-      str "Cannot remove " ++ ppid id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key env sigma ev ++ str" without candidates."
-
-let replacing_dependency_msg env sigma id err inglobal =
-  let pp = clear_in_global_msg inglobal in
-  match err with
-  | Evarutil.OccurHypInSimpleClause None ->
-      str "Cannot change " ++ Id.print id ++ str ", it is used" ++ pp ++ str " in conclusion."
-  | Evarutil.OccurHypInSimpleClause (Some id') ->
-      str "Cannot change " ++ Id.print id ++
-      strbrk ", it is used" ++ pp ++ str " in hypothesis " ++ Id.print id' ++ str"."
-  | Evarutil.EvarTypingBreak ev ->
-      str "Cannot change " ++ Id.print id ++
-      strbrk " without breaking the typing of " ++
-      Printer.pr_leconstr_env env sigma (mkEvar ev) ++ str"."
-  | Evarutil.NoCandidatesLeft ev ->
-      str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key env sigma ev ++ str" without candidates."
-
-let msg_quantified_hypothesis = function
-  | NamedHyp id ->
-      str "quantified hypothesis named " ++ Id.print id.CAst.v
-  | AnonHyp n ->
-      pr_nth n ++
-      str " non dependent hypothesis"
-
-let explain_unexpected_extra_pattern bound pat =
-  let nb = Option.get bound in
-  let s1,s2,s3 = match pat with
-  | IntroNaming (IntroIdentifier _) ->
-      "name", (String.plural nb " introduction pattern"), "no"
-  | _ -> "introduction pattern", "", "none" in
-  str "Unexpected " ++ str s1 ++ str " (" ++
-  (if Int.equal nb 0 then (str s3 ++ str s2) else
-   (str "at most " ++ int nb ++ str s2)) ++ spc () ++
-  str (if Int.equal nb 1 then "was" else "were") ++
-  strbrk " expected in the branch)."
-
-exception Unhandled
-
-let wrap_unhandled f e =
-  try Some (f e)
-  with Unhandled -> None
-
-let tactic_interp_error_handler = function
-  | IntroAlreadyDeclared id ->
-      Id.print id ++ str " is already declared."
-  | ClearDependency (env,sigma,id,err,inglobal) ->
-      clear_dependency_msg env sigma id err inglobal
-  | ReplacingDependency (env,sigma,id,err,inglobal) ->
-      replacing_dependency_msg env sigma id err inglobal
-  | AlreadyUsed id ->
-      Id.print id ++ str " is already used."
-  | UsedTwice id ->
-      Id.print id ++ str" is used twice."
-  | VariableHasNoValue id ->
-      Id.print id ++ str" is not a defined hypothesis."
-  | ConvertIncompatibleTypes (env,sigma,t1,t2) ->
-      str "The first term has type" ++ spc () ++
-      quote (Termops.Internal.print_constr_env env sigma t1) ++ spc () ++
-      strbrk "while the second term has incompatible type" ++ spc () ++
-      quote (Termops.Internal.print_constr_env env sigma t2) ++ str "."
-  | ConvertNotAType ->
-      str "Not a type."
-  | NotConvertible ->
-      str "Not convertible."
-  | NotUnfoldable ->
-     str "Cannot unfold a non-constant."
-  | NoQuantifiedHypothesis (id,red) ->
-      str "No " ++ msg_quantified_hypothesis id ++
-      strbrk " in current goal" ++
-      (if red then strbrk " even after head-reduction" else mt ()) ++ str"."
-  | CannotFindInstance id ->
-      str "Cannot find an instance for " ++ Id.print id ++ str"."
-  | NothingToRewrite id ->
-      str "Nothing to rewrite in " ++ Id.print id ++ str"."
-  | IllFormedEliminationType ->
-      str "The type of elimination clause is not well-formed."
-  | UnableToApplyLemma (env,sigma,thm,t) ->
-      str "Unable to apply lemma of type" ++ brk(1,1) ++
-      quote (Printer.pr_leconstr_env env sigma thm) ++ spc() ++
-      str "on hypothesis of type" ++ brk(1,1) ++
-      quote (Printer.pr_leconstr_env env sigma t) ++
-      str "."
-  | DependsOnBody (idl,ids,where) ->
-     let idl = List.filter (fun id -> Id.Set.mem id ids) idl in
-     let on_the_bodies = function
-       | [] -> assert false
-       | [id] -> str " depends on the body of " ++ Id.print id
-       | l -> str " depends on the bodies of " ++ pr_sequence Id.print l
-     in
-     (match where with
-     | None -> str "Conclusion" ++ on_the_bodies idl
-     | Some id -> str "Hypothesis " ++ Id.print id ++ on_the_bodies idl)
-  | NotRightNumberConstructors n ->
-      str "Not an inductive goal with " ++ int n ++ str (String.plural n " constructor") ++ str "."
-  | NotEnoughConstructors ->
-      str "Not enough constructors."
-  | ConstructorNumberedFromOne ->
-      str "The constructors are numbered starting from 1."
-  | NoConstructors ->
-      str "The type has no constructors."
-  | UnexpectedExtraPattern (bound,pat) ->
-      explain_unexpected_extra_pattern bound pat
-  | CannotFindInductiveArgument ->
-      str "Cannot find inductive argument of elimination scheme."
-  | OneIntroPatternExpected ->
-      str "Introduction pattern for one hypothesis expected."
-  | KeepAndClearModifierOnlyForHypotheses ->
-      str "keep/clear modifiers apply only to hypothesis names."
-  | FixpointOnNonInductiveType ->
-      str "Cannot do a fixpoint on a non inductive type."
-  | NotEnoughProducts ->
-      str "Not enough products."
-  | AllMethodsInCoinductiveType ->
-      str "All methods must construct elements in coinductive types."
-  | ReplacementIllTyped e ->
-      str "Replacement would lead to an ill-typed term:" ++ spc () ++ CErrors.print e
-  | NotEnoughPremises ->
-      str "Applied theorem does not have enough premises."
-  | NeedDependentProduct ->
-      str "Needs a non-dependent product."
-  | _ -> raise Unhandled
-
-let _ = CErrors.register_handler (wrap_unhandled tactic_interp_error_handler)
-
-let error_clear_dependency env sigma id err inglobal =
-  error (ClearDependency (env,sigma,Some id,err,inglobal))
-
-let error_replacing_dependency env sigma id err inglobal =
-  error (ReplacingDependency (env,sigma,id,err,inglobal))
 
 (*********************************************)
 (*                 Tactics                   *)
@@ -285,7 +98,7 @@ let introduction id =
     let hyps = named_context_val (Proofview.Goal.env gl) in
     let env = Proofview.Goal.env gl in
     let () = if mem_named_context_val id hyps then
-      error (IntroAlreadyDeclared id)
+      TacticErrors.intro_already_declared id
     in
     let open Context.Named.Declaration in
     match EConstr.kind sigma concl with
@@ -304,7 +117,7 @@ let convert_concl ~cast ~check ty k =
         if check then begin
           let sigma, _ = Typing.type_of env sigma ty in
           match Reductionops.infer_conv env sigma ty conclty with
-          | None -> error NotConvertible
+          | None -> TacticErrors.not_convertible ()
           | Some sigma -> sigma
         end else sigma
       in
@@ -331,11 +144,11 @@ let convert_gen pb x y =
   Proofview.Goal.enter begin fun gl ->
     match Tacmach.pf_apply (Reductionops.infer_conv ~pb) gl x y with
     | Some sigma -> Proofview.Unsafe.tclEVARS sigma
-    | None -> error NotConvertible
+    | None -> TacticErrors.not_convertible ()
     | exception e when CErrors.noncritical e ->
       let _, info = Exninfo.capture e in
       (* FIXME: Sometimes an anomaly is raised from conversion *)
-      error ?loc:(Loc.get_loc info) NotConvertible
+      TacticErrors.not_convertible ?loc:(Loc.get_loc info) ()
 end
 
 let convert x y = convert_gen Conversion.CONV x y
@@ -362,15 +175,24 @@ let clear_gen fail = function
     end)
   end
 
-let clear ids = clear_gen error_clear_dependency ids
-let clear_for_replacing ids = clear_gen error_replacing_dependency ids
+let clear ids =
+  let fail env sigma id err inglobal =
+    TacticErrors.clear_dependency env sigma (Some id) err inglobal
+  in
+  clear_gen fail ids
+
+let clear_for_replacing ids =
+  let fail env sigma id err inglobal =
+    TacticErrors.replacing_dependency env sigma id err inglobal
+  in
+  clear_gen fail ids
 
 let apply_clear_request clear_flag dft c =
   let doclear = match clear_flag with
     | None -> if dft then c else None
     | Some true ->
       begin match c with
-      | None -> error KeepAndClearModifierOnlyForHypotheses
+      | None -> TacticErrors.keep_and_clear_modifier_only_for_hypotheses ()
       | Some id -> Some id
       end
     | Some false -> None
@@ -428,7 +250,7 @@ let rename_hyp repl =
       let () =
         try
           let elt = Id.Set.choose (Id.Set.inter dst mods) in
-          error (AlreadyUsed elt)
+          TacticErrors.already_used elt
         with Not_found -> ()
       in
       (* All is well *)
@@ -505,7 +327,7 @@ let find_name mayrepl decl naming gl = match naming with
      (* When name is given, we allow to hide a global name. *)
      let ids_of_hyps = Tacmach.pf_ids_set_of_hyps gl in
      if not mayrepl && Id.Set.mem id ids_of_hyps then
-       error ?loc (AlreadyUsed id);
+      TacticErrors.already_used ?loc id;
      id
 
 (**************************************************************)
@@ -539,8 +361,8 @@ let get_previous_hyp_position env sigma id =
 let clear_hyps2 env sigma ids sign t cl =
   try
     Evarutil.clear_hyps2_in_evi env sigma sign t cl ids
-  with Evarutil.ClearDependencyError (id,err,inglobal) ->
-    error_replacing_dependency env sigma id err inglobal
+  with Evarutil.ClearDependencyError (id, err, inglobal) ->
+    TacticErrors.replacing_dependency env sigma id err inglobal
 
 let internal_cut ?(check=true) replace id t =
   Proofview.Goal.enter begin fun gl ->
@@ -557,7 +379,7 @@ let internal_cut ?(check=true) replace id t =
         Environ.reset_with_named_context sign' env,t,concl,sigma
       else
         (if check && mem_named_context_val id sign then
-           error (IntroAlreadyDeclared id);
+          TacticErrors.intro_already_declared id;
          push_named (LocalAssum (make_annot id r,t)) env,t,concl,sigma) in
     let nf_t = nf_betaiota env sigma t in
     Proofview.tclTHEN
@@ -621,14 +443,14 @@ let rec check_mutind env sigma k cl = match EConstr.kind sigma (strip_outer_cast
 | Prod (na, c1, b) ->
   if Int.equal k 1 then
     try ignore (find_inductive env sigma c1)
-    with Not_found -> error FixpointOnNonInductiveType
+    with Not_found -> TacticErrors.fixpoint_on_non_inductive_type ()
   else
     let open Context.Rel.Declaration in
     check_mutind (push_rel (LocalAssum (na, c1)) env) sigma (pred k) b
 | LetIn (na, c1, t, b) ->
     let open Context.Rel.Declaration in
     check_mutind (push_rel (LocalDef (na, c1, t)) env) sigma k b
-| _ -> error NotEnoughProducts
+| _ -> TacticErrors.not_enough_products ()
 
 let mutual_fix f n others = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
@@ -647,7 +469,7 @@ let mutual_fix f n others = Proofview.Goal.enter begin fun gl ->
     let open Context.Named.Declaration in
     let ()  = check_mutind env sigma n ar in
     if mem_named_context_val f sign then
-      error (IntroAlreadyDeclared f);
+      TacticErrors.intro_already_declared f;
     mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
   in
   let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
@@ -676,7 +498,7 @@ let rec check_is_mutcoind env sigma cl =
     try
       let _ = find_coinductive env sigma b in ()
     with Not_found ->
-      error AllMethodsInCoinductiveType
+      TacticErrors.all_methods_in_coinductive_type ()
 
 let mutual_cofix f others = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
@@ -690,7 +512,7 @@ let mutual_cofix f others = Proofview.Goal.enter begin fun gl ->
   | (f, r, ar) :: oth ->
     let open Context.Named.Declaration in
     if mem_named_context_val f sign then
-      error (AlreadyUsed f);
+      TacticErrors.already_used f;
     mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
   in
   let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
@@ -724,9 +546,7 @@ let e_pf_change_decl (redfun : bool -> Tacred.change_function) where env sigma d
   let open Context.Named.Declaration in
   match decl with
   | LocalAssum (id,ty) ->
-    let () =
-      if where == InHypValueOnly then error (VariableHasNoValue id.binder_name)
-    in
+    if where == InHypValueOnly then TacticErrors.variable_has_no_value id.binder_name;
     let* (sigma, ty') = redfun false env sigma ty in
     Changed (sigma, LocalAssum (id, ty'))
   | LocalDef (id,b,ty) ->
@@ -914,12 +734,12 @@ let check_types env sigma mayneedglobalcheck deep newc origc =
         isSort sigma (whd_all env sigma t2)
       then (mayneedglobalcheck := true; sigma)
       else
-        error (ConvertIncompatibleTypes (env,sigma,t2,t1))
+        TacticErrors.convert_incompatible_types env sigma t2 t1
     | Some sigma -> sigma
   end
   else
     if not (isSort sigma (whd_all env sigma t1)) then
-      error ConvertNotAType
+      TacticErrors.convert_not_a_type ()
     else sigma
 
 (* Now we introduce different instances of the previous tacticals *)
@@ -928,7 +748,7 @@ let change_and_check cv_pb mayneedglobalcheck deep t env sigma c = match t env s
 | Changed (sigma, t') ->
   let sigma = check_types env sigma mayneedglobalcheck deep t' c in
   match infer_conv ~pb:cv_pb env sigma t' c with
-  | None -> error NotConvertible
+  | None -> TacticErrors.not_convertible ()
   | Some sigma -> Changed (sigma, t')
 
 (* Use cumulativity only if changing the conclusion not a subterm *)
@@ -954,7 +774,7 @@ let change_on_subterm ~check cv_pb deep t where env sigma c =
       begin
         try fst (Typing.type_of env sigma c)
         with e when noncritical e ->
-          error (ReplacementIllTyped e)
+          TacticErrors.replacement_ill_typed e
       end else sigma
     in
     Changed (sigma, c)
@@ -1090,7 +910,7 @@ let reduce redexp cl =
 let unfold_constr = function
   | GlobRef.ConstRef sp -> unfold_in_concl [(AllOccurrences, EvalConstRef sp)]
   | GlobRef.VarRef id -> unfold_in_concl [(AllOccurrences, EvalVarRef id)]
-  | _ -> error NotUnfoldable
+  | _ -> TacticErrors.not_unfoldable ()
 
 (*******************************************)
 (*         Introduction tactics            *)
@@ -1354,8 +1174,8 @@ let warn_deprecated_intros_until_0 =
 let depth_of_quantified_hypothesis red h gl =
   if h = AnonHyp 0 then warn_deprecated_intros_until_0 ();
   match lookup_hypothesis_as_renamed_gen red h gl with
-    | Some depth -> depth
-    | None -> error (NoQuantifiedHypothesis(h,red))
+  | Some depth -> depth
+  | None -> TacticErrors.no_quantified_hypothesis h red
 
 let intros_until_gen red h =
   Proofview.Goal.enter begin fun gl ->
@@ -1487,7 +1307,7 @@ let check_unresolved_evars_of_metas sigma clenv =
                      && not (Evd.mem sigma evk) ->
       let na = Unification.Meta.meta_name metas mv in
       let id = match na with Name id -> id | _ -> anomaly (Pp.str "unnamed dependent meta.") in
-      error (CannotFindInstance id)
+      TacticErrors.cannot_find_instance id
     | _ -> ()
     end
   | None -> ()
@@ -1536,7 +1356,7 @@ let index_of_ind_arg sigma t =
       else aux i (j+1) u
   | _ -> match i with
       | Some i -> i
-      | None -> error CannotFindInductiveArgument
+      | None -> TacticErrors.cannot_find_inductive_argument ()
   in aux None 0 t
 
 (*
@@ -1570,7 +1390,7 @@ let general_elim_clause0 with_evars flags (submetas, c, ty) elim =
   let elimclause = make_clenv_binding env sigma clause bindings in
   let indmv =
     try nth_arg index (clenv_arguments elimclause)
-    with Failure _ | Invalid_argument _ -> error IllFormedEliminationType
+    with Failure _ | Invalid_argument _ -> TacticErrors.ill_formed_elimination_type ()
   in
   let elimclause = clenv_instantiate ~flags ~submetas indmv elimclause (c, ty) in
   Clenv.res_pf elimclause ~with_evars ~with_classes:true ~flags
@@ -1586,13 +1406,13 @@ let general_elim_clause_in0 with_evars flags id (submetas, c, ty) elim =
   let elimclause = mk_clenv_from env sigma (elimc, elimt) in
   let indmv =
     try nth_arg (Some i) (clenv_arguments elimclause)
-    with Failure _ | Invalid_argument _ -> error IllFormedEliminationType
+    with Failure _ | Invalid_argument _ -> TacticErrors.ill_formed_elimination_type ()
   in
   (* Assumes that the metas of [c] are part of [sigma] already *)
   let hypmv =
     match List.remove Int.equal indmv (clenv_independent elimclause) with
     | [a] -> a
-    | _ -> error IllFormedEliminationType
+    | _ -> TacticErrors.ill_formed_elimination_type ()
   in
   let elimclause = clenv_instantiate ~flags ~submetas indmv elimclause (c, ty) in
   let hyp = mkVar id in
@@ -1605,7 +1425,7 @@ let general_elim_clause_in0 with_evars flags id (submetas, c, ty) elim =
   in
   let new_hyp_typ  = clenv_type elimclause in
   if EConstr.eq_constr sigma hyp_typ new_hyp_typ then
-    error (NothingToRewrite id);
+    TacticErrors.nothing_to_rewrite id;
   clenv_refine_in with_evars id true env sigma elimclause
   end
 
@@ -1884,7 +1704,7 @@ let general_apply ?(with_classes=true) ?(respect_opaque=false) with_delta with_d
     let try_apply thm_ty nprod =
       try
         let n = nb_prod_modulo_zeta sigma thm_ty - nprod in
-        if n<0 then error NotEnoughPremises;
+        if n < 0 then TacticErrors.not_enough_premises ();
         let clause = make_clenv_binding_apply env sigma (Some n) (c,thm_ty) lbind in
         Clenv.res_pf clause ~with_classes ~with_evars ~flags
       with exn when noncritical exn ->
@@ -2006,7 +1826,7 @@ let apply_in_once_main flags (id, t) env sigma (loc,d,lbind) =
     | Some (mv, dep, clause) -> aux clause (if dep then [] else [mv])
     | None ->
       match e with
-      | UnableToApply -> error ?loc (UnableToApplyLemma (env,sigma,thm,t))
+      | UnableToApply -> TacticErrors.unable_to_apply_lemma ?loc env sigma thm t
       | _ -> Exninfo.iraise e'
   in
   let clenv = make_clenv_binding env sigma (d,thm) lbind in
@@ -2086,7 +1906,7 @@ let cut_and_apply c =
             let (sigma, x) = Evarutil.new_evar env sigma c1 in
             (sigma, mkApp (f, [|mkApp (c, [|x|])|]))
           end)
-    | _ -> error NeedDependentProduct
+    | _ -> TacticErrors.need_dependent_product ()
   end
 
 (********************************************************************)
@@ -2168,7 +1988,7 @@ let check_is_type env sigma idl ids ty =
     let sigma, _ = Typing.sort_of env sigma ty in
     sigma
   with e when CErrors.noncritical e ->
-    raise (DependsOnBody (idl, ids, None))
+    TacticErrors.depends_on_body idl ids None
 
 let check_decl env sigma idl ids decl =
   let open Context.Named.Declaration in
@@ -2182,7 +2002,7 @@ let check_decl env sigma idl ids decl =
     sigma
   with e when CErrors.noncritical e ->
     let id = NamedDecl.get_id decl in
-    raise (DependsOnBody (idl, ids, Some id))
+    TacticErrors.depends_on_body idl ids (Some id)
 
 let clear_body idl =
   let open Context.Named.Declaration in
@@ -2207,7 +2027,7 @@ let clear_body idl =
             | LocalAssum (id,t) ->
               let () =
                 if Id.Set.mem id.binder_name ids then
-                  error (VariableHasNoValue id.binder_name)
+                  TacticErrors.variable_has_no_value id.binder_name
               in
               decl, ids, false
             | LocalDef (id,_,t) as decl ->
@@ -2235,14 +2055,15 @@ let clear_body idl =
       let sigma, ev = Evarutil.new_evar env sigma concl in
       sigma, ev, Some (fst @@ destEvar sigma ev)
     end
-    with DependsOnBody _ as exn ->
+    with TacticErrors.DependsOnBody _ as exn ->
       let _, info = Exninfo.capture exn in
       Proofview.tclZERO ~info exn
     end
 
 let clear_wildcards ids =
   let clear_wildcards_msg ?loc env sigma _id err inglobal =
-    user_err ?loc (clear_dependency_msg env sigma None err inglobal) in
+    user_err ?loc (TacticErrors.clear_dependency_msg env sigma None err inglobal)
+  in
   Tacticals.tclMAP (fun {CAst.loc;v=id} -> clear_gen (clear_wildcards_msg ?loc) [id]) ids
 
 let rec intros_clearing = function
@@ -2296,13 +2117,13 @@ let apply_type ~typecheck newcl args =
 (************************)
 
 let check_number_of_constructors expctdnumopt i nconstr =
-  if Int.equal i 0 then error ConstructorNumberedFromOne;
+  if Int.equal i 0 then TacticErrors.constructors_numbered_from_one ();
   begin match expctdnumopt with
     | Some n when not (Int.equal n nconstr) ->
-        error (NotRightNumberConstructors n)
+      TacticErrors.not_right_number_constructors n
     | _ -> ()
   end;
-  if i > nconstr then error NotEnoughConstructors
+  if i > nconstr then TacticErrors.not_enough_constructors ()
 
 let constructor_core with_evars cstr lbind =
   Proofview.Goal.enter begin fun gl ->
@@ -2350,7 +2171,7 @@ let any_constructor with_evars tacopt =
     let (ind,_),redcl = Tacmach.pf_apply Tacred.reduce_to_quantified_ind gl cl in
     let nconstr =
       Array.length (snd (Inductive.lookup_mind_specif env ind)).mind_consnames in
-    if Int.equal nconstr 0 then error NoConstructors;
+    if Int.equal nconstr 0 then TacticErrors.no_constructors ();
     Tacticals.tclTHENLIST [
       convert_concl ~cast:false ~check:false redcl DEFAULTcast;
       intros;
@@ -2504,10 +2325,10 @@ let rec check_name_unicity env ok seen = let open CAst in function
 | {loc;v=IntroNaming (IntroIdentifier id)} :: l ->
    (try
       ignore (if List.mem_f Id.equal id ok then raise Not_found else lookup_named id env);
-      error ?loc (AlreadyUsed id)
+      TacticErrors.already_used ?loc id
    with Not_found ->
      if List.mem_f Id.equal id seen then
-       error ?loc (UsedTwice id)
+      TacticErrors.used_twice ?loc id
      else
        check_name_unicity env ok (id::seen) l)
 | {v=IntroAction (IntroOrAndPattern l)} :: l' ->
@@ -2579,7 +2400,7 @@ let rec intro_patterns_core with_evars avoid ids thin destopt bound n tac =
       intro_patterns_core with_evars avoid ids thin destopt bound n tac
         [CAst.make @@ IntroNaming IntroAnonymous]
   | {CAst.loc;v=pat} :: l ->
-  if exceed_bound n bound then error ?loc (UnexpectedExtraPattern(bound,pat)) else
+  if exceed_bound n bound then TacticErrors.unexpected_extra_pattern ?loc bound pat else
   match pat with
   | IntroForthcoming onlydeps ->
       let naming = Id.Set.union avoid (explicit_intro_names l) in
@@ -2627,7 +2448,7 @@ and prepare_action ?loc with_evars destopt = function
           (fun _ l -> clear_wildcards l) in
       fun id ->
         intro_pattern_action ?loc with_evars ipat [] destopt tac id)
-  | IntroForthcoming _ -> error ?loc OneIntroPatternExpected
+  | IntroForthcoming _ -> TacticErrors.one_intro_pattern_expected ?loc ()
 
 let intro_patterns_head_core with_evars destopt bound pat =
   Proofview.Goal.enter begin fun gl ->
@@ -2794,7 +2615,7 @@ let pose_tac na c =
     let id = match na with
     | Name id ->
       let () = if mem_named_context_val id hyps then
-        error (IntroAlreadyDeclared id)
+        TacticErrors.intro_already_declared id
       in
       id
     | Anonymous ->
@@ -3097,7 +2918,7 @@ let unfold_body x =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let xval = match Environ.lookup_named x env with
-  | LocalAssum _ -> error (VariableHasNoValue x)
+  | LocalAssum _ -> TacticErrors.variable_has_no_value x
   | LocalDef (_,xval,_) -> xval
   in
   let xval = EConstr.of_constr xval in
@@ -3587,3 +3408,5 @@ let clear_wildcards = clear_wildcards
 let dest_intro_patterns = dest_intro_patterns
 
 end
+
+exception NotConvertible = TacticErrors.NotConvertible

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -20,10 +20,7 @@ open Tactypes
 open Locus
 open Ltac_pretype
 
-(** Main tactics defined in ML. This file is huge and should probably be split
-    in more reasonable units at some point. Because of its size and age, the
-    implementation features various styles and stages of the proof engine.
-    This has to be uniformized someday. *)
+(** Main tactics defined in ML. *)
 
 (** {6 General functions. } *)
 
@@ -54,8 +51,6 @@ val cofix : Id.t -> unit Proofview.tactic
 val mutual_cofix : Id.t -> (Id.t * constr) list -> unit Proofview.tactic
 
 (** {6 Conversion tactics. } *)
-
-exception NotConvertible
 
 (** [vm_cast_no_check new_concl] changes the conclusion to [new_concl] by inserting a [VMcast].
     It does not check that the new conclusion is indeed convertible to the old conclusion. *)
@@ -758,3 +753,11 @@ val dest_intro_patterns : evars_flag -> Id.Set.t -> lident list ->
   (Id.t list -> lident list -> unit Proofview.tactic) -> unit Proofview.tactic
 
 end
+
+(** {6 Moved functions} *)
+
+(** The functions below have been moved to other files but are kept here
+    for backwards compatibility. Don't use in new code. *)
+
+(** Deprecated, use [TacticErrors.not_convertible ()] instead. *)
+exception NotConvertible


### PR DESCRIPTION
This PR is the first step in splitting `tactics/tactics.ml` in small chunks. It extracts errors commonly raised by tactics into a separate file `tacticErrors.ml`.