### PR TITLE
Handle focusing braces in rocqtop ReST directive

### DIFF
--- a/doc/tools/rocqrst/rocqdomain.py
+++ b/doc/tools/rocqrst/rocqdomain.py
@@ -756,7 +756,7 @@ class RocqtopBlocksTransform(Transform):
         multi-line comments.  Nested comments are not supported.
 
         A chunk is a minimal sequence of consecutive lines of the input that
-        ends with a '.', possibly followed by blanks and/or comments.
+        ends with a '.' or a focusing brace, possibly followed by blanks and/or comments.
 
         >>> split_lines('A.\nB.''')
         ['A.\n', 'B.']
@@ -790,12 +790,14 @@ class RocqtopBlocksTransform(Transform):
         """
         comment = r"\(\*.*\*\)"
         # the end of a chunk is marked by
-        # a period (\.)
+        # a period (\.) or a focusing brace (:\s*\{)
         # optional blanks or comments (?:[ \t]*|{comment})*
         # followed by a newline \n
         # We capture everything starting from the '.' to recover it afterwards
         blank = r"[ \t]"
-        end_of_chunk = fr"(\.(?:{blank}*|{comment})*\n)"
+        dot = r"\."
+        focusing_brace = r":\s*\{"
+        end_of_chunk = fr"((?:{dot}|{focusing_brace})(?:{blank}*|{comment})*\n)"
         splits = re.split(end_of_chunk, source.strip())
         return [''.join(splits[i:i+2]) for i in range(0, len(splits), 2)]
 


### PR DESCRIPTION
This PR makes the `rocqtop::` directive in the reference manual correctly handle focusing braces. In particular, it fixes the output shown for the "Working with named goals" example:

Current output (https://rocq-prover.org/doc/master/refman/proofs/writing-proofs/proof-mode.html#curly-braces):

<img width="659" height="325" alt="image" src="https://github.com/user-attachments/assets/d9a7f152-b2d0-4764-bb31-e000264cd1e4" />

With this PR:
<img width="659" height="339" alt="image" src="https://github.com/user-attachments/assets/ef592950-86a3-4611-94e2-abbdad244293" />


