### PR TITLE
Extend and cleanup the abbreviation API.

### DIFF
--- a/dev/ci/user-overlays/21016-rlepigre-skylabs-ai-fold_abbreviations.sh
+++ b/dev/ci/user-overlays/21016-rlepigre-skylabs-ai-fold_abbreviations.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/rlepigre-skylabs-ai/coq-elpi fold_abbreviations 21016

--- a/interp/abbreviation.mli
+++ b/interp/abbreviation.mli
@@ -9,24 +9,51 @@
 (************************************************************************)
 
 open Names
-open Notation_term
 open Notationextern
-open Globnames
 
-(** Abbreviations. *)
+(** Abbreviations *)
 
-val declare_abbreviation : local:Libobject.locality -> Globnames.extended_global_reference UserWarn.with_qf option -> Id.t ->
-  onlyparsing:bool -> interpretation -> unit
+(** Representation of the data associated to an abbreviation. *)
+type data
 
-val search_abbreviation : abbreviation -> interpretation
+(** [interp a] gives the interpretation of abbreviation [a]. *)
+val interp : data -> Notation_term.interpretation
 
-val search_filtered_abbreviation :
-  (interpretation -> 'a option) -> abbreviation -> 'a option
+(** [full_path a] gives the full path of abbreviation [a]. *)
+val full_path : data -> Libnames.full_path
 
-val import_abbreviation : int -> Libnames.full_path -> KerName.t -> unit
+(** [enabled a] indicates whether the abbreviation [a] is enabled. *)
+val enabled : data -> bool
 
-(** Activate (if on:true) or deactivate (if on:false) an abbreviation assumed to exist *)
-val toggle_abbreviation : on:bool -> use:notation_use -> abbreviation -> unit
+(** [only_parsing a] indicates whether the abbreviation [a] is only used for
+    parsing, and not for printing. *)
+val only_parsing : data -> bool
 
-(** Activate (if on:true) or deactivate (if on:false) all abbreviations satisfying a criterion *)
-val toggle_abbreviations : on:bool -> use:notation_use -> (Libnames.full_path -> interpretation -> bool) -> unit
+(** [fold f acc] folds function [f] over the current abbreviation map, using
+    [acc] as the initial accumulator value. *)
+val fold : (Globnames.abbreviation -> data -> 'a -> 'a) -> 'a -> 'a
+
+(** [find_opt k] gives the abbreviation associated with the key [k] in the
+    abbreviation map, if there is one. *)
+val find_opt : Globnames.abbreviation -> data option
+
+(** [find_interp k] gives the interpretation of the abbreviation associated
+    with the key [k] in the abbreviation map. The [Not_found] exception is
+    raised if [k] is not mapped. *)
+val find_interp : Globnames.abbreviation -> Notation_term.interpretation
+
+(** [toggle ~on ~use key] actives (if [on]) or deactivates (if [not on]) the
+    abbreviation with the given [key]. An abbreviation associated with [key]
+    should exist, otherwise [Not_found] is raised. *)
+val toggle : on:bool -> use:notation_use -> Globnames.abbreviation -> unit
+
+(** [toggle_if ~on ~use pred] is equivalent to running [toggle ~on ~use] on
+    all abbreviations satisfying the given predicate [pred]. *)
+val toggle_if : on:bool -> use:notation_use ->
+  (Globnames.abbreviation -> data -> bool) -> unit
+
+val declare : local:Libobject.locality ->
+  Globnames.extended_global_reference UserWarn.with_qf option -> Id.t ->
+  onlyparsing:bool -> Notation_term.interpretation -> unit
+
+val import : int -> Libnames.full_path -> Globnames.abbreviation -> unit

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1368,7 +1368,7 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       raise Not_found
   | TrueGlobal ref -> (DAst.make ?loc @@ GRef (ref, us)), Some ref, args
   | Abbrev sp ->
-      let (ids,c) = Abbreviation.search_abbreviation sp in
+      let (ids,c) = Abbreviation.find_interp sp in
       let nids = List.length ids in
       if List.length args < nids then error_not_enough_arguments ?loc;
       let args1,args2 = List.chop nids args in
@@ -1430,7 +1430,10 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
         let args = List.map (intern_not subst) args in
         Some (g, Some args, pats2)
       | _ -> None in
-    match Abbreviation.search_filtered_abbreviation filter kn with
+    match Abbreviation.find_opt kn with
+    | None -> raise Not_found
+    | Some abbrev ->
+    match filter (Abbreviation.interp abbrev) with
     | Some (g, pats1, pats2) ->
       Nametab.is_warned_xref xref
       |> Option.iter (fun warn -> Nametab.warn_user_warn_xref ?loc:qid.loc warn (Abbrev kn));

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1718,14 +1718,16 @@ let toggle_abbreviations ~on found ntn_pattern =
       | Some (Inl _), _, _ | None, _::_, _ | None, _, Some _ -> raise Exit (* Not about abbreviation, shortcut *)
       | None, [], None -> None
     in
-    let test sp a =
+    let test _ abbrev =
+      let sp = Abbreviation.full_path abbrev in
+      let a = Abbreviation.interp abbrev in
       let res = match_notation_interpretation ntn_pattern.interpretation_pattern a in
       let res' = match qid with
         | Some qid -> Libnames.is_qualid_suffix_of_full_path qid sp
         | None -> true in
       let res'' = res && res' in
       if res'' then found := (Inr sp, a) :: !found; res'' in
-    Abbreviation.toggle_abbreviations ~on ~use:ntn_pattern.use_pattern test
+    Abbreviation.toggle_if ~on ~use:ntn_pattern.use_pattern test
   with Exit -> ()
 
 let warn_nothing_to_enable_or_disable =

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -18,13 +18,12 @@ open Pp
 open CErrors
 open Libnames
 open Globnames
-open Abbreviation
 open Notation_term
 
 let global_of_extended_global_head = function
   | TrueGlobal ref -> ref
   | Abbrev kn ->
-      let _, syn_def = search_abbreviation kn in
+      let _, syn_def = Abbreviation.find_interp kn in
       let rec head_of = function
         | NRef (ref,None) -> ref
         | NApp (rc, _) -> head_of rc
@@ -36,7 +35,7 @@ let global_of_extended_global_head = function
 let global_of_extended_global_exn = function
   | TrueGlobal ref -> ref
   | Abbrev kn ->
-  match search_abbreviation kn with
+  match Abbreviation.find_interp kn with
   | [],NRef (ref,None) -> ref
   | [],NApp (NRef (ref,None),[]) -> ref
   | _ -> raise Not_found

--- a/plugins/syntax/number_string.ml
+++ b/plugins/syntax/number_string.ml
@@ -225,7 +225,7 @@ let locate_global_sort_inductive_or_constant env sigma qid =
     match Nametab.locate_extended qid with
     | Globnames.TrueGlobal _ -> raise Not_found
     | Globnames.Abbrev kn ->
-    match Abbreviation.search_abbreviation kn with
+    match Abbreviation.find_interp kn with
     | [], Notation_term.NSort r ->
        let sigma,c = Glob_ops.fresh_glob_sort_in_quality sigma r in
        let c = EConstr.ESorts.kind sigma c in
@@ -432,7 +432,7 @@ let locate_global_inductive_with_params allow_params qid =
     match Nametab.locate_extended qid with
     | Globnames.TrueGlobal _ -> raise Not_found
     | Globnames.Abbrev kn ->
-    match Abbreviation.search_abbreviation kn with
+    match Abbreviation.find_interp kn with
     | [], Notation_term.(NApp (NRef (GlobRef.IndRef i,None), l)) ->
        i,
        List.map (function

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -2087,7 +2087,7 @@ let add_abbreviation ~local user_warns env ident (vars,c) modl =
   let interp = make_interpretation_vars ~default_if_binding:AsAnyPattern [] acvars level (List.map in_pat vars) in
   let vars = List.map (fun (x,_) -> (x, Id.Map.find x interp)) vars in
   let onlyparsing = only_parsing || fst (printability None [] vars false reversibility pat) in
-  Abbreviation.declare_abbreviation ~local user_warns ident ~onlyparsing (vars,pat)
+  Abbreviation.declare ~local user_warns ident ~onlyparsing (vars,pat)
 
 (**********************************************************************)
 (* Activating/deactivating notations                                  *)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -646,7 +646,7 @@ let print_global_reference access env sigma gref udecl =
   | VarRef id -> print_section_variable_with_infos env sigma id
 
 let glob_constr_of_abbreviation kn =
-  let (vars,a) = Abbreviation.search_abbreviation kn in
+  let (vars,a) = Abbreviation.find_interp kn in
   (List.map fst vars, Notation_ops.glob_constr_of_notation_constr a)
 
 let print_abbreviation_body env kn (vars,c) =
@@ -658,7 +658,7 @@ let print_abbreviation_body env kn (vars,c) =
         spc () ++ str ":=") ++
      spc () ++
      Vernacstate.System.protect (fun () ->
-         Abbreviation.toggle_abbreviation ~on:false ~use:ParsingAndPrinting kn;
+         Abbreviation.toggle ~on:false ~use:ParsingAndPrinting kn;
          pr_glob_constr_env env (Evd.from_env env) c) ())
 
 let print_abbreviation access env sigma kn =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1490,7 +1490,7 @@ let cache_name (len,n) =
   let open Globnames in
   let open GlobRef in
   match n with
-  | Abbrev kn -> Abbreviation.import_abbreviation (len+1) (Nametab.path_of_abbreviation kn) kn
+  | Abbrev kn -> Abbreviation.import (len+1) (Nametab.path_of_abbreviation kn) kn
   | TrueGlobal (VarRef _) -> assert false
   | TrueGlobal (ConstRef c) when Declare.is_local_constant c ->
     (* Can happen through functor application *)


### PR DESCRIPTION
See [this Zulip thread](https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/.E2.9C.94.20Collecting.20information.20about.20abbreviations), CC @ppedrot.

I it not clear to me if more should be exposed, for example whether an abbreviation is `onlyparsing`.

**Edit:** changed to a more accurate title, now that this is cleaning up the whole API, and not just adding a `fold` function on abbreviations.

Overlay pull requests:
- https://github.com/LPCIC/coq-elpi/pull/892