### PR TITLE
Add an API for canonicalizing maps in Environ.

### DIFF
--- a/dev/ci/user-overlays/21020-ppedrot-qmap-api.sh
+++ b/dev/ci/user-overlays/21020-ppedrot-qmap-api.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/ppedrot/coq-elpi qmap-api 21020
+
+overlay vsrocq https://github.com/ppedrot/vsrocq qmap-api 21020

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -435,7 +435,7 @@ and apply_notation_to_pattern ?loc gr ((terms,termlists,binders),(no_implicit,nb
     ((custom, lev_after), (tmp_scope, scopes) as allscopes) vars pat rule =
   let lev_after = if List.is_empty more_args then lev_after else Some Notation.app_level in
   let extra_args =
-    let subscopes = find_arguments_scope gr in
+    let subscopes = find_arguments_scope (Global.env ()) gr in
     let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
     let more_args = fill_arg_scopes more_args more_args_scopes (snd allscopes) in
     let more_args = List.map (fun (c,allscopes) -> extern_cases_pattern_in_scope allscopes vars c) more_args in
@@ -1025,7 +1025,7 @@ let rec extern depth0 inctx scopes vars r =
   | GApp (f,args) ->
       (match DAst.get f with
          | GRef (ref,us) ->
-             let subscopes = find_arguments_scope ref in
+             let subscopes = find_arguments_scope (Global.env ()) ref in
              let args = fill_arg_scopes args subscopes (snd scopes) in
              let args = extern_args (extern depth true) vars args in
              (* Try a "{|...|}" record notation *)
@@ -1312,7 +1312,7 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
         let argsscopes,argsimpls =
           match DAst.get f with
           | GRef (ref,_) ->
-            let subscopes = find_arguments_scope ref in
+            let subscopes = find_arguments_scope (Global.env ()) ref in
             let impls = select_stronger_impargs (implicits_of_global ref) in
             subscopes, impls
           | _ ->
@@ -1408,7 +1408,7 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
 
 and extern_applied_proj depth inctx scopes vars (cst,us) params c extraargs =
   let ref = GlobRef.ConstRef cst in
-  let subscopes = find_arguments_scope ref in
+  let subscopes = find_arguments_scope (Global.env ()) ref in
   let nparams = List.length params in
   let args = params @ c :: extraargs in
   let args = fill_arg_scopes args subscopes (snd scopes) in

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -120,7 +120,7 @@ let add_constant_kind kn k = csttab := Names.Cmap.add kn k !csttab
 let constant_kind kn = Names.Cmap.find kn !csttab
 
 let type_of_global_ref gr =
-  if Typeclasses.is_class gr then
+  if Typeclasses.is_class (Global.env ()) gr then
     "class"
   else
     let open Names.GlobRef in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -540,9 +540,10 @@ let implicits_table = Summary.ref GlobRefMap.empty ~name:"implicits"
 
 let implicits_of_global ref =
   try
-    let l = GlobRefMap.find (Global.env ()) ref !implicits_table in
+    let env = Global.env () in
+    let l = GlobRefMap.find env ref !implicits_table in
     try
-      let rename_l = Arguments_renaming.arguments_names ref in
+      let rename_l = Arguments_renaming.arguments_names env ref in
       let rec rename implicits names = match implicits, names with
         | [], _ -> []
         | _, [] -> implicits

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -534,11 +534,13 @@ type implicit_discharge_request =
   | ImplInteractive of implicits_flags *
       implicit_interactive_request
 
-let implicits_table = Summary.ref GlobRef.Map.empty ~name:"implicits"
+module GlobRefMap = Environ.QMap(GlobRef.Map_env)(Environ.QGlobRef)
+
+let implicits_table = Summary.ref GlobRefMap.empty ~name:"implicits"
 
 let implicits_of_global ref =
   try
-    let l = GlobRef.Map.find ref !implicits_table in
+    let l = GlobRefMap.find (Global.env ()) ref !implicits_table in
     try
       let rename_l = Arguments_renaming.arguments_names ref in
       let rec rename implicits names = match implicits, names with
@@ -553,7 +555,7 @@ let implicits_of_global ref =
   with Not_found -> [DefaultImpArgs,[]]
 
 let cache_implicits_decl (ref, imps) =
-  implicits_table := GlobRef.Map.add ref imps !implicits_table
+  implicits_table := GlobRefMap.add (Global.env ()) ref imps !implicits_table
 
 let load_implicits _ (_,l) = List.iter cache_implicits_decl l
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -188,7 +188,7 @@ val interp_notation_as_global_reference_expanded : ?loc:Loc.t -> head:bool ->
 val declare_arguments_scope :
   bool (** true=local *) -> GlobRef.t -> scope_name list list -> unit
 
-val find_arguments_scope : GlobRef.t -> scope_name list list
+val find_arguments_scope : Environ.env -> GlobRef.t -> scope_name list list
 
 type scope_class
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -290,6 +290,12 @@ val instantiate_context : UVars.Instance.t -> Vars.substl -> Name.t binder_annot
 
 (** {6 Name quotients} *)
 
+module type QS =
+sig
+  type t
+  val canonize : env -> t -> t
+end
+
 module type QNameS =
 sig
   type t
@@ -298,6 +304,23 @@ sig
   val hash : env -> t -> int
   val canonize : env -> t -> t
 end
+
+module type QMapS =
+sig
+  type key
+  type (+'a) t
+  val empty: 'a t
+  val is_empty: 'a t -> bool
+  val mem: env -> key -> 'a t -> bool
+  val add: env -> key -> 'a -> 'a t -> 'a t
+  val remove: env -> key -> 'a t -> 'a t
+  val fold: (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val merge: (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
+  val find: env -> key -> 'a t -> 'a
+  val find_opt : env -> key -> 'a t -> 'a option
+end
+
+module QMap (M : CSig.UMapS) (_ : QS with type t = M.key) : QMapS with type key = M.key
 
 module QConstant : QNameS with type t = Constant.t
 

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -51,7 +51,7 @@ module PropGlobal = struct
   let respectful_ref () = Rocqlib.lib_ref "rewrite.prop.respectful"
 
   let proper_class =
-    fun () -> Option.get (TC.class_info (Rocqlib.lib_ref "rewrite.prop.Proper"))
+    fun () -> Option.get (TC.class_info (Global.env ()) (Rocqlib.lib_ref "rewrite.prop.Proper"))
 
   let proper_proj () = Rocqlib.lib_ref "rewrite.prop.proper_prf"
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -805,7 +805,7 @@ let saturate ?(beta=false) ?(bi_types=false) env sigma c ?ty m =
   | ProdType (_, src, tgt) ->
       let sigma = create_evar_defs sigma in
       let argty = if bi_types then Reductionops.nf_betaiota env sigma src else src in
-      let typeclass_candidate = Typeclasses.is_maybe_class_type sigma argty in
+      let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma argty in
       let (sigma, x) = Evarutil.new_evar ~typeclass_candidate env sigma argty in
       loop (EConstr.Vars.subst1 x tgt) ((m - n,x,argty) :: args) sigma (n-1)
   | CastType (t, _) -> loop t args sigma n
@@ -851,7 +851,7 @@ let applyn ?(beta=false) ~with_evars ?(first_goes_last=false) n t =
         else match EConstr.kind sigma c with
         | Lambda (_, argty, c) ->
           let argty = Reductionops.nf_betaiota env sigma (EConstr.Vars.substl args argty) in
-          let typeclass_candidate = Typeclasses.is_maybe_class_type sigma argty in
+          let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma argty in
           let (sigma, x) = Evarutil.new_evar ~typeclass_candidate env sigma argty in
           saturate c (x :: args) sigma (n-1)
         | _ -> assert false

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -171,7 +171,7 @@ let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
     let elimty =
       let rename_elimty r =
         EConstr.of_constr
-          (Arguments_renaming.rename_type
+          (Arguments_renaming.rename_type env
             (EConstr.to_constr ~abort_on_undefined_evars:false sigma
               elimty) r) in
       match EConstr.kind sigma elim with
@@ -224,7 +224,7 @@ let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
           Array.mapi (fun j (ctx, cty) ->
             let t = Term.it_mkProd_or_LetIn cty ctx in
                   debug_ssr (fun () -> Pp.(str "Search" ++ Printer.pr_constr_env env sigma t));
-            let t = Arguments_renaming.rename_type t
+            let t = Arguments_renaming.rename_type env t
               (GlobRef.ConstructRef((kn,i),j+1)) in
             debug_ssr (fun () -> Pp.(str"Done Search " ++ Printer.pr_constr_env env sigma t));
               t)

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -405,7 +405,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
   in
   (* The resulting goal *)
   let evty = beta (EConstr.Vars.subst1 new_rdx pred) in
-  let typeclass_candidate = Typeclasses.is_maybe_class_type sigma evty in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma evty in
   let sigma, p = Evarutil.new_evar ~typeclass_candidate env sigma evty in
   (* We check the proof is well typed. We assume that the type of [elim] is of
      the form [forall (A : Type) (x : A) (P : A -> Type@{s}), T] s.t. the only
@@ -578,7 +578,7 @@ let rwprocess_rule env dir rule =
       match EConstr.kind sigma t with
       | Prod (_, xt, at) ->
         let sigma = Evd.create_evar_defs sigma in
-        let typeclass_candidate = Typeclasses.is_maybe_class_type sigma xt in
+        let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma xt in
         let (sigma, x) = Evarutil.new_evar ~typeclass_candidate env sigma xt in
         loop d sigma EConstr.(mkApp (r, [|x|])) (EConstr.Vars.subst1 x at) rs 0
       | App (pr, a) when is_ind_ref env sigma pr prod_type ->

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -251,7 +251,7 @@ let rec nb_deps_assums cur env sigma t =
   match EConstr.kind sigma t' with
   | Constr.Prod(name,ty,body) ->
      if EConstr.Vars.noccurn sigma 1 body &&
-        not (Typeclasses.is_class_type sigma ty) then cur
+        not (Typeclasses.is_class_type env sigma ty) then cur
      else nb_deps_assums (cur+1) env sigma body
   | Constr.LetIn(name,ty,t1,t2) ->
      nb_deps_assums (cur+1) env sigma t2

--- a/pretyping/arguments_renaming.mli
+++ b/pretyping/arguments_renaming.mli
@@ -15,9 +15,9 @@ open Constr
 val rename_arguments : bool -> GlobRef.t -> Name.t list -> unit
 
 (** [Not_found] is raised if no names are defined for [r] *)
-val arguments_names : GlobRef.t -> Name.t list
+val arguments_names : env -> GlobRef.t -> Name.t list
 
-val rename_type : types -> GlobRef.t -> types
+val rename_type : env -> types -> GlobRef.t -> types
 
 val rename_typing : env -> constr -> unsafe_judgment
 (** Typechecks using the kernel [Typeops.infer] *)

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -319,7 +319,7 @@ let inductive_template env sigma tmloc ind =
           let ctx, _ = destArity sigma ty in
           sigma, mkArity (ctx, s)
       in
-      let typeclass_candidate = Typeclasses.is_maybe_class_type sigma ty in
+      let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma ty in
       let sigma, e =
         Evarutil.new_evar ~typeclass_candidate env ~src:(hole_source n) sigma ty
       in

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -51,7 +51,7 @@ let apply_coercion_args env sigma isproj bo ty arg arg_ty nparams =
   let rec apply_rec sigma acc typ nparams =
     if nparams <= 0 then sigma, List.rev acc, typ else
       let c1, c2 = destProd sigma typ in
-      let typeclass_candidate = Typeclasses.is_maybe_class_type sigma c1 in
+      let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma c1 in
       let sigma, x = Evarutil.new_evar ~typeclass_candidate env sigma c1 in
       apply_rec sigma (x :: acc) (subst1 x c2) (nparams - 1) in
   let sigma, params, typ = apply_rec sigma [] ty nparams in
@@ -97,7 +97,7 @@ let make_existential ?loc ?(opaque = not (get_proofs_transparency ())) na env si
       Evar_kinds.qm_obligation=Evar_kinds.Define opaque;
       Evar_kinds.qm_name=na;
   }) in
-  let typeclass_candidate = Typeclasses.is_maybe_class_type sigma c in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma c in
   let sigma, v = Evarutil.new_evar ~typeclass_candidate env sigma ~src c in
   let sigma = Evd.set_obligation_evar sigma (fst (destEvar sigma v)) in
   sigma, v
@@ -703,7 +703,7 @@ let inh_coerce_to_fail ?(use_coercions=true) flags env sigma rigidonly v v_ty ta
           let target_type_has_args, v_ty_has_args, reversible, direct =
             lookup_reversible_path_to_common_point env sigma ~src_expected:target_type ~src_inferred:v_ty in
           if not (v_ty_has_args || target_type_has_args) then raise Not_found;
-          let typeclass_candidate = Typeclasses.is_maybe_class_type sigma target_type in
+          let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma target_type in
           let sigma, x = Evarutil.new_evar ~typeclass_candidate env sigma target_type in
           let sigma, rev_x, _, _ = apply_coercion env sigma reversible x target_type in
           let sigma, direct_v, _, _ = apply_coercion env sigma direct v v_ty in

--- a/pretyping/combinators.ml
+++ b/pretyping/combinators.ml
@@ -193,7 +193,7 @@ let sig_clausal_form env sigma sort_of_ty siglen ty dflt =
       let (a,p_i_minus_1) = match Reductionops.whd_beta_stack env sigma p_i with
         | (_sigT,[a;p]) -> (a, p)
         | _ -> anomaly ~label:"sig_clausal_form" (Pp.str "should be a sigma type.") in
-      let typeclass_candidate = Typeclasses.is_maybe_class_type sigma a in
+      let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma a in
       let sigma, ev = Evarutil.new_evar ~typeclass_candidate env sigma a in
       let rty = Reductionops.beta_applist sigma (p_i_minus_1,[ev]) in
       let sigma, tuple_tail = sigrec_clausal_form sigma (siglen-1) rty in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1394,7 +1394,7 @@ and conv_record flags env (evd,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c
           else
             let dloc = Loc.tag Evar_kinds.InternalHole in
             let ty = substl ks b in
-            let typeclass_candidate = Typeclasses.is_maybe_class_type i ty in
+            let typeclass_candidate = Typeclasses.is_maybe_class_type env i ty in
             let (i', ev) = Evarutil.new_evar ~typeclass_candidate env i ~src:dloc ty in
             (i', ev :: ks, m - 1,test))
         (evd,[],List.length bs,fun i -> Success i) bs
@@ -1742,7 +1742,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
                 env_evar_unf evd evty
             else evd, evty in
           (* XXX incorrect relevance *)
-          let typeclass_candidate = Typeclasses.is_maybe_class_type evd evty in
+          let typeclass_candidate = Typeclasses.is_maybe_class_type env_evar evd evty in
           let (evd, evk) = new_pure_evar ~typeclass_candidate sign evd ~relevance:ERelevance.relevant evty ~filter in
           let EvarInfo evi = Evd.find evd evk in
           let instance = Evd.evar_identity_subst evi in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -144,7 +144,7 @@ let define_pure_evar_as_lambda env evd name evk =
   let src = subterm_source evk ~where:Body (evar_source evi) in
   let abstract_arguments = Abstraction.abstract_last (Evd.evar_abstract_arguments evi) in
   let evty = subst1 (mkVar id.binder_name) rng in
-  let typeclass_candidate = Typeclasses.is_maybe_class_type evd1 evty in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type newenv evd1 evty in
   let evd2,body = new_evar ~typeclass_candidate newenv evd1 ~src evty ~filter ~abstract_arguments in
   let lam = mkLambda (map_annot Name.mk_name id, dom, subst_var evd2 id.binder_name body) in
   Evd.define evk lam evd2, lam

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -890,7 +890,7 @@ let materialize_evar define_fun env evd k (evk1,args1) ty_in_env =
     define_evar_from_virtual_equation define_fun env evd src ty_in_env
       ty_t_in_sign sign2 filter2 inst2_in_env in
   let (evd, ev2_in_sign) =
-  let typeclass_candidate = Typeclasses.is_maybe_class_type evd ev2ty_in_sign in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type env evd ev2ty_in_sign in
     (* XXX is this relevance correct? I don't really understand this code *)
     new_pure_evar sign2 ~typeclass_candidate evd ~relevance:(ESorts.relevance_of_sort s) ev2ty_in_sign ~filter:filter2 ~src in
   let ev2_in_env = (ev2_in_sign, inst2_in_env) in

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -106,7 +106,7 @@ let new_evar env sigma ?src ?rrpat ?(naming = Namegen.IntroAnonymous) ?relevance
     | Some r -> r
     | None -> Retyping.relevance_of_type env.static_env sigma typ
   in
-  let typeclass_candidate = Typeclasses.is_maybe_class_type sigma typ' in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type env.static_env sigma typ' in
   let (sigma, evk) = new_pure_evar ~typeclass_candidate sign sigma typ' ?src ?rrpat ~relevance ?name in
   (sigma, mkEvar (evk, instance))
 

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -28,13 +28,13 @@ let type_of_inductive env (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
  Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif,u) in
- EConstr.of_constr @@ Arguments_renaming.rename_type t (IndRef ind)
+ EConstr.of_constr @@ Arguments_renaming.rename_type env t (IndRef ind)
 
 let e_type_of_inductive env sigma (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
  Reductionops.check_hyps_inclusion env sigma (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif, EConstr.Unsafe.to_instance u) in
- EConstr.of_constr (Arguments_renaming.rename_type t (IndRef ind))
+ EConstr.of_constr (Arguments_renaming.rename_type env t (IndRef ind))
 
 (* Return type as quoted by the user *)
 let type_of_constructor env (cstr,u) =
@@ -43,14 +43,14 @@ let type_of_constructor env (cstr,u) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
  Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,u) specif in
- EConstr.of_constr @@ Arguments_renaming.rename_type t (ConstructRef cstr)
+ EConstr.of_constr @@ Arguments_renaming.rename_type env t (ConstructRef cstr)
 
 let e_type_of_constructor env sigma (cstr,u) =
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
  Reductionops.check_hyps_inclusion env sigma (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,EConstr.Unsafe.to_instance u) specif in
- EConstr.of_constr (Arguments_renaming.rename_type t (ConstructRef cstr))
+ EConstr.of_constr (Arguments_renaming.rename_type env t (ConstructRef cstr))
 
 (* Return constructor types in user form *)
 let type_of_constructors env (ind,u as indu) =

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -51,17 +51,19 @@ type typing_constraint = IsType | OfType of types | WithoutTypeConstraint
 
 let (!!) env = GlobEnv.env env
 
+module GlobRefMap = Environ.QMap(GlobRef.Map_env)(Environ.QGlobRef)
+
 let bidi_hints =
-  Summary.ref (GlobRef.Map.empty : int GlobRef.Map.t) ~name:"bidirectionalityhints"
+  Summary.ref (GlobRefMap.empty : int GlobRefMap.t) ~name:"bidirectionalityhints"
 
-let add_bidirectionality_hint gr n =
-  bidi_hints := GlobRef.Map.add gr n !bidi_hints
+let add_bidirectionality_hint env gr n =
+  bidi_hints := GlobRefMap.add env gr n !bidi_hints
 
-let get_bidirectionality_hint gr =
-  GlobRef.Map.find_opt gr !bidi_hints
+let get_bidirectionality_hint env gr =
+  GlobRefMap.find_opt env gr !bidi_hints
 
-let clear_bidirectionality_hint gr =
-  bidi_hints := GlobRef.Map.remove gr !bidi_hints
+let clear_bidirectionality_hint env gr =
+  bidi_hints := GlobRefMap.remove env gr !bidi_hints
 
 (************************************************************************)
 (* This concerns Cases *)
@@ -1068,7 +1070,7 @@ struct
       (* if `f` is a global, we retrieve bidirectionality hints *)
         try
           let (gr,_) = destRef sigma fj.uj_val in
-          Option.default length @@ get_bidirectionality_hint gr
+          Option.default length @@ get_bidirectionality_hint !!env gr
         with DestKO ->
           length
     in

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -21,14 +21,14 @@ open EConstr
 open Glob_term
 open Ltac_pretype
 
-val add_bidirectionality_hint : GlobRef.t -> int -> unit
+val add_bidirectionality_hint : env -> GlobRef.t -> int -> unit
 (** A bidirectionality hint `n` for a global `g` tells the pretyper to use
     typing information from the context after typing the `n` for arguments of an
     application of `g`. *)
 
-val get_bidirectionality_hint : GlobRef.t -> int option
+val get_bidirectionality_hint : env -> GlobRef.t -> int option
 
-val clear_bidirectionality_hint : GlobRef.t -> unit
+val clear_bidirectionality_hint : env -> GlobRef.t -> unit
 
 (** An auxiliary function for searching for fixpoint guard indices *)
 

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -137,7 +137,7 @@ let type_of_constant env sigma (c,u) =
   let cb = lookup_constant c env in
   let () = check_hyps_inclusion env sigma (GlobRef.ConstRef c) cb.const_hyps in
   let ty = CVars.subst_instance_constr (EConstr.Unsafe.to_instance u) cb.const_type in
-  EConstr.of_constr (rename_type ty (GlobRef.ConstRef c))
+  EConstr.of_constr (rename_type env ty (GlobRef.ConstRef c))
 
 let safe_meta_type metas n = match metas with
 | None -> None
@@ -311,7 +311,7 @@ let retype ?metas ?(polyprop=true) sigma =
       let ty =
         if mib.mind_nparams <= Array.length args then
         (* Fully applied parameters, we do not have to substitute *)
-          EConstr.of_constr (rename_type mip.mind_user_lc.(i - 1) (ConstructRef ctor))
+          EConstr.of_constr (rename_type env mip.mind_user_lc.(i - 1) (ConstructRef ctor))
       else
         type_of_global_reference_knowing_parameters env c args
       in
@@ -325,7 +325,7 @@ let retype ?metas ?(polyprop=true) sigma =
       ESorts.kind sigma s
     in
     let rename_type typ gr =
-      EConstr.of_constr @@ rename_type (EConstr.Unsafe.to_constr typ) gr
+      EConstr.of_constr @@ rename_type env (EConstr.Unsafe.to_constr typ) gr
     in
     match EConstr.kind sigma c with
     | Ind (ind, _) ->

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -91,7 +91,6 @@ type t =
   | Default_cs
 
 val equal : Environ.env -> t -> t -> bool
-val compare : t -> t -> int
 val print : t -> Pp.t
 
 (** Return the form of the component of a canonical structure *)
@@ -153,7 +152,7 @@ val entries : unit -> entry list
 
 (** [entries_for p] returns the list of canonical entries that have
     p as their FieldName *)
-val entries_for : projection:Names.GlobRef.t -> entry list
+val entries_for : Environ.env -> projection:Names.GlobRef.t -> entry list
 
 end
 

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -65,7 +65,7 @@ type instance = {
   is_impl: GlobRef.t;
 }
 
-val instances : GlobRef.t -> instance list option
+val instances : env -> GlobRef.t -> instance list option
 (** [None] if not a class *)
 
 val instances_exn : env -> evar_map -> GlobRef.t -> instance list
@@ -74,12 +74,12 @@ val instances_exn : env -> evar_map -> GlobRef.t -> instance list
 val typeclasses : unit -> typeclass list
 val all_instances : unit -> instance list
 
-val load_class : typeclass -> unit
+val load_class : env -> typeclass -> unit
 
-val load_instance : instance -> unit
-val remove_instance : instance -> unit
+val load_instance : env -> instance -> unit
+val remove_instance : env -> instance -> unit
 
-val class_info : GlobRef.t -> typeclass option
+val class_info : env -> GlobRef.t -> typeclass option
 (** [None] if not a class *)
 
 val class_info_exn : env -> evar_map -> GlobRef.t -> typeclass
@@ -98,7 +98,7 @@ val instance_impl : instance -> GlobRef.t
 
 val hint_priority : instance -> int option
 
-val is_class : GlobRef.t -> bool
+val is_class : env -> GlobRef.t -> bool
 
 (** Filter which evars to consider for resolution. *)
 type evar_filter = Evar.t -> Evar_kinds.t Lazy.t -> bool
@@ -117,8 +117,8 @@ val no_goals_or_obligations : evar_filter
 
 val make_unresolvables : (Evar.t -> bool) -> evar_map -> evar_map
 
-val is_class_evar : evar_map -> undefined evar_info -> bool
-val is_class_type : evar_map -> EConstr.types -> bool
+val is_class_evar : env -> evar_map -> undefined evar_info -> bool
+val is_class_type : env -> evar_map -> EConstr.types -> bool
 
 val resolve_typeclasses : ?filter:evar_filter -> ?unique:bool ->
   ?fail:bool -> env -> evar_map -> evar_map
@@ -134,7 +134,7 @@ val set_solve_all_instances : (env -> evar_map -> evar_filter -> bool -> bool ->
 
 val get_typeclasses_unique_solutions : unit -> bool
 
-val is_maybe_class_type : evar_map -> EConstr.types -> bool
+val is_maybe_class_type : env -> evar_map -> EConstr.types -> bool
 
 (* Deprecated *)
 val resolve_one_typeclass : ?unique:bool -> env -> evar_map -> EConstr.types -> evar_map * EConstr.constr

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -141,7 +141,7 @@ let judge_of_applied_inductive_knowing_parameters ~check env sigma (ind, u) argj
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_inductive_knowing_parameters (specif, u0) paramstyp in
   let sigma = Evd.add_constraints sigma csts in
-  let funj = { uj_val = mkIndU (ind, u); uj_type = EConstr.of_constr (rename_type ty (GR.IndRef ind)) } in
+  let funj = { uj_val = mkIndU (ind, u); uj_type = EConstr.of_constr (rename_type env ty (GR.IndRef ind)) } in
   judge_of_applied ~check env sigma funj argjv
 
 let judge_of_applied_constructor_knowing_parameters ~check env sigma ((ind, _ as cstr), u) argjv =
@@ -151,7 +151,7 @@ let judge_of_applied_constructor_knowing_parameters ~check env sigma ((ind, _ as
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_constructor_knowing_parameters (cstr, u0) specif paramstyp in
   let sigma = Evd.add_constraints sigma csts in
-  let funj = { uj_val = mkConstructU (cstr, u); uj_type = (EConstr.of_constr (rename_type ty (GR.ConstructRef cstr))) } in
+  let funj = { uj_val = mkConstructU (cstr, u); uj_type = (EConstr.of_constr (rename_type env ty (GR.ConstructRef cstr))) } in
   judge_of_applied ~check env sigma funj argjv
 
 let judge_of_apply env sigma fj args =
@@ -419,7 +419,7 @@ let type_of_constant env sigma (c,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Environ.constant_type env (c,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.ConstRef c)))
+  sigma, (EConstr.of_constr (rename_type env ty (GR.ConstRef c)))
 
 let type_of_inductive env sigma (ind,u) =
   let open Declarations in
@@ -428,7 +428,7 @@ let type_of_inductive env sigma (ind,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_inductive (specif,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.IndRef ind)))
+  sigma, (EConstr.of_constr (rename_type env ty (GR.IndRef ind)))
 
 let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let open Declarations in
@@ -437,7 +437,7 @@ let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_constructor (ctor,u) specif in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (GR.ConstructRef ctor)))
+  sigma, (EConstr.of_constr (rename_type env ty (GR.ConstructRef ctor)))
 
 let type_of_int env = EConstr.of_constr (Typeops.type_of_int env)
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -429,7 +429,7 @@ let occurrence_test env sigma c1 c2 =
      with UniversesDiffer | UGraph.UniverseInconsistency _ -> false, sigma
 
 let abstract_list_all_with_dependencies env evd typ c l =
-  let typeclass_candidate = Typeclasses.is_maybe_class_type evd typ in
+  let typeclass_candidate = Typeclasses.is_maybe_class_type env evd typ in
   let (evd, ev) = new_evar ~typeclass_candidate env evd typ in
   let evd,ev' = evar_absorb_arguments env evd (destEvar evd ev) l in
   let n = List.length l in
@@ -487,7 +487,7 @@ let pose_all_metas_as_evars ~metas env evd t =
         let ty = if Metaset.is_empty mvs then ty else aux ty in
         let ty = nf_betaiota env !evdref ty in
         let src = Meta.evar_source_of_meta mv !metas in
-        let typeclass_candidate = Typeclasses.is_maybe_class_type !evdref ty in
+        let typeclass_candidate = Typeclasses.is_maybe_class_type env !evdref ty in
         let evd, ev = Evarutil.new_evar ~typeclass_candidate env !evdref ~src ty in
         let evd, nmetas = Meta.meta_assign mv (ev, TypeNotProcessed) !metas evd in
         let () = evdref := evd in
@@ -1743,7 +1743,7 @@ let applyHead ~metas env evd c cl =
           | _ ->
             (* Does not matter, the evar will be later instantiated by [a] *)
             Loc.tag Evar_kinds.InternalHole in
-        let typeclass_candidate = Typeclasses.is_maybe_class_type evd c1 in
+        let typeclass_candidate = Typeclasses.is_maybe_class_type env evd c1 in
         let (evd,evar) = Evarutil.new_evar ~typeclass_candidate env evd ~src c1 in
         apprec (mkApp(c,[|evar|])) cl (subst1 evar c2) evd
       | _ -> user_err Pp.(str "Apply_Head_Then")

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -488,7 +488,7 @@ let clenv_pose_metas_as_evars ~metas env sigma dep_mvs =
       else
         let src = Meta.evar_source_of_meta mv metas in
         let src = adjust_meta_source ~metas sigma mv src in
-        let typeclass_candidate = Typeclasses.is_maybe_class_type sigma ty in
+        let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma ty in
         let (sigma, evar) = new_evar ~typeclass_candidate env sigma ~src ty in
         let sigma, metas = clenv_assign ~metas env sigma mv evar in
         fold metas sigma mvs in

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -137,7 +137,7 @@ let let_evar name typ =
       Namegen.next_ident_away_in_goal env id (Termops.vars_of_env env)
     | Name.Name id -> id
     in
-    let typeclass_candidate = Typeclasses.is_maybe_class_type sigma typ in
+    let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma typ in
     let (sigma, evar) = Evarutil.new_evar ~typeclass_candidate env sigma ~src ~naming:(Namegen.IntroFresh id) typ in
     Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
     (Tactics.pose_tac (Name.Name id) evar)

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -244,11 +244,11 @@ end) = struct
 
   let proper_class =
     let r = lazy (bind_rewrite_ref "Proper" ()) in
-    fun () -> Option.get (TC.class_info (Lazy.force r))
+    fun () -> Option.get (TC.class_info (Global.env ()) (Lazy.force r))
 
   let proper_proxy_class =
     let r = lazy (bind_rewrite_ref "ProperProxy" ()) in
-    fun () -> Option.get (TC.class_info (Lazy.force r))
+    fun () -> Option.get (TC.class_info (Global.env ()) (Lazy.force r))
 
   let proper_proj () = bind_rewrite_ref "proper_prf" ()
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3002,7 +3002,7 @@ let specialize (c,lbind) ipat =
     | LocalAssum (na, t) :: decls ->
       let t = Vars.esubst Vars.lift_substituend subst t in
       let env = push_rel (LocalAssum (na, t)) env in
-      let typeclass_candidate = Typeclasses.is_maybe_class_type sigma t in
+      let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma t in
       let sigma, ev = Evarutil.new_evar ~typeclass_candidate env sigma (lift 1 t) in
       let subst = Esubst.subs_cons (Vars.make_substituend ev) (Esubst.subs_shft (1, subst)) in
       instantiate sigma env subst ((env, ev) :: accu) decls
@@ -3157,7 +3157,7 @@ let specialize_eqs id =
         | _ ->
             if in_eqs then acc, in_eqs, ctx, ty
             else
-              let typeclass_candidate = Typeclasses.is_maybe_class_type !evars t in
+              let typeclass_candidate = Typeclasses.is_maybe_class_type env !evars t in
               let sigma, e = Evarutil.new_evar ~typeclass_candidate (push_rel_context ctx env) !evars t in
               evars := sigma;
                 aux false (LocalDef (na,e,t) :: ctx) (mkApp (lift 1 acc, [| mkRel 1 |])) b)

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -79,7 +79,7 @@ let add_instance_base inst =
  *)
 let perform_instance i =
   let i = { is_class = i.class_name; is_info = i.info; is_impl = i.instance } in
-  Typeclasses.load_instance i
+  Typeclasses.load_instance (Global.env ()) i
 
 let cache_instance inst =
   perform_instance inst;
@@ -193,7 +193,7 @@ let declare_instance ?(warn = false) env sigma info local glob =
  * classes persistent object
  *)
 
-let cache_class c = load_class c
+let cache_class c = load_class (Global.env ()) c
 
 let subst_class (subst,cl) =
   let do_subst_con c = Mod_subst.subst_constant subst c

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -20,8 +20,8 @@ let smart_global r =
 
 let cache_bidi_hints (gr, ohint) =
   match ohint with
-  | None -> Pretyping.clear_bidirectionality_hint gr
-  | Some nargs -> Pretyping.add_bidirectionality_hint gr nargs
+  | None -> Pretyping.clear_bidirectionality_hint (Global.env ()) gr
+  | Some nargs -> Pretyping.add_bidirectionality_hint (Global.env ()) gr nargs
 
 let load_bidi_hints _ r =
   cache_bidi_hints r
@@ -311,14 +311,14 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   if bidi_hint_specified then begin
     let n = Option.get nargs_before_bidi in
     if section_local then
-      Pretyping.add_bidirectionality_hint sr n
+      Pretyping.add_bidirectionality_hint env sr n
     else
       Lib.add_leaf (inBidiHints (sr, Some n))
   end;
 
   if clear_bidi_hint then begin
     if section_local then
-      Pretyping.clear_bidirectionality_hint sr
+      Pretyping.clear_bidirectionality_hint env sr
     else
       Lib.add_leaf (inBidiHints (sr, None))
   end;

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -117,7 +117,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
     List.map pi1 (Impargs.compute_implicits_names env sigma (EConstr.of_constr ty))
   in
   let prev_names =
-    try Arguments_renaming.arguments_names sr with Not_found -> inf_names
+    try Arguments_renaming.arguments_names env sr with Not_found -> inf_names
   in
   let num_args = List.length inf_names in
   assert (Int.equal num_args (List.length prev_names));

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -164,7 +164,7 @@ let encapsulate_Fix_sub env sigma recname ctx body ccl (extradecl, rel, relargty
   (* Making Fix_sub ready to take the extended body as argument *)
   let sigma, fix_sub =
     let sigma, fix_sub_term = Evd.fresh_global (Global.env ()) sigma fix_sub_ref in
-    let typeclass_candidate = Typeclasses.is_maybe_class_type sigma wf_type in
+    let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma wf_type in
     let sigma, wf_proof = Evarutil.new_evar ~typeclass_candidate env sigma
         ~src:(Loc.tag @@ Evar_kinds.QuestionMark {
             Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Evar_kinds.Define false;

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -162,7 +162,7 @@ let model_conclusion env sigma ind_rel params n arity_indices =
     List.fold_right
       (fun (_,t) (sigma, subst) ->
         let t = EConstr.Vars.substl subst (EConstr.Vars.liftn n (List.length subst + 1) t) in
-        let typeclass_candidate = Typeclasses.is_maybe_class_type sigma t in
+        let typeclass_candidate = Typeclasses.is_maybe_class_type env sigma t in
         let sigma, c = Evarutil.new_evar ~typeclass_candidate env sigma t in
         sigma, c::subst)
       arity_indices (sigma, []) in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -64,7 +64,7 @@ let print_ref env reduce ref udecl =
       let ctx,ccl = Reductionops.whd_decompose_prod_decls env sigma (EConstr.of_constr typ)
       in EConstr.to_constr sigma (EConstr.it_mkProd_or_LetIn ccl ctx)
     else typ in
-  let typ = Arguments_renaming.rename_type typ ref in
+  let typ = Arguments_renaming.rename_type env typ ref in
   let impargs = select_stronger_impargs (implicits_of_global ref) in
   let impargs = List.map binding_kind_of_status impargs in
   let variance = let open GlobRef in match ref with
@@ -414,7 +414,7 @@ let print_arguments env ref =
     | _ -> [], [], None
   in
   let names, not_renamed =
-    try Arguments_renaming.arguments_names ref, false
+    try Arguments_renaming.arguments_names env ref, false
     with Not_found ->
       let ty, _ = Typeops.type_of_global_in_context env ref in
       List.map pi1 (Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty)), true in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -427,7 +427,7 @@ let print_arguments env ref =
   in
   let impls = main_implicits 0 names recargs scopes impls in
   let moreimpls = List.map (fun (_,i) -> List.map extra_implicit_kind_of_status i) moreimpls in
-  let bidi = Pretyping.get_bidirectionality_hint ref in
+  let bidi = Pretyping.get_bidirectionality_hint env ref in
   let impls = insert_fake_args nargs_for_red bidi impls in
   if List.for_all is_dummy impls && moreimpls = [] && flags = [] then []
   else
@@ -459,8 +459,8 @@ let print_section_deps env ref =
 
 (** Printing bidirectionality status *)
 
-let print_bidi_hints gr =
-  match Pretyping.get_bidirectionality_hint gr with
+let print_bidi_hints env gr =
+  match Pretyping.get_bidirectionality_hint env gr with
   | None -> []
   | Some nargs ->
     [str "Using typing information from context after typing the " ++ int nargs ++ str " first arguments"]
@@ -1062,7 +1062,7 @@ let print_about_global_reference ?loc env ref udecl =
     print_name_infos env ref @
     print_reduction_behaviour ref @
     print_opacity env ref @
-    print_bidi_hints ref @
+    print_bidi_hints env ref @
     [hov 0 (str "Expands to: " ++ pr_located_qualid env (Term ref)) ++
     loc_info (TrueGlobal ref)])
 

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -418,7 +418,7 @@ let print_arguments env ref =
     with Not_found ->
       let ty, _ = Typeops.type_of_global_in_context env ref in
       List.map pi1 (Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty)), true in
-  let scopes = Notation.find_arguments_scope ref in
+  let scopes = Notation.find_arguments_scope env ref in
   let flags = if needs_extra_scopes env ref scopes then `ExtraScopes::flags else flags in
   let impls = Impargs.extract_impargs_data (Impargs.implicits_of_global ref) in
   let impls, moreimpls = match impls with

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -105,14 +105,14 @@ let print_fields envpar sigma cstrtypes =
         Id.print id ++ str (if b then " : " else " := ") ++
         Printer.pr_lconstr_env envpar sigma c) fields) ++ str" }"
 
-let is_canonical_as ind indname id =
+let is_canonical_as env ind indname id =
   (* See record.ml *)
-  let canonical_id = Record.canonical_inhabitant_id ~isclass:(Typeclasses.is_class (IndRef ind)) indname in
+  let canonical_id = Record.canonical_inhabitant_id ~isclass:(Typeclasses.is_class env (IndRef ind)) indname in
   Id.equal id canonical_id
 
-let print_as ind indname = function
+let print_as env ind indname = function
   | Anonymous -> mt () (* TODO: get the "as" name also for non-primitive records *)
-  | Name id -> if is_canonical_as ind indname id then mt () else str " as " ++ Id.print id
+  | Name id -> if is_canonical_as env ind indname id then mt () else str " as " ++ Id.print id
 
 let print_one_inductive env sigma isrecord mib ((_,i) as ind, as_clause) =
   let u = UVars.make_abstract_instance (Declareops.inductive_polymorphic_context mib) in
@@ -138,7 +138,7 @@ let print_one_inductive env sigma isrecord mib ((_,i) as ind, as_clause) =
     if not isrecord then
       brk(0,2) ++ print_constructors env_params sigma mip.mind_consnames cstrtypes
     else
-      brk(1,2) ++ print_fields env_params sigma cstrtypes ++ print_as ind mip.mind_typename as_clause
+      brk(1,2) ++ print_fields env_params sigma cstrtypes ++ print_as env ind mip.mind_typename as_clause
 
 let pr_mutual_inductive_body env mind mib udecl =
   let inds = List.init (Array.length mib.mind_packets) (fun x -> (mind, x)) in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -1051,7 +1051,7 @@ let warn_already_existing_class =
       Printer.pr_global g ++ str " is already declared as a typeclass.")
 
 let declare_existing_class g =
-  if Typeclasses.is_class g then warn_already_existing_class g
+  if Typeclasses.is_class (Global.env ()) g then warn_already_existing_class g
   else
     match g with
     | GlobRef.ConstRef x -> add_constant_class x


### PR DESCRIPTION
We use it in several places to reduce the amount of calls to maps relying on canonical parts of names.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/867
- https://github.com/rocq-prover/vsrocq/pull/1140