### PR TITLE
Use binary sets rather than lists in coqdep loadpaths.

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -81,16 +81,21 @@ let safe_assoc ?(warn_clashes=true) st ?(what=Library) from file k =
     | External -> Loadpath.search_other_known st in
   match search ?from k with
   | None -> None
-  | Some (Loadpath.ExactMatches (f :: l)) ->
+  | Some (Loadpath.ExactMatches fs) ->
+    let f = fs.Loadpath.point in
+    let l = Loadpath.FileSet.elements fs.files in
+    let l = List.map Loadpath.Filename.repr l in
+    let l = List.filter (fun f' -> not (String.equal f f')) l in
     if warn_clashes then warn_if_clash ~what true file k f l;
     Some [f]
   | Some (Loadpath.PartialMatchesInSameRoot (root, l)) ->
+    let l = Loadpath.FileSet.elements l.files in
+    let l = List.map Loadpath.Filename.repr l in
     (match List.sort String.compare l with [] -> assert false | f :: l as all ->
     (* If several files match, it will fail at Require;
        To be "fair", in rocq dep, we add dependencies on all matching files *)
     if warn_clashes then warn_if_clash ~what false file k f l;
     Some all)
-  | Some (Loadpath.ExactMatches []) -> assert false
 
 let file_name ~separator_hack s = function
   | None     -> s

--- a/tools/coqdep/lib/loadpath.mli
+++ b/tools/coqdep/lib/loadpath.mli
@@ -19,9 +19,22 @@ type filename = string
 type dirpath = string list
 type root = filename * dirpath
 
+module Filename :
+sig
+  type t
+  val repr : t -> filename
+end
+
+module FileSet : Set.S with type elt = Filename.t
+
+type fileset = private {
+  point : filename;
+  files : FileSet.t; (* guaranteed to contain [point] *)
+}
+
 type result =
-  | ExactMatches of filename list
-  | PartialMatchesInSameRoot of root * filename list
+  | ExactMatches of fileset
+  | PartialMatchesInSameRoot of root * fileset
 
 module State : sig
   type t


### PR DESCRIPTION
The new behaviour should be extensionally the same, as we rely on the same canonization algorithm to identify filenames and compare them in the set. Yet this is algorithmically much faster.

Fixes #21022: rocqdep should be faster.