### PR TITLE
Slightly better compilation of functional cases in the VM / native.

### DIFF
--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -740,8 +740,11 @@ let rec lambda_of_constr cache env sigma c =
       else
         let b =
           match b.node with
-          | Llam(ids, body) when Array.length ids = arity -> (ids, body)
+          | Llam (ids, body) when arity <= Array.length ids ->
+            let ids, rem = Array.chop arity ids in
+            (ids, mkLlam rem body)
           | _ ->
+            (* happens when the branch contains let-bindings *)
             let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
             let ids = Array.make arity anon in
             let args = make_args arity 1 in


### PR DESCRIPTION
A pattern-matching that returned a function was compiled in an inefficient way, introducing dummy beta cuts. We now use the same code for all cases (pun intended) on let-free inductive types.