### PR TITLE
Fix stale CI job after organization renaming.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     # Do not run on forks (we want this request to happen only once every night)
     permissions:
       contents: none
-    if: github.repository_owner == 'coq'
+    if: github.repository_owner == 'rocq-prover'
     runs-on: ubuntu-latest
     steps:
-      - run: curl -d "coq:coq:${{ secrets.DAILY_SCHEDULE_SECRET }}" https://coqbot.herokuapp.com/check-stale-pr
+      - run: curl -d "rocq-prover:rocq:${{ secrets.DAILY_SCHEDULE_SECRET }}" https://coqbot.herokuapp.com/check-stale-pr


### PR DESCRIPTION
This should fix the issue reported by @ppedrot in [Zulip](https://rocq-prover.zulipchat.com/#narrow/channel/243318-coqbot-devs-.26-users/topic/coqbot.20not.20checking.20staleness.20anymore.3F).