### PR TITLE
Fix #21035 (don't print goals in -emacs mode)

### DIFF
--- a/doc/changelog/09-cli-tools/21038-fix21035-Changed.rst
+++ b/doc/changelog/09-cli-tools/21038-fix21035-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  in ``-emacs`` mode, goals are no longer spontaneously printed
+  (`#21038 <https://github.com/rocq-prover/rocq/pull/21038>`_,
+  fixes `#21035 <https://github.com/rocq-prover/rocq/issues/21035>`_,
+  by Pierre Roux).

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -478,7 +478,7 @@ let process_toplevel_command ~state stm =
 
   | VernacControl { CAst.loc; v=c } ->
     let nstate = Vernac.process_expr ~state (CAst.make ?loc c) in
-    let () = match nstate.proof with
+    let () = if not !print_emacs then match nstate.proof with
     | None -> ()
     | Some proof -> top_goal_print ~doc:state.doc c state.proof proof
     in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21035 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] ~Opened **overlay** pull requests.~

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: off
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
