### PR TITLE
Refactor fixpoint tactics

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -20,6 +20,7 @@ open Namegen
 open Names
 open Pp
 open Tactics
+open FixTactics
 open Induction
 open Indfun_common
 open Libnames
@@ -1161,7 +1162,7 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
                 (fun _ _ -> str "h_fix " ++ int (this_fix_info.idx + 1))
                 (fix this_fix_info.name (this_fix_info.idx + 1))
           else
-            Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
+            FixTactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
               other_fix_infos
       in
       let first_tac : unit Proofview.tactic =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1222,7 +1222,7 @@ let termination_proof_header is_mes input_type ids args_id relation rec_arg_num
                    (onNLastHypsId (nargs + 1)
                       (tclMAP (fun id ->
                            tclTHEN (Generalize.generalize [mkVar id]) (clear [id]))))
-               ; observe_tac (fun _ _ -> str "fix") (fix hrec (nargs + 1))
+               ; observe_tac (fun _ _ -> str "fix") (FixTactics.fix hrec (nargs + 1))
                ; h_intros args_id
                ; Simple.intro wf_rec_arg
                ; observe_tac

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -264,13 +264,13 @@ END
 (* Fix *)
 
 TACTIC EXTEND fix
-| [ "fix" ident(id) natural(n) ] -> { Tactics.fix id n }
+| [ "fix" ident(id) natural(n) ] -> { FixTactics.fix id n }
 END
 
 (* Cofix *)
 
 TACTIC EXTEND cofix
-| [ "cofix" ident(id) ] -> { Tactics.cofix id }
+| [ "cofix" ident(id) ] -> { FixTactics.cofix id }
 END
 
 (* Clear *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1720,7 +1720,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_fix (interp_ident ist env sigma id) n l_interp)
+        (FixTactics.mutual_fix (interp_ident ist env sigma id) n l_interp)
       end
       end
   | TacMutualCofix (id,l) ->
@@ -1735,7 +1735,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_cofix (interp_ident ist env sigma id) l_interp)
+        (FixTactics.mutual_cofix (interp_ident ist env sigma id) l_interp)
       end
       end
   | TacAssert (ev,b,t,ipat,c) ->

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -633,10 +633,10 @@ let () =
   define "tac_admit" (unit @-> tac unit) (fun _ -> Proofview.give_up)
 
 let () =
-  define "tac_fix" (ident @-> int @-> tac unit) Tactics.fix
+  define "tac_fix" (ident @-> int @-> tac unit) FixTactics.fix
 
 let () =
-  define "tac_cofix" (ident @-> tac unit) Tactics.cofix
+  define "tac_cofix" (ident @-> tac unit) FixTactics.cofix
 
 let () =
   define "tac_clear" (list ident @-> tac unit) Tactics.clear

--- a/tactics/fixTactics.ml
+++ b/tactics/fixTactics.ml
@@ -1,0 +1,117 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Util
+open Names
+open Context
+open Termops
+open Environ
+open EConstr
+open Inductiveops
+open Reductionops
+
+let rec mk_holes env sigma = function
+| [] -> (sigma, [])
+| arg :: rem ->
+  let (sigma, arg) = Evarutil.new_evar env sigma arg in
+  let (sigma, rem) = mk_holes env sigma rem in
+  (sigma, arg :: rem)
+
+let rec check_mutind env sigma k cl = match EConstr.kind sigma (strip_outer_cast sigma cl) with
+| Prod (na, c1, b) ->
+  if Int.equal k 1 then
+    try ignore (find_inductive env sigma c1)
+    with Not_found -> TacticErrors.fixpoint_on_non_inductive_type ()
+  else
+    let open Context.Rel.Declaration in
+    check_mutind (push_rel (LocalAssum (na, c1)) env) sigma (pred k) b
+| LetIn (na, c1, t, b) ->
+    let open Context.Rel.Declaration in
+    check_mutind (push_rel (LocalDef (na, c1, t)) env) sigma k b
+| _ -> TacticErrors.not_enough_products ()
+
+let mutual_fix f n others = Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let sigma = Tacmach.project gl in
+  let concl = Proofview.Goal.concl gl in
+  let () = check_mutind env sigma n concl in
+  let all = (f, n, concl) :: others in
+  let all = List.map (fun (f, n, ar) ->
+      let r = Retyping.relevance_of_type env sigma ar in
+      (f, r, n, ar))
+      all
+  in
+  let rec mk_sign sign = function
+  | [] -> sign
+  | (f, r, n, ar) :: oth ->
+    let open Context.Named.Declaration in
+    let ()  = check_mutind env sigma n ar in
+    if mem_named_context_val f sign then
+      TacticErrors.intro_already_declared f;
+    mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
+  in
+  let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
+  Refine.refine ~typecheck:false begin fun sigma ->
+    let (sigma, evs) = mk_holes nenv sigma (List.map (fun (_,_,_,ar) -> ar) all) in
+    let ids, rs, _, ars = List.split4 all in
+    let evs = List.map (Vars.subst_vars sigma (List.rev ids)) evs in
+    let indxs = Array.of_list (List.map (fun n -> n-1) (List.map (fun (_,_,n,_) -> n) all)) in
+    let funnames = Array.of_list (List.map2 (fun i r -> make_annot (Name i) r) ids rs) in
+    let bodies = Array.of_list evs in
+    let typarray = Array.of_list ars in
+    let oterm = mkFix ((indxs,0),(funnames,typarray,bodies)) in
+    (sigma, oterm)
+  end
+end
+
+let fix id n = mutual_fix id n []
+
+let rec check_is_mutcoind env sigma cl =
+  let b = whd_all env sigma cl in
+  match EConstr.kind sigma b with
+  | Prod (na, c1, b) ->
+    let open Context.Rel.Declaration in
+    check_is_mutcoind (push_rel (LocalAssum (na,c1)) env) sigma b
+  | _ ->
+    try
+      let _ = find_coinductive env sigma b in ()
+    with Not_found ->
+      TacticErrors.all_methods_in_coinductive_type ()
+
+let mutual_cofix f others = Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let sigma = Tacmach.project gl in
+  let concl = Proofview.Goal.concl gl in
+  let all = (f, concl) :: others in
+  List.iter (fun (_, c) -> check_is_mutcoind env sigma c) all;
+  let all = List.map (fun (id,t) -> (id, Retyping.relevance_of_type env sigma t, t)) all in
+  let rec mk_sign sign = function
+  | [] -> sign
+  | (f, r, ar) :: oth ->
+    let open Context.Named.Declaration in
+    if mem_named_context_val f sign then
+      TacticErrors.already_used f;
+    mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
+  in
+  let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
+  Refine.refine ~typecheck:false begin fun sigma ->
+    let (ids, rs, types) = List.split3 all in
+    let (sigma, evs) = mk_holes nenv sigma types in
+    let evs = List.map (Vars.subst_vars sigma (List.rev ids)) evs in
+    (* TODO relevance *)
+    let funnames = Array.of_list (List.map2 (fun i r -> make_annot (Name i) r) ids rs) in
+    let typarray = Array.of_list types in
+    let bodies = Array.of_list evs in
+    let oterm = mkCoFix (0, (funnames, typarray, bodies)) in
+    (sigma, oterm)
+  end
+end
+
+let cofix id = mutual_cofix id []

--- a/tactics/fixTactics.mli
+++ b/tactics/fixTactics.mli
@@ -1,0 +1,36 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open EConstr
+
+(** Fixpoint and co-fixpoint tactics. *)
+
+(** [fix f idx] refines the goal using a fixpoint.
+    - [f] is the name of the variable which represents the fixpoint.
+    - [idx] is the index of the structurally recursive argument (starting at 1). *)
+val fix : Id.t -> int -> unit Proofview.tactic
+
+(** [mutual_fix f idx fs] refines the goal using a mutual fixpoint.
+    - [f] and [idx] are the name and recursive argument index for the first fixpoint.
+      The type of [f] is simply the conclusion of the goal.
+    - [fs] contains the name, recursive argument index, and type of every other fixpoint
+      in the mutual block. *)
+val mutual_fix :
+  Id.t -> int -> (Id.t * int * constr) list -> unit Proofview.tactic
+
+(** [cofix f] refines the goal using a cofixpoint.
+    - [f] is the name of the variable which represents the cofixpoint. *)
+val cofix : Id.t -> unit Proofview.tactic
+
+(** [mutual_cofix f fs] refines the goal using a mutual cofixpoint.
+    - [f] is the name of the first cofixpoint. The type of [f] is simply the conclusion of the goal.
+    - [fs] contains the name and type of every other cofixpoint in the mutual block. *)
+val mutual_cofix : Id.t -> (Id.t * constr) list -> unit Proofview.tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -429,109 +429,6 @@ let assert_after na = assert_after_gen false (naming_of_name na)
 let assert_after_replacing id = assert_after_gen true (NamingMustBe (CAst.make id))
 
 (**************************************************************)
-(*          Fixpoints and CoFixpoints                         *)
-(**************************************************************)
-
-let rec mk_holes env sigma = function
-| [] -> (sigma, [])
-| arg :: rem ->
-  let (sigma, arg) = Evarutil.new_evar env sigma arg in
-  let (sigma, rem) = mk_holes env sigma rem in
-  (sigma, arg :: rem)
-
-let rec check_mutind env sigma k cl = match EConstr.kind sigma (strip_outer_cast sigma cl) with
-| Prod (na, c1, b) ->
-  if Int.equal k 1 then
-    try ignore (find_inductive env sigma c1)
-    with Not_found -> TacticErrors.fixpoint_on_non_inductive_type ()
-  else
-    let open Context.Rel.Declaration in
-    check_mutind (push_rel (LocalAssum (na, c1)) env) sigma (pred k) b
-| LetIn (na, c1, t, b) ->
-    let open Context.Rel.Declaration in
-    check_mutind (push_rel (LocalDef (na, c1, t)) env) sigma k b
-| _ -> TacticErrors.not_enough_products ()
-
-let mutual_fix f n others = Proofview.Goal.enter begin fun gl ->
-  let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
-  let concl = Proofview.Goal.concl gl in
-  let () = check_mutind env sigma n concl in
-  let all = (f, n, concl) :: others in
-  let all = List.map (fun (f, n, ar) ->
-      let r = Retyping.relevance_of_type env sigma ar in
-      (f, r, n, ar))
-      all
-  in
-  let rec mk_sign sign = function
-  | [] -> sign
-  | (f, r, n, ar) :: oth ->
-    let open Context.Named.Declaration in
-    let ()  = check_mutind env sigma n ar in
-    if mem_named_context_val f sign then
-      TacticErrors.intro_already_declared f;
-    mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
-  in
-  let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
-  Refine.refine ~typecheck:false begin fun sigma ->
-    let (sigma, evs) = mk_holes nenv sigma (List.map (fun (_,_,_,ar) -> ar) all) in
-    let ids, rs, _, ars = List.split4 all in
-    let evs = List.map (Vars.subst_vars sigma (List.rev ids)) evs in
-    let indxs = Array.of_list (List.map (fun n -> n-1) (List.map (fun (_,_,n,_) -> n) all)) in
-    let funnames = Array.of_list (List.map2 (fun i r -> make_annot (Name i) r) ids rs) in
-    let bodies = Array.of_list evs in
-    let typarray = Array.of_list ars in
-    let oterm = mkFix ((indxs,0),(funnames,typarray,bodies)) in
-    (sigma, oterm)
-  end
-end
-
-let fix id n = mutual_fix id n []
-
-let rec check_is_mutcoind env sigma cl =
-  let b = whd_all env sigma cl in
-  match EConstr.kind sigma b with
-  | Prod (na, c1, b) ->
-    let open Context.Rel.Declaration in
-    check_is_mutcoind (push_rel (LocalAssum (na,c1)) env) sigma b
-  | _ ->
-    try
-      let _ = find_coinductive env sigma b in ()
-    with Not_found ->
-      TacticErrors.all_methods_in_coinductive_type ()
-
-let mutual_cofix f others = Proofview.Goal.enter begin fun gl ->
-  let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
-  let concl = Proofview.Goal.concl gl in
-  let all = (f, concl) :: others in
-  List.iter (fun (_, c) -> check_is_mutcoind env sigma c) all;
-  let all = List.map (fun (id,t) -> (id, Retyping.relevance_of_type env sigma t, t)) all in
-  let rec mk_sign sign = function
-  | [] -> sign
-  | (f, r, ar) :: oth ->
-    let open Context.Named.Declaration in
-    if mem_named_context_val f sign then
-      TacticErrors.already_used f;
-    mk_sign (push_named_context_val (LocalAssum (make_annot f r, ar)) sign) oth
-  in
-  let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in
-  Refine.refine ~typecheck:false begin fun sigma ->
-    let (ids, rs, types) = List.split3 all in
-    let (sigma, evs) = mk_holes nenv sigma types in
-    let evs = List.map (Vars.subst_vars sigma (List.rev ids)) evs in
-    (* TODO relevance *)
-    let funnames = Array.of_list (List.map2 (fun i r -> make_annot (Name i) r) ids rs) in
-    let typarray = Array.of_list types in
-    let bodies = Array.of_list evs in
-    let oterm = mkCoFix (0, (funnames, typarray, bodies)) in
-    (sigma, oterm)
-  end
-end
-
-let cofix id = mutual_cofix id []
-
-(**************************************************************)
 (*          Reduction and conversion tactics                  *)
 (**************************************************************)
 
@@ -3409,4 +3306,16 @@ let dest_intro_patterns = dest_intro_patterns
 
 end
 
+(**********************************************************)
+(** Moved functions.                                      *)
+(**********************************************************)
+
 exception NotConvertible = TacticErrors.NotConvertible
+
+let fix = FixTactics.fix
+
+let mutual_fix = FixTactics.mutual_fix
+
+let cofix = FixTactics.cofix
+
+let mutual_cofix = FixTactics.mutual_cofix

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -26,30 +26,6 @@ open Ltac_pretype
 
 val is_quantified_hypothesis : Id.t -> Proofview.Goal.t -> bool
 
-(** {6 Fixpoint tactics. } *)
-
-(** [fix f idx] refines the goal using a fixpoint.
-    - [f] is the name of the variable which represents the fixpoint.
-    - [idx] is the index of the structurally recursive argument (starting at 1). *)
-val fix : Id.t -> int -> unit Proofview.tactic
-
-(** [mutual_fix f idx fs] refines the goal using a mutual fixpoint.
-    - [f] and [idx] are the name and recursive argument index for the first fixpoint.
-      The type of [f] is simply the conclusion of the goal.
-    - [fs] contains the name, recursive argument index, and type of every other fixpoint
-      in the mutual block. *)
-val mutual_fix :
-  Id.t -> int -> (Id.t * int * constr) list -> unit Proofview.tactic
-
-(** [cofix f] refines the goal using a cofixpoint.
-    - [f] is the name of the variable which represents the cofixpoint. *)
-val cofix : Id.t -> unit Proofview.tactic
-
-(** [mutual_cofix f fs] refines the goal using a mutual cofixpoint.
-    - [f] is the name of the first cofixpoint. The type of [f] is simply the conclusion of the goal.
-    - [fs] contains the name and type of every other cofixpoint in the mutual block. *)
-val mutual_cofix : Id.t -> (Id.t * constr) list -> unit Proofview.tactic
-
 (** {6 Conversion tactics. } *)
 
 (** [vm_cast_no_check new_concl] changes the conclusion to [new_concl] by inserting a [VMcast].
@@ -759,5 +735,18 @@ end
 (** The functions below have been moved to other files but are kept here
     for backwards compatibility. Don't use in new code. *)
 
-(** Deprecated, use [TacticErrors.not_convertible ()] instead. *)
+(** Deprecated since 9.2, use [TacticErrors.not_convertible ()] instead. *)
 exception NotConvertible
+
+val fix : Id.t -> int -> unit Proofview.tactic
+[@@ocaml.deprecated "(since 9.2) Use [FixTactics.fix]"]
+
+val mutual_fix :
+  Id.t -> int -> (Id.t * int * constr) list -> unit Proofview.tactic
+[@@ocaml.deprecated "(since 9.2) Use [FixTactics.mutual_fix]"]
+
+val cofix : Id.t -> unit Proofview.tactic
+[@@ocaml.deprecated "(since 9.2) Use [FixTactics.cofix]"]
+
+val mutual_cofix : Id.t -> (Id.t * constr) list -> unit Proofview.tactic
+[@@ocaml.deprecated "(since 9.2) Use [FixTactics.mutual_cofix]"]


### PR DESCRIPTION
This PR extracts fixpoint and co-fixpoint tactics from `tactics.ml` into a separate file `fixTactics.ml`.