### PR TITLE
Reduce the amount of casts between module bodies and types

### DIFF
--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -249,9 +249,8 @@ let rec translate_apply ustate env inl mp subst (sign, reso, cst) args = match a
     if is_empty_subst subst then farg_b
     else subst_modtype subst_codom subst (MPbound farg_id) farg_b
   in
-  let mtb = module_type_of_module (lookup_module mp1 env) in
   let cst = Subtyping.check_subtypes (cst, ustate) env mp1 (MPbound farg_id) farg_b in
-  let mp_delta = discr_resolver mp1 mtb in
+  let mp_delta = discr_resolver mp1 (lookup_module mp1 env) in
   let mp_delta = inline_delta_resolver env inl mp1 farg_id farg_b mp_delta in
   let nsubst = map_mbid farg_id mp1 mp_delta in
   let subst = join subst nsubst in

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -323,11 +323,11 @@ let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) resty
     mb, cst, vm
   | Some (params_mte,inl) ->
     let res_mtb, cst, vm = translate_modtype (cst, ustate) (vm, vmstate) env mp inl params_mte in
-    let auto_mtb = mk_modtype sign reso in
+    let auto_mtb = Mod_declarations.make_module_body sign reso [] in
     (* This function is supposed to be called in a state where the current module
        is about to be closed, so all subcomponents of the module are already
        part of the environment. We only need to add the toplevel module entry. *)
-    let env = Environ.shallow_add_module mp (module_body_of_type auto_mtb) env in
+    let env = Environ.shallow_add_module mp auto_mtb env in
     let cst = Subtyping.check_subtypes (cst, ustate) env mp mp res_mtb in
     let impl = match alg with
     | Some e -> Algebraic e

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -133,9 +133,6 @@ let get_global_delta mb = match mod_global_delta mb with
 
 (** {6 Misc operations } *)
 
-let module_type_of_module = Mod_declarations.module_type_of_module
-let module_body_of_type = Mod_declarations.module_body_of_type
-
 let check_modpath_equiv env mp1 mp2 =
   if ModPath.equal mp1 mp2 then ()
   else

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -26,11 +26,6 @@ val destr_functor : ('ty,'a) functorize -> MBId.t * 'ty * ('ty,'a) functorize
 
 val destr_nofunctor : ModPath.t -> ('ty,'a) functorize -> 'a
 
-(** Conversions between [module_body] and [module_type_body] *)
-
-val module_type_of_module : module_body -> module_type_body
-val module_body_of_type : module_type_body -> module_body
-
 val check_modpath_equiv : env -> ModPath.t -> ModPath.t -> unit
 
 val annotate_module_expression : module_expression -> module_signature ->

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1422,13 +1422,13 @@ let add_include me is_module inl senv =
   let senv = set_vm_library vmtab senv in
   (* Include Self support  *)
   let struc = NoFunctor (List.rev senv.revstruct) in
-  let mb = build_mtb struc senv.modresolver in
+  let mb = Mod_declarations.make_module_body struc senv.modresolver [] in
   let rec compute_sign sign resolver =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
       let state = check_state senv in
       (* Module subcomponents are already part of senv.env at this point *)
-      let env = Environ.shallow_add_module mp_sup (module_body_of_type mb) senv.env in
+      let env = Environ.shallow_add_module mp_sup mb senv.env in
       let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1301,7 +1301,7 @@ let add_module_parameter mbid mte inl senv =
   | None -> senv.paramresolver
   | Some delta -> ParamResolver.add_delta_resolver mp delta senv.paramresolver
   in
-  mod_delta mtb,
+  mtb,
   { senv with
     modvariant = new_variant;
     paramresolver = new_paramresolver }

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -203,7 +203,7 @@ val start_modtype : Label.t -> ModPath.t safe_transformer
 
 val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> Declarations.inline ->
-    Mod_subst.delta_resolver safe_transformer
+    Mod_declarations.module_type_body safe_transformer
 
 (** returns the number of module (type) parameters following the nested module
     structure. The inner module (type) comes first in the list. *)

--- a/library/global.mli
+++ b/library/global.mli
@@ -121,7 +121,7 @@ val end_modtype : Summary.Interp.frozen -> Id.t -> ModPath.t * MBId.t list
 
 val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> inline ->
-    Mod_subst.delta_resolver
+    module_type_body
 
 (** {6 Queries in the global environment } *)
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1043,7 +1043,8 @@ let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
     let id = MBId.to_id mbid in
     let sp = Libnames.make_path DirPath.empty id in
     let mp = MPbound mbid in
-    let resolver = Global.add_module_parameter mbid mty inl in
+    let mtb = Global.add_module_parameter mbid mty inl in
+    let resolver = mod_delta mtb in
     let sobjs = subst_sobjs (map_mp mp0 mp resolver) sobjs in
     InterpVisitor.load_module 1 sp mp sobjs;
     (mbid,mty,inl)::acc

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -1436,13 +1436,13 @@ let declare_one_include_core (me,base,kind,inl) =
   let () = Global.add_constraints cst in
   let () = assert (ModPath.equal cur_mp (Global.current_modpath ())) in
   (* Include Self support  *)
-  let mb = make_module_type (RawModOps.Interp.current_struct ()) (RawModOps.Interp.current_modresolver ()) in
+  let mb = make_module_body (RawModOps.Interp.current_struct ()) (RawModOps.Interp.current_modresolver ()) [] in
   let rec compute_sign sign =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
       let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
       (* Module subcomponents are already part of env at this point *)
-      let env = Environ.shallow_add_module cur_mp (module_body_of_type mb) (Global.env ()) in
+      let env = Environ.shallow_add_module cur_mp mb (Global.env ()) in
       let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) mtb in
       let () = Global.add_constraints cst in
       let mpsup_delta = match mod_global_delta mb with


### PR DESCRIPTION
Despite the API claiming the contrary, module body and module types are two very different beasts. We reduce the unfortunate reliance on conversion between them in this series of trivial patches.