### PR TITLE
Keep delta resolvers of sealed module bodies.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -245,12 +245,12 @@ let rec check_module env opac mp mb opacify =
     check_signature env opac (mod_type mb) mp delta_mb opacify
   in
   let optsign, opac = match Mod_declarations.mod_expr mb with
-    | Struct sign_struct ->
+    | Struct (reso, sign_struct) ->
       let opacify = collect_constants_without_body (mod_type mb) mp opacify in
       (* TODO: a bit wasteful, we recheck the types of parameters twice *)
       let sign_struct = Modops.annotate_struct_body sign_struct (mod_type mb) in
-      let opac = check_signature env opac sign_struct mp delta_mb opacify in
-      Some (sign_struct, delta_mb), opac
+      let opac = check_signature env opac sign_struct mp reso opacify in
+      Some (sign_struct, reso), opac
     | Algebraic me -> Some (check_mexpression env opac me (mod_type mb) mp delta_mb), opac
     | Abstract|FullStruct -> None, opac
   in

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -567,7 +567,7 @@ let [_v_sfb;_v_struc;_v_sign;_v_mexpr;_v_impl;v_module;_v_modtype] : _ Vector.t 
   and v_impl =
     v_sum_c ("module_impl",2, (* Abstract, FullStruct *)
          [|[|v_mexpr|];  (* Algebraic *)
-           [|v_struc|]|])  (* Struct *)
+           [|v_resolver; v_struc|]|])  (* Struct *)
   and v_module =
     v_tuple_c ("module_body",
            [|v_sum_c ("when_mod_body", 0, [|[|v_impl|]|]);v_sign;v_opt v_mexpr;v_resolver;v_retroknowledge|])

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -31,7 +31,7 @@ and module_signature = (module_type_body,structure_body) functorize
 and module_implementation =
   | Abstract (** no accessible implementation *)
   | Algebraic of module_expression (** non-interactive algebraic expression *)
-  | Struct of structure_body (** interactive body living in the parameter context of [mod_type] *)
+  | Struct of delta_resolver * structure_body (** interactive body living in the parameter context of [mod_type] *)
   | FullStruct (** special case of [Struct] : the body is exactly [mod_type] *)
 
 and 'a generic_module_body =
@@ -202,9 +202,9 @@ and hcons_module_implementation mip = match mip with
 | Algebraic me ->
   let me' = hcons_module_expression me in
   if me == me' then mip else Algebraic me'
-| Struct ms ->
+| Struct (reso, ms) ->
   let ms' = hcons_structure_body ms in
-  if ms == ms' then mip else Struct ms
+  if ms == ms' then mip else Struct (reso, ms)
 | FullStruct -> FullStruct
 
 and hcons_generic_module_body :
@@ -252,8 +252,12 @@ let implem_smart_map (type a) fs fa (expr : (a, _) when_mod_body) : (a, _) when_
   | ModTypeNul -> ModTypeNul
   | ModBodyVal impl ->
     match impl with
-    | Struct e -> let e' = fs e in if e==e' then expr else ModBodyVal (Struct e')
-    | Algebraic a -> let a' = fa a in if a==a' then expr else ModBodyVal (Algebraic a')
+    | Struct (reso, e) ->
+      let reso', e' = fs (reso, e) in
+      if reso==reso' && e==e' then expr else ModBodyVal (Struct (reso', e'))
+    | Algebraic a ->
+      let a' = fa a in
+      if a==a' then expr else ModBodyVal (Algebraic a')
     | Abstract | FullStruct -> expr
 
 let functorize params init =
@@ -334,7 +338,7 @@ and subst_module_body : type a. _ -> _ -> _ -> _ -> a generic_module_body -> a g
     else add_mp mp mp' (empty_delta_resolver mp') subst
   in
   let ty' = subst_signature skind subst mp ty in
-  let me' = subst_impl subst mp me in
+  let me' = subst_impl skind subst mp me in
   let aty' = Option.Smart.map (subst_expression subst) aty in
   let retro' = subst_retro subst retro in
   let delta' = apply_subst skind subst mb.mod_delta in
@@ -352,10 +356,10 @@ and subst_module_body : type a. _ -> _ -> _ -> _ -> a generic_module_body -> a g
 and subst_module skind subst mp mb =
   subst_module_body true skind subst mp mb
 
-and subst_impl : type a. _ -> _ -> (a, _) when_mod_body -> (a, _) when_mod_body =
-  fun subst mp me ->
+and subst_impl : type a. _ -> _ -> _ -> (a, _) when_mod_body -> (a, _) when_mod_body =
+  fun skind subst mp me ->
   implem_smart_map
-    (fun sign -> subst_structure Neither subst mp sign) (subst_expression subst) me
+    (fun (reso, sign) -> apply_subst skind subst reso, subst_structure Neither subst mp sign) (subst_expression subst) me
 
 and subst_modtype skind subst mp mtb = subst_module_body false skind subst mp mtb
 
@@ -417,6 +421,9 @@ and clean_field l field = match field with
 
 and clean_structure l = List.Smart.map (clean_field l)
 
+and clean_body l (reso, v) =
+  (reso, clean_structure l v)
+
 and clean_signature l =
   functor_smart_map (fun _ mb -> clean_module_body l mb) (clean_structure l)
 
@@ -427,5 +434,5 @@ and clean_mod_expr : type a. _ -> a mod_expr -> a mod_expr =
   | ModBodyVal (Algebraic (MENoFunctor m)) when is_bounded_expr l m ->
     ModBodyVal FullStruct
   | _ ->
-    let me' = implem_smart_map (clean_structure l) (clean_expression l) me in
+    let me' = implem_smart_map (clean_body l) (clean_expression l) me in
     if me == me' then me else me'

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -43,7 +43,7 @@ type module_signature = (module_type_body,structure_body) functorize
 type module_implementation =
   | Abstract (** no accessible implementation *)
   | Algebraic of module_expression (** non-interactive algebraic expression *)
-  | Struct of structure_body (** interactive body living in the parameter context of [mod_type] *)
+  | Struct of delta_resolver * structure_body (** interactive body living in the parameter context of [mod_type] *)
   | FullStruct (** special case of [Struct] : the body is exactly [mod_type] *)
 
 (** Extra invariants :

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -336,7 +336,7 @@ let finalize_module_alg (cst, ustate) (vm, vmstate) env mp (sign,alg,reso) resty
       | NoFunctor s -> s
       | MoreFunctor _ -> assert false (* All non-algebraic callers enforce this *)
       in
-      Struct sign
+      Struct (reso,sign)
     in
     let mb = module_body_of_type res_mtb in
     let mb = set_implementation impl mb in

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -476,12 +476,12 @@ and extract_module table access venv env mp ~all mb =
   let impl = match Mod_declarations.mod_expr mb with
     | Abstract -> error_no_module_expr mp
     | Algebraic me -> extract_mexpression table access venv env mp (mod_type mb) me
-    | Struct sign ->
+    | Struct (reso, sign) ->
       (* This module has a signature, otherwise it would be FullStruct.
          We extract just the elements required by this signature. *)
       let () = add_labels venv mp (mod_type mb) in
       let sign = Modops.annotate_struct_body sign (mod_type mb) in
-      extract_msignature table access venv env mp (mod_delta mb) ~all:false sign
+      extract_msignature table access venv env mp reso ~all:false sign
     | FullStruct -> extract_msignature table access venv env mp (mod_delta mb) ~all (mod_type mb)
   in
   (* Slight optimization: for modules without explicit signatures

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -101,7 +101,7 @@ and fields_of_mp mp =
 
 and fields_of_mb subs mp mb args = match Mod_declarations.mod_expr mb with
   | Algebraic expr -> fields_of_expression subs mp args (mod_type mb) expr
-  | Struct sign ->
+  | Struct (_, sign) ->
     let sign = Modops.annotate_struct_body sign (mod_type mb) in
     fields_of_signature subs mp args sign
   | Abstract|FullStruct -> fields_of_signature subs mp args (mod_type mb)

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -400,7 +400,7 @@ let unsafe_print_module extent env mp with_body mb =
     | _, Algebraic me ->
       let me = Modops.annotate_module_expression me (mod_type mb) in
       pr_equals ++ print_expression' false extent env mp me
-    | _, Struct sign ->
+    | _, Struct (_, sign) ->
       let sign = Modops.annotate_struct_body sign (mod_type mb) in
       pr_equals ++ print_signature' false extent env mp sign
     | _, FullStruct -> pr_equals ++ print_signature' false extent env mp (mod_type mb)


### PR DESCRIPTION
This data is critical for the body to make sense, but we were just dropping it regardless. Now the checker should be a little bit more correct and only see constant names with a reasonable canonical component.

Revival of #20327.