### PR TITLE
Check correctness of canonical constant and inductive names when typing. 

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -309,6 +309,8 @@ let explain_exn = function
       | UndeclaredUniverses _ -> str"UndeclaredUniverse"
       | BadVariance _ -> str "BadVariance"
       | UndeclaredUsedVariables _ -> str "UndeclaredUsedVariables"
+      | IllFormedConstant _ -> str "IllFormedConstant"
+      | IllFormedInductive _ -> str "IllFormedInductive"
       ))
 
   | InductiveError (env,e) ->

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -37,9 +37,9 @@ type link_info =
 
 type key = int CEphemeron.key option ref
 
-type constant_key = constant_body * (link_info ref * key)
+type constant_key = constant_body * (link_info ref * key) * KerName.t
 
-type mind_key = mutual_inductive_body * link_info ref
+type mind_key = mutual_inductive_body * link_info ref * KerName.t
 
 type named_context_val = private {
   env_named_ctx : Constr.named_context;
@@ -241,7 +241,7 @@ val get_projections : env -> inductive -> (Names.Projection.Repr.t * Sorts.relev
 
 (** {5 Inductive types } *)
 val lookup_mind_key : MutInd.t -> env -> mind_key
-val add_mind_key : MutInd.t -> mind_key -> env -> env
+val add_mind_key : MutInd.t -> mutual_inductive_body -> link_info -> env -> env
 val add_mind : MutInd.t -> mutual_inductive_body -> env -> env
 
 (** Looks up in the context of global inductive names

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -175,7 +175,7 @@ let rec add_structure mp sign resolver linkinfo env =
           { mib with mind_private = Some true }
         else mib
       in
-      Environ.add_mind_key mind (mib,ref linkinfo) env
+      Environ.add_mind_key mind mib linkinfo env
     | SFBmodule mb -> add_module (MPdot (mp, l)) mb linkinfo env (* adds components as well *)
     | SFBmodtype mtb -> Environ.add_modtype (MPdot (mp, l)) mtb env
     | SFBrules r -> Environ.add_rewrite_rules r.rewrules_rules env

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -79,13 +79,13 @@ type prefix = string
 
 (* Linked code location utilities *)
 let get_mind_prefix env mind =
-   let _,name = lookup_mind_key mind env in
+   let _,name,_ = lookup_mind_key mind env in
    match !name with
    | NotLinked -> ""
    | Linked s -> s
 
 let get_const_prefix env c =
-   let _,(nameref,_) = lookup_constant_key c env in
+   let _,(nameref,_),_ = lookup_constant_key c env in
    match !nameref with
    | NotLinked -> ""
    | Linked s -> s
@@ -2242,7 +2242,7 @@ let empty_updates = Mindmap_env.empty, Cmap_env.empty
 
 let compile_mind_deps env prefix
     (comp_stack, (mind_updates, const_updates) as init) mind =
-  let mib,nameref = lookup_mind_key mind env in
+  let mib,nameref,_ = lookup_mind_key mind env in
   if is_code_loaded nameref
     || Mindmap_env.mem mind mind_updates
   then init
@@ -2265,7 +2265,7 @@ let compile_deps env sigma prefix init t =
   | Ind ((mind,_),_u) -> compile_mind_deps env prefix init mind
   | Const (c, _u) ->
     let c, _ = get_alias env c in
-    let cb,(nameref,_) = lookup_constant_key c env in
+    let cb,(nameref,_),_ = lookup_constant_key c env in
     let (_, (_, const_updates)) = init in
     if is_code_loaded nameref
     || (Cmap_env.mem c const_updates)

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -80,6 +80,8 @@ type ('constr, 'types, 'r) ptype_error =
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
   | UndeclaredUsedVariables of { declared_vars : Id.Set.t; inferred_vars : Id.Set.t }
+  | IllFormedConstant of Constant.t * KerName.t
+  | IllFormedInductive of MutInd.t * KerName.t
 
 type type_error = (constr, types, Sorts.relevance) ptype_error
 
@@ -181,6 +183,12 @@ let error_bad_variance env ~lev ~expected ~actual =
 let error_undeclared_used_variables env ~declared_vars ~inferred_vars =
   raise (TypeError (env, UndeclaredUsedVariables {declared_vars; inferred_vars}))
 
+let error_ill_formed_constant env cst kn =
+  raise (TypeError (env, IllFormedConstant (cst, kn)))
+
+let error_ill_formed_inductive env ind kn =
+  raise (TypeError (env, IllFormedInductive (ind, kn)))
+
 let map_pfix_guard_error f = function
 | NotEnoughAbstractionInFixBody -> NotEnoughAbstractionInFixBody
 | RecursionNotOnInductiveType c -> RecursionNotOnInductiveType (f c)
@@ -209,7 +217,7 @@ let map_ptype_error fr f = function
 | UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _ | IllFormedCaseParams
 | UndeclaredQualities _ | UndeclaredUniverses _ | DisallowedSProp
 | UnsatisfiedQConstraints _ | UnsatisfiedConstraints _
-| ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ as e -> e
+| ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ | IllFormedConstant _ | IllFormedInductive _ as e -> e
 | NotAType j -> NotAType (on_judgment f j)
 | BadAssumption j -> BadAssumption (on_judgment f j)
 | ElimArity (pi, c, ar) -> ElimArity (pi, f c, ar)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -82,6 +82,8 @@ type ('constr, 'types, 'r) ptype_error =
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
   | UndeclaredUsedVariables of { declared_vars : Id.Set.t; inferred_vars : Id.Set.t }
+  | IllFormedConstant of Constant.t * KerName.t
+  | IllFormedInductive of MutInd.t * KerName.t
 
 type type_error = (constr, types, Sorts.relevance) ptype_error
 
@@ -166,6 +168,10 @@ val error_bad_invert : env -> 'a
 val error_bad_variance : env -> lev:Level.t -> expected:Variance.t -> actual:Variance.t -> 'a
 
 val error_undeclared_used_variables : env -> declared_vars:Id.Set.t -> inferred_vars:Id.Set.t -> 'a
+
+val error_ill_formed_constant : env -> Constant.t -> KerName.t -> 'a
+
+val error_ill_formed_inductive : env -> MutInd.t -> KerName.t -> 'a
 
 val map_pguard_error : ('c -> 'd) -> 'c pguard_error -> 'd pguard_error
 val map_ptype_error : ('r1 -> 'r2) -> ('c -> 'd) -> ('c, 'c, 'r1) ptype_error -> ('d, 'd, 'r2) ptype_error

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -266,7 +266,7 @@ let envcache_of_rel i envcache = {
 }
 
 let rec slot_for_getglobal env sigma kn envcache table =
-  let (cb,(_,rk)) = lookup_constant_key kn env in
+  let (cb,(_,rk),_) = lookup_constant_key kn env in
   try key rk
   with NotEvaluated ->
 (*    Pp.msgnl(str"not yet evaluated");*)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -948,6 +948,16 @@ let explain_undeclared_used_variables env sigma ~declared_vars ~inferred_vars =
       str "to" ++ fnl () ++
       str "Proof using " ++ inferred_vars)
 
+let explain_ill_formed_constant env sigma cst kn =
+  strbrk "Ill-formed constant" ++ spc () ++ pr_constant env cst ++ str ":" ++ spc () ++
+  strbrk "expected canonical name" ++ spc () ++ KerName.print kn ++ spc () ++
+  strbrk "but found" ++ spc () ++ KerName.print (Constant.canonical cst)
+
+let explain_ill_formed_inductive env sigma mind kn =
+  strbrk "Ill-formed inductive" ++ spc () ++ pr_inductive env (mind, 0) ++ str ":" ++ spc () ++
+  strbrk "expected canonical name" ++ spc () ++ KerName.print kn ++ spc () ++
+  strbrk "but found" ++ spc () ++ KerName.print (MutInd.canonical mind)
+
 let explain_type_error env sigma err =
   let env = make_all_name_different env sigma in
   match err with
@@ -1002,6 +1012,10 @@ let explain_type_error env sigma err =
   | BadVariance {lev;expected;actual} -> explain_bad_variance env sigma ~lev ~expected ~actual
   | UndeclaredUsedVariables {declared_vars;inferred_vars} ->
       explain_undeclared_used_variables env sigma ~declared_vars ~inferred_vars
+  | IllFormedConstant (cst, kn) ->
+    explain_ill_formed_constant env sigma cst kn
+  | IllFormedInductive (mind, kn) ->
+    explain_ill_formed_inductive env sigma mind kn
 
 let pr_position (cl,pos) =
   let clpos = match cl with


### PR DESCRIPTION
Fixes #7609: Kernel happily accepts nonsense kerpairs.