### PR TITLE
Fix subterm_specif on match not filtering the stack as in check_one_fix

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -74,6 +74,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [Incorrect specification of PrimFloat.leb](#incorrect-specification-of-primfloatleb)
       - [Incorrect implementation of SFclassify.](#incorrect-implementation-of-sfclassify)
       - [nativenorm reading back closures as arbitrary floating-point values](#nativenorm-reading-back-closures-as-arbitrary-floating-point-values)
+      - [guard condition issue made it inconsistent with univalence](#guard-condition-issue-made-it-inconsistent-with-univalence)
     - [Deserialization](#deserialization)
       - [deserialization of .vo data not properly checked](#deserialization-of-vo-data-not-properly-checked)
   - [Probably non exploitable fixed bugs](#probably-non-exploitable-fixed-bugs)
@@ -819,6 +820,18 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - found by: Jason Gross
 - GH issue number: rocq-prover/rocq#17871
 - risk: proof of false when using primitive floats and native_compute
+
+#### guard condition issue made it inconsistent with univalence
+
+- component: guard condition
+- introduced: variant of [the issue with propositional extensionality](#guard-condition-was-unknown-to-be-inconsistent-with-propositional-extensionality-in-library-Sets) that was not fixed then
+- impacted released versions: the relative inconsistency was present from the very beginning, until 9.0
+- impacted coqchk versions: *-9.0
+- fixed in: 9.0.1
+- fixed by further constraining the guard condition: [PR 21050](https://github.com/rocq-prover/rocq/pull/21050)
+- found by: Thomas Lamiaux, Yann Leray, Pierre-Marie Pédrot, Nicolas Tabareau
+- GH issue number: [21053](https://github.com/rocq-prover/issues/21053)
+- risk: unlikely to be exploited by chance (?)
 
 ### Deserialization
 

--- a/doc/changelog/01-kernel/21050-fix-match-as-subterm-Fixed.rst
+++ b/doc/changelog/01-kernel/21050-fix-match-as-subterm-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Fix guard checker making univalence inconsistent
+  (`#21050 <https://github.com/rocq-prover/rocq/pull/21050>`_,
+  fixes `#21053 <https://github.com/rocq-prover/rocq/issues/21053>`_,
+  by Yann Leray).

--- a/test-suite/bugs/bug_21053.v
+++ b/test-suite/bugs/bug_21053.v
@@ -1,0 +1,41 @@
+Notation "'rew' [ f ] e 'in' x" := (eq_rect _ f x _ e) (at level 10, x at level 10).
+
+Definition cast_rev e : nat -> nat :=
+  rew [fun (T : Set) => T -> nat] eq_sym e in fun x => x.
+
+Fail Fixpoint f (e : nat = nat) (n : nat) {struct n} :=
+  match n with
+  | 0 => 0
+  | S n => S (f e (cast_rev e n))
+end.
+(* Problematic fixpoint : [cast_rev_e n] should not be a subterm of [n] *)
+
+#[bypass_check(guard)]
+Fixpoint f (e : nat = nat) (n : nat) {struct n} :=
+  match n with
+  | 0 => 0
+  | S n => S (f e (cast_rev e n))
+end.
+
+Section Issue.
+Context (e : nat = nat). (* Supposed non-trivial *)
+Context (e0 : rew [fun (T : Set) => T] e in 0 = 1).
+(* How the non triviality may appear *)
+
+Corollary e0' : cast_rev e 0 = 1.
+Proof.
+  rewrite <- e0. clear e0.
+  unfold cast_rev.
+  generalize 0.
+  destruct e.
+  reflexivity.
+Defined.
+
+Theorem Boom : False.
+  enough (f e 1 = S (f e 1)) by now induction (f e 1); auto.
+  change (f e 1) with (S (f e (cast_rev e 0))) at 1.
+  f_equal. f_equal.
+  apply e0'.
+Qed.
+
+End Issue.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21053


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added to **critical-bugs**.
