### PR TITLE
Fix substitution of functor delta-resolvers when performing strengthening

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -31,6 +31,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [module subtyping disrespected squashing status of inductives](#module-subtyping-disrespected-squashing-status-of-inductives)
       - [Functor inlining drops universe substitution](#functor-inlining-drops-universe-substitution)
       - [Primitives are incorrectly considered convertible to anything by module subtyping](#primitives-are-incorrectly-considered-convertible-to-anything-by-module-subtyping)
+      - [missing substitution when strengthening functors](#missing-substitution-when-strengthening-functors)
     - [Universes](#universes)
       - [issue with two parameters in the same universe level](#issue-with-two-parameters-in-the-same-universe-level)
       - [universe polymorphism can capture global universes](#universe-polymorphism-can-capture-global-universes)
@@ -331,6 +332,18 @@ and lack of checking of relevance marks on constants in coqchk
 - GH issue number: rocq-prover/rocq#18503
 - exploit: see issue
 - risk: high if there is a Primitive in a Module Type, otherwise low
+
+#### Missing substitution when strengthening functors
+
+- component: modules
+- introduced: 8.5 for the kernel (c5b699f), 8.10 for the checker (#8773)
+- impacted released versions: 8.5-9.0.0
+- impacted coqchk version: 8.10-9.0.0
+- fixed in: V9.0.1
+- found by: Pierre-Marie Pédrot
+- GH issue number: rocq-prover/rocq#21051
+- exploit: see issue
+- risk: could be exploited by mistake when using heavy module machinery
 
 ### Universes
 

--- a/doc/changelog/01-kernel/21057-fix-module-strengthening-subst-Fixed.rst
+++ b/doc/changelog/01-kernel/21057-fix-module-strengthening-subst-Fixed.rst
@@ -1,0 +1,9 @@
+- **Fixed:**
+  substitution of functor delta-resolvers when strengthening.
+  The previous code was only substituting the inner delta resolvers
+  and ignoring the codomain of functors. In particular this was generating
+  ill-formed constants whose canonical component was pointing to a bound name
+  that did not exist in the global environment, leading to an inconsistency
+  (`#21057 <https://github.com/rocq-prover/rocq/pull/21057>`_,
+  fixes `#21051 <https://github.com/rocq-prover/rocq/issues/21051>`_,
+  by Pierre-Marie Pédrot).

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -275,7 +275,7 @@ let rec strengthen_and_subst_module mb subst mp_from mp_to =
       strengthen_module_body ~src:mp_from (NoFunctor struc') reso' mb
   | MoreFunctor _ ->
     let subst = add_mp mp_from mp_to (empty_delta_resolver mp_to) subst in
-    subst_module subst_dom subst mp_from mb
+    subst_module subst_dom_codom subst mp_from mb
 
 and strengthen_and_subst_struct struc subst mp_from mp_to alias incl reso =
   let strengthen_and_subst_field reso' item = match item with

--- a/test-suite/bugs/bug_21051.v
+++ b/test-suite/bugs/bug_21051.v
@@ -1,0 +1,55 @@
+Module Type T.
+Parameter n : bool.
+End T.
+
+Module M.
+Definition n := true.
+End M.
+
+Module M'.
+Definition n := false.
+End M'.
+
+Module MAKE.
+
+Module FUN (E : T).
+
+Module F.
+Definition bug := E.n.
+End F.
+
+Module G := F.
+
+End FUN.
+
+End MAKE.
+
+Include MAKE.
+
+Module RES := FUN M.
+Module RES' := FUN M'.
+
+Lemma foo : RES.G.bug = RES'.G.bug.
+Proof.
+Fail reflexivity. (* Was succeeding, allowing to derive False with the code below. *)
+Abort.
+
+(*
+Lemma foo0 : RES.G.bug = true.
+Proof.
+reflexivity.
+Qed.
+
+Lemma foo1 : RES'.G.bug = false.
+Proof.
+reflexivity.
+Qed.
+
+Lemma unsound : False.
+Proof.
+assert (true = false); [|congruence].
+rewrite <- foo0; rewrite <- foo1; apply foo.
+Qed.
+
+Print Assumptions unsound.
+*)


### PR DESCRIPTION
The previous code was only substituting the inner delta resolvers and ignoring the codomain of functors. In particular this was generating ill-formed constants whose canonical component was pointing to a bound name that did not exist in the global environment. We fix the code by also substituting the codomain of module bodies. This is actually in line with what we do in the related function strengthen_and_subst_module_body, where we were also correctly substituting the codomain.

This is a quite old soundness bug that was also affecting the checker. It seems to have been introduced by c5b699f8 by an oversight when refactoring tricky code.

Fixes #21051: Unsoundness with heavy module machinery.