### PR TITLE
Use user name for comparison in kernel side-effects.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -420,7 +420,7 @@ struct
 module SeffOrd = struct
 type t = side_effect
 let compare e1 e2 =
-  Constant.CanOrd.compare e1.seff_constant e2.seff_constant
+  Constant.UserOrd.compare e1.seff_constant e2.seff_constant
 end
 
 module SeffSet = Set.Make(SeffOrd)


### PR DESCRIPTION
This does not change anything because all side-effects are created in the same module. Furthermore, private constants should never be aliases.