### PR TITLE
Declarations support mixed record/nonrecord inductive blocks

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -424,11 +424,16 @@ let v_wfp =
 
 let v_squash_info = v_sum "squash_info" 1 [|[|v_set v_quality|]|]
 
+let v_record_info =
+  v_sum "record_info" 2
+    [| [| v_tuple "record" [| v_id; v_array v_id; v_array v_relevance; v_array v_constr |] |] |]
+
 let v_one_ind = v_tuple "one_inductive_body"
   [|v_id;
     v_rctxt;
     v_sort;
     v_constr;
+    v_record_info;
     v_array v_id;
     v_array v_constr;
     v_int;
@@ -445,13 +450,8 @@ let v_one_ind = v_tuple "one_inductive_body"
 
 let v_finite = v_enum "recursivity_kind" 3
 
-let v_record_info =
-  v_sum "record_info" 2
-    [| [| v_array (v_tuple "record" [| v_id; v_array v_id; v_array v_relevance; v_array v_constr |]) |] |]
-
 let v_ind_pack = v_tuple "mutual_inductive_body"
   [|v_array v_one_ind;
-    v_record_info;
     v_finite;
     v_section_ctxt;
     v_instance;

--- a/dev/ci/user-overlays/21069-SkySkimmer-mip-mind-record.sh
+++ b/dev/ci/user-overlays/21069-SkySkimmer-mip-mind-record.sh
@@ -1,0 +1,7 @@
+overlay metarocq https://github.com/SkySkimmer/metarocq mip-mind-record 21069
+
+overlay lean_importer https://github.com/SkySkimmer/rocq-lean-import mip-mind-record 21069
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi mip-mind-record 21069
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp mip-mind-record 21069

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -133,7 +133,7 @@ let type_of_global_ref gr =
       "var" ^ type_of_logical_kind knd
     | IndRef ind ->
         let (mib,oib) = Inductive.lookup_mind_specif (Global.env ()) ind in
-          if mib.Declarations.mind_record <> Declarations.NotRecord then
+          if oib.Declarations.mind_record <> Declarations.NotRecord then
             begin match mib.Declarations.mind_finite with
             | Finite -> "indrec"
             | BiFinite -> "rec"

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -147,7 +147,7 @@ v}
 (** Record information:
     If the type is not a record, then NotRecord
     If the type is a non-primitive record, then FakeRecord
-    If it is a primitive record, for every type in the block, we get:
+    If it is a primitive record, PrimRecord of:
     - The identifier for the binder name of the record in primitive projections.
     - The constants associated to each projection.
     - The projection types (under parameters).
@@ -160,7 +160,7 @@ v}
 type record_info =
 | NotRecord
 | FakeRecord
-| PrimRecord of (Id.t * Label.t array * Sorts.relevance array * types array) array
+| PrimRecord of (Id.t * Label.t array * Sorts.relevance array * types array)
 
 type squash_info =
   | AlwaysSquashed
@@ -192,6 +192,8 @@ type one_inductive_body = {
     (** Original user arity, convertible to [mkArity (mind_arity_ctxt, mind_sort)].
         As such it contains the parameters.
         (not necessarily a syntactic arity, eg [relation A] instead of [A -> A -> Prop]) *)
+
+    mind_record : record_info; (** The record information *)
 
     mind_consnames : Id.t array; (** Names of the constructors: [cij] *)
 
@@ -256,8 +258,6 @@ type recursivity_kind =
 type mutual_inductive_body = {
 
     mind_packets : one_inductive_body array;  (** The component of the mutual inductive block *)
-
-    mind_record : record_info; (** The record information *)
 
     mind_finite : recursivity_kind;  (** Whether the type is inductive, coinductive or non-recursive *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -721,10 +721,10 @@ let lookup_projection p env =
   let mib = lookup_mind mind env in
   (if not (Int.equal mib.mind_nparams (Projection.npars p))
    then anomaly ~label:"lookup_projection" Pp.(str "Bad number of parameters on projection."));
-  match mib.mind_record with
+  match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord -> anomaly ~label:"lookup_projection" Pp.(str "not a projection")
   | PrimRecord infos ->
-    let _,_,rs,typs = infos.(i) in
+    let _,_,rs,typs = infos in
     let arg = Projection.arg p in
     rs.(arg), typs.(arg)
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -461,8 +461,8 @@ let is_allowed_fixpoint sind star =
 (************************************************************************)
 
 let is_private (mib,_) = mib.mind_private = Some true
-let is_primitive_record (mib,_) =
-  match mib.mind_record with
+let is_primitive_record (_,mip) =
+  match mip.mind_record with
   | PrimRecord _ -> true
   | NotRecord | FakeRecord -> false
 

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2218,10 +2218,10 @@ let compile_mind mb mind stack =
       let gn = Gproj ("", ind, proj_arg) in
       Glet (gn, mkMLlam [|c_uid|] code) :: acc
     in
-    let projs = match mb.mind_record with
+    let projs = match ob.mind_record with
     | NotRecord | FakeRecord -> []
     | PrimRecord info ->
-      let _, _, _, pbs = info.(i) in
+      let _, _, _, pbs = info in
       Array.fold_left_i add_proj [] pbs
     in
     projs @ gtype :: accu :: stack

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -34,11 +34,11 @@ let relevance_of_constructor env ((ind,_),u) =
 let relevance_of_projection_repr env (p, u) =
   let mib = lookup_mind (Names.Projection.Repr.mind p) env in
   let _mind,i = Names.Projection.Repr.inductive p in
-  match mib.mind_record with
+  match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord ->
     CErrors.anomaly ~label:"relevance_of_projection" Pp.(str "not a projection")
   | PrimRecord infos ->
-    let _,_,rs,_ = infos.(i) in
+    let _,_,rs,_ = infos in
     UVars.subst_instance_relevance u rs.(Names.Projection.Repr.arg p)
 
 let relevance_of_projection env (p,u) =

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -249,13 +249,12 @@ let parse_ind_args si args relmax =
          | _ -> parse (i+1) (j+1) s)
   in parse 1 1 si
 
-let relevance_of_projection_repr mib p =
-  let _mind,i = Names.Projection.Repr.inductive p in
-  match mib.mind_record with
+let relevance_of_projection_repr mip p =
+  match mip.mind_record with
   | NotRecord | FakeRecord ->
     CErrors.anomaly ~label:"relevance_of_projection" Pp.(str "not a projection")
   | PrimRecord infos ->
-    let _,_,rs,_ = infos.(i) in
+    let _,_,rs,_ = infos in
     rs.(Names.Projection.Repr.arg p)
 
 (** Because of automatic unboxing the easy way [mk_def c] on the
@@ -285,11 +284,11 @@ let fake_match_projection env p =
     ci_pp_info;
   }
   in
-  let relevance = relevance_of_projection_repr mib p in
-  let x = match mib.mind_record with
+  let relevance = relevance_of_projection_repr mip p in
+  let x = match mip.mind_record with
     | NotRecord | FakeRecord -> assert false
     | PrimRecord info ->
-      let x, _, _, _ = info.(snd ind) in
+      let x, _, _, _ = info in
       make_annot (Name x) mip.mind_relevance
   in
   let indty = mkApp (indu, Context.Rel.instance mkRel 0 paramslet) in
@@ -560,7 +559,7 @@ and extract_really_ind table env kn inst mib =
         let typ = p.ip_types.(0) in
         let l = if conservative_types () then [] else List.filter (fun t -> not (isTdummy (expand table env t))) typ in
         if List.is_empty l then raise (I Standard);
-        if mib.mind_record == Declarations.NotRecord then
+        if mip0.mind_record == Declarations.NotRecord then
           if not (keep_singleton ()) && Int.equal (List.length l) 1 && not (type_mem_kn kn (List.hd l))
           then raise (I Singleton)
           else raise (I Standard);

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -284,8 +284,8 @@ let is_squashed sigma specifu =
     (loc_squashed_to_quality sigma)
     specifu
 
-let is_allowed_elimination sigma (((mib,_),_) as specifu) s =
-  match mib.mind_record with
+let is_allowed_elimination sigma (((_,mip),_) as specifu) s =
+  match mip.mind_record with
   | PrimRecord _ -> true
   | NotRecord | FakeRecord ->
      let s = EConstr.ESorts.kind sigma s in
@@ -311,8 +311,8 @@ let make_allowed_elimination_actions sigma s =
                  try Some (Evd.set_leq_sort sigma (mk sq) (mk indq))
                  with UGraph.UniverseInconsistency _ -> None }
 
-let make_allowed_elimination sigma ((mib,_),_ as specifu) s =
-  match mib.mind_record with
+let make_allowed_elimination sigma ((_,mip),_ as specifu) s =
+  match mip.mind_record with
   | PrimRecord _ -> Some sigma
   | NotRecord | FakeRecord ->
      Inductive.allowed_elimination_gen
@@ -325,7 +325,7 @@ let make_allowed_elimination sigma ((mib,_),_ as specifu) s =
 (* XXX questionable for sort poly inductives *)
 let elim_sort (mib,mip) =
   let is_record =
-    match mib.mind_record with
+    match mip.mind_record with
     | NotRecord | FakeRecord -> false
     | PrimRecord _ -> true in
   let has_args mip =
@@ -359,7 +359,7 @@ let sorts_for_schemes specif =
   constant_sorts_below (elim_sort specif)
 
 let has_dependent_elim (mib,mip) =
-  match mib.mind_record with
+  match mip.mind_record with
   | PrimRecord _ -> mib.mind_finite == BiFinite || mip.mind_relevance == Irrelevant
   | NotRecord | FakeRecord -> true
 
@@ -581,11 +581,11 @@ let compute_projections env (kn, i as ind) =
   let mib = Environ.lookup_mind kn env in
   let u = UVars.make_abstract_instance (Declareops.inductive_polymorphic_context mib) in
   let u = EInstance.make u in
-  let x = match mib.mind_record with
+  let x = match mib.mind_packets.(i).mind_record with
   | NotRecord | FakeRecord ->
     anomaly Pp.(str "Trying to build primitive projections for a non-primitive record")
   | PrimRecord info ->
-    let id, _, _, _ = info.(i) in
+    let id, _, _, _ = info in
     make_annot (Name id) (ERelevance.make mib.mind_packets.(i).mind_relevance)
   in
   let pkt = mib.mind_packets.(i) in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1018,12 +1018,12 @@ let rec is_neutral env sigma ts t =
 
 let is_eta_constructor_app env sigma ts f l1 term =
   match EConstr.kind sigma f with
-  | Construct (((_, i as ind), j), u) when j == 1 ->
+  | Construct (((mind, i), j), u) when j == 1 ->
     let open Declarations in
-    let mib = lookup_mind (fst ind) env in
-      (match mib.Declarations.mind_record with
+    let mib = lookup_mind mind env in
+      (match mib.mind_packets.(i).mind_record with
       | PrimRecord info when mib.Declarations.mind_finite == Declarations.BiFinite &&
-          let (_, projs, _, _) = info.(i) in
+          let (_, projs, _, _) = info in
           Array.length projs == Array.length l1 - mib.Declarations.mind_nparams ->
         (* Check that the other term is neutral *)
         is_neutral env sigma ts term

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -315,10 +315,10 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
     let ((ind, u), args) = Inductiveops.find_mrectype env sigma (EConstr.of_constr t) in
     let (mib, mip) = Inductive.lookup_mind_specif env ind in
     let pars = List.firstn mib.mind_nparams args in
-    let ty = match mib.mind_record with
+    let ty = match mip.mind_record with
     | NotRecord | FakeRecord -> assert false
     | PrimRecord infos ->
-      let _, _, _, tys = infos.(snd ind) in
+      let _, _, _, tys = infos in
       let ty = Vars.subst_instance_constr (EConstr.Unsafe.to_instance u) tys.(p) in
       substl (c :: List.rev_map EConstr.Unsafe.to_constr pars) ty
     in

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -98,7 +98,7 @@ let rec general_decompose_aux recognizer id =
   let ((ind, u), t) = pf_apply Tacred.reduce_to_atomic_ind gl (pf_get_type_of gl (mkVar id)) in
   let _, args = decompose_app (Proofview.Goal.sigma gl) t in
   let rec_flag, mkelim =
-    match (Environ.lookup_mind (fst ind) env).mind_record with
+    match (Environ.lookup_mind (fst ind) env).mind_packets.(snd ind).mind_record with
     | NotRecord -> true, Elim
     | FakeRecord | PrimRecord _ -> false, Case false
   in

--- a/test-suite/bugs/bug_21068.v
+++ b/test-suite/bugs/bug_21068.v
@@ -1,0 +1,7 @@
+Module Type T.
+  Inductive foo := { x : nat } with bar := { y : nat }.
+End T.
+Module M <: T.
+  Inductive foo := { x : nat } with bar := { y : nat }.
+End M.
+(* Anomaly "File "kernel/subtyping.ml", line 205, characters 4-10: Assertion failed." *)

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -211,10 +211,10 @@ bind_univs.mono = Type@{bind_univs.mono.u}
 bind_univs.poly@{u} = Type@{u}
      : Type@{u+1}
 (* u |=  *)
-Inductive MutualR1@{u} (A : Type@{u}) : Prop :=
-    Build_MutualR1 : MutualR2@{u} A -> MutualR1@{u} A
-  with MutualR2@{u} (A : Type@{u}) : Prop :=
-    Build_MutualR2 : MutualR1@{u} A -> MutualR2@{u} A.
+Inductive MutualR1@{u} (A : Type@{u}) : Prop := Build_MutualR1
+  { p1 : MutualR2@{u} A }
+  with MutualR2@{u} (A : Type@{u}) : Prop := Build_MutualR2
+  { p2 : MutualR1@{u} A }.
 (* u |=  *)
 
 Arguments MutualR1 A%_type_scope
@@ -233,10 +233,10 @@ Arguments MutualI1 A%_type_scope
 Arguments C1 A%_type_scope p1
 Arguments MutualI2 A%_type_scope
 Arguments C2 A%_type_scope p2
-CoInductive MutualR1'@{u} (A : Type@{u}) : Prop :=
-    Build_MutualR1' : MutualR2'@{u} A -> MutualR1'@{u} A
-  with MutualR2'@{u} (A : Type@{u}) : Prop :=
-    Build_MutualR2' : MutualR1'@{u} A -> MutualR2'@{u} A.
+CoInductive MutualR1'@{u} (A : Type@{u}) : Prop := Build_MutualR1'
+  { p1' : MutualR2'@{u} A }
+  with MutualR2'@{u} (A : Type@{u}) : Prop := Build_MutualR2'
+  { p2' : MutualR1'@{u} A }.
 (* u |=  *)
 
 Arguments MutualR1' A%_type_scope

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -314,20 +314,22 @@ let print_type_in_type env ref =
 
 (** Printing primitive projection status *)
 
-let print_primitive_record recflag mipv = function
+let print_primitive_record recflag mipv =
+  let mipv = Array.to_list mipv in
+  mipv |> List.concat_map @@ fun mip -> match mip.mind_record with
   | PrimRecord _ ->
     let eta = match recflag with
-    | CoFinite | Finite -> str" without eta conversion"
-    | BiFinite -> str " with eta conversion"
+      | CoFinite | Finite -> str" without eta conversion"
+      | BiFinite -> str " with eta conversion"
     in
-    [Id.print mipv.(0).mind_typename ++ str" has primitive projections" ++ eta ++ str"."]
+    [Id.print mip.mind_typename ++ str" has primitive projections" ++ eta ++ str"."]
   | FakeRecord | NotRecord -> []
 
 let print_primitive env ref =
   match ref with
   | GlobRef.IndRef ind ->
     let mib = Environ.lookup_mind (fst ind) env in
-      print_primitive_record mib.mind_finite mib.mind_packets mib.mind_record
+      print_primitive_record mib.mind_finite mib.mind_packets
   | _ -> []
 
 (** Printing arguments status (scopes, implicit, names) *)
@@ -552,7 +554,7 @@ let print_inductive_with_infos env mind udecl =
   let mipv = mib.mind_packets in
   Printmod.pr_mutual_inductive_body env mind mib udecl ++
   with_line_skip
-    (print_primitive_record mib.mind_finite mipv mib.mind_record @
+    (print_primitive_record mib.mind_finite mipv @
      print_inductive_args env mind mib)
 
 let print_section_variable_with_infos env sigma id =

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -659,7 +659,7 @@ let declare_projections indsp ~kind ~inhabitant_id flags ?fieldlocs fieldimpls =
   let fields = instantiate_possibly_recursive_type (fst indsp) uinstance (Declareops.mind_ntypes mib) paramdecls fields in
   let lifted_fields = Vars.lift_rel_context 1 fields in
   let primitive =
-    match mib.mind_record with
+    match mip.mind_record with
     | PrimRecord _ -> true
     | FakeRecord | NotRecord -> false
   in


### PR DESCRIPTION
No support yet to actually declare them (entries / high level syntax)

This also fixes printing of mutual records (which used to get printed as mutual inductives), cf output test diff.

Overlays:
- https://github.com/MetaRocq/metarocq/pull/1205
- https://github.com/rocq-community/rocq-lean-import/pull/41
- https://github.com/LPCIC/coq-elpi/pull/887
- https://github.com/ejgallego/coq-lsp/pull/1019