### PR TITLE
Check for coherence of primitive constants using user names.

### DIFF
--- a/kernel/primred.ml
+++ b/kernel/primred.ml
@@ -12,11 +12,11 @@ type _ action_kind =
 type exn += IncompatibleDeclarations : 'a action_kind * 'a * 'a -> exn
 
 let check_same_types typ c1 c2 =
-  if not (Constant.CanOrd.equal c1 c2)
+  if not (Constant.UserOrd.equal c1 c2)
   then raise (IncompatibleDeclarations (IncompatTypes typ, c1, c2))
 
 let check_same_inds ind i1 i2 =
-  if not (Ind.CanOrd.equal i1 i2)
+  if not (Ind.UserOrd.equal i1 i2)
   then raise (IncompatibleDeclarations (IncompatInd ind, i1, i2))
 
 let add_retroknowledge retro action =


### PR DESCRIPTION
The previous code was relying instead on canonical names. While there may be weird situations where aliasing a module might generate primitive operations which is non-canonical, I believe this is actively looking for trouble. See also #14822 for a lengthier argumentation. The new code is stricter than the previous one, so we are erring on the safe side. If ever somebody comes up with a crazy scheme requiring to have aliased primitive operations we may reconsider, but for the time being I am convinced this patch is a net enhancement.