### PR TITLE
Use user names to cache computation of inductive case tables in Genlambda

### DIFF
--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -623,14 +623,7 @@ let empty_args = [||]
 module Cache =
   struct
 
-    module ConstrHash =
-    struct
-      type t = constructor
-      let equal = Construct.CanOrd.equal
-      let hash = Construct.CanOrd.hash
-    end
-
-    module ConstrTable = Hashtbl.Make(ConstrHash)
+    module ConstrTable = Hashtbl.Make(Construct.UserOrd)
 
     type constructor_info = tag * int * int (* nparam nrealargs *)
 


### PR DESCRIPTION
This is very unlikely to make any difference, it should be quite rare to mix inductive types with the same canonical name but different user names in the same term. At any rate I am not even sure this cache is really useful and not just some premature optimization, I never see this popping anywhere.
