### PR TITLE
Remove incorrect comment

### DIFF
--- a/theories/Ltac2/Init.v
+++ b/theories/Ltac2/Init.v
@@ -10,7 +10,6 @@
 
 Require Corelib.Init.Ltac.
 
-(* EJGA: Seems that Rocq's findlib loader is not loading this correctly? *)
 Declare ML Module "rocq-runtime.plugins.ltac2".
 Declare ML Module "rocq-runtime.plugins.ltac2_ltac1".
 


### PR DESCRIPTION
findlib is loading correctly. We need both Declare ML Module because we want side effects (grammar) from them, not just code loading.
