### PR TITLE
Ltac2 add "lpreterm" builtin syntactic class (like lconstr etc)

### DIFF
--- a/doc/changelog/06-Ltac2-language/21094-ltac2-lpreterm-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21094-ltac2-lpreterm-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :ref:`syntactic class <syntactic_classes>` `lpreterm` parsing terms
+  at precedence levl 200 and interpreting them as preterms
+  (`#21094 <https://github.com/rocq-prover/rocq/pull/21094>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -623,11 +623,8 @@ The current implementation recognizes the following built-in quotations:
 - ``ident``, which parses identifiers (type ``Init.ident``).
 - ``constr``, which parses Rocq terms and produces an evar-free term at runtime
   (type ``Init.constr``).
-- ``lconstr``, which is equivalent to ``constr`` but at precedence level 200.
 - ``open_constr``, which parses Rocq terms and produces a term potentially with
   holes at runtime (type ``Init.constr`` as well).
-- ``open_lconstr``, which is equivalent to ``open_constr`` but at precedence
-  level 200.
 - ``preterm``, which parses Rocq terms and produces a value which must
   be typechecked with ``Constr.pretype`` (type ``Init.preterm``).
 - ``pat``, which parses Rocq patterns and produces a pattern used for term
@@ -1498,15 +1495,24 @@ table further down lists the classes that are handled plainly.
     the term (as described in  :ref:`LocalInterpretationRulesForNotations`).  The last
     :token:`scope_key` is the top of the scope stack that's applied to the :token:`term`.
 
+  :n:`lconstr {? ( {+, @scope_key } ) }`
+     Identical to `constr` but the term is parsed at precedence level 200.
+
   :n:`open_constr {? ( {+, @scope_key } ) }`
     Parses an open :token:`term`. Like :n:`constr` above, this class
     accepts a list of notation scopes with the same effects.
+
+  :n:`open_lconstr {? ( {+, @scope_key } ) }`
+     Identical to `open_constr` but the term is parsed at precedence level 200.
 
 .. _preterm:
 
   :n:`preterm {? ( {+, @scope_key } ) }`
     Parses a non-typechecked :token:`term`. Like :n:`constr` above, this class
     accepts a list of notation scopes with the same effects.
+
+  :n:`lpreterm {? ( {+, @scope_key } ) }`
+     Identical to `preterm` but the term is parsed at precedence level 200.
 
   :n:`ident`
     Parses :token:`ident` or :n:`$@ident`.  The first form returns :n:`ident:(@ident)`,

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -566,6 +566,12 @@ let () = add_syntax_class "preterm" begin function arg ->
   Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.constr, act)
 end
 
+let () = add_syntax_class "lpreterm" begin function arg ->
+  let delimiters = constr_delimiters "lpreterm" arg in
+  let act e = Tac2quote.of_preterm ~delimiters e in
+  Tac2entries.SyntaxRule (Procq.Symbol.nterm Procq.Constr.lconstr, act)
+end
+
 let () = add_expr_syntax_class "ident" q_ident (fun id -> Tac2quote.of_anti Tac2quote.of_ident id)
 let () = add_expr_syntax_class "bindings" q_bindings Tac2quote.of_bindings
 let () = add_expr_syntax_class "with_bindings" q_with_bindings Tac2quote.of_bindings

--- a/test-suite/ltac2/preterm.v
+++ b/test-suite/ltac2/preterm.v
@@ -21,3 +21,7 @@ Fail Ltac2 baz () := preterm:(notbound).
 Ltac2 Eval
   let x := preterm:(n = n) in
   constr:(forall n:nat, ltac2:(Control.refine (fun () => Constr.pretype x))).
+
+Ltac2 Notation "mypreterm:(" x(lpreterm) ")" := x.
+
+Ltac2 Eval mypreterm:(0 = 0).


### PR DESCRIPTION
also fix ltac2 doc: lconstr and open_lconstr are syntactic
classes (arguments to Ltac2 Notation) not quotations.
