### PR TITLE
Allow passing an explicit environment to Proof.solve.

### DIFF
--- a/dev/ci/user-overlays/21110-ppedrot-proof-solve-explicit-env.sh
+++ b/dev/ci/user-overlays/21110-ppedrot-proof-solve-explicit-env.sh
@@ -1,0 +1,9 @@
+overlay coq_lsp https://github.com/ppedrot/coq-lsp proof-solve-explicit-env 21110
+
+overlay equations https://github.com/ppedrot/Coq-Equations proof-solve-explicit-env 21110
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 proof-solve-explicit-env 21110
+
+overlay rewriter https://github.com/ppedrot/rewriter proof-solve-explicit-env 21110
+
+overlay tactician https://github.com/ppedrot/coq-tactician proof-solve-explicit-env 21110

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -888,7 +888,7 @@ let generate_equation_lemma env evd fnames f fun_num nb_params nb_args rec_args_
     Declare.CInfo.make ~name:(mk_equation_id f_id) ~typ:lemma_type ()
   in
   let lemma = Declare.Proof.start ~cinfo ~info evd in
-  let lemma, _ = Declare.Proof.by prove_replacement lemma in
+  let lemma, _ = Declare.Proof.by (Global.env ()) prove_replacement lemma in
   let (_ : _ list) =
     Declare.Proof.save_regular ~proof:lemma ~opaque:Vernacexpr.Transparent
       ~idopt:None

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1484,7 +1484,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let info = Declare.Info.make () in
           let cinfo = Declare.CInfo.make ~name:lem_id ~typ () in
           let lemma = Declare.Proof.start ~cinfo ~info !evd in
-          let lemma = fst @@ Declare.Proof.by (proving_tac i) lemma in
+          let lemma = fst @@ Declare.Proof.by (Global.env ()) (proving_tac i) lemma in
           let (_ : _ list) =
             Declare.Proof.save_regular ~proof:lemma
               ~opaque:Vernacexpr.Transparent ~idopt:None
@@ -1553,7 +1553,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
           let lemma = Declare.Proof.start ~cinfo sigma ~info in
           let lemma =
             fst
-              (Declare.Proof.by
+              (Declare.Proof.by (Global.env ())
                  (observe_tac
                     ("prove completeness (" ^ Id.to_string f_id ^ ")")
                     (proving_tac i))

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1467,10 +1467,10 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
   let lemma = Declare.Proof.start ~cinfo ~info sigma in
   let lemma =
     if Indfun_common.is_strict_tcc () then
-      fst @@ Declare.Proof.by tclIDTAC lemma
+      fst @@ Declare.Proof.by (Global.env ()) tclIDTAC lemma
     else
       fst
-      @@ Declare.Proof.by
+      @@ Declare.Proof.by (Global.env ())
            (tclTHEN decompose_and_tac
               (tclORELSE
                  (tclFIRST
@@ -1502,12 +1502,12 @@ let com_terminate interactive_proof tcc_lemma_name tcc_lemma_ref is_mes
     let lemma = Declare.Proof.start ~cinfo ~info ctx in
     let lemma =
       fst
-      @@ Declare.Proof.by
+      @@ Declare.Proof.by (Global.env ())
            (observe_tac (fun _ _ -> str "starting_tac") tac_start)
            lemma
     in
     fst
-    @@ Declare.Proof.by
+    @@ Declare.Proof.by (Global.env ())
          (observe_tac
             (fun _ _ -> str "whole_start")
             (whole_start tac_end nb_args is_mes fonctional_ref input_type
@@ -1573,7 +1573,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
   let lemma = Declare.Proof.start ~cinfo evd ~info in
   let lemma =
     fst
-    @@ Declare.Proof.by
+    @@ Declare.Proof.by (Global.env ())
          (start_equation f_ref terminate_ref (fun x ->
               prove_eq
                 (fun _ -> Proofview.tclUNIT ())

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -228,7 +228,7 @@ let add_morphism_interactive atts ~tactic m n : Declare.Proof.t =
        let cinfo = Declare.CInfo.make ?loc:instance_id.loc ~name:instance_id.v ~typ:morph () in
        let info = Declare.Info.make ~poly ~hook ~kind () in
        let lemma = Declare.Proof.start ~cinfo ~info evd in
-       fst (Declare.Proof.by tactic lemma)) ()
+       fst (Declare.Proof.by (Global.env ()) tactic lemma)) ()
 
 let add_morphism atts ~tactic binders m s n =
   init_setoid ();

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -341,7 +341,7 @@ let infoH ~pstate (tac : raw_tactic_expr) : unit =
         ++  (str "</infoH>")) in
     Proofview.tclUNIT ()
   in
-  ignore (Declare.Proof.by tac pstate)
+  ignore (Declare.Proof.by (Global.env ()) tac pstate)
 
 let declare_equivalent_keys c c' =
   let get_key c =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -436,7 +436,7 @@ let register_side_effects eff =
   in
   List.iter iter cst
 
-let solve ?with_end_tac gi info_lvl tac pr =
+let solve ?with_end_tac env gi info_lvl tac pr =
     let tac = match with_end_tac with
       | None -> tac
       | Some etac -> Proofview.tclTHEN tac etac in
@@ -454,7 +454,6 @@ let solve ?with_end_tac gi info_lvl tac pr =
         Proofview.tclTHEN tac solve_constraints
       else tac
     in
-    let env = Global.env () in
     let env = Environ.update_typing_flags ?typing_flags:pr.typing_flags env in
     let (p,(_env,status,info),()) = run_tactic env tac pr in
     let () = register_side_effects (Evd.eval_side_effects (Proofview.return p.proofview)) in

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -189,6 +189,7 @@ val all_goals : t -> Evar.Set.t
 
 val solve :
      ?with_end_tac:unit Proofview.tactic
+  -> Environ.env
   -> Goal_select.t
   -> int option
   -> unit Proofview.tactic

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1936,7 +1936,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
                Option.iter PG_compat.unfreeze lemmas;
                PG_compat.with_current_proof (fun p ->
                  feedback ~id:id Feedback.AddedAxiom;
-                 fst (Proof.solve Goal_select.SelectAll None tac p), ());
+                 fst (Proof.solve (Global.env ()) Goal_select.SelectAll None tac p), ());
                (* STATE SPEC:
                 * - start: Modifies the input state adding a proof.
                 * - end  : maybe after recovery command.

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -40,7 +40,7 @@ let name_op_to_name ~name_op ~name suffix =
   | Some s -> s
   | None -> Nameops.add_suffix name suffix
 
-let declare_abstract = ref (fun ~name ~poly ~sign ~secsign ~opaque ~solve_tac sigma concl ->
+let declare_abstract = ref (fun ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl ->
   CErrors.anomaly (Pp.str "Abstract declaration hook not registered"))
 
 let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
@@ -76,7 +76,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
          tac)
     in
     let effs, sigma, lem, args, safe =
-      !declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac sigma concl
+      !declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac (Global.env ()) sigma concl
     in
     let pose_tac = match name_op with
     | None -> Proofview.tclUNIT ()

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -28,6 +28,7 @@ val declare_abstract :
   -> secsign:Environ.named_context_val
   -> opaque:bool
   -> solve_tac:unit Proofview.tactic
+  -> Environ.env
   -> Evd.evar_map
   -> EConstr.t
   -> Evd.side_effects * Evd.evar_map * EConstr.t * EConstr.t list * bool) ref

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -377,15 +377,15 @@ let declare_instance_open sigma ?hook ~tac ~locality ~poly (id:lident) pri impar
           Tactics.reduce_after_refine;
         ]
       in
-      let lemma, _ = Declare.Proof.by init_refine lemma in
+      let lemma, _ = Declare.Proof.by (Global.env ()) init_refine lemma in
       lemma
     | None ->
-      let lemma, _ = Declare.Proof.by (Tactics.auto_intros_tac ids) lemma in
+      let lemma, _ = Declare.Proof.by (Global.env ()) (Tactics.auto_intros_tac ids) lemma in
       lemma
   in
   match tac with
   | Some tac ->
-    let lemma, _ = Declare.Proof.by tac lemma in
+    let lemma, _ = Declare.Proof.by (Global.env ()) tac lemma in
     lemma
   | None ->
     lemma

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -194,5 +194,5 @@ let do_definition_refine ?loc ?hook ~name ~scope ?clearbody ~poly ~typing_flags 
       Tactics.reduce_after_refine;
     ]
   in
-  let lemma, _ = Declare.Proof.by init_refine lemma in
+  let lemma, _ = Declare.Proof.by (Global.env ()) init_refine lemma in
   lemma

--- a/vernac/comTactic.ml
+++ b/vernac/comTactic.ml
@@ -79,7 +79,7 @@ let solve_core ~pstate n ~info ?(with_end_tac=CAst.make false) t =
   let pstate, status = Declare.Proof.map_fold_endline ~f:(fun etac p ->
       let with_end_tac = use_end_tac ~with_end_tac etac in
       let info = Option.append info (print_info_trace ()) in
-      let (p,status) = Proof.solve n info t ?with_end_tac p in
+      let (p,status) = Proof.solve (Global.env ()) n info t ?with_end_tac p in
       (* in case a strict subtree was completed,
          go back to the top of the prooftree *)
       let p = Proof.maximal_unfocus Vernacentries.command_focus p in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -251,10 +251,10 @@ module Proof : sig
   (** Admit a proof *)
   val save_admitted : pm:OblState.t -> proof:t -> OblState.t
 
-  (** [by tac] applies tactic [tac] to the 1st subgoal of the current
+  (** [by env tac] applies tactic [tac] to the 1st subgoal of the current
       focused proof.
       Returns [false] if an unsafe tactic has been used. *)
-  val by : unit Proofview.tactic -> t -> t * bool
+  val by : Environ.env -> unit Proofview.tactic -> t -> t * bool
 
   (** Operations on ongoing proofs *)
   val get : t -> Proof.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -929,7 +929,7 @@ let vernac_exact_proof ~lemma ~pm c =
   deprecated_exact_proof ();
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the beginning of a proof. *)
-  let lemma, status = Declare.Proof.by (Tactics.exact_proof c) lemma in
+  let lemma, status = Declare.Proof.by (Global.env ()) (Tactics.exact_proof c) lemma in
   let pm, _ = Declare.Proof.save ~pm ~proof:lemma ~opaque:Opaque ~idopt:None in
   if not status then Feedback.feedback Feedback.AddedAxiom;
   pm


### PR DESCRIPTION
This gives a finer control about the expected state and lets the caller decide to work around dubious global changes due to side-effects.

Overlays:
- https://github.com/ejgallego/coq-lsp/pull/1031
- https://github.com/mattam82/Coq-Equations/pull/663
- https://github.com/Mtac2/Mtac2/pull/412
- https://github.com/mit-plv/rewriter/pull/178
- https://github.com/coq-tactician/coq-tactician/pull/108
