### PR TITLE
Deprecate adding a hint to an undeclared hint database.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21114-hintdb-strict-check-Deprecated.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21114-hintdb-strict-check-Deprecated.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  implicitly creating hint databases when declaring hints.
+  (`#21114 <https://github.com/rocq-prover/rocq/pull/21114>`_,
+  fixes `#4117 <https://github.com/rocq-prover/rocq/issues/4117>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -308,10 +308,12 @@ pattern or when the hint has no pattern.
 Creating hint databases
 ```````````````````````
 
-Hint databases can be created with the :cmd:`Create HintDb` command or implicitly
-by adding a hint to an unknown database.  We recommend you always use :cmd:`Create HintDb`
-and then imediately use :cmd:`Hint Constants` and :cmd:`Hint Variables` to make
-those settings explicit.
+Hint databases can be created with the :cmd:`Create HintDb` command.
+After a call to :cmd:`Create HintDb`, we recommend to immediately use
+:cmd:`Hint Constants` and :cmd:`Hint Variables` to make those settings explicit.
+
+Alternatively, adding a hint to an unknown database creates the latter
+implicitly, but this behavior is deprecated as of Rocq 9.2.
 
 Note that the default transparency
 settings differ between these two methods of creation.  Databases created with
@@ -419,6 +421,11 @@ Creating Hints
 
       The default value for hint locality outside sections is
       now :attr:`export`. It used to be :attr:`global`.
+
+   .. deprecated:: 9.2
+
+      Implicitly creating a unknown database is now deprecated and will become
+      an error.
 
    The `Hint` commands are:
 

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -552,6 +552,7 @@ Creating Hints
          .. rocqtop:: reset all
 
             Require Import ListDef.
+            Create HintDb eqdec.
             Hint Extern 5 ({?X1 = ?X2} + {?X1 <> ?X2}) =>
               generalize  X1, X2; decide equality : eqdec.
             Goal forall a b:list (nat * nat), {a = b} + {a <> b}.
@@ -650,6 +651,7 @@ Creating Hints
       .. rocqtop:: all reset
 
          Parameter plus : nat -> nat -> nat -> Prop.
+         Create HintDb plus.
          Hint Mode plus ! - - : plus.
          Hint Mode plus - ! - : plus.
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -27,6 +27,12 @@ module NamedDecl = Context.Named.Declaration
 (** Hint database named "typeclass_instances", created in prelude *)
 let typeclasses_db = "typeclass_instances"
 
+let check_typeclasses_db ?loc () =
+  try ignore (Hints.searchtable_map typeclasses_db)
+  with Not_found ->
+    CErrors.user_err (strbrk "The built-in typeclass hint database " ++
+      quote (str typeclasses_db) ++ strbrk " has not been registered.")
+
 (** Options handling *)
 
 let typeclasses_depth_opt_name = ["Typeclasses";"Depth"]

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -15,6 +15,8 @@ open EConstr
 
 val typeclasses_db : string
 
+val check_typeclasses_db : ?loc:Loc.t -> unit -> unit
+
 val set_typeclasses_debug : bool -> unit
 
 val set_typeclasses_depth : int option -> unit

--- a/test-suite/bugs/HoTT_coq_107.v
+++ b/test-suite/bugs/HoTT_coq_107.v
@@ -40,6 +40,8 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
     | trunc_S n' => forall (x y : A), IsTrunc_internal n' (x = y)
   end.
 
+Create HintDb typeclass_instances discriminated.
+
 Class IsTrunc (n : trunc_index) (A : Type) : Type :=
   Trunc_is_trunc : IsTrunc_internal n A.
 

--- a/test-suite/bugs/bug_21114.v
+++ b/test-suite/bugs/bug_21114.v
@@ -1,0 +1,14 @@
+Module Type S.
+#[global] Create HintDb bugdb.
+End S.
+
+Module F(X : S).
+
+#[global] Hint Immediate true : bugdb.
+
+End F.
+
+Module M.
+End M.
+
+Module Import N := F(M). (* anomaly because bugdb is actually not declared *)

--- a/test-suite/bugs/bug_3881.v
+++ b/test-suite/bugs/bug_3881.v
@@ -16,6 +16,7 @@ Definition ap {A B:Type} (f:A -> B) {x y:A} (p:x = y) : f x = f y := match p wit
 Class IsEquiv {A B : Type} (f : A -> B) := { equiv_inv : B -> A ; eisretr : forall x, f (equiv_inv x) = x }.
 Arguments eisretr {A B} f {_} _.
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'").
+Create HintDb typeclass_instances discriminated.
 Global Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g} : IsEquiv (g o f) | 1000 := admit.
 Definition isequiv_homotopic {A B} (f : A -> B) (g : A -> B) `{IsEquiv A B f} (h : forall x, f x = g x) : IsEquiv g := admit.
 Global Instance isequiv_inverse {A B} (f : A -> B) {feq : IsEquiv f} : IsEquiv f^-1 | 10000 := admit.

--- a/test-suite/bugs/bug_4121.v
+++ b/test-suite/bugs/bug_4121.v
@@ -11,6 +11,7 @@ Set Default Proof Mode "Classic".
 Set Universe Polymorphism.
 Class Contr_internal (A : Type) := BuildContr { center : A }.
 Arguments center A {_}.
+Create HintDb typeclass_instances discriminated.
 Class Contr (A : Type) : Type := Contr_is_trunc : Contr_internal A.
 #[export] Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 Definition contr_paths_contr0 {A} `{Contr A} : Contr A := {| center := center A |}.

--- a/test-suite/bugs/bug_4533.v
+++ b/test-suite/bugs/bug_4533.v
@@ -149,6 +149,8 @@ Type2le@{j a}} {Q_inO : In@{u a j} O Q},
 
 End ReflectiveSubuniverses.
 
+Create HintDb typeclass_instances discriminated.
+
 Module ReflectiveSubuniverses_Theory (Os : ReflectiveSubuniverses).
   Export Os.
   Existing Class In.

--- a/test-suite/bugs/bug_4544.v
+++ b/test-suite/bugs/bug_4544.v
@@ -136,6 +136,8 @@ Record Equiv A B := BuildEquiv {
 
 Coercion equiv_fun : Equiv >-> Funclass.
 
+Create HintDb typeclass_instances discriminated.
+
 Global Existing Instance equiv_isequiv.
 
 Notation "A <~> B" := (Equiv A B) (at level 85) : type_scope.

--- a/test-suite/bugs/bug_5198.v
+++ b/test-suite/bugs/bug_5198.v
@@ -20,6 +20,8 @@ Axiom barrett_reduce_function_bundled : forall {params : BarrettParameters}
                                                (_ : @LargeT _ (@ops params)),
     @SmallT _ (@ops params).
 
+Create HintDb typeclass_instances discriminated.
+
 Global Instance ZZLikeOps e : ZLikeOps (f (S O) e)
   := { LargeT := nat ; SmallT := nat ; CarryAdd x y := y }.
 Definition SRep := nat.

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -28,7 +28,7 @@ negb is not universe polymorphic
 Arguments negb b%_bool_scope
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 84, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
 a : bool -> bool
 
 a is not universe polymorphic
@@ -43,7 +43,7 @@ negb is not universe polymorphic
 Arguments negb b
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 84, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
 negb' : bool -> bool
 
 negb' is not universe polymorphic
@@ -68,7 +68,7 @@ negb is not universe polymorphic
 Arguments negb b
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 84, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
 negb' : bool -> bool
 
 negb' is not universe polymorphic

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -23,7 +23,7 @@ eq_refl is template universe polymorphic
 Arguments eq_refl {B}%_type_scope {y}, [_] _
   (where some original arguments have been renamed)
 Expands to: Constructor Corelib.Init.Logic.eq_refl
-Declared in library Corelib.Init.Logic, line 379, characters 4-11
+Declared in library Corelib.Init.Logic, line 382, characters 4-11
 Inductive myEq (B : Type) (x : A) : A -> Prop :=  myrefl : B -> myEq B x x.
 
 Arguments myEq B%_type_scope x _

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -17,13 +17,13 @@ option : Type -> Type
 option is template universe polymorphic
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 202, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 209, characters 10-16
 option : Type@{option.u0} -> Type@{max(Set,option.u0)}
 
 option is template universe polymorphic on option.u0 (cannot be instantiated to Prop)
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 202, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 209, characters 10-16
 File "./output/Inductive.v", line 27, characters 4-13:
 The command has indeed failed with message:
 Parameters should be syntactically the same for each inductive type.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -21,7 +21,7 @@ eq_refl : forall {A : Type} {x : A}, x = x
 eq_refl is template universe polymorphic
 Arguments eq_refl {A}%_type_scope {x}, [_] _
 Expands to: Constructor Corelib.Init.Logic.eq_refl
-Declared in library Corelib.Init.Logic, line 379, characters 4-11
+Declared in library Corelib.Init.Logic, line 382, characters 4-11
 eq_refl : forall {A : Type} {x : A}, x = x
 
 When applied to no arguments:
@@ -63,7 +63,7 @@ comparison : Set
 
 comparison is not universe polymorphic
 Expands to: Inductive Corelib.Init.Datatypes.comparison
-Declared in library Corelib.Init.Datatypes, line 360, characters 10-20
+Declared in library Corelib.Init.Datatypes, line 367, characters 10-20
 Inductive comparison : Set :=
     Eq : comparison | Lt : comparison | Gt : comparison.
 bar : foo
@@ -84,7 +84,7 @@ Arguments bar {x}
 Module Corelib.Init.Peano
 Notation sym_eq := eq_sym
 Expands to: Notation Corelib.Init.Logic.sym_eq
-Declared in library Corelib.Init.Logic, line 757, characters 0-45
+Declared in library Corelib.Init.Logic, line 760, characters 0-45
 
 eq_sym : forall [A : Type] [x y : A], x = y -> y = x
 
@@ -92,7 +92,7 @@ eq_sym is not universe polymorphic
 Arguments eq_sym [A]%_type_scope [x y] _
 eq_sym is transparent
 Expands to: Constant Corelib.Init.Logic.eq_sym
-Declared in library Corelib.Init.Logic, line 419, characters 12-18
+Declared in library Corelib.Init.Logic, line 422, characters 12-18
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x.
 
 Arguments eq {A}%_type_scope x _
@@ -115,14 +115,14 @@ Alias.eq is template universe polymorphic
 Arguments Alias.eq {A}%_type_scope x _
 Expands to: Inductive PrintInfos.Alias.eq (syntactically equal to
             Corelib.Init.Logic.eq)
-Declared in library Corelib.Init.Logic, line 378, characters 10-12
+Declared in library Corelib.Init.Logic, line 381, characters 10-12
 Alias.eq_refl : forall {A : Type} {x : A}, x = x
 
 Alias.eq_refl is template universe polymorphic
 Arguments Alias.eq_refl {A}%_type_scope {x}, [_] _
 Expands to: Constructor PrintInfos.Alias.eq_refl (syntactically equal to
             Corelib.Init.Logic.eq_refl)
-Declared in library Corelib.Init.Logic, line 379, characters 4-11
+Declared in library Corelib.Init.Logic, line 382, characters 4-11
 Alias.eq_ind :
 forall [A : Type] (x : A) (P : A -> Prop), P x -> forall y : A, x = y -> P y
 
@@ -132,7 +132,7 @@ Arguments Alias.eq_ind [A]%_type_scope x P%_function_scope eq_refl y e
 Alias.eq_ind is transparent
 Expands to: Constant PrintInfos.Alias.eq_ind (syntactically equal to
             Corelib.Init.Logic.eq_ind)
-Declared in library Corelib.Init.Logic, line 378, characters 0-115
+Declared in library Corelib.Init.Logic, line 381, characters 0-115
 fst : forall A B : Type, prod A B -> A
 
 fst is not universe polymorphic

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -13,6 +13,6 @@ Debug: 1.1-1.1-1.1-1.1-1 : foo
 Debug: 1.1-1.1-1.1-1.1-1: looking for foo without backtracking
 Debug: 1.1-1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
-File "./output/TypeclassDebug.v", line 9, characters 5-33:
+File "./output/TypeclassDebug.v", line 13, characters 5-33:
 The command has indeed failed with message:
 Tactic failure: Proof search reached its limit.

--- a/test-suite/output/TypeclassDebug.v
+++ b/test-suite/output/TypeclassDebug.v
@@ -2,6 +2,10 @@
 
 Parameter foo : Prop.
 Axiom H : foo -> foo.
+
+#[global]
+Create HintDb foo.
+
 #[global]
 Hint Resolve H : foo.
 Goal foo.

--- a/test-suite/output/auto_order.out
+++ b/test-suite/output/auto_order.out
@@ -27,6 +27,6 @@ first
 fifth, different hintDb
 fourth
 third
-File "./output/auto_order.v", line 16, characters 5-45:
+File "./output/auto_order.v", line 26, characters 5-45:
 The command has indeed failed with message:
 Tactic failure: Proof search failed.

--- a/test-suite/output/auto_order.v
+++ b/test-suite/output/auto_order.v
@@ -1,8 +1,18 @@
+Create HintDb plus.
+Hint Constants Opaque : plus.
+Hint Projections Opaque : plus.
+Hint Variables Opaque : plus.
+
 Hint Extern 1 => idtac "first"; fail : plus.
 Hint Extern 1 => idtac "second"; fail : plus.
 
 Hint Extern 2 => idtac "third"; fail : plus.
 Hint Extern 2 => idtac "fourth"; fail : plus.
+
+Create HintDb plus2.
+Hint Constants Opaque : plus2.
+Hint Projections Opaque : plus2.
+Hint Variables Opaque : plus2.
 
 Hint Extern 1 => idtac "fifth, different hintDb"; fail : plus2.
 

--- a/test-suite/output/bug_15020.out
+++ b/test-suite/output/bug_15020.out
@@ -7,4 +7,4 @@ Arguments eq_rect {A}%_type_scope {x} P%_function_scope eq_refl {y} e
   (where some original arguments have been renamed)
 eq_rect is transparent
 Expands to: Constant Corelib.Init.Logic.eq_rect
-Declared in library Corelib.Init.Logic, line 378, characters 0-115
+Declared in library Corelib.Init.Logic, line 381, characters 0-115

--- a/test-suite/output/bug_20754.out
+++ b/test-suite/output/bug_20754.out
@@ -5,4 +5,4 @@ prod : Type -> Type -> Type
 prod is template universe polymorphic
 Arguments prod (A B)%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.prod
-Declared in library Corelib.Init.Datatypes, line 248, characters 10-14
+Declared in library Corelib.Init.Datatypes, line 255, characters 10-14

--- a/theories/Corelib/Classes/CRelationClasses.v
+++ b/theories/Corelib/Classes/CRelationClasses.v
@@ -236,6 +236,9 @@ Hint Extern 4 (subrelation (flip _) _) =>
   class_apply @subrelation_symmetric : typeclass_instances.
 
 #[global]
+Create HintDb ord.
+
+#[global]
 Hint Resolve irreflexivity : ord.
 
 Unset Implicit Arguments.
@@ -245,6 +248,9 @@ Ltac solve_crelation :=
   | [ |- ?R ?x ?x ] => reflexivity
   | [ H : ?R ?x ?y |- ?R ?y ?x ] => symmetry ; exact H
   end.
+
+#[global]
+Create HintDb crelations.
 
 #[global]
 Hint Extern 4 => solve_crelation : crelations.

--- a/theories/Corelib/Classes/RelationClasses.v
+++ b/theories/Corelib/Classes/RelationClasses.v
@@ -248,6 +248,9 @@ Arguments transitivity {A} {R} {_} [x] [y] [z] _ _.
 Arguments Antisymmetric A eqA {_} _.
 
 #[global]
+Create HintDb ord.
+
+#[global]
 Hint Resolve irreflexivity : ord.
 
 Unset Implicit Arguments.
@@ -257,6 +260,9 @@ Ltac solve_relation :=
   | [ |- ?R ?x ?x ] => reflexivity
   | [ H : ?R ?x ?y |- ?R ?y ?x ] => symmetry ; exact H
   end.
+
+#[global]
+Create HintDb relations.
 
 #[global]
 Hint Extern 4 => solve_relation : relations.

--- a/theories/Corelib/Init/Datatypes.v
+++ b/theories/Corelib/Init/Datatypes.v
@@ -59,6 +59,10 @@ Register false as core.bool.false.
 Inductive reflect (P : Prop) : bool -> Set :=
   | ReflectT : P -> reflect P true
   | ReflectF : ~ P -> reflect P false.
+
+#[global]
+Create HintDb bool.
+
 #[global]
 Hint Constructors reflect : bool.
 Arguments ReflectT : clear implicits.
@@ -116,6 +120,9 @@ Register andb_true_intro as core.bool.andb_true_intro.
 (** Interpretation of booleans as propositions *)
 
 Inductive eq_true : bool -> Prop := is_eq_true : eq_true true.
+
+#[global]
+Create HintDb eq_true.
 
 #[global]
 Hint Constructors eq_true : eq_true.

--- a/theories/Corelib/Init/Logic.v
+++ b/theories/Corelib/Init/Logic.v
@@ -127,6 +127,9 @@ Theorem iff_sym : forall A B:Prop, (A <-> B) -> (B <-> A).
 End Equivalence.
 
 #[global]
+Create HintDb extcore.
+
+#[global]
 Hint Unfold iff: extcore.
 
 (** Backward direction of the equivalences above does not need assumptions *)

--- a/theories/Corelib/Relations/Relation_Definitions.v
+++ b/theories/Corelib/Relations/Relation_Definitions.v
@@ -69,6 +69,9 @@ Section Relation_Definition.
 End Relation_Definition.
 
 #[global]
+Create HintDb sets.
+
+#[global]
 Hint Unfold reflexive transitive antisymmetric symmetric: sets.
 
 #[global]

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -30,6 +30,7 @@ let warn_default_mode = CWarnings.create ~name:"class-declaration-default-mode" 
     spc () ++ str "for" ++ spc () ++ Printer.pr_global gr))
 
 let set_typeclass_transparency ~locality c b =
+  let () = check_typeclasses_db () in
   Hints.add_hints ~locality [typeclasses_db]
     (Hints.HintsTransparencyEntry (Hints.HintsReferences c, b))
 
@@ -43,14 +44,16 @@ let set_typeclass_transparency_com ~locality refs b =
   set_typeclass_transparency ~locality refs b
 
 let set_typeclass_mode ~locality c b =
+  let () = check_typeclasses_db () in
   Hints.add_hints ~locality [typeclasses_db]
     (Hints.HintsModeEntry (c, b))
 
 let add_instance_hint gr ~locality info =
-     Flags.silently (fun () ->
-       Hints.add_hints ~locality [typeclasses_db]
-          (Hints.HintsResolveEntry
-             [info, false, gr])) ()
+  let () = check_typeclasses_db () in
+  Flags.silently (fun () ->
+    Hints.add_hints ~locality [typeclasses_db]
+      (Hints.HintsResolveEntry
+          [info, false, gr])) ()
 
 (* short names without opening all Hints *)
 type locality = Hints.hint_locality = Local | Export | SuperGlobal


### PR DESCRIPTION
This is a real footgun that users keep complaining about, and it is actually easy to fix nowadays.

Fixes #4117: Option to force declaration of hint database creation.