### PR TITLE
Purer scheme creation

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -444,6 +444,7 @@ type side_effect_role =
 type side_effects = {
   seff_private : Safe_typing.private_constants;
   seff_roles : side_effect_role Cmap.t;
+  seff_univs : UState.named_universes_entry Cmap.t;
 }
 
 module FutureGoals : sig
@@ -923,6 +924,7 @@ let empty_evar_flags =
 let empty_side_effects = {
   seff_private = Safe_typing.empty_private_constants;
   seff_roles = Cmap.empty;
+  seff_univs = Cmap.empty;
 }
 
 let empty = {
@@ -1266,6 +1268,7 @@ let emit_side_effects eff evd =
   let effects = {
   seff_private = Safe_typing.concat_private eff.seff_private evd.effects.seff_private;
   seff_roles = Cmap.fold Cmap.add eff.seff_roles evd.effects.seff_roles;
+  seff_univs = Cmap.fold Cmap.add eff.seff_univs evd.effects.seff_univs;
   } in
   { evd with effects; universes = UState.emit_side_effects eff.seff_private evd.universes }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -390,6 +390,8 @@ type side_effect_role =
 type side_effects = {
   seff_private : Safe_typing.private_constants;
   seff_roles : side_effect_role Cmap.t;
+  seff_univs : UState.named_universes_entry Cmap.t;
+  (* only used by Declare to register names for mono universes *)
 }
 
 val empty_side_effects : side_effects

--- a/library/global.ml
+++ b/library/global.ml
@@ -100,7 +100,6 @@ let set_rewrite_rules_allowed b = globalize0 (Safe_typing.set_rewrite_rules_allo
 let rewrite_rules_allowed () = Environ.rewrite_rules_allowed (env())
 let export_private_constants cd = globalize (Safe_typing.export_private_constants cd)
 let add_constant ?typing_flags id d = globalize (Safe_typing.add_constant ?typing_flags (i2l id) d)
-let add_private_constant id u d = globalize (Safe_typing.add_private_constant (i2l id) u d)
 let fill_opaque c = globalize0 (Safe_typing.fill_opaque c)
 let add_rewrite_rules id c = globalize0 (Safe_typing.add_rewrite_rules (i2l id) c)
 let add_mind ?typing_flags id mie = globalize (Safe_typing.add_mind ?typing_flags (i2l id) mie)
@@ -257,3 +256,10 @@ let set_share_reduction b =
 
 let set_VM b = globalize0 (Safe_typing.set_VM b)
 let set_native_compiler b = globalize0 (Safe_typing.set_native_compiler b)
+
+module Internal =
+struct
+
+let reset_safe_env = GlobalSafeEnv.set_safe_env
+
+end

--- a/library/global.mli
+++ b/library/global.mli
@@ -56,8 +56,6 @@ val add_constant :
   ?typing_flags:typing_flags ->
   Id.t -> Entries.constant_entry -> Constant.t
 val fill_opaque : Safe_typing.opaque_certificate -> unit
-val add_private_constant :
-  Id.t -> Univ.ContextSet.t -> Safe_typing.side_effect_declaration -> Constant.t * Safe_typing.private_constants
 val add_rewrite_rules : Id.t -> rewrite_rules_body -> unit
 val add_mind :
   ?typing_flags:typing_flags ->
@@ -205,3 +203,11 @@ val current_dirpath : unit -> DirPath.t
 val with_global : (Environ.env -> DirPath.t -> 'a Univ.in_universe_context_set) -> 'a
 
 val global_env_summary_tag : Safe_typing.safe_environment Summary.Dyn.tag
+
+module Internal :
+sig
+
+val reset_safe_env : Safe_typing.safe_environment -> unit
+(** Only use for manipulation of private constants *)
+
+end

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -80,20 +80,37 @@ let scheme_kind_name (key : _ scheme_kind) : string = key
 
 let is_visible_name id =
   try ignore (Nametab.locate (Libnames.qualid_of_ident id)); true
-  with Not_found -> false
+  with Not_found ->
+    (* FIXME: due to private constant declaration being imperative, we have to
+       also check in the global env *)
+    Global.exists_objlabel (Label.of_id id)
 
-let compute_name internal id =
+let compute_name internal id avoid =
   if internal then
-    Namegen.next_ident_away_from (add_prefix "internal_" id) is_visible_name
+    let visible id = is_visible_name id || Id.Set.mem id avoid in
+    Namegen.next_ident_away_from (add_prefix "internal_" id) visible
   else id
 
-let declare_definition_scheme = ref (fun ~internal ~univs ~role ~name ~effs ?loc c ->
+let declare_definition_scheme = ref (fun ~univs ~role ~name ~effs c ->
     CErrors.anomaly (Pp.str "scheme declaration not registered"))
+
+let register_definition_scheme = ref (fun ~internal ~name ~const ~univs ?loc () ->
+  CErrors.anomaly (Pp.str "scheme registering not registered"))
 
 let lookup_scheme kind ind =
   try Some (DeclareScheme.lookup_scheme kind ind) with Not_found -> None
 
-let redeclare_schemes eff =
+type schemes = {
+  sch_eff : Evd.side_effects;
+  sch_reg : (Id.t * Constant.t * Loc.t option * UState.named_universes_entry) list;
+}
+
+let empty_schemes = {
+  sch_eff = Evd.empty_side_effects;
+  sch_reg = [];
+}
+
+let redeclare_schemes { sch_eff = eff } =
   let fold c role accu = match role with
   | Evd.Schema (ind, kind) ->
     try
@@ -119,19 +136,24 @@ let local_lookup_scheme eff kind ind = match lookup_scheme kind ind with
      this is very rarely called *)
   try let _ = Cmap.iter iter eff.Evd.seff_roles in None with Found c -> Some c
 
-let local_check_scheme kind ind eff =
+let local_check_scheme kind ind { sch_eff = eff } =
   Option.has_some (local_lookup_scheme eff kind ind)
 
-let define ?loc internal role id c poly uctx effs =
-  let id = compute_name internal id in
+let define ?loc internal role id c poly uctx sch =
+  let avoid = Safe_typing.constants_of_private sch.sch_eff.Evd.seff_private in
+  let avoid = Id.Set.of_list @@ List.map (fun cst -> Label.to_id @@ Constant.label cst) avoid in
+  let id = compute_name internal id avoid in
   let uctx = UState.collapse_above_prop_sort_variables ~to_prop:true uctx in
   let uctx = UState.minimize uctx in
   let c = UState.nf_universes uctx c in
   let uctx = UState.restrict uctx (Vars.universes_of_constr c) in
   let univs = UState.univ_entry ~poly uctx in
-  !declare_definition_scheme ~internal ~univs ~role ~name:id ~effs ?loc c
+  let effs = sch.sch_eff in
+  let cst, effs = !declare_definition_scheme ~univs ~role ~name:id ~effs c in
+  let reg = (id, cst, loc, univs) :: sch.sch_reg in
+  cst, { sch_eff = effs; sch_reg = reg }
 
-  module Locmap : sig
+module Locmap : sig
 
     type t
 
@@ -168,7 +190,7 @@ end = struct
 (* Assumes that dependencies are already defined *)
 let rec define_individual_scheme_base ?loc kind suff f ~internal idopt (mind,i as ind) eff =
   (* FIXME: do not rely on the imperative modification of the global environment *)
-  let (c, ctx) = f (Global.env ()) eff ind in
+  let (c, ctx) = f (Global.env ()) eff.sch_eff ind in
   let mib = Global.lookup_mind mind in
   let id = match idopt with
     | Some id -> id
@@ -189,7 +211,7 @@ and define_individual_scheme ?loc kind ~internal names (mind,i as ind) eff =
 (* Assumes that dependencies are already defined *)
 and define_mutual_scheme_base ?(locmap=Locmap.default None) kind suff f ~internal names mind eff =
   (* FIXME: do not rely on the imperative modification of the global environment *)
-  let (cl, ctx) = f (Global.env ()) eff mind in
+  let (cl, ctx) = f (Global.env ()) eff.sch_eff mind in
   let mib = Global.lookup_mind mind in
   let ids = Array.init (Array.length mib.mind_packets) (fun i ->
       try Int.List.assoc i names
@@ -232,22 +254,30 @@ let find_scheme kind (mind,i as ind) =
       match Hashtbl.find scheme_object_table kind with
       | s,IndividualSchemeFunction (f, deps) ->
         let deps = match deps with None -> [] | Some deps -> deps (Global.env ()) ind in
-        let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+        let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) empty_schemes deps in
         let c, eff = define_individual_scheme_base kind s f ~internal:true None ind eff in
-        Proofview.tclEFFECTS eff <*> Proofview.tclUNIT c
+        Proofview.tclEFFECTS eff.sch_eff <*> Proofview.tclUNIT c
       | s,MutualSchemeFunction (f, deps) ->
         let deps = match deps with None -> [] | Some deps -> deps (Global.env ()) mind in
-        let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) Evd.empty_side_effects deps in
+        let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) empty_schemes deps in
         let ca, eff = define_mutual_scheme_base kind s f ~internal:true [] mind eff in
-        Proofview.tclEFFECTS eff <*> Proofview.tclUNIT ca.(i)
+        Proofview.tclEFFECTS eff.sch_eff <*> Proofview.tclUNIT ca.(i)
     with Rocqlib.NotFoundRef _ as e ->
       let e, info = Exninfo.capture e in
       Proofview.tclZERO ~info e
 
+let register_schemes sch =
+  let iter (id, kn, loc, univs) =
+    !register_definition_scheme ~internal:false ~name:id ~const:kn ~univs ?loc ()
+  in
+  List.iter iter (List.rev sch.sch_reg)
+
 let define_individual_scheme ?loc kind names ind =
-  let eff = define_individual_scheme ?loc kind ~internal:false names ind Evd.empty_side_effects in
+  let eff = define_individual_scheme ?loc kind ~internal:false names ind empty_schemes in
+  let () = register_schemes eff in
   redeclare_schemes eff
 
 let define_mutual_scheme ?locmap kind names mind =
-  let eff = define_mutual_scheme ?locmap kind ~internal:false names mind Evd.empty_side_effects in
+  let eff = define_mutual_scheme ?locmap kind ~internal:false names mind empty_schemes in
+  let () = register_schemes eff in
   redeclare_schemes eff

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -94,11 +94,18 @@ val local_lookup_scheme : handle -> 'a scheme_kind -> inductive -> Constant.t op
 val pr_scheme_kind : 'a scheme_kind -> Pp.t
 
 val declare_definition_scheme :
-  (internal : bool
-   -> univs:UState.named_universes_entry
+  (univs:UState.named_universes_entry
    -> role:Evd.side_effect_role
    -> name:Id.t
    -> effs:Evd.side_effects
-   -> ?loc:Loc.t
    -> Constr.t
    -> Constant.t * Evd.side_effects) ref
+
+val register_definition_scheme :
+  (internal:bool
+  -> name:Id.t
+  -> const:Constant.t
+  -> univs:UState.named_universes_entry
+  -> ?loc:Loc.t
+  -> unit
+  -> unit) ref

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -97,9 +97,9 @@ val declare_definition_scheme :
   (univs:UState.named_universes_entry
    -> role:Evd.side_effect_role
    -> name:Id.t
-   -> effs:Evd.side_effects
+   -> effs:(Evd.side_effects * Safe_typing.safe_environment)
    -> Constr.t
-   -> Constant.t * Evd.side_effects) ref
+   -> Constant.t * (Evd.side_effects * Safe_typing.safe_environment)) ref
 
 val register_definition_scheme :
   (internal:bool


### PR DESCRIPTION
We reduce the amount of global state needed for the runtime scheme creation mechanism. This is done in two orthogonal ways, first by registering the non-logical data late and second by threading a logical environment instead of calling the global one.