### PR TITLE
Fix extra ltac:() when printing ltac arguments

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1057,6 +1057,7 @@ let pr_let_clauses recflag pr_gen pr l =
             keyword "type_term" ++ pr.pr_constr env sigma c
           | TacNumgoals ->
             keyword "numgoals"
+          | TacGeneric (Some _, _) as a -> pr_tac ltop (CAst.make (TacArg a))
           | (TacCall _|Tacexp _ | TacGeneric _) as a ->
             hov 0 (keyword "ltac:" ++ surround (pr_tac ltop (CAst.make (TacArg a))))
 

--- a/test-suite/output/bug_6613.out
+++ b/test-suite/output/bug_6613.out
@@ -1,0 +1,1 @@
+Ltac bar := foo constr:(5)

--- a/test-suite/output/bug_6613.v
+++ b/test-suite/output/bug_6613.v
@@ -1,0 +1,5 @@
+Ltac foo n := idtac.
+
+Ltac bar := foo constr:(5).
+
+Print Ltac bar.


### PR DESCRIPTION
Fix #6613

Not entirely sure the ltac:() is correct in the cases where it's still printed, I just avoided it for the case where I'm sure.
