### PR TITLE
Helper scripts to update and reset local CI repositories

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -114,7 +114,7 @@ CI_VIRTUAL_TARGETS= \
     ci-elpi_hb \
     ci-platform_full
 
-.PHONY: ci-all ci-update $(CI_TARGETS) $(CI_VIRTUAL_TARGETS)
+.PHONY: ci-all ci-update ci-reset $(CI_TARGETS) $(CI_VIRTUAL_TARGETS)
 
 ci-help:
 	echo '*** Coq CI system, please specify a target to build.'
@@ -269,6 +269,10 @@ $(CI_TARGETS): ci-%:
 # Helper to update all CI repositories already downloaded
 ci-update:
 	./dev/ci/ci-update.sh
+
+# Helper to reset all CI repositories already downloaded
+ci-reset:
+	./dev/ci/ci-reset.sh
 
 # if we do eg "make states ci-foo", ci-foo will wait for states
 # if we just do "make ci-foo" it will just run ci-foo

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -114,7 +114,7 @@ CI_VIRTUAL_TARGETS= \
     ci-elpi_hb \
     ci-platform_full
 
-.PHONY: ci-all $(CI_TARGETS) $(CI_VIRTUAL_TARGETS)
+.PHONY: ci-all ci-update $(CI_TARGETS) $(CI_VIRTUAL_TARGETS)
 
 ci-help:
 	echo '*** Coq CI system, please specify a target to build.'
@@ -265,6 +265,10 @@ ci-platform_full: $(CI_PLATFORM_FULL)
 # Generic rule, we use make to ease CI integration
 $(CI_TARGETS): ci-%:
 	+./dev/ci/ci-wrapper.sh $*
+
+# Helper to update all CI repositories already downloaded
+ci-update:
+	./dev/ci/ci-update.sh
 
 # if we do eg "make states ci-foo", ci-foo will wait for states
 # if we just do "make ci-foo" it will just run ci-foo

--- a/dev/ci/ci-reset.sh
+++ b/dev/ci/ci-reset.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+CI_QUIET=1
+
+set +x
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/scripts/ci-common.sh"
+
+# [git_reset <project>] will reset the repository for <project> to the upstream branch
+git_reset()
+{
+  local project=$1
+  local dest="${CI_BUILD_DIR}/$project"
+  local ref_var="${project}_CI_REF"
+  local ref="${!ref_var}"
+
+  echo "Resetting $project..."
+
+  if [ ! -d "$dest" ]; then
+    echo "Warning: reset of $project skipped because $dest does not exist."
+  else
+    # TODO: properly handle submodules
+    pushd "$dest" > /dev/null
+    # check that the reference is an actual branch
+    local ref_hash=$(git rev-parse --verify --quiet "refs/heads/$ref")
+    if [ -n "$ref_hash" ]; then
+      git reset --hard --quiet
+      git checkout $ref --quiet
+      git reset --hard "origin/$ref" --quiet
+      echo "$project reset to $ref ($ref_hash)"
+    fi
+    popd > /dev/null
+  fi
+}
+
+git_reset_all() {
+  for project in "${projects[@]}"; do
+    if [ -d "${CI_BUILD_DIR}/$project" ]; then
+      git_reset $project
+    fi
+  done
+}
+
+if [ -n "$1" ]; then
+  git_reset "$1"
+else
+  git_reset_all
+fi

--- a/dev/ci/ci-update.sh
+++ b/dev/ci/ci-update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+CI_QUIET=1
+
+set +x
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/scripts/ci-common.sh"
+
+# [git_update <project>] will update the git repository associated to <project>
+git_update()
+{
+  local project=$1
+  local dest="${CI_BUILD_DIR}/$project"
+
+  echo "Updating $project..."
+
+  if [ ! -d "$dest" ]; then
+    echo "Warning: update of $project skipped because $dest does not exist."
+  else
+    pushd "$dest" > /dev/null
+    git remote update > /dev/null
+    popd > /dev/null
+  fi
+}
+
+git_update_all() {
+  for project in "${projects[@]}"; do
+    if [ -d "${CI_BUILD_DIR}/$project" ]; then
+      git_update $project
+    fi
+  done
+}
+
+if [ -n "$1" ]; then
+  git_update "$1"
+else
+  git_update_all
+fi

--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-set -xe
+if [ -z "${CI_QUIET}" ];
+then
+  set -xe
+fi
 
 # default value for NJOBS
 : "${NJOBS:=1}"
@@ -46,12 +49,18 @@ export PATH="$COQBIN:$PATH"
 # Rocq's tools need an ending slash :S, we should fix them.
 export COQBIN="$COQBIN/"
 
-ls -l "$COQBIN"
+if [ -z "${CI_QUIET}" ];
+then
+  ls -l "$COQBIN"
+fi
 
 # Where we download and build external developments
 CI_BUILD_DIR="$PWD/_build_ci"
 
-ls -l "$CI_BUILD_DIR" || true
+if [ -z "${CI_QUIET}" ];
+then
+  ls -l "$CI_BUILD_DIR" || true
+fi
 
 declare -A overlays
 
@@ -86,7 +95,11 @@ for overlay in "$(dirname "${BASH_SOURCE[0]}")"/../user-overlays/*.sh; do
     # the directoy can be empty
     if [ -e "${overlay}" ]; then . "${overlay}"; fi
 done
-set -x
+
+if [ -z "${CI_QUIET}" ];
+then
+  set -x
+fi
 
 # [git_download <project> [<destination>]] will download <project> and
 # unpack it in <destination> (if given; default:


### PR DESCRIPTION
This is a pair of quick, dirty and incomplete scripts to ease the maintenance of local git repos for the CI. It introduces two standalone scripts further made available through the CI Makefile as `ci-update` and `ci-reset`. They respectively update the remote and reset the head to the branch tracked in the CI.

Still incomplete, e.g. submodules are not handled very well when dirty, but it's already saving me some time.