### PR TITLE
Only accept SELF on the left for left-associative levels

### DIFF
--- a/dev/ci/user-overlays/21126-ia0-assoc.sh
+++ b/dev/ci/user-overlays/21126-ia0-assoc.sh
@@ -1,0 +1,2 @@
+overlay coq_lsp https://github.com/proux01/coq-lsp rocq21126 21126
+overlay autosubst_ocaml https://github.com/proux01/autosubst-ocaml rocq21126 21126

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1587,7 +1587,7 @@ dependently-typed style:
 
 .. rocqtop:: in
 
-   Notation " t --> t' " := (arrow t t') (at level 20, t' at next level).
+   Notation " t --> t' " := (arrow t t') (at level 20, right associativity).
 
 .. rocqtop:: in
 
@@ -1597,7 +1597,7 @@ dependently-typed style:
 
 .. rocqtop:: in
 
-   Notation " G , tau " := (snoc G tau) (at level 20, tau at next level).
+   Notation " G , tau " := (snoc G tau) (at level 21, left associativity).
 
 .. rocqtop:: in
 
@@ -1609,7 +1609,7 @@ dependently-typed style:
 
 .. rocqtop:: in
 
-   Notation " G ; D " := (conc G D) (at level 20).
+   Notation " G ; D " := (conc G D) (at level 21).
 
 .. rocqtop:: in
 

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1262,11 +1262,11 @@ Custom entries
       | Add : Expr -> Expr -> Expr.
 
       Declare Custom Entry expr.
-      Notation "[ e ]" := e (e custom expr at level 2).
+      Notation "[ e ]" := e (e custom expr at level 3).
       Notation "1" := One (in custom expr at level 0).
       Notation "x y" := (Mul x y) (in custom expr at level 1, left associativity).
       Notation "x + y" := (Add x y) (in custom expr at level 2, left associativity).
-      Notation "( x )" := x (in custom expr, x at level 2).
+      Notation "( x )" := x (in custom expr, x at level 3).
       Notation "{ x }" := x (in custom expr, x constr).
       Notation "x" := x (in custom expr at level 0, x ident).
 
@@ -1329,9 +1329,9 @@ main grammar, or from another custom entry as is the case in
 
 .. rocqtop:: in
 
-   Notation "[ e ]" := e (e custom expr at level 2).
+   Notation "[ e ]" := e (e custom expr at level 3).
 
-to indicate that ``e`` has to be parsed at level ``2`` of the grammar
+to indicate that ``e`` has to be parsed at level ``3`` of the grammar
 associated with the custom entry ``expr``. The level can be omitted, as in
 
 .. rocqdoc::
@@ -1361,7 +1361,7 @@ right-hand side, as it is the case above for
 
 .. rocqtop:: in
 
-   Notation "( x )" := x (in custom expr at level 0, x at level 2).
+   Notation "( x )" := x (in custom expr at level 0, x at level 3).
 
 and
 
@@ -1376,10 +1376,10 @@ in another grammar or in another level of the current grammar. For instance,
 
 .. rocqtop:: in
 
-   Notation "( x )" := x (in custom expr at level 0, x at level 2).
+   Notation "( x )" := x (in custom expr at level 0, x at level 3).
 
 tells that parentheses can be inserted to parse or print an expression
-declared at level ``2`` of ``expr`` whenever this expression is
+declared at level ``3`` of ``expr`` whenever this expression is
 expected to be used as a subterm at level 0 or 1.  This allows for
 instance to parse and print :g:`Add x y` as a subterm of :g:`Mul (Add
 x y) z` using the syntax ``(x + y) z``. Similarly,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2486,7 +2486,7 @@ RENAME: [
 | ltac2_expr6 ltac2_expr
 | starredidentref starred_ident_ref
 | constr_pattern one_pattern
-| hints_path hints_regexp
+| hints_path_entry hints_regexp
 | clause_dft_concl occurrences
 | in_clause goal_occurrences
 | unfold_occ reference_occs

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -639,7 +639,7 @@ command: [
 | "Declare" "Equivalent" "Keys" constr constr
 | "Print" "Equivalent" "Keys"
 | "infoH" tactic
-| "Hint" "Cut" "[" hints_path "]" opthints
+| "Hint" "Cut" "[" hints_path_entry "]" opthints
 | "Typeclasses" "Transparent" LIST1 reference
 | "Typeclasses" "Opaque" LIST1 reference
 | "Typeclasses" "eauto" ":=" debug eauto_search_strategy OPT natural
@@ -2112,15 +2112,23 @@ auto_using: [
 |
 ]
 
-hints_path: [
-| "(" hints_path ")"
-| hints_path "*"
+hints_path_entry: [
+| hints_path1
+]
+
+hints_path1: [
+| hints_path1 "*"
+| hints_path1 "|" hints_path0
+| hints_path1 hints_path0
+| hints_path0
+]
+
+hints_path0: [
+| "(" hints_path1 ")"
 | "emp"
 | "eps"
-| hints_path "|" hints_path
 | LIST1 global
 | "_"
-| hints_path hints_path
 ]
 
 opthints: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1297,14 +1297,22 @@ number_string_via: [
 ]
 
 hints_regexp: [
-| LIST1 qualid
-| "_"
-| hints_regexp "|" hints_regexp
-| hints_regexp hints_regexp
-| hints_regexp "*"
+| hints_path1
+]
+
+hints_path1: [
+| hints_path1 "*"
+| hints_path1 "|" hints_path0
+| hints_path1 hints_path0
+| hints_path0
+]
+
+hints_path0: [
+| "(" hints_path1 ")"
 | "emp"
 | "eps"
-| "(" hints_regexp ")"
+| LIST1 qualid
+| "_"
 ]
 
 coercion_class: [

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -8,9 +8,20 @@ type position =
   | Before of string
   | After of string
 
-type g_assoc = NonA | RightA | LeftA
+type g_assoc = NonA | RightA | LeftA | BothA
 
 let pr_assoc = function
+  | BothA -> Pp.str "multi associativity"
   | LeftA -> Pp.str "left associativity"
   | RightA -> Pp.str "right associativity"
   | NonA -> Pp.str "no associativity"
+
+(** Returns whether SELF means SELF, respectively on the left and on the right. *)
+let split_assoc = function
+  | BothA -> (true, true)
+  | LeftA -> (true, false)
+  | RightA -> (false, true)
+  | NonA -> (false, false)
+
+let self_on_the_left assoc = fst (split_assoc assoc)
+let self_on_the_right assoc = snd (split_assoc assoc)

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -8,7 +8,13 @@ type position =
   | Before of string
   | After of string
 
-type g_assoc = NonA | RightA | LeftA
+type g_assoc = NonA | RightA | LeftA | BothA
 
 val pr_assoc : g_assoc -> Pp.t
 (** Prints a [g_assoc] value. *)
+
+val self_on_the_left : g_assoc -> bool
+(** Returns whether SELF means SELF on the left. *)
+
+val self_on_the_right : g_assoc -> bool
+(** Returns whether SELF means SELF on the right. *)

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1053,8 +1053,8 @@ let warn_tolerance =
         strbrk " This tolerance will be eventually removed." ++
         strbrk " Insert parentheses or try to lower the level at which the top symbol of this expression is parsed."))
 
-let warn_recover ename bp strm__ =
-  let ep = LStream.count strm__ in
+let warn_recover ename bp ?ep strm__ =
+  let ep = match ep with Some ep -> ep | None -> LStream.count strm__ in
   let loc = LStream.interval_loc bp ep strm__ in
   warn_tolerance ~loc (ename, "by the notation started on the left")
 
@@ -1164,9 +1164,10 @@ and parser_cont : type s tr tr' a r.
           let* s' = entry_of_symb entry s in
           continue_parser_of_entry gstate s' None 0 bp a0 strm__
         in
+        let ep = LStream.count strm__ in
         let a = or_fail a0 a in
         let act = or_fail a (p1 gstate strm__) in
-        warn_recover entry.ename bp strm__;
+        warn_recover entry.ename bp ~ep strm__;
         Ok (act a)
 
 (** [parser_of_token_list] attempts to look-ahead an arbitrary-long

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1049,23 +1049,22 @@ let warn_tolerance =
                           ~from:[CoreCategories.parsing; Deprecation.Version.v9_2] ())
     Pp.(fun (e, msg) ->
         strbrk "In " ++ str e ++ str ", tolerating this expression at" ++
-        strbrk " a higher level than expected." ++
-        pr_opt (fun m -> strbrk (" " ^ m)) msg ++
+        strbrk " a higher level than expected " ++ strbrk msg ++ str "." ++
         strbrk " This tolerance will be eventually removed." ++
         strbrk " Insert parentheses or try to lower the level at which the top symbol of this expression is parsed."))
 
 let warn_recover ename bp strm__ =
   let ep = LStream.count strm__ in
   let loc = LStream.interval_loc bp ep strm__ in
-  warn_tolerance ~loc (ename, None)
+  warn_tolerance ~loc (ename, "by the notation started on the left")
 
 let warn_recover_continuation ename bp ep strm__ =
   let loc = LStream.interval_loc bp ep strm__ in
-  warn_tolerance ~loc (ename, None)
+  warn_tolerance ~loc (ename, "by the notation continuing on the right")
 
 let warn_recover_last_start ename bp ep strm__ =
   let loc = LStream.interval_loc bp ep strm__ in
-  warn_tolerance ~loc (ename, Some "(there is no next level of last level)")
+  warn_tolerance ~loc (ename, "(there is no next level of last level)")
 
 let empty_entry ename levn strm =
   raise (ParseError ("entry [" ^ ename ^ "] is empty"))

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -870,7 +870,8 @@ let print_levels ppf elev =
          | None -> ()
        end;
        begin match lev.assoc with
-           LeftA -> fprintf ppf "LEFTA"
+           BothA -> fprintf ppf "BOTHA"
+         | LeftA -> fprintf ppf "LEFTA"
          | RightA -> fprintf ppf "RIGHTA"
          | NonA -> fprintf ppf "NONA"
        end;
@@ -1399,11 +1400,7 @@ let rec start_parser_of_levels entry clevn =
       match lev.lprefix with
         DeadEnd -> p1
       | tree ->
-          let alevn =
-            match lev.assoc with
-              LeftA | NonA -> succ clevn
-            | RightA -> clevn
-          in
+          let alevn = if self_on_the_right lev.assoc then clevn else succ clevn in
           let p2 = parser_of_tree entry (succ clevn) alevn tree in
           match levs with
             [] ->
@@ -1455,15 +1452,11 @@ let rec continue_parser_of_levels entry clevn =
       match lev.lsuffix with
         DeadEnd -> p1
       | tree ->
-          let alevn =
-            match lev.assoc with
-              LeftA | NonA -> succ clevn
-            | RightA -> clevn
-          in
+          let alevn = if self_on_the_right lev.assoc then clevn else succ clevn in
           let p2 = parser_of_tree entry (succ clevn) alevn tree in
           fun gstate levfrom levn bp a strm ->
             let tolerance = match levfrom with
-              | Some levfrom when levfrom = clevn && lev.assoc <> LeftA -> Some true
+              | Some levfrom when levfrom = clevn && not (self_on_the_left lev.assoc) -> Some true
               | Some levfrom when levfrom < clevn -> Some false
               | _ -> None
             in

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -12,6 +12,7 @@
 
 open Pp
 open Stdarg
+open Procq
 open Procq.Prim
 open Procq.Constr
 open Pltac
@@ -162,19 +163,31 @@ END
 
 let pr_pre_hints_path c = Hints.pp_hints_path_gen Libnames.pr_qualid c
 
+let hints_path = Entry.make "hints_path"
+
 }
 
-VERNAC ARGUMENT EXTEND hints_path
+VERNAC ARGUMENT EXTEND hints_path_entry
 PRINTED BY { pr_pre_hints_path }
+| [ hints_path(p) ] -> { p }
+END
 
-| [ "(" hints_path(p) ")"  ] -> { p }
-| [ hints_path(p) "*" ] -> { Hints.PathStar p }
-| [ "emp" ] -> { Hints.PathEmpty }
-| [ "eps" ] -> { Hints.PathEpsilon }
-| [ hints_path(p) "|" hints_path(q) ] -> { Hints.PathOr (p, q) }
-| [ ne_global_list(g) ] -> { Hints.PathAtom (Hints.PathHints g) }
-| [ "_" ] -> { Hints.PathAtom Hints.PathAny }
-| [ hints_path(p) hints_path(q) ] -> { Hints.PathSeq (p, q) }
+GRAMMAR EXTEND Gram
+  GLOBAL: hints_path;
+  hints_path:
+    [ "1" LEFTA
+      [ p = hints_path; "*" -> { Hints.PathStar p }
+      | p = hints_path; "|"; q = hints_path LEVEL "0" -> { Hints.PathOr (p, q) }
+      | p = hints_path; q = hints_path LEVEL "0" -> { Hints.PathSeq (p, q) }
+      ]
+    | "0" NONA
+      [ "("; p = hints_path; ")" -> { p }
+      | IDENT "emp" -> { Hints.PathEmpty }
+      | IDENT "eps" -> { Hints.PathEpsilon }
+      | g = LIST1 global -> { Hints.PathAtom (Hints.PathHints g) }
+      | "_" -> { Hints.PathAtom Hints.PathAny }
+      ]
+    ];
 END
 
 ARGUMENT EXTEND opthints
@@ -185,7 +198,7 @@ ARGUMENT EXTEND opthints
 END
 
 VERNAC COMMAND EXTEND HintCut CLASSIFIED AS SIDEFF
-| #[ locality = Attributes.hint_locality; ] [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> {
+| #[ locality = Attributes.hint_locality; ] [ "Hint" "Cut" "[" hints_path_entry(p) "]" opthints(dbnames) ] -> {
   let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
   Hints.add_hints ~locality
     (match dbnames with None -> ["core"] | Some l -> l) entry;

--- a/plugins/ltac/g_auto.mli
+++ b/plugins/ltac/g_auto.mli
@@ -21,7 +21,7 @@ val wit_auto_using :
 
 val auto_using : Constrexpr.constr_expr list Procq.Entry.t
 
-val wit_hints_path :
+val wit_hints_path_entry :
   Libnames.qualid Hints.hints_path_gen Genarg.vernac_genarg_type
 
 val hints_path : Libnames.qualid Hints.hints_path_gen Procq.Entry.t

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -146,7 +146,7 @@ GRAMMAR EXTEND Gram
   GLOBAL: ltac2_expr ltac2_type tac2def_val tac2def_typ tac2def_ext tac2def_syn tac2abbrev_syn
           tac2def_mut tac2expr_in_env ltac2_atom;
   tac2pat:
-    [ "3" NONA
+    [ "3" LEFTA
       [ p = tac2pat; "|"; pl = LIST1 tac2pat LEVEL "2" SEP "|" ->
         { let pl = p :: pl in
           CAst.make ~loc @@ CPatOr pl }

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -933,10 +933,8 @@ let perform_notation syn st =
   let rule = match fresh with
     | None -> Procq.Reuse (pos, [rule])
     | Some pos' ->
-      (* with RightA, SELF on the right means really self, with LeftA/NonA it means next
-         we could simulate "really self" with a LeftA by using the explicit "entry(level)" form,
-         but RightA is slightly simpler *)
-      Procq.Fresh (pos', [pos, Some RightA, [rule]])
+      (* BothA means we can have SELF on both the left and right of a rule. *)
+      Procq.Fresh (pos', [pos, Some BothA, [rule]])
   in
   let entry = match entry with
     | None -> Pltac.ltac2_expr

--- a/test-suite/bugs/bug_3330.v
+++ b/test-suite/bugs/bug_3330.v
@@ -66,7 +66,7 @@ Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
 
 Notation "1" := idpath : path_scope.
 
-Notation "p @ q" := (concat p q) (at level 20) : path_scope.
+Notation "p @ q" := (concat p q) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p) (at level 3) : path_scope.
 

--- a/test-suite/bugs/bug_3754.v
+++ b/test-suite/bugs/bug_3754.v
@@ -38,7 +38,7 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 
 Notation "1" := idpath : path_scope.
 
-Notation "p @ q" := (concat p q) (at level 20) : path_scope.
+Notation "p @ q" := (concat p q) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p) (at level 3, format "p '^'") : path_scope.
 

--- a/test-suite/bugs/bug_4089.v
+++ b/test-suite/bugs/bug_4089.v
@@ -118,7 +118,7 @@ Arguments concat {A x y z} p q : simpl nomatch.
 
 Notation "1" := idpath : path_scope.
 
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
 

--- a/test-suite/bugs/bug_4116.v
+++ b/test-suite/bugs/bug_4116.v
@@ -56,7 +56,7 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 
 Notation "1" := idpath : path_scope.
 
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
 

--- a/test-suite/bugs/bug_4527.v
+++ b/test-suite/bugs/bug_4527.v
@@ -93,7 +93,7 @@ Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
 Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
   match p, q with idpath, idpath => idpath end.
 
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
 

--- a/test-suite/bugs/bug_4533.v
+++ b/test-suite/bugs/bug_4533.v
@@ -66,7 +66,7 @@ Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
 Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
   match p, q with idpath, idpath => idpath end.
 Notation "1" := idpath : path_scope.
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) (at level 20, left associativity) : path_scope.
 Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
 Definition ap {A B:Type} (f:A -> B) {x y:A} (p:x = y) : f x = f y
   := match p with idpath => idpath end.

--- a/test-suite/bugs/bug_4544.v
+++ b/test-suite/bugs/bug_4544.v
@@ -102,7 +102,7 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 
 Notation "1" := idpath : path_scope.
 
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) (at level 20, left associativity) : path_scope.
 
 Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
 

--- a/test-suite/bugs/bug_5762.v
+++ b/test-suite/bugs/bug_5762.v
@@ -22,7 +22,7 @@ where "# v" := (f v).
 
 (* The following was working in 8.6 *)
 
-Reserved Notation "%% a" (at level 70).
+Reserved Notation "%% a" (at level 69).
 Record R :=
   {g : forall {A} (a:A), a=a where "%% x" := (g x);
    k : %% 0 = eq_refl}.

--- a/test-suite/bugs/bug_7462.v
+++ b/test-suite/bugs/bug_7462.v
@@ -1,13 +1,13 @@
 (* Adding an only-printing notation should not override existing
    interpretations for the same notation. *)
 
-Notation "$ x" := (@id nat x) (only parsing, at level 0).
-Notation "$ x" := (@id bool x) (only printing, at level 0).
+Notation "$ x" := (@id nat x) (only parsing, at level 1).
+Notation "$ x" := (@id bool x) (only printing, at level 1).
 Check $1. (* Was: Error: Unknown interpretation for notation "$ _". *)
 
 (* Adding an only-printing notation should not let believe
    that a parsing rule has been given *)
 
-Notation "$ x" := (@id bool x) (only printing, at level 0).
-Notation "$ x" := (@id nat x) (only parsing, at level 0).
+Notation "$ x" := (@id bool x) (only printing, at level 1).
+Notation "$ x" := (@id nat x) (only parsing, at level 1).
 Check $1. (* Was: Error: Syntax Error: Lexer: Undefined token *)

--- a/test-suite/bugs/bug_8672.v
+++ b/test-suite/bugs/bug_8672.v
@@ -1,5 +1,5 @@
 (* Was generating a dangling "pat" variable at some time *)
 
 Notation "'plet' x := e 'in' t" :=
-  ((fun H => let x := id H in t) e) (at level 0, x pattern).
+  ((fun H => let x := id H in t) e) (at level 1, x pattern).
 Definition bla := plet (pair x y) := pair 1 2 in x.

--- a/test-suite/ltac2/ltac2_recursive_nota.v
+++ b/test-suite/ltac2/ltac2_recursive_nota.v
@@ -4,6 +4,6 @@ Notation binder x := (binder_act :> x = x) (only parsing).
 
 #[local] Notation "'test{' x .. y } P" :=
   ((fun x => .. ((fun y => P), binder (fun y => I)) ..), binder (fun x => I))
-    (at level 0, x binder, y binder, only parsing).
+    (at level 1, x binder, y binder, only parsing).
 
 Check (test{(aa : nat) (bb : bool)} True).

--- a/test-suite/output-coqtop/LevelTolerance.out
+++ b/test-suite/output-coqtop/LevelTolerance.out
@@ -250,6 +250,9 @@ the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 3154-3154 with (
+Replace Toplevel input, characters 3166-3166 with )
 
 Rocq < Rocq < Toplevel input, characters 20-25:
 > Check Reject 90 [2 atom2 post11 ].
@@ -305,6 +308,9 @@ the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 3452-3452 with (
+Replace Toplevel input, characters 3468-3468 with )
 
 Rocq < Rocq < Toplevel input, characters 21-26:
 > Check Reject 110 [2 atom2 op12 atom2 ].
@@ -336,6 +342,9 @@ the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 3613-3613 with (
+Replace Toplevel input, characters 3629-3629 with )
 
 Rocq < Rocq < Toplevel input, characters 21-26:
 > Check Reject 120 [1 atom2 op10 atom0].
@@ -509,6 +518,9 @@ the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 4794-4794 with (
+Replace Toplevel input, characters 4817-4817 with )
 
 Rocq < Accept 202 (F (G E E))
      : Parsing
@@ -938,6 +950,9 @@ expected by the notation continuing on the right. This tolerance will be
 eventually removed. Insert parentheses or try to lower the level at which the
 top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 5725-5725 with (
+Replace Toplevel input, characters 5730-5730 with )
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 231 ltac:(atom4 ; atom4).
@@ -999,6 +1014,9 @@ left-associative). This tolerance will be eventually removed. Insert
 parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 6164-6164 with (
+Replace Toplevel input, characters 6169-6169 with )
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 261 ltac:(atom1 + atom3).
@@ -1030,6 +1048,9 @@ left-associative). This tolerance will be eventually removed. Insert
 parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 6335-6335 with (
+Replace Toplevel input, characters 6340-6340 with )
 
 Rocq < Toplevel input, characters 23-34:
 > Check Reject 271 ltac:(pre21 atom1 + atom2).
@@ -1040,6 +1061,9 @@ left-associative). This tolerance will be eventually removed. Insert
 parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 6374-6374 with (
+Replace Toplevel input, characters 6385-6385 with )
 
 Rocq < Accept 272 ?Goal
      : Parsing
@@ -1062,6 +1086,9 @@ left-associative). This tolerance will be eventually removed. Insert
 parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 6510-6510 with (
+Replace Toplevel input, characters 6522-6522 with )
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 281 ltac:(atom1 + atom2 post12).
@@ -1072,6 +1099,9 @@ left-associative). This tolerance will be eventually removed. Insert
 parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace Toplevel input, characters 6564-6564 with (
+Replace Toplevel input, characters 6569-6569 with )
 
 Rocq < Accept 282 ?Goal
      : Parsing

--- a/test-suite/output-coqtop/LevelTolerance.out
+++ b/test-suite/output-coqtop/LevelTolerance.out
@@ -1,0 +1,965 @@
+
+Rocq < 
+Rocq < 
+Rocq < 
+Rocq < 
+Rocq < Rocq < T is defined
+T_rect is defined
+T_ind is defined
+T_rec is defined
+T_sind is defined
+
+Rocq < Parsing is defined
+Parsing_rect is defined
+Parsing_ind is defined
+Parsing_rec is defined
+Parsing_sind is defined
+
+Rocq < Rocq < 
+Rocq < Rocq < Identifier 'op22' now a keyword
+
+Rocq < Identifier 'op12' now a keyword
+
+Rocq < Identifier 'op10' now a keyword
+
+Rocq < Rocq < Setting notation at level 0.
+
+Rocq < Setting notation at level 0.
+
+Rocq < Setting notation at level 0.
+
+Rocq < Setting notation at level 0.
+
+Rocq < Rocq < Identifier 'atom3' now a keyword
+
+Rocq < Identifier 'atom2' now a keyword
+
+Rocq < Identifier 'atom1' now a keyword
+
+Rocq < 
+Rocq < Rocq < Identifier 'pre22' now a keyword
+
+Rocq < Identifier 'pre21' now a keyword
+
+Rocq < Identifier 'pre11' now a keyword
+
+Rocq < Identifier 'pre10' now a keyword
+
+Rocq < 
+Rocq < 
+Rocq < Rocq < Identifier 'post12' now a keyword
+
+Rocq < Identifier 'post11' now a keyword
+
+Rocq < Rocq < Entry custom:Top.expr is
+[ "3" RIGHTA
+  [ SELF; "op22"; NEXT
+  | "atom3" ]
+| "2" RIGHTA
+  [ SELF; "post12"
+  | SELF; "op12"; custom:Top.expr LEVEL "2"
+  | "pre21"; NEXT
+  | "pre22"; custom:Top.expr LEVEL "2"
+  | "atom2" ]
+| "1" LEFTA
+  [ SELF; "post11"
+  | SELF; "op10"; NEXT
+  | "pre10"; NEXT
+  | "pre11"; custom:Top.expr LEVEL "1"
+  | "atom1" ]
+| "0" RIGHTA
+  [ IDENT "pre0x"; NEXT
+  | IDENT "pre00"; custom:Top.expr LEVEL "0"
+  | IDENT "atom0" ] ]
+
+
+Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Toplevel input, characters 496-503:
+> Check Reject 10 [2 atom3 ].
+>                    ^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 11 E
+     : Parsing
+
+Rocq < Toplevel input, characters 19-26:
+> Check Reject 12 [1 atom2 ].
+>                    ^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 13 E
+     : Parsing
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 20 [2 pre22 atom3 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 21 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-32:
+> Check Reject 22 [1 pre22 atom2 ].
+>                    ^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 30 [2 pre21 atom2 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 31 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-32:
+> Check Reject 32 [1 pre21 atom1 ].
+>                    ^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 40 [2 pre11 atom2 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Toplevel input, characters 25-30:
+> Check Reject 41 [1 pre11 atom2 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 42 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-32:
+> Check Reject 43 [0 pre11 atom1 ].
+>                    ^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 50 [1 pre10 atom1 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 51 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-32:
+> Check Reject 52 [0 pre10 atom0 ].
+>                    ^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 60 [1 pre00 atom1 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Toplevel input, characters 25-30:
+> Check Reject 61 [0 pre00 atom1 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 62 (F E)
+     : Parsing
+
+Rocq < Rocq < Toplevel input, characters 26-31:
+> Check Reject 70 [0 pre0x atom0 ].
+>                          ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected.  (there is no next level of last level) This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 20-25:
+> Check Reject 80 [2 atom3 post12 ].
+>                    ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < AcceptTmp 81 (F E)
+     : Parsing
+
+Rocq < Accept 82 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-33:
+> Check Reject 83 [1 atom1 post12 ].
+>                    ^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 20-25:
+> Check Reject 90 [2 atom2 post11 ].
+>                    ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 91 (F E)
+     : Parsing
+
+Rocq < Accept 92 (F E)
+     : Parsing
+
+Rocq < Toplevel input, characters 19-33:
+> Check Reject 93 [0 atom1 post11 ].
+>                    ^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < AcceptTmp 100 (G E E)
+     : Parsing
+
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 101 [3 atom2 op22 atom3 ].
+>                                ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 102 (G E E)
+     : Parsing
+
+Rocq < Toplevel input, characters 20-38:
+> Check Reject 103 [2 atom2 op22 atom2 ].
+>                     ^^^^^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < AcceptTmp 110 (G E E)
+     : Parsing
+
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 111 [2 atom1 op12 atom3 ].
+>                                ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 112 (G E E)
+     : Parsing
+
+Rocq < Toplevel input, characters 20-38:
+> Check Reject 113 [1 atom1 op12 atom2 ].
+>                     ^^^^^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Toplevel input, characters 21-26:
+> Check Reject 120 [1 atom2 op10 atom0].
+>                     ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 121 [1 atom1 op10 atom1].
+>                                ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 122 (G E E)
+     : Parsing
+
+Rocq < Toplevel input, characters 20-37:
+> Check Reject 123 [0 atom1 op10 atom0].
+>                     ^^^^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < AcceptTmp 130 (F (G E E))
+     : Parsing
+
+Rocq < AcceptTmp 131 (G (F E) E)
+     : Parsing
+
+Rocq < Accept 132 (F (G E E))
+     : Parsing
+
+Rocq < Rocq < AcceptTmp 140 (G (F E) E)
+     : Parsing
+
+Rocq < AcceptTmp 141 (G (F E) E)
+     : Parsing
+
+Rocq < Accept 142 (G (F E) E)
+     : Parsing
+
+Rocq < Rocq < Accept 150 (G E (F E))
+     : Parsing
+
+Rocq < Toplevel input, characters 37-42:
+> Check Reject 151 [2 atom1 op12 pre21 atom2 ].
+>                                      ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 152 (G E (F E))
+     : Parsing
+
+Rocq < Rocq < AcceptTmp 160 (G E (F E))
+     : Parsing
+
+Rocq < Accept 161 (G E (F E))
+     : Parsing
+
+Rocq < Toplevel input, characters 31-43:
+> Check Reject 162 [2 atom1 op10 atom1 post12 ].
+>                                ^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 163 (F (G E E))
+     : Parsing
+
+Rocq < Rocq < Accept 170 (F (G E E))
+     : Parsing
+
+Rocq < Toplevel input, characters 26-42:
+> Check Reject 171 [1 pre10 atom1 op10 atom0 ].
+>                           ^^^^^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 172 (G (F E) E)
+     : Parsing
+
+Rocq < Rocq < Toplevel input, characters 21-33:
+> Check Reject 180 [1 atom1 post12 op10 atom0 ].
+>                     ^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 181 (G (F E) E)
+     : Parsing
+
+Rocq < Rocq < Toplevel input, characters 32-43:
+> Check Reject 190 [1 atom1 op10 pre11 atom0 ].
+>                                ^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Toplevel input, characters 31-42:
+> Check Reject 191 [1 atom1 op10 pre10 atom0 ].
+>                                ^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Rocq < Accept 200 (F (G E E))
+     : Parsing
+
+Rocq < Toplevel input, characters 20-45:
+> Check Reject 201 [1 atom1 op10 atom0 post12 ].
+>                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In term, tolerating this expression at a higher level than expected.
+This tolerance will be eventually removed. Insert parentheses or try to lower
+the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 202 (F (G E E))
+     : Parsing
+
+Rocq < Rocq < AcceptTmp 210 (G E (G E E))
+     : Parsing
+
+Rocq < Accept 211 (G E (G E E))
+     : Parsing
+
+Rocq < Rocq < Toplevel input, characters 32-48:
+> Check Reject 220 [1 atom1 op10 atom1 op10 atom0 ].
+>                                ^^^^^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 221 (G (G E E) E)
+     : Parsing
+
+Rocq < Rocq < 
+Rocq < Rocq < 
+Rocq < 
+Rocq < 
+Rocq < 
+Rocq < 
+Rocq < Rocq < 
+Rocq < 
+Rocq < 
+Rocq < 
+Rocq < Rocq < 
+Rocq < 
+Rocq < Rocq < Entry ltac_expr is
+[ "5" RIGHTA
+  [ IDENT "atom5" ]
+| "4" LEFTA
+  [ SELF; IDENT "post44"
+  | SELF; ";"; SELF
+  | SELF; ";"; tactic_then_locality; for_each_goal; "]"
+  | IDENT "pre43"; NEXT
+  | IDENT "pre44"; SELF
+  | IDENT "atom4" ]
+| "3" RIGHTA
+  [ "atom3"
+  | IDENT "try"; SELF
+  | IDENT "do"; nat_or_var; SELF
+  | IDENT "timeout"; nat_or_var; SELF
+  | IDENT "time"; OPT string; SELF
+  | IDENT "repeat"; SELF
+  | IDENT "progress"; SELF
+  | IDENT "once"; SELF
+  | IDENT "exactly_once"; SELF
+  | IDENT "abstract"; NEXT; "using"; ident
+  | IDENT "abstract"; NEXT
+  | IDENT "only"; goal_selector; ":"; SELF ]
+| "2" RIGHTA
+  [ SELF; "post12"
+  | SELF; "+"; SELF
+  | SELF; "||"; SELF
+  | "pre21"; NEXT
+  | "pre22"; SELF
+  | "atom2"
+  | IDENT "tryif"; SELF; "then"; SELF; "else"; SELF ]
+| "1l" LEFTA
+  [  ]
+| "1" RIGHTA
+  [ "atom1"
+  | "fun"; LIST1 input_fun; "=>"; ltac_expr LEVEL "5"
+  | "let"; [ IDENT "rec" |  ]; LIST1 let_clause SEP "with"; "in"; ltac_expr
+    LEVEL "5"
+  | IDENT "first"; "["; LIST0 ltac_expr SEP "|"; "]"
+  | IDENT "solve"; "["; LIST0 ltac_expr SEP "|"; "]"
+  | IDENT "idtac"; LIST0 message_token
+  | match_key; IDENT "goal"; "with"; match_context_list; "end"
+  | match_key; IDENT "reverse"; IDENT "goal"; "with"; match_context_list;
+    "end"
+  | match_key; SELF; "with"; match_list; "end"
+  | failkw; [ nat_or_var |  ]; LIST0 message_token
+  | simple_tactic
+  | tactic_value
+  | reference; LIST0 tactic_arg ]
+| "0" LEFTA
+  [ "("; SELF; ")"
+  | "["; ">"; for_each_goal; "]"
+  | tactic_atom ] ]
+
+Entry simple_tactic is
+[ LEFTA
+  [ IDENT "firstorder"; OPT tactic; "with"; LIST1 preident
+  | IDENT "firstorder"; OPT tactic; firstorder_using; "with"; LIST1 preident
+  | IDENT "firstorder"; OPT tactic; firstorder_using
+  | IDENT "congruence"; OPT natural; "with"; LIST1 constr
+  | IDENT "congruence"; OPT natural
+  | IDENT "dintuition"; tactic
+  | IDENT "dintuition"
+  | IDENT "intuition"; tactic
+  | IDENT "intuition"
+  | IDENT "assert_fails"; ltac_expr LEVEL "3"
+  | IDENT "inversion_sigma"; hyp; "as"; simple_intropattern
+  | IDENT "inversion_sigma"; hyp
+  | IDENT "inversion_sigma"
+  | IDENT "now"; tactic
+  | IDENT "rewrite_all"; "<-"; constr
+  | IDENT "rewrite_all"; constr
+  | IDENT "destruct_with_eqn"; ":"; ident; ident
+  | IDENT "destruct_with_eqn"; ":"; ident; constr
+  | IDENT "destruct_with_eqn"; ident
+  | IDENT "destruct_with_eqn"; constr
+  | IDENT "clearbody"; LIST1 hyp
+  | IDENT "clear"; IDENT "dependent"; hyp
+  | IDENT "clear"; "-"; LIST1 hyp
+  | IDENT "clear"; LIST0 hyp
+  | IDENT "revert"; IDENT "dependent"; hyp
+  | IDENT "revert"; LIST1 hyp
+  | IDENT "rename"; LIST1 rename SEP ","
+  | IDENT "move"; hyp; "at"; IDENT "top"
+  | IDENT "move"; hyp; "at"; IDENT "bottom"
+  | IDENT "move"; hyp; IDENT "after"; hyp
+  | IDENT "move"; hyp; IDENT "before"; hyp
+  | IDENT "intro"; "at"; IDENT "top"
+  | IDENT "intro"; "at"; IDENT "bottom"
+  | IDENT "intro"; IDENT "after"; hyp
+  | IDENT "intro"; IDENT "before"; hyp
+  | IDENT "intro"; ident; "at"; IDENT "top"
+  | IDENT "intro"; ident; "at"; IDENT "bottom"
+  | IDENT "intro"; ident; IDENT "after"; hyp
+  | IDENT "intro"; ident; IDENT "before"; hyp
+  | IDENT "intro"; ident
+  | IDENT "intro"
+  | IDENT "eexists"; LIST1 bindings SEP ","
+  | IDENT "eexists"
+  | "exists"; LIST1 bindings SEP ","
+  | "exists"
+  | IDENT "esplit"; "with"; bindings
+  | IDENT "split"; "with"; bindings
+  | IDENT "symmetry"; "in"; in_clause
+  | IDENT "specialize"; constr_with_bindings; "as"; simple_intropattern
+  | IDENT "specialize"; constr_with_bindings
+  | IDENT "econstructor"; nat_or_var; "with"; bindings
+  | IDENT "econstructor"; nat_or_var
+  | IDENT "econstructor"
+  | IDENT "constructor"; nat_or_var; "with"; bindings
+  | IDENT "constructor"; nat_or_var
+  | IDENT "constructor"
+  | IDENT "eright"; "with"; bindings
+  | IDENT "right"; "with"; bindings
+  | IDENT "eleft"; "with"; bindings
+  | IDENT "left"; "with"; bindings
+  | IDENT "exact"; uconstr
+  | IDENT "with_strategy"; strategy_level_or_var; "["; LIST1 smart_global;
+    "]"; ltac_expr LEVEL "3"
+  | IDENT "guard"; test
+  | IDENT "swap"; int_or_var; int_or_var
+  | IDENT "cycle"; int_or_var
+  | IDENT "unshelve"; ltac_expr LEVEL "1"
+  | IDENT "transparent_abstract"; ltac_expr LEVEL "3"; "using"; ident
+  | IDENT "transparent_abstract"; ltac_expr LEVEL "3"
+  | IDENT "specialize_eqs"; hyp
+  | IDENT "generalize_eqs_vars"; hyp
+  | IDENT "generalize_eqs"; hyp
+  | IDENT "stepr"; constr; "by"; tactic
+  | IDENT "stepr"; constr
+  | IDENT "stepl"; constr; "by"; tactic
+  | IDENT "stepl"; constr
+  | IDENT "instantiate"; "("; ident; ":="; lconstr; ")"
+  | IDENT "instantiate"; "("; natural; ":="; lconstr; ")"; hloc
+  | IDENT "evar"; test_lpar_id_colon; "("; ident; ":"; lconstr; ")"
+  | IDENT "evar"; constr
+  | IDENT "subst"; LIST1 hyp
+  | IDENT "subst"
+  | IDENT "notypeclasses"; IDENT "refine"; uconstr
+  | IDENT "refine"; uconstr
+  | IDENT "autorewrite"; "*"; "with"; LIST1 preident; clause; "using"; tactic
+  | IDENT "autorewrite"; "*"; "with"; LIST1 preident; clause
+  | IDENT "autorewrite"; "with"; LIST1 preident; clause; "using"; tactic
+  | IDENT "autorewrite"; "with"; LIST1 preident; clause
+  | IDENT "contradiction"; OPT constr_with_bindings
+  | IDENT "decompose"; "["; LIST1 constr; "]"; constr
+  | IDENT "decompose"; IDENT "record"; constr
+  | IDENT "decompose"; IDENT "sum"; constr
+  | IDENT "einjection"; "as"; LIST0 simple_intropattern
+  | IDENT "einjection"; destruction_arg; "as"; LIST0 simple_intropattern
+  | IDENT "einjection"; destruction_arg
+  | IDENT "einjection"
+  | IDENT "injection"; "as"; LIST0 simple_intropattern
+  | IDENT "injection"; destruction_arg; "as"; LIST0 simple_intropattern
+  | IDENT "injection"; destruction_arg
+  | IDENT "injection"
+  | IDENT "ediscriminate"; destruction_arg
+  | IDENT "ediscriminate"
+  | IDENT "discriminate"; destruction_arg
+  | IDENT "discriminate"
+  | IDENT "esimplify_eq"; destruction_arg
+  | IDENT "esimplify_eq"
+  | IDENT "simplify_eq"; destruction_arg
+  | IDENT "simplify_eq"
+  | IDENT "replace"; "<-"; uconstr; "with"; constr; clause; by_arg_tac
+  | IDENT "replace"; "<-"; uconstr; clause
+  | IDENT "replace"; "->"; uconstr; "with"; constr; clause; by_arg_tac
+  | IDENT "replace"; "->"; uconstr; clause
+  | IDENT "replace"; uconstr; "with"; constr; clause; by_arg_tac
+  | IDENT "replace"; uconstr; clause
+  | IDENT "assert_succeeds"; ltac_expr LEVEL "3"
+  | IDENT "unify"; constr; constr; "with"; preident
+  | IDENT "unify"; constr; constr
+  | IDENT "autounfold_one"; hintbases; "in"; hyp
+  | IDENT "autounfold_one"; hintbases
+  | IDENT "autounfold"; hintbases; clause
+  | IDENT "info_eauto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "eauto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "info_auto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "auto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "debug"; IDENT "eauto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "debug"; IDENT "auto"; OPT nat_or_var; auto_using; hintbases
+  | IDENT "debug"; IDENT "trivial"; auto_using; hintbases
+  | IDENT "info_trivial"; auto_using; hintbases
+  | IDENT "trivial"; auto_using; hintbases
+  | IDENT "autoapply"; constr; "with"; preident
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "bfs"; OPT nat_or_var; "with";
+    LIST1 preident
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "bfs"; OPT nat_or_var
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "dfs"; OPT nat_or_var; "with";
+    LIST1 preident
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "dfs"; OPT nat_or_var
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "best_effort"; OPT nat_or_var;
+    "with"; LIST1 preident
+  | IDENT "typeclasses"; IDENT "eauto"; IDENT "best_effort"; OPT nat_or_var
+  | IDENT "typeclasses"; IDENT "eauto"; OPT nat_or_var; "with";
+    LIST1 preident
+  | IDENT "typeclasses"; IDENT "eauto"; OPT nat_or_var
+  | IDENT "decide"; IDENT "equality"
+  | IDENT "decide"; constr; "with"; constr
+  | IDENT "setoid_transitivity"; constr
+  | IDENT "setoid_etransitivity"
+  | IDENT "setoid_symmetry"; "in"; hyp
+  | IDENT "setoid_symmetry"
+  | IDENT "setoid_rewrite"; orient; constr_with_bindings; "at"; occurrences;
+    "in"; hyp
+  | IDENT "setoid_rewrite"; orient; constr_with_bindings; "at"; occurrences
+  | IDENT "setoid_rewrite"; orient; constr_with_bindings; "in"; hyp; "at";
+    occurrences
+  | IDENT "setoid_rewrite"; orient; constr_with_bindings; "in"; hyp
+  | IDENT "setoid_rewrite"; orient; constr_with_bindings
+  | IDENT "substitute"; orient; constr_with_bindings
+  | IDENT "rewrite_strat"; rewstrategy; "in"; hyp
+  | IDENT "rewrite_strat"; rewstrategy
+  | IDENT "rewrite_db"; preident; "in"; hyp
+  | IDENT "rewrite_db"; preident
+  | IDENT "finish_timing"; "("; string; ")"; OPT string
+  | IDENT "finish_timing"; OPT string
+  | IDENT "restart_timer"; OPT string
+  | IDENT "show"; IDENT "ltac"; IDENT "profile"; IDENT "cutoff"; integer
+  | IDENT "show"; IDENT "ltac"; IDENT "profile"; string
+  | IDENT "show"; IDENT "ltac"; IDENT "profile"
+  | IDENT "reset"; IDENT "ltac"; IDENT "profile"
+  | IDENT "stop"; IDENT "ltac"; IDENT "profiling"
+  | IDENT "start"; IDENT "ltac"; IDENT "profiling"
+  | IDENT "intros"; IDENT "until"; quantified_hypothesis
+  | IDENT "intros"; ne_intropatterns
+  | IDENT "intros"
+  | IDENT "eintros"; ne_intropatterns
+  | IDENT "eintros"
+  | IDENT "apply"; "<-"; constr; "in"; hyp
+  | IDENT "apply"; "<-"; constr
+  | IDENT "apply"; "->"; constr; "in"; hyp
+  | IDENT "apply"; "->"; constr
+  | IDENT "apply"; LIST1 constr_with_bindings_arg SEP ","; in_hyp_as
+  | IDENT "eapply"; LIST1 constr_with_bindings_arg SEP ","; in_hyp_as
+  | IDENT "elim"; constr_with_bindings_arg; OPT eliminator
+  | IDENT "eelim"; constr_with_bindings_arg; OPT eliminator
+  | IDENT "case"; induction_clause_list
+  | IDENT "ecase"; induction_clause_list
+  | "fix"; ident; natural; "with"; LIST1 fixdecl
+  | "fix"; ident; natural
+  | "cofix"; ident; "with"; LIST1 cofixdecl
+  | "cofix"; ident
+  | IDENT "set"; bindings_with_parameters; clause
+  | IDENT "set"; constr; as_name; clause
+  | IDENT "eset"; bindings_with_parameters; clause
+  | IDENT "eset"; constr; as_name; clause
+  | IDENT "remember"; constr; as_name; eqn_ipat; clause_dft_all
+  | IDENT "eremember"; constr; as_name; eqn_ipat; clause_dft_all
+  | IDENT "assert"; lpar_id_coloneq; "("; identref; ":="; lconstr; ")"
+  | IDENT "assert"; test_lpar_id_colon; "("; identref; ":"; lconstr; ")";
+    by_tactic
+  | IDENT "assert"; constr; as_ipat; by_tactic
+  | IDENT "eassert"; lpar_id_coloneq; "("; identref; ":="; lconstr; ")"
+  | IDENT "eassert"; test_lpar_id_colon; "("; identref; ":"; lconstr; ")";
+    by_tactic
+  | IDENT "eassert"; constr; as_ipat; by_tactic
+  | IDENT "pose"; IDENT "proof"; lpar_id_coloneq; "("; identref; ":=";
+    lconstr; ")"
+  | IDENT "pose"; IDENT "proof"; lconstr; as_ipat
+  | IDENT "pose"; bindings_with_parameters
+  | IDENT "pose"; constr; as_name
+  | IDENT "epose"; IDENT "proof"; lpar_id_coloneq; "("; identref; ":=";
+    lconstr; ")"
+  | IDENT "epose"; IDENT "proof"; lconstr; as_ipat
+  | IDENT "epose"; bindings_with_parameters
+  | IDENT "epose"; constr; as_name
+  | IDENT "enough"; test_lpar_id_colon; "("; identref; ":"; lconstr; ")";
+    by_tactic
+  | IDENT "enough"; constr; as_ipat; by_tactic
+  | IDENT "eenough"; test_lpar_id_colon; "("; identref; ":"; lconstr; ")";
+    by_tactic
+  | IDENT "eenough"; constr; as_ipat; by_tactic
+  | IDENT "generalize"; IDENT "dependent"; constr
+  | IDENT "generalize"; constr; LIST1 constr
+  | IDENT "generalize"; constr; lookup_at_as_comma; occs; as_name;
+    LIST0 [ ","; pattern_occ; as_name ]
+  | IDENT "generalize"; constr
+  | IDENT "induction"; induction_clause_list
+  | IDENT "einduction"; induction_clause_list
+  | IDENT "destruct"; induction_clause_list
+  | IDENT "edestruct"; induction_clause_list
+  | IDENT "rewrite"; "*"; orient; uconstr; "in"; hyp; "at"; occurrences;
+    by_arg_tac
+  | IDENT "rewrite"; "*"; orient; uconstr; "in"; hyp; by_arg_tac
+  | IDENT "rewrite"; "*"; orient; uconstr; "at"; occurrences; "in"; hyp;
+    by_arg_tac
+  | IDENT "rewrite"; "*"; orient; uconstr; "at"; occurrences; by_arg_tac
+  | IDENT "rewrite"; "*"; orient; uconstr; by_arg_tac
+  | IDENT "rewrite"; LIST1 oriented_rewriter SEP ","; clause; by_tactic
+  | IDENT "erewrite"; LIST1 oriented_rewriter SEP ","; clause; by_tactic
+  | IDENT "dependent"; IDENT "destruction"; ident
+  | IDENT "dependent"; IDENT "induction"; ident
+  | IDENT "dependent"; IDENT "generalize_eqs_vars"; hyp
+  | IDENT "dependent"; IDENT "generalize_eqs"; hyp
+  | IDENT "dependent"; IDENT "rewrite"; orient; constr; "in"; hyp
+  | IDENT "dependent"; IDENT "rewrite"; orient; constr
+  | IDENT "dependent";
+    [ IDENT "simple"; IDENT "inversion" | IDENT "inversion"
+    | IDENT "inversion_clear" ]; quantified_hypothesis; as_or_and_ipat;
+    OPT [ "with"; constr ]
+  | IDENT "simple"; IDENT "congruence"; OPT natural; "with"; LIST1 constr
+  | IDENT "simple"; IDENT "congruence"; OPT natural
+  | IDENT "simple"; IDENT "destruct"; quantified_hypothesis
+  | IDENT "simple"; IDENT "induction"; quantified_hypothesis
+  | IDENT "simple"; IDENT "subst"
+  | IDENT "simple"; IDENT "notypeclasses"; IDENT "refine"; uconstr
+  | IDENT "simple"; IDENT "refine"; uconstr
+  | IDENT "simple"; IDENT "injection"; destruction_arg
+  | IDENT "simple"; IDENT "injection"
+  | IDENT "simple"; IDENT "apply"; LIST1 constr_with_bindings_arg SEP ",";
+    in_hyp_as
+  | IDENT "simple"; IDENT "eapply"; LIST1 constr_with_bindings_arg SEP ",";
+    in_hyp_as
+  | IDENT "simple"; IDENT "inversion"; quantified_hypothesis; as_or_and_ipat;
+    in_hyp_list
+  | IDENT "inversion_clear"; quantified_hypothesis; as_or_and_ipat;
+    in_hyp_list
+  | IDENT "inversion"; quantified_hypothesis; "using"; constr; in_hyp_list
+  | IDENT "inversion"; quantified_hypothesis; as_or_and_ipat; in_hyp_list
+  | IDENT "red"; clause
+  | IDENT "hnf"; clause
+  | IDENT "simpl"; OPT [ IDENT "head" ]; delta_flag; OPT ref_or_pattern_occ;
+    clause
+  | IDENT "cbv"; strategy_flag; clause
+  | IDENT "cbn"; strategy_flag; clause
+  | IDENT "lazy"; strategy_flag; clause
+  | IDENT "compute"; delta_flag; clause
+  | IDENT "vm_compute"; OPT ref_or_pattern_occ; clause
+  | IDENT "native_compute"; OPT ref_or_pattern_occ; clause
+  | IDENT "unfold"; LIST1 unfold_occ SEP ","; clause
+  | IDENT "fold"; LIST1 constr; clause
+  | IDENT "pattern"; LIST1 pattern_occ SEP ","; clause
+  | IDENT "change"; conversion; clause
+  | IDENT "change_no_check"; conversion; clause ] ]
+
+Entry tactic_value is
+[ LEFTA
+  [ IDENT "firstorder_using"; ":"; "("; firstorder_using; ")"
+  | IDENT "test"; ":"; "("; test; ")"
+  | IDENT "comparison"; ":"; "("; comparison; ")"
+  | IDENT "opthints"; ":"; "("; opthints; ")"
+  | IDENT "auto_using"; ":"; "("; auto_using; ")"
+  | IDENT "hintbases"; ":"; "("; hintbases; ")"
+  | IDENT "eauto_search_strategy"; ":"; "("; eauto_search_strategy; ")"
+  | IDENT "eauto_search_strategy_name"; ":"; "("; eauto_search_strategy_name;
+    ")"
+  | IDENT "debug"; ":"; "("; debug; ")"
+  | IDENT "rewstrategy"; ":"; "("; rewstrategy; ")"
+  | IDENT "glob_constr_with_bindings"; ":"; "("; constr_with_bindings; ")"
+  | IDENT "strategy_level_or_var"; ":"; "("; strategy_level_or_var; ")"
+  | IDENT "strategy_level"; ":"; "("; strategy_level; ")"
+  | IDENT "test_lpar_id_colon"; ":"; "("; test_lpar_id_colon; ")"
+  | IDENT "in_clause"; ":"; "("; in_clause; ")"
+  | IDENT "by_arg_tac"; ":"; "("; by_arg_tac; ")"
+  | IDENT "rename"; ":"; "("; rename; ")"
+  | IDENT "hloc"; ":"; "("; hloc; ")"
+  | IDENT "lglob"; ":"; "("; lconstr; ")"
+  | IDENT "lconstr"; ":"; "("; lconstr; ")"
+  | IDENT "glob"; ":"; "("; constr; ")"
+  | IDENT "occurrences"; ":"; "("; occurrences; ")"
+  | IDENT "natural"; ":"; "("; natural; ")"
+  | IDENT "orient"; ":"; "("; orient; ")"
+  | IDENT "ltac"; ":"; "("; ltac_expr LEVEL "5"; ")"
+  | IDENT "open_constr"; ":"; "("; lconstr; ")"
+  | IDENT "ipattern"; ":"; "("; simple_intropattern; ")"
+  | IDENT "constr"; ":"; "("; lconstr; ")"
+  | IDENT "uconstr"; ":"; "("; lconstr; ")"
+  | IDENT "reference"; ":"; "("; reference; ")"
+  | IDENT "ident"; ":"; "("; ident; ")"
+  | IDENT "smart_global"; ":"; "("; smart_global; ")"
+  | IDENT "string"; ":"; "("; string; ")"
+  | IDENT "integer"; ":"; "("; integer; ")"
+  | IDENT "fresh"; LIST0 fresh_id
+  | IDENT "type_term"; uconstr
+  | IDENT "numgoals"
+  | constr_eval ] ]
+
+
+Rocq < Rocq < Toplevel input, characters 24-29:
+> Check Reject 230 ltac:(atom5 ; atom3).
+>                        ^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 231 ltac:(atom4 ; atom4).
+>                                ^^^^^
+Error: The reference atom4 was not found in the current environment.
+
+Rocq < Accept 232 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 233 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Rocq < Toplevel input, characters 30-35:
+> Check Reject 240 ltac:(pre43 atom4 ; atom3).
+>                              ^^^^^
+Error: The reference atom4 was not found in the current environment.
+
+Rocq < Accept 241 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Toplevel input, characters 29-34:
+> Check Reject 242 ltac:(pre44 atom4 ; atom3).
+>                              ^^^^^
+Error: The reference atom4 was not found in the current environment.
+
+Rocq < Accept 243 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Rocq < Accept 250 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 251 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Rocq < AcceptTmp 260 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 261 ltac:(atom1 + atom3).
+>                                ^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected. This tolerance will be eventually removed. Insert parentheses or
+try to lower the level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+
+Rocq < Accept 262 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 263 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Rocq < AcceptTmp 270 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < AcceptTmp 271 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 272 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 273 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Rocq < AcceptTmp 280 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < AcceptTmp 281 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < Accept 282 ?Goal
+     : Parsing
+where
+?A : [ |- Type]
+?Goal : [ |- ?A]
+
+Rocq < 

--- a/test-suite/output-coqtop/LevelTolerance.out
+++ b/test-suite/output-coqtop/LevelTolerance.out
@@ -76,9 +76,10 @@ Rocq < Rocq < Entry custom:Top.expr is
 Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Rocq < Toplevel input, characters 496-503:
 > Check Reject 10 [2 atom3 ].
 >                    ^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 11 E
@@ -87,9 +88,10 @@ Rocq < Accept 11 E
 Rocq < Toplevel input, characters 19-26:
 > Check Reject 12 [1 atom2 ].
 >                    ^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 13 E
@@ -99,8 +101,9 @@ Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 20 [2 pre22 atom3 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 21 (F E)
@@ -109,17 +112,19 @@ Rocq < Accept 21 (F E)
 Rocq < Toplevel input, characters 19-32:
 > Check Reject 22 [1 pre22 atom2 ].
 >                    ^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 30 [2 pre21 atom2 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 31 (F E)
@@ -128,25 +133,28 @@ Rocq < Accept 31 (F E)
 Rocq < Toplevel input, characters 19-32:
 > Check Reject 32 [1 pre21 atom1 ].
 >                    ^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 40 [2 pre11 atom2 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 25-30:
 > Check Reject 41 [1 pre11 atom2 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 42 (F E)
@@ -155,17 +163,19 @@ Rocq < Accept 42 (F E)
 Rocq < Toplevel input, characters 19-32:
 > Check Reject 43 [0 pre11 atom1 ].
 >                    ^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 50 [1 pre10 atom1 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 51 (F E)
@@ -174,25 +184,28 @@ Rocq < Accept 51 (F E)
 Rocq < Toplevel input, characters 19-32:
 > Check Reject 52 [0 pre10 atom0 ].
 >                    ^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 60 [1 pre00 atom1 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 25-30:
 > Check Reject 61 [0 pre00 atom1 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 62 (F E)
@@ -202,7 +215,7 @@ Rocq < Rocq < Toplevel input, characters 26-31:
 > Check Reject 70 [0 pre0x atom0 ].
 >                          ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected.  (there is no next level of last level) This tolerance will be
+expected (there is no next level of last level). This tolerance will be
 eventually removed. Insert parentheses or try to lower the level at which the
 top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
@@ -211,8 +224,9 @@ Rocq < Rocq < Toplevel input, characters 20-25:
 > Check Reject 80 [2 atom3 post12 ].
 >                    ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation continuing on the right. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < AcceptTmp 81 (F E)
@@ -224,17 +238,19 @@ Rocq < Accept 82 (F E)
 Rocq < Toplevel input, characters 19-33:
 > Check Reject 83 [1 atom1 post12 ].
 >                    ^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 20-25:
 > Check Reject 90 [2 atom2 post11 ].
 >                    ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation continuing on the right. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 91 (F E)
@@ -246,9 +262,10 @@ Rocq < Accept 92 (F E)
 Rocq < Toplevel input, characters 19-33:
 > Check Reject 93 [0 atom1 post11 ].
 >                    ^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < AcceptTmp 100 (G E E)
@@ -258,8 +275,9 @@ Rocq < Toplevel input, characters 31-36:
 > Check Reject 101 [3 atom2 op22 atom3 ].
 >                                ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 102 (G E E)
@@ -268,9 +286,10 @@ Rocq < Accept 102 (G E E)
 Rocq < Toplevel input, characters 20-38:
 > Check Reject 103 [2 atom2 op22 atom2 ].
 >                     ^^^^^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < AcceptTmp 110 (G E E)
@@ -280,8 +299,9 @@ Rocq < Toplevel input, characters 31-36:
 > Check Reject 111 [2 atom1 op12 atom3 ].
 >                                ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 112 (G E E)
@@ -290,25 +310,28 @@ Rocq < Accept 112 (G E E)
 Rocq < Toplevel input, characters 20-38:
 > Check Reject 113 [1 atom1 op12 atom2 ].
 >                     ^^^^^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Toplevel input, characters 21-26:
 > Check Reject 120 [1 atom2 op10 atom0].
 >                     ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation continuing on the right. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 121 [1 atom1 op10 atom1].
 >                                ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 122 (G E E)
@@ -317,9 +340,10 @@ Rocq < Accept 122 (G E E)
 Rocq < Toplevel input, characters 20-37:
 > Check Reject 123 [0 atom1 op10 atom0].
 >                     ^^^^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < AcceptTmp 130 (F (G E E))
@@ -347,8 +371,9 @@ Rocq < Toplevel input, characters 37-42:
 > Check Reject 151 [2 atom1 op12 pre21 atom2 ].
 >                                      ^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 152 (G E (F E))
@@ -364,8 +389,9 @@ Rocq < Toplevel input, characters 31-43:
 > Check Reject 162 [2 atom1 op10 atom1 post12 ].
 >                                ^^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 163 (F (G E E))
@@ -378,8 +404,9 @@ Rocq < Toplevel input, characters 26-42:
 > Check Reject 171 [1 pre10 atom1 op10 atom0 ].
 >                           ^^^^^^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 172 (G (F E) E)
@@ -389,8 +416,9 @@ Rocq < Rocq < Toplevel input, characters 21-33:
 > Check Reject 180 [1 atom1 post12 op10 atom0 ].
 >                     ^^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation continuing on the right. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 181 (G (F E) E)
@@ -400,16 +428,18 @@ Rocq < Rocq < Toplevel input, characters 32-43:
 > Check Reject 190 [1 atom1 op10 pre11 atom0 ].
 >                                ^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-42:
 > Check Reject 191 [1 atom1 op10 pre10 atom0 ].
 >                                ^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Rocq < Accept 200 (F (G E E))
@@ -418,9 +448,10 @@ Rocq < Rocq < Accept 200 (F (G E E))
 Rocq < Toplevel input, characters 20-45:
 > Check Reject 201 [1 atom1 op10 atom0 post12 ].
 >                     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: In term, tolerating this expression at a higher level than expected.
-This tolerance will be eventually removed. Insert parentheses or try to lower
-the level at which the top symbol of this expression is parsed.
+Error: In term, tolerating this expression at a higher level than expected by
+the notation started on the left. This tolerance will be eventually removed.
+Insert parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 202 (F (G E E))
@@ -436,8 +467,9 @@ Rocq < Rocq < Toplevel input, characters 32-48:
 > Check Reject 220 [1 atom1 op10 atom1 op10 atom0 ].
 >                                ^^^^^^^^^^^^^^^^
 Error: In custom:Top.expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 221 (G (G E E) E)
@@ -839,8 +871,9 @@ Rocq < Rocq < Toplevel input, characters 24-29:
 > Check Reject 230 ltac:(atom5 ; atom3).
 >                        ^^^^^
 Error: In ltac_expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation continuing on the right. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-36:
@@ -904,8 +937,9 @@ Rocq < Toplevel input, characters 31-36:
 > Check Reject 261 ltac:(atom1 + atom3).
 >                                ^^^^^
 Error: In ltac_expr, tolerating this expression at a higher level than
-expected. This tolerance will be eventually removed. Insert parentheses or
-try to lower the level at which the top symbol of this expression is parsed.
+expected by the notation started on the left. This tolerance will be
+eventually removed. Insert parentheses or try to lower the level at which the
+top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 262 ?Goal

--- a/test-suite/output-coqtop/LevelTolerance.out
+++ b/test-suite/output-coqtop/LevelTolerance.out
@@ -229,8 +229,15 @@ eventually removed. Insert parentheses or try to lower the level at which the
 top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < AcceptTmp 81 (F E)
-     : Parsing
+Rocq < Toplevel input, characters 19-24:
+> Check Reject 81 [2 atom2 post12 ].
+>                    ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 82 (F E)
      : Parsing
@@ -268,8 +275,15 @@ Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < Rocq < AcceptTmp 100 (G E E)
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 21-26:
+> Check Reject 100 [3 atom3 op22 atom2 ].
+>                     ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 101 [3 atom2 op22 atom3 ].
@@ -292,8 +306,15 @@ Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < Rocq < AcceptTmp 110 (G E E)
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 21-26:
+> Check Reject 110 [2 atom2 op12 atom2 ].
+>                     ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 111 [2 atom1 op12 atom3 ].
@@ -346,20 +367,48 @@ Insert parentheses or try to lower the level at which the top symbol of this
 expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < Rocq < AcceptTmp 130 (F (G E E))
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 27-32:
+> Check Reject 130 [2 pre22 atom2 op12 atom2 ].
+>                           ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < AcceptTmp 131 (G (F E) E)
-     : Parsing
+Rocq < Toplevel input, characters 20-31:
+> Check Reject 131 [2 pre21 atom1 op12 atom2 ].
+>                     ^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 132 (F (G E E))
      : Parsing
 
-Rocq < Rocq < AcceptTmp 140 (G (F E) E)
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 21-33:
+> Check Reject 140 [2 atom2 post12 op12 atom2 ].
+>                     ^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < AcceptTmp 141 (G (F E) E)
-     : Parsing
+Rocq < Toplevel input, characters 20-32:
+> Check Reject 141 [2 atom1 post12 op12 atom2 ].
+>                     ^^^^^^^^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 142 (G (F E) E)
      : Parsing
@@ -379,8 +428,15 @@ top symbol of this expression is parsed.
 Rocq < Accept 152 (G E (F E))
      : Parsing
 
-Rocq < Rocq < AcceptTmp 160 (G E (F E))
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 32-37:
+> Check Reject 160 [2 atom1 op12 atom2 post12 ].
+>                                ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 161 (G E (F E))
      : Parsing
@@ -457,8 +513,15 @@ expression is parsed.
 Rocq < Accept 202 (F (G E E))
      : Parsing
 
-Rocq < Rocq < AcceptTmp 210 (G E (G E E))
-     : Parsing
+Rocq < Rocq < Toplevel input, characters 32-37:
+> Check Reject 210 [2 atom1 op12 atom2 op12 atom2 ].
+>                                ^^^^^
+Error: In custom:Top.expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 211 (G E (G E E))
      : Parsing
@@ -927,11 +990,15 @@ where
 ?A : [ |- Type]
 ?Goal : [ |- ?A]
 
-Rocq < Rocq < AcceptTmp 260 ?Goal
-     : Parsing
-where
-?A : [ |- Type]
-?Goal : [ |- ?A]
+Rocq < Rocq < Toplevel input, characters 24-29:
+> Check Reject 260 ltac:(atom2 + atom2).
+>                        ^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Toplevel input, characters 31-36:
 > Check Reject 261 ltac:(atom1 + atom3).
@@ -954,17 +1021,25 @@ where
 ?A : [ |- Type]
 ?Goal : [ |- ?A]
 
-Rocq < Rocq < AcceptTmp 270 ?Goal
-     : Parsing
-where
-?A : [ |- Type]
-?Goal : [ |- ?A]
+Rocq < Rocq < Toplevel input, characters 30-35:
+> Check Reject 270 ltac:(pre22 atom2 + atom2).
+>                              ^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < AcceptTmp 271 ?Goal
-     : Parsing
-where
-?A : [ |- Type]
-?Goal : [ |- ?A]
+Rocq < Toplevel input, characters 23-34:
+> Check Reject 271 ltac:(pre21 atom1 + atom2).
+>                        ^^^^^^^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 272 ?Goal
      : Parsing
@@ -978,17 +1053,25 @@ where
 ?A : [ |- Type]
 ?Goal : [ |- ?A]
 
-Rocq < Rocq < AcceptTmp 280 ?Goal
-     : Parsing
-where
-?A : [ |- Type]
-?Goal : [ |- ?A]
+Rocq < Rocq < Toplevel input, characters 24-36:
+> Check Reject 280 ltac:(atom1 post12 + atom2).
+>                        ^^^^^^^^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
-Rocq < AcceptTmp 281 ?Goal
-     : Parsing
-where
-?A : [ |- Type]
-?Goal : [ |- ?A]
+Rocq < Toplevel input, characters 31-36:
+> Check Reject 281 ltac:(atom1 + atom2 post12).
+>                                ^^^^^
+Error: In ltac_expr, tolerating this expression at a higher level than
+expected by the notation continuing on the right (which is not
+left-associative). This tolerance will be eventually removed. Insert
+parentheses or try to lower the level at which the top symbol of this
+expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 
 Rocq < Accept 282 ?Goal
      : Parsing

--- a/test-suite/output-coqtop/LevelTolerance.out
+++ b/test-suite/output-coqtop/LevelTolerance.out
@@ -235,9 +235,9 @@ Rocq < AcceptTmp 81 (F E)
 Rocq < Accept 82 (F E)
      : Parsing
 
-Rocq < Toplevel input, characters 19-33:
+Rocq < Toplevel input, characters 19-31:
 > Check Reject 83 [1 atom1 post12 ].
->                    ^^^^^^^^^^^^^^
+>                    ^^^^^^^^^^^^
 Error: In term, tolerating this expression at a higher level than expected by
 the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
@@ -283,9 +283,9 @@ top symbol of this expression is parsed.
 Rocq < Accept 102 (G E E)
      : Parsing
 
-Rocq < Toplevel input, characters 20-38:
+Rocq < Toplevel input, characters 20-36:
 > Check Reject 103 [2 atom2 op22 atom2 ].
->                     ^^^^^^^^^^^^^^^^^^
+>                     ^^^^^^^^^^^^^^^^
 Error: In term, tolerating this expression at a higher level than expected by
 the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
@@ -307,9 +307,9 @@ top symbol of this expression is parsed.
 Rocq < Accept 112 (G E E)
      : Parsing
 
-Rocq < Toplevel input, characters 20-38:
+Rocq < Toplevel input, characters 20-36:
 > Check Reject 113 [1 atom1 op12 atom2 ].
->                     ^^^^^^^^^^^^^^^^^^
+>                     ^^^^^^^^^^^^^^^^
 Error: In term, tolerating this expression at a higher level than expected by
 the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this
@@ -445,9 +445,9 @@ top symbol of this expression is parsed.
 Rocq < Rocq < Accept 200 (F (G E E))
      : Parsing
 
-Rocq < Toplevel input, characters 20-45:
+Rocq < Toplevel input, characters 20-43:
 > Check Reject 201 [1 atom1 op10 atom0 post12 ].
->                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+>                     ^^^^^^^^^^^^^^^^^^^^^^^
 Error: In term, tolerating this expression at a higher level than expected by
 the notation started on the left. This tolerance will be eventually removed.
 Insert parentheses or try to lower the level at which the top symbol of this

--- a/test-suite/output-coqtop/LevelTolerance.v
+++ b/test-suite/output-coqtop/LevelTolerance.v
@@ -4,7 +4,7 @@ Set Warnings "-level-0-notation-not-closed".
 Set Warnings "-postfix-notation-not-level-1".
 
 Inductive T := E : T | F : T -> T | G : T -> T -> T.
-Inductive Parsing {A} := AcceptTmp (_ : nat) (_ : A) | Accept (_ : nat) (_ : A) | Reject (_ : nat) (_ : A).
+Inductive Parsing {A} := Accept (_ : nat) (_ : A) | Reject (_ : nat) (_ : A).
 
 Declare Custom Entry expr.
 
@@ -74,7 +74,7 @@ Check Accept 62 [0 pre00 atom0 ].
 Check Reject 70 [0 pre0x atom0 ].
 
 Check Reject 80 [2 atom3 post12 ].
-Check AcceptTmp 81 [2 atom2 post12 ].
+Check Reject 81 [2 atom2 post12 ].
 Check Accept 82 [2 atom1 post12 ].
 Check Reject 83 [1 atom1 post12 ].
 
@@ -83,12 +83,12 @@ Check Accept 91 [2 atom1 post11 ].
 Check Accept 92 [1 atom1 post11 ].
 Check Reject 93 [0 atom1 post11 ].
 
-Check AcceptTmp 100 [3 atom3 op22 atom2 ].
+Check Reject 100 [3 atom3 op22 atom2 ].
 Check Reject 101 [3 atom2 op22 atom3 ].
 Check Accept 102 [3 atom2 op22 atom2 ].
 Check Reject 103 [2 atom2 op22 atom2 ].
 
-Check AcceptTmp 110 [2 atom2 op12 atom2 ].
+Check Reject 110 [2 atom2 op12 atom2 ].
 Check Reject 111 [2 atom1 op12 atom3 ].
 Check Accept 112 [2 atom1 op12 atom2 ].
 Check Reject 113 [1 atom1 op12 atom2 ].
@@ -98,19 +98,19 @@ Check Reject 121 [1 atom1 op10 atom1].
 Check Accept 122 [1 atom1 op10 atom0].
 Check Reject 123 [0 atom1 op10 atom0].
 
-Check AcceptTmp 130 [2 pre22 atom2 op12 atom2 ].
-Check AcceptTmp 131 [2 pre21 atom1 op12 atom2 ].
+Check Reject 130 [2 pre22 atom2 op12 atom2 ].
+Check Reject 131 [2 pre21 atom1 op12 atom2 ].
 Check Accept 132 [2 pre22 atom1 op12 atom2 ].
 
-Check AcceptTmp 140 [2 atom2 post12 op12 atom2 ].
-Check AcceptTmp 141 [2 atom1 post12 op12 atom2 ].
+Check Reject 140 [2 atom2 post12 op12 atom2 ].
+Check Reject 141 [2 atom1 post12 op12 atom2 ].
 Check Accept 142 [2 atom1 post11 op12 atom2 ].
 
 Check Accept 150 [2 atom1 op12 pre22 atom2 ].
 Check Reject 151 [2 atom1 op12 pre21 atom2 ].
 Check Accept 152 [2 atom1 op12 pre21 atom1 ].
 
-Check AcceptTmp 160 [2 atom1 op12 atom2 post12 ].
+Check Reject 160 [2 atom1 op12 atom2 post12 ].
 Check Accept 161 [2 atom1 op12 atom1 post12 ].
 Check Reject 162 [2 atom1 op10 atom1 post12 ].
 Check Accept 163 [2 atom1 op10 atom0 post12 ].
@@ -129,7 +129,7 @@ Check Accept 200 [2 atom1 op10 atom0 post12 ].
 Check Reject 201 [1 atom1 op10 atom0 post12 ].
 Check Accept 202 [1 atom1 op10 atom0 post11 ].
 
-Check AcceptTmp 210 [2 atom1 op12 atom2 op12 atom2 ].
+Check Reject 210 [2 atom1 op12 atom2 op12 atom2 ].
 Check Accept 211 [2 atom1 op12 atom1 op12 atom2 ].
 
 Check Reject 220 [1 atom1 op10 atom1 op10 atom0 ].
@@ -166,16 +166,16 @@ Check Accept 243 ltac:(pre44 atom3 ; atom3).
 Check Accept 250 ltac:(atom4 post44 ; atom3).
 Check Accept 251 ltac:(atom4 ; atom3 post44).
 
-Check AcceptTmp 260 ltac:(atom2 + atom2).
+Check Reject 260 ltac:(atom2 + atom2).
 Check Reject 261 ltac:(atom1 + atom3).
 Check Accept 262 ltac:(atom1 + atom2).
 Check Accept 263 ltac:(atom1 + atom1 + atom2).
 
-Check AcceptTmp 270 ltac:(pre22 atom2 + atom2).
-Check AcceptTmp 271 ltac:(pre21 atom1 + atom2).
+Check Reject 270 ltac:(pre22 atom2 + atom2).
+Check Reject 271 ltac:(pre21 atom1 + atom2).
 Check Accept 272 ltac:(pre22 atom1 + atom2).
 Check Accept 273 ltac:(atom1 + pre22 atom2).
 
-Check AcceptTmp 280 ltac:(atom1 post12 + atom2).
-Check AcceptTmp 281 ltac:(atom1 + atom2 post12).
+Check Reject 280 ltac:(atom1 post12 + atom2).
+Check Reject 281 ltac:(atom1 + atom2 post12).
 Check Accept 282 ltac:(atom1 + atom1 post12).

--- a/test-suite/output-coqtop/LevelTolerance.v
+++ b/test-suite/output-coqtop/LevelTolerance.v
@@ -1,0 +1,181 @@
+Set Warnings "+level-tolerance".
+Set Warnings "-closed-notation-not-level-0".
+Set Warnings "-level-0-notation-not-closed".
+Set Warnings "-postfix-notation-not-level-1".
+
+Inductive T := E : T | F : T -> T | G : T -> T -> T.
+Inductive Parsing {A} := AcceptTmp (_ : nat) (_ : A) | Accept (_ : nat) (_ : A) | Reject (_ : nat) (_ : A).
+
+Declare Custom Entry expr.
+
+Notation "x 'op22' y" := (G x y) (in custom expr at level 3, only parsing, no associativity).
+Notation "x 'op12' y" := (G x y) (in custom expr at level 2, only parsing, right associativity).
+Notation "x 'op10' y" := (G x y) (in custom expr at level 1, only parsing, left associativity).
+
+Notation "[3 e ]" := e (e custom expr at level 3, only parsing).
+Notation "[2 e ]" := e (e custom expr at level 2, only parsing).
+Notation "[1 e ]" := e (e custom expr at level 1, only parsing).
+Notation "[0 e ]" := e (e custom expr at level 0, only parsing).
+
+Notation "'atom3'" := E (in custom expr at level 3, only parsing).
+Notation "'atom2'" := E (in custom expr at level 2, only parsing).
+Notation "'atom1'" := E (in custom expr at level 1, only parsing).
+Notation "'atom0'" := E (in custom expr at level 0, only parsing).
+
+Notation "'pre22' x" := (F x) (in custom expr at level 2, x at level 2, only parsing).
+Notation "'pre21' x" := (F x) (in custom expr at level 2, x at next level, only parsing).
+Notation "'pre11' x" := (F x) (in custom expr at level 1, x at level 1, only parsing).
+Notation "'pre10' x" := (F x) (in custom expr at level 1, x at next level, only parsing).
+Notation "'pre00' x" := (F x) (in custom expr at level 0, x at level 0, only parsing).
+Notation "'pre0x' x" := (F x) (in custom expr at level 0, x at next level, only parsing).
+
+Notation "x 'post12'" := (F x) (in custom expr at level 2, only parsing).
+Notation "x 'post11'" := (F x) (in custom expr at level 1, only parsing).
+
+Print Custom Grammar expr.
+
+(* The following sed script prints the first line with a wrong result:
+
+     sed -En '/Accept/{/^(Rocq < )+Accept/!bf};/Reject/{/^> Check Reject/!bf};b;:f;p;q1' \
+       test-suite/output-coqtop/LevelTolerance.out
+
+   The script checks that:
+   - Each line containing "Reject" starts with "> Check Reject"
+   - Each line containing "Accept" starts with one or more "Rocq < " followed by "Accept"
+
+   In case of failure, it prints the line containing "Reject" or "Accept". *)
+
+Check Reject 10 [2 atom3 ].
+Check Accept 11 [2 atom2 ].
+Check Reject 12 [1 atom2 ].
+Check Accept 13 [1 atom1 ].
+
+Check Reject 20 [2 pre22 atom3 ].
+Check Accept 21 [2 pre22 atom2 ].
+Check Reject 22 [1 pre22 atom2 ].
+
+Check Reject 30 [2 pre21 atom2 ].
+Check Accept 31 [2 pre21 atom1 ].
+Check Reject 32 [1 pre21 atom1 ].
+
+Check Reject 40 [2 pre11 atom2 ].
+Check Reject 41 [1 pre11 atom2 ].
+Check Accept 42 [1 pre11 atom1 ].
+Check Reject 43 [0 pre11 atom1 ].
+
+Check Reject 50 [1 pre10 atom1 ].
+Check Accept 51 [1 pre10 atom0 ].
+Check Reject 52 [0 pre10 atom0 ].
+
+Check Reject 60 [1 pre00 atom1 ].
+Check Reject 61 [0 pre00 atom1 ].
+Check Accept 62 [0 pre00 atom0 ].
+
+Check Reject 70 [0 pre0x atom0 ].
+
+Check Reject 80 [2 atom3 post12 ].
+Check AcceptTmp 81 [2 atom2 post12 ].
+Check Accept 82 [2 atom1 post12 ].
+Check Reject 83 [1 atom1 post12 ].
+
+Check Reject 90 [2 atom2 post11 ].
+Check Accept 91 [2 atom1 post11 ].
+Check Accept 92 [1 atom1 post11 ].
+Check Reject 93 [0 atom1 post11 ].
+
+Check AcceptTmp 100 [3 atom3 op22 atom2 ].
+Check Reject 101 [3 atom2 op22 atom3 ].
+Check Accept 102 [3 atom2 op22 atom2 ].
+Check Reject 103 [2 atom2 op22 atom2 ].
+
+Check AcceptTmp 110 [2 atom2 op12 atom2 ].
+Check Reject 111 [2 atom1 op12 atom3 ].
+Check Accept 112 [2 atom1 op12 atom2 ].
+Check Reject 113 [1 atom1 op12 atom2 ].
+
+Check Reject 120 [1 atom2 op10 atom0].
+Check Reject 121 [1 atom1 op10 atom1].
+Check Accept 122 [1 atom1 op10 atom0].
+Check Reject 123 [0 atom1 op10 atom0].
+
+Check AcceptTmp 130 [2 pre22 atom2 op12 atom2 ].
+Check AcceptTmp 131 [2 pre21 atom1 op12 atom2 ].
+Check Accept 132 [2 pre22 atom1 op12 atom2 ].
+
+Check AcceptTmp 140 [2 atom2 post12 op12 atom2 ].
+Check AcceptTmp 141 [2 atom1 post12 op12 atom2 ].
+Check Accept 142 [2 atom1 post11 op12 atom2 ].
+
+Check Accept 150 [2 atom1 op12 pre22 atom2 ].
+Check Reject 151 [2 atom1 op12 pre21 atom2 ].
+Check Accept 152 [2 atom1 op12 pre21 atom1 ].
+
+Check AcceptTmp 160 [2 atom1 op12 atom2 post12 ].
+Check Accept 161 [2 atom1 op12 atom1 post12 ].
+Check Reject 162 [2 atom1 op10 atom1 post12 ].
+Check Accept 163 [2 atom1 op10 atom0 post12 ].
+
+Check Accept 170 [1 pre11 atom1 op10 atom0 ].
+Check Reject 171 [1 pre10 atom1 op10 atom0 ].
+Check Accept 172 [1 pre10 atom0 op10 atom0 ].
+
+Check Reject 180 [1 atom1 post12 op10 atom0 ].
+Check Accept 181 [1 atom1 post11 op10 atom0 ].
+
+Check Reject 190 [1 atom1 op10 pre11 atom0 ].
+Check Reject 191 [1 atom1 op10 pre10 atom0 ].
+
+Check Accept 200 [2 atom1 op10 atom0 post12 ].
+Check Reject 201 [1 atom1 op10 atom0 post12 ].
+Check Accept 202 [1 atom1 op10 atom0 post11 ].
+
+Check AcceptTmp 210 [2 atom1 op12 atom2 op12 atom2 ].
+Check Accept 211 [2 atom1 op12 atom1 op12 atom2 ].
+
+Check Reject 220 [1 atom1 op10 atom1 op10 atom0 ].
+Check Accept 221 [1 atom1 op10 atom0 op10 atom0 ].
+
+From Corelib Require Import Notations.
+
+Tactic Notation (at level 5) "atom5" := idtac.
+Tactic Notation (at level 4) "atom4" := idtac.
+Tactic Notation (at level 3) "atom3" := idtac.
+Tactic Notation (at level 2) "atom2" := idtac.
+Tactic Notation (at level 1) "atom1" := idtac.
+
+Tactic Notation (at level 4) "pre44" tactic4(x) := x.
+Tactic Notation (at level 4) "pre43" tactic3(x) := x.
+Tactic Notation (at level 2) "pre22" tactic2(x) := x.
+Tactic Notation (at level 2) "pre21" tactic1(x) := x.
+
+Tactic Notation (at level 4) tactic4(x) "post44" := x.
+Tactic Notation (at level 2) tactic2(x) "post12" := x.
+
+Print Grammar tactic.
+
+Check Reject 230 ltac:(atom5 ; atom3).
+Check Reject 231 ltac:(atom4 ; atom4).
+Check Accept 232 ltac:(atom4 ; atom3).
+Check Accept 233 ltac:(atom4 ; atom3 ; atom3).
+
+Check Reject 240 ltac:(pre43 atom4 ; atom3).
+Check Accept 241 ltac:(pre43 atom3 ; atom3).
+Check Reject 242 ltac:(pre44 atom4 ; atom3).
+Check Accept 243 ltac:(pre44 atom3 ; atom3).
+
+Check Accept 250 ltac:(atom4 post44 ; atom3).
+Check Accept 251 ltac:(atom4 ; atom3 post44).
+
+Check AcceptTmp 260 ltac:(atom2 + atom2).
+Check Reject 261 ltac:(atom1 + atom3).
+Check Accept 262 ltac:(atom1 + atom2).
+Check Accept 263 ltac:(atom1 + atom1 + atom2).
+
+Check AcceptTmp 270 ltac:(pre22 atom2 + atom2).
+Check AcceptTmp 271 ltac:(pre21 atom1 + atom2).
+Check Accept 272 ltac:(pre22 atom1 + atom2).
+Check Accept 273 ltac:(atom1 + pre22 atom2).
+
+Check AcceptTmp 280 ltac:(atom1 post12 + atom2).
+Check AcceptTmp 281 ltac:(atom1 + atom2 post12).
+Check Accept 282 ltac:(atom1 + atom1 post12).

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -49,11 +49,11 @@ Inductive Expr :=
  | One : Expr.
 
 Declare Custom Entry expr.
-Notation "[ expr ]" := expr (expr custom expr at level 2).
+Notation "[ expr ]" := expr (expr custom expr at level 3).
 Notation "1" := One (in custom expr at level 0).
 Notation "x y" := (Mul x y) (in custom expr at level 1, left associativity).
 Notation "x + y" := (Add x y) (in custom expr at level 2, left associativity).
-Notation "( x )" := x (in custom expr at level 0, x at level 2).
+Notation "( x )" := x (in custom expr at level 0, x at level 3).
 Notation "{ x }" := x (in custom expr at level 0, x constr).
 Notation "x" := x (in custom expr at level 0, x ident).
 

--- a/test-suite/output/PrintNotation.out
+++ b/test-suite/output/PrintNotation.out
@@ -6,6 +6,9 @@ by the notation continuing on the right (which is not left-associative). This
 tolerance will be eventually removed. Insert parentheses or try to lower the
 level at which the top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace File "./output/PrintNotation.v", line 8, characters 9-9 with (
+Replace File "./output/PrintNotation.v", line 8, characters 14-14 with )
 bar (bar ?f ?f0) ?f1
      : foo
 where
@@ -20,6 +23,9 @@ by the notation continuing on the right (which is not left-associative). This
 tolerance will be eventually removed. Insert parentheses or try to lower the
 level at which the top symbol of this expression is parsed.
 [level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
+Quickfix:
+Replace File "./output/PrintNotation.v", line 17, characters 9-9 with (
+Replace File "./output/PrintNotation.v", line 17, characters 14-14 with )
 bar (bar ?f ?f0) ?f1
      : foo
 where

--- a/test-suite/output/PrintNotation.out
+++ b/test-suite/output/PrintNotation.out
@@ -1,5 +1,11 @@
 Notation "_ $ _" at level 123 with arguments constr at next level, constr
 at next level, no associativity.
+File "./output/PrintNotation.v", line 8, characters 9-14:
+Warning: In term, tolerating this expression at a higher level than expected
+by the notation continuing on the right (which is not left-associative). This
+tolerance will be eventually removed. Insert parentheses or try to lower the
+level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 bar (bar ?f ?f0) ?f1
      : foo
 where
@@ -8,6 +14,12 @@ where
 ?f1 : [ |- foo]
 Notation "_ $ _" at level 123 with arguments constr at next level, constr
 at next level, no associativity.
+File "./output/PrintNotation.v", line 17, characters 9-14:
+Warning: In term, tolerating this expression at a higher level than expected
+by the notation continuing on the right (which is not left-associative). This
+tolerance will be eventually removed. Insert parentheses or try to lower the
+level at which the top symbol of this expression is parsed.
+[level-tolerance,deprecated-since-9.2,deprecated,parsing,default]
 bar (bar ?f ?f0) ?f1
      : foo
 where

--- a/test-suite/prerequisite/ssr_mini_mathcomp.v
+++ b/test-suite/prerequisite/ssr_mini_mathcomp.v
@@ -425,7 +425,7 @@ Open Scope nat_scope.
 Lemma ltnS m n : (m < n.+1) = (m <= n). Proof. by []. Qed.
 Lemma leq0n n : 0 <= n.                 Proof. by []. Qed.
 Lemma ltn0Sn n : 0 < n.+1.              Proof. by []. Qed.
-Lemma ltn0 n : n < 0 = false.           Proof. by []. Qed.
+Lemma ltn0 n : (n < 0) = false.         Proof. by []. Qed.
 Lemma leqnn n : n <= n.                 Proof. by elim: n. Qed.
 #[global] Hint Resolve leqnn : core.
 Lemma leqnSn n : n <= n.+1.             Proof. by elim: n. Qed.
@@ -1324,7 +1324,7 @@ Definition index_iota m n := iota m (n - m).
 
 Definition index_enum (T : finType) := Finite.enum T.
 
-Lemma mem_index_iota m n i : i \in index_iota m n = (m <= i < n).
+Lemma mem_index_iota m n i : (i \in index_iota m n) = (m <= i < n).
 Admitted.
 
 Lemma mem_index_enum T i : i \in index_enum T.

--- a/test-suite/primitive/float/compare.v
+++ b/test-suite/primitive/float/compare.v
@@ -6,170 +6,170 @@ Definition min_denorm := 0x0.0000000000001p-1022%float.  (* Z.ldexp one (-1074)%
 
 Definition min_norm := 0x0.4p-1022%float.  (* Z.ldexp_one (-1024)%Z *)
 
-Check (eq_refl : nan =? nan = false).
-Check (eq_refl : nan =? nan = false).
+Check (eq_refl : (nan =? nan) = false).
+Check (eq_refl : (nan =? nan) = false).
 
-Check (eq_refl : nan <? nan = false).
-Check (eq_refl : nan <? nan = false).
+Check (eq_refl : (nan <? nan) = false).
+Check (eq_refl : (nan <? nan) = false).
 
-Check (eq_refl : nan <=? nan = false).
-Check (eq_refl : nan <=? nan = false).
+Check (eq_refl : (nan <=? nan) = false).
+Check (eq_refl : (nan <=? nan) = false).
 
-Check (eq_refl : nan ?= nan = FNotComparable).
-Check (eq_refl : nan ?= nan = FNotComparable).
+Check (eq_refl : (nan ?= nan) = FNotComparable).
+Check (eq_refl : (nan ?= nan) = FNotComparable).
 
-Check (eq_refl : nan =? - nan = false).
-Check (eq_refl : - nan =? nan = false).
+Check (eq_refl : (nan =? - nan) = false).
+Check (eq_refl : (- nan =? nan) = false).
 
-Check (eq_refl : nan <? - nan = false).
-Check (eq_refl : - nan <? nan = false).
+Check (eq_refl : (nan <? - nan) = false).
+Check (eq_refl : (- nan <? nan) = false).
 
-Check (eq_refl : nan <=? - nan = false).
-Check (eq_refl : - nan <=? nan = false).
+Check (eq_refl : (nan <=? - nan) = false).
+Check (eq_refl : (- nan <=? nan) = false).
 
-Check (eq_refl : nan ?= - nan = FNotComparable).
-Check (eq_refl : - nan ?= nan = FNotComparable).
+Check (eq_refl : (nan ?= - nan) = FNotComparable).
+Check (eq_refl : (- nan ?= nan) = FNotComparable).
 
-Check (eq_refl : one =? one = true).
-Check (eq_refl : one =? one = true).
+Check (eq_refl : (one =? one) = true).
+Check (eq_refl : (one =? one) = true).
 
-Check (eq_refl : one <? one = false).
-Check (eq_refl : one <? one = false).
+Check (eq_refl : (one <? one) = false).
+Check (eq_refl : (one <? one) = false).
 
-Check (eq_refl : one <=? one = true).
-Check (eq_refl : one <=? one = true).
+Check (eq_refl : (one <=? one) = true).
+Check (eq_refl : (one <=? one) = true).
 
-Check (eq_refl : one ?= one = FEq).
-Check (eq_refl : one ?= one = FEq).
+Check (eq_refl : (one ?= one) = FEq).
+Check (eq_refl : (one ?= one) = FEq).
 
-Check (eq_refl : zero =? zero = true).
-Check (eq_refl : zero =? zero = true).
+Check (eq_refl : (zero =? zero) = true).
+Check (eq_refl : (zero =? zero) = true).
 
-Check (eq_refl : zero <? zero = false).
-Check (eq_refl : zero <? zero = false).
+Check (eq_refl : (zero <? zero) = false).
+Check (eq_refl : (zero <? zero) = false).
 
-Check (eq_refl : zero <=? zero = true).
-Check (eq_refl : zero <=? zero = true).
+Check (eq_refl : (zero <=? zero) = true).
+Check (eq_refl : (zero <=? zero) = true).
 
-Check (eq_refl : zero ?= zero = FEq).
-Check (eq_refl : zero ?= zero = FEq).
+Check (eq_refl : (zero ?= zero) = FEq).
+Check (eq_refl : (zero ?= zero) = FEq).
 
-Check (eq_refl : zero =? - zero = true).
-Check (eq_refl : - zero =? zero = true).
+Check (eq_refl : (zero =? - zero) = true).
+Check (eq_refl : (- zero =? zero) = true).
 
-Check (eq_refl : zero <? - zero = false).
-Check (eq_refl : - zero <? zero = false).
+Check (eq_refl : (zero <? - zero) = false).
+Check (eq_refl : (- zero <? zero) = false).
 
-Check (eq_refl : zero <=? - zero = true).
-Check (eq_refl : - zero <=? zero = true).
+Check (eq_refl : (zero <=? - zero) = true).
+Check (eq_refl : (- zero <=? zero) = true).
 
-Check (eq_refl : zero ?= - zero = FEq).
-Check (eq_refl : - zero ?= zero = FEq).
+Check (eq_refl : (zero ?= - zero) = FEq).
+Check (eq_refl : (- zero ?= zero) = FEq).
 
-Check (eq_refl : - zero =? - zero = true).
-Check (eq_refl : - zero =? - zero = true).
+Check (eq_refl : (- zero =? - zero) = true).
+Check (eq_refl : (- zero =? - zero) = true).
 
-Check (eq_refl : - zero <? - zero = false).
-Check (eq_refl : - zero <? - zero = false).
+Check (eq_refl : (- zero <? - zero) = false).
+Check (eq_refl : (- zero <? - zero) = false).
 
-Check (eq_refl : - zero <=? - zero = true).
-Check (eq_refl : - zero <=? - zero = true).
+Check (eq_refl : (- zero <=? - zero) = true).
+Check (eq_refl : (- zero <=? - zero) = true).
 
-Check (eq_refl : - zero ?= - zero = FEq).
-Check (eq_refl : - zero ?= - zero = FEq).
+Check (eq_refl : (- zero ?= - zero) = FEq).
+Check (eq_refl : (- zero ?= - zero) = FEq).
 
-Check (eq_refl : infinity =? infinity = true).
-Check (eq_refl : infinity =? infinity = true).
+Check (eq_refl : (infinity =? infinity) = true).
+Check (eq_refl : (infinity =? infinity) = true).
 
-Check (eq_refl : infinity <? infinity = false).
-Check (eq_refl : infinity <? infinity = false).
+Check (eq_refl : (infinity <? infinity) = false).
+Check (eq_refl : (infinity <? infinity) = false).
 
-Check (eq_refl : infinity <=? infinity = true).
-Check (eq_refl : infinity <=? infinity = true).
+Check (eq_refl : (infinity <=? infinity) = true).
+Check (eq_refl : (infinity <=? infinity) = true).
 
-Check (eq_refl : infinity ?= infinity = FEq).
-Check (eq_refl : infinity ?= infinity = FEq).
+Check (eq_refl : (infinity ?= infinity) = FEq).
+Check (eq_refl : (infinity ?= infinity) = FEq).
 
-Check (eq_refl : - infinity =? - infinity = true).
-Check (eq_refl : - infinity =? - infinity = true).
+Check (eq_refl : (- infinity =? - infinity) = true).
+Check (eq_refl : (- infinity =? - infinity) = true).
 
-Check (eq_refl : - infinity <? - infinity = false).
-Check (eq_refl : - infinity <? - infinity = false).
+Check (eq_refl : (- infinity <? - infinity) = false).
+Check (eq_refl : (- infinity <? - infinity) = false).
 
-Check (eq_refl : - infinity <=? - infinity = true).
-Check (eq_refl : - infinity <=? - infinity = true).
+Check (eq_refl : (- infinity <=? - infinity) = true).
+Check (eq_refl : (- infinity <=? - infinity) = true).
 
-Check (eq_refl : - infinity ?= - infinity = FEq).
-Check (eq_refl : - infinity ?= - infinity = FEq).
+Check (eq_refl : (- infinity ?= - infinity) = FEq).
+Check (eq_refl : (- infinity ?= - infinity) = FEq).
 
-Check (eq_refl : min_denorm =? min_norm = false).
-Check (eq_refl : min_norm =? min_denorm = false).
+Check (eq_refl : (min_denorm =? min_norm) = false).
+Check (eq_refl : (min_norm =? min_denorm) = false).
 
-Check (eq_refl : min_denorm <? min_norm = true).
-Check (eq_refl : min_norm <? min_denorm = false).
+Check (eq_refl : (min_denorm <? min_norm) = true).
+Check (eq_refl : (min_norm <? min_denorm) = false).
 
-Check (eq_refl : min_denorm <=? min_norm = true).
-Check (eq_refl : min_norm <=? min_denorm = false).
+Check (eq_refl : (min_denorm <=? min_norm) = true).
+Check (eq_refl : (min_norm <=? min_denorm) = false).
 
-Check (eq_refl : min_denorm ?= min_norm = FLt).
-Check (eq_refl : min_norm ?= min_denorm = FGt).
+Check (eq_refl : (min_denorm ?= min_norm) = FLt).
+Check (eq_refl : (min_norm ?= min_denorm) = FGt).
 
-Check (eq_refl : min_denorm =? one = false).
-Check (eq_refl : one =? min_denorm = false).
+Check (eq_refl : (min_denorm =? one) = false).
+Check (eq_refl : (one =? min_denorm) = false).
 
-Check (eq_refl : min_denorm <? one = true).
-Check (eq_refl : one <? min_denorm = false).
+Check (eq_refl : (min_denorm <? one) = true).
+Check (eq_refl : (one <? min_denorm) = false).
 
-Check (eq_refl : min_denorm <=? one = true).
-Check (eq_refl : one <=? min_denorm = false).
+Check (eq_refl : (min_denorm <=? one) = true).
+Check (eq_refl : (one <=? min_denorm) = false).
 
-Check (eq_refl : min_denorm ?= one = FLt).
-Check (eq_refl : one ?= min_denorm = FGt).
+Check (eq_refl : (min_denorm ?= one) = FLt).
+Check (eq_refl : (one ?= min_denorm) = FGt).
 
-Check (eq_refl : min_norm =? one = false).
-Check (eq_refl : one =? min_norm = false).
+Check (eq_refl : (min_norm =? one) = false).
+Check (eq_refl : (one =? min_norm) = false).
 
-Check (eq_refl : min_norm <? one = true).
-Check (eq_refl : one <? min_norm = false).
+Check (eq_refl : (min_norm <? one) = true).
+Check (eq_refl : (one <? min_norm) = false).
 
-Check (eq_refl : min_norm <=? one = true).
-Check (eq_refl : one <=? min_norm = false).
+Check (eq_refl : (min_norm <=? one) = true).
+Check (eq_refl : (one <=? min_norm) = false).
 
-Check (eq_refl : min_norm ?= one = FLt).
-Check (eq_refl : one ?= min_norm = FGt).
+Check (eq_refl : (min_norm ?= one) = FLt).
+Check (eq_refl : (one ?= min_norm) = FGt).
 
-Check (eq_refl : one =? infinity = false).
-Check (eq_refl : infinity =? one = false).
+Check (eq_refl : (one =? infinity) = false).
+Check (eq_refl : (infinity =? one) = false).
 
-Check (eq_refl : one <? infinity = true).
-Check (eq_refl : infinity <? one = false).
+Check (eq_refl : (one <? infinity) = true).
+Check (eq_refl : (infinity <? one) = false).
 
-Check (eq_refl : one <=? infinity = true).
-Check (eq_refl : infinity <=? one = false).
+Check (eq_refl : (one <=? infinity) = true).
+Check (eq_refl : (infinity <=? one) = false).
 
-Check (eq_refl : one ?= infinity = FLt).
-Check (eq_refl : infinity ?= one = FGt).
+Check (eq_refl : (one ?= infinity) = FLt).
+Check (eq_refl : (infinity ?= one) = FGt).
 
-Check (eq_refl : - infinity =? infinity = false).
-Check (eq_refl : infinity =? - infinity = false).
+Check (eq_refl : (- infinity =? infinity) = false).
+Check (eq_refl : (infinity =? - infinity) = false).
 
-Check (eq_refl : - infinity <? infinity = true).
-Check (eq_refl : infinity <? - infinity = false).
+Check (eq_refl : (- infinity <? infinity) = true).
+Check (eq_refl : (infinity <? - infinity) = false).
 
-Check (eq_refl : - infinity <=? infinity = true).
-Check (eq_refl : infinity <=? - infinity = false).
+Check (eq_refl : (- infinity <=? infinity) = true).
+Check (eq_refl : (infinity <=? - infinity) = false).
 
-Check (eq_refl : - infinity ?= infinity = FLt).
-Check (eq_refl : infinity ?= - infinity = FGt).
+Check (eq_refl : (- infinity ?= infinity) = FLt).
+Check (eq_refl : (infinity ?= - infinity) = FGt).
 
-Check (eq_refl : - infinity =? one = false).
-Check (eq_refl : one =? - infinity = false).
+Check (eq_refl : (- infinity =? one) = false).
+Check (eq_refl : (one =? - infinity) = false).
 
-Check (eq_refl : - infinity <? one = true).
-Check (eq_refl : one <? - infinity = false).
+Check (eq_refl : (- infinity <? one) = true).
+Check (eq_refl : (one <? - infinity) = false).
 
-Check (eq_refl : - infinity <=? one = true).
-Check (eq_refl : one <=? - infinity = false).
+Check (eq_refl : (- infinity <=? one) = true).
+Check (eq_refl : (one <=? - infinity) = false).
 
-Check (eq_refl : - infinity ?= one = FLt).
-Check (eq_refl : one ?= - infinity = FGt).
+Check (eq_refl : (- infinity ?= one) = FLt).
+Check (eq_refl : (one ?= - infinity) = FGt).

--- a/test-suite/primitive/float/gen_compare.sh
+++ b/test-suite/primitive/float/gen_compare.sh
@@ -28,8 +28,8 @@ genTest() {
         op="${OPS[$i]}"
         op1="${OPS1[$i]}"
         op2="${OPS2[$i]}"
-        echo "Check (eq_refl : $x $op $y = $op1)."
-        echo "Check (eq_refl : $y $op $x = $op2)."
+        echo "Check (eq_refl : ($x $op $y) = $op1)."
+        echo "Check (eq_refl : ($y $op $x) = $op2)."
         echo
     done
 }

--- a/test-suite/ssr/intro_noop.v
+++ b/test-suite/ssr/intro_noop.v
@@ -16,10 +16,10 @@ Axiom daemon : False. Ltac myadmit := case: daemon.
 
 Lemma v : True -> bool -> bool. Proof. by []. Qed.
 
-Reserved Notation " a -/ b " (at level 0).
-Reserved Notation " a -// b " (at level 0).
-Reserved Notation " a -/= b " (at level 0).
-Reserved Notation " a -//= b " (at level 0).
+Reserved Notation " a -/ b " (at level 1).
+Reserved Notation " a -// b " (at level 1).
+Reserved Notation " a -/= b " (at level 1).
+Reserved Notation " a -//= b " (at level 1).
 
 Lemma test : forall a b c, a || b || c.
 Proof.

--- a/test-suite/ssr/ipat_tac.v
+++ b/test-suite/ssr/ipat_tac.v
@@ -23,7 +23,7 @@ Qed.
 
 Ltac unfld what := rewrite /what.
 
-Notation "% n" := (ltac:( unfld n )) (at level 0) : ssripat_scope.
+Notation "% n" := (ltac:( unfld n )) (at level 1) : ssripat_scope.
 Notation "% n" := n : nat_scope.
 
 Open Scope nat_scope.

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -164,7 +164,7 @@ Notation "####" := 0 (in custom foo2).
 
 Module M17.
 
-Notation "# x ## t & u" := ((fun x => (x,t)),(fun x => (x,u))) (at level 0, x pattern).
+Notation "# x ## t & u" := ((fun x => (x,t)),(fun x => (x,u))) (at level 1, x pattern).
 Check fun y : nat => # (x,z) ## y & y.
 
 End M17.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -174,7 +174,7 @@ Generalizable All Variables.
 
 Module mon.
 
-Reserved Notation "'return' t" (at level 0).
+Reserved Notation "'return' t" (at level 1).
 Reserved Notation "x >>= y" (at level 65, left associativity).
 
 

--- a/test-suite/success/coercions.v
+++ b/test-suite/success/coercions.v
@@ -150,7 +150,7 @@ Module TestPropAsSourceCoercion.
 
   Parameter hstar : hprop -> hprop -> hprop.
 
-  Notation "H1 \* H2" := (hstar H1 H2) (at level 69).
+  Notation "H1 \* H2" := (hstar H1 H2) (at level 69, left associativity).
 
   Definition test := heap_single 4 5 \* (5 <> 4) \* heap_single 2 4 \* (True).
 

--- a/vernac/egramrocq.ml
+++ b/vernac/egramrocq.ml
@@ -82,6 +82,7 @@ let save_levels levels custom lev =
 let admissible_assoc = function
   | Gramlib.Gramext.LeftA, Some (Gramlib.Gramext.RightA | Gramlib.Gramext.NonA) -> false
   | Gramlib.Gramext.RightA, Some Gramlib.Gramext.LeftA -> false
+  | Gramlib.Gramext.BothA, _ | _, Some Gramlib.Gramext.BothA -> assert false
   | _ -> true
 
 let create_assoc = function
@@ -201,6 +202,7 @@ let camlp5_assoc =
   let open Gramlib.Gramext in function
     | Some NonA | Some RightA -> RightA
     | None | Some LeftA -> LeftA
+    | Some BothA -> assert false
 
 let assoc_eq al ar =
   let open Gramlib.Gramext in
@@ -208,6 +210,7 @@ let assoc_eq al ar =
   | NonA, NonA
   | RightA, RightA
   | LeftA, LeftA -> true
+  | BothA, _ | _, BothA -> assert false
   | _, _ -> false
 
 (** [adjust_level assoc fromlev prod] where [assoc] and [fromlev] are the name
@@ -249,6 +252,7 @@ let adjust_level custom assoc {notation_entry = custom'; notation_level = fromle
 (* Compute production name elsewhere *)
   | (NumLevel n,InternalProd) ->
     if fromlev = n + 1 then NextLevel else NumLevel n
+  | (_,BorderProd (_,Some BothA)) -> assert false
 
 type _ target =
 | ForConstr : constr_expr target

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -364,7 +364,8 @@ let precedence_of_position_and_level from_level = function
      | RightA, Right -> LevelLe n
      | LeftA, Left -> LevelLe n
      | LeftA, Right -> LevelLt n
-     | NonA, _ -> LevelLt n in
+     | NonA, _ -> LevelLt n
+     | BothA, _ -> assert false in
     {notation_subentry = InConstrEntry; notation_relative_level = prec; notation_position = Some b}
   | NumLevel n, b -> {notation_subentry = InConstrEntry; notation_relative_level = LevelLe n; notation_position = side b}
   | NextLevel, b -> {notation_subentry = InConstrEntry; notation_relative_level = LevelLt from_level; notation_position = side b}

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -500,6 +500,7 @@ let pr_syntax_modifier = let open Gramlib.Gramext in CAst.with_val (function
       prlist_with_sep sep_v2 str l ++ spc () ++ str"in scope" ++ str s
     | SetLevel n -> pr_at_level (NumLevel n)
     | SetCustomEntry (s,n) -> keyword "in" ++ spc() ++ keyword "custom" ++ spc() ++ pr_qualid s ++ (match n with None -> mt () | Some n -> pr_at_level (NumLevel n))
+    | SetAssoc BothA -> assert false
     | SetAssoc LeftA -> keyword "left associativity"
     | SetAssoc RightA -> keyword "right associativity"
     | SetAssoc NonA -> keyword "no associativity"


### PR DESCRIPTION
This PR is a follow-up of the discussion in #21072, initially started by #21029. This can also be seen as the continuation of the work started in #17876. In particular, this PR provides proper support for non-associativity and fixes leniency in right-associativity (namely that the left component recognizes the non-recursive part of the same level instead of the next level only).

~Depends on: https://github.com/rocq-prover/rocq/pull/21244~ (merged)

#### Overlays (to be merged before the current PR)

* [x] https://github.com/math-comp/math-comp/pull/1490
* [x] https://github.com/rocq-prover/stdlib/pull/222

#### Overlays (to be merged in sync with the current PR)

* [x] https://github.com/uds-psl/autosubst-ocaml/pull/31
* [x] https://github.com/ejgallego/rocq-lsp/pull/1063