### PR TITLE
Minor enhancement to the ci-reset script.

### DIFF
--- a/dev/ci/ci-reset.sh
+++ b/dev/ci/ci-reset.sh
@@ -15,10 +15,18 @@ git_reset()
   local ref_var="${project}_CI_REF"
   local ref="${!ref_var}"
 
+  # Check whether it may be a submodule
+  if [ -z "$ref" ]; then
+    ref_var="${project}_CI_SUBMODULE_BRANCH"
+    ref="${!ref_var}"
+  fi
+
   echo "Resetting $project..."
 
   if [ ! -d "$dest" ]; then
     echo "Warning: reset of $project skipped because $dest does not exist."
+  else if [ -z "$ref" ]; then
+    echo "Warning: reset of $project skipped as no branch could be found."
   else
     # TODO: properly handle submodules
     pushd "$dest" > /dev/null
@@ -29,8 +37,17 @@ git_reset()
       git checkout $ref --quiet
       git reset --hard "origin/$ref" --quiet
       echo "$project reset to $ref ($ref_hash)"
+    else if [ $(git rev-parse --verify --quiet "$ref") ]; then
+    # if the reference is a hash just check it out
+      git reset --hard --quiet
+      git checkout $ref --quiet
+      echo "$project reset to $ref"
+    else
+      echo "Warning: reset of $project skipped as $ref is not valid reference."
+    fi
     fi
     popd > /dev/null
+  fi
   fi
 }
 


### PR DESCRIPTION
We handle submodules a bit more nicely, and we also support direct references as hashes rather than branches.

This stdpp/iris ecosystem still needs special handling because it does not rely on git references directly.