### PR TITLE
Stop using auto with * in intuition solver.

### DIFF
--- a/doc/changelog/04-tactics/21129-intuition-stop-using-auto-with-star-Removed.rst
+++ b/doc/changelog/04-tactics/21129-intuition-stop-using-auto-with-star-Removed.rst
@@ -1,0 +1,6 @@
+- **Removed:**
+  the implicit call to `auto with *` in intuition solver, that
+  was deprecated since 8.17
+  (`#21129 <https://github.com/rocq-prover/rocq/pull/21129>`_,
+  fixes `#4949 <https://github.com/rocq-prover/rocq/issues/4949>`_,
+  by Pierre-Marie Pédrot).

--- a/theories/Corelib/Init/Tauto.v
+++ b/theories/Corelib/Init/Tauto.v
@@ -105,9 +105,7 @@ Local Ltac tauto_gen flags := tauto_intuitionistic flags || tauto_classical flag
 Ltac tauto := with_uniform_flags ltac:(fun flags => tauto_gen flags).
 Ltac dtauto := with_power_flags ltac:(fun flags => tauto_gen flags).
 
-Ltac intuition_solver :=
-  first [solve [auto]
-        | tryif solve [auto with *] then warn_auto_with_star else idtac].
+Ltac intuition_solver := auto.
 
 Local Ltac intuition_then tac := with_uniform_flags ltac:(fun flags => intuition_gen flags tac).
 Ltac intuition := intuition_then ltac:(idtac;intuition_solver).


### PR DESCRIPTION
This started to spit a warning from 8.17 onwards, it is probably time to get rid of this dubious behaviour.

Fixes #4949: [intuition] should not use [auto with *] by default.

Backwards compatible overlays:
- https://github.com/mit-plv/bbv/pull/54
- https://github.com/rocq-community/coq-ext-lib/pull/156
- https://github.com/jwiegley/category-theory/pull/165
- https://github.com/smtcoq/smtcoq/pull/156
- https://github.com/rocq-community/math-classes/pull/140
- https://github.com/MetaRocq/metarocq/pull/1206
- https://github.com/mit-plv/fiat/pull/125
- https://github.com/rocq-community/corn/pull/220
- https://github.com/liyishuai/coq-http/pull/7
- https://github.com/adampetcher/fcf/pull/50
- https://github.com/mit-plv/cross-crypto/pull/41

