### PR TITLE
Use user name equality in checker rtree test.

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -148,7 +148,7 @@ let check_squashed orig generated = match orig, generated with
    Try with to see test-suite/coqchk/include.v *)
 let eq_recarg_type ty1 ty2 = match ty1, ty2 with
   | RecArgInd ind1, RecArgInd ind2 -> eq_ind_chk ind1 ind2
-  | RecArgPrim c1, RecArgPrim c2 -> Names.Constant.CanOrd.equal c1 c2
+  | RecArgPrim c1, RecArgPrim c2 -> Names.Constant.UserOrd.equal c1 c2
   | (RecArgInd _ | RecArgPrim _), _ -> false
 
 let eq_recarg r1 r2 = match r1, r2 with


### PR DESCRIPTION
The use of canonical equality was doubly wrong. First, this test is only to check that the recomputation of an inductive block by the checker is the same as the original one, so the translation process should never introduce module aliases. Second, this precise check only occurs whenever nesting primitive arrays, and anybody coming up with a inductive type nesting over aliased primitive arrays and expecting it to be fine should seriously reconsider their life choices.