### PR TITLE
Proper error for projection type mismatch in Typeops.

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -275,6 +275,7 @@ let explain_exn = function
       | NumberBranches _ -> str"NumberBranches"
       | IllFormedBranch _ -> str"IllFormedBranch"
       | IllFormedCaseParams -> str "IllFormedCaseParams"
+      | BadProjType _ -> str "BadProjType"
       | Generalization _ -> str"Generalization"
       | ActualType _ -> str"ActualType"
       | IncorrectPrimitive _ -> str"IncorrectPrimitive"

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -62,6 +62,7 @@ type ('constr, 'types, 'r) ptype_error =
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
   | IllFormedCaseParams
   | IllFormedBranch of 'constr * pconstructor * 'constr * 'constr
+  | BadProjType of ('constr, 'types) punsafe_judgment * Projection.t
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
@@ -131,6 +132,9 @@ let error_number_branches env cj expn =
 
 let error_ill_formed_branch env c i actty expty =
   raise (TypeError (env, IllFormedBranch (c, i, actty, expty)))
+
+let error_bad_proj_type env cj p =
+  raise (TypeError (env, BadProjType (cj, p)))
 
 let error_generalization env nvar c =
   raise (TypeError (env, Generalization (nvar,c)))
@@ -225,6 +229,7 @@ let map_ptype_error fr f = function
 | WrongCaseInfo (pi, ci) -> WrongCaseInfo (pi, ci)
 | NumberBranches (j, n) -> NumberBranches (on_judgment f j, n)
 | IllFormedBranch (c, pc, t1, t2) -> IllFormedBranch (f c, pc, f t1, f t2)
+| BadProjType (j, p) -> BadProjType (on_judgment f j, p)
 | Generalization ((na, t), j) -> Generalization ((na, f t), on_judgment f j)
 | ActualType (j, t) -> ActualType (on_judgment f j, f t)
 | IncorrectPrimitive (p, t) -> IncorrectPrimitive ({p with uj_type=f p.uj_type}, f t)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -64,6 +64,7 @@ type ('constr, 'types, 'r) ptype_error =
   | NumberBranches of ('constr, 'types) punsafe_judgment * int
   | IllFormedCaseParams
   | IllFormedBranch of 'constr * pconstructor * 'constr * 'constr
+  | BadProjType of ('constr, 'types) punsafe_judgment * Projection.t
   | Generalization of (Name.t * 'types) * ('constr, 'types) punsafe_judgment
   | ActualType of ('constr, 'types) punsafe_judgment * 'types
   | IncorrectPrimitive of (CPrimitives.op_or_type,'types) punsafe_judgment * 'types
@@ -131,6 +132,8 @@ val error_number_branches : env -> unsafe_judgment -> int -> 'a
 val error_ill_formed_branch : env -> constr -> pconstructor -> constr -> constr -> 'a
 
 val error_generalization : env -> Name.t * types -> unsafe_judgment -> 'a
+
+val error_bad_proj_type : env -> unsafe_judgment -> Projection.t -> 'a
 
 val error_actual_type : env -> unsafe_judgment -> types -> 'a
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -579,7 +579,10 @@ let type_of_projection env p c ct =
     try find_rectype env ct
     with Not_found -> error_case_not_inductive env (make_judge c ct)
   in
-  assert(Ind.CanOrd.equal (Projection.inductive p) ind);
+  let () =
+    if not (Environ.QInd.equal env (Projection.inductive p) ind) then
+      error_bad_proj_type env (make_judge c ct) p
+  in
   let pr = UVars.subst_instance_relevance u pr in
   let ty = Vars.subst_instance_constr u pty in
   pr, substl (c :: CList.rev args) ty

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -333,6 +333,14 @@ let explain_ill_formed_branch env sigma c ci actty expty =
   spc () ++ str "has type" ++ brk(1,1) ++ pa ++ spc () ++
   str "which should be" ++ brk(1,1) ++ pe ++ str "."
 
+let explain_bad_proj_type env sigma cj p =
+  let pc = pr_leconstr_env env sigma cj.uj_val in
+  let pct = pr_leconstr_env env sigma cj.uj_type in
+  let rcd = pr_global (GlobRef.IndRef (Projection.inductive p)) in
+  str "The term" ++ brk(1,1) ++ pc ++ spc () ++
+  str "has type" ++ brk(1,1) ++ pct ++ spc () ++
+  str "which is not an instance of record type " ++ rcd ++ str "."
+
 let explain_generalization env sigma (name,var) j =
   let pe = pr_ne_context_of (str "In environment") env sigma in
   let pv = pr_letype_env env sigma var in
@@ -981,6 +989,8 @@ let explain_type_error env sigma err =
   | IllFormedCaseParams -> explain_ill_formed_case_params env sigma
   | IllFormedBranch (c, i, actty, expty) ->
       explain_ill_formed_branch env sigma c i actty expty
+  | BadProjType (cj, p) ->
+    explain_bad_proj_type env sigma cj p
   | Generalization (nvar, c) ->
       explain_generalization env sigma nvar c
   | ActualType (j, pt) ->


### PR DESCRIPTION
The previous code was failing with an assertion failure, and furthermore relied on the canonical name mechanism. This assert could be trigger with handcrafted terms, so we introduce a proper error message for this case.