### PR TITLE
Remove Constr.isRefX from the API.

### DIFF
--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -220,15 +220,6 @@ let isRef c = match kind c with
   | Const _ | Ind _ | Construct _ | Var _ -> true
   | _ -> false
 
-let isRefX x c =
-  let open GlobRef in
-  match x, kind c with
-  | ConstRef c, Const (c', _) -> Constant.CanOrd.equal c c'
-  | IndRef i, Ind (i', _) -> Ind.CanOrd.equal i i'
-  | ConstructRef i, Construct (i', _) -> Construct.CanOrd.equal i i'
-  | VarRef id, Var id' -> Id.equal id id'
-  | _ -> false
-
 (* Destructs a de Bruijn index *)
 let destRel c = match kind c with
   | Rel n -> n

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -310,7 +310,6 @@ val isRelN : int -> constr -> bool
 val isVar  : constr -> bool
 val isVarId : Id.t -> constr -> bool
 val isRef : constr -> bool
-val isRefX : GlobRef.t -> constr -> bool
 val isInd  : constr -> bool
 val isEvar : constr -> bool
 val isMeta : constr -> bool

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -943,7 +943,10 @@ let compute_case_signature env mind dep names_info =
   | Prod (_,t,c) ->
     let hd, _ = Constr.decompose_app t in
     (* no recursive call in case analysis *)
-    let arg = if Constr.isRefX indref hd then RecArg else OtherArg in
+    let arg = match Constr.kind hd with
+    | Ind (ind, _) when Environ.QInd.equal env mind ind -> RecArg
+    | _ -> OtherArg
+    in
     (arg, true, not (CVars.noccurn 1 c)) :: check_branch c
   | LetIn (_,_,_,c) ->
     (OtherArg, false, not (CVars.noccurn 1 c)) :: check_branch c


### PR DESCRIPTION
It is only used in a single place in our codebase, for what seems not to be a great reason, and relies on canonical equality.