### PR TITLE
Use user equality in comparison of native values.

### DIFF
--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -107,11 +107,11 @@ type gname =
 let eq_gname gn1 gn2 =
   match gn1, gn2 with
   | Gind (s1, ind1), Gind (s2, ind2) ->
-     String.equal s1 s2 && Ind.CanOrd.equal ind1 ind2
+     String.equal s1 s2 && Ind.UserOrd.equal ind1 ind2
   | Gconstant (s1, c1), Gconstant (s2, c2) ->
-      String.equal s1 s2 && Constant.CanOrd.equal c1 c2
+      String.equal s1 s2 && Constant.UserOrd.equal c1 c2
   | Gproj (s1, ind1, i1), Gproj (s2, ind2, i2) ->
-    String.equal s1 s2 && Ind.CanOrd.equal ind1 ind2 && Int.equal i1 i2
+    String.equal s1 s2 && Ind.UserOrd.equal ind1 ind2 && Int.equal i1 i2
   | Gcase (None, i1), Gcase (None, i2) -> Int.equal i1 i2
   | Gcase (Some l1, i1), Gcase (Some l2, i2) -> Int.equal i1 i2 && Label.equal l1 l2
   | Gpred (None, i1), Gpred (None, i2) -> Int.equal i1 i2
@@ -138,9 +138,9 @@ open Hashset.Combine
 
 let gname_hash gn = match gn with
 | Gind (s, ind) ->
-   combinesmall 1 (combine (String.hash s) (Ind.CanOrd.hash ind))
+   combinesmall 1 (combine (String.hash s) (Ind.UserOrd.hash ind))
 | Gconstant (s, c) ->
-   combinesmall 2 (combine (String.hash s) (Constant.CanOrd.hash c))
+   combinesmall 2 (combine (String.hash s) (Constant.UserOrd.hash c))
 | Gcase (l, i) -> combinesmall 3 (combine (Option.hash Label.hash l) (Int.hash i))
 | Gpred (l, i) -> combinesmall 4 (combine (Option.hash Label.hash l) (Int.hash i))
 | Gfixtype (l, i) -> combinesmall 5 (combine (Option.hash Label.hash l) (Int.hash i))
@@ -149,7 +149,7 @@ let gname_hash gn = match gn with
 | Ginternal s -> combinesmall 8 (String.hash s)
 | Grel i -> combinesmall 9 (Int.hash i)
 | Gnamed id -> combinesmall 10 (Id.hash id)
-| Gproj (s, p, i) -> combinesmall 11 (combine (String.hash s) (combine (Ind.CanOrd.hash p) i))
+| Gproj (s, p, i) -> combinesmall 11 (combine (String.hash s) (combine (Ind.UserOrd.hash p) i))
 
 let case_ctr = ref (-1)
 
@@ -181,6 +181,16 @@ let fresh_gnormtbl l =
   incr normtbl_ctr;
   Gnormtbl (l,!normtbl_ctr)
 
+(* We compare only what is relevant for generation of ml code *)
+let eq_annot_sw asw1 asw2 =
+  Ind.UserOrd.equal asw1.asw_ind asw2.asw_ind &&
+  String.equal asw1.asw_prefix asw2.asw_prefix
+
+open Hashset.Combine
+
+let hash_annot_sw asw =
+  combine (Ind.UserOrd.hash asw.asw_ind) (String.hash asw.asw_prefix)
+
 (** Symbols (pre-computed values) **)
 
 let eq_symbol sy1 sy2 =
@@ -188,12 +198,12 @@ let eq_symbol sy1 sy2 =
   | SymbValue v1, SymbValue v2 -> (=) v1 v2 (** FIXME: how is this even valid? *)
   | SymbSort s1, SymbSort s2 -> Sorts.equal s1 s2
   | SymbName n1, SymbName n2 -> Name.equal n1 n2
-  | SymbConst kn1, SymbConst kn2 -> Constant.CanOrd.equal kn1 kn2
+  | SymbConst kn1, SymbConst kn2 -> Constant.UserOrd.equal kn1 kn2
   | SymbMatch sw1, SymbMatch sw2 -> eq_annot_sw sw1 sw2
-  | SymbInd ind1, SymbInd ind2 -> Ind.CanOrd.equal ind1 ind2
+  | SymbInd ind1, SymbInd ind2 -> Ind.UserOrd.equal ind1 ind2
   | SymbEvar evk1, SymbEvar evk2 -> Evar.equal evk1 evk2
   | SymbInstance u1, SymbInstance u2 -> UVars.Instance.equal u1 u2
-  | SymbProj (i1, k1), SymbProj (i2, k2) -> Ind.CanOrd.equal i1 i2 && Int.equal k1 k2
+  | SymbProj (i1, k1), SymbProj (i2, k2) -> Ind.UserOrd.equal i1 i2 && Int.equal k1 k2
 
   | (SymbValue _
     | SymbSort _
@@ -212,12 +222,12 @@ let hash_symbol symb =
   | SymbValue v -> combinesmall 1 (Hashtbl.hash v) (** FIXME *)
   | SymbSort s -> combinesmall 2 (Sorts.hash s)
   | SymbName name -> combinesmall 3 (Name.hash name)
-  | SymbConst c -> combinesmall 4 (Constant.CanOrd.hash c)
+  | SymbConst c -> combinesmall 4 (Constant.UserOrd.hash c)
   | SymbMatch sw -> combinesmall 5 (hash_annot_sw sw)
-  | SymbInd ind -> combinesmall 6 (Ind.CanOrd.hash ind)
+  | SymbInd ind -> combinesmall 6 (Ind.UserOrd.hash ind)
   | SymbEvar evk -> combinesmall 7 (Evar.hash evk)
   | SymbInstance u -> combinesmall 8 (UVars.Instance.hash u)
-  | SymbProj (i, k) -> combinesmall 9 (combine (Ind.CanOrd.hash i) k)
+  | SymbProj (i, k) -> combinesmall 9 (combine (Ind.UserOrd.hash i) k)
 
 module HashedTypeSymbol = struct
   type t = symbol
@@ -562,7 +572,7 @@ let rec eq_mllambda gn1 gn2 n env1 env2 t1 t2 =
       eq_mllam_branches gn1 gn2 n env1 env2 br1 br2
   | MLconstruct (pf1, ind1, tag1, args1), MLconstruct (pf2, ind2, tag2, args2) ->
       String.equal pf1 pf2 &&
-      Ind.CanOrd.equal ind1 ind2 &&
+      Ind.UserOrd.equal ind1 ind2 &&
       Int.equal tag1 tag2 &&
       Array.equal (eq_mllambda gn1 gn2 n env1 env2) args1 args2
   | MLint i1, MLint i2 ->
@@ -583,7 +593,7 @@ let rec eq_mllambda gn1 gn2 n env1 env2 t1 t2 =
       Array.equal (eq_mllambda gn1 gn2 n env1 env2) arr1 arr2
 
   | MLisaccu (s1, ind1, ml1), MLisaccu (s2, ind2, ml2) ->
-    String.equal s1 s2 && Ind.CanOrd.equal ind1 ind2 &&
+    String.equal s1 s2 && Ind.UserOrd.equal ind1 ind2 &&
     eq_mllambda gn1 gn2 n env1 env2 ml1 ml2
   | (MLlocal _ | MLglobal _ | MLprimitive _ | MLlam _ | MLletrec _ | MLlet _ |
     MLapp _ | MLif _ | MLmatch _ | MLconstruct _ | MLint _ | MLuint _ |
@@ -656,7 +666,7 @@ let rec hash_mllambda gn n env t =
       combinesmall 9 (hash_mllam_branches gn n env (combine3 hannot hc haccu) br)
   | MLconstruct (pf, ind, tag, args) ->
       let hpf = String.hash pf in
-      let hcs = Ind.CanOrd.hash ind in
+      let hcs = Ind.UserOrd.hash ind in
       let htag = Int.hash tag in
       combinesmall 10 (hash_mllambda_array gn n env (combine3 hpf hcs htag) args)
   | MLint i ->
@@ -674,7 +684,7 @@ let rec hash_mllambda gn n env t =
   | MLarray arr ->
       combinesmall 15 (hash_mllambda_array gn n env 1 arr)
   | MLisaccu (s, ind, c) ->
-      combinesmall 16 (combine (String.hash s) (combine (Ind.CanOrd.hash ind) (hash_mllambda gn n env c)))
+      combinesmall 16 (combine (String.hash s) (combine (Ind.UserOrd.hash ind) (hash_mllambda gn n env c)))
   | MLfloat f ->
       combinesmall 17 (Float64.hash f)
   | MLstring s ->
@@ -825,7 +835,7 @@ let eq_global g1 g2 =
       eq_mllambda gn1 gn2 (Array.length lns1) env1 env2 t1 t2
   | Gopen s1, Gopen s2 -> String.equal s1 s2
   | Gtype (ind1, arr1), Gtype (ind2, arr2) ->
-    Ind.CanOrd.equal ind1 ind2 &&
+    Ind.UserOrd.equal ind1 ind2 &&
     Array.equal (fun (tag1,ar1) (tag2,ar2) -> Int.equal tag1 tag2 && Int.equal ar1 ar2) arr1 arr2
   | Gcomment s1, Gcomment s2 -> String.equal s1 s2
   | _, _ -> false
@@ -862,7 +872,7 @@ let hash_global g =
     let hash_aux acc (tag,ar) =
       combine3 acc (Int.hash tag) (Int.hash ar)
     in
-    combinesmall 7 (combine (Ind.CanOrd.hash ind) (Array.fold_left hash_aux 0 arr))
+    combinesmall 7 (combine (Ind.UserOrd.hash ind) (Array.fold_left hash_aux 0 arr))
   | Gcomment s -> combinesmall 8 (String.hash s)
 
 let global_stack = ref ([] : global list)

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -63,16 +63,6 @@ type annot_sw = {
     asw_prefix : string
   }
 
-(* We compare only what is relevant for generation of ml code *)
-let eq_annot_sw asw1 asw2 =
-  Ind.CanOrd.equal asw1.asw_ind asw2.asw_ind &&
-  String.equal asw1.asw_prefix asw2.asw_prefix
-
-open Hashset.Combine
-
-let hash_annot_sw asw =
-  combine (Ind.CanOrd.hash asw.asw_ind) (String.hash asw.asw_prefix)
-
 type sort_annot = string * int
 
 type rec_pos = int array

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -39,10 +39,6 @@ type annot_sw = {
     asw_prefix : string
   }
 
-val eq_annot_sw : annot_sw -> annot_sw -> bool
-
-val hash_annot_sw : annot_sw -> int
-
 type sort_annot = string * int
 
 type rec_pos = int array


### PR DESCRIPTION
This is a slight change of semantics, since it means aliased constants will be compiled separately. In practice it probably doesn't matter because most aliased constants have a body that is exactly the constant they alias, so the only difference is that we will recompile definitions that have the same body up to aliasing. This should be very rare for native use cases though.