### PR TITLE
Bubble up the imperative registering of constants in proof APIs

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1935,8 +1935,11 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
            | FullState { Vernacstate.interp = { lemmas } } ->
                Option.iter PG_compat.unfreeze lemmas;
                PG_compat.with_current_proof (fun p ->
-                 feedback ~id:id Feedback.AddedAxiom;
-                 fst (Proof.solve (Global.env ()) Goal_select.SelectAll None tac p), ());
+                 let () = feedback ~id:id Feedback.AddedAxiom in
+                 let (pf, _) = Proof.solve (Global.env ()) Goal_select.SelectAll None tac p in
+                 (* XXX is it really necessary to register the effects here? *)
+                 let pf = Declare.Internal.register_side_effects pf in
+                 pf, ());
                (* STATE SPEC:
                 * - start: Modifies the input state adding a proof.
                 * - end  : maybe after recovery command.

--- a/vernac/comTactic.ml
+++ b/vernac/comTactic.ml
@@ -80,6 +80,7 @@ let solve_core ~pstate n ~info ?(with_end_tac=CAst.make false) t =
       let with_end_tac = use_end_tac ~with_end_tac etac in
       let info = Option.append info (print_info_trace ()) in
       let (p,status) = Proof.solve (Global.env ()) n info t ?with_end_tac p in
+      let p = Declare.Internal.register_side_effects p in
       (* in case a strict subtree was completed,
          go back to the top of the prooftree *)
       let p = Proof.maximal_unfocus Vernacentries.command_focus p in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2200,7 +2200,7 @@ let build_constant_by_tactic ~name ?warn_incomplete ~sigma ~env ~sign ~poly (typ
   let info = Info.make ~poly () in
   let pinfo = Proof_info.make ~cinfo ~info () in
   let pf = start_proof_core ~name ~pinfo sigma [Some sign, typ] in
-  let pf, status = by env tac pf in
+  let pf, status = map_fold ~f:(Proof.solve env (Goal_select.select_nth 1) None tac) pf in
   let proof = close_proof ?warn_incomplete ~keep_body_ucst_separate:false ~opaque:Vernacexpr.Transparent pf in
   let entries = process_proof ~info proof.proof_object in
   let { Proof.sigma } = Proof.data pf.proof in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -491,6 +491,19 @@ let export_side_effects eff =
   let export = get_roles export eff in
   List.iter register_side_effect export
 
+let register_side_effects pf =
+  (* TODO: factorize this with [register_side_effect] above *)
+  let open Names in
+  let eff = Evd.eval_side_effects (Proof.data pf).Proof.sigma in
+  let cst = Safe_typing.constants_of_private eff.Evd.seff_private in
+  let iter kn =
+    let gr = GlobRef.ConstRef kn in
+    let id = Label.to_id (Constant.label kn) in
+    let sp = Lib.make_path id in
+    Nametab.push (Nametab.Until 1) sp gr
+  in
+  List.iter iter cst
+
 let record_aux env s_ty s_bo =
   let open Environ in
   let in_ty = keep_hyps env s_ty in
@@ -841,6 +854,10 @@ module Internal = struct
   let objVariable = objVariable
 
   let export_side_effects = export_side_effects
+
+  let register_side_effects pf =
+    let () = register_side_effects pf in
+    pf
 
 end
 
@@ -1764,6 +1781,7 @@ end
 module Proof_ = Proof
 module Proof = struct
 
+type proof = Proof.t
 type nonrec closed_proof_output = closed_proof_output
 type proof_object = Proof_object.t
 
@@ -2172,7 +2190,9 @@ let update_sigma_univs ugraph p =
 let next = let n = ref 0 in fun () -> incr n; !n
 
 let by env tac pf =
-  map_fold ~f:(Proof.solve env (Goal_select.select_nth 1) None tac) pf
+  let pf, safe = map_fold ~f:(Proof.solve env (Goal_select.select_nth 1) None tac) pf in
+  let () = register_side_effects pf.proof in
+  pf, safe
 
 let build_constant_by_tactic ~name ?warn_incomplete ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
   let loc = fallback_loc ~warn:false name None in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -257,6 +257,7 @@ module Proof : sig
   val by : Environ.env -> unit Proofview.tactic -> t -> t * bool
 
   (** Operations on ongoing proofs *)
+  type proof = Proof.t
   val get : t -> Proof.t
   val get_name : t -> Names.Id.t
 
@@ -656,5 +657,7 @@ module Internal : sig
     one may need to declare them by hand, for example because the
     tactic was run as part of a command *)
   val export_side_effects : Evd.side_effects -> unit
+
+  val register_side_effects : Proof.proof -> Proof.proof
 
 end


### PR DESCRIPTION
Yet another small step towards untangling the abstract mess. We make some APIs purer by moving the globally imperative bits higher up. The two changes are the following:
- `Proof.solve` is now pure and does not register globally the seff constants in the nametab anymore. Callers we adapted accordingly.
- Similarly `Declare.build_constant_by_tactic` does not perform this registering, but in this case callers were not adapted since they're all ultimately called in a context that will register these constants.