### PR TITLE
CI don't print error summary for coq_tools

### DIFF
--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -56,7 +56,9 @@ if [ "$CI_NAME" != stdlib_test ]; then
   tools/make-one-time-file.py --real "$CI_NAME.log"
 fi
 
-if [ "$CI" ] && ! [ $code = 0 ]; then
+# don't print error summary for coq_tools as it gets spammy, and hides jason_msg
+# see eg https://gitlab.inria.fr/coq/coq/-/jobs/6292796
+if [ "$CI" ] && ! [ $code = 0 ] && [ "$CI_NAME" != coq_tools ]; then
   set +x
 
   escape_re=$(printf '\033%s' '\[[0-9;]+m')


### PR DESCRIPTION
At least with our current method it hides the nicer summary from coq_tools and the jason_msg, see eg https://gitlab.inria.fr/coq/coq/-/jobs/6292796