### PR TITLE
Index schemes by their user name in DeclareSchemes.

### DIFF
--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -10,10 +10,10 @@
 
 open Names
 
-let scheme_map = Summary.ref Indmap.empty ~name:"Schemes"
+let scheme_map = Summary.ref Indmap_env.empty ~name:"Schemes"
 
 let cache_one_scheme kind (ind,const) =
-  scheme_map := Indmap.update ind (function
+  scheme_map := Indmap_env.update ind (function
       | None -> Some (CString.Map.singleton kind const)
       | Some map -> Some (CString.Map.add kind const map))
       !scheme_map
@@ -38,6 +38,6 @@ let inScheme : Libobject.locality * (string * (inductive * Constant.t)) -> Libob
 let declare_scheme local kind indcl =
   Lib.add_leaf (inScheme (local,(kind,indcl)))
 
-let lookup_scheme kind ind = CString.Map.find kind (Indmap.find ind !scheme_map)
+let lookup_scheme kind ind = CString.Map.find kind (Indmap_env.find ind !scheme_map)
 
 let all_schemes () = !scheme_map

--- a/tactics/declareScheme.mli
+++ b/tactics/declareScheme.mli
@@ -12,4 +12,4 @@ open Names
 
 val declare_scheme : Libobject.locality -> string -> (inductive * Constant.t) -> unit
 val lookup_scheme : string -> inductive -> Constant.t
-val all_schemes : unit -> Constant.t CString.Map.t Indmap.t
+val all_schemes : unit -> Constant.t CString.Map.t Indmap_env.t

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -56,7 +56,7 @@ let kind_searcher env = Decls.(function
   | IsDefinition Scheme ->
     let schemes = DeclareScheme.all_schemes () in
     let schemes = lazy begin
-      Indmap.fold (fun _ schemes acc ->
+      Indmap_env.fold (fun _ schemes acc ->
           CString.Map.fold (fun _ c acc -> Cset.add c acc) schemes acc)
         schemes Cset.empty
     end

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -364,7 +364,7 @@ let print_registered_schemes () =
   let pr_schemes_of_ind (ind, schemes) =
     prlist_with_sep fnl (pr_one_scheme ind) (CString.Map.bindings schemes)
   in
-  hov 0 (prlist_with_sep fnl pr_schemes_of_ind (Indmap.bindings schemes))
+  hov 0 (prlist_with_sep fnl pr_schemes_of_ind (Indmap_env.bindings schemes))
 
 let dump_universes output g =
   let open Univ in


### PR DESCRIPTION
The previous code was using the canonical name instead, but this does not seem to be the naturally expected behaviour.