### PR TITLE
Properly handle `Timeout x Fail cmd`

### DIFF
--- a/dev/ci/user-overlays/21149-SkySkimmer-timeout-exns.sh
+++ b/dev/ci/user-overlays/21149-SkySkimmer-timeout-exns.sh
@@ -1,0 +1,5 @@
+overlay lean_importer https://github.com/SkySkimmer/rocq-lean-import timeout-exns 21149
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof timeout-exns 21149
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician timeout-exns 21149

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -74,7 +74,7 @@ module NonLogical : sig
 
   (** [try ... with ...] but restricted to {!Exception}. *)
   val catch : 'a t -> (Exninfo.iexn -> 'a t) -> 'a t
-  val timeout : float -> 'a t -> 'a option t
+  val timeout : float -> 'a t -> ('a, Exninfo.info) result t
 
   (** Construct a monadified side-effect. Exceptions raised by the argument are
       wrapped with {!Exception}. *)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1034,9 +1034,9 @@ let tclTIMEOUTF n t =
     let open Logic_monad.NonLogical in
     timeout n (Proof.repr (Proof.run t envvar initial)) >>= fun r ->
     match r with
-    | None -> return (Util.Inr (Logic_monad.Tac_Timeout, Exninfo.null))
-    | Some (Logic_monad.Nil e) -> return (Util.Inr e)
-    | Some (Logic_monad.Cons (r, _)) -> return (Util.Inl r)
+    | Error info -> return (Util.Inr (Logic_monad.Tac_Timeout, info))
+    | Ok (Logic_monad.Nil e) -> return (Util.Inr e)
+    | Ok (Logic_monad.Cons (r, _)) -> return (Util.Inl r)
   end >>= function
     | Util.Inl (res,s,m,i) ->
         Proof.set s >>

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -46,8 +46,6 @@ let user_err ?loc ?info strm =
   let info = Option.cata (Loc.add_loc info) info loc in
   Exninfo.iraise (UserError strm, info)
 
-exception Timeout = Control.Timeout
-
 (** Only anomalies should reach the bottom of the handler stack.
     In usual situation, the [handle_stack] is treated as it if was always
     non-empty with [print_anomaly] as its bottom handler. *)

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -38,8 +38,6 @@ val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> Pp.t -> 'a
 (** Main error raising primitive. [user_err ?loc pp] signals an
     error [pp] with optional header and location [loc] *)
 
-exception Timeout
-
 (** [register_handler h] registers [h] as a handler.
     When an expression is printed with [print e], it
     goes through all registered handles (the most

--- a/lib/control.mli
+++ b/lib/control.mli
@@ -24,13 +24,14 @@ val check_for_interrupt : unit -> unit
 (** Use this function as a potential yield function. If {!interrupt} has been
     set, il will raise [Sys.Break]. *)
 
-val timeout : float -> ('a -> 'b) -> 'a -> 'b option
-(** [timeout n f x] tries to compute [Some (f x)], and if it fails to do so
-    before [n] seconds, returns [None] instead. *)
+val timeout : float -> ('a -> 'b) -> 'a -> ('b, Exninfo.info) result
+(** [timeout n f x] tries to compute [Ok (f x)], and if it fails to do
+    so before [n] seconds, returns [Error info] instead (where [info]
+    contains the backtrace of the timeout exception). *)
 
 (** Set a particular timeout function; warning, this is an internal
    API and it is scheduled to go away. *)
-type timeout = { timeout : 'a 'b. float -> ('a -> 'b) -> 'a -> 'b option }
+type timeout = { timeout : 'a 'b. float -> ('a -> 'b) -> 'a -> ('b,Exninfo.info) result }
 val set_timeout : timeout -> unit
 
 (** [protect_sigalrm f x] computes [f x], but if SIGALRM is received during that

--- a/test-suite/output/bug_4900.out
+++ b/test-suite/output/bug_4900.out
@@ -1,0 +1,8 @@
+File "./output/bug_4900.v", line 1, characters 0-48:
+The command has indeed failed with message:
+Timeout!
+File "./output/bug_4900.v", line 2, characters 0-48:
+Error: Timeout!
+
+
+coqc exited with code 1

--- a/test-suite/output/bug_4900.v
+++ b/test-suite/output/bug_4900.v
@@ -1,0 +1,2 @@
+Fail Timeout 1 Check ltac:(repeat pose proof I).
+Timeout 1 Fail Check ltac:(repeat pose proof I).

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1679,7 +1679,7 @@ let explain_exn_default = function
   | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
   | Out_of_memory -> hov 0 (str "Out of memory.")
   | Stack_overflow -> hov 0 (str "Stack overflow.")
-  | CErrors.Timeout -> hov 0 (str "Timeout!")
+  | Control.Timeout -> hov 0 (str "Timeout!")
   | Sys.Break -> hov 0 (str "User interrupt.")
   (* Otherwise, not handled here *)
   | _ -> raise Unhandled

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1679,7 +1679,6 @@ let explain_exn_default = function
   | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
   | Out_of_memory -> hov 0 (str "Out of memory.")
   | Stack_overflow -> hov 0 (str "Stack overflow.")
-  | Control.Timeout -> hov 0 (str "Timeout!")
   | Sys.Break -> hov 0 (str "User interrupt.")
   (* Otherwise, not handled here *)
   | _ -> raise Unhandled

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -130,11 +130,11 @@ let with_timeout ~timeout:n f =
   check_timeout_f n;
   let start = Unix.gettimeofday () in
   begin match Control.timeout n f () with
-  | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+  | None -> Exninfo.iraise (Exninfo.capture Control.Timeout)
   | Some v ->
     let stop = Unix.gettimeofday () in
     let remaining = n -. (stop -. start) in
-    if remaining <= 0. then Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+    if remaining <= 0. then Exninfo.iraise (Exninfo.capture Control.Timeout)
     else Some (ControlTimeout { remaining }, v)
   end
 
@@ -152,7 +152,7 @@ let with_fail f : (Loc.t option * Pp.t, 'a) result =
   | e ->
     (* The error has to be printed in the failing state *)
     let _, info as exn = Exninfo.capture e in
-    if CErrors.is_anomaly e && e != CErrors.Timeout then Exninfo.iraise exn;
+    if CErrors.is_anomaly e && e != Control.Timeout then Exninfo.iraise exn;
     Ok (Loc.get_loc info, CErrors.iprint exn)
 
 type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -138,8 +138,8 @@ let with_timeout ~timeout:n f =
   check_timeout_f n;
   let start = Unix.gettimeofday () in
   begin match Control.timeout n f () with
-  | None -> Exninfo.iraise (CmdTimeout, snd (Exninfo.capture Control.Timeout))
-  | Some v ->
+  | Error info -> Exninfo.iraise (CmdTimeout, info)
+  | Ok v ->
     let stop = Unix.gettimeofday () in
     let remaining = n -. (stop -. start) in
     if remaining <= 0. then raise CmdTimeout

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -126,15 +126,23 @@ let fmt_profile to_file v =
     );
   fmt_profiling counters sums
 
+(* do not reuse Control.Timeout: once we hit the timeout handler the
+   exn becomes a regular, noncritical error *)
+exception CmdTimeout
+
+let () = CErrors.register_handler (function
+  | CmdTimeout -> Some Pp.(str "Timeout!")
+  | _ -> None)
+
 let with_timeout ~timeout:n f =
   check_timeout_f n;
   let start = Unix.gettimeofday () in
   begin match Control.timeout n f () with
-  | None -> Exninfo.iraise (Exninfo.capture Control.Timeout)
+  | None -> Exninfo.iraise (CmdTimeout, snd (Exninfo.capture Control.Timeout))
   | Some v ->
     let stop = Unix.gettimeofday () in
     let remaining = n -. (stop -. start) in
-    if remaining <= 0. then Exninfo.iraise (Exninfo.capture Control.Timeout)
+    if remaining <= 0. then raise CmdTimeout
     else Some (ControlTimeout { remaining }, v)
   end
 
@@ -148,11 +156,12 @@ let with_fail f : (Loc.t option * Pp.t, 'a) result =
     let x = f () in
     Error x
   with
-  (* Fail Timeout is a common pattern so we need to support it. *)
   | e ->
     (* The error has to be printed in the failing state *)
     let _, info as exn = Exninfo.capture e in
-    if CErrors.is_anomaly e && e != Control.Timeout then Exninfo.iraise exn;
+    (* Don't turn Sys.Break and anomalies into successes
+       NB: on windows Sys.Break is used instead of Control.Timeout *)
+    if e = Sys.Break || CErrors.is_anomaly e then Exninfo.iraise exn;
     Ok (Loc.get_loc info, CErrors.iprint exn)
 
 type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }

--- a/vernac/vernacControl.mli
+++ b/vernac/vernacControl.mli
@@ -43,3 +43,6 @@ val under_control : loc:Loc.t option ->
     command failed or [Succeed] where it succeeded).
 *)
 val after_last_phase : loc:Loc.t option -> _ control_entries -> bool
+
+(** Exposed so that waterproof can change the error message. *)
+exception CmdTimeout


### PR DESCRIPTION
Fix #4900

The error from timing out does not reuse the async, cricital exn
`Control.Timeout` and is instead a regular error
`vernacControl.CmdTimeout` (the `timeout` tactic already does
something like this with `Logic_monad.Tac_Timeout` BTW).

Overlays:
- https://github.com/rocq-community/rocq-lean-import/pull/42
- https://github.com/impermeable/coq-waterproof/pull/188
- https://github.com/coq-tactician/coq-tactician/pull/109