### PR TITLE
Refine the notation-incompatible-prefix warning

### DIFF
--- a/dev/ci/user-overlays/21159-proux01-refine-common-prefix.sh
+++ b/dev/ci/user-overlays/21159-proux01-refine-common-prefix.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/proux01/stdlib rocq21159 21159

--- a/doc/changelog/03-notations/21159-refine-common-prefix-Changed.rst
+++ b/doc/changelog/03-notations/21159-refine-common-prefix-Changed.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  the ``notation-incompatible-prefix`` no longer warns about
+  common prefixes followed by terminal symbols. For instance
+  ``"x #0`` and ``"x #0 #1"`` are not incompatible since our
+  parser isn't exactly LL1, considering successive terminal
+  symbols as a single token. Note that this change has an
+  impact on the default levels of such notations
+  (`#21159 <https://github.com/rocq-prover/rocq/pull/21159>`_,
+  by Pierre Roux).

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -36,7 +36,12 @@ let list_prefixes ntn =
          | Terminal s when String.equal s (Names.Id.to_string Notation_ops.ldots_var) -> 0, true
            (* the above is horribly hackish but we plan to rewrite recursive notations soon anyway *)
          | Terminal _ | SProdList _ | Break _ -> 0, inrec in
-       ([s], nt) :: List.map (fun (l, k) -> s :: l, k + nt) (aux inrec symbols) in
+       let q = List.map (fun (l, k) -> s :: l, k + nt) (aux inrec symbols) in
+       match s, symbols with
+       (* successive Terminal are considered at once by the parser,
+          don't list "'T1'" as prefix of "'T1' 'T2'" *)
+       | Terminal _, Terminal _ :: _ -> q
+       | _ -> ([s], nt) :: q in
   let entry, symbols = decompose_notation_key ntn in
   let symbols = match symbols with
     (* don't consider notations "{ _ ..." that have a special treatment *)

--- a/test-suite/output/notation_prefix_incompatible_level.out
+++ b/test-suite/output/notation_prefix_incompatible_level.out
@@ -1,8 +1,3 @@
-File "./output/notation_prefix_incompatible_level.v", line 4, characters 0-43:
-Warning: Notations "#0 #1" defined at level 30 and "#0 #1 #2"
-defined at level 40 have incompatible prefixes.
-One of them will likely not work.
-[notation-incompatible-prefix,parsing,default]
 File "./output/notation_prefix_incompatible_level.v", line 7, characters 0-63:
 Warning: Notations "#20 #21 _ #3 _" defined at level 50 with arguments constr
 at level 30 and "#20 #21 _ #34" defined at level 50 with arguments constr

--- a/test-suite/output/notation_prefix_incompatible_level.v
+++ b/test-suite/output/notation_prefix_incompatible_level.v
@@ -1,7 +1,7 @@
 Set Warnings "-closed-notation-not-level-0".
 
 Reserved Notation "#0 #1" (at level 30).
-Reserved Notation "#0 #1 #2" (at level 40).
+Reserved Notation "#0 #1 #2" (at level 40).  (* no warning, parser takes successive terminals at once *)
 
 Reserved Notation "#20 #21 x #3 y" (x at level 30, at level 50).
 Reserved Notation "#20 #21 x #34" (x at level 40, at level 50).

--- a/test-suite/output/notation_previous_prefix.out
+++ b/test-suite/output/notation_previous_prefix.out
@@ -1,6 +1,6 @@
-Notation "#0 #1 _" at level 30 with arguments constr at next level,
-no associativity.
-Notation "#0 #1 _" in foo at level 40 with arguments custom foo
+Notation "#0 _ #1 _" at level 30 with arguments constr at next level, constr
 at next level, no associativity.
+Notation "#0 _ #1 _" in foo at level 40 with arguments custom foo
+at next level, custom foo at next level, no associativity.
 Notation "#2 _ #3 _ #4 _" at level 30 with arguments constr at level 20,
 constr at level 25, constr at next level, no associativity.

--- a/test-suite/output/notation_previous_prefix.v
+++ b/test-suite/output/notation_previous_prefix.v
@@ -1,11 +1,11 @@
 Reserved Notation "#0 x" (at level 30).
-Reserved Notation "#0 #1 x".
-Print Notation "#0 #1 _".
+Reserved Notation "#0 x #1 y".
+Print Notation "#0 _ #1 _".
 
 Declare Custom Entry foo.
 Reserved Notation "#0 x" (in custom foo at level 40).
-Reserved Notation "#0 #1 x" (in custom foo).
-Print Notation "#0 #1 _" in custom foo.
+Reserved Notation "#0 x #1 y" (in custom foo).
+Print Notation "#0 _ #1 _" in custom foo.
 
 Reserved Notation "#2 x #3 y" (at level 30, x at level 20, y at level 25).
 Reserved Notation "#2 z #3 x #4 y".


### PR DESCRIPTION
Our parser is not exactly LL1 but considers successive terminal symbols as a single token, thus notations like "x #0" and "x #0 #1" can safely be put at different levels and we do not need to warn about them.

This follows a discussion in https://github.com/rocq-prover/stdlib/pull/210#discussion_r2399204915

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

#### Overlays (to be merged before the current PR)

- [x] https://github.com/math-comp/math-comp/pull/1477
- [x] https://github.com/math-comp/analysis/pull/1730

#### Overlays (to be merged in sync with the current PR)

- [x] https://github.com/rocq-prover/stdlib/pull/211

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
