### PR TITLE
parametrize typeclass interface by its DB of hints to allow the use of other DBs 

### DIFF
--- a/dev/ci/user-overlays/21161-tabareau-parametrize-typeclass_db-.sh
+++ b/dev/ci/user-overlays/21161-tabareau-parametrize-typeclass_db-.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/tabareau/coq-elpi parametrize-typeclass_db- 21161

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -12,8 +12,9 @@
 
 open Names
 open EConstr
+open Hints
 
-val typeclasses_db : string
+val typeclasses_db : hint_db_name
 
 val check_typeclasses_db : ?loc:Loc.t -> unit -> unit
 
@@ -55,14 +56,15 @@ val not_evar : constr -> unit Proofview.tactic
 
 val is_ground : constr -> unit Proofview.tactic
 
-val autoapply : constr -> Hints.hint_db_name -> unit Proofview.tactic
+val autoapply : constr -> hint_db_name -> unit Proofview.tactic
 
-val resolve_one_typeclass : Environ.env -> Evd.evar_map -> types -> Evd.evar_map * constr
+val resolve_one_typeclass : ?db:hint_db -> Environ.env -> Evd.evar_map -> types -> Evd.evar_map * constr
 (** Tries to find a solution for the given type. Raises Not_found it it fails. *)
 
 val resolve_tc : constr -> unit Proofview.tactic
 
 type solver = { solver :
+  ?db:hint_db ->
   Environ.env ->
   Evd.evar_map ->
   depth:int option ->

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -29,9 +29,13 @@ let warn_default_mode = CWarnings.create ~name:"class-declaration-default-mode" 
   Pp.(fun (gr, m) -> hov 2 (str "Using an inferred default mode: " ++ prlist_with_sep spc Hints.pp_hint_mode m ++
     spc () ++ str "for" ++ spc () ++ Printer.pr_global gr))
 
-let set_typeclass_transparency ~locality c b =
+let set_typeclass_transparency ?typeclasses_db ~locality c b =
+  let db_name = match typeclasses_db with
+  | None -> Class_tactics.typeclasses_db
+  | Some s -> s
+  in
   let () = check_typeclasses_db () in
-  Hints.add_hints ~locality [typeclasses_db]
+  Hints.add_hints ~locality [db_name]
     (Hints.HintsTransparencyEntry (Hints.HintsReferences c, b))
 
 let set_typeclass_transparency_com ~locality refs b =
@@ -43,12 +47,12 @@ let set_typeclass_transparency_com ~locality refs b =
   in
   set_typeclass_transparency ~locality refs b
 
-let set_typeclass_mode ~locality c b =
+let set_typeclass_mode ?(typeclasses_db=typeclasses_db) ~locality c b =
   let () = check_typeclasses_db () in
   Hints.add_hints ~locality [typeclasses_db]
     (Hints.HintsModeEntry (c, b))
 
-let add_instance_hint gr ~locality info =
+let add_instance_hint ?(typeclasses_db=typeclasses_db) gr ~locality info =
   let () = check_typeclasses_db () in
   Flags.silently (fun () ->
     Hints.add_hints ~locality [typeclasses_db]

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -104,7 +104,8 @@ val deactivate_observer : observer -> unit
 (** Setting opacity *)
 
 val set_typeclass_transparency
-  :  locality:Hints.hint_locality
+  :  ?typeclasses_db:Hints.hint_db_name ->
+     locality:Hints.hint_locality
   -> Evaluable.t list
   -> bool
   -> unit
@@ -116,7 +117,8 @@ val set_typeclass_transparency_com
   -> unit
 
 val set_typeclass_mode
-  :  locality:Hints.hint_locality
+  :  ?typeclasses_db:string ->
+     locality:Hints.hint_locality
   -> GlobRef.t
   -> Hints.hint_mode list
   -> unit


### PR DESCRIPTION
Functions like `resolve_one_typeclass` now accept an additional argument whose default is the typeclass_instances db.

This PR is helpful to use the typeclass mechanism for PR#21098 without being sensitive to the local content of typeclass_instances.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/901
