### PR TITLE
Ltac2: More forward compatible relevance API

### DIFF
--- a/doc/changelog/06-Ltac2-language/21162-tac2relevance-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21162-tac2relevance-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  module `Ltac2.Constr.Relevance` for APIs about proof relevance annotations
+  (`#21162 <https://github.com/rocq-prover/rocq/pull/21162>`_,
+  by Gaëtan Gilbert).

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -819,6 +819,14 @@ let () =
   EConstr.Unsafe.to_relevance na.binder_relevance
 
 let () =
+  define "constr_relevance_equal" (relevance @-> relevance @-> eret bool) @@ fun r1 r2 _ sigma ->
+  EConstr.ERelevance.(equal sigma (make r1) (make r2))
+
+let () = define "constr_relevance_relevant" (ret relevance) Sorts.Relevant
+
+let () = define "constr_relevance_irrelevant" (ret relevance) Sorts.Irrelevant
+
+let () =
   define "constr_has_evar" (constr @-> tac bool) @@ fun c ->
   Proofview.tclEVARMAP >>= fun sigma ->
   return (Evarutil.has_undefined_evars sigma c)


### PR DESCRIPTION
Eventually I think we want the relevance type to be abstract, for this we need equality test and constructors for relevance.

There is currently no API producing relevance_var so I didn't add a `relevance_var -> relevance` function.
