### PR TITLE
Attribute to control scheme declaration

### DIFF
--- a/dev/ci/user-overlays/21163-SkySkimmer-scheme-attr.sh
+++ b/dev/ci/user-overlays/21163-SkySkimmer-scheme-attr.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi scheme-attr 21163

--- a/doc/changelog/08-vernac-commands-and-options/21163-scheme-attr-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21163-scheme-attr-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  attribute :attr:`schemes` to control automatic scheme declaration
+  (`#21163 <https://github.com/rocq-prover/rocq/pull/21163>`_,
+  fixes `#19480 <https://github.com/rocq-prover/rocq/issues/19480>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1262,6 +1262,14 @@ Generation of induction principles with ``Scheme``
 Automatic declaration of schemes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. attr:: schemes = {| default | none }
+   :name: schemes
+
+   When this attribute is not provided or provided with value
+   `default`, schemes are automatically declared according to the following flags.
+
+   When it is provided with value `none`, no schemes are automatically declared.
+
 .. flag:: Elimination Schemes
 
    This :term:`flag` enables automatic declaration of induction principles when defining a new

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1524,6 +1524,7 @@ let do_build_inductive evd (funconstants : pconstant list)
       template = Some false;
       finite = Finite;
       mode = None;
+      schemes = Default;
     }
     in
     with_full_print

--- a/test-suite/success/Scheme.v
+++ b/test-suite/success/Scheme.v
@@ -61,3 +61,49 @@ Proof.
   intros f.
   Fail induction f.
 Abort.
+
+Module Attribute.
+  (* test schemes attribute *)
+
+  Set Elimination Schemes.
+
+  #[schemes=none]
+    Inductive foo1 := Foo1.
+  Fail Check foo1_ind.
+
+  #[schemes=default]
+    Inductive foo2 := Foo2.
+  Check foo2_ind.
+
+  Unset Elimination Schemes.
+
+  #[schemes=none]
+    Inductive foo3 := Foo3.
+  Fail Check foo3_ind.
+
+  (* XXX should default ignore Elimination Schemes? *)
+  #[schemes=default]
+    Inductive foo4 := Foo4.
+  Fail Check foo4_ind.
+
+  Set Elimination Schemes.
+  Set Rewriting Schemes.
+
+  #[schemes=default]
+    Inductive foo5 : bool -> Prop := Foo5 : foo5 true.
+  Check foo5_ind.
+  Check foo5_rew.
+
+  #[schemes=none]
+    Inductive foo6 : bool -> Prop := Foo6 : foo6 true.
+  Fail Check foo6_ind.
+  Fail Check foo6_rew.
+
+  (* can't do rewriting schemes for this *)
+  Fail Inductive foo7 := Foo7.
+
+  (* but disabling schemes doesn't try rewriting schemes *)
+  #[schemes=none]
+    Inductive foo7 := Foo7.
+
+End Attribute.

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -128,9 +128,9 @@ let pr_possible_values ~values =
   Pp.(str "{" ++ prlist_with_sep pr_comma str (List.map fst values) ++ str "}")
 
 (** [key_value_attribute ~key ~default ~values] parses a attribute [key=value]
-  with possible [key] [value] in [values], [default] is for compatibility for users
-  doing [qualif(key)] which is parsed as [qualif(key=default)] *)
-let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option attribute =
+  with possible [key] [value] in [values], [empty] is for compatibility for users
+  doing [qualif(key)] which is parsed as [qualif(key=empty)] *)
+let key_value_attribute ~key ?empty ~(values : (string * 'a) list) : 'a option attribute =
   let parser ?loc = function
     | Some v ->
       CErrors.user_err ?loc Pp.(str "key '" ++ str key ++ str "' has been already set.")
@@ -145,8 +145,8 @@ let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option
                     str "use one of " ++ pr_possible_values ~values)
             | value -> value
           end
-        | VernacFlagEmpty ->
-          default
+        | VernacFlagEmpty when Option.has_some empty ->
+          Option.get empty
         | err ->
           CErrors.user_err ?loc
             Pp.(str "Invalid syntax " ++ pr_vernac_flag_r (key, err) ++ str ", try "
@@ -157,7 +157,7 @@ let key_value_attribute ~key ~default ~(values : (string * 'a) list) : 'a option
 
 let bool_attribute ~name : bool option attribute =
   let values = ["yes", true; "no", false] in
-  key_value_attribute ~key:name ~default:true ~values
+  key_value_attribute ~key:name ~empty:true ~values
 
 (* Variant of the [bool] attribute with only two values (bool has three). *)
 let qualid_is_this_ident fp id =

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -108,6 +108,11 @@ val parse_with_extra : 'a attribute -> vernac_flags -> vernac_flags * 'a
 
 (** * Defining attributes. *)
 
+(** [key_value_attribute ~key ~empty ~values] parses a attribute [key=value]
+  with possible [key,value] in [values], if [empty=Some v] it is for compatibility for users
+  doing [qualif(key)] which is parsed as [qualif(key=v)] *)
+val key_value_attribute : key:string -> ?empty:'a -> values:(string * 'a) list -> 'a option attribute
+
 type 'a key_parser = ?loc:Loc.t -> 'a option -> vernac_flag_value -> 'a
 (** A parser for some key in an attribute. It is given a nonempty ['a
     option] when the attribute is multiply set for some command.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -33,6 +33,7 @@ type flags = {
   template : bool option;
   finite : Declarations.recursivity_kind;
   mode : Hints.hint_mode list option;
+  schemes : DeclareInd.declare_schemes;
 }
 
 (* 3b| Mutual inductive definitions *)
@@ -934,7 +935,7 @@ let do_mutual_inductive ~flags ?typing_flags udecl indl ~private_ind ~uniform =
   (* Declare the global universes *)
   Global.push_context_set uctx;
   (* Declare the mutual inductive block with its associated schemes *)
-  ignore (DeclareInd.declare_mutual_inductive_with_eliminations ~default_dep_elim ?typing_flags ~indlocs mie univ_binders implicits);
+  ignore (DeclareInd.declare_mutual_inductive_with_eliminations ~default_dep_elim ?typing_flags ~indlocs mie univ_binders implicits ~schemes:flags.schemes);
   (* Declare the possible notations of inductive types *)
   List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) where_notations;
   (* Declare the coercions *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -19,6 +19,7 @@ type flags = {
   template : bool option;
   finite : Declarations.recursivity_kind;
   mode : Hints.hint_mode list option;
+  schemes : DeclareInd.declare_schemes;
 }
 
 (** Entry points for the vernacular commands Inductive and CoInductive *)

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -20,10 +20,15 @@ type default_dep_elim = DefaultElim | PropButDepElim
 type indlocs = (Loc.t option * Loc.t option list) list
 (** Inductive type and constructor locs, for .glob and src loc info *)
 
+type declare_schemes = None | Default
+
+val schemes_attr : declare_schemes Attributes.attribute
+
 val declare_mutual_inductive_with_eliminations
   : ?typing_flags:Declarations.typing_flags
   -> ?indlocs:indlocs
   -> ?default_dep_elim:default_dep_elim list
+  -> ?schemes:declare_schemes
   -> Entries.mutual_inductive_entry (* Inductive types declaration *)
   -> UState.named_universes_entry (* Global universes, including the template default instance *)
   -> one_inductive_impls list (* Implicit arguments *)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -834,7 +834,7 @@ module Declared = struct
     | Record of MutInd.t
 end
 
-let declare_structure (decl:Record_decl.t) =
+let declare_structure (decl:Record_decl.t) ~schemes =
   Global.push_context_set decl.entry.global_univs;
   (* XXX no implicit arguments for constructors? *)
   let impls = List.make (List.length decl.entry.mie.mind_entry_inds) (decl.entry.param_impls, []) in
@@ -845,6 +845,7 @@ let declare_structure (decl:Record_decl.t) =
       impls
       ~indlocs:decl.indlocs
       ~default_dep_elim
+      ~schemes
   in
   let map i ({ RecordEntry.inhabitant_id; implfs; fieldlocs }, { Data.is_coercion; proj_flags; }) =
     let rsp = (kn, i) in (* This is ind path of idstruc *)
@@ -1074,7 +1075,7 @@ let definition_structure ~flags udecl kind ~primitive_proj (records : Ast.t list
       declare_class_constant entry data
     | RecordEntry entry ->
       let structure = interp_structure_core entry ~projections_kind ~indlocs data in
-      declare_structure structure
+      declare_structure structure ~schemes:flags.schemes
   in
   if kind_class kind <> NotClass then declare_class ~mode:flags.mode declared;
   inds

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1143,7 +1143,7 @@ let preprocess_defclass ~atts udecl (id, bl, c, l) =
   in
   let flags = {
     (* flags which don't matter for definitional classes *)
-    ComInductive.template=None; cumulative=false; finite=BiFinite;
+    ComInductive.template=None; cumulative=false; finite=BiFinite; schemes=None;
     (* real flags *)
     poly; mode;
   }
@@ -1187,16 +1187,18 @@ let preprocess_record ~atts udecl kind indl =
     | Class _ -> mode_attr
     | _ -> Notations.return None
   in
-  let ((template, (poly, cumulative)), primitive_proj), mode =
+  let (((template, (poly, cumulative)), primitive_proj), mode), schemes =
     Attributes.(
       parse Notations.(
           template
           ++ polymorphic_cumulative
-          ++ primitive_proj ++ hint_mode_attr)
+          ++ primitive_proj
+          ++ hint_mode_attr
+          ++ DeclareInd.schemes_attr)
         atts)
   in
   let finite = finite_of_kind kind in
-  let flags = { ComInductive.template; cumulative; poly; finite; mode } in
+  let flags = { ComInductive.template; cumulative; poly; finite; mode; schemes } in
   let parse_record_field_attr (x, f) =
     let attr =
       let rev = match f.rfu_coercion with
@@ -1253,16 +1255,19 @@ let preprocess_inductive ~atts udecl kind indl =
     | Class _ -> mode_attr
     | _ -> Notations.return None
   in
-  let (((template, (poly, cumulative)), private_ind), typing_flags), mode =
+  let ((((template, (poly, cumulative)), private_ind), typing_flags), mode), schemes =
     Attributes.(
       parse Notations.(
           template
           ++ polymorphic_cumulative
-          ++ private_ind ++ typing_flags ++ hint_mode_attr)
+          ++ private_ind
+          ++ typing_flags
+          ++ hint_mode_attr
+          ++ DeclareInd.schemes_attr)
         atts)
   in
   let finite = finite_of_kind kind in
-  let flags = { ComInductive.template; cumulative; poly; finite; mode } in
+  let flags = { ComInductive.template; cumulative; poly; finite; mode; schemes } in
   let unpack (((_, id) , bl, c, decl), ntn) = match decl with
     | Constructors l -> (id, bl, c, l), ntn
     | RecordDecl _ -> assert false (* ruled out above *)


### PR DESCRIPTION
Close #19480

For now only 2 values: `none` and `default`.

Not sure if `default` should obey flag Elimination Schemes (such that no attribute == default)
or if it should produce schemes regardless
(such that Elimination Schemes controls whether no attribute == no or == default)

Currently implemented is no attribute == default, the other option is more complex as eg unsetting elim schemes ut setting rewrite schemes does produce rewrite schemes.

EDIT after some thought IMO the current meaning of `default` should be fine.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/906