### PR TITLE
Pick the node with highest rank to merge neighbours in AcyclicGraph.

### DIFF
--- a/lib/acyclicGraph.ml
+++ b/lib/acyclicGraph.ml
@@ -355,6 +355,12 @@ module Make (Point:Point) = struct
     let status = Status.create g in
     status, find_to_merge status g x v
 
+  let rec find_max_rank cur accu l = match l with
+  | [] -> cur, accu
+  | hd :: tl ->
+    if hd.rank > cur.rank then find_max_rank hd (cur :: accu) tl
+    else find_max_rank cur (hd :: accu) tl
+
   let get_new_edges g to_merge =
     (* Computing edge sets. *)
     let ltle =
@@ -367,9 +373,11 @@ module Make (Point:Point) = struct
         in
         PMap.fold fold n.ltle acc
       in
-      match to_merge with
+      let max, rem = match to_merge with
       | [] -> assert false
-      | hd :: tl -> List.fold_left fold hd.ltle tl
+      | hd :: tl -> find_max_rank hd [] tl
+      in
+      List.fold_left fold max.ltle rem
     in
     let ltle, _ = clean_ltle g ltle in
     let fold accu a =


### PR DESCRIPTION
This is equivalent semantically, but in a typical situation, the node with highest rank will have many more graph neighbours than the other ones, making the reconstruction of the set of neighbours much faster.

On microbenchmarks this is quite effective, let's see what it gives on a real bench.