### PR TITLE
Remove the destauto tactic, deprecated since 8.20.

### DIFF
--- a/doc/changelog/04-tactics/21172-rm-destauto-Removed.rst
+++ b/doc/changelog/04-tactics/21172-rm-destauto-Removed.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the `destauto` tactic, which was deprecated in 8.20
+  (`#21172 <https://github.com/rocq-prover/rocq/pull/21172>`_,
+  fixes `#11537 <https://github.com/rocq-prover/rocq/issues/11537>`__,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -1620,7 +1620,7 @@ Tactics
   (`#19129 <https://github.com/rocq-prover/rocq/pull/19129>`_,
   by Pierre-Marie Pédrot).
 - **Deprecated:**
-  :tacn:`destauto`,
+  `destauto`,
   see `#11537 <https://github.com/rocq-prover/rocq/issues/11537#issuecomment-2154260216>`_
   (`#19179 <https://github.com/rocq-prover/rocq/pull/99999>`_,
   by Jim Fehrle).

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -281,16 +281,6 @@ analysis on inductive or coinductive objects (see :ref:`variants`).
       like :g:`and` and :g:`exists` and those defined with the :cmd:`Record`
       command.
 
-.. tacn:: destauto {? in @ident }
-
-   .. todo: keep or remove destauto?
-      destauto added in https://github.com/rocq-prover/rocq/commit/f3a53027589813ff19b3a7c46d84e5bd2fc65741
-
-   Reduces one :n:`match t with ...` by doing :n:`destruct t`.  If :n:`t` is
-   not a variable, the tactic does
-   :n:`case_eq t;intros ... heq;rewrite heq in *|-`.
-   :n:`heq` is preserved.
-
 Induction
 ---------
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1105,9 +1105,6 @@ simple_tactic: [
 | DELETE "unify" constr constr
 | REPLACE "unify" constr constr "with" preident
 | WITH "unify" constr constr OPT ( "with" preident )
-| DELETE "destauto"
-| REPLACE "destauto" "in" hyp
-| WITH "destauto" OPT ( "in" hyp )
 | REPLACE "autounfold_one" hintbases "in" hyp
 | WITH "autounfold_one" hintbases OPT ( "in" hyp )
 | DELETE "autounfold_one" hintbases

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1799,8 +1799,6 @@ simple_tactic: [
 | "generalize_eqs_vars" hyp
 | "dependent" "generalize_eqs_vars" hyp
 | "specialize_eqs" hyp
-| "destauto"
-| "destauto" "in" hyp
 | "transparent_abstract" tactic3
 | "transparent_abstract" tactic3 "using" ident
 | "constr_eq" constr constr

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1461,7 +1461,6 @@ simple_tactic: [
 | "generalize_eqs_vars" ident
 | "dependent" "generalize_eqs_vars" ident
 | "specialize_eqs" ident
-| "destauto" OPT ( "in" ident )
 | "transparent_abstract" ltac_expr3 OPT ( "using" ident )
 | "constr_eq" one_term one_term
 | "constr_eq_strict" one_term one_term

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -458,11 +458,6 @@ TACTIC EXTEND specialize_eqs
 | [ "specialize_eqs" hyp(id) ] -> { specialize_eqs id }
 END
 
-TACTIC EXTEND destauto DEPRECATED { Deprecation.make ~since:"8.20" () }
-| [ "destauto" ] -> { Internals.destauto }
-| [ "destauto" "in" hyp(id) ] -> { Internals.destauto_in id }
-END
-
 (**********************************************************************)
 
 (**********************************************************************)

--- a/plugins/ltac/internals.mli
+++ b/plugins/ltac/internals.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Proofview
 open Ltac_pretype
 
@@ -41,9 +40,6 @@ val injHyp : Names.Id.t -> unit tactic
 
 val refine_tac : Tacinterp.interp_sign -> simple:bool -> with_classes:bool ->
   closed_glob_constr -> unit tactic
-
-val destauto : unit tactic
-val destauto_in : Id.t -> unit tactic
 
 val has_evar : EConstr.t -> unit tactic
 val is_evar : EConstr.t -> unit tactic


### PR DESCRIPTION
Fixes #11537: tactic "destauto" is undocumented and perhaps broken.