### PR TITLE
Ltac don't drop tactic name for "not fully applied" error

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -131,12 +131,10 @@ let is_traced () =
 
 (** More naming applications *)
 let name_vfun appl vle =
-  if is_traced () then
-    match to_tacvalue vle with
-    | Some (VFun (appl0,trace,loc,lfun,vars,t)) ->
-      of_tacvalue (VFun (combine_appl appl0 appl,trace,loc,lfun,vars,t))
-    | Some (VRec _) | None -> vle
-  else vle
+  match to_tacvalue vle with
+  | Some (VFun (appl0,trace,loc,lfun,vars,t)) ->
+    of_tacvalue (VFun (combine_appl appl0 appl,trace,loc,lfun,vars,t))
+  | Some (VRec _) | None -> vle
 
 module TacStore = Geninterp.TacStore
 

--- a/test-suite/output/bug_12463.out
+++ b/test-suite/output/bug_12463.out
@@ -1,0 +1,5 @@
+File "./output/bug_12463.v", line 4, characters 2-11:
+The command has indeed failed with message:
+The user-defined tactic "foo" was not fully applied:
+There is a missing argument for variable H,
+no arguments at all were provided.

--- a/test-suite/output/bug_12463.v
+++ b/test-suite/output/bug_12463.v
@@ -1,0 +1,7 @@
+Ltac foo H := idtac H.
+Goal True.
+Proof.
+  Fail foo.
+(* Error: An unnamed user-defined tactic was not fully applied:
+There is a missing argument for variable H, no arguments at all were provided. *)
+Abort.


### PR DESCRIPTION
IDK why the name was only added with is_traced.

Fix #12463
