### PR TITLE
Deprecate Names.Label

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -172,7 +172,7 @@ let check_rhs env holes_profile rhs =
   check 0 rhs
 
 let check_rewrite_rule env lab i (symb, rule) =
-  Flags.if_verbose Feedback.msg_notice (str "  checking rule:" ++ Label.print lab ++ str"#" ++ Pp.int i);
+  Flags.if_verbose Feedback.msg_notice (str "  checking rule:" ++ Id.print lab ++ str"#" ++ Pp.int i);
   let { nvars; lhs_pat; rhs } = rule in
   let symb_cb = Environ.lookup_constant symb env in
   let () =

--- a/dev/ci/user-overlays/21174-SkySkimmer-nolab.sh
+++ b/dev/ci/user-overlays/21174-SkySkimmer-nolab.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp nolab 21174
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician nolab 21174
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof nolab 21174

--- a/dev/ml_toplevel/include_printers
+++ b/dev/ml_toplevel/include_printers
@@ -1,7 +1,6 @@
 #install_printer (* identifier *) Top_printers.ppid;;
 #install_printer (* identifier *) Top_printers.ppidset;;
 #install_printer (* Intset.t *) Top_printers.ppintset;;
-#install_printer (* label *) Top_printers.pplab;;
 #install_printer (* mod_bound_id *) Top_printers.ppmbid;;
 #install_printer (* dir_path *) Top_printers.ppdir;;
 #install_printer (* module_path *) Top_printers.ppmp;;

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -1,7 +1,6 @@
 install_printer Top_printers.pP
 install_printer Top_printers.ppfuture
 install_printer Top_printers.ppid
-install_printer Top_printers.pplab
 install_printer Top_printers.ppmbid
 install_printer Top_printers.ppdir
 install_printer Top_printers.ppmp

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -38,7 +38,6 @@ let ppfuture kx = pp (Future.print (fun _ -> str "_") kx)
 
 (* name printers *)
 let ppid id = pp (Id.print id)
-let pplab l = pp (Label.print l)
 let ppmbid mbid = pp (str (MBId.debug_to_string mbid))
 let ppdir dir = pp (DirPath.print dir)
 let ppmp mp = pp(str (ModPath.debug_to_string mp))
@@ -695,27 +694,27 @@ let encode_path ?loc prefix mpdir suffix id =
 let raw_string_of_ref ?loc _ = let open GlobRef in function
   | ConstRef cst ->
       let (mp,id) = KerName.repr (Constant.user cst) in
-      encode_path ?loc "CST" (Some mp) [] (Label.to_id id)
+      encode_path ?loc "CST" (Some mp) [] id
   | IndRef (kn,i) ->
       let (mp,id) = KerName.repr (MutInd.user kn) in
-      encode_path ?loc "IND" (Some mp) [Label.to_id id]
+      encode_path ?loc "IND" (Some mp) [id]
         (Id.of_string ("_"^string_of_int i))
   | ConstructRef ((kn,i),j) ->
       let (mp,id) = KerName.repr (MutInd.user kn) in
       encode_path ?loc "CSTR" (Some mp)
-        [Label.to_id id;Id.of_string ("_"^string_of_int i)]
+        [id;Id.of_string ("_"^string_of_int i)]
         (Id.of_string ("_"^string_of_int j))
   | VarRef id ->
       encode_path ?loc "SECVAR" None [] id
 
 let short_string_of_ref ?loc _ = let open GlobRef in function
   | VarRef id -> qualid_of_ident ?loc id
-  | ConstRef cst -> qualid_of_ident ?loc (Label.to_id (Constant.label cst))
-  | IndRef (kn,0) -> qualid_of_ident ?loc (Label.to_id (MutInd.label kn))
+  | ConstRef cst -> qualid_of_ident ?loc (Constant.label cst)
+  | IndRef (kn,0) -> qualid_of_ident ?loc (MutInd.label kn)
   | IndRef (kn,i) ->
-      encode_path ?loc "IND" None [Label.to_id (MutInd.label kn)]
+      encode_path ?loc "IND" None [MutInd.label kn]
         (Id.of_string ("_"^string_of_int i))
   | ConstructRef ((kn,i),j) ->
       encode_path ?loc "CSTR" None
-        [Label.to_id (MutInd.label kn);Id.of_string ("_"^string_of_int i)]
+        [MutInd.label kn; Id.of_string ("_"^string_of_int i)]
         (Id.of_string ("_"^string_of_int j))

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -18,7 +18,6 @@ val pp_as_format : Pp.t -> unit
 val ppfuture : 'a Future.computation -> unit
 
 val ppid : Names.Id.t -> unit
-val pplab : Names.Label.t -> unit
 val ppmbid : Names.MBId.t -> unit
 val ppdir : Names.DirPath.t -> unit
 val ppmp : Names.ModPath.t -> unit

--- a/doc/plugin_tutorial/tuto4/src/myexternals.ml
+++ b/doc/plugin_tutorial/tuto4/src/myexternals.ml
@@ -169,7 +169,7 @@ let () = define "sum2" (custom2 @-> ret int) @@ fun (i,j) ->
 let loader_module_name = ModPath.MPfile (DirPath.make @@ List.map Id.of_string ["Loader"; "Tuto4"])
 
 (* the type in that module is "custom2" *)
-let custom2_type_name = KerName.make loader_module_name (Label.of_id @@ Id.of_string "custom2")
+let custom2_type_name = KerName.make loader_module_name (Id.of_string "custom2")
 
 (* the printing system gives us the current env and evar map, the
    value to be printed, and the type arguments at which we are printing. *)

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -118,7 +118,7 @@ let head_name sigma c = (* Find the head constant of a constr if any *)
     match EConstr.kind sigma c with
     | Prod (_,_,c) | Lambda (_,_,c) | LetIn (_,_,_,c)
     | Cast (c,_,_) | App (c,_) -> hdrec c
-    | Proj (kn,_,_) -> Some (Label.to_id (Constant.label (Projection.constant kn)))
+    | Proj (kn,_,_) -> Some (Constant.label (Projection.constant kn))
     | Const _ | Ind _ | Construct _ | Var _ as c ->
         Some (Nametab.basename_of_global (global_of_constr c))
     | Fix ((_,i),(lna,_,_)) | CoFix (i,(lna,_,_)) ->
@@ -152,8 +152,8 @@ let hdchar env sigma c =
     match EConstr.kind sigma c with
     | Prod (_,_,c) | Lambda (_,_,c) | LetIn (_,_,_,c) -> hdrec (k+1) c
     | Cast (c,_,_) | App (c,_) -> hdrec k c
-    | Proj (kn,_,_) -> lowercase_first_char (Label.to_id (Constant.label (Projection.constant kn)))
-    | Const (kn,_) -> lowercase_first_char (Label.to_id (Constant.label kn))
+    | Proj (kn,_,_) -> lowercase_first_char (Constant.label (Projection.constant kn))
+    | Const (kn,_) -> lowercase_first_char (Constant.label kn)
     | Ind (x,_) -> (try lowercase_first_char (Nametab.basename_of_global (GlobRef.IndRef x)) with Not_found when !Flags.in_debugger -> "zz")
     | Construct (x,_) -> (try lowercase_first_char (Nametab.basename_of_global (GlobRef.ConstructRef x)) with Not_found when !Flags.in_debugger -> "zz")
     | Var id  -> lowercase_first_char id
@@ -421,7 +421,7 @@ let next_name_away_in_goal (type a) (gen : a Generator.t) env na (avoid : a) =
 
 let next_global_ident_away senv id avoid =
   let id = if Id.Set.mem id avoid then restart_subscript id else id in
-  let bad id = Id.Set.mem id avoid || Safe_typing.exists_objlabel (Label.of_id id) senv in
+  let bad id = Id.Set.mem id avoid || Safe_typing.exists_objlabel id senv in
   next_ident_away_from id bad
 
 (* 4- Looks for next fresh name outside a list; if name already used,

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -183,18 +183,18 @@ let extern_evar n l = CEvar (n,l)
 let rec dirpath_of_modpath = function
   | MPfile dp -> dp
   | MPbound mbid -> let (_,id,_) = MBId.repr mbid in DirPath.make [id]
-  | MPdot (t, l) -> Libnames.add_dirpath_suffix (dirpath_of_modpath t) (Label.to_id l)
+  | MPdot (t, l) -> Libnames.add_dirpath_suffix (dirpath_of_modpath t) l
 
 let qualid_of_global = function
   | GlobRef.VarRef id -> Libnames.qualid_of_ident id
   (* We rely on the tacite invariant that the label of a constant is used to build its internal name *)
-  | GlobRef.ConstRef cst -> Libnames.make_qualid (dirpath_of_modpath (Constant.modpath cst)) (Label.to_id (Constant.label cst))
+  | GlobRef.ConstRef cst -> Libnames.make_qualid (dirpath_of_modpath (Constant.modpath cst)) (Constant.label cst)
   (* We rely on the tacite invariant that an inductive block inherits the name of its first type *)
-  | GlobRef.IndRef (ind,1) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Label.to_id (MutInd.label ind))
+  | GlobRef.IndRef (ind,1) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (MutInd.label ind)
   (* These are hacks *)
-  | GlobRef.IndRef (ind,n) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
-  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
-  | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Label.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.IndRef (ind,n) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
+  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
 
 let default_extern_reference ?loc vars r =
   try Nametab.shortest_qualid_of_global ?loc vars r

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -81,7 +81,7 @@ let lookup_polymorphism env base kind fqid =
     | [] -> assert false
     | [id] ->
       let test (lab,obj) =
-        match Id.equal (Label.to_id lab) id, obj with
+        match Id.equal lab id, obj with
         | false, _ | _, (SFBrules _ | SFBmodule _ | SFBmodtype _) -> None
         | true, SFBmind mind -> Some (Declareops.inductive_is_polymorphic mind)
         | true, SFBconst const -> Some (Declareops.constant_is_polymorphic const)
@@ -93,7 +93,7 @@ let lookup_polymorphism env base kind fqid =
         | NoFunctor body -> aux body rem
       in
       let test (lab,obj) =
-        match Id.equal (Label.to_id lab) id, obj with
+        match Id.equal lab id, obj with
         | false, _ | _, (SFBrules _ | SFBconst _ | SFBmind _) -> None
         | true, SFBmodule body -> Some (next @@ mod_type body)
         | true, SFBmodtype body ->  (* XXX is this valid? If not error later *)

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -160,7 +160,7 @@ v}
 type record_info =
 | NotRecord
 | FakeRecord
-| PrimRecord of (Id.t * Label.t array * Sorts.relevance array * types array)
+| PrimRecord of (Id.t * Id.t array * Sorts.relevance array * types array)
 
 type squash_info =
   | AlwaysSquashed
@@ -389,4 +389,4 @@ type ('mod_body, 'mod_type) structure_field_body =
     a [structure_body], once for a module ([SFBmodule] or [SFBmodtype])
     and once for an object ([SFBconst] or [SFBmind]) *)
 
-and ('mod_body, 'mod_type) structure_body = (Label.t * ('mod_body, 'mod_type) structure_field_body) list
+and ('mod_body, 'mod_type) structure_body = (Id.t * ('mod_body, 'mod_type) structure_field_body) list

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -77,7 +77,7 @@ let pp_sort s =
   | Sorts.SProp -> str "SProp"
   | Sorts.Type _ | Sorts.QSort _ -> str "Type"
 
-let pr_con sp = str(Names.Label.to_string (Constant.label sp))
+let pr_con sp = str(Names.Id.to_string (Constant.label sp))
 
 let rec pp_lam lam =
   match lam.node with
@@ -202,7 +202,7 @@ let mkLlam ids body =
 
 (* Hack: brutally pierce through the abstraction of PArray *)
 let unsafe_mkPArray args def =
-  let dummy = KerName.make (ModPath.MPfile DirPath.empty) (Names.Label.of_id @@ Id.of_string "dummy") in
+  let dummy = KerName.make (ModPath.MPfile DirPath.empty) (Id.of_string "dummy") in
   let dummy = (MutInd.make1 dummy, 0) in
   let ar = mknode @@ Lmakeblock (dummy, 0, args) in
   let kind = mknode @@ Lmakeblock (dummy, 0, [|ar; def|]) in (* Parray.Array *)
@@ -210,7 +210,7 @@ let unsafe_mkPArray args def =
 
 (* Same as above but with a blob instead of a block *)
 let unsafe_mkPArray_val v def =
-  let dummy = KerName.make (ModPath.MPfile DirPath.empty) (Names.Label.of_id @@ Id.of_string "dummy") in
+  let dummy = KerName.make (ModPath.MPfile DirPath.empty) (Id.of_string "dummy") in
   let dummy = (MutInd.make1 dummy, 0) in
   let ar = mknode @@ Lval v in
   let kind = mknode @@ Lmakeblock (dummy, 0, [|ar; def|]) in (* Parray.Array *)

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -446,8 +446,7 @@ let compute_projections ind ~nparamargs ~nf_lc ~consnrealdecls =
       match na.Context.binder_name with
       | Name id ->
         let r = na.Context.binder_relevance in
-        let lab = Label.of_id id in
-        let kn = Projection.Repr.make ind ~proj_npars:nparamargs ~proj_arg:i lab in
+        let kn = Projection.Repr.make ind ~proj_npars:nparamargs ~proj_arg:i id in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)
         let t = liftn 1 j t in
@@ -457,7 +456,7 @@ let compute_projections ind ~nparamargs ~nf_lc ~consnrealdecls =
         (* from [params, x:I, field1,..,fieldj |- t(field1,..,fieldj)]
            to [params, x:I |- t(proj1 x,..,projj x)] *)
         let fterm = mkProj (Projection.make kn false, r, mkRel 1) in
-        (i + 1, j + 1, lab :: labs, r :: rs, projty :: pbs, fterm :: letsubst)
+        (i + 1, j + 1, id :: labs, r :: rs, projty :: pbs, fterm :: letsubst)
       | Anonymous -> assert false (* checked by indTyping *)
   in
   let (_, _, labs, rs, pbs, _letsubst) =

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -188,7 +188,7 @@ let rec hcons_structure_field_body sb = match sb with
 and hcons_structure_body sb =
   (** FIXME *)
   let map (l, sfb as fb) =
-    let _, l' = Names.Label.hcons l in
+    let _, l' = Names.Id.hcons l in
     let sfb' = hcons_structure_field_body sfb in
     if l == l' && sfb == sfb' then fb else (l', sfb')
   in

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -203,7 +203,7 @@ let debug_pr_subst subst =
 let add_inline_delta_resolver kn (lev,oc) = Deltamap.add_kn kn (Inline (lev,oc))
 
 let add_kn_delta_resolver kn kn' =
-  assert (Label.equal (KerName.label kn) (KerName.label kn'));
+  assert (Id.equal (KerName.label kn) (KerName.label kn'));
   Deltamap.add_kn kn (Equiv kn')
 
 let add_mp_delta_resolver mp1 mp2 = Deltamap.add_mp mp1 mp2

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -38,7 +38,7 @@ let is_modular = function
 let split_struc k m struc =
   let rec split rev_before = function
     | [] -> raise Not_found
-    | (k',b)::after when Label.equal k k' && (is_modular b) == (m : bool) ->
+    | (k',b)::after when Id.equal k k' && (is_modular b) == (m : bool) ->
       List.rev rev_before,b,after
     | h::tail -> split (h::rev_before) tail
   in split [] struc
@@ -50,7 +50,7 @@ let discr_resolver mp mtb = match mod_type mtb with
 let rec rebuild_mp mp l =
   match l with
   | []-> mp
-  | i::r -> rebuild_mp (MPdot(mp,Label.of_id i)) r
+  | i::r -> rebuild_mp (MPdot(mp,i)) r
 
 let infer_gen_conv state env c1 c2 =
   Conversion.generic_conv Conversion.CONV ~l2r:false TransparentState.full env state c1 c2
@@ -67,7 +67,7 @@ type with_body = {
 let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
   let lab,idl = match idl with
     | [] -> assert false
-    | id::idl -> Label.of_id id, idl
+    | id::idl -> id, idl
   in
   try
     let modular = not (List.is_empty idl) in
@@ -158,7 +158,7 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
 let rec check_with_mod (cst, ustate) env struc (idl,new_mp) mp reso =
   let lab,idl = match idl with
     | [] -> assert false
-    | id::idl -> Label.of_id id, idl
+    | id::idl -> id, idl
   in
   try
     let before,spec,after = split_struc lab true struc in

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -55,22 +55,22 @@ type signature_mismatch_error =
   | NoRewriteRulesSubtyping
 
 type subtyping_trace_elt =
-  | Submodule of Label.t
+  | Submodule of Id.t
   | FunctorArgument of int
 
 type module_typing_error =
-  | SignatureMismatch of subtyping_trace_elt list * Label.t * signature_mismatch_error
-  | LabelAlreadyDeclared of Label.t
+  | SignatureMismatch of subtyping_trace_elt list * Id.t * signature_mismatch_error
+  | LabelAlreadyDeclared of Id.t
   | NotAFunctor
   | IsAFunctor of ModPath.t
   | IncompatibleModuleTypes of module_type_body * module_type_body
   | NotEqualModulePaths of ModPath.t * ModPath.t
-  | NoSuchLabel of Label.t * ModPath.t
-  | NotAModuleLabel of Label.t
-  | NotAConstant of Label.t
-  | IncorrectWithConstraint of Label.t
-  | GenerativeModuleExpected of Label.t
-  | LabelMissing of Label.t * string
+  | NoSuchLabel of Id.t * ModPath.t
+  | NotAModuleLabel of Id.t
+  | NotAConstant of Id.t
+  | IncorrectWithConstraint of Id.t
+  | GenerativeModuleExpected of Id.t
+  | LabelMissing of Id.t * string
   | IncludeRestrictedFunctor of ModPath.t
 
 exception ModuleTypingError of module_typing_error

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -109,44 +109,44 @@ type signature_mismatch_error =
   | NoRewriteRulesSubtyping
 
 type subtyping_trace_elt =
-  | Submodule of Label.t
+  | Submodule of Id.t
   | FunctorArgument of int
 
 type module_typing_error =
-  | SignatureMismatch of subtyping_trace_elt list * Label.t * signature_mismatch_error
-  | LabelAlreadyDeclared of Label.t
+  | SignatureMismatch of subtyping_trace_elt list * Id.t * signature_mismatch_error
+  | LabelAlreadyDeclared of Id.t
   | NotAFunctor
   | IsAFunctor of ModPath.t
   | IncompatibleModuleTypes of module_type_body * module_type_body
   | NotEqualModulePaths of ModPath.t * ModPath.t
-  | NoSuchLabel of Label.t * ModPath.t
-  | NotAModuleLabel of Label.t
-  | NotAConstant of Label.t
-  | IncorrectWithConstraint of Label.t
-  | GenerativeModuleExpected of Label.t
-  | LabelMissing of Label.t * string
+  | NoSuchLabel of Id.t * ModPath.t
+  | NotAModuleLabel of Id.t
+  | NotAConstant of Id.t
+  | IncorrectWithConstraint of Id.t
+  | GenerativeModuleExpected of Id.t
+  | LabelMissing of Id.t * string
   | IncludeRestrictedFunctor of ModPath.t
 
 exception ModuleTypingError of module_typing_error
 
-val error_existing_label : Label.t -> 'a
+val error_existing_label : Id.t -> 'a
 
 val error_incompatible_modtypes :
   module_type_body -> module_type_body -> 'a
 
 val error_signature_mismatch :
-  subtyping_trace_elt list -> Label.t -> signature_mismatch_error -> 'a
+  subtyping_trace_elt list -> Id.t -> signature_mismatch_error -> 'a
 
-val error_no_such_label : Label.t -> ModPath.t -> 'a
+val error_no_such_label : Id.t -> ModPath.t -> 'a
 
-val error_not_a_module_label : Label.t -> 'a
+val error_not_a_module_label : Id.t -> 'a
 
-val error_not_a_constant : Label.t -> 'a
+val error_not_a_constant : Id.t -> 'a
 
-val error_incorrect_with_constraint : Label.t -> 'a
+val error_incorrect_with_constraint : Id.t -> 'a
 
-val error_generative_module_expected : Label.t -> 'a
+val error_generative_module_expected : Id.t -> 'a
 
-val error_no_such_label_sub : Label.t->string->'a
+val error_no_such_label_sub : Id.t -> string -> 'a
 
 val error_include_restricted_functor : ModPath.t -> 'a

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -17,7 +17,6 @@
     - Name.t is an ad-hoc variant of Id.t option allowing to handle optionally
       named objects.
     - DirPath.t represents generic paths as sequences of identifiers.
-    - Label.t is an equivalent of Id.t made distinct for semantical purposes.
     - ModPath.t are module paths.
     - KerName.t are absolute names of objects in Rocq.
 *)
@@ -166,44 +165,6 @@ end
 module DPset = DirPath.Set [@@deprecated "Use DirPath.Set"]
 module DPmap = DirPath.Map [@@deprecated "Use DirPath.Map"]
 
-(** {6 Names of structure elements } *)
-
-module Label :
-sig
-  type t
-  (** Type of labels *)
-
-  val equal : t -> t -> bool
-  (** Equality over labels *)
-
-  val compare : t -> t -> int
-  (** Comparison over labels. *)
-
-  val hash : t -> int
-  (** Hash over labels. *)
-
-  val make : string -> t
-  (** Create a label out of a string. *)
-
-  val of_id : Id.t -> t
-  (** Conversion from an identifier. *)
-
-  val to_id : t -> Id.t
-  (** Conversion to an identifier. *)
-
-  val to_string : t -> string
-  (** Conversion to string. *)
-
-  val print : t -> Pp.t
-  (** Pretty-printer. *)
-
-  module Set : Set.ExtS with type elt = t
-  module Map : Map.ExtS with type key = t and module Set := Set
-
-  val hcons : t Hashcons.f
-
-end
-
 (** {6 Unique names for bound modules} *)
 
 module MBId :
@@ -252,7 +213,7 @@ sig
   type t =
     | MPfile of DirPath.t
     | MPbound of MBId.t
-    | MPdot of t * Label.t
+    | MPdot of t * Id.t
 
   val compare : t -> t -> int
   val equal : t -> t -> bool
@@ -292,12 +253,12 @@ sig
   type t
 
   (** Constructor and destructor *)
-  val make : ModPath.t -> Label.t -> t
-  val repr : t -> ModPath.t * Label.t
+  val make : ModPath.t -> Id.t -> t
+  val repr : t -> ModPath.t * Id.t
 
   (** Projections *)
   val modpath : t -> ModPath.t
-  val label : t -> Label.t
+  val label : t -> Id.t
 
   val to_string : t -> string
   (** Encode as a string (not to be used for user-facing messages). *)
@@ -394,7 +355,7 @@ sig
   val make1 : KerName.t -> t
   (** Special case of [make] where the user name is canonical.  *)
 
-  val make2 : ModPath.t -> Label.t -> t
+  val make2 : ModPath.t -> Id.t -> t
   (** Shortcut for [(make1 (KerName.make ...))] *)
 
   (** Projections *)
@@ -405,7 +366,7 @@ sig
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)
 
-  val label : t -> Label.t
+  val label : t -> Id.t
   (** Shortcut for [KerName.label (user ...)] *)
 
   (** Comparisons *)
@@ -418,7 +379,7 @@ sig
   val hash : t -> int [@@ocaml.deprecated "(8.13) Use QConstant.hash"]
   (** Hashing function *)
 
-  val change_label : t -> Label.t -> t
+  val change_label : t -> Id.t -> t
   (** Builds a new constant name with a different label *)
 
   (** Displaying *)
@@ -465,7 +426,7 @@ sig
   val make1 : KerName.t -> t
   (** Special case of [make] where the user name is canonical.  *)
 
-  val make2 : ModPath.t -> Label.t -> t
+  val make2 : ModPath.t -> Id.t -> t
   (** Shortcut for [(make1 (KerName.make ...))] *)
 
   (** Projections *)
@@ -476,7 +437,7 @@ sig
   val modpath : t -> ModPath.t
   (** Shortcut for [KerName.modpath (user ...)] *)
 
-  val label : t -> Label.t
+  val label : t -> Id.t
   (** Shortcut for [KerName.label (user ...)] *)
 
   (** Comparisons *)
@@ -601,14 +562,14 @@ val eq_constant_key : Constant.t -> Constant.t -> bool
 type module_path = ModPath.t =
   | MPfile of DirPath.t
   | MPbound of MBId.t
-  | MPdot of ModPath.t * Label.t
+  | MPdot of ModPath.t * Id.t
 [@@ocaml.deprecated "(8.8) Alias type"]
 
 module Projection : sig
   module Repr : sig
     type t
 
-    val make : inductive -> proj_npars:int -> proj_arg:int -> Label.t -> t
+    val make : inductive -> proj_npars:int -> proj_arg:int -> Id.t -> t
 
     include QNameS with type t := t
 
@@ -619,7 +580,7 @@ module Projection : sig
     val mind : t -> MutInd.t
     val npars : t -> int
     val arg : t -> int
-    val label : t -> Label.t
+    val label : t -> Id.t
 
     val equal : t -> t -> bool [@@ocaml.deprecated "(8.13) Use QProjection.equal"]
     val hash : t -> int [@@ocaml.deprecated "(8.13) Use QProjection.hash"]
@@ -647,7 +608,7 @@ module Projection : sig
   val inductive : t -> inductive
   val npars : t -> int
   val arg : t -> int
-  val label : t -> Label.t
+  val label : t -> Id.t
   val unfolded : t -> bool
   val unfold : t -> t
 
@@ -725,3 +686,39 @@ type lname = Name.t CAst.t
 type lstring = string CAst.t
 
 val lident_eq : lident -> lident -> bool
+
+(** Deprecated *)
+module Label : sig
+  type t = Id.t
+  (** Type of labels *)
+
+  val equal : t -> t -> bool
+  (** Equality over labels *)
+
+  val compare : t -> t -> int
+  (** Comparison over labels. *)
+
+  val hash : t -> int
+  (** Hash over labels. *)
+
+  val make : string -> t
+  (** Create a label out of a string. *)
+
+  val of_id : Id.t -> t
+  (** Conversion from an identifier. *)
+
+  val to_id : t -> Id.t
+  (** Conversion to an identifier. *)
+
+  val to_string : t -> string
+  (** Conversion to string. *)
+
+  val print : t -> Pp.t
+  (** Pretty-printer. *)
+
+  module Set : Set.ExtS with type elt = t
+  module Map : Map.ExtS with type key = t and module Set := Set
+
+  val hcons : t Hashcons.f
+
+end [@@deprecated "(9.2) Use Id"]

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -64,10 +64,10 @@ val is_loaded_native_file : string -> bool
 val compile_constant_field : env -> Constant.t ->
   global list -> constant_body -> global list
 
-val compile_mind_field : ModPath.t -> Label.t ->
+val compile_mind_field : ModPath.t -> Id.t ->
   global list -> mutual_inductive_body -> global list
 
-val compile_rewrite_rules : env -> Label.t ->
+val compile_rewrite_rules : env -> Id.t ->
   global list -> rewrite_rules_body -> global list
 
 val mk_conv_code : env -> Genlambda.evars -> string -> constr -> constr -> linkable_code

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -47,7 +47,7 @@ and translate_field mp env acc (l,x) =
      compile_mind_field mp l acc mb
   | SFBrules rrb ->
      (debug_native_compiler (fun () ->
-        let msg = Printf.sprintf "Not Compiling rules %s..." (Label.to_string l) in
+        let msg = Printf.sprintf "Not Compiling rules %s..." (Id.to_string l) in
         Pp.str msg));
      compile_rewrite_rules env l acc rrb
   | SFBmodule md ->

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -91,11 +91,11 @@ val export_private_constants :
 (** returns the main constant *)
 val add_constant :
   ?typing_flags:Declarations.typing_flags ->
-  Label.t -> Entries.constant_entry -> Constant.t safe_transformer
+  Id.t -> Entries.constant_entry -> Constant.t safe_transformer
 
 (** Similar to add_constant but also returns a certificate *)
 val add_private_constant :
-  Label.t -> Univ.ContextSet.t -> side_effect_declaration -> (Constant.t * private_constants) safe_transformer
+  Id.t -> Univ.ContextSet.t -> side_effect_declaration -> (Constant.t * private_constants) safe_transformer
 
 (** {5 Delayed proofs} *)
 
@@ -128,7 +128,7 @@ val repr_certificate : opaque_certificate ->
 (** {5 Rewrite rules} *)
 
 (** Add a rewrite rule corresponding to the equality witnessed by the constant. *)
-val add_rewrite_rules : Label.t -> Declarations.rewrite_rules_body -> safe_environment -> safe_environment
+val add_rewrite_rules : Id.t -> Declarations.rewrite_rules_body -> safe_environment -> safe_environment
 
 (** {5 Inductive blocks} *)
 
@@ -136,16 +136,16 @@ val add_rewrite_rules : Label.t -> Declarations.rewrite_rules_body -> safe_envir
 
 val add_mind :
   ?typing_flags:Declarations.typing_flags ->
-  Label.t -> Entries.mutual_inductive_entry ->
+  Id.t -> Entries.mutual_inductive_entry ->
   (MutInd.t * IndTyping.NotPrimRecordReason.t option) safe_transformer
 
 (** Adding a module or a module type *)
 
 val add_module :
-  Label.t -> Entries.module_entry -> Declarations.inline ->
+  Id.t -> Entries.module_entry -> Declarations.inline ->
     (ModPath.t * Mod_subst.delta_resolver) safe_transformer
 val add_modtype :
-  Label.t -> Entries.module_type_entry -> Declarations.inline ->
+  Id.t -> Entries.module_type_entry -> Declarations.inline ->
     ModPath.t safe_transformer
 
 (** Adding universe constraints *)
@@ -196,9 +196,9 @@ val push_section_context : UVars.UContext.t -> safe_transformer0
 
 (** {6 Interactive module functions } *)
 
-val start_module : Label.t -> ModPath.t safe_transformer
+val start_module : Id.t -> ModPath.t safe_transformer
 
-val start_modtype : Label.t -> ModPath.t safe_transformer
+val start_modtype : Id.t -> ModPath.t safe_transformer
 
 val add_module_parameter :
   MBId.t -> Entries.module_struct_entry -> Declarations.inline ->
@@ -220,10 +220,10 @@ val allow_delayed_constants : bool ref
 (** The optional result type is given without its functorial part *)
 
 val end_module :
-  Label.t -> (Entries.module_struct_entry * Declarations.inline) option ->
+  Id.t -> (Entries.module_struct_entry * Declarations.inline) option ->
     (ModPath.t * MBId.t list * Mod_subst.delta_resolver) safe_transformer
 
-val end_modtype : Label.t -> (ModPath.t * MBId.t list) safe_transformer
+val end_modtype : Id.t -> (ModPath.t * MBId.t list) safe_transformer
 
 val add_include :
   Entries.module_struct_entry -> bool -> Declarations.inline ->
@@ -265,7 +265,7 @@ val typing : safe_environment -> Constr.constr -> judgment
 
 (** {6 Queries } *)
 
-val exists_objlabel : Label.t -> safe_environment -> bool
+val exists_objlabel : Id.t -> safe_environment -> bool
 
 val delta_of_senv : safe_environment -> Mod_subst.delta_resolver
 

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -51,37 +51,37 @@ let add_mib_nameobjects mp l mib map =
     let map =
       Array.fold_right_i
       (fun i id map ->
-        Label.Map.add (Label.of_id id) (IndConstr((ip,i+1), mib)) map)
+        Id.Map.add id (IndConstr((ip,i+1), mib)) map)
       oib.mind_consnames
       map
     in
-      Label.Map.add (Label.of_id oib.mind_typename) (IndType (ip, mib)) map
+      Id.Map.add oib.mind_typename (IndType (ip, mib)) map
   in
   Array.fold_right_i add_mip_nameobjects mib.mind_packets map
 
 
 (* creates (namedobject/namedmodule) map for the whole signature *)
 
-type labmap = { objs : namedobject Label.Map.t; mods : namedmodule Label.Map.t }
+type labmap = { objs : namedobject Id.Map.t; mods : namedmodule Id.Map.t }
 
-let empty_labmap = { objs = Label.Map.empty; mods = Label.Map.empty }
+let empty_labmap = { objs = Id.Map.empty; mods = Id.Map.empty }
 
 let get_obj mp map l =
-  try Label.Map.find l map.objs
+  try Id.Map.find l map.objs
   with Not_found -> error_no_such_label_sub l (ModPath.to_string mp)
 
 let get_mod mp map l =
-  try Label.Map.find l map.mods
+  try Id.Map.find l map.mods
   with Not_found -> error_no_such_label_sub l (ModPath.to_string mp)
 
 let make_labmap mp list =
   let add_one (l,e) map =
    match e with
-    | SFBconst cb -> { map with objs = Label.Map.add l (Constant cb) map.objs }
-    | SFBrules _ -> { map with objs = Label.Map.add l Rules map.objs }
+    | SFBconst cb -> { map with objs = Id.Map.add l (Constant cb) map.objs }
+    | SFBrules _ -> { map with objs = Id.Map.add l Rules map.objs }
     | SFBmind mib -> { map with objs = add_mib_nameobjects mp l mib map.objs }
-    | SFBmodule mb -> { map with mods = Label.Map.add l (Module mb) map.mods }
-    | SFBmodtype mtb -> { map with mods = Label.Map.add l (Modtype mtb) map.mods }
+    | SFBmodule mb -> { map with mods = Id.Map.add l (Module mb) map.mods }
+    | SFBmodtype mtb -> { map with mods = Id.Map.add l (Modtype mtb) map.mods }
   in
   CList.fold_right add_one list empty_labmap
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -78,8 +78,6 @@ let globalize_with_summary fs f =
 
 (** [Safe_typing] operations, now operating on the global environment *)
 
-let i2l = Label.of_id
-
 let push_named_assum a = globalize0 (Safe_typing.push_named_assum a)
 let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let push_section_context c = globalize0 (Safe_typing.push_section_context c)
@@ -99,12 +97,12 @@ let sprop_allowed () = Environ.sprop_allowed (env())
 let set_rewrite_rules_allowed b = globalize0 (Safe_typing.set_rewrite_rules_allowed b)
 let rewrite_rules_allowed () = Environ.rewrite_rules_allowed (env())
 let export_private_constants cd = globalize (Safe_typing.export_private_constants cd)
-let add_constant ?typing_flags id d = globalize (Safe_typing.add_constant ?typing_flags (i2l id) d)
+let add_constant ?typing_flags id d = globalize (Safe_typing.add_constant ?typing_flags id d)
 let fill_opaque c = globalize0 (Safe_typing.fill_opaque c)
-let add_rewrite_rules id c = globalize0 (Safe_typing.add_rewrite_rules (i2l id) c)
-let add_mind ?typing_flags id mie = globalize (Safe_typing.add_mind ?typing_flags (i2l id) mie)
-let add_modtype id me inl = globalize (Safe_typing.add_modtype (i2l id) me inl)
-let add_module id me inl = globalize (Safe_typing.add_module (i2l id) me inl)
+let add_rewrite_rules id c = globalize0 (Safe_typing.add_rewrite_rules id c)
+let add_mind ?typing_flags id mie = globalize (Safe_typing.add_mind ?typing_flags id mie)
+let add_modtype id me inl = globalize (Safe_typing.add_modtype id me inl)
+let add_module id me inl = globalize (Safe_typing.add_module id me inl)
 let add_include me ismod inl = globalize (Safe_typing.add_include me ismod inl)
 
 let open_section () = globalize0 Safe_typing.open_section
@@ -150,14 +148,14 @@ let discharge_proj_repr p =
     else
       p
 
-let start_module id = globalize (Safe_typing.start_module (i2l id))
-let start_modtype id = globalize (Safe_typing.start_modtype (i2l id))
+let start_module id = globalize (Safe_typing.start_module id)
+let start_modtype id = globalize (Safe_typing.start_modtype id)
 
 let end_module fs id mtyo =
-  globalize_with_summary fs (Safe_typing.end_module (i2l id) mtyo)
+  globalize_with_summary fs (Safe_typing.end_module id mtyo)
 
 let end_modtype fs id =
-  globalize_with_summary fs (Safe_typing.end_modtype (i2l id))
+  globalize_with_summary fs (Safe_typing.end_modtype id)
 
 let add_module_parameter mbid mte inl =
   globalize (Safe_typing.add_module_parameter mbid mte inl)

--- a/library/global.mli
+++ b/library/global.mli
@@ -133,7 +133,7 @@ val lookup_pinductive : Constr.pinductive ->
 val lookup_mind      : MutInd.t -> mutual_inductive_body
 val lookup_module    : ModPath.t -> module_body
 val lookup_modtype   : ModPath.t -> module_type_body
-val exists_objlabel  : Label.t -> bool
+val exists_objlabel  : Id.t -> bool
 
 val constant_of_delta_kn : KerName.t -> Constant.t
 val mind_of_delta_kn : KerName.t -> MutInd.t

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -16,7 +16,7 @@ type export_flag = Export | Import
 type export = (export_flag * Libobject.open_filter) option (* None for a Module Type *)
 
 let make_oname Libobject.{ obj_path; obj_mp } id =
-  Names.(Libnames.add_path_suffix obj_path id, KerName.make obj_mp (Label.of_id id))
+  Names.(Libnames.add_path_suffix obj_path id, KerName.make obj_mp id)
 
 type 'summary node =
   | CompilingLibrary of Libobject.object_prefix
@@ -209,7 +209,7 @@ let make_path_except_section id =
 
 let make_kn id =
   let mp = current_mp () in
-  Names.KerName.make mp (Names.Label.of_id id)
+  Names.KerName.make mp id
 
 let make_foname id = make_oname !synterp_state.path_prefix id
 
@@ -300,7 +300,7 @@ let rec split_modpath = function
   |Names.MPbound mbid -> library_dp (), [Names.MBId.to_id mbid]
   |Names.MPdot (mp,l) ->
     let (dp,ids) = split_modpath mp in
-    (dp, Names.Label.to_id l :: ids)
+    (dp, l :: ids)
 
 let library_part = function
   | GlobRef.VarRef id -> library_dp ()

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -168,7 +168,7 @@ let declare_object_gen odecl =
   tag
 
 let make_oname { obj_path; obj_mp } id =
-  Libnames.add_path_suffix obj_path id, Names.KerName.make obj_mp (Names.Label.of_id id)
+  Libnames.add_path_suffix obj_path id, Names.KerName.make obj_mp id
 
 let declare_named_object_full odecl =
   let odecl =

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -183,9 +183,9 @@ type phase = Pre | Impl | Intf
 
 module DupOrd =
 struct
-  type t = ModPath.t * Label.t
+  type t = ModPath.t * Id.t
   let compare (mp1, l1) (mp2, l2) =
-    let c = Label.compare l1 l2 in
+    let c = Id.compare l1 l2 in
     if Int.equal c 0 then ModPath.compare mp1 mp2 else c
 end
 
@@ -212,7 +212,7 @@ module DupMap = CMap.Make(DupOrd)
 
 type visible_layer = { mp : ModPath.t;
                        params : MBId.t list;
-                       content : Label.t KMap.t; }
+                       content : Id.t KMap.t; }
 
 module State =
 struct
@@ -228,7 +228,7 @@ type state = {
 
 type modular = {
   mutable mpfiles : DirPath.Set.t; (* List of external modules that will be opened initially *)
-  mutable mpfiles_content : Label.t KMap.t DirPath.Map.t; (* table recording objects in the first level of all MPfile *)
+  mutable mpfiles_content : Id.t KMap.t DirPath.Map.t; (* table recording objects in the first level of all MPfile *)
 }
 
 let empty_modular () = {
@@ -424,8 +424,7 @@ let modular_rename table k id =
 (*s For monolithic extraction, first-level modules might have to be renamed
     with unique numbers *)
 
-let modfstlev_rename table l =
-  let id = Label.to_id l in
+let modfstlev_rename table id =
   try
     let n = State.get_mod_index table id in
     let () = State.add_mod_index table id (n+1) in
@@ -448,7 +447,7 @@ let rec mp_renaming_fun table mp = match mp with
       let lmp = mp_renaming table mp in
       let mp = match lmp with
       | [""] -> modfstlev_rename table l
-      | _ -> modular_rename table Mod (Label.to_id l)
+      | _ -> modular_rename table Mod l
       in
       mp ::lmp
   | MPbound mbid ->

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -51,7 +51,7 @@ sig
   val get_library : t -> bool
   val get_keywords : t -> Id.Set.t
   val get_phase : t -> phase
-  val get_duplicate : t -> ModPath.t -> Label.t -> string option
+  val get_duplicate : t -> ModPath.t -> Id.t -> string option
 
   (** Setters *)
   val set_phase : t -> phase -> t

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -219,8 +219,8 @@ let flatten_modtype env mp me_alg struc_opt =
 
 let env_for_mtb_with_def env mp me reso idl =
   let struc = Modops.destr_nofunctor mp me in
-  let l = Label.of_id (List.hd idl) in
-  let spot = function (l',SFBconst _) -> Label.equal l l' | _ -> false in
+  let l = List.hd idl in
+  let spot = function (l',SFBconst _) -> Id.equal l l' | _ -> false in
   let before = fst (List.split_when spot struc) in
   Modops.add_structure mp before reso env
 
@@ -832,7 +832,7 @@ let show_extraction ~pstate =
     (* FIXME: substitute relevances with ground ones *)
     let ast, ty = extract_constr table env sigma t in
     let mp = Lib.current_mp () in
-    let l = Label.of_id (Declare.Proof.get_name pstate) in
+    let l = Declare.Proof.get_name pstate in
     let fake_ref = { glob = GlobRef.ConstRef (Constant.make2 mp l); inst = InfvInst.empty } in
     let decl = Dterm (fake_ref, ast, ty) in
     print_one_decl table [] mp decl

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -297,7 +297,7 @@ let fake_match_projection env p =
     | LocalAssum (na,ty) :: rem ->
       let ty = Vars.substl subst (liftn 1 j ty) in
       if arg != proj_arg then
-        let lab = match na.binder_name with Name id -> Label.of_id id | Anonymous -> assert false in
+        let lab = match na.binder_name with Name id -> id | Anonymous -> assert false in
         let kn = Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg:arg lab in
         fold (arg+1) (j+1) (mkProj (Projection.make kn false, na.binder_relevance, mkRel 1)::subst) rem
       else
@@ -585,7 +585,7 @@ and extract_really_ind table env kn inst mib =
           | {binder_name=Anonymous}::l, typ::typs ->
               None :: (select_fields (i+1) l typs)
           | {binder_name=Name id}::l, typ::typs ->
-              let knp = Constant.make2 mp (Label.of_id id) in
+              let knp = Constant.make2 mp id in
               (* Is it safe to use [id] for projections [foo.id] ? *)
               if List.for_all ((==) Keep) (type2signature table env typ)
               then (* for OCaml inlining: *) add_projection (Common.State.get_table table) nparams knp ip;

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -227,7 +227,7 @@ and ml_with_declaration =
   | ML_With_type of InfvInst.t * Id.t list * Id.t list * ml_type
   | ML_With_module of Id.t list * ModPath.t
 
-and ml_module_sig = (Label.t * ml_specif) list
+and ml_module_sig = (Id.t * ml_specif) list
 
 type ml_structure_elem =
   | SEdecl of ml_decl
@@ -240,7 +240,7 @@ and ml_module_expr =
   | MEstruct of ModPath.t * ml_module_structure
   | MEapply of ml_module_expr * ml_module_expr
 
-and ml_module_structure = (Label.t * ml_structure_elem) list
+and ml_module_structure = (Id.t * ml_structure_elem) list
 
 and ml_module =
     { ml_mod_expr : ml_module_expr;

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -198,7 +198,7 @@ and ml_with_declaration =
   | ML_With_type of InfvInst.t * Id.t list * Id.t list * ml_type
   | ML_With_module of Id.t list * ModPath.t
 
-and ml_module_sig = (Label.t * ml_specif) list
+and ml_module_sig = (Id.t * ml_specif) list
 
 type ml_structure_elem =
   | SEdecl of ml_decl
@@ -211,7 +211,7 @@ and ml_module_expr =
   | MEstruct of ModPath.t * ml_module_structure
   | MEapply of ml_module_expr * ml_module_expr
 
-and ml_module_structure = (Label.t * ml_structure_elem) list
+and ml_module_structure = (Id.t * ml_structure_elem) list
 
 and ml_module =
     { ml_mod_expr : ml_module_expr;

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1540,7 +1540,7 @@ let inline_test r t =
 
 let con_of_string s =
   let d, id = Libnames.split_dirpath (dirpath_of_string s) in
-  Constant.make2 (ModPath.MPfile d) (Label.of_id id)
+  Constant.make2 (ModPath.MPfile d) id
 
 let manual_inline_set =
   List.fold_right (fun x -> Cset_env.add (con_of_string x))

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -39,15 +39,15 @@ let se_iter do_decl do_spec do_mp =
         let mp_mt = msid_of_mt mt in
         let l',idl' = List.sep_last idl in
         let mp_w =
-          List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl'
+          List.fold_left (fun mp l -> MPdot(mp, l)) mp_mt idl'
         in
-        let r = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l')) in
+        let r = GlobRef.ConstRef (Constant.make2 mp_w l') in
         let r = { glob = r; inst = rlv } in
         mt_iter mt; do_spec (Stype(r,l,Some t))
     | MTwith (mt,ML_With_module(idl,mp))->
         let mp_mt = msid_of_mt mt in
         let mp_w =
-          List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl
+          List.fold_left (fun mp l -> MPdot(mp, l)) mp_mt idl
         in
         mt_iter mt; do_mp mp_w; do_mp mp
     | MTsig (_, sign) -> List.iter spec_iter sign
@@ -223,7 +223,7 @@ let is_modular = function
 
 let rec search_structure l m = function
   | [] -> raise Not_found
-  | (lab,d)::_ when Label.equal lab l && (is_modular d : bool) == m -> d
+  | (lab,d)::_ when Id.equal lab l && (is_modular d : bool) == m -> d
   | _::fields -> search_structure l m fields
 
 let get_decl_in_structure r struc =
@@ -269,7 +269,7 @@ let dfix_to_mlfix rv av i =
         (try MLrel (n + (Refmap'.find refe s)) with Not_found -> t)
     | _ -> ast_map_lift subst n t
   in
-  let ids = Array.map (fun r -> Label.to_id (label_of_r r)) rv in
+  let ids = Array.map label_of_r rv in
   let c = Array.map (subst 0) av
   in MLfix(i, ids, c)
 

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -710,9 +710,9 @@ and pp_module_type table params = function
       let mp_mt = msid_of_mt mt in
       let l,idl' = List.sep_last idl in
       let mp_w =
-        List.fold_left (fun mp l -> MPdot(mp,Label.of_id l)) mp_mt idl'
+        List.fold_left (fun mp l -> MPdot(mp, l)) mp_mt idl'
       in
-      let r = { glob = GlobRef.ConstRef (Constant.make2 mp_w (Label.of_id l)); inst = rlv } in
+      let r = { glob = GlobRef.ConstRef (Constant.make2 mp_w l); inst = rlv } in
       let pp_w = State.with_visibility table mp_mt [] begin fun table ->
         str " with type " ++ ids ++ pp_global table Type r
       end in
@@ -720,7 +720,7 @@ and pp_module_type table params = function
   | MTwith(mt,ML_With_module(idl,mp)) ->
       let mp_mt = msid_of_mt mt in
       let mp_w =
-        List.fold_left (fun mp id -> MPdot(mp,Label.of_id id)) mp_mt idl
+        List.fold_left (fun mp id -> MPdot(mp, id)) mp_mt idl
       in
       let pp_w = State.with_visibility table mp_mt [] begin fun table ->
         str " with module " ++ pp_modname table mp_w

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -133,7 +133,7 @@ type table = {
   (* projs: working modulo name equivalence is ok *)
   info_axioms : Refset'.t;
   log_axioms : Refset'.t;
-  symbols : Label.t list Refmap'.t;
+  symbols : Id.t list Refmap'.t;
   opaques:  Refset'.t;
   modfile_ids : Id.Set.t;
   modfile_mps : string DirPath.Map.t;
@@ -236,7 +236,7 @@ let record_fields_of_type table = function
 let add_recursors table env ind =
   let kn = MutInd.canonical ind in
   let mk_kn id =
-    KerName.make (KerName.modpath kn) (Label.of_id id)
+    KerName.make (KerName.modpath kn) id
   in
   let mib = Environ.lookup_mind ind env in
   Array.iter
@@ -284,14 +284,14 @@ let safe_basename_of_global_gen table r =
   let last_chance r (kn, pos) =
     try Nametab.basename_of_global r
     with Not_found ->
-      let id = Id.to_string (Label.to_id (MutInd.label kn)) in
+      let id = Id.to_string (MutInd.label kn) in
       Id.of_string (id ^ "_" ^ String.concat "_" (List.map string_of_int pos))
   in
   let unsafe_lookup_ind table kn = snd (InfvMap.find r.inst (Mindmap_env.find kn !table.inductives)) in
   let open GlobRef in
   match r.glob with
-    | ConstRef kn -> Label.to_id (Constant.label kn)
-    | IndRef (kn,0) -> Label.to_id (MutInd.label kn)
+    | ConstRef kn -> Constant.label kn
+    | IndRef (kn,0) -> MutInd.label kn
     | IndRef (kn,i) ->
       let r = r.glob in
       begin match table with
@@ -325,7 +325,7 @@ let safe_pr_long_global r =
   with Not_found -> match r.glob with
     | GlobRef.ConstRef kn ->
         let mp,l = KerName.repr (Constant.user kn) in
-        str ((ModPath.to_string mp)^"."^(Label.to_string l))
+        str ((ModPath.to_string mp)^"."^(Id.to_string l))
     | _ -> assert false
 
 let pr_long_mp mp =
@@ -362,7 +362,7 @@ let warn_extraction_symbols =
   let pp_symb_with_rules (symb, rules) =
     safe_pr_global symb ++
     if List.is_empty rules then str " (no rules)" else
-    str ":" ++ spc() ++ prlist_with_sep spc Label.print rules
+    str ":" ++ spc() ++ prlist_with_sep spc Id.print rules
   in
   CWarnings.create ~name:"extraction-symbols" ~category:CWarnings.CoreCategories.extraction
     (fun symbols ->

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -51,7 +51,7 @@ val info_file : string -> unit
 val occur_kn_in_ref : MutInd.t -> global -> bool
 val repr_of_r : global -> KerName.t
 val modpath_of_r : global -> ModPath.t
-val label_of_r : global -> Label.t
+val label_of_r : global -> Id.t
 val base_mp : ModPath.t -> ModPath.t
 val is_modfile : ModPath.t -> bool
 val string_of_modfile : t -> DirPath.t -> string
@@ -62,8 +62,8 @@ val mp_length : ModPath.t -> int
 val prefixes_mp : ModPath.t -> ModPath.Set.t
 val common_prefix_from_list :
   ModPath.t -> ModPath.t list -> ModPath.t option
-val get_nth_label_mp : int -> ModPath.t -> Label.t
-val labels_of_ref : global -> ModPath.t * Label.t list
+val get_nth_label_mp : int -> ModPath.t -> Id.t
+val labels_of_ref : global -> ModPath.t * Id.t list
 
 (*s Some table-related operations *)
 
@@ -102,7 +102,7 @@ val add_info_axiom : t -> global -> unit
 val remove_info_axiom : t -> global -> unit
 val add_log_axiom : t -> global-> unit
 val add_symbol : t -> global -> unit
-val add_symbol_rule : t -> global -> Label.t -> unit
+val add_symbol_rule : t -> global -> Id.t -> unit
 
 val add_opaque : t -> global -> unit
 val remove_opaque : t -> global -> unit

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -868,7 +868,7 @@ let generate_equation_lemma env evd fnames f fun_num nb_params nb_args rec_args_
   let eqn = mkApp (Lazy.force eq, [|type_of_f; eq_lhs; eq_rhs|]) in
   let lemma_type = it_mkProd_or_LetIn eqn type_ctxt in
   (* Pp.msgnl (str "lemma type " ++ Printer.pr_lconstr lemma_type ++ fnl () ++ str "f_body " ++ Printer.pr_lconstr f_body); *)
-  let f_id = Label.to_id (Constant.label (fst (destConst evd f))) in
+  let f_id = Constant.label (fst (destConst evd f)) in
   let prove_replacement =
     tclTHENLIST
       [ tclDO (nb_params + rec_args_num + 1) intro
@@ -914,7 +914,7 @@ let do_replace (evd : Evd.evar_map ref) params rec_arg_num rev_args_id f fun_num
           in
           mkConst cst
         with (Not_found | NoLemma) as e ->
-          let f_id = Label.to_id (Constant.label (fst (destConst !evd f))) in
+          let f_id = Constant.label (fst (destConst !evd f)) in
           (*i The next call to mk_equation_id is valid since we will construct the lemma
             Ensures by: obvious
             i*)

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -260,7 +260,7 @@ let generate_functional_principle (evd : Evd.evar_map ref) old_princ_type sorts
       match new_princ_name with
       | Some {CAst.v=id; loc} -> (id, id, loc)
       | None ->
-        let id_of_f = Label.to_id (Constant.label (fst f)) in
+        let id_of_f = Constant.label (fst f) in
         (id_of_f, Elimschemes.make_elimination_ident id_of_f (EConstr.ESorts.quality_or_set !evd type_sort), None)
     in
     let names = ref [new_princ_name] in
@@ -847,7 +847,7 @@ let tauto =
   let open Ltac_plugin in
   let dp = List.map Id.of_string ["Tauto"; "Init"; "Corelib"] in
   let mp = ModPath.MPfile (DirPath.make dp) in
-  let kn = KerName.make mp (Label.make "tauto") in
+  let kn = KerName.make mp (Id.of_string "tauto") in
   Proofview.tclBIND (Proofview.tclUNIT ()) (fun () ->
       let body = Tacenv.interp_ltac kn in
       Tacinterp.eval_tactic body)
@@ -1196,7 +1196,7 @@ let get_funs_constant mp =
         (fun i na ->
           match na.Context.binder_name with
           | Name id ->
-            let const = Constant.make2 mp (Label.of_id id) in
+            let const = Constant.make2 mp id in
             (const, i)
           | Anonymous -> CErrors.anomaly (Pp.str "Anonymous fix."))
         na
@@ -1474,7 +1474,7 @@ let derive_correctness (funs : Constant.t EConstr.puniverses list) (graphs : ind
       in
       Array.iteri
         (fun i f_as_constant ->
-          let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
+          let f_id = Constant.label (fst f_as_constant) in
           (*i The next call to mk_correct_id is valid since we are constructing the lemma
               Ensures by: obvious
             i*)
@@ -1540,7 +1540,7 @@ let derive_correctness (funs : Constant.t EConstr.puniverses list) (graphs : ind
       in
       Array.iteri
         (fun i f_as_constant ->
-          let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
+          let f_id = Constant.label (fst f_as_constant) in
           (*i The next call to mk_complete_id is valid since we are constructing the lemma
               Ensures by: obvious
             i*)
@@ -2091,7 +2091,7 @@ let make_graph (f_ref : GlobRef.t) =
         in
         l
       | _ ->
-        let fname = CAst.make (Label.to_id (Constant.label c)) in
+        let fname = CAst.make (Constant.label c) in
         [ None, { Vernacexpr.fname
           ; univs = None
           ; binders = nal_tas
@@ -2109,7 +2109,7 @@ let make_graph (f_ref : GlobRef.t) =
     (* We register the infos *)
     List.iter
       (fun {Vernacexpr.fname = {CAst.v = id}} ->
-        add_Function false (Constant.make2 mp (Label.of_id id)))
+        add_Function false (Constant.make2 mp id))
       (snd expr_list)
 
 (* *************** statically typed entrypoints ************************* *)

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1278,7 +1278,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     returned_types (rtl : glob_constr list) =
   let funnames =
     List.map
-      (fun c -> Label.to_id (KerName.label (Constant.canonical (fst c))))
+      (fun c -> Constant.label (fst c))
       funconstants
   in
   (*   Pp.msgnl (prlist_with_sep fnl Printer.pr_glob_constr rtl); *)

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -76,7 +76,7 @@ let functional_induction with_clean c princl pat =
                       (or f_rec, f_rect) i*)
               let princ_name =
                 Elimschemes.make_elimination_ident
-                  (Label.to_id (Constant.label c'))
+                  (Constant.label c')
                   (elimination_sort_of_goal gl)
               in
               let princ_ref =

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -269,7 +269,7 @@ let update_Function finfo =
   Lib.add_leaf (in_Function finfo)
 
 let add_Function is_general f =
-  let f_id = Label.to_id (Constant.label f) in
+  let f_id = Constant.label f in
   let equation_lemma = find_or_none (mk_equation_id f_id)
   and correctness_lemma = find_or_none (mk_correct_id f_id)
   and completeness_lemma = find_or_none (mk_complete_id f_id)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -69,7 +69,7 @@ let def_of_const t =
     with Not_found ->
       anomaly
         ( str "Cannot find definition of constant "
-        ++ Id.print (Label.to_id (Constant.label (fst sp)))
+        ++ Id.print (Constant.label (fst sp))
         ++ str "." ) )
   | _ -> assert false
 
@@ -1705,7 +1705,7 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls
   let tcc_lemma_constr = ref Undefined in
   (* let _ = Pp.msgnl (fun _ _ -> str "relation := " ++ Printer.pr_lconstr_env env_with_pre_rec_args relation) in *)
   let hook {Declare.Hook.S.uctx; dref; _ } =
-    assert (match dref with GlobRef.ConstRef cst -> Id.equal (Label.to_id (Constant.label cst)) term_id | _ -> assert false);
+    assert (match dref with GlobRef.ConstRef cst -> Id.equal (Constant.label cst) term_id | _ -> assert false);
     let f_ref =
       declare_f function_name Decls.(IsProof Lemma) arg_ctx dref
     in

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -256,7 +256,7 @@ let coerce_to_ident_not_fresh sigma v =
         | None -> fail ()
         | Some id -> id
         end
-       | Const (cst,_) -> Label.to_id (Constant.label cst)
+       | Const (cst,_) -> Constant.label cst
        | Construct (cstr,_) ->
           let ref = GlobRef.ConstructRef cstr in
           let basename = Nametab.basename_of_global ref in
@@ -268,10 +268,10 @@ let coerce_to_ident_not_fresh sigma v =
        | Sort s ->
           begin
             match ESorts.kind sigma s with
-            | Sorts.SProp -> Label.to_id (Label.make "SProp")
-            | Sorts.Prop -> Label.to_id (Label.make "Prop")
-            | Sorts.Set -> Label.to_id (Label.make "Set")
-            | Sorts.Type _ | Sorts.QSort _ -> Label.to_id (Label.make "Type")
+            | Sorts.SProp -> Id.of_string "SProp"
+            | Sorts.Prop -> Id.of_string "Prop"
+            | Sorts.Set -> Id.of_string "Set"
+            | Sorts.Type _ | Sorts.QSort _ -> Id.of_string "Type"
           end
        | _ -> fail()
 

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -118,7 +118,7 @@ type typdef = {
 
 let change_kn_label kn id =
   let mp = KerName.modpath kn in
-  KerName.make mp (Label.of_id id)
+  KerName.make mp id
 
 let change_sp_label sp id =
   let (dp, _) = Libnames.repr_path sp in
@@ -236,7 +236,7 @@ type typext = {
 let push_typext vis prefix def =
   let iter data =
     let spc = Libnames.add_path_suffix prefix.obj_path data.edata_name in
-    let knc = KerName.make prefix.obj_mp (Label.of_id data.edata_name) in
+    let knc = KerName.make prefix.obj_mp data.edata_name in
     let user_warns = data.edata_warn in
     Tac2env.push_constructor ?user_warns vis spc knc
   in
@@ -244,7 +244,7 @@ let push_typext vis prefix def =
 
 let define_typext mp def =
   let iter data =
-    let knc = KerName.make mp (Label.of_id data.edata_name) in
+    let knc = KerName.make mp data.edata_name in
     let cdata = {
       Tac2env.cdata_prms = def.typext_prms;
       cdata_type = def.typext_type;
@@ -1211,7 +1211,7 @@ let pr_frame = function
 
 let () = register_handler begin function
 | Tac2interp.LtacError (kn, args) ->
-  let t_exn = KerName.make Tac2env.rocq_prefix (Label.make "exn") in
+  let t_exn = KerName.make Tac2env.rocq_prefix (Id.of_string "exn") in
   let v = Tac2ffi.of_open (kn, args) in
   let t = GTypRef (Other t_exn, []) in
   let c = Tac2print.pr_valexpr (Global.env ()) Evd.empty v t in
@@ -1483,7 +1483,7 @@ let register_prim_alg name params def =
   let def = { typdef_local = false; typdef_abstract = false; typdef_expr = def } in
   Lib.add_leaf (inTypDef id def)
 
-let rocq_def n = KerName.make Tac2env.rocq_prefix (Label.make n)
+let rocq_def n = KerName.make Tac2env.rocq_prefix (Id.of_string n)
 
 let def_unit = {
   typdef_local = false;

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -247,7 +247,7 @@ let of_rewstrategy ev = of_ext val_rewstrategy ev
 let to_rewstrategy ev = to_ext val_rewstrategy ev
 let rewstrategy = repr_ext val_rewstrategy
 
-let rocq_core n = Names.(KerName.make Tac2env.rocq_prefix (Label.of_id @@ Id.of_string_soft n))
+let rocq_core n = Names.(KerName.make Tac2env.rocq_prefix (Id.of_string_soft n))
 
 let internal_err = rocq_core "Internal"
 

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -22,7 +22,7 @@ open Tac2typing_env
 
 (** Hardwired types and constants *)
 
-let rocq_type n = KerName.make Tac2env.rocq_prefix (Label.make n)
+let rocq_type n = KerName.make Tac2env.rocq_prefix (Id.of_string n)
 
 let t_int = rocq_type "int"
 let t_string = rocq_type "string"

--- a/plugins/ltac2/tac2print.ml
+++ b/plugins/ltac2/tac2print.ml
@@ -19,19 +19,19 @@ let pr_tacref avoid kn =
   try Libnames.pr_qualid (Tac2env.shortest_qualid_of_ltac avoid (TacConstant kn))
   with Not_found when !Flags.in_debugger || KerName.Map.mem kn (Tac2env.globals()) ->
     str (ModPath.to_string (KerName.modpath kn))
-    ++ str"." ++ Label.print (KerName.label kn)
+    ++ str"." ++ Id.print (KerName.label kn)
     ++ if !Flags.in_debugger then mt() else str " (* local *)"
 
 (** Utils *)
 
 let change_kn_label kn id =
   let mp = KerName.modpath kn in
-  KerName.make mp (Label.of_id id)
+  KerName.make mp id
 
 let paren p = hov 2 (str "(" ++ p ++ str ")")
 
 let t_list =
-  KerName.make Tac2env.rocq_prefix (Label.of_id (Id.of_string "list"))
+  KerName.make Tac2env.rocq_prefix (Id.of_string "list")
 
 let c_nil = change_kn_label t_list (Id.of_string_soft "[]")
 let c_cons = change_kn_label t_list (Id.of_string_soft "::")
@@ -46,7 +46,7 @@ type typ_level =
 | T0
 
 let t_unit =
-  KerName.make Tac2env.rocq_prefix (Label.of_id (Id.of_string "unit"))
+  KerName.make Tac2env.rocq_prefix (Id.of_string "unit")
 
 let pr_typref kn =
   Libnames.pr_qualid (Tac2env.shortest_qualid_of_type kn)
@@ -936,7 +936,7 @@ and pr_val_list env sigma args tpe =
 let pr_valexpr env sigma v t = pr_valexpr_gen env sigma E5 v t
 
 let register_init n f =
-  let kn = KerName.make Tac2env.rocq_prefix (Label.make n) in
+  let kn = KerName.make Tac2env.rocq_prefix (Id.of_string n) in
   register_val_printer kn { val_printer = fun env sigma v _ -> f env sigma v }
 
 let () = register_init "int" begin fun _ _ n ->
@@ -983,7 +983,7 @@ let () = register_init "err" begin fun _ _ e ->
 end
 
 let () =
-  let kn = KerName.make Tac2env.rocq_prefix (Label.make "array") in
+  let kn = KerName.make Tac2env.rocq_prefix (Id.of_string "array") in
   let val_printer env sigma v arg = match arg with
   | [arg] ->
     let (_, v) = to_block v in

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -35,9 +35,9 @@ let control_prefix = prefix_gen "Control"
 let pattern_prefix = prefix_gen "Pattern"
 let array_prefix = prefix_gen "Array"
 let constr_prefix = prefix_gen "Constr"
-let format_prefix = MPdot (prefix_gen "Message", Label.make "Format")
+let format_prefix = MPdot (prefix_gen "Message", Id.of_string "Format")
 
-let kername prefix n = KerName.make prefix (Label.of_id (Id.of_string_soft n))
+let kername prefix n = KerName.make prefix (Id.of_string_soft n)
 let std_core n = kername Tac2env.std_prefix n
 let rocq_core n = kername Tac2env.rocq_prefix n
 let control_core n = kername control_prefix n
@@ -74,7 +74,7 @@ open Refs
 (** Quoters *)
 
 let in_constr mods n =
-  let mp = List.fold_left (fun mp mod_ -> MPdot (mp, Label.of_id @@ Id.of_string mod_))
+  let mp = List.fold_left (fun mp mod_ -> MPdot (mp, Id.of_string mod_))
       constr_prefix
       mods
   in

--- a/plugins/ltac2_ltac1/tac2core_ltac1.ml
+++ b/plugins/ltac2_ltac1/tac2core_ltac1.ml
@@ -120,7 +120,7 @@ let gtypref kn = GTypRef (Other kn, [])
 
 open Tac2quote.Refs
 
-let core_prefix path n = KerName.make path (Label.of_id (Id.of_string_soft n))
+let core_prefix path n = KerName.make path (Id.of_string_soft n)
 let ltac1_core n = core_prefix Tac2env.ltac1_prefix n
 let t_ltac1 = ltac1_core "t"
 let ltac1_lambda = ltac1_core "lambda"

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -264,7 +264,7 @@ let cdir = ["Stdlib";plugin_dir]
 let znew_ring_path =
   DirPath.make (List.map Id.of_string ["InitialRing";plugin_dir;"Stdlib"])
 let zltac s =
-  lazy(KerName.make (ModPath.MPfile znew_ring_path) (Label.make s))
+  lazy(KerName.make (ModPath.MPfile znew_ring_path) (Id.of_string s))
 
 (* Ring theory *)
 
@@ -707,7 +707,7 @@ let new_field_path =
   DirPath.make (List.map Id.of_string ["Field_tac";plugin_dir;"Stdlib"])
 
 let field_ltac s =
-  lazy(KerName.make (ModPath.MPfile new_field_path) (Label.make s))
+  lazy(KerName.make (ModPath.MPfile new_field_path) (Id.of_string s))
 
 
 let _ = add_map "field"

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -601,7 +601,7 @@ let abs_cterm env sigma n c0 =
 let rec constr_name sigma c = match EConstr.kind sigma c with
   | Var id -> Name id
   | Cast (c', _, _) -> constr_name sigma c'
-  | Const (cn,_) -> Name (Label.to_id (Constant.label cn))
+  | Const (cn,_) -> Name (Constant.label cn)
   | App (c', _) -> constr_name sigma c'
   | _ -> Anonymous
 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -397,7 +397,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_
       if dir = R2L then sigma, elim else
       let elim, _ = EConstr.destConst sigma elim in
       let mp,l = KerName.repr (Constant.canonical elim) in
-      let l' = Label.of_id (Nameops.add_suffix (Label.to_id l) "_r")  in
+      let l' = Nameops.add_suffix l "_r"  in
       let c1' = Global.constant_of_delta_kn (Constant.canonical (Constant.make2 mp l')) in
       Evd.fresh_global env sigma (ConstRef c1')
   in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -97,7 +97,7 @@ let register_ssrtac name f prods =
     | TacNonTerm (_, (_, ido)) -> ido in
   let ids = List.map_filter get_id prods in
   let tac = CAst.make (TacML (ssrtac_entry name, List.map map ids)) in
-  let key = KerName.make path (Label.make ("ssrparser_" ^ name)) in
+  let key = KerName.make path (Id.of_string ("ssrparser_" ^ name)) in
   let body = Tacenv.{ alias_args = ids; alias_body = tac; alias_deprecation = None } in
   let parule = {
     pptac_level = 0;

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -909,7 +909,7 @@ and detype_r d flags avoid env sigma t =
     | Proj (p,_,c) ->
       if Projection.unfolded p && print_unfolded_primproj_asmatch () then
         let c = detype d flags avoid env sigma c in
-        let id = Label.to_id @@ Projection.label p in
+        let id = Projection.label p in
         let nargs, parg =
           try
             let _, mip = Global.lookup_inductive (Projection.inductive p) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -653,8 +653,7 @@ let compute_projections env (kn, i as ind) =
         (proj_arg, j+1, pbs, subst)
     | LocalAssum (na,t) ->
       match na.binder_name with
-      | Name id ->
-        let lab = Label.of_id id in
+      | Name lab ->
         let proj_relevant = na.binder_relevance in
         let kn = Projection.Repr.make ind ~proj_npars:mib.mind_nparams ~proj_arg lab in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -355,7 +355,7 @@ let invert_recursive_names infos env sigma ref u names i =
           | EvalRel _ | EvalEvar _ -> None
           | EvalVar id' -> Some (EvalVar id)
           | EvalConst kn ->
-            let kn = Constant.change_label kn (Label.of_id id) in
+            let kn = Constant.change_label kn id in
             if Environ.mem_constant kn env then Some (EvalConst kn) else None
         in
         match refi with

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -142,8 +142,8 @@ let pr_in_comment x = str "(* " ++ x ++ str " *)"
     (needs an environment for this). *)
 
 let id_of_global env = let open GlobRef in function
-  | ConstRef kn -> Label.to_id (Constant.label kn)
-  | IndRef (kn,0) -> Label.to_id (MutInd.label kn)
+  | ConstRef kn -> Constant.label kn
+  | IndRef (kn,0) -> MutInd.label kn
   | IndRef (kn,i) ->
     (Environ.lookup_mind kn env).mind_packets.(i).mind_typename
   | ConstructRef ((kn,i),j) ->
@@ -154,7 +154,7 @@ let rec dirpath_of_mp = function
   | MPfile sl -> sl
   | MPbound uid -> DirPath.make [MBId.to_id uid]
   | MPdot (mp,l) ->
-    Libnames.add_dirpath_suffix (dirpath_of_mp mp) (Label.to_id l)
+    Libnames.add_dirpath_suffix (dirpath_of_mp mp) l
 
 let dirpath_of_global = let open GlobRef in function
   | ConstRef kn -> dirpath_of_mp (Constant.modpath kn)
@@ -1152,9 +1152,9 @@ let pr_assumptionset env sigma s =
               | ConstRef kn -> Constant.label kn
               | IndRef (kn,_)
               | ConstructRef ((kn,_),_) -> MutInd.label kn
-              | VarRef id -> Label.of_id id
+              | VarRef id -> id
             in
-            str "used in " ++ Label.print lab ++
+            str "used in " ++ Id.print lab ++
             str " to prove" ++ fnl() ++ safe_pr_ltype_relctx (ctx,ty))
           l in
         (v, ax :: a, o, tr)

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -69,7 +69,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
     let bad id = match lookup_named_val id section_sign with
     | (_ : named_declaration) -> true
     | exception Not_found ->
-      Safe_typing.exists_objlabel (Names.Label.of_id id) (Global.safe_env ()) ||
+      Safe_typing.exists_objlabel id (Global.safe_env ()) ||
       (* The local environment is OK when it comes to constants though,
          including those defined by [tclABSTRACT]. *)
       let kn = Lib.make_kn id in

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -74,7 +74,7 @@ struct
     | DArray
 
   let compare_ci ci1 ci2 =
-    let c = Label.compare (MutInd.label @@ fst ci1.ci_ind) (MutInd.label @@ fst ci2.ci_ind) in
+    let c = Id.compare (MutInd.label @@ fst ci1.ci_ind) (MutInd.label @@ fst ci2.ci_ind) in
     if c = 0 then
       let c = Int.compare ci1.ci_npar ci2.ci_npar in
       if c = 0 then
@@ -449,7 +449,7 @@ let fresh_key =
     let lbl = Id.of_string_soft (Printf.sprintf "%s#%i"
       (ModPath.to_string mp) cur)
     in
-    KerName.make mp (Label.of_id lbl)
+    KerName.make mp lbl
 
 let auto_multi_rewrite_with ?(conds=Naive) tac_main lbas cl =
   let onconcl = match cl.Locus.concl_occs with NoOccurrences -> false | _ -> true in

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -435,7 +435,7 @@ let magically_constant_of_fixbody env sigma (reference, params) bd = function
   | Name.Anonymous -> bd
   | Name.Name id ->
     let open UnivProblem in
-    let cst = Constant.change_label reference (Label.of_id id) in
+    let cst = Constant.change_label reference id in
     if not (Environ.mem_constant cst env) then bd
     else
       let (cst, u), ctx = UnivGen.fresh_constant_instance env cst in

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -171,9 +171,8 @@ let lookup_eliminator_by_name env ind_sp s =
   let mpc = KerName.modpath @@ MutInd.canonical kn in
   let ind_id = (lookup_mind kn env).mind_packets.(i).mind_typename in
   let id = make_elimination_ident ind_id s in
-  let l = Label.of_id id in
-  let knu = KerName.make mpu l in
-  let knc = KerName.make mpc l in
+  let knu = KerName.make mpu id in
+  let knc = KerName.make mpc id in
   (* Try first to get an eliminator defined in the same section as the *)
   (* inductive type *)
   let cst = Constant.make knu knc in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -363,11 +363,11 @@ let find_elim lft2rgt dep cls ((_, hdcncl, _) as t) =
           | None ->
              let c1 = destConstRef (Elimschemes.lookup_eliminator env ind_sp sort) in
              let mp,l = KerName.repr (Constant.canonical c1) in
-             let l' = Label.of_id (add_suffix (Label.to_id l) "_r")  in
+             let l' = add_suffix l "_r"  in
              let c1' = Global.constant_of_delta_kn (KerName.make mp l') in
              if not (Environ.mem_constant c1' (Global.env ())) then
                user_err
-                 (str "Cannot find rewrite principle " ++ Label.print l' ++ str ".");
+                 (str "Cannot find rewrite principle " ++ Id.print l' ++ str ".");
              c1'
           end
         | _ ->

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -211,7 +211,7 @@ let fresh_key =
     let lbl = Id.of_string_soft (Printf.sprintf "%s#%i"
       (ModPath.to_string mp) cur)
     in
-    KerName.make mp (Label.of_id lbl)
+    KerName.make mp lbl
 
 let pri_order_int (id1, {pri=pri1}) (id2, {pri=pri2}) =
   let d = Int.compare pri1 pri2 in

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -83,7 +83,7 @@ let is_visible_name id =
   with Not_found ->
     (* FIXME: due to private constant declaration being imperative, we have to
        also check in the global env *)
-    Global.exists_objlabel (Label.of_id id)
+    Global.exists_objlabel id
 
 let compute_name internal id avoid =
   if internal then
@@ -143,7 +143,7 @@ let local_check_scheme kind ind { sch_eff = eff } =
 
 let define ?loc internal role id c poly uctx sch =
   let avoid = Safe_typing.constants_of_private sch.sch_eff.Evd.seff_private in
-  let avoid = Id.Set.of_list @@ List.map (fun cst -> Label.to_id @@ Constant.label cst) avoid in
+  let avoid = Id.Set.of_list @@ List.map (fun cst -> Constant.label cst) avoid in
   let id = compute_name internal id avoid in
   let uctx = UState.collapse_above_prop_sort_variables ~to_prop:true uctx in
   let uctx = UState.minimize uctx in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -32,17 +32,17 @@ let modcache = ref (ModPath.Map.empty : structure_body ModPath.Map.t)
 
 let rec search_mod_label lab = function
   | [] -> raise Not_found
-  | (l, SFBmodule mb) :: _ when Label.equal l lab -> mb
+  | (l, SFBmodule mb) :: _ when Id.equal l lab -> mb
   | _ :: fields -> search_mod_label lab fields
 
 let rec search_cst_label lab = function
   | [] -> raise Not_found
-  | (l, SFBconst cb) :: _ when Label.equal l lab -> cb
+  | (l, SFBconst cb) :: _ when Id.equal l lab -> cb
   | _ :: fields -> search_cst_label lab fields
 
 let rec search_mind_label lab = function
   | [] -> raise Not_found
-  | (l, SFBmind mind) :: _ when Label.equal l lab -> mind
+  | (l, SFBmind mind) :: _ when Id.equal l lab -> mind
   | _ :: fields -> search_mind_label lab fields
 
 (* TODO: using [empty_delta_resolver] below is probably slightly incorrect. But:

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -540,7 +540,7 @@ let build_beq_scheme env handle kn =
         if Reduction.is_arity env (Typeops.type_of_constant_in env cst) then
           (* Support for working in a context with "eq_x : x -> x -> bool" *)
           (* Needs Hints, see test suite *)
-          let eq_lbl = Label.make ("eq_" ^ Label.to_string (Constant.label kn)) in
+          let eq_lbl = Id.of_string ("eq_" ^ Id.to_string (Constant.label kn)) in
           let kneq = Constant.change_label kn eq_lbl in
           if Environ.mem_constant kneq env then
             let _ = Environ.constant_opt_value_in env (kneq, u) in
@@ -918,9 +918,9 @@ let do_replace_lb handle aavoid narg p q =
       (* Works in specific situations where the args have to be already declared as a
          Parameter (see example "J" in test file SchemeEquality.v);
          We assume the parameter to have the same polymorphic arity as cst *)
-        let lbl = Label.to_string (Constant.label cst) in
+        let lbl = Id.to_string (Constant.label cst) in
         let newlbl = if Int.equal offset 1 then ("eq_" ^ lbl) else (lbl ^ "_lb") in
-        let newcst = Constant.change_label cst (Label.make newlbl) in
+        let newcst = Constant.change_label cst (Id.of_string newlbl) in
         if Environ.mem_constant newcst env then mkConstU (newcst,u)
         else raise (ConstructorWithNonParametricInductiveType (fst hd))
     | _ -> raise (ConstructorWithNonParametricInductiveType (fst hd))
@@ -965,9 +965,9 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
       (* Works in specific situations where the args have to be already declared as a
          Parameter (see example "J" in test file SchemeEquality.v)
          We assume the parameter to have the same polymorphic arith as cst *)
-        let lbl = Label.to_string (Constant.label cst) in
+        let lbl = Id.to_string (Constant.label cst) in
         let newlbl = if Int.equal offset 1 then ("eq_" ^ lbl) else (lbl ^ "_bl") in
-        let newcst = Constant.change_label cst (Label.make newlbl) in
+        let newcst = Constant.change_label cst (Id.of_string newlbl) in
         if Environ.mem_constant newcst env then mkConstU (newcst,u)
         else raise (ConstructorWithNonParametricInductiveType (fst hd))
     | _ -> raise (ConstructorWithNonParametricInductiveType (fst hd))

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -567,7 +567,7 @@ let interp_instance_context ~program_mode env ctx pl tclass =
 let id_of_class env ref =
   let open GlobRef in
   match ref with
-    | ConstRef kn -> Label.to_id @@ Constant.label kn
+    | ConstRef kn -> Constant.label kn
     | IndRef (kn,i) ->
         let mip = (Environ.lookup_mind kn env).Declarations.mind_packets in
           mip.(0).Declarations.mind_typename

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -162,9 +162,9 @@ let get_strength stre ref cls clt =
 let ident_key_of_class = function
   | CL_FUN -> "Funclass"
   | CL_SORT -> "Sortclass"
-  | CL_CONST sp -> Label.to_string (Constant.label sp)
-  | CL_PROJ sp -> Label.to_string (Projection.Repr.label sp)
-  | CL_IND (sp,_) -> Label.to_string (MutInd.label sp)
+  | CL_CONST sp -> Id.to_string (Constant.label sp)
+  | CL_PROJ sp -> Id.to_string (Projection.Repr.label sp)
+  | CL_IND (sp,_) -> Id.to_string (MutInd.label sp)
   | CL_SECVAR id -> Id.to_string id
 
 (* Identity coercion *)

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -139,8 +139,8 @@ let input_sort_names (src, l) =
 
 
 let label_of = let open GlobRef in function
-| ConstRef c -> Label.to_id @@ Constant.label c
-| IndRef (c,_) -> Label.to_id @@ MutInd.label c
+| ConstRef c -> Constant.label c
+| IndRef (c,_) -> MutInd.label c
 | VarRef id -> id
 | ConstructRef _ ->
   CErrors.anomaly ~label:"declare_univ_binders"

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -664,7 +664,7 @@ let import_modules ~export mpl =
     the ModSubstObjs table, we compensate this by explicit traversal
     of Module Types inner objects when needed. Quite a hack... *)
 
-let mp_id mp id = MPdot (mp, Label.of_id id)
+let mp_id mp id = MPdot (mp, id)
 
 let rec register_mod_objs mp obj = match obj with
   | ModuleObject (id,sobjs) -> ModSubstObjs.set (mp_id mp id) sobjs
@@ -706,7 +706,7 @@ let rec replace_module_object idl mp0 objs0 mp1 objs1 =
   | _,[] -> []
   | id::idl,(ModuleObject (id', sobjs))::tail when Id.equal id id' ->
     begin
-      let mp_id = MPdot(mp0, Label.of_id id) in
+      let mp_id = MPdot(mp0, id) in
       let objs = match idl with
         | [] -> subst_objects (map_mp mp1 mp_id (empty_delta_resolver mp_id)) objs1
         | _ ->
@@ -864,7 +864,7 @@ let start_module_core id args res =
         Some (mte, inl), Enforce (mte, base, kind, inl)
     | Check resl -> None, Check (build_subtypes resl)
   in
-  let mp = ModPath.MPdot((openmod_syntax_info ()).cur_mp, Label.of_id id) in
+  let mp = ModPath.MPdot((openmod_syntax_info ()).cur_mp, id) in
   mp, res_entry_o, mbids, sign, args
 
 let start_module export id args res =
@@ -924,7 +924,7 @@ let declare_module id args res mexpr_o =
   let fs = Summary.Synterp.freeze_summaries () in
   (* We simulate the beginning of an interactive module,
      then we adds the module parameters to the global env. *)
-  let mp = ModPath.MPdot((openmod_syntax_info ()).cur_mp, Label.of_id id) in
+  let mp = ModPath.MPdot((openmod_syntax_info ()).cur_mp, id) in
   let args = intern_args args in
   let mbids = List.flatten @@ List.map fst args in
   let mty_entry_o = match res with
@@ -1213,7 +1213,7 @@ module RawModTypeOps = struct
 module Synterp = struct
 
 let start_modtype_core id cur_mp args mtys =
-  let mp = ModPath.MPdot(cur_mp, Label.of_id id) in
+  let mp = ModPath.MPdot(cur_mp, id) in
   let args = RawModOps.Synterp.intern_args args in
   let mbids = List.flatten @@ List.map (fun (mbidl,_) -> mbidl) args in
   let sub_mty_l = RawModOps.Synterp.build_subtypes mtys in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1177,7 +1177,7 @@ let pr_modtype_subpath upper mp =
       Libnames.add_dirpath_suffix dir id, []
     with Not_found ->
       match mp with
-      | MPdot (mp',id) -> let mp, suff = aux mp' in mp, Label.to_id id::suff
+      | MPdot (mp',id) -> let mp, suff = aux mp' in mp, id::suff
       | _ -> assert false
   in
   let mp, suff = aux mp in
@@ -1286,7 +1286,7 @@ let rec get_submodules acc = function
 
 let get_submodules trace =
   let submodules, trace = get_submodules [] trace in
-  (String.concat "." (List.map Label.to_string submodules)), trace
+  (String.concat "." (List.map Id.to_string submodules)), trace
 
 let rec print_trace = function
   | [] -> assert false
@@ -1300,15 +1300,15 @@ let rec print_trace = function
 
 let explain_signature_mismatch trace l why =
   let submodules, trace = get_submodules trace in
-  let l = if String.is_empty submodules then Label.print l
-    else str submodules ++ str"." ++ Label.print l
+  let l = if String.is_empty submodules then Id.print l
+    else str submodules ++ str"." ++ Id.print l
   in
   str "Signature components for field " ++ l ++
   (if List.is_empty trace then mt() else str " in " ++ print_trace trace) ++
   str " do not match:" ++ spc () ++ explain_not_match_error why ++ str "."
 
 let explain_label_already_declared l =
-  str "The label " ++ Label.print l ++ str " is already declared."
+  str "The label " ++ Id.print l ++ str " is already declared."
 
 let explain_not_a_functor () =
   str "Application of a non-functor."
@@ -1334,25 +1334,25 @@ let explain_not_equal_module_paths mp1 mp2 =
   str "Module " ++ pr_modpath mp1 ++ strbrk " is not equal to " ++ pr_module_or_modtype_subpath mp2 ++ str "."
 
 let explain_no_such_label l mp =
-  str "No field named " ++ Label.print l ++ str " in " ++ pr_modtype_subpath false mp ++ str "."
+  str "No field named " ++ Id.print l ++ str " in " ++ pr_modtype_subpath false mp ++ str "."
 
 let explain_not_a_module_label l =
-  Label.print l ++ str " is not the name of a module field."
+  Id.print l ++ str " is not the name of a module field."
 
 let explain_not_a_constant l =
-  quote (Label.print l) ++ str " is not a constant."
+  quote (Id.print l) ++ str " is not a constant."
 
 let explain_incorrect_label_constraint l =
   str "Incorrect constraint for label " ++
-  quote (Label.print l) ++ str "."
+  quote (Id.print l) ++ str "."
 
 let explain_generative_module_expected l =
-  str "The module " ++ Label.print l ++ str " is not generative." ++
+  str "The module " ++ Id.print l ++ str " is not generative." ++
   strbrk " Only components of generative modules can be changed" ++
   strbrk " using the \"with\" construct."
 
 let explain_label_missing l s =
-  str "The field " ++ Label.print l ++ str " is missing in "
+  str "The field " ++ Id.print l ++ str " is missing in "
   ++ str s ++ str "."
 
 let explain_include_restricted_functor mp =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -39,7 +39,7 @@ let () = CErrors.register_handler @@ function
 let compat_custom_names = Summary.ref ~stage:Synterp ~name:"compat-custom-names" Id.Map.empty
 
 let add_custom_compat kn =
-  let id = CustomName.label kn |> Label.to_id in
+  let id = CustomName.label kn in
   compat_custom_names :=
     Id.Map.update id (fun existing -> Some (kn :: Option.default [] existing))
       !compat_custom_names

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -717,20 +717,20 @@ let print_library_leaf env sigma ~with_values mp lobj =
           (try Some(print_named_decl env sigma false id) with Not_found -> None)
       end @@
       DynHandle.add Declare.Internal.Constant.tag begin fun (id,_) ->
-        let kn = Constant.make2 mp (Label.of_id id) in
+        let kn = Constant.make2 mp id in
         Some (print_constant env ~with_values false kn None)
       end @@
       DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-        let kn = MutInd.make2 mp (Label.of_id id) in
+        let kn = MutInd.make2 mp id in
         Some (print_inductive env kn None)
       end @@
       DynHandle.empty
     in
     handle handler o
   | ModuleObject (id,_) ->
-    Some (Printmod.print_module ~with_body:(Option.has_some with_values) (MPdot (mp,Label.of_id id)))
+    Some (Printmod.print_module ~with_body:(Option.has_some with_values) (MPdot (mp, id)))
   | ModuleTypeObject (id,_) ->
-    Some (print_modtype (MPdot (mp, Label.of_id id)))
+    Some (print_modtype (MPdot (mp, id)))
   | IncludeObject _ | KeepObject _ | EscapeObject _ | ExportObject _ -> None
 
 let decr = Option.map ((+) (-1))
@@ -782,7 +782,7 @@ let handleF h (Libobject.Dyn.Dyn (tag, o)) = match DynHandleF.find tag h with
 let print_full_pure_atomic access env sigma mp lobj =
   let handler =
     DynHandleF.add Declare.Internal.Constant.tag begin fun (id,_) ->
-      let kn = KerName.make mp (Label.of_id id) in
+      let kn = KerName.make mp id in
       let con = Global.constant_of_delta_kn kn in
       let cb = Global.lookup_constant con in
       let typ = cb.const_type in
@@ -809,7 +809,7 @@ let print_full_pure_atomic access env sigma mp lobj =
       ++ str "." ++ fnl () ++ fnl ()
     end @@
     DynHandleF.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-      let kn = KerName.make mp (Label.of_id id) in
+      let kn = KerName.make mp id in
       let mind = Global.mind_of_delta_kn kn in
       let mib = Global.lookup_mind mind in
       Printmod.pr_mutual_inductive_body (Global.env()) mind mib None ++
@@ -823,10 +823,10 @@ let print_full_pure_leaf access env sigma mp = function
   | AtomicObject lobj -> print_full_pure_atomic access env sigma mp lobj
   | ModuleObject (id, _) ->
     (* TODO: make it reparsable *)
-    print_module (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+    print_module (MPdot (mp, id)) ++ str "." ++ fnl () ++ fnl ()
   | ModuleTypeObject (id, _) ->
     (* TODO: make it reparsable *)
-    print_modtype (MPdot (mp,Label.of_id id)) ++ str "." ++ fnl () ++ fnl ()
+    print_modtype (MPdot (mp, id)) ++ str "." ++ fnl () ++ fnl ()
   | _ -> mt()
 
 let print_full_pure_context access env sigma =

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -175,7 +175,7 @@ let pr_mutual_inductive_body env mind mib udecl =
 let rec print_local_modpath locals = function
   | MPbound mbid -> Id.print (Util.List.assoc_f MBId.equal mbid locals)
   | MPdot(mp,l) ->
-      print_local_modpath locals mp ++ str "." ++ Label.print l
+      print_local_modpath locals mp ++ str "." ++ Id.print l
   | MPfile _ -> raise Not_found
 
 let print_modpath locals mp =
@@ -217,7 +217,7 @@ let nametab_register_body mp dir (l,body) =
     | SFBmodtype _ -> () (* TODO *)
     | SFBrules _ -> () (* TODO? *)
     | SFBconst _ ->
-      push (Label.to_id l) (GlobRef.ConstRef (Constant.make2 mp l))
+      push l (GlobRef.ConstRef (Constant.make2 mp l))
     | SFBmind mib ->
       let mind = MutInd.make2 mp l in
       Array.iteri
@@ -263,7 +263,7 @@ let nametab_register_modparam used mbid mtb =
       id
 
 let print_body is_impl extent env mp (l,body) =
-  let name = Label.print l in
+  let name = Id.print l in
   hov 2 (match body with
     | SFBmodule _ -> keyword "Module" ++ spc () ++ name
     | SFBmodtype _ -> keyword "Module Type" ++ spc () ++ name

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -568,7 +568,7 @@ let build_named_proj ~primitive ~flags ~univs ~uinstance ~kind env paramdecls
       (* [ccl'] is defined in context [params;x:rp;x:rp] *)
       if primitive then
         let p = Projection.Repr.make indsp
-            ~proj_npars:mib.mind_nparams ~proj_arg:i (Label.of_id fid) in
+            ~proj_npars:mib.mind_nparams ~proj_arg:i fid in
         mkProj (Projection.make p false, rci, mkRel 1), Some (p,rci)
       else
         let ccl' = liftn 1 2 ccl in
@@ -955,7 +955,7 @@ let declare_class ?mode declared =
         | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> assert false
       in
       let params, field = Term.decompose_lambda_decls class_body in
-      let fname = Name (Label.to_id @@ Constant.label proj_kn) in
+      let fname = Name (Constant.label proj_kn) in
       let frelevance = proj_cb.const_relevance in
       let fields = [ RelDecl.LocalAssum ({binder_name=fname; binder_relevance=frelevance}, field) ] in
       let proj = {

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -83,7 +83,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
     | AtomicObject o ->
       let handler =
         DynHandle.add Declare.Internal.Constant.tag begin fun (id,obj) ->
-          let kn = KerName.make prefix.obj_mp (Label.of_id id) in
+          let kn = KerName.make prefix.obj_mp id in
           let cst = Global.constant_of_delta_kn kn in
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
@@ -91,7 +91,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
           fn gr (Some kind) env sigma typ
         end @@
         DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
-          let kn = KerName.make prefix.obj_mp (Label.of_id id) in
+          let kn = KerName.make prefix.obj_mp id in
           let mind = Global.mind_of_delta_kn kn in
           let mib = Global.lookup_mind mind in
           let iter_packet i mip =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -257,8 +257,7 @@ let print_namespace ~pstate ns =
   let rec match_modulepath ns = function
     | MPbound _ -> None (* Not a proper namespace. *)
     | MPfile dir -> match_dirpath ns (Names.DirPath.repr dir)
-    | MPdot (mp,lbl) ->
-        let id = Names.Label.to_id lbl in
+    | MPdot (mp,id) ->
         begin match match_modulepath ns mp with
         | Some [] as y -> y
         | Some (a::ns') ->
@@ -277,14 +276,14 @@ let print_namespace ~pstate ns =
     let rec list_of_modulepath = function
       | MPbound _ -> assert false (* MPbound never matches *)
       | MPfile dir -> Names.DirPath.repr dir
-      | MPdot (mp,lbl) -> (Names.Label.to_id lbl)::(list_of_modulepath mp)
+      | MPdot (mp,lbl) -> lbl::(list_of_modulepath mp)
     in
     snd (Util.List.chop n (List.rev (list_of_modulepath mp)))
   in
   let print_list pr l = prlist_with_sep (fun () -> str".") pr l in
   let print_kn kn =
     let (mp,lbl) = Names.KerName.repr kn in
-    let qn = (qualified_minus (List.length ns) mp)@[Names.Label.to_id lbl] in
+    let qn = (qualified_minus (List.length ns) mp)@[lbl] in
     print_list Id.print qn
   in
   let print_constant ~pstate k body =


### PR DESCRIPTION
This opaque alias of Id does not seem useful and mostly results in sprinkling Label.to/of_id around the codebase.

Close #21102

Overlays:
- https://github.com/impermeable/coq-waterproof/pull/189
- https://github.com/coq-tactician/coq-tactician/pull/113
- https://github.com/ejgallego/rocq-lsp/pull/1044