### PR TITLE
Do not rely on canonical names in side-effect internal implementation.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -445,8 +445,8 @@ type side_effect_role =
 
 type side_effects = {
   seff_private : Safe_typing.private_constants;
-  seff_roles : side_effect_role Cmap.t;
-  seff_univs : UState.named_universes_entry Cmap.t;
+  seff_roles : side_effect_role Cmap_env.t;
+  seff_univs : UState.named_universes_entry Cmap_env.t;
 }
 
 module FutureGoals : sig
@@ -926,8 +926,8 @@ let empty_evar_flags =
 
 let empty_side_effects = {
   seff_private = Safe_typing.empty_private_constants;
-  seff_roles = Cmap.empty;
-  seff_univs = Cmap.empty;
+  seff_roles = Cmap_env.empty;
+  seff_univs = Cmap_env.empty;
 }
 
 let empty = {
@@ -1270,8 +1270,8 @@ exception UniversesDiffer = UState.UniversesDiffer
 let emit_side_effects eff evd =
   let effects = {
   seff_private = Safe_typing.concat_private eff.seff_private evd.effects.seff_private;
-  seff_roles = Cmap.fold Cmap.add eff.seff_roles evd.effects.seff_roles;
-  seff_univs = Cmap.fold Cmap.add eff.seff_univs evd.effects.seff_univs;
+  seff_roles = Cmap_env.fold Cmap_env.add eff.seff_roles evd.effects.seff_roles;
+  seff_univs = Cmap_env.fold Cmap_env.add eff.seff_univs evd.effects.seff_univs;
   } in
   { evd with effects; universes = UState.emit_side_effects eff.seff_private evd.universes }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -391,8 +391,8 @@ type side_effect_role =
 
 type side_effects = {
   seff_private : Safe_typing.private_constants;
-  seff_roles : side_effect_role Cmap.t;
-  seff_univs : UState.named_universes_entry Cmap.t;
+  seff_roles : side_effect_role Cmap_env.t;
+  seff_univs : UState.named_universes_entry Cmap_env.t;
   (* only used by Declare to register names for mono universes *)
 }
 

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -122,7 +122,7 @@ let redeclare_schemes { sch_eff = eff } =
       let old = try String.Map.find kind accu with Not_found -> [] in
       String.Map.add kind ((ind, c) :: old) accu
   in
-  let schemes = Cmap.fold fold eff.Evd.seff_roles String.Map.empty in
+  let schemes = Cmap_env.fold fold eff.Evd.seff_roles String.Map.empty in
   let iter kind defs = List.iter (DeclareScheme.declare_scheme SuperGlobal kind) defs in
   String.Map.iter iter schemes
 
@@ -136,7 +136,7 @@ let local_lookup_scheme eff kind ind = match lookup_scheme kind ind with
   in
   (* Inefficient O(n), but the number of locally declared schemes is small and
      this is very rarely called *)
-  try let _ = Cmap.iter iter eff.Evd.seff_roles in None with Found c -> Some c
+  try let _ = Cmap_env.iter iter eff.Evd.seff_roles in None with Found c -> Some c
 
 let local_check_scheme kind ind { sch_eff = eff } =
   Option.has_some (local_lookup_scheme eff kind ind)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -480,8 +480,8 @@ let register_side_effect (c, body, role, univs) =
 
 let get_roles export eff =
   let map (c, body) =
-    let role = try Some (Cmap.find c eff.Evd.seff_roles) with Not_found -> None in
-    let univs = try Some (Cmap.find c eff.Evd.seff_univs) with Not_found -> None in
+    let role = try Some (Cmap_env.find c eff.Evd.seff_roles) with Not_found -> None in
+    let univs = try Some (Cmap_env.find c eff.Evd.seff_univs) with Not_found -> None in
     (c, body, role, univs)
   in
   List.map map export
@@ -696,11 +696,11 @@ let declare_private_constant ?role ~name ~opaque de effs senv =
   let (kn, eff), senv = Safe_typing.add_private_constant (Label.of_id name) ctx de senv in
   let seff_univs =
     if Univ.Level.Set.is_empty (fst ctx) then effs.Evd.seff_univs
-    else Cmap.add kn (UState.Monomorphic_entry ctx, UnivNames.empty_binders) effs.Evd.seff_univs
+    else Cmap_env.add kn (UState.Monomorphic_entry ctx, UnivNames.empty_binders) effs.Evd.seff_univs
   in
   let seff_roles = match role with
   | None -> effs.Evd.seff_roles
-  | Some r -> Cmap.add kn r effs.Evd.seff_roles
+  | Some r -> Cmap_env.add kn r effs.Evd.seff_roles
   in
   let seff_private = Safe_typing.concat_private eff effs.Evd.seff_private in
   let effs = Evd.({ seff_private; seff_roles; seff_univs }) in


### PR DESCRIPTION
Just like for the kernel, there is no point in trying to enforce a quotient here since all side-effects will be generated from the same proof and thus a fortiori within the same module, making it impossible to consider local constants aliasing to some other constant.