### PR TITLE
Merge the Dumpglob API to start dumping and to push a glob output.

### DIFF
--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -103,15 +103,14 @@
 
 *)
 
-val start_dump_glob : vfile:string -> vofile:string -> unit
-val end_dump_glob : unit -> unit
+type glob_file = { vfile : string; vofile : string }
 
 val dump : unit -> bool
 
 type glob_output =
   | NoGlob
   | Feedback
-  | MultFiles                   (* one glob file per .v file *)
+  | MultFiles of glob_file      (* one glob file per .v file *)
   | File of string              (* Single file for all coqc arguments *)
 
 (** [push_output o] temporarily overrides the output location to [o].

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -58,8 +58,13 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
         ~aux_file:(aux_file_name_for long_f_dot_out)
         ~v_file:long_f_dot_in);
 
-      Dumpglob.push_output copts.glob_out;
-      Dumpglob.start_dump_glob ~vfile:long_f_dot_in ~vofile:long_f_dot_out;
+      let dump = match copts.glob_out with
+      | NoGlob -> Dumpglob.NoGlob
+      | Feedback -> Dumpglob.Feedback
+      | MultFiles -> Dumpglob.MultFiles { vofile = long_f_dot_out; vfile = long_f_dot_in }
+      | File f -> Dumpglob.File f
+      in
+      Dumpglob.push_output dump;
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");
 
       let wall_clock1 = Unix.gettimeofday () in
@@ -83,7 +88,6 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       (* In both .vo, and .vok production mode, dump an empty .vok file to
          indicate that proofs are ok. *)
       dump_empty_vok();
-      Dumpglob.end_dump_glob ()
 
   | BuildVos ->
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -59,10 +59,9 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
         ~v_file:long_f_dot_in);
 
       let dump = match copts.glob_out with
-      | NoGlob -> Dumpglob.NoGlob
-      | Feedback -> Dumpglob.Feedback
-      | MultFiles -> Dumpglob.MultFiles { vofile = long_f_dot_out; vfile = long_f_dot_in }
-      | File f -> Dumpglob.File f
+      | None -> Dumpglob.MultFiles { vofile = long_f_dot_out; vfile = long_f_dot_in }
+      | Some NoGlob -> Dumpglob.NoGlob
+      | Some (GlobFile f) -> Dumpglob.File f
       in
       Dumpglob.push_output dump;
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -10,6 +10,12 @@
 
 type compilation_mode = BuildVo | BuildVos | BuildVok
 
+type glob_output =
+| NoGlob
+| Feedback
+| MultFiles                   (* one glob file per .v file *)
+| File of string              (* Single file for all coqc arguments *)
+
 type t =
   { compilation_mode : compilation_mode
 
@@ -18,7 +24,7 @@ type t =
 
   ; echo : bool
 
-  ; glob_out    : Dumpglob.glob_output
+  ; glob_out    : glob_output
 
   ; output_context : bool
   }
@@ -31,7 +37,7 @@ let default =
 
   ; echo = false
 
-  ; glob_out = Dumpglob.MultFiles
+  ; glob_out = MultFiles
 
   ; output_context = false
   }
@@ -118,11 +124,11 @@ let parse arglist : t =
 
         (* Glob options *)
         |"-no-glob" | "-noglob" ->
-          { oval with glob_out = Dumpglob.NoGlob }
+          { oval with glob_out = NoGlob }
 
         |"-dump-glob" ->
           let file = next () in
-          { oval with glob_out = Dumpglob.File file }
+          { oval with glob_out = File file }
 
         (* Rest *)
         | s ->

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -12,9 +12,7 @@ type compilation_mode = BuildVo | BuildVos | BuildVok
 
 type glob_output =
 | NoGlob
-| Feedback
-| MultFiles                   (* one glob file per .v file *)
-| File of string              (* Single file for all coqc arguments *)
+| GlobFile of string              (* Single file for all coqc arguments *)
 
 type t =
   { compilation_mode : compilation_mode
@@ -24,7 +22,7 @@ type t =
 
   ; echo : bool
 
-  ; glob_out    : glob_output
+  ; glob_out    : glob_output option
 
   ; output_context : bool
   }
@@ -37,7 +35,7 @@ let default =
 
   ; echo = false
 
-  ; glob_out = MultFiles
+  ; glob_out = None
 
   ; output_context = false
   }
@@ -124,11 +122,11 @@ let parse arglist : t =
 
         (* Glob options *)
         |"-no-glob" | "-noglob" ->
-          { oval with glob_out = NoGlob }
+          { oval with glob_out = Some NoGlob }
 
         |"-dump-glob" ->
           let file = next () in
-          { oval with glob_out = File file }
+          { oval with glob_out = Some (GlobFile file) }
 
         (* Rest *)
         | s ->

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -22,6 +22,12 @@
 *)
 type compilation_mode = BuildVo | BuildVos | BuildVok
 
+type glob_output =
+| NoGlob
+| Feedback
+| MultFiles                   (* one glob file per .v file *)
+| File of string              (* Single file for all coqc arguments *)
+
 type t =
   { compilation_mode : compilation_mode
 
@@ -30,7 +36,7 @@ type t =
 
   ; echo : bool
 
-  ; glob_out    : Dumpglob.glob_output
+  ; glob_out    : glob_output
 
   ; output_context : bool
   }

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -24,9 +24,7 @@ type compilation_mode = BuildVo | BuildVos | BuildVok
 
 type glob_output =
 | NoGlob
-| Feedback
-| MultFiles                   (* one glob file per .v file *)
-| File of string              (* Single file for all coqc arguments *)
+| GlobFile of string (* Single file for all coqc arguments *)
 
 type t =
   { compilation_mode : compilation_mode
@@ -36,7 +34,7 @@ type t =
 
   ; echo : bool
 
-  ; glob_out    : glob_output
+  ; glob_out    : glob_output option
 
   ; output_context : bool
   }


### PR DESCRIPTION
All users were synchronized, except that the main entry point was forgetting to end the dumping, since it would exit prematurely. Furthermore, we clean up along the way the internal states of the Dumpglob module. I am not sure this code was really designed this way, it looks like its dire state is the result of organic modification, but this resulted in very dubious bits of code.

(This is a first PR to clean up the code before further performance enhancements.)