### PR TITLE
Add dev/ci/ci-env.sh which can be sourced to set paths for CI

### DIFF
--- a/dev/ci/ci-env.sh
+++ b/dev/ci/ci-env.sh
@@ -2,34 +2,47 @@
 
 if which cygpath >/dev/null 2>&1; then OCAMLFINDSEP=\;; else OCAMLFINDSEP=:; fi
 
+if [ "${BASH_SOURCE[0]}" ]; then
+  root="$(dirname "${BASH_SOURCE[0]}")/../.."
+  # make path absolute if relative
+  root=$(cd "$root" && echo "$PWD")
+elif [ -e "$PWD/dev/ci/ci-env.sh" ]; then
+  root=$PWD
+else
+  >&2 echo "BASH_SOURCE not working (too old bash version?)"
+  >&2 echo "update bash or run this script from the rocq repository's root directory"
+  exit 1
+fi
+
+
 # We can remove setting ROCQLIB and ROCQRUNTIMELIB from here, but better to
 # wait until we have merged the coq.boot patch so we can do this in a
 # more controlled way.
 if [ -n "${GITLAB_CI}" ];
 then
     # Gitlab build, Rocq installed into `_install_ci`
-    export COQBIN="$PWD/_install_ci/bin"
-    export OCAMLPATH="$PWD/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
-    export PATH="$PWD/_install_ci/bin:$PATH"
+    export COQBIN="$root/_install_ci/bin"
+    export OCAMLPATH="$root/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
+    export PATH="$root/_install_ci/bin:$PATH"
 
     # Where we install external binaries and ocaml libraries
     # also generally used for dune install --prefix so needs to match coq's expected user-contrib path
-    CI_INSTALL_DIR="$PWD/_install_ci"
+    CI_INSTALL_DIR="$root/_install_ci"
 
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
     if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
     then
         export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
     fi
-elif [ -d "$PWD/_build/install/default/" ];
+elif [ -d "$root/_build/install/default/" ];
 then
     # Full Dune build, we basically do what `dune exec --` does
-    export OCAMLPATH="$PWD/_build/install/default/lib/$OCAMLFINDSEP$OCAMLPATH"
-    export COQBIN="$PWD/_build/install/default/bin"
-    export ROCQLIB="$PWD/_build/install/default/lib/coq"
-    export ROCQRUNTIMELIB="$PWD/_build/install/default/lib/rocq-runtime"
+    export OCAMLPATH="$root/_build/install/default/lib/$OCAMLFINDSEP$OCAMLPATH"
+    export COQBIN="$root/_build/install/default/bin"
+    export ROCQLIB="$root/_build/install/default/lib/coq"
+    export ROCQRUNTIMELIB="$root/_build/install/default/lib/rocq-runtime"
 
-    CI_INSTALL_DIR="$PWD/_build/install/default/"
+    CI_INSTALL_DIR="$root/_build/install/default/"
 
     CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
     export CI_BRANCH

--- a/dev/ci/ci-env.sh
+++ b/dev/ci/ci-env.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if which cygpath >/dev/null 2>&1; then OCAMLFINDSEP=\;; else OCAMLFINDSEP=:; fi
+
+# We can remove setting ROCQLIB and ROCQRUNTIMELIB from here, but better to
+# wait until we have merged the coq.boot patch so we can do this in a
+# more controlled way.
+if [ -n "${GITLAB_CI}" ];
+then
+    # Gitlab build, Rocq installed into `_install_ci`
+    export COQBIN="$PWD/_install_ci/bin"
+    export OCAMLPATH="$PWD/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
+    export PATH="$PWD/_install_ci/bin:$PATH"
+
+    # Where we install external binaries and ocaml libraries
+    # also generally used for dune install --prefix so needs to match coq's expected user-contrib path
+    CI_INSTALL_DIR="$PWD/_install_ci"
+
+    export CI_BRANCH="$CI_COMMIT_REF_NAME"
+    if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
+    then
+        export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
+    fi
+elif [ -d "$PWD/_build/install/default/" ];
+then
+    # Full Dune build, we basically do what `dune exec --` does
+    export OCAMLPATH="$PWD/_build/install/default/lib/$OCAMLFINDSEP$OCAMLPATH"
+    export COQBIN="$PWD/_build/install/default/bin"
+    export ROCQLIB="$PWD/_build/install/default/lib/coq"
+    export ROCQRUNTIMELIB="$PWD/_build/install/default/lib/rocq-runtime"
+
+    CI_INSTALL_DIR="$PWD/_build/install/default/"
+
+    CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export CI_BRANCH
+fi
+
+export PATH="$COQBIN:$PATH"
+
+# Rocq's tools need an ending slash :S, we should fix them.
+export COQBIN="$COQBIN/"

--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -9,7 +9,7 @@ fi
 : "${NJOBS:=1}"
 export NJOBS
 
-. "${BASH_SOURCE[0]}/../ci-env.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../ci-env.sh"
 
 # Where we download and build external developments
 CI_BUILD_DIR="$PWD/_build_ci"

--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -9,45 +9,7 @@ fi
 : "${NJOBS:=1}"
 export NJOBS
 
-if which cygpath >/dev/null 2>&1; then OCAMLFINDSEP=\;; else OCAMLFINDSEP=:; fi
-
-# We can remove setting ROCQLIB and ROCQRUNTIMELIB from here, but better to
-# wait until we have merged the coq.boot patch so we can do this in a
-# more controlled way.
-if [ -n "${GITLAB_CI}" ];
-then
-    # Gitlab build, Rocq installed into `_install_ci`
-    export COQBIN="$PWD/_install_ci/bin"
-    export OCAMLPATH="$PWD/_install_ci/lib$OCAMLFINDSEP$OCAMLPATH"
-    export PATH="$PWD/_install_ci/bin:$PATH"
-
-    # Where we install external binaries and ocaml libraries
-    # also generally used for dune install --prefix so needs to match coq's expected user-contrib path
-    CI_INSTALL_DIR="$PWD/_install_ci"
-
-    export CI_BRANCH="$CI_COMMIT_REF_NAME"
-    if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
-    then
-        export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
-    fi
-elif [ -d "$PWD/_build/install/default/" ];
-then
-    # Full Dune build, we basically do what `dune exec --` does
-    export OCAMLPATH="$PWD/_build/install/default/lib/$OCAMLFINDSEP$OCAMLPATH"
-    export COQBIN="$PWD/_build/install/default/bin"
-    export ROCQLIB="$PWD/_build/install/default/lib/coq"
-    export ROCQRUNTIMELIB="$PWD/_build/install/default/lib/rocq-runtime"
-
-    CI_INSTALL_DIR="$PWD/_build/install/default/"
-
-    CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-    export CI_BRANCH
-fi
-
-export PATH="$COQBIN:$PATH"
-
-# Rocq's tools need an ending slash :S, we should fix them.
-export COQBIN="$COQBIN/"
+. "${BASH_SOURCE[0]}/../ci-env.sh"
 
 # Where we download and build external developments
 CI_BUILD_DIR="$PWD/_build_ci"


### PR DESCRIPTION
ci-common has extra stuff, including `set -xe` which is not wanted in interactive use