### PR TITLE
Use the same code for TC exact resolution as other hint kinds.

### DIFF
--- a/dev/ci/user-overlays/21193-ppedrot-factor-tc-hint-exact.sh
+++ b/dev/ci/user-overlays/21193-ppedrot-factor-tc-hint-exact.sh
@@ -1,0 +1,1 @@
+overlay metarocq https://github.com/ppedrot/metarocq factor-tc-hint-exact 21193

--- a/doc/changelog/04-tactics/21193-factor-tc-hint-exact-Changed.rst
+++ b/doc/changelog/04-tactics/21193-factor-tc-hint-exact-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  type class hints without hypotheses used via functor
+  applications are applied with their type from the module
+  type rather than the module instance
+  (`#21193 <https://github.com/rocq-prover/rocq/pull/21193>`_,
+  by Pierre-Marie Pédrot).

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -155,14 +155,7 @@ let auto_unif_flags ?(allowed_evars = Evarsolve.AllowedEvars.all) st =
 }
 
 let e_give_exact flags h =
-  Proofview.Goal.enter begin fun gl ->
-  let env = Proofview.Goal.env gl in
-  let sigma = Proofview.Goal.sigma gl in
-  let sigma, c = Hints.fresh_hint env sigma h in
-  let (sigma, t1) = Typing.type_of env sigma c in
-  Proofview.Unsafe.tclEVARS sigma <*>
-  Clenv.unify ~flags ~cv_pb:CUMUL t1 <*> exact_no_check c
-  end
+  Hints.hint_res_pf ~with_evars:false ~with_classes:false ~flags h
 
 let unify_resolve ~with_evars flags h diff = match diff with
 | None ->

--- a/test-suite/bugs/bug_21193.v
+++ b/test-suite/bugs/bug_21193.v
@@ -1,0 +1,20 @@
+Class UnivSubst := subst : unit.
+
+Module Type Term.
+  Parameter subst1 : UnivSubst.
+End Term.
+
+Module Environment (T : Term).
+
+#[global] Existing Instance T.subst1.
+
+End Environment.
+
+Module PCUICTerm.
+  (* if we do ": UnivSubst" here we get the same error in master as in PR#21193 *)
+  Definition subst1 : unit := tt.
+End PCUICTerm.
+
+Module Export PCUICEnvironment := Environment PCUICTerm.
+
+Definition infer := subst.


### PR DESCRIPTION
The fact the code was different is probably a historical artifact. By leveraging the same clenv code, we reduce at the same time the dependency on dubious Clenv API while allowing the Clenv internals to rely on more clever unification heuristics for e.g. universe polymorphic code.

Overlay:
- https://github.com/MetaRocq/metarocq/pull/1217