### PR TITLE
Do not rely on term ordering in Search priority ordering.

### DIFF
--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -126,8 +126,6 @@ module ConstrPriority = struct
   type t = GlobRef.t * Decls.logical_kind option * Environ.env * Evd.evar_map * Constr.t * priority
   and priority = int
 
-  module ConstrSet = CSet.Make(Constr)
-
   (** A measure of the size of a term *)
   let rec size t =
     Constr.fold (fun s t -> 1 + s + size t) 0 t
@@ -137,13 +135,13 @@ module ConstrPriority = struct
   let rec symbols acc t =
     let open Constr in
     match kind t with
-    | Const _ | Ind _ | Construct _ -> ConstrSet.add t acc
+    | Const _ | Ind _ | Construct _ -> GlobRef.Set_env.add (fst @@ destRef t) acc
     | _ -> Constr.fold symbols acc t
 
   (** The number of distinct "symbols" (see {!symbols}) which appear
       in a term. *)
   let num_symbols t =
-    ConstrSet.(cardinal (symbols empty t))
+    GlobRef.Set_env.(cardinal (symbols empty t))
 
   let priority gref t : priority =
     -(3*(num_symbols t) + size t)


### PR DESCRIPTION
The code was actually only ever considering global references. This patch is a slight change of semantics for two reasons. First, the previous code was also taking into account the universe instances of the references, which would have resulted in a dubious semantics for universe polymorphic code. Second, we now consider aliased references distinct. In any case, this piece of code is just a heuristic for a printing order, so it should not matter.