### PR TITLE
Introduce a command to create Rewrite hint databases.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21203-create-hint-rewrite-db-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21203-create-hint-rewrite-db-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  a :cmd:`Create Rewrite HintDb` command to explicitly declare
+  rewrite hint databases
+  (`#21203 <https://github.com/rocq-prover/rocq/pull/21203>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -340,6 +340,10 @@ and `Constants`, while implicitly created databases have the `Opaque` setting.
       `Create HintDb` will not change whether a pre-existing database
       is discriminated.
 
+.. cmd:: Create Rewrite HintDb @ident
+
+   Like above, but creates a database for :cmd:`Hint Rewrite` declarations
+   instead.
 
 Hint databases defined in the Rocq standard library
 ```````````````````````````````````````````````````

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -623,6 +623,7 @@ command: [
 | "Hint" "Rewrite" orient LIST1 constr "using" generic_tactic ":" LIST1 preident
 | "Hint" "Rewrite" orient LIST1 constr
 | "Hint" "Rewrite" orient LIST1 constr "using" generic_tactic
+| "Create" "Rewrite" "HintDb" ident
 | "Derive" "Inversion_clear" identref "with" constr "Sort" sort_quality_or_set
 | "Derive" "Inversion_clear" identref "with" constr
 | "Derive" "Inversion" identref "with" constr "Sort" sort_quality_or_set

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -901,6 +901,7 @@ command: [
 | "Functional" "Case" func_scheme_def      (* funind plugin *)
 | "Generate" "graph" "for" qualid      (* funind plugin *)
 | "Hint" "Rewrite" OPT [ "->" | "<-" ] LIST1 one_term OPT ( "using" generic_tactic ) OPT ( ":" LIST1 ident )
+| "Create" "Rewrite" "HintDb" ident
 | "Derive" "Inversion_clear" ident "with" one_term OPT ( "Sort" sort_quality_or_set )
 | "Derive" "Inversion" ident "with" one_term OPT ( "Sort" sort_quality_or_set )
 | "Derive" "Dependent" "Inversion" ident "with" one_term "Sort" sort_quality_or_set

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -238,6 +238,11 @@ VERNAC COMMAND EXTEND HintRewrite CLASSIFIED BY { classify_hint }
   { add_rewrite_hint ~locality ~poly:polymorphic ["core"] o (Some t) l }
 END
 
+VERNAC COMMAND EXTEND HintCreateRewriteDb CLASSIFIED BY { classify_hint }
+| #[ locality = Synterp.module_locality ] [ "Create" "Rewrite" "HintDb" ident(id) ] ->
+  { create_rewrite_hint_db ~local:locality ~name:(Id.to_string id) }
+END
+
 (**********************************************************************)
 (* Refine                                                             *)
 

--- a/tactics/autorewrite.mli
+++ b/tactics/autorewrite.mli
@@ -15,6 +15,8 @@ open Equality
 
 type raw_rew_rule = (constr Univ.in_universe_context_set * bool * Gentactic.raw_generic_tactic option) CAst.t
 
+val create_rewrite_hint_db : local:bool -> name:string -> unit
+
 (** To add rewriting rules to a base *)
 val add_rew_rules : locality:Hints.hint_locality -> string -> raw_rew_rule list -> unit
 


### PR DESCRIPTION
This is long overdue. We have the same command for auto hint databases, and we even deprecated the implicit creation of dbs when declaring hints, but for some reason the corresponding basic mechanism for hint rewrite was missing.