### PR TITLE
Deprecate creating implicitly Hint rewrite databases.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21206-deprecate-implicit-hint-rewrite-db-creation-Deprecated.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21206-deprecate-implicit-hint-rewrite-db-creation-Deprecated.rst
@@ -1,0 +1,6 @@
+- **Deprecated:**
+  creating implicitly rewrite hint databases through the
+  :cmd:`Hint Rewrite` command. One must now do it explicitly
+  through :cmd:`Create Rewrite HintDb`
+  (`#21206 <https://github.com/rocq-prover/rocq/pull/21206>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -214,6 +214,7 @@ the optional tactic of the ``Hint Rewrite`` command.
 
    .. rocqtop:: in
 
+      Create Rewrite HintDb base0.
       Global Hint Rewrite Ack0 Ack1 Ack2 : base0.
 
    .. rocqtop:: all
@@ -244,6 +245,7 @@ the optional tactic of the ``Hint Rewrite`` command.
 
    .. rocqtop:: in extra-stdlib
 
+      Create Rewrite HintDb base1.
       Global Hint Rewrite g0 g1 g2 using lia : base1.
 
    .. rocqtop:: in extra-stdlib


### PR DESCRIPTION
This is in line with the newly introduced behaviour for normal hintdbs.