### PR TITLE
Make "Debug SSrmatching" a regular debug flag

### DIFF
--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -5765,17 +5765,6 @@ Commands
 
    prenex implicits declaration (see :ref:`parametric_polymorphism_ssr`)
 
-Settings
-~~~~~~~~
-
-.. flag:: Debug Ssreflect
-
-   *Developer only.* Print debug information on reflect.
-
-.. flag:: Debug SsrMatching
-
-   *Developer only.* Print debug information on SSR matching.
-
 .. rubric:: Footnotes
 
 .. [#1] Unfortunately, even after a call to the ``Set Printing All`` command,

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -38,23 +38,9 @@ let errorstrm = CErrors.user_err
 let loc_error loc msg = CErrors.user_err ?loc (str msg)
 let ppnl = Feedback.msg_info
 
-(* 0 cost pp function. Active only if env variable SSRDEBUG is set *)
-(* or if SsrDebug is Set                                                  *)
-let pp_ref = ref (fun _ -> ())
-let ssr_pp s = Feedback.msg_debug (str"SSR: "++Lazy.force s)
-let _ =
-  try ignore(Sys.getenv "SSRMATCHINGDEBUG"); pp_ref := ssr_pp
-  with Not_found -> ()
-let debug b =
-  if b then pp_ref := ssr_pp else pp_ref := fun _ -> ()
-let _ =
-  Goptions.declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optkey   = ["Debug";"SsrMatching"];
-      optdepr  = None;
-      optread  = (fun _ -> !pp_ref == ssr_pp);
-      optwrite = debug }
-let pp s = !pp_ref s
+let pp = CDebug.create ~name:"ssrmatching" ()
+let pp s = pp (fun () -> Lazy.force s)
+
 let { Goptions.get = option_LegacyFoUnif } =
   Goptions.declare_bool_option_and_ref ~key:["SsrMatching";"LegacyFoUnif"]
     ~depr:{Deprecation.since=Some "9.2";

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -240,9 +240,6 @@ val cpattern_of_id : Names.Id.t -> cpattern
 val pr_constr_pat : env -> evar_map -> constr -> Pp.t
 val pr_econstr_pat : env -> evar_map -> econstr -> Pp.t
 
-(* One can also "Set SsrMatchingDebug" from a .v *)
-val debug : bool -> unit
-
 val ssrinstancesof : cpattern -> unit Proofview.tactic
 
 (** Functions used for grammar extensions. Do not use. *)


### PR DESCRIPTION
Debug Ssreflect was already a regular debug flag

Close #21198
