### PR TITLE
Ltac2 "constr" syntax classes accept custom entries, explicit levels

### DIFF
--- a/doc/changelog/06-Ltac2-language/21215-ltac2-custom-const-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21215-ltac2-custom-const-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :ref:`syntactic_classes` parsing terms support parsing at a specific level
+  and parsing :ref:`custom-entries`
+  (`#21215 <https://github.com/rocq-prover/rocq/pull/21215>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1492,11 +1492,14 @@ Metasyntactic operations that can be applied to other syntactic classes are:
 The following classes represent nonterminals with some special handling.  The
 table further down lists the classes that are handled plainly.
 
-.. insertprodn ltac2_constr_synclass_arg ltac2_constr_synclass_arg
+.. insertprodn ltac2_constr_delimiters_arg ltac2_constr_synclass_arg
 
 .. prodn::
-   ltac2_constr_synclass_arg ::= @scope_key
+   ltac2_constr_delimiters_arg ::= @scope_key
    | delimiters ( {+, @scope_key } )
+   ltac2_constr_synclass_arg ::= @ltac2_constr_delimiters_arg
+   | custom ( @qualid )
+   | level ( @natural )
 
 Syntactic classes parsing terms may specify :token:`scope_key`\s which
 are used to interpret the term (as described in :ref:`LocalInterpretationRulesForNotations`).
@@ -1504,12 +1507,17 @@ The last :token:`scope_key` is the top of the scope stack that's applied to the
 :token:`term`.
 When more than one :n:`@scope_key` is specified, it should be qualified using `delimiters`.
 
+A :ref:`custom entry <custom-entries>` a parsing level may also be
+specified (except for the "l" syntactic classes which always parse the
+main term entry at level 200). If a custom entry is specified without
+a level, it is parsed at its highest level.
+
   :n:`constr {? ( {+, @ltac2_constr_synclass_arg } ) }`
     Parses a :token:`term`.
     Typechecking the term runs typeclass resolution, after which no
     new undefined existential variables may exist.
 
-  :n:`lconstr {? ( {+, @ltac2_constr_synclass_arg } ) }`
+  :n:`lconstr {? ( {+, @ltac2_constr_delimiters_arg } ) }`
      Identical to `constr` but the term is parsed at precedence level 200.
 
   :n:`open_constr {? ( {+, @ltac2_constr_synclass_arg } ) }`
@@ -1517,7 +1525,7 @@ When more than one :n:`@scope_key` is specified, it should be qualified using `d
     Typechecking the term may create new undefined existential variables,
     and does not run typeclass resolution.
 
-  :n:`open_lconstr {? ( {+, @ltac2_constr_synclass_arg } ) }`
+  :n:`open_lconstr {? ( {+, @ltac2_constr_delimiters_arg } ) }`
      Identical to `open_constr` but the term is parsed at precedence level 200.
 
 .. _preterm:
@@ -1526,7 +1534,7 @@ When more than one :n:`@scope_key` is specified, it should be qualified using `d
     Parses a non-typechecked :token:`term`. Like :n:`constr` above, this class
     accepts a list of notation scopes with the same effects.
 
-  :n:`lpreterm {? ( {+, @ltac2_constr_synclass_arg } ) }`
+  :n:`lpreterm {? ( {+, @ltac2_constr_delimiters_arg } ) }`
      Identical to `preterm` but the term is parsed at precedence level 200.
 
   :n:`ident`

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2132,9 +2132,15 @@ ltac2_induction_clause: [
 | WITH ltac2_destruction_arg ltac2_as_or_and_ipat ltac2_eqn_ipat OPT ltac2_clause  TAG Ltac2
 ]
 
-ltac2_constr_synclass_arg: [
+ltac2_constr_delimiters_arg: [
 | scope_key
 | "delimiters" "(" LIST1 scope_key SEP "," ")"
+]
+
+ltac2_constr_synclass_arg: [
+| ltac2_constr_delimiters_arg
+| "custom" "(" qualid ")"
+| "level" "(" natural ")"
 ]
 
 starredidentref: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1794,9 +1794,15 @@ ltac2_in_clause: [
 | LIST0 ltac2_hypident_occ SEP "," OPT ( "|-" OPT ltac2_concl_occ )      (* Ltac2 plugin *)
 ]
 
-ltac2_constr_synclass_arg: [
+ltac2_constr_delimiters_arg: [
 | scope_key
 | "delimiters" "(" LIST1 scope_key SEP "," ")"
+]
+
+ltac2_constr_synclass_arg: [
+| ltac2_constr_delimiters_arg
+| "custom" "(" qualid ")"
+| "level" "(" natural ")"
 ]
 
 q_occurrences: [

--- a/test-suite/ltac2/custom_constr.v
+++ b/test-suite/ltac2/custom_constr.v
@@ -1,0 +1,50 @@
+
+Require Import Ltac2.Ltac2.
+
+Module B13462.
+
+  Axiom plus: nat -> nat -> nat.
+
+  Declare Custom Entry foo.
+
+  Definition enter{T: Type}: T -> T := @id T.
+
+  Notation "a +++ b" := (plus a b) (in custom foo at level 5, a custom foo, b custom foo).
+  Notation "x" := x (in custom foo at level 0, x ident).
+  Notation "{{ x }}" := (enter x) (x custom foo at level 5).
+
+  Ltac2 Notation "go" "(" a(constr(custom(foo))) ")" := pose $a as x.
+
+  Goal forall (p q: nat), False.
+  Proof.
+    intros.
+    go (p +++ q).
+  Abort.
+
+End B13462.
+
+Declare Custom Entry bar.
+
+Fail Ltac2 Notation "foo" a(constr(custom(foo))) := a.
+Succeed Ltac2 Notation "foo" a(constr(custom(B13462.foo))) := a.
+
+Fail Ltac2 Notation "foo" a(constr(custom(foo,bar))) := a.
+
+Fail Ltac2 Notation "foo" a(constr(level(-10))) := a.
+Fail Ltac2 Notation "foo" a(constr(level(bar))) := a.
+
+Ltac2 Notation "foo" a(constr(level(10))) := a.
+Ltac2 Eval foo S 0.
+Ltac2 Eval (foo S : constr). (* ": constr" is a ltac2 cast not a term cast *)
+
+Fail Ltac2 Notation "bar" a(constr(level(10),level(10))) := a.
+Ltac2 Notation "bar" a(constr(custom(bar),level(0))) "!" := a.
+Ltac2 Notation "bar" a(constr) "!" := a.
+
+Notation "!! x" := (S x : bool) (in custom bar at level 10, x custom bar at level 0).
+Notation "##" := (0:bool) (in custom bar).
+
+Notation "!! x" := (S x) (at level 2).
+
+Ltac2 Eval bar !! 0 !. (* picked bar with argument in constr so succeeds *)
+Fail Ltac2 Eval bar ## !. (* picked bar with argument in custom bar so fails (nat <> bool) *)


### PR DESCRIPTION
eg `Ltac2 Notation "foo" c(constr(custom(bla),level(42),delimiter)) := ...`

Note that the current implementation suffers from #21214

cf #13462 (that issue is for ltac1 so IDK if we should mark as closed)

Depends:
- https://github.com/rocq-prover/rocq/pull/21265