### PR TITLE
Comment out `Fail Timeout` in bteauto test

### DIFF
--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -94,7 +94,7 @@ Module Hierarchies.
   Definition makeB (a : A) : B := _.
   Definition makeA (a : B) : A := _.
 
-  Fail Timeout 1 Definition makeA' : A := _.
+  (* Fail Timeout 1 Definition makeA' : A := _. *)
 
   #[export] Hint Cut [_* mkB aofb] : typeclass_instances.
   Fail Definition makeA' : A := _.
@@ -135,7 +135,7 @@ Proof.
   intros []. constructor. reflexivity.
 Qed.
 
-Fail Timeout 1 Check prf.
+(* Fail Timeout 1 Check prf. *)
 
 #[export] Hint Mode SomeProp + + : typeclass_instances.
 Check prf.
@@ -156,13 +156,13 @@ Module IterativeDeepening.
   
   Goal C -> A.
     intros.
-    Fail Timeout 1 typeclasses eauto.
+    (* Fail Timeout 1 typeclasses eauto. *)
     Set Typeclasses Iterative Deepening.
     Fail typeclasses eauto 1.
     typeclasses eauto 2.
     Undo.
     Unset Typeclasses Iterative Deepening.
-    Fail Timeout 1 typeclasses eauto.
+    (* Fail Timeout 1 typeclasses eauto. *)
     Set Typeclasses Iterative Deepening.
     Typeclasses eauto := debug 3.
     typeclasses eauto.


### PR DESCRIPTION
These commands seem to have a potential for arbitrary memory usage, leading to unreliable CI.

https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/bteauto.20failures.20in.20CI