### PR TITLE
Fix Fixpoint with measure

### DIFF
--- a/test-suite/bugs/bug_21217.v
+++ b/test-suite/bugs/bug_21217.v
@@ -1,0 +1,7 @@
+Require Import ListDef.
+
+Fail Fixpoint test (l:list nat) {measure (length l)} : list nat :=
+match l with
+| nil => nil
+| e::f => test f
+end.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -423,7 +423,7 @@ let interp_wf ~program_mode env sigma recname ctx ccl = function
         sigma, true, extradecl
       else
         let sigma, wf_term = well_founded sigma in
-        let applied_wf = mkApp (wf_term, [| relargty; rel; measure |]) in
+        let applied_wf = mkApp (wf_term, [| relargty; rel |]) in
         let extradecl = RelDecl.LocalAssum (make_annot (Name recproofid) ERelevance.relevant, applied_wf) in
         sigma, false, extradecl
     in


### PR DESCRIPTION
There were 2 issues leading to anomalies:
- we generated an invalid term `@well_founded nat lt (length l)`
- we tolerated unsolved evars in non-program mode (based on some program mode evar source business) then did to_constr

Fix #21217