### PR TITLE
Univ poly doc: dowgrade header level of printing universes

### DIFF
--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -581,7 +581,7 @@ to universes and explicitly instantiate polymorphic definitions.
 .. _printing-universes:
 
 Printing universes
-------------------
+~~~~~~~~~~~~~~~~~~
 
 .. flag:: Printing Universes
 


### PR DESCRIPTION
Before this commit the doc looks like

~~~
- Explicit Universes
- Printing universes
  + Polymorphic definitions 
~~~

after it looks like

~~~
- Explicit Universes
  + Printing universes
  + Polymorphic definitions 
~~~

which makes more sense IMO
