### PR TITLE
Add "Ltac2 Import Type" command

### DIFF
--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -182,6 +182,11 @@ One can define new types with the following commands.
          Ltac2 Eval PositiveInt.get (PositiveInt.make 3).
          Fail Ltac2 Eval PositiveInt.get (PositiveInt.make -1).
 
+.. cmd:: Ltac2 Import Type @qualid as @ident
+
+   Declares :n:`@ident` as an alias of :n:`@qualid` (i.e. `Ltac2 Type @ident := @qualid`),
+   and also makes its constructors or projections to have names accessible from the current module.
+
 .. cmd:: Ltac2 @ external @ident : @ltac2_type := @string__plugin @string__function
    :name: Ltac2 external
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -698,6 +698,7 @@ command: [
 | "Number" "Notation" reference reference reference OPT number_options ":" preident
 | "String" "Notation" reference reference reference OPT string_option ":" preident
 | "Ltac2" ltac2_entry      (* ltac2 plugin *)
+| "Ltac2" "Import" "Type" reference "as" ident      (* ltac2 plugin *)
 | "Ltac2" "Custom" "Entry" identref      (* ltac2 plugin *)
 | "Ltac2" "Notation" ltac2def_syn      (* ltac2 plugin *)
 | "Ltac2" "Abbreviation" ltac2abbrev_syn      (* ltac2 plugin *)

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -910,6 +910,7 @@ command: [
 | "Declare" "Right" "Step" one_term
 | "Number" "Notation" qualid qualid qualid OPT ( "(" LIST1 number_modifier SEP "," ")" ) ":" scope_name
 | "String" "Notation" qualid qualid qualid OPT ( "(" number_string_via ")" ) ":" scope_name
+| "Ltac2" "Import" "Type" qualid "as" ident      (* ltac2 plugin *)
 | "Ltac2" "Custom" "Entry" ident      (* ltac2 plugin *)
 | "Ltac2" "Notation" LIST1 ltac2_syntax_class OPT [ ":" natural | ":" qualid OPT [ "(" natural ")" ] ] ":=" ltac2_expr      (* ltac2 plugin *)
 | "SubClass" ident_decl def_body

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -1036,6 +1036,11 @@ VERNAC COMMAND EXTEND VernacDeclareTactic2Definition
   } -> {
     Tac2entries.register_struct raw_attributes e
   }
+| [ "Ltac2" "Import" "Type" reference(qid) "as" ident(id) ] => {
+    VtSideff ([id], VtLater)
+  } -> {
+  Tac2entries.import_type qid id
+  }
 | [ "Ltac2" "Custom" "Entry" identref(id) ] => { Vernacextend.(VtSideff ([], VtNow)) } SYNTERP AS _ {
   Tac2entries.register_custom_entry id
   } -> {

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -124,9 +124,8 @@ let change_sp_label sp id =
   let (dp, _) = Libnames.repr_path sp in
   Libnames.make_path dp id
 
-let push_typedef visibility sp kn (_, def) = match def with
-| GTydDef _ ->
-  Tac2env.push_type visibility sp kn
+let push_typedef_contents visibility sp kn (_, def) = match def with
+| GTydDef _ -> ()
 | GTydAlg { galg_constructors = cstrs } ->
   (* Register constructors *)
   let iter (user_warns, c, _) =
@@ -134,7 +133,6 @@ let push_typedef visibility sp kn (_, def) = match def with
     let knc = change_kn_label kn c in
     Tac2env.push_constructor ?user_warns visibility spc knc
   in
-  Tac2env.push_type visibility sp kn;
   List.iter iter cstrs
 | GTydRec fields ->
   (* Register fields *)
@@ -143,10 +141,12 @@ let push_typedef visibility sp kn (_, def) = match def with
     let knc = change_kn_label kn c in
     Tac2env.push_projection visibility spc knc
   in
-  Tac2env.push_type visibility sp kn;
   List.iter iter fields
-| GTydOpn ->
-  Tac2env.push_type visibility sp kn
+| GTydOpn -> ()
+
+let push_typedef visibility sp kn def =
+  Tac2env.push_type visibility sp kn;
+  push_typedef_contents visibility sp kn def
 
 let next i =
   let ans = !i in
@@ -562,6 +562,47 @@ let register_type ?local ?abstract isrec types = match types with
   in
   let types = List.map map types in
   register_typedef ?local ?abstract isrec types
+
+let load_import_type i ((sp,kn),orig) =
+  let def = Tac2env.interp_type orig in
+  push_typedef_contents (Until i) sp orig def
+
+let open_import_type i ((sp,kn),orig) =
+  let def = Tac2env.interp_type orig in
+  push_typedef_contents (Exactly i) sp orig def
+
+let cache_import_type o = load_import_type 1 o
+
+let inImportType =
+  declare_named_object
+    { (default_object "TAC2-IMPORT-TYPE") with
+     cache_function = cache_import_type;
+     load_function = load_import_type;
+     open_function = filtered_open open_import_type;
+     subst_function = (fun (subst,kn) -> Mod_subst.subst_kn subst kn);
+     (* NB don't bother supporting Local as it doesn't seem useful *)
+     classify_function = (fun _ -> Substitute);
+    }
+
+(* TODO deprecate attr *)
+let import_type qid as_id =
+  let () =
+    if Lib.sections_are_opened() then
+      (* if you want to implement it take care that the "orig" type isn't local to the section *)
+      CErrors.user_err Pp.(str "Ltac2 Import Type not supported in sections.")
+  in
+  match Tac2env.locate_type qid with
+  | exception Not_found ->
+    CErrors.user_err ?loc:qid.loc Pp.(str "Unknown Ltac2 type " ++ pr_qualid qid ++ str ".")
+  | orig ->
+    let params, _ = Tac2env.interp_type orig in
+    let alias_def = GTypRef (Other orig, List.init params (fun i -> GTypVar i)) in
+    Lib.add_leaf (inTypDef as_id {
+        typdef_local = false;
+        typdef_abstract = false;
+        typdef_expr = params, GTydDef (Some alias_def);
+      });
+    Lib.add_leaf (inImportType as_id orig)
 
 (** Parsing *)
 

--- a/plugins/ltac2/tac2entries.mli
+++ b/plugins/ltac2/tac2entries.mli
@@ -20,6 +20,8 @@ val register_ltac : ?deprecation:Deprecation.t -> ?local:bool -> ?mut:bool -> re
 val register_type : ?local:bool -> ?abstract:bool -> rec_flag ->
   (qualid * redef_flag * raw_quant_typedef) list -> unit
 
+val import_type : qualid -> Id.t -> unit
+
 val register_primitive : ?deprecation:Deprecation.t -> ?local:bool ->
   Names.lident -> raw_typexpr -> ml_tactic_name -> unit
 


### PR DESCRIPTION
This should be useful if we want to move a type up in the dependency graph.

eg if we want to move Std.reference to Init, just doing `Ltac2 Type reference := Init.reference` in Std is not enough for backwards compat since the constructor (Std.ConstRef etc) would not be available from Std.

Making notations is also not enough as they won't be used in patterns.

With this new feature we can instead do
`Ltac2 Reexport Type Init.reference as reference.` and `Std.ConstRef` will refer to `Init.ConstRef` etc.
