### PR TITLE
Stop "optimizing" schemes by reusing preexisting schemes in Type for other sorts

### DIFF
--- a/dev/ci/user-overlays/21241-SkySkimmer-no-opt-schemes.sh
+++ b/dev/ci/user-overlays/21241-SkySkimmer-no-opt-schemes.sh
@@ -1,0 +1,11 @@
+overlay stdlib https://github.com/SkySkimmer/stdlib no-opt-schemes 21241
+
+overlay bbv https://github.com/SkySkimmer/bbv no-opt-schemes 21241
+
+overlay kami https://github.com/SkySkimmer/kami no-opt-schemes 21241
+# Make PRs against https://github.com/mit-plv/kami base branch rv32i
+
+overlay bedrock2 https://github.com/SkySkimmer/bedrock2 no-opt-schemes 21241
+# Make PRs against https://github.com/mit-plv/bedrock2 base branch master
+
+overlay coq_dpdgraph https://github.com/SkySkimmer/coq-dpdgraph no-opt-schemes 21241

--- a/doc/changelog/08-vernac-commands-and-options/21241-no-opt-schemes-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21241-no-opt-schemes-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  `_rec` schemes are not defined using `_rect` schemes anymore.
+  In particular `eq_rec` is not defined using `eq_rect`
+  (`#21241 <https://github.com/rocq-prover/rocq/pull/21241>`_,
+  by Gaëtan Gilbert).

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -15,7 +15,6 @@
 
 (* This file builds schemes related to case analysis and recursion schemes *)
 
-open Constr
 open Indrec
 open Declarations
 open Ind_tables
@@ -30,90 +29,17 @@ let build_induction_scheme_in_type env dep sort ind =
   let sigma, c = build_induction_scheme env sigma pind dep sort in
   EConstr.to_constr sigma c, Evd.ustate sigma
 
-(**********************************************************************)
-(* [modify_sort_scheme s rec] replaces the sort of the scheme
-   [rec] by [s] *)
-
-let change_sort_arity sort =
-  let rec drec a = match kind a with
-    | Cast (c,_,_) -> drec c
-    | Prod (n,t,c) -> let s, c' = drec c in s, mkProd (n, t, c')
-    | LetIn (n,b,t,c) -> let s, c' = drec c in s, mkLetIn (n,b,t,c')
-    | Sort s -> s, mkSort sort
-    | _ -> assert false
-  in
-    drec
-
-
-(** [weaken_sort_scheme env sigma s n c t] derives by subtyping from [c:t]
-   whose conclusion is quantified on [Type i] at position [n] of [t] a
-   scheme quantified on sort [s]. [s] is declared less or equal to [i]. *)
-let weaken_sort_scheme env evd sort npars term ty =
-  let open Context.Rel.Declaration in
-  let evdref = ref evd in
-  let rec drec ctx np elim =
-    match kind elim with
-      | Prod (n,t,c) ->
-          let ctx = LocalAssum (n, t) :: ctx in
-          if Int.equal np 0 then
-            let osort, t' = change_sort_arity (EConstr.ESorts.kind !evdref sort) t in
-              evdref := Evd.set_leq_sort !evdref sort (EConstr.ESorts.make osort);
-              mkProd (n, t', c),
-              mkLambda (n, t', mkApp(term, Context.Rel.instance mkRel 0 ctx))
-          else
-            let c',term' = drec ctx (np-1) c in
-            mkProd (n, t, c'), mkLambda (n, t, term')
-      | LetIn (n,b,t,c) ->
-        let ctx = LocalDef (n, b, t) :: ctx in
-        let c',term' = drec ctx np c in
-        mkLetIn (n,b,t,c'), mkLetIn (n,b,t,term')
-      | _ -> CErrors.anomaly ~label:"weaken_sort_scheme" (Pp.str "wrong elimination type.")
-  in
-  let ty, term = drec [] npars ty in
-    !evdref, ty, term
-
-let optimize_non_type_induction_scheme kind dep sort env _handle ind =
-  (* This non-local call to [lookup_scheme] is fine since we do not use it on a
-     dependency generated on the fly. *)
-  match lookup_scheme kind ind with
-  | Some cte ->
-    let sigma = Evd.from_env env in
-    (* in case the inductive has a type elimination, generates only one
-       induction scheme, the other ones share the same code with the
-       appropriate type *)
-    let sigma, (cst, u) = Evd.fresh_constant_instance env sigma cte in
-    let u = EConstr.EInstance.kind sigma u in
-    let c = mkConstU (cst, u) in
-    let t = Typeops.type_of_constant_in env (cst, u) in
-    let (mib,mip) = Inductive.lookup_mind_specif env ind in
-    let npars =
-      (* if a constructor of [ind] contains a recursive call, the scheme
-         is generalized only wrt recursively uniform parameters *)
-      if (Inductiveops.mis_is_recursive_subset env [ind] (Rtree.Kind.make mip.mind_recargs))
-      then
-        mib.mind_nparams_rec
-      else
-        mib.mind_nparams in
-    (* here, if [sort] is [Type] then it means that it's actually a [Set]:
-       we optimise non-[Type] schemes *)
-    let sigma, sort = Evd.fresh_sort_in_quality sigma sort in
-    let sigma, t', c' = weaken_sort_scheme env sigma sort npars c t in
-    let sigma = Evd.minimize_universes sigma in
-    (Evarutil.nf_evars_universes sigma c', Evd.ustate sigma)
-  | None ->
-    build_induction_scheme_in_type env dep sort ind
-
 let rect_dep =
   declare_individual_scheme_object "rect_dep"
     (fun env _ x -> build_induction_scheme_in_type env true QualityOrSet.qtype x)
 
 let rec_dep =
   declare_individual_scheme_object "rec_dep"
-    (optimize_non_type_induction_scheme rect_dep true QualityOrSet.set)
+    (fun env _ x -> build_induction_scheme_in_type env true QualityOrSet.set x)
 
 let ind_dep =
   declare_individual_scheme_object "ind_dep"
-    (optimize_non_type_induction_scheme rec_dep true QualityOrSet.prop)
+    (fun env _ x -> build_induction_scheme_in_type env true QualityOrSet.prop x)
 
 let sind_dep =
   declare_individual_scheme_object "sind_dep"
@@ -125,11 +51,11 @@ let rect_nodep =
 
 let rec_nodep =
   declare_individual_scheme_object "rec_nodep"
-    (optimize_non_type_induction_scheme rect_nodep false QualityOrSet.set)
+    (fun env _ x -> build_induction_scheme_in_type env false QualityOrSet.set x)
 
 let ind_nodep =
   declare_individual_scheme_object "ind_nodep"
-    (optimize_non_type_induction_scheme rec_nodep false QualityOrSet.prop)
+    (fun env _ x -> build_induction_scheme_in_type env false QualityOrSet.prop x)
 
 let sind_nodep =
   declare_individual_scheme_object "sind_nodep"

--- a/test-suite/bugs/bug_20397_1.v
+++ b/test-suite/bugs/bug_20397_1.v
@@ -23,7 +23,9 @@ Theorem eq_rect_nat_double : forall T (a b c : nat) x ab bc,
 Admitted.
 
 Ltac eq_rect_simpl :=
-  unfold eq_rec_r, eq_rec;
+  unfold eq_rec_r;
+  change eq_rec with (fun A x (P:_ -> Set) => @eq_rect A x P);
+  unfold eq_rect_r;
   repeat rewrite eq_rect_nat_double;
   repeat rewrite <- (eq_rect_eq_dec eq_nat_dec).
 

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -203,9 +203,9 @@ block).
 foo@{i} = Type@{M.i} -> Type@{i}
      : Type@{max(M.i+1,i+1)}
 (* i |=  *)
-Type@{u0} -> Type@{UnivBinders.85}
-     : Type@{max(u0+1,UnivBinders.85+1)}
-(* {UnivBinders.85} |=  *)
+Type@{u0} -> Type@{UnivBinders.83}
+     : Type@{max(u0+1,UnivBinders.83+1)}
+(* {UnivBinders.83} |=  *)
 bind_univs.mono = Type@{bind_univs.mono.u}
      : Type@{bind_univs.mono.u+1}
 bind_univs.poly@{u} = Type@{u}


### PR DESCRIPTION
Overlays (backwards compatible):
- https://github.com/rocq-prover/stdlib/pull/221
- https://github.com/mit-plv/bbv/pull/55
- https://github.com/mit-plv/kami/pull/44
- https://github.com/mit-plv/bedrock2/pull/498

not backwards compatible:
- https://github.com/rocq-community/coq-dpdgraph/pull/154