### PR TITLE
Bring "Fixpoint" output test back from stdlib

### DIFF
--- a/test-suite/output/Fixpoint.out
+++ b/test-suite/output/Fixpoint.out
@@ -1,0 +1,97 @@
+fix F (A B : Set) (f : A -> B) (l : list A) {struct l} : list B :=
+  match l with
+  | nil => nil
+  | a :: l0 => f a :: F A B f l0
+  end
+     : forall A B : Set, (A -> B) -> list A -> list B
+let fix f (m : nat) : nat := match m with
+                             | 0 => 0
+                             | S m' => f m'
+                             end in f 0
+     : nat
+Ltac f id1 id2 := fix id1 2 with (id2 (n:_) (H:odd n) {struct H} : n >= 1)
+     = cofix inf : Inf := {| projS := inf |}
+     : Inf
+File "./output/Fixpoint.v", line 39, characters 0-51:
+Warning: Not a truly recursive fixpoint. [non-recursive,fixpoints,default]
+File "./output/Fixpoint.v", line 42, characters 0-103:
+Warning: Not a fully mutually defined fixpoint
+(k1 depends on k2 but not conversely).
+Well-foundedness check may fail unexpectedly.
+ [non-full-mutual,fixpoints,default]
+File "./output/Fixpoint.v", line 44, characters 0-106:
+Warning: Not a fully mutually defined fixpoint
+(l2 and l1 are not mutually dependent).
+Well-foundedness check may fail unexpectedly.
+ [non-full-mutual,fixpoints,default]
+File "./output/Fixpoint.v", line 46, characters 0-103:
+Warning: Not a fully mutually defined fixpoint
+(m2 and m1 are not mutually dependent).
+Well-foundedness check may fail unexpectedly.
+ [non-full-mutual,fixpoints,default]
+File "./output/Fixpoint.v", line 54, characters 0-25:
+Warning: Not a truly recursive cofixpoint. [non-recursive,fixpoints,default]
+File "./output/Fixpoint.v", line 57, characters 0-48:
+Warning: Not a fully mutually defined cofixpoint
+(a2 and a1 are not mutually dependent).
+ [non-full-mutual,fixpoints,default]
+File "./output/Fixpoint.v", line 73, characters 2-15:
+The command has indeed failed with message:
+Recursive definition of foo and bar is ill-formed.
+As a mutual fixpoint:
+Not enough abstractions in the definition.
+The 1st recursive definition is: "?Goal".
+The 2nd recursive definition is: "?Goal0".
+The condition holds up to here.
+File "./output/Fixpoint.v", line 78, characters 6-19:
+The command has indeed failed with message:
+Recursive definition of foo and bar is ill-formed.
+As a mutual fixpoint decreasing on the 1st argument of foo and
+1st argument of bar:
+Recursive call to bar has principal argument equal to 
+"0" instead of
+a subterm of "n".
+As a mutual fixpoint decreasing on the 1st argument of foo and
+2nd argument of bar:
+Recursive call to bar has principal argument equal to 
+"0" instead of
+a subterm of "n".
+As a mutual fixpoint decreasing on the 2nd argument of foo and
+1st argument of bar:
+Recursive call to bar has principal argument equal to 
+"0" instead of
+a subterm of "m".
+As a mutual fixpoint decreasing on the 2nd argument of foo and
+2nd argument of bar:
+Recursive call to bar has principal argument equal to 
+"0" instead of a subterm of "m".
+The 1st recursive definition is:
+"fun n m : nat =>
+ match n with
+ | 0 => bar 0 0
+ | S n0 => (fun n1 : nat => ?Goal0@{n:=n1}) n0
+ end".
+The 2nd recursive definition is: "fun n m : nat => ?Goal".
+The condition holds up to here.
+The condition holds up to here.
+The condition holds up to here.
+The condition holds up to here.
+File "./output/Fixpoint.v", line 105, characters 6-19:
+The command has indeed failed with message:
+Recursive definition of foo' and bar' is ill-formed.
+As a mutual fixpoint decreasing on the 1st argument of foo' and
+1st argument of bar':
+Cannot define a fixpoint with principal argument living in sort 
+"SProp" to produce a value in sort "Set"
+because "SProp" does not eliminate to "Set".
+As a mutual fixpoint decreasing on the 1st argument of foo' and
+2nd argument of bar':
+Recursive call to bar' has principal argument equal to 
+"0" instead of a subterm of "n".
+The 1st recursive definition is:
+"fun (n : nat) (m : Prop) =>
+ match n with
+ | 0 => bar' SI 0
+ | S n0 => (fun n1 : nat => ?Goal0@{n:=n1}) n0
+ end".
+The 2nd recursive definition is: "fun (n : STrue) (m : nat) => ?Goal".

--- a/test-suite/output/Fixpoint.v
+++ b/test-suite/output/Fixpoint.v
@@ -1,0 +1,108 @@
+Require Import ListDef.
+
+Check
+  (fix F (A B : Set) (f : A -> B) (l : list A) {struct l} :
+   list B := match l with
+             | nil => nil
+             | a :: l => f a :: F _ _ f l
+             end).
+
+(* V8 printing of this term used to failed in V8.0 and V8.0pl1 (cf BZ#860) *)
+Check
+  let fix f (m : nat) : nat :=
+    match m with
+    | O => 0
+    | S m' => f m'
+    end
+  in f 0.
+
+Inductive even : nat -> Type :=
+  | even_O : even 0
+  | even_S : forall n, odd n -> even (S n)
+with odd : nat -> Type :=
+    odd_S : forall n, even n -> odd (S n).
+
+(* Check printing of fix *)
+Ltac f id1 id2 := fix id1 2 with (id2 n (H:odd n) {struct H} : n >= 1).
+Print Ltac f.
+
+CoInductive Inf := IS { projS : Inf }.
+Definition expand_Inf (x : Inf) := IS (projS x).
+CoFixpoint inf := IS inf.
+Eval compute in inf.
+
+Module Recursivity.
+
+Open Scope nat_scope.
+
+Fixpoint f n := match n with 0 => 0 | S n => f n end.
+Fixpoint g n := match n with 0 => 0 | S n => n end.
+Fixpoint h1 n := match n with 0 => 0 | S n => h2 n end
+with h2 n := match n with 0 => 0 | S n => h1 n end.
+Fixpoint k1 n := match n with 0 => 0 | S n => k2 n end
+with k2 n := match n with 0 => 0 | S n => n end.
+Fixpoint l1 n := match n with 0 => 0 | S n => l1 n end
+with l2 n := match n with 0 => 0 | S n => l2 n end.
+Fixpoint m1 n := match n with 0 => 0 | S n => m1 n end
+with m2 n := match n with 0 => 0 | S n => n end.
+(* Why not to allow this definition ?
+Fixpoint h1' n := match n with 0 => 0 | S n => h2' n end
+with h2' n := h1' n.
+*)
+CoInductive S := cons : nat -> S -> S.
+CoFixpoint c := cons 0 c.
+CoFixpoint d := cons 0 c.
+CoFixpoint e1 := cons 0 e2
+with e2 := cons 1 e1.
+CoFixpoint a1 := cons 0 a1
+with a2 := cons 1 a2.
+(* Why not to allow this definition ?
+CoFixpoint b1 := cons 0 b2
+with b2 := b1.
+*)
+
+End Recursivity.
+
+Module Guard.
+
+Open Scope nat_scope.
+
+Lemma foo : nat -> nat -> bool
+with bar : nat -> nat -> bool.
+Proof.
+  Fail Guarded. (* not enough abstractions in the definition *)
+  all:intros n m.
+  Guarded.
+  - destruct n as [|n].
+    + exact (bar 0 0).
+      Fail Guarded. (* failure is correct here *)
+Abort.
+
+Lemma foo : nat -> nat -> bool
+with bar : nat -> nat -> bool.
+Proof.
+  all:intros n m.
+  - destruct n as [|n].
+    + exact true.
+    + Guarded.
+      exact (bar m n).
+  - Guarded.
+    destruct m as [|m].
+    + exact false.
+    + exact (foo m n).
+      Guarded.
+Defined.
+
+Inductive STrue : SProp := SI.
+
+Lemma foo' : nat -> Prop -> bool
+with bar' : STrue -> nat -> bool.
+Proof.
+  all:intros n m.
+  - destruct n as [|n].
+    Guarded.
+    + exact (bar' SI 0).
+      Fail Guarded.
+Abort.
+
+End Guard.


### PR DESCRIPTION
NB: use of Z was removed but output is the same except for changed line numbers

cf https://github.com/rocq-prover/stdlib/pull/220