### PR TITLE
Abstract away the Evd.side_effects record type.

### DIFF
--- a/dev/ci/user-overlays/21243-ppedrot-side-effect-abstract-evd-api.sh
+++ b/dev/ci/user-overlays/21243-ppedrot-side-effect-abstract-evd-api.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/ppedrot/coq-tactician side-effect-abstract-evd-api 21243

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1291,6 +1291,30 @@ let drop_side_effects evd =
 
 let eval_side_effects evd = evd.effects
 
+let push_side_effects prv ?univs ?role effs =
+  let kn = match Safe_typing.constants_of_private prv with
+  | [cst] -> cst
+  | _ -> assert false
+  in
+  let seff_univs = match univs with
+  | None -> effs.seff_univs
+  | Some ctx -> Cmap_env.add kn ctx effs.seff_univs
+  in
+  let seff_roles = match role with
+  | None -> effs.seff_roles
+  | Some r -> Cmap_env.add kn r effs.seff_roles
+  in
+  let seff_private = Safe_typing.concat_private prv effs.seff_private in
+  {
+    seff_private = Safe_typing.concat_private prv seff_private;
+    seff_roles = seff_roles;
+    seff_univs = seff_univs;
+  }
+
+let seff_private eff = eff.seff_private
+let seff_roles effs = effs.seff_roles
+let seff_univs effs = effs.seff_univs
+
 (* Future goals *)
 let declare_future_goal evk evd =
   let future_goals = FutureGoals.add evk evd.future_goals in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -389,12 +389,7 @@ val dependent_evar_ident : Evar.t -> evar_map -> Id.t
 type side_effect_role =
 | Schema of inductive * string
 
-type side_effects = {
-  seff_private : Safe_typing.private_constants;
-  seff_roles : side_effect_role Cmap_env.t;
-  seff_univs : UState.named_universes_entry Cmap_env.t;
-  (* only used by Declare to register names for mono universes *)
-}
+type side_effects
 
 val empty_side_effects : side_effects
 
@@ -406,6 +401,15 @@ val eval_side_effects : evar_map -> side_effects
 
 val drop_side_effects : evar_map -> evar_map
 (** This should not be used. For hacking purposes. *)
+
+val push_side_effects : Safe_typing.private_constants ->
+  ?univs:UState.named_universes_entry -> ?role:side_effect_role -> side_effects -> side_effects
+
+(** {6 Accessors} *)
+
+val seff_private : side_effects -> Safe_typing.private_constants
+val seff_roles : side_effects -> side_effect_role Cmap_env.t
+val seff_univs : side_effects -> UState.named_universes_entry Names.Cmap_env.t
 
 (** {5 Future goals} *)
 

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -497,7 +497,7 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
      other goals that were already present during its invocation, so that
      those goals rely on effects that are not present anymore. Hopefully,
      this hack will work in most cases. *)
-  let neff = neff.Evd.seff_private in
+  let neff = Evd.seff_private neff in
   let (ans, _) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
   EConstr.of_constr ans, sigma
 

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -58,8 +58,8 @@ let generic_refine ~typecheck f gl =
   Proofview.tclEVARMAP >>= fun sigma' ->
   Proofview.wrap_exceptions begin fun () ->
   (* Redo the effects in sigma in the monad's env *)
-  let privates_csts = Evd.eval_side_effects sigma' in
-  let env = Safe_typing.push_private_constants env privates_csts.Evd.seff_private in
+  let privates_csts = Evd.seff_private (Evd.eval_side_effects sigma') in
+  let env = Safe_typing.push_private_constants env privates_csts in
   (* Check that the introduced evars are well-typed *)
   let fold accu ev = typecheck_evar ev env accu in
   let sigma = if typecheck then Evd.fold_future_goals fold sigma' else sigma' in
@@ -98,7 +98,7 @@ let generic_refine ~typecheck f gl =
                                    Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.tclENV >>= fun env ->
-  Proofview.Unsafe.tclSETENV (Safe_typing.push_private_constants env privates_csts.Evd.seff_private) <*>
+  Proofview.Unsafe.tclSETENV (Safe_typing.push_private_constants env privates_csts) <*>
   Proofview.Unsafe.tclEVARS sigma <*>
   Proofview.Unsafe.tclSETGOALS comb <*>
   Proofview.tclUNIT v

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -122,7 +122,7 @@ let redeclare_schemes { sch_eff = eff } =
       let old = try String.Map.find kind accu with Not_found -> [] in
       String.Map.add kind ((ind, c) :: old) accu
   in
-  let schemes = Cmap_env.fold fold eff.Evd.seff_roles String.Map.empty in
+  let schemes = Cmap_env.fold fold (Evd.seff_roles eff) String.Map.empty in
   let iter kind defs = List.iter (DeclareScheme.declare_scheme SuperGlobal kind) defs in
   String.Map.iter iter schemes
 
@@ -136,13 +136,13 @@ let local_lookup_scheme eff kind ind = match lookup_scheme kind ind with
   in
   (* Inefficient O(n), but the number of locally declared schemes is small and
      this is very rarely called *)
-  try let _ = Cmap_env.iter iter eff.Evd.seff_roles in None with Found c -> Some c
+  try let _ = Cmap_env.iter iter (Evd.seff_roles eff) in None with Found c -> Some c
 
 let local_check_scheme kind ind { sch_eff = eff } =
   Option.has_some (local_lookup_scheme eff kind ind)
 
 let define ?loc internal role id c poly uctx sch =
-  let avoid = Safe_typing.constants_of_private sch.sch_eff.Evd.seff_private in
+  let avoid = Safe_typing.constants_of_private (Evd.seff_private sch.sch_eff) in
   let avoid = Id.Set.of_list @@ List.map (fun cst -> Constant.label cst) avoid in
   let id = compute_name internal id avoid in
   let uctx = UState.collapse_above_prop_sort_variables ~to_prop:true uctx in


### PR DESCRIPTION
The main advantage of this change is that we reduce the amount of side-effect generating APIs to a single function.

Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/114