### PR TITLE
Fix ssrintro

### DIFF
--- a/doc/changelog/07-ssreflect/21244-fix-ssrintro-Changed.rst
+++ b/doc/changelog/07-ssreflect/21244-fix-ssrintro-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  level of ``tactic => intro_pattern`` notation to a left-associative
+  notation level with higher priority than level 3, rather than being
+  repeated in levels 3 (right-associative) and 4 (left-associative)
+  (`#21244 <https://github.com/rocq-prover/rocq/pull/21244>`_,
+  by Pierre Roux).

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2437,6 +2437,7 @@ SPLICE: [
 | enable_notation_flags
 | opt_scope
 | located_notation
+| ltac_expr1l
 ] (* end SPLICE *)
 
 RENAME: [

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -541,7 +541,7 @@ let autoloaded_mlgs = [ (* productions from other mlgs are marked with TAGs *)
 let has_match p prods = List.exists (fun p2 -> ematch p p2) prods
 
 let plugin_regex = Str.regexp "^plugins/\\([a-zA-Z0-9_]+\\)/"
-let level_regex = Str.regexp "[a-zA-Z0-9_]*$"
+let level_regex = Str.regexp "[a-zA-Z0-9_]*l?$"
 
 let get_plugin_name file =
   if Str.string_match plugin_regex file 0 then

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2185,6 +2185,10 @@ ltac_expr2: [
 | ltac_expr2 "+" ltac_expr2
 | "tryif" ltac_expr5 "then" ltac_expr5 "else" ltac_expr2
 | ltac_expr2 "||" ltac_expr2
+| ltac_expr1l
+]
+
+ltac_expr1l: [
 | ltac_expr1
 ]
 

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -127,6 +127,8 @@ GRAMMAR EXTEND Gram
               "then" ; tat = ltac_expr ;
               "else" ; tae = ltac_expr -> { CAst.make ~loc (TacIfThenCatch (ta,tat,tae)) }
       | ta0 = ltac_expr; "||"; ta1 = ltac_expr -> { CAst.make ~loc (TacOrelse (ta0,ta1)) } ]
+    | "1l" LEFTA
+      [ ]
     | "1" RIGHTA
       [ "fun"; it = LIST1 input_fun ; "=>"; body = ltac_expr LEVEL "5" ->
           { CAst.make ~loc (TacFun (it,body)) }

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1705,10 +1705,7 @@ let tclintros_expr ?loc tac ipats =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ltac_expr;
-  ltac_expr: LEVEL "3" [
-    [ tac = ltac_expr; intros = ssrintros_ne -> { tclintros_expr ~loc tac intros }
-    ] ];
-  ltac_expr: LEVEL "4" [
+  ltac_expr: LEVEL "1l" [
     [ tac = ltac_expr; intros = ssrintros_ne -> { tclintros_expr ~loc tac intros }
     ] ];
 END

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -137,9 +137,10 @@ let tcldokey =
   end in
   register_ssrtac "tcldo" tac prods
 
-let ssrdotac_expr ?loc n m tac clauses =
+let ssrdotac_expr ~loc n m tac clauses ipats =
   let arg = ((n, m), tac), clauses in
-  ssrtac_expr ?loc tcldokey [in_gen (rawwit wit_ssrdoarg) arg]
+  let tac = ssrtac_expr ~loc tcldokey [in_gen (rawwit wit_ssrdoarg) arg] in
+  List.fold_left (tclintros_expr ~loc) tac ipats
 
 }
 
@@ -150,13 +151,15 @@ GRAMMAR EXTEND Gram
     | tacs = ssrortacarg -> { tacs }
   ] ];
   ltac_expr: LEVEL "3" [
-    [ IDENT "do"; m = ssrmmod; tac = ssrdotac; clauses = ssrclauses ->
-      { ssrdotac_expr ~loc noindex m tac clauses }
-    | IDENT "do"; tac = ssrortacarg; clauses = ssrclauses ->
-      { ssrdotac_expr ~loc noindex Once tac clauses }
-    | IDENT "do"; n = nat_or_var; m = ssrmmod;
-                  tac = ssrdotac; clauses = ssrclauses ->
-      { ssrdotac_expr ~loc (mk_index ~loc n) m tac clauses }
+    [ IDENT "do"; m = ssrmmod; tac = ssrdotac;
+                  clauses = ssrclauses; ipats = LIST0 ssrintros_ne ->
+      { ssrdotac_expr ~loc noindex m tac clauses ipats }
+    | IDENT "do"; tac = ssrortacarg;
+                  clauses = ssrclauses; ipats = LIST0 ssrintros_ne ->
+      { ssrdotac_expr ~loc noindex Once tac clauses ipats }
+    | IDENT "do"; n = nat_or_var; m = ssrmmod; tac = ssrdotac;
+                  clauses = ssrclauses; ipats = LIST0 ssrintros_ne ->
+      { ssrdotac_expr ~loc (mk_index ~loc n) m tac clauses ipats }
     ] ];
 END
 


### PR DESCRIPTION
The `tactic => intro_pattern` ssreflect notation was moved from notation level 1 to notation levels 3 and 4 in https://github.com/rocq-prover/rocq/commit/39131994a85de4cd2edcb27bbed8428c8301cae9 in order to minimize use of the recovery mode. This still wasn't fully satisfying as seen in https://github.com/rocq-prover/rocq/pull/21126
This moves it back to level 1l, just below 1 but left associative (level 1 is right associative).
This should be a better, more definitive, fix than https://github.com/rocq-prover/rocq/pull/18224/commits/39131994a85de4cd2edcb27bbed8428c8301cae9

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] ~Added / updated **test-suite**.~

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] ~Added / updated **documentation**.~
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
