### PR TITLE
Collapse NonLogical thunks in the logic monad.

### DIFF
--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -243,10 +243,10 @@ struct
 
   (** For [reflect] and [split] see the "Backtracking, Interleaving,
       and Terminating Monad Transformers" paper.  *)
-  type ('a, 'e) reified = ('a, ('a, 'e) reified_, 'e) list_view_ NonLogical.t
-  and ('a, 'e) reified_ = {r : 'e -> ('a, 'e) reified} [@@unboxed]
+  type ('a, 'e) reified = ('a, ('a, 'e) reified_, 'e) list_view_
+  and ('a, 'e) reified_ = {r : 'e -> ('a, 'e) reified NonLogical.t} [@@unboxed]
 
-  let rec reflect (m : ('a * 'o, 'e) reified) =
+  let rec reflect (m : ('a * 'o, 'e) reified NonLogical.t) =
     { iolist = fun s0 nil cons ->
       let next = function
       | Nil e -> nil e
@@ -273,7 +273,7 @@ struct
       let p = (x, s) in
       NonLogical.return (Cons (p, {r=l}))
     in
-    m.iolist s rnil rcons
+    m.iolist s rnil rcons ()
 
   let repr x = x
 end
@@ -385,6 +385,6 @@ struct
       let p = (x, s.sstate, s.wstate, s.ustate) in
       NonLogical.return (Cons (p, {r=l}))
     in
-    m.iolist s rnil rcons
+    m.iolist s rnil rcons ()
 
  end

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -182,9 +182,23 @@ struct
       [split] is pattern-matching. *)
 
   type ('a, 'i, 'o, 'e) t =
-      { iolist : 'r. 'i -> ('e -> 'r NonLogical.t) ->
-                     ('a -> 'o -> ('e -> 'r NonLogical.t) -> 'r NonLogical.t) ->
-                     'r NonLogical.t }
+    { iolist : 'r. 'i -> ('e -> 'r) -> ('a -> 'o -> ('e -> 'r) -> 'r) -> 'r }
+  (* IMPORTANT: to play well with side-effects, all functions involved in the
+     above type must have AT LEAST the same arity as the one implied by their
+     type. This is to ensure that applying them to the expected arguments only
+     triggers side-effects once fully applied. If OCaml had a type for pure
+     functions a ~> b ⊆ a -> b, we could write this type instead as
+
+     type ('a, 'i, 'o, 'e) t =
+      { iolist : 'r. 'i ~> ('e -> 'r) ~> ('a ~> 'o ~> ('e -> 'r) -> 'r) -> 'r }
+
+     Alternatively we could use records but then it would incur a runtime
+     overhead.
+
+     An easy way to ensure that is to eta-expand the functions on sight.
+
+     Since the type is abstract in the API, this means we must locally enforce
+     this property only in this module. *)
 
   let return x =
     { iolist = fun s nil cons -> cons x s nil }
@@ -210,7 +224,7 @@ struct
     { iolist = fun s nil cons -> m.iolist s nil (fun _ s next -> cons () s next) }
 
   let lift m =
-    { iolist = fun s nil cons -> NonLogical.(m >>= fun x -> cons x s nil) }
+    { iolist = fun s nil cons -> cons (m ()) s nil }
 
   (** State related *)
 
@@ -244,36 +258,35 @@ struct
   (** For [reflect] and [split] see the "Backtracking, Interleaving,
       and Terminating Monad Transformers" paper.  *)
   type ('a, 'e) reified = ('a, ('a, 'e) reified_, 'e) list_view_
-  and ('a, 'e) reified_ = {r : 'e -> ('a, 'e) reified NonLogical.t} [@@unboxed]
+  and ('a, 'e) reified_ = {r : 'e -> ('a, 'e) reified} [@@unboxed]
 
-  let rec reflect (m : ('a * 'o, 'e) reified NonLogical.t) =
-    { iolist = fun s0 nil cons ->
-      let next = function
+  let rec reflect0 : type r. _ -> _ -> _ -> (_ -> r) -> (_ -> _ -> (_ -> r) -> r) -> r =
+    fun e m s0 nil cons ->
+      match m e with
       | Nil e -> nil e
-      | Cons ((x, s), {r=l}) -> cons x s (fun e -> (reflect (l e)).iolist s0 nil cons)
-      in
-      NonLogical.(m >>= next)
-    }
+      | Cons ((x, s), {r=l}) -> cons x s (fun e -> reflect0 e l s0 nil cons)
+
+  let reflect (e : 'e) (m : 'e -> ('a * 'o, 'e) reified) =
+    { iolist = fun s0 nil cons -> reflect0 e m s0 nil cons }
 
   let split m : (_ list_view, _, _, _) t =
-    let rnil e = NonLogical.return (Nil e) in
-    let rcons p s l = NonLogical.return (Cons ((p, s), {r=l})) in
+    let rnil e = Nil e in
+    let rcons p s l = Cons ((p, s), {r=l}) in
     { iolist = fun s nil cons ->
-      let open NonLogical in
-      m.iolist s rnil rcons >>= begin function
+      begin match m.iolist s rnil rcons with
       | Nil e -> cons (Nil e) s nil
       | Cons ((x, s), {r=l}) ->
-        let l e = reflect (l e) in
+        let l e = reflect e l in
         cons (Cons (x, l)) s nil
       end }
 
   let run m s =
-    let rnil e = NonLogical.return (Nil e) in
+    let rnil e = Nil e in
     let rcons x s l =
       let p = (x, s) in
-      NonLogical.return (Cons (p, {r=l}))
+      Cons (p, {r=l})
     in
-    m.iolist s rnil rcons ()
+    m.iolist s rnil rcons
 
   let repr x = x
 end
@@ -380,11 +393,11 @@ struct
 
   let run m r s =
     let s = { wstate = P.wunit; ustate = P.uunit; rstate = r; sstate = s } in
-    let rnil e = NonLogical.return (Nil e) in
+    let rnil e = Nil e in
     let rcons x s l =
       let p = (x, s.sstate, s.wstate, s.ustate) in
-      NonLogical.return (Cons (p, {r=l}))
+      Cons (p, {r=l})
     in
-    m.iolist s rnil rcons ()
+    m.iolist s rnil rcons
 
  end

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -148,7 +148,7 @@ module BackState : sig
   type ('a, 'e) reified
   type ('a, 'e) reified_
 
-  val repr : ('a, 'e) reified -> ('a, ('a, 'e) reified_, 'e) list_view_ NonLogical.t
+  val repr : ('a, 'e) reified -> ('a, ('a, 'e) reified_, 'e) list_view_
 
   val run : ('a, 'i, 'o, 'e) t -> 'i -> ('a * 'o, 'e) reified
 
@@ -204,7 +204,7 @@ module Logical (P:Param) : sig
   type 'a reified = ('a, Exninfo.iexn) BackState.reified
   type 'a reified_ = ('a, Exninfo.iexn) BackState.reified_
 
-  val repr : 'a reified -> ('a, 'a reified_, Exninfo.iexn) list_view_ NonLogical.t
+  val repr : 'a reified -> ('a, 'a reified_, Exninfo.iexn) list_view_
 
   val run : 'a t -> P.e -> P.s -> ('a * P.s * P.w * P.u) reified
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -245,15 +245,15 @@ type +'a tactic = 'a Proof.t
 (** Applies a tactic to the current proofview. *)
 let apply ~name ~poly env t sp =
   let open Logic_monad in
-  NewProfile.profile "Proofview.apply" (fun () ->
-  let ans = Proof.repr (Proof.run t P.{trace=false; name; poly} (sp,env)) in
-  let ans = Logic_monad.NonLogical.run ans in
-  match ans with
+  NewProfile.profile "Proofview.apply" begin fun () ->
+  match Proof.repr (Proof.run t P.{trace=false; name; poly} (sp,env)) with
   | Nil (e, info) -> Exninfo.iraise (TacticFailure e, info)
   | Cons ((r, (state, env), status, info), _) ->
-    r, state, env, status, Trace.to_tree info)
-    ()
-
+    r, state, env, status, Trace.to_tree info
+  | exception (Exception e as src) ->
+    let (src, info) = Exninfo.capture src in
+    Exninfo.iraise (e, info)
+  end ()
 
 (** {7 Monadic primitives} *)
 
@@ -1022,7 +1022,7 @@ let tclTIMEOUTF n t =
   Proof.current >>= fun envvar ->
   Proof.lift begin
     let open Logic_monad.NonLogical in
-    timeout n (Proof.repr (Proof.run t envvar initial)) >>= fun r ->
+    timeout n (make (fun () -> Proof.repr (Proof.run t envvar initial))) >>= fun r ->
     match r with
     | Error info -> return (Util.Inr (Logic_monad.Tac_Timeout, info))
     | Ok (Logic_monad.Nil e) -> return (Util.Inr e)


### PR DESCRIPTION
We leverage the fact that a ~> unit -> b ≅ a -> b where ~> stands for a hypothetical pure arrow type. This allows replacing all instances of the NonLogical.t monad in the logic monad type with basically nothing, leaving effects implicits in the rightmost arrow type. Since all clients evaluate the thunk directly, the new code should be equivalent to the previous one.

Actually, it may even be more correct given that we already implicitly use the function space in the monadic bind operator to perform side-effects.