### PR TITLE
Windows opam file patch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (name rocq-runtime)
  (depends
   (ocaml (>= 4.14.0))
-  (ocamlfind (and (>= 1.9.1) (or (>= 1.9.8) (<> :os "windows"))))
+  (ocamlfind (and (>= 1.9.1) (or (>= 1.9.8) (<> :os-family "windows"))))
   (zarith (>= 1.11))
   (conf-linux-libc-dev (= :os "linux")))
  (conflicts
@@ -136,7 +136,7 @@ structured way."))
   conf-adwaita-icon-theme
   (coqide-server (= :version))
   (cairo2 (>= 0.6.4))
-  (lablgtk3-sourceview3 (and (>= 3.1.2) (or (>= 3.1.5) (<> :os "windows")))))
+  (lablgtk3-sourceview3 (and (>= 3.1.2) (or (>= 3.1.5) (<> :os-family "windows")))))
  (synopsis "The Rocq Prover --- GTK3 IDE")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
 a formal language to write mathematical definitions, executable

--- a/rocq-runtime.opam
+++ b/rocq-runtime.opam
@@ -31,7 +31,7 @@ bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.14.0"}
-  "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os != "windows")}
+  "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}
   "odoc" {with-doc}

--- a/rocqide.opam
+++ b/rocqide.opam
@@ -25,7 +25,7 @@ depends: [
   "conf-adwaita-icon-theme"
   "coqide-server" {= version}
   "cairo2" {>= "0.6.4"}
-  "lablgtk3-sourceview3" {>= "3.1.2" & (>= "3.1.5" | os != "windows")}
+  "lablgtk3-sourceview3" {>= "3.1.2" & (>= "3.1.5" | os-family != "windows")}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes a buggy windows condition spotted upstream on the opam-repository: https://github.com/ocaml/opam-repository/pull/28805

On windows the correct condition is either `os-family != "windows"` or `os != "win32"`:
https://github.com/ocaml/opam-repository/wiki/Depexts-os-distribution---os-family-values

No changelog entry needed.