### PR TITLE
Stop catching async exceptions in hacks that catch anomalies

### DIFF
--- a/dev/ci/user-overlays/21254-SkySkimmer-stop-anomalies.sh
+++ b/dev/ci/user-overlays/21254-SkySkimmer-stop-anomalies.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi stop-anomalies 21254
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations stop-anomalies 21254
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp stop-anomalies 21254

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -25,8 +25,16 @@ val anomaly : ?loc:Loc.t -> ?info:Exninfo.info -> ?label:string -> Pp.t -> 'a
 (** Raise an anomaly, with an optional location and an optional
     label identifying the anomaly. *)
 
-val is_anomaly : exn -> bool
-(** Check whether a given exception is an anomaly.
+val exit_code : exn -> int
+(** Return [1] for most exceptions and [129] for exceptions which
+    would print the "Please report" message. *)
+
+val is_async : exn -> bool
+(** Whether the exception may have been raised asynchronously
+    (Timeout, stack overflow, etc). Avoid catching such exceptions at all costs! *)
+
+val is_sync_anomaly : exn -> bool
+(** Check whether a given exception is an anomaly and not asynchronous.
     This is mostly provided for compatibility. Please avoid doing specific
     tricks with anomalies thanks to it. See rather [noncritical] below. *)
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1868,7 +1868,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
         let op = interp_typed_pattern ist env sigma op in
-        let to_catch = function Not_found -> true | e -> CErrors.is_anomaly e in
+        let to_catch = function Not_found -> true | e -> CErrors.is_sync_anomaly e in
         let c_interp patvars env sigma =
           let lfun' = Id.Map.fold (fun id c lfun ->
             Id.Map.add id (Value.of_constr c) lfun)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1143,7 +1143,8 @@ let clos_norm_flags flgs env sigma t =
       (Evarutil.create_clos_infos env sigma flgs)
       (CClosure.create_tab ())
       (Esubst.subs_id 0, UVars.Instance.empty) (EConstr.Unsafe.to_constr t))
-  with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
+  with e when is_sync_anomaly e ->
+    user_err Pp.(str "Tried to normalize ill-typed term")
 
 let clos_whd_flags flgs env sigma t =
   try
@@ -1151,7 +1152,8 @@ let clos_whd_flags flgs env sigma t =
       (Evarutil.create_clos_infos env sigma flgs)
       (CClosure.create_tab ())
       (CClosure.inject (EConstr.Unsafe.to_constr t)))
-  with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
+  with e when is_sync_anomaly e ->
+    user_err Pp.(str "Tried to normalize ill-typed term")
 
 let nf_beta = clos_norm_flags RedFlags.beta
 let nf_betaiota = clos_norm_flags RedFlags.betaiota
@@ -1192,7 +1194,7 @@ let _ = CErrors.register_handler (function
 
 let report_anomaly (e, info) =
   let e =
-    if is_anomaly e then AnomalyInConversion e
+    if is_sync_anomaly e then AnomalyInConversion e
     else e
   in
   Exninfo.iraise (e, info)

--- a/stm/stmargs.ml
+++ b/stm/stmargs.ml
@@ -10,7 +10,7 @@
 
 let fatal_error exn =
   Topfmt.(in_phase ~phase:ParsingCommandLine print_err_exn exn);
-  let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
+  let exit_code = CErrors.exit_code exn in
   exit exit_code
 
 let set_worker_id opt s =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2103,7 +2103,7 @@ let declare_intro_decomp_eq f = intro_decomp_eq_function := f
 
 let my_find_eq_data_decompose env sigma t =
   try Some (find_eq_data_decompose env sigma t)
-  with e when is_anomaly e
+  with e when is_sync_anomaly e
     (* Hack in case equality is not yet defined... one day, maybe,
        known equalities will be dynamically registered *)
       -> None

--- a/topbin/rocqnative.ml
+++ b/topbin/rocqnative.ml
@@ -386,5 +386,5 @@ let () =
     compile senv ~in_file
   with exn ->
     Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with (CErrors.print exn);
-    let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
+    let exit_code = CErrors.exit_code exn in
     exit exit_code

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -57,7 +57,7 @@ let coqc_run copts ~opts injections =
     flush_all();
     Topfmt.print_err_exn exn;
     flush_all();
-    let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
+    let exit_code = CErrors.exit_code exn in
     exit exit_code
 
 let fix_stm_opts opts stm_opts = match opts.Coqcargs.compilation_mode with

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -46,7 +46,7 @@ let depr opt =
 (* XXX Remove this duplication with Coqargs *)
 let fatal_error exn =
   Topfmt.(in_phase ~phase:ParsingCommandLine print_err_exn exn);
-  let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
+  let exit_code = CErrors.exit_code exn in
   exit exit_code
 
 let error_missing_arg s =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -45,7 +45,7 @@ let fatal_error_exn exn =
   Topfmt.(in_phase ~phase:Initialization print_err_exn exn);
   flush_all ();
   let exit_code =
-    if (CErrors.is_anomaly exn) then 129 else 1
+    CErrors.exit_code exn
   in
   exit exit_code
 

--- a/vernac/vernacControl.ml
+++ b/vernac/vernacControl.ml
@@ -159,9 +159,8 @@ let with_fail f : (Loc.t option * Pp.t, 'a) result =
   | e ->
     (* The error has to be printed in the failing state *)
     let _, info as exn = Exninfo.capture e in
-    (* Don't turn Sys.Break and anomalies into successes
-       NB: on windows Sys.Break is used instead of Control.Timeout *)
-    if e = Sys.Break || CErrors.is_anomaly e then Exninfo.iraise exn;
+    (* Don't catch async exceptions, don't turn anomalies into successes *)
+    if CErrors.is_async e || CErrors.is_sync_anomaly e then Exninfo.iraise exn;
     Ok (Loc.get_loc info, CErrors.iprint exn)
 
 type ('st0,'st) with_local_state = { with_local_state : 'a. 'st0 -> (unit -> 'a) -> 'st * 'a }


### PR DESCRIPTION
Typically the reductionops "Tried to normalize ill-typed term" hack deliberately catches anomalies (including those from CErrors.anomaly) but shouldn't catch async exceptions.

Hopefully fixes the non working Fail Timeout in bedrock2, we could also revert #21216 for our own test suite.

(debugging tip: apply

~~~diff
@@ -32,7 +32,14 @@ let check_for_interrupt () =
 (* This function assumes it is the only function calling [setitimer] *)
 let unix_timeout n f x =
   let open Unix in
-  let timeout_handler _ = raise Timeout in
+  let timeout_handler _ =
+    let info = Exninfo.reify () in
+    let () =
+      Exninfo.get_backtrace info |> Option.iter @@ fun bt ->
+      Printf.eprintf "timeout at %s\n%!" (Exninfo.backtrace_to_string bt)
+    in
+    raise Timeout
+  in
   let old_timer = getitimer ITIMER_REAL in
   (* Here we assume that the existing timer will also interrupt us. *)
   if old_timer.it_value > 0. && old_timer.it_value <= n then Ok (f x) else
~~~

then run a buggy Timeout with `Set Debug "backtrace"` on until you get the bug, the function which catches the timeout exn should be in the printed backtrace. For instance I had

~~~
Called from Reductionops.infer_conv_gen in file "pretyping/reductionops.ml", line 1324, characters 10-52
~~~
when trying the Fail Timeout in bedrock2 LeakageSemantics.)

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/666
- https://github.com/LPCIC/coq-elpi/pull/921
- https://github.com/ejgallego/rocq-lsp/pull/1053