### PR TITLE
Refine the fast path in w_unify_to_subterm

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2399,7 +2399,7 @@ let get_head_kind ~metas env sigma c =
 let fast_head_check sigma knd c = match EConstr.kind sigma c, knd with
 | Lambda _, (HeadInd | HeadSort) -> false
 | Sort _, (HeadInd | HeadProd) -> false
-| Construct _, (HeadProd | HeadSort) -> false
+| Construct _, HeadSort -> false
 | Prod _, (HeadInd | HeadProd) -> false
 | Ind _, HeadInd -> false
 | App (hd, _), _ ->

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2402,6 +2402,12 @@ let fast_head_check sigma knd c = match EConstr.kind sigma c, knd with
 | Construct _, (HeadProd | HeadSort) -> false
 | Prod _, (HeadInd | HeadProd) -> false
 | Ind _, HeadInd -> false
+| App (hd, _), _ ->
+  begin match EConstr.kind sigma hd, knd with
+  | Construct _, HeadSort -> false
+  | Ind _, HeadInd -> false
+  | _ -> true
+  end
 | _ -> true
 
 (* Tries to find an instance of term [cl] in term [op].


### PR DESCRIPTION
We now also handle applied constructors and inductives, and fix an oversight that lead to an unsound but probably very rarely taken heuristic.