### PR TITLE
Remove unused type variable

### DIFF
--- a/ide/rocqide/wg_Detachable.ml
+++ b/ide/rocqide/wg_Detachable.ml
@@ -15,7 +15,7 @@ class type detachable_signals =
     method detached : callback:(GObj.widget -> unit) -> unit
   end
 
-class detachable (obj : ([> Gtk.box] as 'a) Gobject.obj) =
+class detachable (obj : [> Gtk.box] Gobject.obj) =
 
   object(self)
     inherit GPack.box_skel (obj :> Gtk.box Gobject.obj) as super

--- a/ide/rocqide/wg_Detachable.mli
+++ b/ide/rocqide/wg_Detachable.mli
@@ -15,7 +15,7 @@ class type detachable_signals =
     method detached : callback:(GObj.widget -> unit) -> unit
   end
 
-class detachable : ([> Gtk.box] as 'a) Gobject.obj ->
+class detachable : [> Gtk.box] Gobject.obj ->
   object
     inherit GPack.box_skel
     val obj : Gtk.box Gobject.obj


### PR DESCRIPTION
Fixes a warning turned error when compiling rocqide locally with OCaml 5.4.0
