### PR TITLE
Remove unused print_implicits_explicit_args

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -37,13 +37,7 @@ module NamedDecl = Context.Named.Declaration
 (**********************************************************************)
 (* Parametrization                                                    *)
 
-(* This governs printing of implicit arguments.  When
-   [print_implicits] is on then [print_implicits_explicit_args] tells
-   how implicit args are printed. If on, implicit args are printed
-   with the form (id:=arg) otherwise arguments are printed normally and
-   the function is prefixed by "@" *)
 let print_implicits = ref false
-let print_implicits_explicit_args = ref false
 
 (* Tells if implicit arguments not known to be inferable from a rigid
    position are systematically printed *)
@@ -599,7 +593,6 @@ let adjust_implicit_arguments inctx n args impl =
         let tail = exprec (args,impl) in
         let visible =
           !Flags.raw_print ||
-          (!print_implicits && !print_implicits_explicit_args) ||
           (is_needed_for_correct_partial_application tail imp) ||
           (!print_implicits_defensive &&
            (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
@@ -685,8 +678,7 @@ let extern_global impl f us =
 let extern_applied_ref inctx impl (cf,f) us args =
   try
     if not !Constrintern.parsing_explicit &&
-       ((!Flags.raw_print ||
-         (!print_implicits && not !print_implicits_explicit_args)) &&
+       ((!Flags.raw_print || !print_implicits) &&
         List.exists is_status_implicit impl)
     then raise Expl;
     let impl = if !Constrintern.parsing_explicit then [] else impl in


### PR DESCRIPTION
We could also argue that it should be exposed as a printing flag (it makes `@eq T u v`  print as `eq (A:=T) u v` and so on)

https://rocq-prover.zulipchat.com/#narrow/channel/237977-Rocq-users/topic/implicit.20argument.20printing.20option/with/554043141