### PR TITLE
Instances-mod-elim-constraints

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -223,7 +223,7 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
   | MEapply (f,mp) ->
     let sign, delta = check_mexpr env opac f mp_mse res in
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
-    let state = (Environ.universes env, Conversion.checked_universes env) in
+    let state = (Environ.universes env, Conversion.checked_universes) in
     let _ : UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
     let subst = Mod_subst.map_mbid farg_id mp (Mod_subst.empty_delta_resolver mp) in
     Modops.subst_signature subst mp_mse fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
@@ -259,7 +259,7 @@ let rec check_module env opac mp mb opacify =
   | Some (sign,delta) ->
     let mtb1 = mk_mtb sign delta
     and mtb2 = mk_mtb (mod_type mb) delta_mb in
-    let state = (Environ.universes env, Conversion.checked_universes env) in
+    let state = (Environ.universes env, Conversion.checked_universes) in
     let env = Modops.add_module mp (module_body_of_type mtb1) env in
     let _ : UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
     ()

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -223,8 +223,8 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
   | MEapply (f,mp) ->
     let sign, delta = check_mexpr env opac f mp_mse res in
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
-    let state = (Environ.universes env, Conversion.checked_universes) in
-    let _ : UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
+    let state = ((Environ.qualities env, Environ.universes env), Conversion.checked_universes) in
+    let _ : QGraph.t * UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
     let subst = Mod_subst.map_mbid farg_id mp (Mod_subst.empty_delta_resolver mp) in
     Modops.subst_signature subst mp_mse fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")
@@ -259,9 +259,9 @@ let rec check_module env opac mp mb opacify =
   | Some (sign,delta) ->
     let mtb1 = mk_mtb sign delta
     and mtb2 = mk_mtb (mod_type mb) delta_mb in
-    let state = (Environ.universes env, Conversion.checked_universes) in
+    let state = ((Environ.qualities env, Environ.universes env), Conversion.checked_universes) in
     let env = Modops.add_module mp (module_body_of_type mtb1) env in
-    let _ : UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
+    let _ : QGraph.t * UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
     ()
   in
   opac

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -88,6 +88,7 @@ install_printer Top_printers.ppqconstraints
 install_printer Top_printers.ppuniverseconstraints
 install_printer Top_printers.ppuniverse_context_future
 install_printer Top_printers.ppuniverses
+install_printer Top_printers.ppqualities
 install_printer Top_printers.pp_partialfsubst
 install_printer Top_printers.pp_partialsubst
 install_printer Top_printers.ppnamedcontextval

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -295,6 +295,7 @@ let ppuniverse_context_future c =
   let ctx = Future.force c in
     ppuniverse_context ctx
 let ppuniverses u = pp (UGraph.pr_universes Level.raw_pr (UGraph.repr u))
+let ppqualities q = pp (QGraph.pr_qualities Quality.raw_pr q)
 let ppnamedcontextval e =
   let env = Global.env () in
   let sigma = Evd.from_env env in

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -167,6 +167,7 @@ val ppqconstraints : Sorts.ElimConstraints.t -> unit
 val ppuniverseconstraints : UnivProblem.Set.t -> unit
 val ppuniverse_context_future : UVars.UContext.t Future.computation -> unit
 val ppuniverses : UGraph.t -> unit
+val ppqualities : QGraph.t -> unit
 
 val pp_partialfsubst : (CClosure.fconstr, Sorts.Quality.t, Univ.Universe.t) Partial_subst.t -> unit
 val pp_partialsubst : (EConstr.constr, Sorts.Quality.t, Univ.Universe.t) Partial_subst.t -> unit

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -799,7 +799,7 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   let eq_universes _ u1 u2 =
     let u1 = EConstr.EInstance.(kind !sigma (make u1)) in
     let u2 = EConstr.EInstance.(kind !sigma (make u2)) in
-    UGraph.check_eq_instances (universes !sigma) u1 u2
+    UGraph.check_eq_instances (elim_graph !sigma) (universes !sigma) u1 u2
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -879,7 +879,6 @@ let get_senv_side_effects eff = match eff.seff_safeenv with
 
 let evar_handler sigma =
   let evar_expand ev = existential_expand_value0 sigma ev in
-  let qnorm q = UState.nf_qvar sigma.universes q in
   let qvar_irrelevant q = is_relevance_irrelevant sigma (Sorts.RelevanceVar q) in
   let evar_irrelevant (evk, _) = match find sigma evk with
   | EvarInfo evi -> is_relevance_irrelevant sigma evi.evar_relevance
@@ -905,7 +904,7 @@ let evar_handler sigma =
     in
     { cb with const_body = drop_opaque cb.const_body; const_body_code = drop_code cb.const_body_code }
   in
-  { CClosure.evar_expand; evar_irrelevant; evar_repack; qnorm; qvar_irrelevant; abstr_const }
+  { CClosure.evar_expand; evar_irrelevant; evar_repack; qvar_irrelevant; abstr_const }
 
 let existential_type_opt d (n, args) =
   match find_undefined d n with

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -842,7 +842,16 @@ let add_quconstraints uctx (qcstrs,ucstrs) =
   add_universe_constraints uctx cstrs
 
 let check_qconstraints uctx csts =
-  true
+  Sorts.QCumulConstraints.for_all (fun (l,k,r) ->
+    let l = nf_quality uctx l in
+    let r = nf_quality uctx r in
+    match k with
+    | Eq -> QGraph.check_eq (QState.elims uctx.sort_variables) l r
+    | Leq ->
+      match l, r with
+      | QConstant QProp, QConstant QType -> true
+      | _ -> QGraph.check_eq (QState.elims uctx.sort_variables) l r)
+  csts
 
 let check_elim_constraints uctx csts =
   Sorts.ElimConstraints.for_all (fun (l,k,r) ->

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -50,8 +50,8 @@ val pr_universe_subst : (Level.t -> Pp.t) -> universe_subst -> Pp.t
 val enforce_eq : Universe.t constraint_function
 val enforce_leq : Universe.t constraint_function
 
-val enforce_eq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
-val enforce_leq_sort : Sorts.t -> Sorts.t -> Univ.Constraints.t -> Univ.Constraints.t
+val enforce_eq_sort : Sorts.t -> Sorts.t -> Sorts.QUConstraints.t -> Sorts.QUConstraints.t
+val enforce_leq_sort : Sorts.t -> Sorts.t -> Sorts.QUConstraints.t -> Sorts.QUConstraints.t
 
 (** Picks an arbitrary set of constraints sufficient to ensure [u <= v]. *)
-val enforce_leq_alg_sort : Sorts.t -> Sorts.t -> UGraph.t -> Univ.Constraints.t * UGraph.t
+val enforce_leq_alg_sort : Sorts.t -> Sorts.t -> UGraph.t -> Sorts.QUConstraints.t * UGraph.t

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -127,7 +127,6 @@ type evar_handler = {
   evar_expand : constr pexistential -> constr evar_expansion;
   evar_repack : Evar.t * constr list -> constr;
   evar_irrelevant : constr pexistential -> bool;
-  qnorm : Sorts.QVar.t -> Sorts.Quality.t;
   qvar_irrelevant : Sorts.QVar.t -> bool;
   abstr_const : Constant.t -> (unit, (unit -> Vmemitcodes.to_patch) Vmemitcodes.pbody_code) Declarations.pconstant_body;
 }
@@ -136,9 +135,6 @@ let default_evar_handler env = {
   evar_expand = (fun _ -> assert false);
   evar_repack = (fun _ -> assert false);
   evar_irrelevant = (fun _ -> assert false);
-  qnorm = (fun q ->
-      assert (Sorts.QVar.Set.mem q (Environ.qvars env));
-      Sorts.Quality.QVar q);
   qvar_irrelevant = (fun q ->
       assert (Sorts.QVar.Set.mem q (Environ.qvars env));
       false);
@@ -180,7 +176,6 @@ type clos_infos = {
 let info_flags info = info.i_flags
 let info_env info = info.i_cache.i_env
 let info_univs info = info.i_cache.i_univs
-let info_qnorm info = info.i_cache.i_sigma.qnorm
 let info_elims info = Environ.qualities (info_env info)
 
 let push_relevance infos x =

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -128,7 +128,6 @@ type evar_handler = {
   evar_expand : constr pexistential -> constr evar_expansion;
   evar_repack : Evar.t * constr list -> constr;
   evar_irrelevant : constr pexistential -> bool;
-  qnorm : Sorts.QVar.t -> Sorts.Quality.t;
   qvar_irrelevant : Sorts.QVar.t -> bool;
   abstr_const : Constant.t -> (unit, (unit -> Vmemitcodes.to_patch) Vmemitcodes.pbody_code) Declarations.pconstant_body;
 }
@@ -148,7 +147,6 @@ val create_tab : unit -> clos_tab
 val info_env : clos_infos -> env
 val info_flags: clos_infos -> reds
 val info_univs : clos_infos -> UGraph.t
-val info_qnorm : clos_infos -> (Sorts.QVar.t -> Sorts.Quality.t)
 val info_elims : clos_infos -> QGraph.t
 val unfold_projection : clos_infos -> Projection.t -> Sorts.relevance -> stack_member option
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -988,7 +988,7 @@ let equal n m = eq_constr 0 m n (* to avoid tracing a recursive fun *)
 let eq_constr_univs quals univs m n =
   if m == n then true
   else
-    let eq_universes _ = UGraph.check_eq_instances univs in
+    let eq_universes _ = UGraph.check_eq_instances quals univs in
     let eq_sorts s1 s2 = s1 == s2 || UGraph.check_eq_sort quals univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n ||	compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' nargs m n
@@ -997,7 +997,7 @@ let eq_constr_univs quals univs m n =
 let leq_constr_univs quals univs m n =
   if m == n then true
   else
-    let eq_universes _ = UGraph.check_eq_instances univs in
+    let eq_universes _ = UGraph.check_eq_instances quals univs in
     let eq_sorts s1 s2 = s1 == s2 ||
       UGraph.check_eq_sort quals univs s1 s2 in
     let leq_sorts s1 s2 = s1 == s2 ||

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -149,9 +149,9 @@ type conv_pb =
   | CUMUL
 
 type ('a, 'err) universe_compare = {
-  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
-  compare_instances: env -> flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
-  compare_cumul_instances : env -> conv_pb -> UVars.Variance.t array ->
+  compare_sorts : conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
+  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
+  compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
     UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
 }
 
@@ -159,18 +159,18 @@ type ('a, 'err) universe_state = 'a * ('a, 'err) universe_compare
 
 type ('a, 'err) generic_conversion_function = ('a, 'err) universe_state -> constr -> constr -> ('a, 'err option) result
 
-let sort_cmp_universes env pb s0 s1 (u, check) =
-  (check.compare_sorts env pb s0 s1 u, check)
+let sort_cmp_universes pb s0 s1 (u, check) =
+  (check.compare_sorts pb s0 s1 u, check)
 
 (* [flex] should be true for constants, false for inductive types and
    constructors. *)
-let convert_instances env ~flex u u' (s, check) =
-  (check.compare_instances env ~flex u u' s, check)
+let convert_instances ~flex u u' (s, check) =
+  (check.compare_instances ~flex u u' s, check)
 
 exception MustExpand
 
-let convert_instances_cumul env pb var u u' (s, check) =
-  (check.compare_cumul_instances env pb var u u' s, check)
+let convert_instances_cumul pb var u u' (s, check) =
+  (check.compare_cumul_instances pb var u u' s, check)
 
 let get_cumulativity_constraints cv_pb variance u u' =
   match cv_pb with
@@ -209,8 +209,8 @@ let fail_check (infos : 'err conv_tab) (state, check) = match state with
 | Result.Error None -> raise NotConvertible
 | Result.Error (Some err) -> raise (NotConvertibleTrace (infos.err_ret err))
 
-let convert_inductives env cv_pb ind nargs u1 u2 (s, check) =
-  convert_inductives_gen (check.compare_instances env ~flex:false) (check.compare_cumul_instances env)
+let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
+  convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
     cv_pb ind nargs u1 u2 s, check
 
 let constructor_cumulativity_arguments (mind, ind, ctor) =
@@ -231,8 +231,8 @@ let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u
       let variance = Array.make (snd (UVars.Instance.length u1)) UVars.Variance.Irrelevant in
       cmp_cumul CONV variance u1 u2 s
 
-let convert_constructors env ctor nargs u1 u2 (s, check) =
-  convert_constructors_gen (check.compare_instances env ~flex:false) (check.compare_cumul_instances env)
+let convert_constructors ctor nargs u1 u2 (s, check) =
+  convert_constructors_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
     ctor nargs u1 u2 s, check
 
 let conv_table_key infos ~nargs k1 k2 cuniv =
@@ -244,7 +244,7 @@ let conv_table_key infos ~nargs k1 k2 cuniv =
     else
       let flex = evaluable_constant cst (info_env infos.cnv_inf)
         && RedFlags.red_set (info_flags infos.cnv_inf) (RedFlags.fCONST cst)
-      in fail_check infos @@ convert_instances (info_env infos.cnv_inf) ~flex u u' cuniv
+      in fail_check infos @@ convert_instances ~flex u u' cuniv
   | VarKey id, VarKey id' when Id.equal id id' -> cuniv
   | RelKey n, RelKey n' when Int.equal n n' -> cuniv
   | _ -> raise NotConvertible
@@ -404,7 +404,7 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
                if not (is_empty_stack v1 && is_empty_stack v2) then
                  (* May happen because we convert application right to left *)
                  raise NotConvertible;
-              fail_check infos @@ sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
+              fail_check infos @@ sort_cmp_universes cv_pb s1 s2 cuniv
            | (Meta n, Meta m) ->
                if Int.equal n m
                then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
@@ -625,12 +625,12 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
     | (FInd (ind1,u1 as pind1), FInd (ind2,u2 as pind2)) ->
       if Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = fail_check infos @@ convert_instances (info_env infos.cnv_inf) ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check infos @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
           let nargs = same_args_size v1 v2 in
-          match fail_check infos @@ convert_inductives (info_env infos.cnv_inf) cv_pb (mind, snd ind1) nargs u1 u2 cuniv with
+          match fail_check infos @@ convert_inductives cv_pb (mind, snd ind1) nargs u1 u2 cuniv with
           | cuniv -> convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
           | exception MustExpand ->
             let env = info_env infos.cnv_inf in
@@ -648,11 +648,11 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
       let v2 = append_stack args2 v2 in
       if Int.equal j1 j2 && Ind.CanOrd.equal ind1 ind2 then
         if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-          let cuniv = fail_check infos @@ convert_instances (info_env infos.cnv_inf) ~flex:false u1 u2 cuniv in
+          let cuniv = fail_check infos @@ convert_instances ~flex:false u1 u2 cuniv in
           convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
-          match fail_check infos @@ convert_constructors (info_env infos.cnv_inf) (mind, snd ind1, j1) nargs u1 u2 cuniv with
+          match fail_check infos @@ convert_constructors (mind, snd ind1, j1) nargs u1 u2 cuniv with
           | cuniv -> convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
           | exception MustExpand ->
             let env = info_env infos.cnv_inf in
@@ -746,7 +746,7 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
         let nargs = inductive_cumulativity_arguments ind in
         let u1 = CClosure.usubst_instance e1 u1 in
         let u2 = CClosure.usubst_instance e2 u2 in
-        fail_check infos @@ convert_inductives (info_env infos.cnv_inf) CONV ind nargs u1 u2 cuniv
+        fail_check infos @@ convert_inductives CONV ind nargs u1 u2 cuniv
       in
       let pms1 = mk_clos_vect e1 pms1 in
       let pms2 = mk_clos_vect e2 pms2 in
@@ -758,7 +758,7 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
     | FArray (u1,t1,ty1), FArray (u2,t2,ty2) ->
       let len = Parray.length_int t1 in
       if not (Int.equal len (Parray.length_int t2)) then raise NotConvertible;
-      let cuniv = fail_check infos @@ convert_instances_cumul (info_env infos.cnv_inf) CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
+      let cuniv = fail_check infos @@ convert_instances_cumul CONV [|UVars.Variance.Irrelevant|] u1 u2 cuniv in
       let el1 = el_stack lft1 v1 in
       let el2 = el_stack lft2 v2 in
       let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
@@ -834,13 +834,13 @@ and convert_stacks ?(mask = [||]) l2r infos lft1 lft2 stk1 stk2 cuniv =
                 let mip = mind.Declarations.mind_packets.(snd ci1.ci_ind) in
                 let cu =
                   if UVars.Instance.is_empty u1 || UVars.Instance.is_empty u2 then
-                    convert_instances (info_env infos.cnv_inf) ~flex:false u1 u2 cu
+                    convert_instances ~flex:false u1 u2 cu
                   else
                     let u1 = CClosure.usubst_instance e1 u1 in
                     let u2 = CClosure.usubst_instance e2 u2 in
                     match mind.Declarations.mind_variance with
-                    | None -> convert_instances (info_env infos.cnv_inf) ~flex:false u1 u2 cu
-                    | Some variances -> convert_instances_cumul (info_env infos.cnv_inf) CONV variances u1 u2 cu
+                    | None -> convert_instances ~flex:false u1 u2 cu
+                    | Some variances -> convert_instances_cumul CONV variances u1 u2 cu
                 in
                 let cu = fail_check infos cu in
                 let pms1 = mk_clos_vect e1 pms1 in
@@ -951,30 +951,30 @@ let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 
       | NotConvertibleTrace _ -> assert false
   end ()
 
-let check_eq univs elims u u' =
+let check_eq (elims, univs as state) u u' =
   if UGraph.check_eq_sort elims univs u u'
-  then Result.Ok univs
+  then Result.Ok state
   else Result.Error None
 
-let check_leq univs elims u u' =
+let check_leq (elims, univs as state) u u' =
   if UGraph.check_leq_sort elims univs u u'
-  then Result.Ok univs
+  then Result.Ok state
   else Result.Error None
 
-let checked_sort_cmp_universes env pb s0 s1 univs =
+let checked_sort_cmp_universes pb s0 s1 state =
   match pb with
-  | CUMUL -> check_leq univs (Environ.qualities env) s0 s1
-  | CONV -> check_eq univs (Environ.qualities env) s0 s1
+  | CUMUL -> check_leq state s0 s1
+  | CONV -> check_eq state s0 s1
 
-let check_convert_instances env ~flex:_ u u' univs =
-  if UGraph.check_eq_instances (Environ.qualities env) univs u u' then Result.Ok univs
+let check_convert_instances ~flex:_ u u' (elims, univs as state) =
+  if UGraph.check_eq_instances elims univs u u' then Result.Ok state
   else Result.Error None
 
 (* general conversion and inference functions *)
-let check_inductive_instances env cv_pb variance u1 u2 univs =
+let check_inductive_instances cv_pb variance u1 u2 (elims, univs as state) =
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
-  if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts) (Environ.qualities env) && UGraph.check_constraints ucsts univs
-  then Result.Ok univs
+  if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts) elims && UGraph.check_constraints ucsts univs
+  then Result.Ok state
   else Result.Error None
 
 let checked_universes =
@@ -986,12 +986,12 @@ let () =
   let conv infos tab a b =
     try
       let box = Empty.abort in
-      let univs = info_univs infos in
+      let state = info_elims infos, info_univs infos in
       let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box } in
-      let univs', _ = ccnv CONV false infos el_id el_id a b
-          (univs, checked_universes)
+      let state', _ = ccnv CONV false infos el_id el_id a b
+          (state, checked_universes)
       in
-      assert (univs==univs');
+      assert (state==state');
       true
     with
     | NotConvertible -> false
@@ -1002,22 +1002,23 @@ let () =
 let gen_conv ~typed cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=default_evar_handler env) t1 t2 =
   let univs = Environ.universes env in
   let elims = Environ.qualities env in
+  let state = elims, univs in
   let b =
     if cv_pb = CUMUL then leq_constr_univs elims univs t1 t2
     else eq_constr_univs elims univs t1 t2
   in
     if b then Result.Ok ()
-    else match clos_gen_conv ~typed reds cv_pb l2r evars env univs (univs, checked_universes) t1 t2 with
-    | Result.Ok (_ : UGraph.t * (UGraph.t, Empty.t) universe_compare)-> Result.Ok ()
+    else match clos_gen_conv ~typed reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
+    | Result.Ok (_ : 'a * ('a, Empty.t) universe_compare)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e
 
 let conv = gen_conv ~typed:false CONV
 let conv_leq = gen_conv ~typed:false CUMUL
 
-let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) univs t1 t2 =
+let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) state t1 t2 =
   let graph = Environ.universes env in
-  match clos_gen_conv ~typed:false reds cv_pb l2r evars env graph univs t1 t2 with
+  match clos_gen_conv ~typed:false reds cv_pb l2r evars env graph state t1 t2 with
   | Result.Ok (s, _) -> Result.Ok s
   | Result.Error e -> Result.Error e
 

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -24,8 +24,8 @@ type conv_pb = CONV | CUMUL
 
 type ('a, 'err) universe_compare = {
   compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
-  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
-  compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
+  compare_instances: env -> flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
+  compare_cumul_instances : env -> conv_pb -> UVars.Variance.t array ->
     UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
 }
 
@@ -44,7 +44,7 @@ val sort_cmp_universes : env -> conv_pb -> Sorts.t -> Sorts.t ->
 
 (* [flex] should be true for constants, false for inductive types and
 constructors. *)
-val convert_instances : flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
+val convert_instances : env -> flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
   'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (** This function never returns an non-empty error. *)

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -23,9 +23,9 @@ type 'a extended_conversion_function =
 type conv_pb = CONV | CUMUL
 
 type ('a, 'err) universe_compare = {
-  compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
-  compare_instances: env -> flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
-  compare_cumul_instances : env -> conv_pb -> UVars.Variance.t array ->
+  compare_sorts : conv_pb -> Sorts.t -> Sorts.t -> 'a -> ('a, 'err option) result;
+  compare_instances: flex:bool -> UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
+  compare_cumul_instances : conv_pb -> UVars.Variance.t array ->
     UVars.Instance.t -> UVars.Instance.t -> 'a -> ('a, 'err option) result;
 }
 
@@ -39,16 +39,16 @@ val get_cumulativity_constraints : conv_pb -> UVars.Variance.t array ->
 val inductive_cumulativity_arguments : (Declarations.mutual_inductive_body * int) -> int
 val constructor_cumulativity_arguments : (Declarations.mutual_inductive_body * int * int) -> int
 
-val sort_cmp_universes : env -> conv_pb -> Sorts.t -> Sorts.t ->
+val sort_cmp_universes : conv_pb -> Sorts.t -> Sorts.t ->
   'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (* [flex] should be true for constants, false for inductive types and
 constructors. *)
-val convert_instances : env -> flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
+val convert_instances : flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
   'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (** This function never returns an non-empty error. *)
-val checked_universes : (UGraph.t, 'err) universe_compare
+val checked_universes : (QGraph.t * UGraph.t, 'err) universe_compare
 
 (** These two functions can only fail with unit *)
 val conv : constr extended_conversion_function

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -48,7 +48,7 @@ val convert_instances : flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
   'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (** This function never returns an non-empty error. *)
-val checked_universes : env -> (UGraph.t, 'err) universe_compare
+val checked_universes : (UGraph.t, 'err) universe_compare
 
 (** These two functions can only fail with unit *)
 val conv : constr extended_conversion_function

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -494,7 +494,7 @@ let push_qualities qs env =
             (fun v -> QGraph.add_quality (Sorts.Quality.QVar v)) qs env.env_qualities in
   set_qualities g env
 
-let set_qualities qs env =
+let set_qvars qs env =
   let g = QGraph.initial_graph in
   let g = Sorts.QVar.Set.fold (fun v -> QGraph.add_quality (Sorts.Quality.QVar v)) qs g in
   { env with env_qualities = g }

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -74,10 +74,11 @@ val named_context : env -> Constr.named_context
 val named_context_val : env -> named_context_val
 
 val set_universes : UGraph.t -> env -> env
+val set_qualities : QGraph.t -> env -> env
+val set_qvars : Sorts.QVar.Set.t -> env -> env
 
 val qualities : env -> QGraph.t
 val qvars : env -> Sorts.QVar.Set.t
-val set_qualities : Sorts.QVar.Set.t -> env -> env
 
 val typing_flags    : env -> typing_flags
 val is_impredicative_set : env -> bool

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -27,12 +27,12 @@ let fail_check state check box = match state with
 | Result.Error None -> raise NotConvertible
 | Result.Error (Some err) -> box.fail err
 
-let convert_instances env ~flex u1 u2 (state, check, box) =
-  let state, check = Conversion.convert_instances env ~flex u1 u2 (state, check) in
+let convert_instances ~flex u1 u2 (state, check, box) =
+  let state, check = Conversion.convert_instances ~flex u1 u2 (state, check) in
   fail_check state check box
 
-let sort_cmp_universes env pb s1 s2 (state, check, box) =
-  let state, check = Conversion.sort_cmp_universes env pb s1 s2 (state, check) in
+let sort_cmp_universes pb s1 s2 (state, check, box) =
+  let state, check = Conversion.sort_cmp_universes pb s1 s2 (state, check) in
   fail_check state check box
 
 let rec conv_val env pb lvl v1 v2 cu =
@@ -103,13 +103,13 @@ and conv_atom env pb lvl a1 a2 cu =
     | Arel i1, Arel i2 ->
         if Int.equal i1 i2 then cu else raise NotConvertible
     | Aind (ind1,u1), Aind (ind2,u2) ->
-       if Ind.CanOrd.equal ind1 ind2 then convert_instances env ~flex:false u1 u2 cu
+       if Ind.CanOrd.equal ind1 ind2 then convert_instances ~flex:false u1 u2 cu
        else raise NotConvertible
     | Aconstant (c1,u1), Aconstant (c2,u2) ->
-       if Constant.CanOrd.equal c1 c2 then convert_instances env ~flex:true u1 u2 cu
+       if Constant.CanOrd.equal c1 c2 then convert_instances ~flex:true u1 u2 cu
        else raise NotConvertible
     | Asort s1, Asort s2 ->
-      sort_cmp_universes env pb s1 s2 cu
+      sort_cmp_universes pb s1 s2 cu
     | Avar id1, Avar id2 ->
         if Id.equal id1 id2 then cu else raise NotConvertible
     | Acase(a1,ac1,p1,bs1), Acase(a2,ac2,p2,bs2) ->
@@ -203,17 +203,18 @@ let native_conv_gen pb sigma env univs t1 t2 =
 let native_conv cv_pb sigma env t1 t2 =
   let univs = Environ.universes env in
   let elims = Environ.qualities env in
+  let state = elims, univs in
   let b =
     if cv_pb = CUMUL then Constr.leq_constr_univs elims univs t1 t2
     else Constr.eq_constr_univs elims univs t1 t2
   in
   if b then Result.Ok ()
   else
-    let state = (univs, checked_universes) in
+    let state = (state, checked_universes) in
     let t1 = Term.it_mkLambda_or_LetIn t1 (Environ.rel_context env) in
     let t2 = Term.it_mkLambda_or_LetIn t2 (Environ.rel_context env) in
     match native_conv_gen cv_pb sigma env state t1 t2 with
-    | Result.Ok (_ : UGraph.t) -> Result.Ok ()
+    | Result.Ok (_ : QGraph.t * UGraph.t) -> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some _) ->
       (* checked_universes cannot raise this *)

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -27,8 +27,8 @@ let fail_check state check box = match state with
 | Result.Error None -> raise NotConvertible
 | Result.Error (Some err) -> box.fail err
 
-let convert_instances ~flex u1 u2 (state, check, box) =
-  let state, check = Conversion.convert_instances ~flex u1 u2 (state, check) in
+let convert_instances env ~flex u1 u2 (state, check, box) =
+  let state, check = Conversion.convert_instances env ~flex u1 u2 (state, check) in
   fail_check state check box
 
 let sort_cmp_universes env pb s1 s2 (state, check, box) =
@@ -103,10 +103,10 @@ and conv_atom env pb lvl a1 a2 cu =
     | Arel i1, Arel i2 ->
         if Int.equal i1 i2 then cu else raise NotConvertible
     | Aind (ind1,u1), Aind (ind2,u2) ->
-       if Ind.CanOrd.equal ind1 ind2 then convert_instances ~flex:false u1 u2 cu
+       if Ind.CanOrd.equal ind1 ind2 then convert_instances env ~flex:false u1 u2 cu
        else raise NotConvertible
     | Aconstant (c1,u1), Aconstant (c2,u2) ->
-       if Constant.CanOrd.equal c1 c2 then convert_instances ~flex:true u1 u2 cu
+       if Constant.CanOrd.equal c1 c2 then convert_instances env ~flex:true u1 u2 cu
        else raise NotConvertible
     | Asort s1, Asort s2 ->
       sort_cmp_universes env pb s1 s2 cu

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -209,7 +209,7 @@ let native_conv cv_pb sigma env t1 t2 =
   in
   if b then Result.Ok ()
   else
-    let state = (univs, checked_universes env) in
+    let state = (univs, checked_universes) in
     let t1 = Term.it_mkLambda_or_LetIn t1 (Environ.rel_context env) in
     let t2 = Term.it_mkLambda_or_LetIn t2 (Environ.rel_context env) in
     match native_conv_gen cv_pb sigma env state t1 t2 with

--- a/kernel/qGraph.ml
+++ b/kernel/qGraph.ml
@@ -275,6 +275,32 @@ let qvar_domain g =
 
 let is_empty g = QVar.Set.is_empty (qvar_domain g)
 
+(* Pretty printing *)
+
+let pr_pmap sep pr map =
+  let cmp (u,_) (v,_) = Quality.compare u v in
+  Pp.prlist_with_sep sep pr (List.sort cmp (Quality.Map.bindings map))
+
+let pr_arc prq =
+  let open Pp in
+  function
+  | u, G.Node ltle ->
+    if Quality.Map.is_empty ltle then mt ()
+    else
+      prq u ++ str " " ++
+      v 0
+        (pr_pmap spc (fun (v, strict) ->
+              (if strict then str "< " else str "<= ") ++ prq v)
+            ltle) ++
+      fnl ()
+  | u, G.Alias v ->
+    prq u  ++ str " = " ++ prq v ++ fnl ()
+
+
+let repr g = G.repr g.graph
+
+let pr_qualities prq g = pr_pmap Pp.mt (pr_arc prq) (repr g)
+
 let explain_quality_inconsistency prv r =
   let open Pp in
   let pr_cst = function

--- a/kernel/qGraph.mli
+++ b/kernel/qGraph.mli
@@ -99,4 +99,6 @@ val qvar_domain : t -> QVar.Set.t
 
 val is_empty : t -> bool
 
+val pr_qualities : (Quality.t -> Pp.t) -> t -> Pp.t
+
 val explain_quality_inconsistency : (QVar.t -> Pp.t) -> explanation option -> Pp.t

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1392,7 +1392,7 @@ let end_module l restype senv =
   let mbids = List.rev_map fst params in
   let mb = build_module_body params restype senv in
   let newenv = Environ.set_universes (Environ.universes senv.env) oldsenv.env in
-  let newenv = Environ.set_qualities (Environ.qvars senv.env) newenv in
+  let newenv = Environ.set_qualities (Environ.qualities senv.env) newenv in
   let newenv = if Environ.rewrite_rules_allowed senv.env then Environ.allow_rewrite_rules newenv else newenv in
   let newenv = Environ.set_vm_library (Environ.vm_library senv.env) newenv in
   let senv' = propagate_loads { senv with env = newenv } in

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1216,7 +1216,7 @@ let add_mind ?typing_flags l mie senv =
 (** Insertion of module types *)
 
 let check_state senv =
-  (Environ.universes senv.env, Conversion.checked_universes senv.env)
+  (Environ.universes senv.env, Conversion.checked_universes)
 
 let vm_handler env univs c vmtab =
   let env = Environ.set_vm_library vmtab env in

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1216,7 +1216,7 @@ let add_mind ?typing_flags l mie senv =
 (** Insertion of module types *)
 
 let check_state senv =
-  (Environ.universes senv.env, Conversion.checked_universes)
+  ((Environ.qualities senv.env, Environ.universes senv.env), Conversion.checked_universes)
 
 let vm_handler env univs c vmtab =
   let env = Environ.set_vm_library vmtab env in
@@ -1443,7 +1443,7 @@ let add_include me is_module inl senv =
       let state = check_state senv in
       (* Module subcomponents are already part of senv.env at this point *)
       let env = Environ.shallow_add_module mp_sup mb senv.env in
-      let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
+      let (_ : QGraph.t * UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver
       in

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -436,18 +436,6 @@ let levels s = match s with
 | Set -> Level.Set.singleton Level.set
 | Type u | QSort (_, u) -> Universe.levels u
 
-let subst_quality fq = function
-  | SProp | Prop | Set | Type _ as s -> s
-  | QSort (q, v) as s ->
-    let open Quality in
-    match fq q with
-    | QVar q' ->
-      if q' == q then s
-      else qsort q' v
-    | QConstant QSProp -> sprop
-    | QConstant QProp -> prop
-    | QConstant QType -> sort_of_univ v
-
 let subst_fn (fq,fu) = function
   | SProp | Prop | Set as s -> s
   | Type v as s ->

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -329,6 +329,8 @@ module QCumulConstraint = struct
   let raw_pr x = pr QVar.raw_pr x
 
   let trivial ((a,(Eq|Leq),b) : t) = Quality.equal a b
+
+  let to_elim ((a,(Eq|Leq),b) : t) : ElimConstraint.t = ElimConstraint.(a, Equal, b)
 end
 
 module QCumulConstraints = struct include CSet.Make(QCumulConstraint)
@@ -339,6 +341,11 @@ module QCumulConstraints = struct include CSet.Make(QCumulConstraint)
        (elements c))
 
   let trivial = for_all QCumulConstraint.trivial
+
+  let to_elims s =
+    to_seq s
+    |> Seq.map QCumulConstraint.to_elim
+    |> ElimConstraints.of_seq
 end
 
 let enforce_eq_cumul_quality a b csts =

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -208,8 +208,6 @@ val levels : t -> Univ.Level.Set.t
 
 val super : t -> t
 
-val subst_quality : (QVar.t -> Quality.t) -> t -> t
-
 val subst_fn : (QVar.t -> Quality.t) * (Univ.Universe.t -> Univ.Universe.t)
   -> t -> t
 

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -150,6 +150,7 @@ module QCumulConstraint : sig
   type t = Quality.t * kind * Quality.t
 
   val trivial : t -> bool
+  val to_elim : t -> ElimConstraint.t
   val equal : t -> t -> bool
   val compare : t -> t -> int
   val pr : (QVar.t -> Pp.t) -> t -> Pp.t
@@ -160,6 +161,7 @@ module QCumulConstraints : sig
   include CSig.SetS with type elt = QCumulConstraint.t
   val pr : (QVar.t -> Pp.t) -> t -> Pp.t
   val trivial : t -> bool
+  val to_elims : t -> ElimConstraints.t
 end
 
 val enforce_eq_cumul_quality : Quality.t -> Quality.t -> QCumulConstraints.t -> QCumulConstraints.t

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -231,11 +231,11 @@ let check_subtype univs ctxT ctx =
 
 (** Instances *)
 
-let check_eq_instances g t1 t2 =
+let check_eq_instances quals univs t1 t2 =
   let qt1, ut1 = Instance.to_array t1 in
   let qt2, ut2 = Instance.to_array t2 in
-  CArray.equal Sorts.Quality.equal qt1 qt2
-  && CArray.equal (check_eq_level g) ut1 ut2
+  CArray.equal (QGraph.check_eq quals) qt1 qt2
+  && CArray.equal (check_eq_level univs) ut1 ut2
 
 let domain g = G.domain g.graph
 let choose p g u = G.choose p g.graph u

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -36,7 +36,7 @@ val initial_universes : t
 val initial_universes_with : t -> t
 
 (** Check equality of instances w.r.t. a universe graph *)
-val check_eq_instances : Instance.t check_function
+val check_eq_instances : QGraph.t -> t -> Instance.t -> Instance.t -> bool
 
 (** {6 ... } *)
 (** Merge of constraints in a universes graph.

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -84,8 +84,6 @@ module Instance : sig
     val hcons : t -> int * t
     val hash : t -> int
 
-    val subst_qualities : (Sorts.QVar.t -> Quality.t) -> t -> t
-
     val subst_fn : (Sorts.QVar.t -> Quality.t) * (Level.t -> Level.t) -> t -> t
 
     val pr : (Sorts.QVar.t -> Pp.t) -> (Level.t -> Pp.t) -> ?variance:Variance.t array -> t -> Pp.t
@@ -160,10 +158,6 @@ struct
     of_array (qs,us)
 
   let length (aq,au) = Array.length aq, Array.length au
-
-  let subst_qualities fq (q,u as orig) : t =
-    let q' = CArray.Smart.map (Quality.subst fq) q in
-    if q' == q then orig else q', u
 
   let subst_fn (fq, fn) (q,u as orig) : t =
     let q' = CArray.Smart.map (Quality.subst fq) q in

--- a/kernel/uVars.mli
+++ b/kernel/uVars.mli
@@ -71,8 +71,6 @@ sig
   val levels : t -> Quality.Set.t * Level.Set.t
   (** The set of levels in the instance *)
 
-  val subst_qualities : (Sorts.QVar.t -> Quality.t) -> t -> t
-
   val subst_fn
     : (QVar.t -> Quality.t) * (Level.t -> Level.t)
     -> t -> t

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -17,12 +17,12 @@ let fail_check state check box = match state with
 | Result.Error None -> raise NotConvertible
 | Result.Error (Some err) -> box.fail err
 
-let convert_instances env ~flex u1 u2 (state, check, box) =
-  let state, check = Conversion.convert_instances env ~flex u1 u2 (state, check) in
+let convert_instances ~flex u1 u2 (state, check, box) =
+  let state, check = Conversion.convert_instances ~flex u1 u2 (state, check) in
   fail_check state check box
 
-let sort_cmp_universes env pb s1 s2 (state, check, box) =
-  let state, check = Conversion.sort_cmp_universes env pb s1 s2 (state, check) in
+let sort_cmp_universes pb s1 s2 (state, check, box) =
+  let state, check = Conversion.sort_cmp_universes pb s1 s2 (state, check) in
   fail_check state check box
 
 let table_key_instance env = function
@@ -123,7 +123,7 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
           assert (0 < nargs args2);
           let u1 = uni_instance (arg args1 0) in
           let u2 = uni_instance (arg args2 0) in
-          let cu = convert_instances env ~flex:false u1 u2 cu in
+          let cu = convert_instances ~flex:false u1 u2 cu in
           conv_arguments env ~from:1 k args1 args2
             (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)
@@ -140,13 +140,13 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
           assert (0 < nargs args2);
           let u1 = uni_instance (arg args1 0) in
           let u2 = uni_instance (arg args2 0) in
-          let cu = convert_instances env ~flex:false u1 u2 cu in
+          let cu = convert_instances ~flex:false u1 u2 cu in
           conv_arguments env ~from:1 k args1 args2
             (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)
     else raise NotConvertible
   | Asort s1, Asort s2 ->
-    sort_cmp_universes env pb s1 s2 cu
+    sort_cmp_universes pb s1 s2 cu
   | Asort _ , _ | Aind _, _ | Aid _, _ -> raise NotConvertible
 
 and conv_stack env k stk1 stk2 cu =
@@ -241,19 +241,20 @@ let vm_conv_gen (type err) cv_pb sigma env univs t1 t2 =
 let vm_conv cv_pb env t1 t2 =
   let univs = Environ.universes env in
   let elims = Environ.qualities env in
+  let state = elims, univs in
   let b =
     if cv_pb = CUMUL then Constr.leq_constr_univs elims univs t1 t2
     else Constr.eq_constr_univs elims univs t1 t2
   in
   if b then Result.Ok ()
   else
-    let state = (univs, checked_universes) in
-    let ans : (UGraph.t, 'a option) result =
+    let state = (state, checked_universes) in
+    let ans : (QGraph.t * UGraph.t, 'a option) result =
       NewProfile.profile "vm_conv" (fun () ->
           vm_conv_gen cv_pb (Genlambda.empty_evars env) env state t1 t2)
         ()
     in
     match ans with
-    | Result.Ok (_ : UGraph.t)-> Result.Ok ()
+    | Result.Ok (_ : QGraph.t * UGraph.t)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -17,8 +17,8 @@ let fail_check state check box = match state with
 | Result.Error None -> raise NotConvertible
 | Result.Error (Some err) -> box.fail err
 
-let convert_instances ~flex u1 u2 (state, check, box) =
-  let state, check = Conversion.convert_instances ~flex u1 u2 (state, check) in
+let convert_instances env ~flex u1 u2 (state, check, box) =
+  let state, check = Conversion.convert_instances env ~flex u1 u2 (state, check) in
   fail_check state check box
 
 let sort_cmp_universes env pb s1 s2 (state, check, box) =
@@ -123,7 +123,7 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
           assert (0 < nargs args2);
           let u1 = uni_instance (arg args1 0) in
           let u2 = uni_instance (arg args2 0) in
-          let cu = convert_instances ~flex:false u1 u2 cu in
+          let cu = convert_instances env ~flex:false u1 u2 cu in
           conv_arguments env ~from:1 k args1 args2
             (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)
@@ -140,7 +140,7 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
           assert (0 < nargs args2);
           let u1 = uni_instance (arg args1 0) in
           let u2 = uni_instance (arg args2 0) in
-          let cu = convert_instances ~flex:false u1 u2 cu in
+          let cu = convert_instances env ~flex:false u1 u2 cu in
           conv_arguments env ~from:1 k args1 args2
             (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -247,7 +247,7 @@ let vm_conv cv_pb env t1 t2 =
   in
   if b then Result.Ok ()
   else
-    let state = (univs, checked_universes env) in
+    let state = (univs, checked_universes) in
     let ans : (UGraph.t, 'a option) result =
       NewProfile.profile "vm_conv" (fun () ->
           vm_conv_gen cv_pb (Genlambda.empty_evars env) env state t1 t2)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -193,7 +193,7 @@ let expand_mexpr env mp me =
   (* hack: in order not to overwrite the module binding mp, we first give it a
      name that should not be part of the env and then substitute it away *)
   let mp0 = ModPath.dummy in
-  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let mb, (_, cst), _ = Mod_typing.translate_module state vm_state env mp0 inl (MExpr ([], me, None)) in
   let sign = mod_type mb in
   let reso = mod_delta mb in
@@ -201,7 +201,7 @@ let expand_mexpr env mp me =
 
 let expand_modtype env mp me =
   let inl = Some (Flags.get_inline_level()) in
-  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let mtb, _cst, _ = Mod_typing.translate_modtype state vm_state env mp inl ([],me) in
   mtb
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1336,6 +1336,7 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Conversion.CUMUL)
       | None ->
         let x = EConstr.Unsafe.to_constr x in
         let y = EConstr.Unsafe.to_constr y in
+        let env = Environ.set_qualities (Evd.elim_graph sigma) env in
         let env = Environ.set_universes (Evd.universes sigma) env in
         (* First try conversion with postponed universe problems as a kind of FO
            approximation. This may result in unsatisfiable constraints even if

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1208,19 +1208,19 @@ let check_eq univs u u' =
 let check_leq univs u u' =
   if Evd.check_leq univs u u' then Result.Ok univs else Result.Error None
 
-let checked_sort_cmp_universes _env pb s0 s1 univs =
+let checked_sort_cmp_universes pb s0 s1 univs =
   let s0 = ESorts.make s0 in
   let s1 = ESorts.make s1 in
   match pb with
   | CUMUL -> check_leq univs s0 s1
   | CONV -> check_eq univs s0 s1
 
-let check_convert_instances (_ : env) ~flex:_ u u' univs =
+let check_convert_instances ~flex:_ u u' univs =
   let csts = UVars.enforce_eq_instances u u' (Sorts.QCumulConstraints.empty,Constraints.empty) in
   if Evd.check_quconstraints univs csts then Result.Ok univs else Result.Error None
 
 (* general conversion and inference functions *)
-let check_inductive_instances (_ : env) cv_pb variance u1 u2 univs =
+let check_inductive_instances cv_pb variance u1 u2 univs =
   let csts = get_cumulativity_constraints cv_pb variance u1 u2 in
   if (Evd.check_quconstraints univs csts) then Result.Ok univs
   else Result.Error None
@@ -1263,7 +1263,7 @@ let is_conv_leq ?(reds=TransparentState.full) env sigma x y =
 let check_conv ?(pb=Conversion.CUMUL) ?(ts=TransparentState.full) env sigma x y =
   is_fconv ~reds:ts pb env sigma x y
 
-let sigma_compare_sorts _env pb s0 s1 sigma =
+let sigma_compare_sorts pb s0 s1 sigma =
   match pb with
   | Conversion.CONV ->
     begin
@@ -1276,13 +1276,13 @@ let sigma_compare_sorts _env pb s0 s1 sigma =
       with UGraph.UniverseInconsistency err -> Result.Error (Some err)
     end
 
-let sigma_compare_instances _env ~flex i0 i1 sigma =
+let sigma_compare_instances ~flex i0 i1 sigma =
   match Evd.set_eq_instances ~flex sigma (EInstance.make i0) (EInstance.make i1) with
   | sigma -> Result.Ok sigma
   | exception Evd.UniversesDiffer -> Result.Error None
   | exception UGraph.UniverseInconsistency err -> Result.Error (Some err)
 
-let sigma_check_inductive_instances _env cv_pb variance u1 u2 sigma =
+let sigma_check_inductive_instances cv_pb variance u1 u2 sigma =
   match Evarutil.compare_cumulative_instances cv_pb variance u1 u2 sigma with
   | Inl sigma -> Result.Ok sigma
   | Inr err -> Result.Error (Some err)
@@ -1293,16 +1293,16 @@ let sigma_univ_state =
     compare_instances = sigma_compare_instances;
     compare_cumul_instances = sigma_check_inductive_instances; }
 
-let univproblem_compare_sorts env pb s0 s1 uset =
+let univproblem_compare_sorts pb s0 s1 uset =
   let open UnivProblem in
   match pb with
   | Conversion.CONV -> Result.Ok (UnivProblem.Set.add (UEq (s0, s1)) uset)
   | Conversion.CUMUL -> Result.Ok (UnivProblem.Set.add (ULe (s0, s1)) uset)
 
-let univproblem_compare_instances _env ~flex i0 i1 uset =
+let univproblem_compare_instances ~flex i0 i1 uset =
   Result.Ok (UnivProblem.enforce_eq_instances_univs flex i0 i1 uset)
 
-let univproblem_check_inductive_instances _env cv_pb variance u1 u2 sigma =
+let univproblem_check_inductive_instances cv_pb variance u1 u2 sigma =
   Result.Ok (UnivProblem.compare_cumulative_instances cv_pb variance u1 u2 sigma)
 
 let univproblem_univ_state =
@@ -1688,53 +1688,57 @@ let is_arity env sigma c =
 module Infer = struct
 
 open Conversion
-
 let infer_eq elims (univs, cstrs as cuniv) s s' =
   if UGraph.check_eq_sort elims univs s s' then Result.Ok cuniv
   else try
-    let cstrs' = UnivSubst.enforce_eq_sort s s' Constraints.empty in
-    Result.Ok (UGraph.merge_constraints cstrs' univs, Constraints.union cstrs cstrs')
+    let qcsts', ucstrs' as cstrs' = UnivSubst.enforce_eq_sort s s' Sorts.QUConstraints.empty in
+    if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts') elims then
+      Result.Ok (UGraph.merge_constraints ucstrs' univs, Constraints.union cstrs ucstrs')
+    else Result.Error None
   with UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
 
 let infer_leq elims (univs, cstrs as cuniv) s s' =
   if UGraph.check_leq_sort elims univs s s' then Result.Ok cuniv
   else match UnivSubst.enforce_leq_alg_sort s s' univs with
-  | cstrs', univs ->
-    Result.Ok (univs, Univ.Constraints.union cstrs cstrs')
+  | (qcsts, ucsts), ugraph ->
+    if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts) elims then
+      Result.Ok (univs, Univ.Constraints.union cstrs ucsts)
+    else Result.Error None
   | exception UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
 
-let infer_cmp_universes env pb s0 s1 cuniv =
+let infer_cmp_universes elims pb s0 s1 cuniv =
   match pb with
-  | CUMUL -> infer_leq (Environ.qualities env) cuniv s0 s1
-  | CONV -> infer_eq (Environ.qualities env) cuniv s0 s1
+  | CUMUL -> infer_leq elims cuniv s0 s1
+  | CONV -> infer_eq elims cuniv s0 s1
 
-let infer_convert_instances env ~flex u u' (univs,cstrs as cuniv) =
+let infer_convert_instances elims ~flex u u' (univs, cstrs as cuniv) =
   if flex then
-    if UGraph.check_eq_instances (Environ.qualities env) univs u u' then Result.Ok cuniv
+    if UGraph.check_eq_instances elims univs u u' then Result.Ok cuniv
     else Result.Error None
-  else
-    let qcstrs, cstrs' = UVars.enforce_eq_instances u u' Sorts.QUConstraints.empty in
-    if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcstrs) (Environ.qualities env) then
-      Result.Ok (univs, Constraints.union cstrs cstrs')
-    else
-      Result.Error None
+  else try
+    let qcstrs, ucstrs as cstrs' = UVars.enforce_eq_instances u u' Sorts.QUConstraints.empty in
+    if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcstrs) elims then
+      Result.Ok (UGraph.merge_constraints ucstrs univs, Constraints.union cstrs ucstrs)
+    else Result.Error None
+  with UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
 
-let infer_inductive_instances env cv_pb variance u1 u2 (univs,csts) =
+
+let infer_inductive_instances elims cv_pb variance u1 u2 (univs,csts) =
   let qcsts, csts' = get_cumulativity_constraints cv_pb variance u1 u2 in
-  if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts) (Environ.qualities env)  then
+  if QGraph.check_constraints (Sorts.QCumulConstraints.to_elims qcsts) elims then
     match UGraph.merge_constraints csts' univs with
     | univs -> Result.Ok (univs, Univ.Constraints.union csts csts')
     | exception (UGraph.UniverseInconsistency err) -> Result.Error (Some (Univ err))
   else Result.Error None
 
-let inferred_universes =
-  { compare_sorts = infer_cmp_universes;
-    compare_instances = infer_convert_instances;
-    compare_cumul_instances = infer_inductive_instances; }
+let inferred_universes elims =
+  { compare_sorts = infer_cmp_universes elims;
+    compare_instances = infer_convert_instances elims;
+    compare_cumul_instances = infer_inductive_instances elims; }
 
 end
 
-let inferred_universes = Infer.inferred_universes
+let inferred_universes env = Infer.inferred_universes (Environ.qualities env)
 
 (* Deprecated *)
 

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -316,7 +316,7 @@ val is_head_evar : env -> evar_map -> constr -> bool
 exception AnomalyInConversion of exn
 
 (* inferred_universes just gathers the constraints. *)
-val inferred_universes : (UGraph.t * Univ.Constraints.t, Conversion.graph_inconsistency) Conversion.universe_compare
+val inferred_universes : env -> (UGraph.t * Univ.Constraints.t, Conversion.graph_inconsistency) Conversion.universe_compare
 
 (** Deprecated *)
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -964,7 +964,7 @@ module Interp = struct
 
 let check_sub env mp sub_mtb_l =
   let fold sub_mtb (cst, env) =
-    let state = ((Environ.universes env, cst), Reductionops.inferred_universes) in
+    let state = ((Environ.universes env, cst), Reductionops.inferred_universes env) in
     let ugraph, cst = Subtyping.check_subtypes state env mp mp sub_mtb in
     (cst, Environ.set_universes ugraph env)
   in
@@ -1002,7 +1002,7 @@ let build_subtypes env mp args mtys =
       let mte, ctx' = Modintern.interp_module_ast env Modintern.ModType base mte in
       let env = Environ.push_context_set ~strict:true ctx' env in
       let ctx = Univ.ContextSet.union ctx ctx' in
-      let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
+      let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes env) in
       (* functor arguments are already part of the env, we compute the type
          and requantify over them *)
       let mtb, (_, cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
@@ -1031,7 +1031,7 @@ let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
   let (mty, cst') = Modintern.interp_module_ast env kind base mty in
   let () = Global.push_context_set cst' in
   let () =
-    let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+    let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes env) in
     let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state (Global.env ()) base inl ([], mty) in
     Global.add_constraints cst
   in
@@ -1077,7 +1077,7 @@ let start_module_core id args res =
         let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
         let env = Environ.push_context_set ctx env in
         (* We check immediately that mte is well-formed *)
-        let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes) in
+        let state = ((Environ.universes env, Univ.Constraints.empty), Reductionops.inferred_universes env) in
         let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
         let ctx = Univ.ContextSet.add_constraints cst ctx in
         Some (mte, inl), [], ctx
@@ -1107,7 +1107,7 @@ let end_module_core id m_info objects fs =
 
   let struc = current_struct () in
   let restype' = Option.map (fun (ty,inl) -> (([],ty),inl)) m_info.cur_typ in
-  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes (Global.env ())) in
   let _, (_, cst), _ =
     Mod_typing.finalize_module state vm_state (Global.env ()) (Global.current_modpath ())
       (struc, current_modresolver ()) restype'
@@ -1187,7 +1187,7 @@ let declare_module id args res mexpr_o =
   | _ -> inl_res
   in
   let () = Global.push_context_set ctx in
-  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let _, (_, cst), _ = Mod_typing.translate_module state vm_state (Global.env ()) mp inl entry in
   let () = Global.add_constraints cst in
   let mp_env,resolver = Global.add_module id entry inl in
@@ -1311,7 +1311,7 @@ let declare_modtype id args mtys (mte,base,kind,inl) =
   let () = Global.push_context_set mte_ctx in
   let env = Global.env () in
   (* We check immediately that mte is well-formed *)
-  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let _, (_, mte_cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
   let () = Global.push_context_set (Univ.Level.Set.empty,mte_cst) in
   let params = List.map (fun (mbid, _, mte, b) -> (mbid, mte, b)) params in
@@ -1431,7 +1431,7 @@ let declare_one_include_core (me,base,kind,inl) =
   in
   let base_mp = get_module_path me in
 
-  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+  let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes env) in
   let sign, (), resolver, (_, cst), _ =
     Mod_typing.translate_mse_include is_mod state vm_state (Global.env ()) (Global.current_modpath ()) inl me
   in
@@ -1442,7 +1442,7 @@ let declare_one_include_core (me,base,kind,inl) =
   let rec compute_sign sign =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
-      let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes) in
+      let state = ((Global.universes (), Univ.Constraints.empty), Reductionops.inferred_universes env) in
       (* Module subcomponents are already part of env at this point *)
       let env = Environ.shallow_add_module cur_mp mb (Global.env ()) in
       let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) mtb in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -251,7 +251,7 @@ let explain_elim_arity env sigma ind c okinds =
         if ppunivs then Flags.with_option Constrextern.print_universes pp ()
         else pp ()
       in
-      let env = Environ.set_qualities (QGraph.qvar_domain @@ Evd.elim_graph sigma) env in
+      let env = Environ.set_qualities (Evd.elim_graph sigma) env in
       let squash = Option.get (Inductive.is_squashed env (specif, snd ind)) in
       match squash with
       | SquashToSet ->


### PR DESCRIPTION
Fix #18865 in a less ad-hoc way since the kernel should now treat qualities modulo some graph.
I just added the minimal equalities to that graph, and made sure all functions (including instance comparisons) use that graph.

