### PR TITLE
Stop looking at Printing Universes during externalisation

### DIFF
--- a/dev/ci/user-overlays/21275-SkySkimmer-extern-print-univs.sh
+++ b/dev/ci/user-overlays/21275-SkySkimmer-extern-print-univs.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi extern-print-univs 21275
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician extern-print-univs 21275

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -73,7 +73,7 @@ let pr_econstr t =
 let ppconstr x = pp (pr_constr x)
 let ppeconstr x = pp (pr_econstr x)
 let ppconstr_expr x = let sigma,env = get_current_context () in pp (Ppconstr.pr_constr_expr env sigma x)
-let ppconstr_univ x = Constrextern.with_universes ppconstr x
+let ppconstr_univ x = Flags.with_option Detyping.print_universes ppconstr x
 let ppglob_constr = (fun x -> pp(with_env_evm pr_lglob_constr_env x))
 let pppattern = (fun x -> pp(envpp pr_constr_pattern_env x))
 let pptype = (fun x -> try pp(envpp (fun env evm t -> pr_ltype_env env evm t) x) with e -> pp (str (Printexc.to_string e)))

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -59,7 +59,6 @@ val print_implicits : bool ref
 val print_implicits_defensive : bool ref
 val print_coercions : bool ref
 val print_parentheses : bool ref
-val print_universes : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref
 val print_raw_literal : bool ref
@@ -82,9 +81,6 @@ val get_extern_reference :
     which one is wrong? We should turn this kind of state into an
     explicit argument.
 *)
-
-(** This forces printing universe names of Type\{.\} *)
-val with_universes : ('a -> 'b) -> 'a -> 'b
 
 (** This suppresses printing of primitive tokens and notations *)
 val without_symbols : ('a -> 'b) -> 'a -> 'b

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -83,7 +83,7 @@ val pr_notation_info :
 
 exception No_match
 
-val match_notation_constr : print_parentheses:bool -> print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
+val match_notation_constr : print_parentheses:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
       ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
       ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
       ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -119,8 +119,8 @@ let revert_reserved_type env evd t =
         then I've introduced a bug... *)
     let filter _ pat =
       try
-        let _ = match_notation_constr ~print_parentheses:true ~print_univ:false
-            t ~vars:Id.Set.empty ([], pat)
+        let _ : _ * _ * _ * _ =
+          match_notation_constr ~print_parentheses:true t ~vars:Id.Set.empty ([], pat)
         in
         true
       with No_match -> false

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1580,14 +1580,14 @@ let do_build_inductive evd (funconstants : pconstant list)
 
 let build_inductive evd funconstants funsargs returned_types rtl =
   let pu = !Detyping.print_universes in
-  let cu = !Constrextern.print_universes in
+  let cu = !Detyping.print_universes in
   try
     Detyping.print_universes := true;
-    Constrextern.print_universes := true;
+    Detyping.print_universes := true;
     do_build_inductive evd funconstants funsargs returned_types rtl;
     Detyping.print_universes := pu;
-    Constrextern.print_universes := cu
+    Detyping.print_universes := cu
   with e when CErrors.noncritical e ->
     Detyping.print_universes := pu;
-    Constrextern.print_universes := cu;
+    Detyping.print_universes := cu;
     raise (Building_graph e)

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -86,11 +86,11 @@ let with_full_print f a =
   and old_strict_implicit_args = Impargs.is_strict_implicit_args ()
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
   let old_rawprint = !Flags.raw_print in
-  let old_printuniverses = !Constrextern.print_universes in
+  let old_printuniverses = !Detyping.print_universes in
   let old_printallowmatchdefaultclause =
     Detyping.print_allow_match_default_clause ()
   in
-  Constrextern.print_universes := true;
+  Detyping.print_universes := true;
   Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
     false;
   Flags.raw_print := true;
@@ -104,7 +104,7 @@ let with_full_print f a =
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     Flags.raw_print := old_rawprint;
-    Constrextern.print_universes := old_printuniverses;
+    Detyping.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();
@@ -114,7 +114,7 @@ let with_full_print f a =
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     Flags.raw_print := old_rawprint;
-    Constrextern.print_universes := old_printuniverses;
+    Detyping.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -303,7 +303,7 @@ let pr_universe_instance evd inst =
   str "@{" ++ UVars.Instance.pr prqvar prlev inst ++ str "}"
 
 let pr_puniverses f env sigma (c,u) =
-  if !Constrextern.print_universes
+  if !Detyping.print_universes
   then f env c ++ pr_universe_instance sigma u
   else f env c
 

--- a/test-suite/output/UnivNotations.out
+++ b/test-suite/output/UnivNotations.out
@@ -2,7 +2,7 @@
      : Type
 foo Set nat
      : Type
-! S
+foo Type@{s ; _} S
      : Type
 File "./output/UnivNotations.v", line 20, characters 13-14:
 The command has indeed failed with message:

--- a/test-suite/output/UnivNotations.out
+++ b/test-suite/output/UnivNotations.out
@@ -1,0 +1,26 @@
+! nat
+     : Type
+foo Set nat
+     : Type
+! S
+     : Type
+File "./output/UnivNotations.v", line 20, characters 13-14:
+The command has indeed failed with message:
+The term "S" has type "Type@{s ; _}" while it is expected to have type 
+"Type" (universe inconsistency: Cannot enforce Type@{s | Set} <=
+UnivNotations.24).
+1 goal
+  
+  ============================
+  forall A : Type, A -> ! A
+foo Type@{UnivNotations.27} nat
+     : Type@{foo.u1}
+(* {UnivNotations.27} |= UnivNotations.27 < foo.u0 *)
+foo Type@{s ; Set} S
+     : Type@{foo.u1}
+(* {} |= Set < foo.u0 *)
+1 goal
+  
+  ============================
+  forall A : Type@{α4 ; UnivNotations.29},
+  A -> foo Type@{α4 ; UnivNotations.29} A

--- a/test-suite/output/UnivNotations.v
+++ b/test-suite/output/UnivNotations.v
@@ -1,0 +1,42 @@
+Axiom foo : forall A:Type, A -> Type.
+
+(* this test is about checking when Type in a notation is considered
+   to match a term *)
+Notation "! x" := (foo Type x) (at level 2).
+
+(* first with Printing Universes off *)
+
+(* terms produced using the notation print using the notation  *)
+Check ! nat.
+
+(* Set does not match Type *)
+Check foo Set nat.
+
+Sort s.
+Axiom S : Type@{s;Set}.
+
+(* rigid sorts (here global sort) should not match Type but currently do *)
+Check foo _ S.
+Fail Check ! S.
+
+Goal True.
+  (* sort unification variable matches Type (and is printed as Type in the [forall] annotation) *)
+  (* NB don't use Check here as it collapses before printing (maybe this will change someday?) *)
+  assert (forall A, A -> foo _ A). 2:trivial.
+  Show.
+Abort.
+
+(* now with Printing Universes on *)
+Set Printing Universes.
+
+(* Printing Universes makes universes not match Type *)
+Check ! nat.
+
+(* global sort still doesn't match Type *)
+Check foo _ S.
+
+Goal True.
+  (* sort unif variable doesn't match Type *)
+  assert (forall A, A -> foo _ A). 2:trivial.
+  Show.
+Abort.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -167,6 +167,7 @@ let rec pr_explicit_aux env sigma t1 t2 = function
 
 let explicit_flags =
   let open Constrextern in
+  let open Detyping in
   [ []; (* First, try with the current flags *)
     [print_implicits]; (* Then with implicit *)
     [print_universes]; (* Then with universes *)
@@ -240,7 +241,7 @@ let explain_elim_arity env sigma ind c okinds =
     | None | Some AlwaysSquashed -> pp ()
     | Some (SometimesSquashed _) ->
       (* universe instance matters, so print it regardless of Printing Universes *)
-      Flags.with_option Constrextern.print_universes pp ()
+      Flags.with_option Detyping.print_universes pp ()
   in
   let pc = Option.map (pr_leconstr_env env sigma) c in
   let msg = match okinds with
@@ -248,7 +249,7 @@ let explain_elim_arity env sigma ind c okinds =
     | Some sp ->
       let ppt ?(ppunivs=false) () =
         let pp () = pr_leconstr_env env sigma (mkSort (ESorts.make sp)) in
-        if ppunivs then Flags.with_option Constrextern.print_universes pp ()
+        if ppunivs then Flags.with_option Detyping.print_universes pp ()
         else pp ()
       in
       let env = Environ.set_qualities (QGraph.qvar_domain @@ Evd.elim_graph sigma) env in
@@ -560,7 +561,7 @@ let explain_ill_formed_fix_body env sigma names i = function
           | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
      str "Recursive call to " ++ called ++ str " has not enough arguments"
   | FixpointOnNonEliminable (s, s') ->
-  let pr_sort u = quote @@ Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = quote @@ Flags.with_option Detyping.print_universes (Printer.pr_sort sigma) u in
     fmt "Cannot define a fixpoint@ with principal argument living in sort %t@ \
          to produce a value in sort %t@ because %t does not eliminate to %t"
       (fun () -> pr_sort s)
@@ -1526,7 +1527,7 @@ let error_large_non_prop_inductive_not_in_type () =
 
 let error_inductive_missing_constraints env (us,ind_univ) =
   let sigma = Evd.from_env env in
-  let pr_sort u = Flags.with_option Constrextern.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = Flags.with_option Detyping.print_universes (Printer.pr_sort sigma) u in
   str "Missing universe constraint declared for inductive type:" ++ spc()
   ++ v 0 (prlist_with_sep spc (fun u ->
       hov 0 (pr_sort u ++ str " <= " ++ pr_sort ind_univ))

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2051,8 +2051,8 @@ let () =
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
       optkey   = ["Printing";"Universes"];
-      optread  = (fun () -> !Constrextern.print_universes);
-      optwrite = (fun b -> Constrextern.print_universes:=b) }
+      optread  = (fun () -> !Detyping.print_universes);
+      optwrite = (fun b -> Detyping.print_universes:=b) }
 
 let () =
   (* no summary: handled as part of the debug state *)


### PR DESCRIPTION
It is now used only during detyping + a few adhoc uses eg in Check

The main motivation is code cleanup, but this corrects a slight
notation bug when rigid sort variables are involved, cf test suite
diff in the second commit.

It also changes how glob constrs with explicit universes get
printed (apparently no examples in the test suite, eg

~~~coq
Ltac foo := exact Type@{u}.
Print foo.
(* before: exact Type, after: exact Type@{u} *)
~~~

), IMO this is reasonable.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/923
- https://github.com/coq-tactician/coq-tactician/pull/115
