### PR TITLE
Pass printing flags functionally in constr printers

### DIFF
--- a/dev/ci/user-overlays/21281-SkySkimmer-print-flags.sh
+++ b/dev/ci/user-overlays/21281-SkySkimmer-print-flags.sh
@@ -1,0 +1,21 @@
+overlay simple_io https://github.com/SkySkimmer/coq-simple-io print-flags 21281
+
+overlay autosubst_ocaml https://github.com/SkySkimmer/autosubst-ocaml print-flags 21281
+
+overlay coq_lsp https://github.com/SkySkimmer/coq-lsp print-flags 21281
+
+overlay coqhammer https://github.com/SkySkimmer/coqhammer print-flags 21281
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi print-flags 21281
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations print-flags 21281
+
+overlay smtcoq https://github.com/SkySkimmer/smtcoq print-flags 21281
+
+overlay tactician https://github.com/SkySkimmer/coq-tactician print-flags 21281
+
+overlay vsrocq https://github.com/SkySkimmer/vsrocq print-flags 21281
+
+overlay waterproof https://github.com/SkySkimmer/coq-waterproof print-flags 21281
+
+overlay quickchick https://github.com/SkySkimmer/QuickChick print-flags 21281

--- a/dev/debugger_support.ml
+++ b/dev/debugger_support.ml
@@ -13,7 +13,7 @@ let rawdebug = ref false
 let () =
   Flags.in_debugger := true;
   Goptions.set_bool_option_value ["Printing";"Existential";"Instances"] true;
-  Detyping.print_universes := true;
+  PrintingFlags.print_universes := true;
   Goptions.set_bool_option_value ["Printing";"Matching"] false;
   Goptions.set_bool_option_value ["Printing";"Sort";"Qualities"] true;
   (* When printers are used from ocamldebug, they should not make calls to the global env

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -80,7 +80,7 @@ let pr_econstr t =
 let ppconstr x = pp (pr_constr x)
 let ppeconstr x = pp (pr_econstr x)
 let ppconstr_expr x = let sigma,env = get_current_context () in pp (Ppconstr.pr_constr_expr env sigma x)
-let ppconstr_univ x = Flags.with_option Detyping.print_universes ppconstr x
+let ppconstr_univ x = Flags.with_option PrintingFlags.print_universes ppconstr x
 let ppglob_constr = (fun x -> pp(with_env_evm pr_lglob_constr_env x))
 let pppattern = (fun x -> pp(envpp pr_constr_pattern_env x))
 let pptype = (fun x -> try pp(envpp (fun env evm t -> pr_ltype_env env evm t) x) with e -> pp (str (Printexc.to_string e)))
@@ -232,8 +232,8 @@ let ppmetamap metas =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   pp (Unification.Meta.pr_metamap env sigma metas)
-let ppevm evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes (Some 2) (Global.env ()) evd)
-let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes None (Global.env ()) evd)
+let ppevm evd = pp(Termops.pr_evar_map ~with_univs:!PrintingFlags.print_universes (Some 2) (Global.env ()) evd)
+let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:!PrintingFlags.print_universes None (Global.env ()) evd)
 let pr_existentialset evars =
   prlist_with_sep spc pr_evar (Evar.Set.elements evars)
 let ppexistentialset evars =

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -79,7 +79,9 @@ let pr_econstr t =
   Printer.pr_econstr_env env sigma t
 let ppconstr x = pp (pr_constr x)
 let ppeconstr x = pp (pr_econstr x)
-let ppconstr_expr x = let sigma,env = get_current_context () in pp (Ppconstr.pr_constr_expr env sigma x)
+let ppconstr_expr x = let sigma,env = get_current_context () in
+  let flags = Ppconstr.current_flags() in
+  pp (Ppconstr.pr_constr_expr ~flags env sigma x)
 let ppconstr_univ x = Flags.with_option PrintingFlags.print_universes ppconstr x
 let ppglob_constr = (fun x -> pp(with_env_evm pr_lglob_constr_env x))
 let pppattern = (fun x -> pp(envpp pr_constr_pattern_env x))

--- a/doc/plugin_tutorial/tuto1/src/g_tuto1.mlg
+++ b/doc/plugin_tutorial/tuto1/src/g_tuto1.mlg
@@ -41,7 +41,9 @@ VERNAC COMMAND EXTEND WhatIsThis CLASSIFIED AS QUERY
    {
      let env = Global.env () in (* we'll explain later *)
      let sigma = Evd.from_env env in (* we'll explain later *)
-     Inspector.print_input e (Ppconstr.pr_constr_expr env sigma) "term"
+     (* current Printing settings (specifically the ones applicable to printing constr_expr) *)
+     let flags = Ppconstr.current_flags() in
+     Inspector.print_input e (Ppconstr.pr_constr_expr ~flags env sigma) "term"
    }
 | [ "What" "kind" "of" "term" "is" string(s) ] ->
    { Inspector.print_input s strbrk "string" }

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -220,7 +220,10 @@ let process_goal_diffs ~short diff_goal_map oldp nsigma ng =
   | Some oldp, Some diff_goal_map -> Proof_diffs.map_goal ng diff_goal_map
   | None, _ | _, None -> None
   in
-  let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ~short ?og_s (Proof_diffs.make_goal env nsigma ng) in
+  let (hyps_pp_list, concl_pp) =
+    Proof_diffs.diff_goal ~short ?og_s ~flags:(PrintingFlags.current())
+      (Proof_diffs.make_goal env nsigma ng)
+  in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp;
     Interface.goal_id = Proof.goal_uid ng; Interface.goal_name = name }
 
@@ -408,7 +411,7 @@ let proof_diff (diff_opt, sid) =
   | None -> CErrors.user_err (Pp.str "No proofs to diff.")
   | Some proof ->
       let old = Stm.get_prev_proof ~doc sid in
-      Proof_diffs.diff_proofs ~diff_opt ?old proof
+      Proof_diffs.diff_proofs ~flags:(PrintingFlags.current()) ~diff_opt ?old proof
 
 let debug_cmd = ref DebugHook.Action.Ignore
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -35,21 +35,11 @@ module NamedDecl = Context.Named.Declaration
 (* Translation from glob_constr to front constr *)
 
 (**********************************************************************)
-(* Parametrization                                                    *)
-
-(* This tells to skip types if a variable has this type by default *)
-let { Goptions.get = print_use_implicit_types } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Use";"Implicit";"Types"]
-    ~value:true
-    ()
-
-(**********************************************************************)
 
 let hole = CAst.make @@ CHole (None)
 
 let is_reserved_type na t =
-  not !PrintingFlags.raw_print && print_use_implicit_types () &&
+  not !PrintingFlags.raw_print && PrintingFlags.print_use_implicit_types () &&
   match na with
   | Anonymous -> false
   | Name id ->

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -59,13 +59,6 @@ let without_symbols f = Flags.with_option PrintingFlags.print_no_symbol f
 (**********************************************************************)
 (* Control printing of records *)
 
-(* Set Record Printing flag *)
-let { Goptions.get = get_record_print } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Records"]
-    ~value:true
-    ()
-
 let is_record indsp =
   try
     let _ = Structure.find (Global.env ()) indsp in
@@ -318,7 +311,7 @@ let extern_record_pattern cstrsp args =
       ()
     else if PrintingConstructor.active (fst cstrsp) then
       raise_notrace Exit
-    else if not (get_record_print ()) then
+    else if not (PrintingFlags.get_record_print ()) then
       raise_notrace Exit;
     let rec ip projs args acc =
       match projs, args with
@@ -600,7 +593,7 @@ let extern_record ref args =
       ()
     else if PrintingConstructor.active (fst cstrsp) then
       raise_notrace Exit
-    else if not (get_record_print ()) then
+    else if not (PrintingFlags.get_record_print ()) then
       raise_notrace Exit;
     let projs = struc.Structure.projections in
     let rec cut args n =

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -43,7 +43,6 @@ module NamedDecl = Context.Named.Declaration
    with the form (id:=arg) otherwise arguments are printed normally and
    the function is prefixed by "@" *)
 let print_implicits = ref false
-let print_implicits_explicit_args = ref false
 
 (* Tells if implicit arguments not known to be inferable from a rigid
    position are systematically printed *)
@@ -587,7 +586,7 @@ let adjust_implicit_arguments inctx n args impl =
         let tail = exprec (args,impl) in
         let visible =
           !PrintingFlags.raw_print ||
-          (!print_implicits && !print_implicits_explicit_args) ||
+          (!print_implicits && PrintingFlags.print_implicits_explicit_args()) ||
           (is_needed_for_correct_partial_application tail imp) ||
           (!print_implicits_defensive &&
            (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
@@ -674,7 +673,7 @@ let extern_applied_ref inctx impl (cf,f) us args =
   try
     if not !Constrintern.parsing_explicit &&
        ((!PrintingFlags.raw_print ||
-         (!print_implicits && not !print_implicits_explicit_args)) &&
+         (!print_implicits && not (PrintingFlags.print_implicits_explicit_args()))) &&
         List.exists is_status_implicit impl)
     then raise Expl;
     let impl = if !Constrintern.parsing_explicit then [] else impl in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -49,9 +49,6 @@ let print_implicits_explicit_args = ref false
    position are systematically printed *)
 let print_implicits_defensive = ref true
 
-(* This forces printing of coercions *)
-let print_coercions = ref false
-
 (* This forces printing of parentheses even when
    it is implied by associativity/precedence *)
 let print_parentheses = ref false
@@ -753,7 +750,7 @@ let match_coercion_app c = match DAst.get c with
 
 let remove_one_coercion inctx c =
   try match match_coercion_app c with
-  | Some (loc,r,args) when not (!PrintingFlags.raw_print || !print_coercions) ->
+  | Some (loc,r,args) when not (!PrintingFlags.raw_print || !PrintingFlags.print_coercions) ->
       let nargs = List.length args in
       (match Coercionops.hide_coercion r with
           | Some nparams when

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -37,10 +37,6 @@ module NamedDecl = Context.Named.Declaration
 (**********************************************************************)
 (* Parametrization                                                    *)
 
-(* Tells if implicit arguments not known to be inferable from a rigid
-   position are systematically printed *)
-let print_implicits_defensive = ref true
-
 (* This suppresses printing of notations *)
 let print_no_symbol = ref false
 
@@ -581,7 +577,7 @@ let adjust_implicit_arguments inctx n args impl =
           !PrintingFlags.raw_print ||
           (!PrintingFlags.print_implicits && PrintingFlags.print_implicits_explicit_args()) ||
           (is_needed_for_correct_partial_application tail imp) ||
-          (!print_implicits_defensive &&
+          (!PrintingFlags.print_implicits_defensive &&
            (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
            is_significant_implicit (Lazy.force a))
         in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -37,9 +37,6 @@ module NamedDecl = Context.Named.Declaration
 (**********************************************************************)
 (* Parametrization                                                    *)
 
-(* This suppresses printing of notations *)
-let print_no_symbol = ref false
-
 (* This tells to skip types if a variable has this type by default *)
 let { Goptions.get = print_use_implicit_types } =
   Goptions.declare_bool_option_and_ref
@@ -70,7 +67,7 @@ let is_reserved_type na t =
 (**********************************************************************)
 (* Turning notations and scopes on and off for printing *)
 
-let without_symbols f = Flags.with_option print_no_symbol f
+let without_symbols f = Flags.with_option PrintingFlags.print_no_symbol f
 
 (**********************************************************************)
 (* Control printing of records *)
@@ -369,7 +366,7 @@ let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as
           (insert_pat_alias ?loc (insert_pat_delimiters ?loc (CAst.make ?loc @@ CPatPrim p) key) na)
   with No_match ->
     try
-      if !Flags.in_debugger || !PrintingFlags.raw_print || !print_no_symbol then raise No_match;
+      if !Flags.in_debugger || !PrintingFlags.raw_print || !PrintingFlags.print_no_symbol then raise No_match;
       extern_notation_pattern allscopes vars pat
         (uninterp_cases_pattern_notations (Global.env ()) pat)
     with No_match ->
@@ -509,7 +506,7 @@ let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
     CAst.make @@ CPatCstr (c, Some args, [])
   else
     try
-      if !PrintingFlags.raw_print || !print_no_symbol || Inductiveops.inductive_has_local_defs (Global.env()) ind
+      if !PrintingFlags.raw_print || !PrintingFlags.print_no_symbol || Inductiveops.inductive_has_local_defs (Global.env()) ind
         then raise No_match;
       extern_notation_ind_pattern allscopes vars ind args
           (uninterp_ind_pattern_notations (Global.env ()) ind)
@@ -1269,7 +1266,7 @@ and extern_notations depth inctx scopes eenv nargs t =
   if !PrintingFlags.raw_print then raise No_match;
   try extern_possible_prim_token scopes t
   with No_match ->
-    if !print_no_symbol then raise No_match;
+    if !PrintingFlags.print_no_symbol then raise No_match;
     let t = flatten_application t in
     extern_notation depth inctx scopes eenv t (filter_enough_applied nargs (uninterp_notations (Global.env ()) t))
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -49,10 +49,6 @@ let print_implicits_explicit_args = ref false
    position are systematically printed *)
 let print_implicits_defensive = ref true
 
-(* This forces printing of parentheses even when
-   it is implied by associativity/precedence *)
-let print_parentheses = ref false
-
 (* This suppresses printing of notations *)
 let print_no_symbol = ref false
 
@@ -218,7 +214,7 @@ let overlap_right_left {notation_entry = entry} lev_after ((typs,_):Notation_ter
 
 let update_with_subscope from_entry (entry,(scopt,scl)) lev_after closed scopes =
   let {notation_subentry = entry; notation_relative_level = lev; notation_position = side} = entry in
-  let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
+  let lev = if !PrintingFlags.print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
   let lev_after =
     match side with
     | Some Left -> Some from_entry.notation_level
@@ -1332,7 +1328,7 @@ and extern_notation depth inctx ((custom,(lev_after: int option)),scopes as alls
           | AppBoundedNotation _ -> raise No_match in
         (* Try matching ... *)
         let terms,termlists,binders,binderlists =
-          match_notation_constr ~print_parentheses:!print_parentheses t ~vars:eenv.vars pat
+          match_notation_constr ~print_parentheses:!PrintingFlags.print_parentheses t ~vars:eenv.vars pat
         in
         let lev_after = if List.is_empty args then lev_after else Some Notation.app_level in
         (* Try externing extra args... *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -69,8 +69,6 @@ let is_reserved_type na t =
 
 (**********************************************************************)
 (* Turning notations and scopes on and off for printing *)
-(* This governs printing of projections using the dot notation symbols *)
-let print_projections = ref false
 
 let without_symbols f = Flags.with_option print_no_symbol f
 
@@ -539,7 +537,7 @@ let is_gvar id c = match DAst.get c with
 | _ -> false
 
 let is_projection nargs r =
-  if not !Flags.in_debugger && not !PrintingFlags.raw_print && !print_projections then
+  if not !Flags.in_debugger && not !PrintingFlags.raw_print && !PrintingFlags.print_projections then
     try
       match r with
       | GlobRef.ConstRef c ->
@@ -681,7 +679,7 @@ let extern_applied_ref inctx impl (cf,f) us args =
   (* A [@f args] node *)
     let args = List.map Lazy.force args in
     match is_projection (List.length args) cf with
-    | Some n when !print_projections ->
+    | Some n when !PrintingFlags.print_projections ->
        let args = List.map (fun c -> (c,None)) args in
        let args1, args2 = List.chop n args in
        let (c1,_), args1 = List.sep_last args1 in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -44,9 +44,6 @@ let { Goptions.get = print_use_implicit_types } =
     ~value:true
     ()
 
-(* Print primitive tokens, like strings *)
-let print_raw_literal = ref false
-
 (**********************************************************************)
 
 let hole = CAst.make @@ CHole (None)
@@ -356,7 +353,7 @@ let extern_record_pattern cstrsp args =
 (* Better to use extern_glob_constr composed with injection/retraction ?? *)
 let rec extern_cases_pattern_in_scope ((custom,(lev_after:int option)),scopes as allscopes) vars pat =
   try
-    if !Flags.in_debugger || !PrintingFlags.raw_print || !print_raw_literal then raise No_match;
+    if !Flags.in_debugger || !PrintingFlags.raw_print || !PrintingFlags.print_raw_literal then raise No_match;
     let (na,p,key) = uninterp_prim_token_cases_pattern pat scopes in
     match availability_of_entry_coercion custom constr_lowest_level with
       | None -> raise No_match
@@ -775,7 +772,7 @@ let same_binder_type ty nal c =
 (* one with no delimiter if possible)                                 *)
 
 let extern_possible_prim_token ((custom,_),scopes) r =
-   if !print_raw_literal then raise No_match;
+   if !PrintingFlags.print_raw_literal then raise No_match;
    let (n,key) = uninterp_prim_token r scopes in
    match availability_of_entry_coercion custom constr_lowest_level with
    | None -> raise No_match

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -37,13 +37,6 @@ module NamedDecl = Context.Named.Declaration
 (**********************************************************************)
 (* Parametrization                                                    *)
 
-(* This governs printing of implicit arguments.  When
-   [print_implicits] is on then [print_implicits_explicit_args] tells
-   how implicit args are printed. If on, implicit args are printed
-   with the form (id:=arg) otherwise arguments are printed normally and
-   the function is prefixed by "@" *)
-let print_implicits = ref false
-
 (* Tells if implicit arguments not known to be inferable from a rigid
    position are systematically printed *)
 let print_implicits_defensive = ref true
@@ -261,7 +254,7 @@ let drop_implicits_in_patt cst nb_expl ?(tags=[]) args =
   in
   let try_impls_fit (imps,args,tags) =
     if not !Constrintern.parsing_explicit &&
-       ((!PrintingFlags.raw_print || !print_implicits) &&
+       ((!PrintingFlags.raw_print || !PrintingFlags.print_implicits) &&
         List.exists is_status_implicit imps)
        (* Note: !print_implicits_explicit_args=true not supported for patterns *)
     then None
@@ -335,7 +328,7 @@ let pattern_printable_in_both_syntax (ind,_ as c) =
   List.exists (fun (_,impls) ->
     (List.length impls >= nb_params) &&
       let params,args = Util.List.chop nb_params impls in
-      not !PrintingFlags.raw_print && not !print_implicits &&
+      not !PrintingFlags.raw_print && not !PrintingFlags.print_implicits &&
       (List.for_all is_status_implicit params)&&(List.for_all (fun x -> not (is_status_implicit x)) args)
   ) impl_st
 
@@ -586,7 +579,7 @@ let adjust_implicit_arguments inctx n args impl =
         let tail = exprec (args,impl) in
         let visible =
           !PrintingFlags.raw_print ||
-          (!print_implicits && PrintingFlags.print_implicits_explicit_args()) ||
+          (!PrintingFlags.print_implicits && PrintingFlags.print_implicits_explicit_args()) ||
           (is_needed_for_correct_partial_application tail imp) ||
           (!print_implicits_defensive &&
            (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
@@ -673,7 +666,7 @@ let extern_applied_ref inctx impl (cf,f) us args =
   try
     if not !Constrintern.parsing_explicit &&
        ((!PrintingFlags.raw_print ||
-         (!print_implicits && not (PrintingFlags.print_implicits_explicit_args()))) &&
+         (!PrintingFlags.print_implicits && not (PrintingFlags.print_implicits_explicit_args()))) &&
         List.exists is_status_implicit impl)
     then raise Expl;
     let impl = if !Constrintern.parsing_explicit then [] else impl in

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -57,7 +57,6 @@ val extern_rel_context : env -> Evd.evar_map ->
 (** Printing options *)
 val print_implicits : bool ref
 val print_implicits_defensive : bool ref
-val print_coercions : bool ref
 val print_parentheses : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -55,7 +55,6 @@ val extern_rel_context : env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
 (** Printing options *)
-val print_no_symbol : bool ref
 val print_raw_literal : bool ref
 
 (** Customization of the global_reference printer *)

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -55,7 +55,6 @@ val extern_rel_context : env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
 (** Printing options *)
-val print_implicits_defensive : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref
 val print_raw_literal : bool ref

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -55,7 +55,6 @@ val extern_rel_context : env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
 (** Printing options *)
-val print_implicits : bool ref
 val print_implicits_defensive : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -54,9 +54,6 @@ val extern_sort : Evd.evar_map -> Sorts.t -> sort_expr
 val extern_rel_context : env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
-(** Printing options *)
-val print_raw_literal : bool ref
-
 (** Customization of the global_reference printer *)
 val set_extern_reference :
   (?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid) -> unit

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -56,7 +56,6 @@ val extern_rel_context : env -> Evd.evar_map ->
 
 (** Printing options *)
 val print_no_symbol : bool ref
-val print_projections : bool ref
 val print_raw_literal : bool ref
 
 (** Customization of the global_reference printer *)

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -25,18 +25,19 @@ open Ltac_pretype
 type extern_env = {
   vars : Id.Set.t;
   uvars : UnivNames.universe_binders;
+  flags : PrintingFlags.Extern.t;
 }
-val extern_env : env -> Evd.evar_map -> extern_env
+val extern_env : flags:PrintingFlags.Extern.t -> env -> Evd.evar_map -> extern_env
 
-val extern_cases_pattern : Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
+val extern_cases_pattern : flags:PrintingFlags.Extern.t -> Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
 val extern_glob_constr : extern_env -> 'a glob_constr_g -> constr_expr
 val extern_glob_type : ?impargs:Glob_term.binding_kind list -> extern_env -> 'a glob_constr_g -> constr_expr
-val extern_constr_pattern : names_context -> Evd.evar_map ->
+val extern_constr_pattern : flags:PrintingFlags.Extern.t -> names_context -> Evd.evar_map ->
   constr_pattern -> constr_expr
-val extern_uninstantiated_pattern : names_context -> Evd.evar_map ->
+val extern_uninstantiated_pattern : flags:PrintingFlags.Extern.t -> names_context -> Evd.evar_map ->
   uninstantiated_pattern -> constr_expr
 val extern_closed_glob : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name ->
-  env -> Evd.evar_map -> closed_glob_constr -> constr_expr
+  flags:PrintingFlags.t -> env -> Evd.evar_map -> closed_glob_constr -> constr_expr
 
 (** If [b=true] in [extern_constr b env c] then the variables in the first
    level of quantification clashing with the variables in [env] are renamed.
@@ -45,13 +46,15 @@ val extern_closed_glob : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_n
 *)
 
 val extern_constr : ?inctx:bool -> ?scope:scope_name ->
-  env -> Evd.evar_map -> constr -> constr_expr
+  flags:PrintingFlags.t -> env -> Evd.evar_map -> constr -> constr_expr
 val extern_constr_in_scope : ?inctx:bool -> scope_name ->
-  env -> Evd.evar_map -> constr -> constr_expr
+  flags:PrintingFlags.t -> env -> Evd.evar_map -> constr -> constr_expr
 val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val extern_type : ?goal_concl_style:bool -> env -> Evd.evar_map -> ?impargs:Glob_term.binding_kind list -> types -> constr_expr
-val extern_sort : Evd.evar_map -> Sorts.t -> sort_expr
-val extern_rel_context : env -> Evd.evar_map ->
+val extern_type : ?goal_concl_style:bool ->
+  flags:PrintingFlags.t -> env -> Evd.evar_map ->
+  ?impargs:Glob_term.binding_kind list -> types -> constr_expr
+val extern_sort : universes:bool -> qualities:bool -> Evd.evar_map -> Sorts.t -> sort_expr
+val extern_rel_context : flags:PrintingFlags.t -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
 (** Customization of the global_reference printer *)
@@ -60,23 +63,7 @@ val set_extern_reference :
 val get_extern_reference :
   unit -> (?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid)
 
-(** WARNING: The following functions are evil due to
-    side-effects. Think of the following case as used in the printer:
-
-    without_specific_symbols [AbbrevRule kn] (pr_glob_constr_env env) c
-
-    vs
-
-    without_specific_symbols [AbbrevRule kn] pr_glob_constr_env env c
-
-    which one is wrong? We should turn this kind of state into an
-    explicit argument.
-*)
-
-(** This suppresses printing of primitive tokens and notations *)
-val without_symbols : ('a -> 'b) -> 'a -> 'b
-
 (** Probably shouldn't be used *)
-val empty_extern_env : extern_env
+val empty_extern_env : flags:PrintingFlags.Extern.t -> extern_env
 
 val set_max_depth : int option -> unit

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -57,7 +57,6 @@ val extern_rel_context : env -> Evd.evar_map ->
 (** Printing options *)
 val print_implicits : bool ref
 val print_implicits_defensive : bool ref
-val print_parentheses : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref
 val print_raw_literal : bool ref

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -800,12 +800,12 @@ let rec find_uninterpretation need_delim def find = function
   | LonelyNotationItem ntn::scopes ->
       find_uninterpretation (ntn::need_delim) def find scopes
 
-let uninterp_prim_token c local_scopes =
+let uninterp_prim_token ~print_float c local_scopes =
   match glob_prim_constr_key c with
   | None -> raise Notation_ops.No_match
   | Some r ->
      let uninterp (sc,(info,_)) =
-       match PrimNotations.do_uninterp info c with
+       match PrimNotations.do_uninterp ~print_float info c with
        | None -> None
        | Some n -> Some (sc,n)
      in
@@ -832,10 +832,10 @@ let uninterp_prim_token c local_scopes =
      try find_uninterpretation [] l find scopes
      with Not_found -> match l with (_,n,k)::_ -> n,k | [] -> raise Notation_ops.No_match
 
-let uninterp_prim_token_cases_pattern c local_scopes =
+let uninterp_prim_token_cases_pattern ~print_float c local_scopes =
   match glob_constr_of_closed_cases_pattern (Global.env()) c with
   | exception Not_found -> raise Notation_ops.No_match
-  | na,c -> let (sc,n) = uninterp_prim_token c local_scopes in (na,sc,n)
+  | na,c -> let (sc,n) = uninterp_prim_token ~print_float c local_scopes in (na,sc,n)
 
 (* Miscellaneous *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -117,9 +117,9 @@ val interp_prim_token_cases_pattern_expr : ?loc:Loc.t -> (Glob_term.glob_constr 
    raise [No_match] if no such token *)
 
 val uninterp_prim_token :
-  'a glob_constr_g -> subscopes -> prim_token * delimiters option
+  print_float:bool -> 'a glob_constr_g -> subscopes -> prim_token * delimiters option
 val uninterp_prim_token_cases_pattern :
-  'a cases_pattern_g -> subscopes -> Name.t * prim_token * delimiters option
+  print_float:bool -> 'a cases_pattern_g -> subscopes -> Name.t * prim_token * delimiters option
 
 val availability_of_prim_token :
   prim_token -> scope_name -> subscopes -> delimiters option option

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -83,7 +83,9 @@ val pr_notation_info :
 
 exception No_match
 
-val match_notation_constr : print_parentheses:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
+val match_notation_constr : print_parentheses:bool ->
+  factorize_eqns:PrintingFlags.Extern.FactorizeEqns.t ->
+  'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
       ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
       ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
       ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *

--- a/interp/primNotations.ml
+++ b/interp/primNotations.ml
@@ -802,15 +802,9 @@ let bigint_of_rocqpos_neg_int63 c = match TokenValue.kind c with
 | TConstruct ((_, 2), [c']) (* Neg *) -> Z.neg (bigint_of_int63 c')
 | _ -> raise NotAValidPrimToken
 
-let { Goptions.get = get_printing_float } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Float"]
-    ~value:true
-    ()
-
 let uninterp_float64 c = match TokenValue.kind c with
 | TFloat f when not (Float64.is_infinity f || Float64.is_neg_infinity f
-                    || Float64.is_nan f) && get_printing_float () ->
+                    || Float64.is_nan f) && PrintingFlags.print_float () ->
   NumTok.Signed.of_string (Float64.to_string f)
 | _ -> raise NotAValidPrimToken
 

--- a/interp/primNotations.mli
+++ b/interp/primNotations.mli
@@ -121,7 +121,7 @@ type prim_token_interp_info =
 
 val do_interp : ?loc:Loc.t -> prim_token_interp_info -> Constrexpr.prim_token -> Glob_term.glob_constr
 
-val do_uninterp : prim_token_interp_info -> _ Glob_term.glob_constr_g -> Constrexpr.prim_token option
+val do_uninterp : print_float:bool -> prim_token_interp_info -> _ Glob_term.glob_constr_g -> Constrexpr.prim_token option
 
 val can_interp : prim_token_interp_info -> Constrexpr.prim_token -> bool
 

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -114,13 +114,14 @@ let constr_key env evd c =
 let revert_reserved_type env evd t =
   try
     let reserved = KeyMap.find (constr_key env evd t) !reserve_revtable in
-    let t = Detyping.detype Detyping.Now env evd t in
+    let t = Detyping.detype Detyping.Now ~flags:(PrintingFlags.Detype.current()) env evd t in
+    let factorize_eqns = PrintingFlags.Extern.FactorizeEqns.current() in
     (* pedrot: if [Notation_ops.match_notation_constr] may raise [Failure _]
         then I've introduced a bug... *)
     let filter _ pat =
       try
         let _ : _ * _ * _ * _ =
-          match_notation_constr ~print_parentheses:true t ~vars:Id.Set.empty ([], pat)
+          match_notation_constr ~print_parentheses:true ~factorize_eqns t ~vars:Id.Set.empty ([], pat)
         in
         true
       with No_match -> false

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -43,8 +43,6 @@ let async_proofs_is_worker () = !async_proofs_worker_id <> "master"
 let in_debugger = ref false
 let in_ml_toplevel = ref false
 
-let raw_print = ref false
-
 let in_synterp_phase = ref None
 
 (* Translate *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -42,9 +42,6 @@ val in_ml_toplevel : bool ref
 (* Used to check stages are used correctly. *)
 val in_synterp_phase : bool option ref
 
-(* Set Printing All flag. For some reason it is a global flag *)
-val raw_print : bool ref
-
 (* Beautify command line flags, should move to printing? *)
 val beautify : bool ref
 val beautify_file : bool ref

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -448,7 +448,8 @@ let cc_tactic depth additional_terms b =
         let env = Proofview.Goal.env gl in
         let hole = DAst.make @@ GHole (GInternalHole) in
         let pr_missing (c, missing) =
-          let c = Detyping.detype Detyping.Now env sigma c in
+          let flags = PrintingFlags.Detype.current() in
+          let c = Detyping.detype ~flags Detyping.Now env sigma c in
           let holes = List.init missing (fun _ -> hole) in
           Printer.pr_glob_constr_env env sigma (DAst.make @@ GApp (c, holes))
         in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -155,10 +155,10 @@ let rebuild_bl aux bl typ = rebuild_bl aux bl typ
 let recompute_binder_list (rec_order, fixpoint_exprl) =
   let typel, sigma = ComFixpoint.interp_fixpoint_short rec_order fixpoint_exprl in
   let constr_expr_typel =
-    with_full_print
-      (List.map (fun c ->
-           Constrextern.extern_constr (Global.env ()) sigma
-             (EConstr.of_constr c)))
+    let flags = full_printing_flags() in
+    (List.map (fun c ->
+         Constrextern.extern_constr ~flags (Global.env ()) sigma
+           (EConstr.of_constr c)))
       typel
   in
   let fixpoint_exprl_with_new_bl =
@@ -2046,12 +2046,10 @@ let make_graph (f_ref : GlobRef.t) =
   | Undef _ | Primitive _ | Symbol _ | OpaqueDef _ -> CErrors.user_err (Pp.str "Cannot build a graph over an axiom!")
   | Def body ->
     let extern_body, extern_type =
-      with_full_print
-        (fun () ->
-          ( Constrextern.extern_constr env sigma (EConstr.of_constr body)
-          , Constrextern.extern_type env sigma
-              (EConstr.of_constr (*FIXME*) c_body.Declarations.const_type) ))
-        ()
+      let flags = full_printing_flags() in
+      ( Constrextern.extern_constr env sigma ~flags (EConstr.of_constr body)
+      , Constrextern.extern_type env sigma ~flags
+          (EConstr.of_constr (*FIXME*) c_body.Declarations.const_type) )
     in
     let nal_tas, b, t = get_args extern_body extern_type in
     let expr_list =

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1579,15 +1579,11 @@ let do_build_inductive evd (funconstants : pconstant list)
     observe msg; raise reraise
 
 let build_inductive evd funconstants funsargs returned_types rtl =
-  let pu = !Detyping.print_universes in
-  let cu = !Detyping.print_universes in
+  let pu = !PrintingFlags.print_universes in
   try
-    Detyping.print_universes := true;
-    Detyping.print_universes := true;
+    PrintingFlags.print_universes := true;
     do_build_inductive evd funconstants funsargs returned_types rtl;
-    Detyping.print_universes := pu;
-    Detyping.print_universes := cu
+    PrintingFlags.print_universes := pu;
   with e when CErrors.noncritical e ->
-    Detyping.print_universes := pu;
-    Detyping.print_universes := cu;
+    PrintingFlags.print_universes := pu;
     raise (Building_graph e)

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -418,6 +418,8 @@ let rec pattern_to_term_and_type env typ =
              (cst_narg - List.length patternl)
              (fun i ->
                Detyping.detype Detyping.Now env
+                 (* XXX should we use full printing flags? *)
+                 ~flags:(PrintingFlags.Detype.current())
                  (Evd.from_env env)
                  csta.(i)))
       in
@@ -507,8 +509,10 @@ let rec build_entry_lc env sigma funnames avoid rt :
       let rt_as_constr, ctx = Pretyping.understand env (Evd.from_env env) rt in
       let rt_typ = Retyping.get_type_of env (Evd.from_env env) rt_as_constr in
       let res_raw_type =
-        Detyping.detype Detyping.Now env (Evd.from_env env)
-          rt_typ
+        Detyping.detype Detyping.Now
+          (* XXX should we use full printing flags? *)
+          ~flags:(PrintingFlags.Detype.current())
+          env (Evd.from_env env) rt_typ
       in
       let res = fresh_id args_res.to_avoid "_res" in
       let new_avoid = res :: args_res.to_avoid in
@@ -765,6 +769,8 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
               let typ_of_id = Typing.type_of_variable env_with_pat_ids id in
               let raw_typ_of_id =
                 Detyping.detype Detyping.Now env_with_pat_ids
+                  (* XXX should we use full printing flags? *)
+                  ~flags:(PrintingFlags.Detype.current())
                   (Evd.from_env env) typ_of_id
               in
               mkGProd (Name id, raw_typ_of_id, acc))
@@ -802,6 +808,8 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
              let this_pat_ids = ids_of_pat pat in
              let typ =
                Detyping.detype Detyping.Now new_env
+                 (* XXX should we use full printing flags? *)
+                 ~flags:(PrintingFlags.Detype.current())
                  (Evd.from_env env) typ_as_constr
              in
              let pat_as_term = pattern_to_term pat in
@@ -818,6 +826,8 @@ and build_entry_lc_from_case_term env sigma types funname make_discr
                    , let typ_of_id = Typing.type_of_variable new_env id in
                      let raw_typ_of_id =
                        Detyping.detype Detyping.Now new_env
+                         (* XXX should we use full printing flags? *)
+                         ~flags:(PrintingFlags.Detype.current())
                          (Evd.from_env env) typ_of_id
                      in
                      raw_typ_of_id )
@@ -979,6 +989,8 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
                , List.map
                    (fun p ->
                      Detyping.detype Detyping.Now env
+                       (* XXX should we use full printing flags? *)
+                       ~flags:(PrintingFlags.Detype.current())
                        (Evd.from_env env) p)
                    params
                  @ Array.to_list
@@ -1014,11 +1026,15 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
                   | Name id' ->
                     ( id'
                     , Detyping.detype Detyping.Now env
+                        (* XXX should we use full printing flags? *)
+                        ~flags:(PrintingFlags.Detype.current())
                         (Evd.from_env env) arg )
                     :: acc
                 else if EConstr.isVar sigma var_as_constr then
                   (EConstr.destVar sigma var_as_constr
                   , Detyping.detype Detyping.Now env
+                      (* XXX should we use full printing flags? *)
+                      ~flags:(PrintingFlags.Detype.current())
                       (Evd.from_env env) arg )
                   :: acc
                 else acc)
@@ -1335,13 +1351,9 @@ let do_build_inductive evd (funconstants : pconstant list)
             CAst.make
             @@ Constrexpr.CLetIn
                  ( CAst.make n
-                 , with_full_print
-                     Constrextern.(extern_glob_constr empty_extern_env)
-                     t
+                 ,  Constrextern.extern_glob_constr (extern_env_full_printing()) t
                  , Some
-                     (with_full_print
-                        Constrextern.(extern_glob_constr empty_extern_env)
-                        typ)
+                     (Constrextern.extern_glob_constr (extern_env_full_printing()) typ)
                  , acc )
           | None ->
             CAst.make
@@ -1350,9 +1362,7 @@ let do_build_inductive evd (funconstants : pconstant list)
                        ( [CAst.make n]
                        , None
                        , Constrexpr_ops.default_binder_kind
-                       , with_full_print
-                           Constrextern.(extern_glob_constr empty_extern_env)
-                           t ) ]
+                       , Constrextern.extern_glob_constr (extern_env_full_printing()) t ) ]
                  , acc ))
         rel_first_args
         (rebuild_return_type returned_types.(i))
@@ -1365,7 +1375,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     Util.Array.fold_left2
       (fun env rel_name rel_ar ->
         let rex =
-          fst (with_full_print (Constrintern.interp_constr env evd) rel_ar)
+          fst (Constrintern.interp_constr env evd rel_ar)
         in
         let r = ERelevance.relevant in
         (* TODO relevance *)
@@ -1424,13 +1434,9 @@ let do_build_inductive evd (funconstants : pconstant list)
           CAst.make
           @@ Constrexpr.CLetIn
                ( CAst.make n
-               , with_full_print
-                   Constrextern.(extern_glob_constr empty_extern_env)
-                   t
+               , Constrextern.extern_glob_constr (extern_env_full_printing()) t
                , Some
-                   (with_full_print
-                      Constrextern.(extern_glob_constr empty_extern_env)
-                      typ)
+                   (Constrextern.extern_glob_constr (extern_env_full_printing()) typ)
                , acc )
         | None ->
           CAst.make
@@ -1439,9 +1445,7 @@ let do_build_inductive evd (funconstants : pconstant list)
                      ( [CAst.make n]
                      , None
                      , Constrexpr_ops.default_binder_kind
-                     , with_full_print
-                         Constrextern.(extern_glob_constr empty_extern_env)
-                         t ) ]
+                     , Constrextern.extern_glob_constr (extern_env_full_printing()) t ) ]
                , acc ))
       rel_first_args
       (rebuild_return_type returned_types.(i))
@@ -1465,17 +1469,15 @@ let do_build_inductive evd (funconstants : pconstant list)
           Constrexpr.CLocalDef
             ( CAst.make n
             , None
-            , Constrextern.(extern_glob_constr empty_extern_env) t
+            , Constrextern.(extern_glob_constr (extern_env_full_printing())) t
             , Some
-                (with_full_print
-                   Constrextern.(extern_glob_constr empty_extern_env)
-                   typ) )
+                (Constrextern.extern_glob_constr (extern_env_full_printing()) typ) )
         | None ->
           Constrexpr.CLocalAssum
             ( [CAst.make n]
             , None
             , Constrexpr_ops.default_binder_kind
-            , Constrextern.(extern_glob_constr empty_extern_env) t ))
+            , Constrextern.(extern_glob_constr (extern_env_full_printing())) t ))
       rels_params
   in
   let ext_rels_constructors =
@@ -1483,8 +1485,7 @@ let do_build_inductive evd (funconstants : pconstant list)
       (List.map (fun (id, t) ->
            ( Vernacexpr.([], NoCoercion, NoInstance)
            , ( CAst.make id
-             , with_full_print
-                 Constrextern.(extern_glob_type empty_extern_env)
+             , Constrextern.extern_glob_type (extern_env_full_printing())
                  ((* zeta_normalize *) alpha_rt rel_params_ids t) ) )))
       rel_constructors
   in
@@ -1526,7 +1527,7 @@ let do_build_inductive evd (funconstants : pconstant list)
       mode = None;
     }
     in
-    with_full_print
+    without_implicit_declarations
       (Flags.silently
          (fun () ->
             ComInductive.do_mutual_inductive ~flags
@@ -1579,6 +1580,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     observe msg; raise reraise
 
 let build_inductive evd funconstants funsargs returned_types rtl =
+  (* XXX pass functionally (is it just the marked XXX near Detype.current calls?) *)
   let pu = !PrintingFlags.print_universes in
   try
     PrintingFlags.print_universes := true;

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -608,7 +608,9 @@ let resolve_and_replace_implicits exptyp env sigma rt =
     match Evd.evar_body evi with
     | Evar_defined c ->
       (* we just have to lift the solution in glob_term *)
-      Detyping.detype Detyping.Now env ctx (f c)
+      (* XXX should we use full printing flags? *)
+      let flags = PrintingFlags.Detype.current() in
+      Detyping.detype Detyping.Now ~flags env ctx (f c)
     | Evar_empty ->
       (* the hole was not solved : we do nothing *)
       default

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -85,7 +85,7 @@ let with_full_print f a =
   let old_implicit_args = Impargs.is_implicit_args ()
   and old_strict_implicit_args = Impargs.is_strict_implicit_args ()
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
-  let old_rawprint = !Flags.raw_print in
+  let old_rawprint = !PrintingFlags.raw_print in
   let old_printuniverses = !Detyping.print_universes in
   let old_printallowmatchdefaultclause =
     Detyping.print_allow_match_default_clause ()
@@ -93,7 +93,7 @@ let with_full_print f a =
   Detyping.print_universes := true;
   Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
     false;
-  Flags.raw_print := true;
+  PrintingFlags.raw_print := true;
   Impargs.make_implicit_args false;
   Impargs.make_strict_implicit_args false;
   Impargs.make_contextual_implicit_args false;
@@ -103,7 +103,7 @@ let with_full_print f a =
     Impargs.make_implicit_args old_implicit_args;
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
-    Flags.raw_print := old_rawprint;
+    PrintingFlags.raw_print := old_rawprint;
     Detyping.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
@@ -113,7 +113,7 @@ let with_full_print f a =
     Impargs.make_implicit_args old_implicit_args;
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
-    Flags.raw_print := old_rawprint;
+    PrintingFlags.raw_print := old_rawprint;
     Detyping.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -87,12 +87,9 @@ let with_full_print f a =
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
   let old_rawprint = !PrintingFlags.raw_print in
   let old_printuniverses = !PrintingFlags.print_universes in
-  let old_printallowmatchdefaultclause =
-    Detyping.print_allow_match_default_clause ()
-  in
+  let old_printallowmatchdefaultclause = !PrintingFlags.print_allow_match_default_clause in
   PrintingFlags.print_universes := true;
-  Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
-    false;
+  PrintingFlags.print_allow_match_default_clause := false;
   PrintingFlags.raw_print := true;
   Impargs.make_implicit_args false;
   Impargs.make_strict_implicit_args false;
@@ -105,8 +102,7 @@ let with_full_print f a =
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     PrintingFlags.raw_print := old_rawprint;
     PrintingFlags.print_universes := old_printuniverses;
-    Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
-      old_printallowmatchdefaultclause;
+    PrintingFlags.print_allow_match_default_clause := old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();
     res
   with reraise ->
@@ -115,8 +111,7 @@ let with_full_print f a =
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     PrintingFlags.raw_print := old_rawprint;
     PrintingFlags.print_universes := old_printuniverses;
-    Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
-      old_printallowmatchdefaultclause;
+    PrintingFlags.print_allow_match_default_clause := old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();
     raise reraise
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -86,11 +86,11 @@ let with_full_print f a =
   and old_strict_implicit_args = Impargs.is_strict_implicit_args ()
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
   let old_rawprint = !PrintingFlags.raw_print in
-  let old_printuniverses = !Detyping.print_universes in
+  let old_printuniverses = !PrintingFlags.print_universes in
   let old_printallowmatchdefaultclause =
     Detyping.print_allow_match_default_clause ()
   in
-  Detyping.print_universes := true;
+  PrintingFlags.print_universes := true;
   Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
     false;
   PrintingFlags.raw_print := true;
@@ -104,7 +104,7 @@ let with_full_print f a =
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     PrintingFlags.raw_print := old_rawprint;
-    Detyping.print_universes := old_printuniverses;
+    PrintingFlags.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();
@@ -114,7 +114,7 @@ let with_full_print f a =
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
     PrintingFlags.raw_print := old_rawprint;
-    Detyping.print_universes := old_printuniverses;
+    PrintingFlags.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
     Dumpglob.pop_output ();

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -36,11 +36,12 @@ val jmeq : unit -> EConstr.constr
 val jmeq_refl : unit -> EConstr.constr
 val make_eq : unit -> EConstr.constr
 
-(* [with_full_print f a] applies [f] to [a] in full printing environment.
+(** Run the function with auto implicits off and dumglob paused  *)
+val without_implicit_declarations : (unit -> unit) -> unit -> unit
 
-   This function preserves the print settings
-*)
-val with_full_print : ('a -> 'b) -> 'a -> 'b
+val full_printing_flags : unit -> PrintingFlags.t
+
+val extern_env_full_printing : unit -> Constrextern.extern_env
 
 (*****************)
 

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -63,7 +63,7 @@ let eval_uconstrs ist cs =
   let map c env sigma = c env sigma in
   List.map (fun c -> map (Tacinterp.type_uconstr ~flags ist c)) cs
 
-let pr_auto_using_raw env sigma _ _ _  = Pptactic.pr_auto_using @@ Ppconstr.pr_constr_expr env sigma
+let pr_auto_using_raw env sigma _ _ _  = Pptactic.pr_auto_using @@ Ppconstr.(pr_constr_expr ~flags:(current_flags())) env sigma
 let pr_auto_using_glob env sigma _ _ _ = Pptactic.pr_auto_using (fun (c,_) ->
     Printer.pr_glob_constr_env env sigma c)
 let pr_auto_using env sigma _ _ _ = Pptactic.pr_auto_using @@

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -235,7 +235,7 @@ let wit_binders =
 let binders = Procq.create_generic_entry2 "binders" (Genarg.rawwit wit_binders)
 
 let () =
-  let raw_printer l = Genprint.PrinterBasic (fun env sigma -> Pp.pr_non_empty_arg (Ppconstr.pr_binders env sigma) l) in
+  let raw_printer l = Genprint.PrinterBasic (fun env sigma -> Pp.pr_non_empty_arg Ppconstr.(pr_binders ~flags:(current_flags()) env sigma) l) in
   Genprint.register_vernac_print0 wit_binders raw_printer
 
 }

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -28,6 +28,12 @@ open Tacexpr
 open Tacarg
 open Tactics
 
+(* XXX pass flag around? *)
+let pr_constr_expr env sigma c = pr_constr_expr ~flags:(current_flags()) env sigma c
+let pr_lconstr_expr env sigma c = pr_lconstr_expr ~flags:(current_flags()) env sigma c
+let pr_constr_pattern_expr env sigma c = pr_constr_pattern_expr ~flags:(current_flags()) env sigma c
+let pr_lconstr_pattern_expr env sigma c = pr_lconstr_pattern_expr ~flags:(current_flags()) env sigma c
+
 module Tag =
 struct
 
@@ -1281,8 +1287,13 @@ let pr_user_red_expr = Redexpr.pr_glob_user_red_expr
 
 let pr_red_expr_env r = Genprint.TopPrinterNeedsContext (fun env sigma ->
   pr_red_expr env sigma ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e),
-                         pr_evaluable_reference_env env, pr_constr_pattern_env,
-                         int, pr_user_red_expr) r)
+                         pr_evaluable_reference_env env,
+                         (fun env sigma c ->
+                            pr_constr_pattern_env
+                              ~flags:(PrintingFlags.Extern.current())
+                              env sigma c),
+                         int,
+                         pr_user_red_expr) r)
 
 let pr_bindings_env bl = Genprint.TopPrinterNeedsContext (fun env sigma ->
   let sigma, bl = bl env sigma in
@@ -1349,19 +1360,19 @@ let () =
   ;
   Genprint.register_print0
     wit_constr
-    (lift_env Ppconstr.pr_constr_expr)
+    (lift_env pr_constr_expr)
     (lift_env (fun env sigma (c, _) -> pr_glob_constr_pptac env sigma c))
     (make_constr_printer Printer.pr_econstr_n_env)
   ;
   Genprint.register_print0
     wit_uconstr
-    (lift_env Ppconstr.pr_constr_expr)
+    (lift_env pr_constr_expr)
     (lift_env (fun env sigma (c,_) -> pr_glob_constr_pptac env sigma c))
     (make_constr_printer Printer.pr_closed_glob_n_env)
   ;
   Genprint.register_print0
     wit_open_constr
-    (lift_env Ppconstr.pr_constr_expr)
+    (lift_env pr_constr_expr)
     (lift_env (fun env sigma (c, _) -> pr_glob_constr_pptac env sigma c))
     (make_constr_printer Printer.pr_econstr_n_env)
   ;

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -75,7 +75,9 @@ let () =
   let intern = intern_constr_tacexpr in
   let interp ist c = interp_constr Tac2core.constr_flags ist c in
   let print env sigma c = str "constr:(" ++ Printer.pr_lglob_constr_env env sigma c ++ str ")" in
-  let raw_print env sigma c = str "constr:(" ++ Ppconstr.pr_lconstr_expr env sigma c ++ str ")" in
+  let raw_print env sigma c =
+    str "constr:(" ++ Ppconstr.(pr_lconstr_expr ~flags:(current_flags())) env sigma c ++ str ")"
+  in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
   let obj = {
     ml_intern = intern;
@@ -90,7 +92,9 @@ let () =
   let intern = intern_constr_tacexpr in
   let interp ist c = interp_constr Tac2core.open_constr_no_classes_flags ist c in
   let print env sigma c = str "open_constr:(" ++ Printer.pr_lglob_constr_env env sigma c ++ str ")" in
-  let raw_print env sigma c = str "open_constr:(" ++ Ppconstr.pr_lconstr_expr env sigma c ++ str ")" in
+  let raw_print env sigma c =
+    str "open_constr:(" ++ Ppconstr.(pr_lconstr_expr ~flags:(current_flags())) env sigma c ++ str ")"
+  in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
   let obj = {
     ml_intern = intern;
@@ -131,7 +135,9 @@ let () =
     Patternops.subst_uninstantiated_pattern env sigma subst c
   in
   let print env sigma pat = str "pat:(" ++ Printer.pr_uninstantiated_lconstr_pattern_env env sigma pat ++ str ")" in
-  let raw_print env sigma pat = str "pat:(" ++ Ppconstr.pr_lconstr_pattern_expr env sigma pat ++ str ")" in
+  let raw_print env sigma pat =
+    str "pat:(" ++ Ppconstr.(pr_lconstr_pattern_expr ~flags:(current_flags())) env sigma pat ++ str ")"
+  in
   let interp env c =
     let ist = to_lvar env in
     Tac2core.pf_apply ~catch_exceptions:true begin fun env sigma ->
@@ -175,7 +181,9 @@ let () =
     in
     hov 2 (str "preterm:(" ++ ppids ++ Printer.pr_lglob_constr_env env sigma c ++ str ")")
   in
-  let raw_print env sigma c = str "preterm:(" ++ Ppconstr.pr_lconstr_expr env sigma c ++ str ")" in
+  let raw_print env sigma c =
+    str "preterm:(" ++ Ppconstr.(pr_lconstr_expr ~flags:(current_flags())) env sigma c ++ str ")"
+  in
   let obj = {
     ml_intern = intern;
     ml_interp = interp;

--- a/plugins/ring/g_ring.mlg
+++ b/plugins/ring/g_ring.mlg
@@ -36,6 +36,8 @@ END
 open Pptactic
 open Ppconstr
 
+let pr_constr_expr env sigma c = pr_constr_expr ~flags:(current_flags()) env sigma c
+
 let pr_ring_mod env sigma = function
   | Ring_kind (Computational eq_test) -> str "decidable" ++ pr_arg (pr_constr_expr env sigma) eq_test
   | Ring_kind Abstract ->  str "abstract"

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -161,7 +161,8 @@ let newssrcongrtac arg ist =
   (fun sigma' ->
     let x = List.find_map_exn (fun (n, x, _) -> if n = 0 then Some x else None) eq_args in
     let ty = fs sigma' x in
-    congrtac (arg, Detyping.detype Detyping.Now env sigma ty) ist)
+    (* should we be using custom detyping flags? *)
+    congrtac (arg, Detyping.detype Detyping.Now ~flags:(PrintingFlags.Detype.current()) env sigma ty) ist)
   (fun () ->
     try
     let sigma, t_lhs = Evarutil.new_Type sigma in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -374,8 +374,9 @@ let interp_index ist env sigma idx =
         | None ->
         begin match Tacinterp.Value.to_constr v with
         | Some c ->
-          let rc = Detyping.detype Detyping.Now env sigma c in
-          begin match Notation.uninterp_prim_token rc ([], []) with
+          let flags = PrintingFlags.Detype.current() in
+          let rc = Detyping.detype Detyping.Now ~flags env sigma c in
+          begin match Notation.uninterp_prim_token ~print_float:false rc ([], []) with
           | Constrexpr.Number n, _ when NumTok.Signed.is_int n ->
             int_of_string (NumTok.Signed.to_string n)
           | _ -> raise Not_found

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -46,11 +46,11 @@ let with_global_env_evm f x =
   let sigma = Evd.from_env env in
   f env sigma x
 
-let prl_constr_expr = with_global_env_evm Ppconstr.pr_lconstr_expr
+let prl_constr_expr c = with_global_env_evm Ppconstr.(pr_lconstr_expr ~flags:(current_flags())) c
 let pr_glob_constr = with_global_env_evm Printer.pr_glob_constr_env
 let prl_glob_constr = with_global_env_evm Printer.pr_lglob_constr_env
 let pr_glob_constr_and_expr = function
-  | _, Some c -> with_global_env_evm Ppconstr.pr_constr_expr c
+  | _, Some c -> with_global_env_evm Ppconstr.(pr_constr_expr ~flags:(current_flags())) c
   | c, None -> pr_glob_constr c
 let pr_term (k, c) = pr_guarded (guard_term k) pr_glob_constr_and_expr c
 
@@ -86,7 +86,7 @@ let pr_simpl = function
 let pr_ast_closure_term { body } =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  Ppconstr.pr_constr_expr env sigma body
+  Ppconstr.(pr_constr_expr ~flags:(current_flags())) env sigma body
 
 let pr_view2 = pr_list mt (fun c -> str "/" ++ pr_ast_closure_term c)
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -80,16 +80,16 @@ let pr_guarded guard prc c =
 let with_global_env_evm f x =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  f env sigma x
+  f ?flags:None env sigma x
 let prl_glob_constr = with_global_env_evm pr_lglob_constr_env
 let pr_glob_constr = with_global_env_evm pr_glob_constr_env
 let prl_constr_expr = pr_lconstr_expr
 let pr_constr_expr = pr_constr_expr
 let prl_glob_constr_and_expr env sigma = function
-  | _, Some c -> prl_constr_expr env sigma c
+  | _, Some c -> prl_constr_expr ~flags:(current_flags()) env sigma c
   | c, None -> prl_glob_constr c
 let pr_glob_constr_and_expr env sigma = function
-  | _, Some c -> pr_constr_expr env sigma c
+  | _, Some c -> pr_constr_expr ~flags:(current_flags()) env sigma c
   | c, None -> pr_glob_constr c
 
 (** Adding a new uninterpreted generic argument type *)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -289,12 +289,6 @@ module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
 (* Flags.for printing or not wildcard and synthetisable types *)
 
-let { Goptions.get = fast_name_generation } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Fast";"Name";"Printing"]
-    ~value:false
-    ()
-
 let { Goptions.get = synthetize_type } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Synth"]
@@ -1081,12 +1075,12 @@ let detype_rel_context d flags avoid env sigma sign =
 
 let detype d ?(isgoal=false) ?avoid env sigma t =
   let flags = { flg_isgoal = isgoal; } in
-  let avoid = Avoid.make ~fast:(fast_name_generation ()) avoid in
+  let avoid = Avoid.make ~fast:(PrintingFlags.fast_name_generation ()) avoid in
   detype d flags avoid (names_of_rel_context env, env) sigma t
 
 let detype_rel_context d ?avoid env sigma sign =
   let flags = { flg_isgoal = false; } in
-  let avoid = Avoid.make ~fast:(fast_name_generation ()) avoid in
+  let avoid = Avoid.make ~fast:(PrintingFlags.fast_name_generation ()) avoid in
   detype_rel_context d flags avoid env sigma sign
 
 let detype_closed_glob ?isgoal ?avoid env sigma t =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -205,13 +205,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** Should we print hidden sort quality variables? *)
-let { Goptions.get = print_sort_quality } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Sort";"Qualities"]
-    ~value:true
-    ()
-
 (** If true, prints local context of evars, whatever print_arguments *)
 let print_evar_arguments = ref false
 
@@ -391,7 +384,7 @@ let detype_sort sigma = function
        else glob_Type_sort)
   | QSort (q, u) ->
     if !PrintingFlags.print_universes then
-      let q = if print_sort_quality () || Evd.is_rigid_qvar sigma q then
+      let q = if PrintingFlags.print_sort_quality () || Evd.is_rigid_qvar sigma q then
           Some (detype_qvar sigma q)
         else None
       in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -397,12 +397,6 @@ let lookup_index_as_renamed env sigma t n =
 (**********************************************************************)
 (* Factorization of match patterns *)
 
-let { Goptions.get = print_factorize_match_patterns } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Factorizable";"Match";"Patterns"]
-    ~value:true
-    ()
-
 let print_allow_match_default_opt_name =
   ["Printing";"Allow";"Match";"Default";"Clause"]
 let { Goptions.get = print_allow_match_default_clause } =
@@ -413,7 +407,7 @@ let { Goptions.get = print_allow_match_default_clause } =
 
 let rec join_eqns (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
-     if not !PrintingFlags.raw_print && print_factorize_match_patterns () &&
+     if not !PrintingFlags.raw_print && PrintingFlags.print_factorize_match_patterns () &&
         List.eq_set Id.equal ids ids' && glob_constr_eq rhs rhs'
      then
        join_eqns x (patl'::patll) rest

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -30,11 +30,16 @@ open Mod_subst
 open Context.Rel.Declaration
 open Ltac_pretype
 
+(* why do we have extern code here? *)
+module ExternFlags = PrintingFlags.Extern
+module DetypeFlags = PrintingFlags.Detype
+
 type detyping_flags = {
+  flg : DetypeFlags.t;
   flg_isgoal : bool;
 }
 
-let nongoal (_:detyping_flags) = { flg_isgoal = false }
+let nongoal (f:detyping_flags) = { f with flg_isgoal = false }
 
 (** Reimplementation of kernel case expansion functions in more lenient way *)
 module RobustExpand :
@@ -312,17 +317,17 @@ let detype_quality sigma q =
 let detype_universe sigma u =
   UNamed (List.map (on_fst (detype_level_name sigma)) (Univ.Universe.repr u))
 
-let detype_sort sigma = function
+let detype_sort ~universes ~qualities sigma = function
   | SProp -> glob_SProp_sort
   | Prop -> glob_Prop_sort
   | Set -> glob_Set_sort
   | Type u ->
-      (if !PrintingFlags.print_universes
+      (if universes
        then None, detype_universe sigma u
        else glob_Type_sort)
   | QSort (q, u) ->
-    if !PrintingFlags.print_universes then
-      let q = if PrintingFlags.print_sort_quality () || Evd.is_rigid_qvar sigma q then
+    if universes then
+      let q = if qualities || Evd.is_rigid_qvar sigma q then
           Some (detype_qvar sigma q)
         else None
       in
@@ -331,8 +336,11 @@ let detype_sort sigma = function
       Some (detype_qvar sigma q), UAnonymous {rigid=UState.univ_flexible}
     else glob_Type_sort
 
-let detype_relevance_info sigma na =
-  if not (PrintingFlags.print_relevances ()) then None
+let detype_sort_f ~flags sigma s =
+  detype_sort ~universes:flags.flg.universes ~qualities:flags.flg.qualities sigma s
+
+let detype_relevance_info ~flags sigma na =
+  if not flags.DetypeFlags.relevances then None
   else match ERelevance.kind sigma na.binder_relevance with
     | Relevant -> Some GRelevant
     | Irrelevant -> Some GIrrelevant
@@ -397,14 +405,15 @@ let lookup_index_as_renamed env sigma t n =
 (**********************************************************************)
 (* Factorization of match patterns *)
 
-let rec join_eqns (ids,rhs as x) patll = function
+let rec join_eqns ~flags (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
-     if not !PrintingFlags.raw_print && PrintingFlags.print_factorize_match_patterns () &&
+    let open ExternFlags.FactorizeEqns in
+     if not flags.raw && flags.factorize_match_patterns &&
         List.eq_set Id.equal ids ids' && glob_constr_eq rhs rhs'
      then
-       join_eqns x (patl'::patll) rest
+       join_eqns  ~flags x (patl'::patll) rest
      else
-       let eqn,rest = join_eqns x patll rest in
+       let eqn,rest = join_eqns ~flags x patll rest in
        eqn, eqn'::rest
   | [] ->
      patll, []
@@ -434,18 +443,19 @@ let rec select_default_clause = function
        let dft, eqns = select_default_clause eqns in dft, eqn :: eqns
   | [] -> None, []
 
-let factorize_eqns eqns =
+let factorize_eqns ~flags eqns =
   let open CAst in
   let rec aux found = function
   | {loc;v=(ids,patl,rhs)}::rest ->
-     let patll,rest = join_eqns (ids,rhs) [patl] rest in
+     let patll,rest = join_eqns ~flags (ids,rhs) [patl] rest in
      aux (CAst.make ?loc (ids,patll,rhs)::found) rest
   | [] ->
      found in
   let eqns = aux [] (List.rev eqns) in
   let mk_anon patl = List.map (fun _ -> DAst.make @@ PatVar Anonymous) patl in
   let open CAst in
-  if not !PrintingFlags.raw_print && !PrintingFlags.print_allow_match_default_clause && eqns <> [] then
+  let open ExternFlags.FactorizeEqns in
+  if not flags.raw && flags.allow_match_default_clause && eqns <> [] then
     match select_default_clause eqns with
     (* At least two clauses and the last one is disjunctive with no variables *)
     | Some {loc=gloc;v=([],patl::_::_,rhs)}, (_::_ as eqns) ->
@@ -462,9 +472,9 @@ let factorize_eqns eqns =
 (**********************************************************************)
 (* Fragile algorithm to reverse pattern-matching compilation          *)
 
-let update_name sigma na ((_,(e,_)),c) =
+let update_name ~flags sigma na ((_,(e,_)),c) =
   match na with
-  | Name _ when PrintingFlags.print_wildcard () && noccurn sigma (List.index Name.equal na e) c ->
+  | Name _ when flags.flg.wildcard && noccurn sigma (List.index Name.equal na e) c ->
       Anonymous
   | _ ->
       na
@@ -485,19 +495,19 @@ let decomp_branch flags e sigma (ctx, c) =
   in
   aux n [] e (EConstr.it_mkLambda_or_LetIn c ctx)
 
-let rec build_tree na isgoal e sigma (ci, u, pms, cl) =
+let rec build_tree ~flags na isgoal e sigma (ci, u, pms, cl) =
   let map i br =
     RobustExpand.branch (snd (snd e)) sigma (ci.ci_ind, i + 1) u pms br
   in
   let cl = Array.mapi map cl in
   let mkpat n rhs pl =
-    let na = update_name sigma na rhs in
+    let na = update_name ~flags sigma na rhs in
     na, DAst.make @@ PatCstr((ci.ci_ind,n+1),pl,na) in
   List.flatten
     (List.init (Array.length cl)
-      (fun i -> contract_branch isgoal e sigma (mkpat i,cl.(i))))
+      (fun i -> contract_branch ~flags isgoal e sigma (mkpat i,cl.(i))))
 
-and align_tree nal isgoal (e,c as rhs) sigma = match nal with
+and align_tree ~flags nal isgoal (e,c as rhs) sigma = match nal with
   | [] -> [Id.Set.empty,[],rhs]
   | na::nal ->
     match EConstr.kind sigma c with
@@ -506,21 +516,21 @@ and align_tree nal isgoal (e,c as rhs) sigma = match nal with
         && not (Int.equal (Array.length cl) 0)
         && (* don't contract if p dependent *)
         computable sigma p (* FIXME: can do better *) ->
-        let clauses = build_tree na isgoal e sigma (ci, u, pms, cl) in
+        let clauses = build_tree ~flags na isgoal e sigma (ci, u, pms, cl) in
         List.flatten
           (List.map (fun (ids,pat,rhs) ->
-              let lines = align_tree nal isgoal rhs sigma in
+              let lines = align_tree ~flags nal isgoal rhs sigma in
               List.map (fun (ids',hd,rest) -> Id.Set.fold Id.Set.add ids ids',pat::hd,rest) lines)
             clauses)
     | _ ->
-        let na = update_name sigma na rhs in
+        let na = update_name ~flags sigma na rhs in
         let pat = DAst.make @@ PatVar na in
-        let mat = align_tree nal isgoal rhs sigma in
+        let mat = align_tree ~flags nal isgoal rhs sigma in
         List.map (fun (ids,hd,rest) -> Nameops.Name.fold_right Id.Set.add na ids,pat::hd,rest) mat
 
-and contract_branch isgoal e sigma (mkpat,rhs) =
+and contract_branch ~flags isgoal e sigma (mkpat,rhs) =
   let nal,rhs = decomp_branch isgoal e sigma rhs in
-  let mat = align_tree nal isgoal rhs sigma in
+  let mat = align_tree ~flags nal isgoal rhs sigma in
   List.map (fun (ids,hd,rhs) ->
       let na, pat = mkpat rhs hd in
       (Nameops.Name.fold_right Id.Set.add na ids, pat, rhs)) mat
@@ -582,11 +592,11 @@ let get_cstr_tags env ind bl =
     let map (nas, _) = Array.map_to_list (fun _ -> false) nas in
     Array.map map bl
 
-let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params, p, iv, c, bl) =
-  let synth_type = PrintingFlags.synthetize_type () in
+let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs, params, p, iv, c, bl) =
+  let synth_type = flags.flg.synth_match_return in
   let tomatch = detype c in
   let tomatch =
-    if not (PrintingFlags.print_match_paramunivs ()) then tomatch
+    if not (flags.flg.match_paramunivs) then tomatch
     else match iv with
       | NoInvert ->
         if Array.is_empty params && EInstance.is_empty univs
@@ -605,7 +615,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
         DAst.make @@ GCast (tomatch, None, detype t)
   in
   let alias, aliastyp, pred =
-    if (not !PrintingFlags.raw_print) && synth_type && computable && not (Int.equal (Array.length bl) 0)
+    if (not flags.flg.raw) && synth_type && computable && not (Int.equal (Array.length bl) 0)
     then
       Anonymous, None, None
     else
@@ -625,7 +635,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
   let constructs = Array.init (Array.length bl) (fun i -> (ci.ci_ind,i+1)) in
   let tag = let st = ci.ci_pp_info.style in
     try
-      if !PrintingFlags.raw_print then
+      if flags.flg.raw then
         RegularStyle
       else if st == LetPatternStyle then
         st
@@ -675,7 +685,7 @@ let rec share_names detype flags n l avoid env sigma c t =
         let t' = detype flags avoid env sigma t in
         let id, avoid = next_name_away flags na.binder_name avoid in
         let env = add_name (set_name (Name id) decl) env in
-        share_names detype flags (n-1) ((Name id,detype_relevance_info sigma na, Explicit,None,t')::l) avoid env sigma c c'
+        share_names detype flags (n-1) ((Name id,detype_relevance_info ~flags:flags.flg sigma na, Explicit,None,t')::l) avoid env sigma c c'
     (* May occur for fix built interactively *)
     | LetIn (na,b,t',c), _ when n > 0 ->
         let decl = LocalDef (na,b,t') in
@@ -683,7 +693,7 @@ let rec share_names detype flags n l avoid env sigma c t =
         let b' = detype flags avoid env sigma b in
         let id, avoid = next_name_away flags na.binder_name avoid in
         let env = add_name (set_name (Name id) decl) env in
-        share_names detype flags n ((Name id,detype_relevance_info sigma na, Explicit,Some b',t'')::l) avoid env sigma c (lift 1 t)
+        share_names detype flags n ((Name id,detype_relevance_info ~flags:flags.flg sigma na, Explicit,Some b',t'')::l) avoid env sigma c (lift 1 t)
     (* Only if built with the f/n notation or w/o let-expansion in types *)
     | _, LetIn (_,b,_,t) when n > 0 ->
         share_names detype flags n l avoid env sigma c (subst1 b t)
@@ -694,7 +704,7 @@ let rec share_names detype flags n l avoid env sigma c t =
         let id, avoid = next_name_away flags na'.binder_name avoid in
         let env = add_name (set_name (Name id) decl) env in
         let appc = mkApp (lift 1 c,[|mkRel 1|]) in
-        share_names detype flags (n-1) ((Name id,detype_relevance_info sigma na',Explicit,None,t'')::l) avoid env sigma appc c'
+        share_names detype flags (n-1) ((Name id,detype_relevance_info ~flags:flags.flg sigma na',Explicit,None,t'')::l) avoid env sigma appc c'
     (* If built with the f/n notation: we renounce to share names *)
     | _ ->
         if n>0 then Feedback.msg_debug (strbrk "Detyping.detype: cannot factorize fix enough");
@@ -761,8 +771,8 @@ type binder_kind = BProd | BLambda | BLetIn
 (**********************************************************************)
 (* Main detyping function                                             *)
 
-let detype_instance sigma l =
-  if not !PrintingFlags.print_universes then None
+let detype_instance ~flags sigma l =
+  if not flags.flg.universes then None
   else
     let l = EInstance.kind sigma l in
     if UVars.Instance.is_empty l then None
@@ -802,7 +812,7 @@ and detype_r d flags avoid env sigma t =
         (* Discriminate between section variable and non-section variable *)
         (try let _ = Global.lookup_named id in GRef (GlobRef.VarRef id, None)
          with Not_found -> GVar id)
-    | Sort s -> GSort (detype_sort sigma (ESorts.kind sigma s))
+    | Sort s -> GSort (detype_sort_f ~flags sigma (ESorts.kind sigma s))
     | Cast (c1,k,c2) ->
       let d1 = detype d flags avoid env sigma c1 in
       let d2 = detype d flags avoid env sigma c2 in
@@ -819,9 +829,9 @@ and detype_r d flags avoid env sigma t =
       in
       mkapp (detype d flags avoid env sigma f)
         (Array.map_to_list (detype d flags avoid env sigma) args)
-    | Const (sp,u) -> GRef (GlobRef.ConstRef sp, detype_instance sigma u)
+    | Const (sp,u) -> GRef (GlobRef.ConstRef sp, detype_instance ~flags sigma u)
     | Proj (p,_,c) ->
-      if Projection.unfolded p && PrintingFlags.print_unfolded_primproj_asmatch () then
+      if Projection.unfolded p && flags.flg.unfolded_primproj_as_match then
         let c = detype d flags avoid env sigma c in
         let id = Projection.label p in
         let nargs, parg =
@@ -852,7 +862,7 @@ and detype_r d flags avoid env sigma t =
                 (args @ [detype d flags avoid env sigma c]))
         in
         if !Flags.in_debugger || !Flags.in_ml_toplevel
-           || not (PrintingFlags.print_primproj_params ())
+           || not flags.flg.primproj_params
         then noparams ()
         else begin
           try
@@ -898,7 +908,7 @@ and detype_r d flags avoid env sigma t =
               l
           in
           let l = get_instance (fun d c ->
-              not !PrintingFlags.print_evar_arguments
+              not flags.flg.evar_instances
               && bound_to_itself_or_letin d c
               && not (match EConstr.kind sigma c with
                   | Rel n -> Int.Set.mem n rels
@@ -915,13 +925,13 @@ and detype_r d flags avoid env sigma t =
         GEvar (CAst.make id,
                List.map (on_snd (detype d flags avoid env sigma)) l)
     | Ind (ind_sp,u) ->
-        GRef (GlobRef.IndRef ind_sp, detype_instance sigma u)
+        GRef (GlobRef.IndRef ind_sp, detype_instance ~flags sigma u)
     | Construct (cstr_sp,u) ->
-        GRef (GlobRef.ConstructRef cstr_sp, detype_instance sigma u)
+        GRef (GlobRef.ConstructRef cstr_sp, detype_instance ~flags sigma u)
     | Case (ci,u,pms,p,iv,c,bl) ->
         let comp = computable sigma (fst p) in
         let case = (ci, u, pms, p, iv, c, bl) in
-        detype_case comp (detype d flags avoid env sigma)
+        detype_case ~flags comp (detype d flags avoid env sigma)
           (detype_eqns d flags avoid env sigma comp)
           avoid env sigma case
     | Fix (nvn,recdef) -> detype_fix (detype d) flags avoid env sigma nvn recdef
@@ -933,13 +943,13 @@ and detype_r d flags avoid env sigma t =
       let t = Array.map (detype d flags avoid env sigma) t in
       let def = detype d flags avoid env sigma def in
       let ty = detype d flags avoid env sigma ty in
-      let u = detype_instance sigma u in
+      let u = detype_instance ~flags sigma u in
       GArray(u, t, def, ty)
 
 and detype_eqns d flags avoid env sigma computable constructs bl =
   try
-    if !PrintingFlags.raw_print || not (PrintingFlags.print_matching ()) then raise_notrace Exit;
-    let mat = build_tree Anonymous flags (avoid,env) sigma bl in
+    if flags.flg.raw || not flags.flg.matching then raise_notrace Exit;
+    let mat = build_tree ~flags Anonymous flags (avoid,env) sigma bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))
       mat
@@ -952,7 +962,7 @@ and detype_eqn d flags avoid env sigma u pms constr br =
   let ctx, body = RobustExpand.branch (snd env) sigma constr u pms br in
   let branch = EConstr.it_mkLambda_or_LetIn body ctx in
   let make_pat decl avoid env b ids =
-    if PrintingFlags.print_wildcard () && not !Flags.in_debugger && noccurn sigma 1 b then
+    if flags.flg.wildcard && not !Flags.in_debugger && noccurn sigma 1 b then
       DAst.make @@ PatVar Anonymous,avoid,(add_name (set_name Anonymous decl) env),ids
     else
       let na,avoid' = compute_name sigma ~let_in:false ~pattern:true flags avoid env (get_name decl) b in
@@ -981,7 +991,7 @@ and detype_binder d flags bk avoid env sigma decl c =
   let na = get_name decl in
   let body = get_value decl in
   let ty = get_type decl in
-  let rinfo = detype_relevance_info sigma (get_annot decl) in
+  let rinfo = detype_relevance_info ~flags:flags.flg sigma (get_annot decl) in
   let na',avoid' = match bk with
   | BLetIn -> compute_name sigma ~let_in:true ~pattern:false flags avoid env na c
   | _ -> compute_name sigma ~let_in:false ~pattern:false flags avoid env na c in
@@ -990,7 +1000,7 @@ and detype_binder d flags bk avoid env sigma decl c =
   | BProd   -> GProd (na',rinfo,Explicit,detype d (nongoal flags) avoid env sigma ty, r)
   | BLambda -> GLambda (na',rinfo,Explicit,detype d (nongoal flags) avoid env sigma ty, r)
   | BLetIn ->
-      let c = detype d { flg_isgoal = false } avoid env sigma (Option.get body) in
+      let c = detype d (nongoal flags) avoid env sigma (Option.get body) in
       (* Heuristic: we display the type if in Prop *)
       let s =
         if !Flags.in_debugger then UnivGen.QualityOrSet.qtype
@@ -1000,7 +1010,7 @@ and detype_binder d flags bk avoid env sigma decl c =
           try Retyping.get_sort_quality_of (snd env) sigma ty
           with Retyping.RetypeError _ -> UnivGen.QualityOrSet.qtype
       in
-      let t = if not (UnivGen.QualityOrSet.is_prop s) && not !PrintingFlags.raw_print
+      let t = if not (UnivGen.QualityOrSet.is_prop s) && not flags.flg.raw
               then None
               else Some (detype d (nongoal flags) avoid env sigma ty) in
       GLetIn (na', rinfo, c, t, r)
@@ -1011,7 +1021,7 @@ let detype_rel_context d flags avoid env sigma sign =
   | decl::rest ->
       let na = get_name decl in
       let t = get_type decl in
-      let r = detype_relevance_info sigma (get_annot decl) in
+      let r = detype_relevance_info ~flags:flags.flg sigma (get_annot decl) in
       let b = match decl with
               | LocalAssum _ -> None
               | LocalDef (_,b,_) -> Some b
@@ -1021,17 +1031,17 @@ let detype_rel_context d flags avoid env sigma sign =
       (na,r,Explicit,b',t') :: aux avoid (add_name (set_name na decl) env) rest
   in aux avoid env (List.rev sign)
 
-let detype d ?(isgoal=false) ?avoid env sigma t =
-  let flags = { flg_isgoal = isgoal; } in
-  let avoid = Avoid.make ~fast:(PrintingFlags.fast_name_generation ()) avoid in
+let detype d ~flags ?(isgoal=false) ?avoid env sigma t =
+  let flags = { flg = flags; flg_isgoal = isgoal; } in
+  let avoid = Avoid.make ~fast:flags.flg.fast_names avoid in
   detype d flags avoid (names_of_rel_context env, env) sigma t
 
-let detype_rel_context d ?avoid env sigma sign =
-  let flags = { flg_isgoal = false; } in
-  let avoid = Avoid.make ~fast:(PrintingFlags.fast_name_generation ()) avoid in
+let detype_rel_context d ~flags ?avoid env sigma sign =
+  let flags = { flg = flags; flg_isgoal = false; } in
+  let avoid = Avoid.make ~fast:flags.flg.fast_names avoid in
   detype_rel_context d flags avoid env sigma sign
 
-let detype_closed_glob ?isgoal ?avoid env sigma t =
+let detype_closed_glob ~flags ?isgoal ?avoid env sigma t =
   let convert_id cl id =
     try Id.Map.find id cl.idents
     with Not_found -> id
@@ -1054,7 +1064,7 @@ let detype_closed_glob ?isgoal ?avoid env sigma t =
              [Printer.pr_constr_under_binders_env] does. *)
           let assums = List.map (fun id -> LocalAssum (make_annot (Name id) ERelevance.relevant,(* dummy *) mkProp)) b in
           let env = push_rel_context assums env in
-          DAst.get (detype Now ?isgoal ?avoid env sigma c)
+          DAst.get (detype Now ~flags ?isgoal ?avoid env sigma c)
         (* if [id] is bound to a [closed_glob_constr]. *)
         with Not_found -> try
           let {closure;term} = Id.Map.find id cl.untyped in
@@ -1109,8 +1119,10 @@ let rec subst_glob_constr env subst = DAst.map (function
         | None -> GRef (ref', u)
         | Some t ->
           let evd = Evd.from_env env in
-          let t = t.UVars.univ_abstracted_value in (* XXX This seems dangerous *)
-          DAst.get (detype Now env evd (EConstr.of_constr t)))
+          let t = t.UVars.univ_abstracted_value in
+          (* XXX This seems dangerous *)
+          let flags = DetypeFlags.current() in
+          DAst.get (detype Now ~flags env evd (EConstr.of_constr t)))
 
   | GSort _
   | GVar _

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,12 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-let { Goptions.get = print_unfolded_primproj_asmatch } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Unfolded";"Projection";"As";"Match"]
-    ~value:false
-    ()
-
 let { Goptions.get = print_match_paramunivs } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Match";"All";"Subterms"]
@@ -853,7 +847,7 @@ and detype_r d flags avoid env sigma t =
         (Array.map_to_list (detype d flags avoid env sigma) args)
     | Const (sp,u) -> GRef (GlobRef.ConstRef sp, detype_instance sigma u)
     | Proj (p,_,c) ->
-      if Projection.unfolded p && print_unfolded_primproj_asmatch () then
+      if Projection.unfolded p && PrintingFlags.print_unfolded_primproj_asmatch () then
         let c = detype d flags avoid env sigma c in
         let id = Projection.label p in
         let nargs, parg =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,12 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-let { Goptions.get = print_primproj_params } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Primitive";"Projection";"Parameters"]
-    ~value:false
-    ()
-
 let { Goptions.get = print_unfolded_primproj_asmatch } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Unfolded";"Projection";"As";"Match"]
@@ -890,7 +884,7 @@ and detype_r d flags avoid env sigma t =
                 (args @ [detype d flags avoid env sigma c]))
         in
         if !Flags.in_debugger || !Flags.in_ml_toplevel
-           || not (print_primproj_params ())
+           || not (PrintingFlags.print_primproj_params ())
         then noparams ()
         else begin
           try

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,12 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-let { Goptions.get = reverse_matching } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Matching"]
-    ~value:true
-    ()
-
 let { Goptions.get = print_primproj_params } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Primitive";"Projection";"Parameters"]
@@ -982,7 +976,7 @@ and detype_r d flags avoid env sigma t =
 
 and detype_eqns d flags avoid env sigma computable constructs bl =
   try
-    if !PrintingFlags.raw_print || not (reverse_matching ()) then raise_notrace Exit;
+    if !PrintingFlags.raw_print || not (PrintingFlags.print_matching ()) then raise_notrace Exit;
     let mat = build_tree Anonymous flags (avoid,env) sigma bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,14 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-(* Flags.for printing or not wildcard and synthetisable types *)
-
-let { Goptions.get = synthetize_type } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Synth"]
-    ~value:true
-    ()
-
 let { Goptions.get = reverse_matching } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Matching"]
@@ -635,7 +627,7 @@ let get_cstr_tags env ind bl =
     Array.map map bl
 
 let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params, p, iv, c, bl) =
-  let synth_type = synthetize_type () in
+  let synth_type = PrintingFlags.synthetize_type () in
   let tomatch = detype c in
   let tomatch =
     if not (print_match_paramunivs ()) then tomatch

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -289,12 +289,6 @@ module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
 (* Flags.for printing or not wildcard and synthetisable types *)
 
-let { Goptions.get = force_wildcard } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Wildcard"]
-    ~value:true
-    ()
-
 let { Goptions.get = fast_name_generation } =
   Goptions.declare_bool_option_and_ref
     ~key:["Fast";"Name";"Printing"]
@@ -528,7 +522,7 @@ let factorize_eqns eqns =
 
 let update_name sigma na ((_,(e,_)),c) =
   match na with
-  | Name _ when force_wildcard () && noccurn sigma (List.index Name.equal na e) c ->
+  | Name _ when PrintingFlags.print_wildcard () && noccurn sigma (List.index Name.equal na e) c ->
       Anonymous
   | _ ->
       na
@@ -1016,7 +1010,7 @@ and detype_eqn d flags avoid env sigma u pms constr br =
   let ctx, body = RobustExpand.branch (snd env) sigma constr u pms br in
   let branch = EConstr.it_mkLambda_or_LetIn body ctx in
   let make_pat decl avoid env b ids =
-    if force_wildcard () && not !Flags.in_debugger && noccurn sigma 1 b then
+    if PrintingFlags.print_wildcard () && not !Flags.in_debugger && noccurn sigma 1 b then
       DAst.make @@ PatVar Anonymous,avoid,(add_name (set_name Anonymous decl) env),ids
     else
       let na,avoid' = compute_name sigma ~let_in:false ~pattern:true flags avoid env (get_name decl) b in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -397,14 +397,6 @@ let lookup_index_as_renamed env sigma t n =
 (**********************************************************************)
 (* Factorization of match patterns *)
 
-let print_allow_match_default_opt_name =
-  ["Printing";"Allow";"Match";"Default";"Clause"]
-let { Goptions.get = print_allow_match_default_clause } =
-  Goptions.declare_bool_option_and_ref
-    ~key:print_allow_match_default_opt_name
-    ~value:true
-    ()
-
 let rec join_eqns (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
      if not !PrintingFlags.raw_print && PrintingFlags.print_factorize_match_patterns () &&
@@ -453,7 +445,7 @@ let factorize_eqns eqns =
   let eqns = aux [] (List.rev eqns) in
   let mk_anon patl = List.map (fun _ -> DAst.make @@ PatVar Anonymous) patl in
   let open CAst in
-  if not !PrintingFlags.raw_print && print_allow_match_default_clause () && eqns <> [] then
+  if not !PrintingFlags.raw_print && !PrintingFlags.print_allow_match_default_clause && eqns <> [] then
     match select_default_clause eqns with
     (* At least two clauses and the last one is disjunctive with no variables *)
     | Some {loc=gloc;v=([],patl::_::_,rhs)}, (_::_ as eqns) ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -205,9 +205,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** Should we keep details of universes during detyping ? *)
-let print_universes = ref false
-
 (** Should we print hidden sort quality variables? *)
 let { Goptions.get = print_sort_quality } =
   Goptions.declare_bool_option_and_ref
@@ -389,11 +386,11 @@ let detype_sort sigma = function
   | Prop -> glob_Prop_sort
   | Set -> glob_Set_sort
   | Type u ->
-      (if !print_universes
+      (if !PrintingFlags.print_universes
        then None, detype_universe sigma u
        else glob_Type_sort)
   | QSort (q, u) ->
-    if !print_universes then
+    if !PrintingFlags.print_universes then
       let q = if print_sort_quality () || Evd.is_rigid_qvar sigma q then
           Some (detype_qvar sigma q)
         else None
@@ -848,7 +845,7 @@ type binder_kind = BProd | BLambda | BLetIn
 (* Main detyping function                                             *)
 
 let detype_instance sigma l =
-  if not !print_universes then None
+  if not !PrintingFlags.print_universes then None
   else
     let l = EInstance.kind sigma l in
     if UVars.Instance.is_empty l then None

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -205,18 +205,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** If true, prints local context of evars, whatever print_arguments *)
-let print_evar_arguments = ref false
-
-let () =
-  let open Goptions in
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
-      optkey   = ["Printing";"Existential";"Instances"];
-      optread  = (fun () -> !print_evar_arguments);
-      optwrite = (:=) print_evar_arguments }
-
 let add_name decl (nenv, env) =
   add_name (get_name decl) nenv, push_rel decl env
 
@@ -974,7 +962,7 @@ and detype_r d flags avoid env sigma t =
               l
           in
           let l = get_instance (fun d c ->
-              not !print_evar_arguments
+              not !PrintingFlags.print_evar_arguments
               && bound_to_itself_or_letin d c
               && not (match EConstr.kind sigma c with
                   | Rel n -> Int.Set.mem n rels

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,12 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-let { Goptions.get = print_match_paramunivs } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Match";"All";"Subterms"]
-    ~value:false
-    ()
-
 let { Goptions.get = print_relevances } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Relevance";"Marks"]
@@ -612,7 +606,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
   let synth_type = PrintingFlags.synthetize_type () in
   let tomatch = detype c in
   let tomatch =
-    if not (print_match_paramunivs ()) then tomatch
+    if not (PrintingFlags.print_match_paramunivs ()) then tomatch
     else match iv with
       | NoInvert ->
         if Array.is_empty params && EInstance.is_empty univs

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -287,12 +287,6 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-let { Goptions.get = print_relevances } =
-  Goptions.declare_bool_option_and_ref
-    ~key:["Printing";"Relevance";"Marks"]
-    ~value:false
-    ()
-
 (** univ and sort detyping *)
 
 let detype_level_name sigma l =
@@ -338,7 +332,7 @@ let detype_sort sigma = function
     else glob_Type_sort
 
 let detype_relevance_info sigma na =
-  if not (print_relevances ()) then None
+  if not (PrintingFlags.print_relevances ()) then None
   else match ERelevance.kind sigma na.binder_relevance with
     | Relevant -> Some GRelevant
     | Irrelevant -> Some GIrrelevant

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -485,7 +485,7 @@ let { Goptions.get = print_allow_match_default_clause } =
 
 let rec join_eqns (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
-     if not !Flags.raw_print && print_factorize_match_patterns () &&
+     if not !PrintingFlags.raw_print && print_factorize_match_patterns () &&
         List.eq_set Id.equal ids ids' && glob_constr_eq rhs rhs'
      then
        join_eqns x (patl'::patll) rest
@@ -531,7 +531,7 @@ let factorize_eqns eqns =
   let eqns = aux [] (List.rev eqns) in
   let mk_anon patl = List.map (fun _ -> DAst.make @@ PatVar Anonymous) patl in
   let open CAst in
-  if not !Flags.raw_print && print_allow_match_default_clause () && eqns <> [] then
+  if not !PrintingFlags.raw_print && print_allow_match_default_clause () && eqns <> [] then
     match select_default_clause eqns with
     (* At least two clauses and the last one is disjunctive with no variables *)
     | Some {loc=gloc;v=([],patl::_::_,rhs)}, (_::_ as eqns) ->
@@ -691,7 +691,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
         DAst.make @@ GCast (tomatch, None, detype t)
   in
   let alias, aliastyp, pred =
-    if (not !Flags.raw_print) && synth_type && computable && not (Int.equal (Array.length bl) 0)
+    if (not !PrintingFlags.raw_print) && synth_type && computable && not (Int.equal (Array.length bl) 0)
     then
       Anonymous, None, None
     else
@@ -711,7 +711,7 @@ let detype_case computable detype detype_eqns avoid env sigma (ci, univs, params
   let constructs = Array.init (Array.length bl) (fun i -> (ci.ci_ind,i+1)) in
   let tag = let st = ci.ci_pp_info.style in
     try
-      if !Flags.raw_print then
+      if !PrintingFlags.raw_print then
         RegularStyle
       else if st == LetPatternStyle then
         st
@@ -1024,7 +1024,7 @@ and detype_r d flags avoid env sigma t =
 
 and detype_eqns d flags avoid env sigma computable constructs bl =
   try
-    if !Flags.raw_print || not (reverse_matching ()) then raise_notrace Exit;
+    if !PrintingFlags.raw_print || not (reverse_matching ()) then raise_notrace Exit;
     let mat = build_tree Anonymous flags (avoid,env) sigma bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))
@@ -1086,7 +1086,7 @@ and detype_binder d flags bk avoid env sigma decl c =
           try Retyping.get_sort_quality_of (snd env) sigma ty
           with Retyping.RetypeError _ -> UnivGen.QualityOrSet.qtype
       in
-      let t = if not (UnivGen.QualityOrSet.is_prop s) && not !Flags.raw_print
+      let t = if not (UnivGen.QualityOrSet.is_prop s) && not !PrintingFlags.raw_print
               then None
               else Some (detype d (nongoal flags) avoid env sigma ty) in
       GLetIn (na', rinfo, c, t, r)

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,10 +21,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** If true, contract branches with same r.h.s. and same matching
-    variables in a disjunctive pattern *)
-val print_factorize_match_patterns : unit -> bool
-
 (** If this flag is true and the last non unique clause of a "match" is a
     variable-free disjunctive pattern, turn it into a catch-call case *)
 val print_allow_match_default_clause : unit -> bool

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -61,8 +61,6 @@ val detype_closed_glob : ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> en
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option
 val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 
-val synthetize_type : unit -> bool
-
 module PrintingInductiveMake :
   functor (_ : sig
     val encode : Environ.env -> Libnames.qualid -> Names.inductive

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,11 +21,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** If this flag is true and the last non unique clause of a "match" is a
-    variable-free disjunctive pattern, turn it into a catch-call case *)
-val print_allow_match_default_clause : unit -> bool
-val print_allow_match_default_opt_name : string list
-
 val subst_cases_pattern : substitution -> cases_pattern -> cases_pattern
 
 val subst_glob_constr : env -> substitution -> glob_constr -> glob_constr

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,9 +21,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** Should we keep details of universes during detyping ? *)
-val print_universes : bool ref
-
 (** If true, prints full local context of evars *)
 val print_evar_arguments : bool ref
 

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -61,7 +61,6 @@ val detype_closed_glob : ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> en
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option
 val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 
-val force_wildcard : unit -> bool
 val synthetize_type : unit -> bool
 
 module PrintingInductiveMake :

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -25,19 +25,23 @@ val subst_cases_pattern : substitution -> cases_pattern -> cases_pattern
 
 val subst_glob_constr : env -> substitution -> glob_constr -> glob_constr
 
-val factorize_eqns : 'a cases_clauses_g -> 'a disjunctive_cases_clauses_g
+val factorize_eqns : flags:PrintingFlags.Extern.FactorizeEqns.t -> 'a cases_clauses_g -> 'a disjunctive_cases_clauses_g
 
 (** [detype isgoal avoid ctx c] turns a closed [c], into a glob_constr
    de Bruijn indexes are turned to bound names, avoiding names in [avoid]
    [isgoal] tells if naming must avoid global-level synonyms as intro does
    [ctx] gives the names of the free variables *)
 
-val detype : 'a delay -> ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> env -> evar_map -> constr -> 'a glob_constr_g
+val detype : 'a delay ->
+  flags:PrintingFlags.Detype.t -> ?isgoal:bool -> ?avoid:'g Namegen.Generator.input ->
+  env -> evar_map -> constr -> 'a glob_constr_g
 
-val detype_sort : evar_map -> Sorts.t -> glob_sort
+val detype_sort : universes:bool -> qualities:bool -> evar_map -> Sorts.t -> glob_sort
 
-val detype_rel_context : 'a delay -> ?avoid:'g Namegen.Generator.input -> (names_context * env) ->
-  evar_map -> rel_context -> 'a glob_decl_g list
+val detype_rel_context : 'a delay ->
+  flags:PrintingFlags.Detype.t ->
+  ?avoid:'g Namegen.Generator.input ->
+  (names_context * env) -> evar_map -> rel_context -> 'a glob_decl_g list
 
 val share_pattern_names :
   ('g Namegen.Generator.input -> names_context -> 'c -> 'd Pattern.constr_pattern_r -> 'a) -> int ->
@@ -46,7 +50,8 @@ val share_pattern_names :
   'd Pattern.constr_pattern_r ->
   (Name.t * 'e option * binding_kind * 'b option * 'a) list * 'a * 'a
 
-val detype_closed_glob : ?isgoal:bool -> ?avoid:'g Namegen.Generator.input -> env -> evar_map -> closed_glob_constr -> glob_constr
+val detype_closed_glob : flags:PrintingFlags.Detype.t -> ?isgoal:bool ->
+  ?avoid:'g Namegen.Generator.input -> env -> evar_map -> closed_glob_constr -> glob_constr
 
 (** look for the index of a named var or a nondep var as it is renamed *)
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,9 +21,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** If true, prints full local context of evars *)
-val print_evar_arguments : bool ref
-
 (** If true, contract branches with same r.h.s. and same matching
     variables in a disjunctive pattern *)
 val print_factorize_match_patterns : unit -> bool

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -25,7 +25,15 @@ let make_flag key v =
 let raw_print = make_flag ["Printing";"All"] false
 
 (* detyping + extern + a few extra things (eg About) *)
+(* XXX why does extern look at this flag? *)
 let print_universes = make_flag ["Printing";"Universes"] false
+
+(* detyping *)
+let { Goptions.get = print_sort_quality } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Sort";"Qualities"]
+    ~value:true
+    ()
 
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -61,3 +61,10 @@ let () =
 
 (* extern *)
 let print_raw_literal = make_flag ["Printing";"Raw";"Literals"] false
+
+(* extern *)
+let { Goptions.get = print_use_implicit_types } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Use";"Implicit";"Types"]
+    ~value:true
+    ()

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -39,3 +39,6 @@ let print_implicits_explicit_args () = false
 
 (* extern *)
 let print_implicits = make_flag ["Printing";"Implicit"] false
+
+(* extern *)
+let print_implicits_defensive = make_flag ["Printing";"Implicit";"Defensive"] true

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -36,3 +36,6 @@ let print_parentheses = make_flag ["Printing";"Parentheses"] false
 (* constant for now, TODO expose as a new option *)
 (* extern *)
 let print_implicits_explicit_args () = false
+
+(* extern *)
+let print_implicits = make_flag ["Printing";"Implicit"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -73,6 +73,13 @@ let { Goptions.get = print_primproj_params } =
     ~value:false
     ()
 
+(* detyping *)
+let { Goptions.get = print_unfolded_primproj_asmatch } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Unfolded";"Projection";"As";"Match"]
+    ~value:false
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -52,6 +52,13 @@ let { Goptions.get = fast_name_generation } =
     ~value:false
     ()
 
+(* detyping *)
+let { Goptions.get = synthetize_type } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Synth"]
+    ~value:true
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -152,3 +152,10 @@ let { Goptions.get = get_record_print } =
     ~key:["Printing";"Records"]
     ~value:true
     ()
+
+(* extern *)
+let { Goptions.get = print_float } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Float"]
+    ~value:true
+    ()

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -58,3 +58,6 @@ let () =
       optread  = (fun () -> not !print_no_symbol);
       optwrite = (fun b ->  print_no_symbol := not b);
     }
+
+(* extern *)
+let print_raw_literal = make_flag ["Printing";"Raw";"Literals"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -94,14 +94,14 @@ let { Goptions.get = print_relevances } =
     ~value:false
     ()
 
-(* detyping *)
+(* detyping.ml but extern time *)
 let { Goptions.get = print_factorize_match_patterns } =
   Goptions.declare_bool_option_and_ref
     ~key:["Printing";"Factorizable";"Match";"Patterns"]
     ~value:true
     ()
 
-(* detyping *)
+(* detyping.ml but extern time *)
 let print_allow_match_default_clause = make_flag ["Printing";"Allow";"Match";"Default";"Clause"] true
 
 (* extern *)
@@ -159,3 +159,95 @@ let { Goptions.get = print_float } =
     ~key:["Printing";"Float"]
     ~value:true
     ()
+
+module Detype = struct
+  type t = {
+    raw : bool;
+    universes : bool;
+    qualities : bool;
+    relevances : bool;
+    evar_instances : bool;
+    wildcard : bool;
+    fast_names : bool;
+    synth_match_return : bool;
+    matching : bool;
+    primproj_params : bool;
+    unfolded_primproj_as_match : bool;
+    match_paramunivs : bool;
+  }
+
+  let current () = {
+    raw = !raw_print;
+    universes = !print_universes;
+    qualities = print_sort_quality();
+    relevances = print_relevances();
+    evar_instances = !print_evar_arguments;
+    wildcard = print_wildcard();
+    fast_names = fast_name_generation();
+    synth_match_return = synthetize_type();
+    matching = print_matching();
+    primproj_params = print_primproj_params();
+    unfolded_primproj_as_match = print_unfolded_primproj_asmatch();
+    match_paramunivs = print_match_paramunivs();
+  }
+end
+
+module Extern = struct
+  module FactorizeEqns = struct
+    type t = {
+      raw : bool;
+      factorize_match_patterns : bool;
+      allow_match_default_clause : bool;
+    }
+
+    let current () = {
+      raw = !raw_print;
+      factorize_match_patterns = print_factorize_match_patterns();
+      allow_match_default_clause = !print_allow_match_default_clause;
+    }
+  end
+
+  type t = {
+    raw : bool;
+    use_implicit_types : bool;
+    records : bool;
+    implicits : bool;
+    implicits_explicit_args : bool;
+    implicits_defensive : bool;
+    coercions : bool;
+    parentheses : bool;
+    notations : bool;
+    raw_literals : bool;
+    projections : bool;
+    float : bool;
+    factorize_eqns : FactorizeEqns.t;
+    (* XXX depth? *)
+  }
+
+  let current () = {
+    raw = !raw_print;
+    use_implicit_types = print_use_implicit_types();
+    records = get_record_print();
+    implicits = !print_implicits;
+    implicits_explicit_args = print_implicits_explicit_args();
+    implicits_defensive = !print_implicits_defensive;
+    coercions = !print_coercions;
+    parentheses = !print_parentheses;
+    notations = not !print_no_symbol;
+    raw_literals = !print_raw_literal;
+    projections = !print_projections;
+    float = print_float();
+    factorize_eqns = FactorizeEqns.current();
+  }
+end
+
+
+type t = {
+  detype : Detype.t;
+  extern : Extern.t;
+}
+
+let current () = {
+  detype = Detype.current();
+  extern = Extern.current();
+}

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -26,3 +26,6 @@ let raw_print = make_flag ["Printing";"All"] false
 
 (* detyping + extern + a few extra things (eg About) *)
 let print_universes = make_flag ["Printing";"Universes"] false
+
+(* extern *)
+let print_coercions = make_flag ["Printing";"Coercions"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -45,6 +45,13 @@ let { Goptions.get = print_wildcard } =
     ~value:true
     ()
 
+(* detyping *)
+let { Goptions.get = fast_name_generation } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Fast";"Name";"Printing"]
+    ~value:false
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -68,3 +68,10 @@ let { Goptions.get = print_use_implicit_types } =
     ~key:["Printing";"Use";"Implicit";"Types"]
     ~value:true
     ()
+
+(* extern *)
+let { Goptions.get = get_record_print } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Records"]
+    ~value:true
+    ()

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -38,6 +38,13 @@ let { Goptions.get = print_sort_quality } =
 (* detyping *)
 let print_evar_arguments = make_flag ["Printing";"Existential";"Instances"] false
 
+(* detyping *)
+let { Goptions.get = print_wildcard } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Wildcard"]
+    ~value:true
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -59,6 +59,13 @@ let { Goptions.get = synthetize_type } =
     ~value:true
     ()
 
+(* detyping *)
+let { Goptions.get = print_matching } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Matching"]
+    ~value:true
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -94,6 +94,13 @@ let { Goptions.get = print_relevances } =
     ~value:false
     ()
 
+(* detyping *)
+let { Goptions.get = print_factorize_match_patterns } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Factorizable";"Match";"Patterns"]
+    ~value:true
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -45,3 +45,16 @@ let print_implicits_defensive = make_flag ["Printing";"Implicit";"Defensive"] tr
 
 (* extern *)
 let print_projections = make_flag ["Printing";"Projections"] false
+
+(* extern *)
+let print_no_symbol = ref false
+
+let () =
+  (* Printing Notations uses a negated ref for convenience in Himsg.explicit_flags *)
+  Goptions.declare_bool_option
+    { optstage = Summary.Stage.Interp;
+      optdepr  = None;
+      optkey   = ["Printing";"Notations"];
+      optread  = (fun () -> not !print_no_symbol);
+      optwrite = (fun b ->  print_no_symbol := not b);
+    }

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -87,6 +87,13 @@ let { Goptions.get = print_match_paramunivs } =
     ~value:false
     ()
 
+(* detyping *)
+let { Goptions.get = print_relevances } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Relevance";"Marks"]
+    ~value:false
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -29,3 +29,6 @@ let print_universes = make_flag ["Printing";"Universes"] false
 
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
+
+(* extern + ppconstr *)
+let print_parentheses = make_flag ["Printing";"Parentheses"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -35,6 +35,9 @@ let { Goptions.get = print_sort_quality } =
     ~value:true
     ()
 
+(* detyping *)
+let print_evar_arguments = make_flag ["Printing";"Existential";"Instances"] false
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -80,6 +80,13 @@ let { Goptions.get = print_unfolded_primproj_asmatch } =
     ~value:false
     ()
 
+(* detyping *)
+let { Goptions.get = print_match_paramunivs } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Match";"All";"Subterms"]
+    ~value:false
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -23,3 +23,6 @@ let make_flag key v =
 
 (* detyping + extern + random stuff *)
 let raw_print = make_flag ["Printing";"All"] false
+
+(* detyping + extern + a few extra things (eg About) *)
+let print_universes = make_flag ["Printing";"Universes"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -101,6 +101,9 @@ let { Goptions.get = print_factorize_match_patterns } =
     ~value:true
     ()
 
+(* detyping *)
+let print_allow_match_default_clause = make_flag ["Printing";"Allow";"Match";"Default";"Clause"] true
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -66,6 +66,13 @@ let { Goptions.get = print_matching } =
     ~value:true
     ()
 
+(* detyping *)
+let { Goptions.get = print_primproj_params } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"Primitive";"Projection";"Parameters"]
+    ~value:false
+    ()
+
 (* extern *)
 let print_coercions = make_flag ["Printing";"Coercions"] false
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -42,3 +42,6 @@ let print_implicits = make_flag ["Printing";"Implicit"] false
 
 (* extern *)
 let print_implicits_defensive = make_flag ["Printing";"Implicit";"Defensive"] true
+
+(* extern *)
+let print_projections = make_flag ["Printing";"Projections"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -1,0 +1,25 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+let make_flag key v =
+  let r = ref v in
+  let () =
+    Goptions.declare_bool_option {
+      optstage = Summary.Stage.Interp;
+      optdepr  = None;
+      optkey   = key;
+      optread  = (fun () -> !r);
+      optwrite = (fun b -> r := b);
+    }
+  in
+  r
+
+(* detyping + extern + random stuff *)
+let raw_print = make_flag ["Printing";"All"] false

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -32,3 +32,7 @@ let print_coercions = make_flag ["Printing";"Coercions"] false
 
 (* extern + ppconstr *)
 let print_parentheses = make_flag ["Printing";"Parentheses"] false
+
+(* constant for now, TODO expose as a new option *)
+(* extern *)
+let print_implicits_explicit_args () = false

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -8,5 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Set Printing All *)
+(* Set Printing All flag. *)
 val raw_print : bool ref
+
+val print_universes : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -39,6 +39,10 @@ val print_relevances : unit -> bool
     variables in a disjunctive pattern *)
 val print_factorize_match_patterns : unit -> bool
 
+(** If this flag is true and the last non unique clause of a "match" is a
+    variable-free disjunctive pattern, turn it into a catch-call case *)
+val print_allow_match_default_clause : bool ref
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -27,6 +27,8 @@ val synthetize_type : unit -> bool
 
 val print_matching : unit -> bool
 
+val print_primproj_params : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -28,3 +28,6 @@ val print_implicits : bool ref
 (** Tells if implicit arguments not known to be inferable from a rigid
     position are systematically printed *)
 val print_implicits_defensive : bool ref
+
+(** This governs printing of projections using the dot notation symbols *)
+val print_projections : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -16,3 +16,9 @@ val print_universes : bool ref
 val print_coercions : bool ref
 
 val print_parentheses : bool ref
+
+(** When [print_implicits] is on then [print_implicits_explicit_args]
+    tells how implicit args are printed. If on, implicit args are
+    printed with the form (id:=arg) otherwise arguments are printed
+    normally and the function is prefixed by "@". *)
+val print_implicits_explicit_args : unit -> bool

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -19,6 +19,8 @@ val print_sort_quality : unit -> bool
 (** If true, prints full local context of evars *)
 val print_evar_arguments : bool ref
 
+val print_wildcard : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -33,6 +33,8 @@ val print_unfolded_primproj_asmatch : unit -> bool
 
 val print_match_paramunivs : unit -> bool
 
+val print_relevances : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -12,3 +12,5 @@
 val raw_print : bool ref
 
 val print_universes : bool ref
+
+val print_coercions : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -22,3 +22,5 @@ val print_parentheses : bool ref
     printed with the form (id:=arg) otherwise arguments are printed
     normally and the function is prefixed by "@". *)
 val print_implicits_explicit_args : unit -> bool
+
+val print_implicits : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -21,6 +21,8 @@ val print_evar_arguments : bool ref
 
 val print_wildcard : unit -> bool
 
+val fast_name_generation : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -34,3 +34,6 @@ val print_projections : bool ref
 
 (** Negated version of Printing Notations (negated for convenience in Himsg.explicit_flags)  *)
 val print_no_symbol : bool ref
+
+(** Print primitive tokens, like strings *)
+val print_raw_literal : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -13,6 +13,9 @@ val raw_print : bool ref
 
 val print_universes : bool ref
 
+(** Should we print hidden sort quality variables? *)
+val print_sort_quality : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -40,3 +40,5 @@ val print_raw_literal : bool ref
 
 (** This tells to skip types if a variable has this type by default *)
 val print_use_implicit_types : unit -> bool
+
+val get_record_print : unit -> bool

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -25,6 +25,8 @@ val fast_name_generation : unit -> bool
 
 val synthetize_type : unit -> bool
 
+val print_matching : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -29,6 +29,8 @@ val print_matching : unit -> bool
 
 val print_primproj_params : unit -> bool
 
+val print_unfolded_primproj_asmatch : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -37,3 +37,6 @@ val print_no_symbol : bool ref
 
 (** Print primitive tokens, like strings *)
 val print_raw_literal : bool ref
+
+(** This tells to skip types if a variable has this type by default *)
+val print_use_implicit_types : unit -> bool

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -14,3 +14,5 @@ val raw_print : bool ref
 val print_universes : bool ref
 
 val print_coercions : bool ref
+
+val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -72,3 +72,5 @@ val print_raw_literal : bool ref
 val print_use_implicit_types : unit -> bool
 
 val get_record_print : unit -> bool
+
+val print_float : unit -> bool

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -31,3 +31,6 @@ val print_implicits_defensive : bool ref
 
 (** This governs printing of projections using the dot notation symbols *)
 val print_projections : bool ref
+
+(** Negated version of Printing Notations (negated for convenience in Himsg.explicit_flags)  *)
+val print_no_symbol : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -1,0 +1,12 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Set Printing All *)
+val raw_print : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -8,69 +8,83 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Set Printing All flag. *)
+module Detype : sig
+  type t = {
+    raw : bool;
+    universes : bool;
+    (** Should we print hidden sort quality variables? *)
+    qualities : bool;
+    relevances : bool;
+    (** If true, prints full local context of evars *)
+    evar_instances : bool;
+    wildcard : bool;
+    fast_names : bool;
+    synth_match_return : bool;
+    matching : bool;
+    primproj_params : bool;
+    unfolded_primproj_as_match : bool;
+    match_paramunivs : bool;
+  }
+
+  val current : unit -> t
+end
+
+module Extern : sig
+  module FactorizeEqns : sig
+    type t = {
+      raw : bool;
+      (** If true, contract branches with same r.h.s. and same matching
+          variables in a disjunctive pattern *)
+      factorize_match_patterns : bool;
+      (** If this flag is true and the last non unique clause of a
+          "match" is a variable-free disjunctive pattern, turn it into a
+          catch-call case *)
+      allow_match_default_clause : bool;
+    }
+
+    val current : unit -> t
+  end
+
+  type t = {
+    raw : bool;
+    (** This tells to skip types if a variable has this type by default *)
+    use_implicit_types : bool;
+    records : bool;
+    implicits : bool;
+    (** When [implicits] is on then [implicits_explicit_args] tells
+        how implicit args are printed. If on, implicit args are
+        printed with the form (id:=arg) otherwise arguments are
+        printed normally and the function is prefixed by "@". *)
+    implicits_explicit_args : bool;
+    (** Tells if implicit arguments not known to be inferable from a rigid
+        position are systematically printed *)
+    implicits_defensive : bool;
+    coercions : bool;
+    parentheses : bool;
+    notations : bool;
+    (** primitive tokens, like strings *)
+    raw_literals : bool;
+    (** This governs printing of projections using the dot notation symbols *)
+    projections : bool;
+    float : bool;
+    factorize_eqns : FactorizeEqns.t;
+    (* XXX depth? *)
+  }
+
+  val current : unit -> t
+end
+
+(** Combined detyping and extern flags. *)
+type t = {
+  detype : Detype.t;
+  extern : Extern.t;
+}
+
+val current : unit -> t
+
+(** The following flags are still accessed directly, but not when printing constr. *)
+
+(** Set Printing All flag. *)
 val raw_print : bool ref
 
 val print_universes : bool ref
-
-(** Should we print hidden sort quality variables? *)
-val print_sort_quality : unit -> bool
-
-(** If true, prints full local context of evars *)
-val print_evar_arguments : bool ref
-
-val print_wildcard : unit -> bool
-
-val fast_name_generation : unit -> bool
-
-val synthetize_type : unit -> bool
-
-val print_matching : unit -> bool
-
-val print_primproj_params : unit -> bool
-
-val print_unfolded_primproj_asmatch : unit -> bool
-
-val print_match_paramunivs : unit -> bool
-
-val print_relevances : unit -> bool
-
-(** If true, contract branches with same r.h.s. and same matching
-    variables in a disjunctive pattern *)
-val print_factorize_match_patterns : unit -> bool
-
-(** If this flag is true and the last non unique clause of a "match" is a
-    variable-free disjunctive pattern, turn it into a catch-call case *)
-val print_allow_match_default_clause : bool ref
-
-val print_coercions : bool ref
-
-val print_parentheses : bool ref
-
-(** When [print_implicits] is on then [print_implicits_explicit_args]
-    tells how implicit args are printed. If on, implicit args are
-    printed with the form (id:=arg) otherwise arguments are printed
-    normally and the function is prefixed by "@". *)
-val print_implicits_explicit_args : unit -> bool
-
-val print_implicits : bool ref
-
-(** Tells if implicit arguments not known to be inferable from a rigid
-    position are systematically printed *)
-val print_implicits_defensive : bool ref
-
-(** This governs printing of projections using the dot notation symbols *)
-val print_projections : bool ref
-
-(** Negated version of Printing Notations (negated for convenience in Himsg.explicit_flags)  *)
-val print_no_symbol : bool ref
-
-(** Print primitive tokens, like strings *)
-val print_raw_literal : bool ref
-
-(** This tells to skip types if a variable has this type by default *)
-val print_use_implicit_types : unit -> bool
-
-val get_record_print : unit -> bool
-
-val print_float : unit -> bool

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -31,6 +31,8 @@ val print_primproj_params : unit -> bool
 
 val print_unfolded_primproj_asmatch : unit -> bool
 
+val print_match_paramunivs : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -16,6 +16,9 @@ val print_universes : bool ref
 (** Should we print hidden sort quality variables? *)
 val print_sort_quality : unit -> bool
 
+(** If true, prints full local context of evars *)
+val print_evar_arguments : bool ref
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -23,6 +23,8 @@ val print_wildcard : unit -> bool
 
 val fast_name_generation : unit -> bool
 
+val synthetize_type : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -24,3 +24,7 @@ val print_parentheses : bool ref
 val print_implicits_explicit_args : unit -> bool
 
 val print_implicits : bool ref
+
+(** Tells if implicit arguments not known to be inferable from a rigid
+    position are systematically printed *)
+val print_implicits_defensive : bool ref

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -35,6 +35,10 @@ val print_match_paramunivs : unit -> bool
 
 val print_relevances : unit -> bool
 
+(** If true, contract branches with same r.h.s. and same matching
+    variables in a disjunctive pattern *)
+val print_factorize_match_patterns : unit -> bool
+
 val print_coercions : bool ref
 
 val print_parentheses : bool ref

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -71,6 +71,18 @@ let lsimpleconstr = LevelLe 8
 let lsimplepatt = LevelLe 1
 let no_after = None
 
+type flags = {
+  parentheses : bool;
+}
+
+let of_extern_flags f = {
+  parentheses = f.PrintingFlags.Extern.parentheses;
+}
+
+let current_flags () = of_extern_flags (PrintingFlags.Extern.current())
+
+let of_printing_flags f = of_extern_flags f.PrintingFlags.extern
+
 let overlap_right_left which s lev_after =
   let { notation_printing_unparsing = unpl } = find_notation_printing_rule which s in
   let rec aux = function
@@ -91,15 +103,15 @@ let prec_of_prim_token = function
   | Number (NumTok.SMinus,_) -> lnegint
   | String _ -> latom
 
-let adjust_level side lev_after l_not prec =
+let adjust_level ~flags side lev_after l_not prec =
   match side with
-  | Some _ when !PrintingFlags.print_parentheses -> no_after, LevelLe 0
+  | Some _ when flags.parentheses -> no_after, LevelLe 0
   | Some Right ->
     (if Notation.may_capture_cont_after lev_after prec then no_after else lev_after), prec
   | Some Left -> Some l_not, prec
   | None -> no_after,prec (* should we care about the separator being possibly empty? *)
 
-let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
+let print_hunks ~flags l_not lev_after pr pr_patt pr_binders (terms, termlists, binders, binderlists) unps =
   let env = ref terms and envlist = ref termlists and bl = ref binders and bll = ref binderlists in
   let pop r = let a = List.hd !r in r := List.tl !r; a in
   let return unp pp1 pp2 = (tag_unparsing unp pp1) ++ pp2 in
@@ -113,7 +125,7 @@ let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders
     | UnpMetaVar {notation_relative_level = prec; notation_position = side} as unp :: l ->
       let c = pop env in
       let pp2 = aux l in
-      let lev_after, prec = adjust_level side lev_after l_not prec in
+      let lev_after, prec = adjust_level ~flags side lev_after l_not prec in
       let pp1 = pr lev_after prec c in
       return unp pp1 pp2
     | UnpBinderMetaVar (subentry,style) as unp :: l ->
@@ -122,7 +134,7 @@ let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders
       let pp1 = pr_patt subentry.notation_relative_level style bk c in
       return unp pp1 pp2
     | UnpListMetaVar ({notation_relative_level = prec; notation_position = side}, sl) as unp :: l ->
-      let lev_after', prec' = adjust_level side lev_after l_not prec in
+      let lev_after', prec' = adjust_level ~flags side lev_after l_not prec in
       let pp1 =
         match pop envlist with
         | [] -> assert false
@@ -154,9 +166,9 @@ let print_hunks l_not lev_after pr pr_patt pr_binders (terms, termlists, binders
   in
   aux unps
 
-let pr_notation lev_after pr pr_patt pr_binders which s env =
+let pr_notation ~flags lev_after pr pr_patt pr_binders which s env =
   let { notation_printing_unparsing = unpl; notation_printing_level = level } = find_notation_printing_rule which s in
-  print_hunks level lev_after pr pr_patt pr_binders env unpl
+  print_hunks ~flags level lev_after pr pr_patt pr_binders env unpl
 
 let pr_delimiters depth key strm =
   let d = match depth with DelimOnlyTmpScope -> "%_" | DelimUnboundedScope -> "%" in
@@ -334,14 +346,14 @@ let lpatrec = 0
 let lpatcast = LevelLe 100
 let lpattop = LevelLe 200
 
-let rec pr_patt_args pr lev_after args =
+let rec pr_patt_args ~flags pr lev_after args =
   match args with
   | [] -> mt ()
   | args ->
     let last, args = List.sep_last args in
-    prlist (pr_patt spc pr (Some lapp) (LevelLt lapp)) args ++ pr_patt spc pr lev_after (LevelLt lapp) last
+    prlist (pr_patt ~flags spc pr (Some lapp) (LevelLt lapp)) args ++ pr_patt ~flags spc pr lev_after (LevelLt lapp) last
 
-and pr_patt sep pr lev_after inh p =
+and pr_patt ~flags sep pr lev_after inh p =
   let return cmds prec =
     let no_surround = Notation.prec_less prec inh in
     let lev_after = if no_surround then lev_after else no_after in
@@ -350,24 +362,24 @@ and pr_patt sep pr lev_after inh p =
     pr_with_comments ?loc:p.CAst.loc (sep() ++ pp) in
   match CAst.(p.v) with
   | CPatRecord l ->
-    return (fun lev_after -> pr_record_body "{|" "|}" (pr_patt spc pr no_after lpattop) l) lpatrec
+    return (fun lev_after -> pr_record_body "{|" "|}" (pr_patt ~flags spc pr no_after lpattop) l) lpatrec
 
   | CPatAlias (p, na) ->
-    return (fun lev_after -> pr_patt mt pr lev_after (LevelLe las) p ++ str " as " ++ pr_lname na) las
+    return (fun lev_after -> pr_patt ~flags mt pr lev_after (LevelLe las) p ++ str " as " ++ pr_lname na) las
 
   | CPatCstr (c, None, []) ->
     return (fun lev_after -> pr_reference c) latom
 
   | CPatCstr (c, None, args) ->
-    return (fun lev_after -> pr_reference c ++ pr_patt_args pr lev_after args) lapp
+    return (fun lev_after -> pr_reference c ++ pr_patt_args ~flags pr lev_after args) lapp
 
   | CPatCstr (c, Some args, []) ->
-    return (fun lev_after -> str "@" ++ pr_reference c ++ pr_patt_args pr lev_after args) lapp
+    return (fun lev_after -> str "@" ++ pr_reference c ++ pr_patt_args ~flags pr lev_after args) lapp
 
   | CPatCstr (c, Some expl_args, extra_args) ->
     return (fun lev_after ->
-        surround (str "@" ++ pr_reference c ++ pr_patt_args pr lev_after expl_args)
-        ++ pr_patt_args pr lev_after extra_args) lapp
+        surround (str "@" ++ pr_reference c ++ pr_patt_args ~flags pr lev_after expl_args)
+        ++ pr_patt_args ~flags pr lev_after extra_args) lapp
 
   | CPatAtom (None) ->
     return (fun lev_after -> str "_") latom
@@ -377,51 +389,51 @@ and pr_patt sep pr lev_after inh p =
 
   | CPatOr pl ->
     return (fun lev_after ->
-        let pp p = hov 0 (pr_patt mt pr lev_after lpattop p) in
+        let pp p = hov 0 (pr_patt ~flags mt pr lev_after lpattop p) in
         surround (hov 0 (prlist_with_sep pr_spcbar pp pl))) lpator
 
   | CPatNotation (_,(_,"( _ )"),([p],[],[]),[]) ->
-    return (fun lev_after -> pr_patt (fun()->str"(") pr no_after lpattop p ++ str")") latom
+    return (fun lev_after -> pr_patt ~flags (fun()->str"(") pr no_after lpattop p ++ str")") latom
 
   | CPatNotation (which,s,(l,ll,bl),args) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let no_inner_surrounding = List.is_empty args || Notation.prec_less l_not (LevelLt lapp) in
     return (fun lev_after ->
         let lev_after' = if no_inner_surrounding then lev_after else no_after in
-        let strm_not = pr_notation lev_after (pr_patt mt pr) (pr_patt_binder pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
+        let strm_not = pr_notation ~flags lev_after (pr_patt ~flags mt pr) (pr_patt_binder ~flags pr) (fun _ _ _ _ -> mt()) which s (l,ll,bl,[]) in
         (if List.is_empty args then strm_not else
          if overlap_right_left which s lev_after then surround strm_not else
          if Notation.prec_less l_not (LevelLt lapp) then strm_not else
            surround strm_not)
-        ++ pr_patt_args pr lev_after' args)
+        ++ pr_patt_args ~flags pr lev_after' args)
       (if not (List.is_empty args) then lapp else if no_inner_surrounding then l_not else latom)
 
   | CPatPrim p ->
     return (fun lev_after -> pr_prim_token p) latom
 
   | CPatDelimiters (depth,k,p) ->
-    return (fun lev_after -> pr_delimiters depth k (pr_patt mt pr (Some 1) lsimplepatt p)) 1
+    return (fun lev_after -> pr_delimiters depth k (pr_patt ~flags mt pr (Some 1) lsimplepatt p)) 1
 
   | CPatCast (p,t) ->
-    return (fun lev_after -> pr_patt mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
+    return (fun lev_after -> pr_patt ~flags mt pr (Some 1) lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t) 1
 
-and pr_patt_binder pr prec style bk c =
+and pr_patt_binder ~flags pr prec style bk c =
   match bk with
-  | MaxImplicit -> str "{" ++ pr_patt mt pr no_after lpattop c ++ str "}"
-  | NonMaxImplicit -> str "[" ++ pr_patt mt pr no_after lpattop c ++ str "]"
+  | MaxImplicit -> str "{" ++ pr_patt ~flags mt pr no_after lpattop c ++ str "}"
+  | NonMaxImplicit -> str "[" ++ pr_patt ~flags mt pr no_after lpattop c ++ str "]"
   | Explicit ->
     match style, c with
-    | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt mt pr no_after prec c
-    | QuotedPattern, _ -> str "'" ++ pr_patt mt pr no_after prec c
+    | NotQuotedPattern, _ | _, {v=CPatAtom _} -> pr_patt ~flags mt pr no_after prec c
+    | QuotedPattern, _ -> str "'" ++ pr_patt ~flags mt pr no_after prec c
 
-let pr_patt = pr_patt mt
+let pr_patt ~flags = pr_patt ~flags mt
 
-let pr_eqn pr {loc;v=(pl,rhs)} =
+let pr_eqn ~flags pr {loc;v=(pl,rhs)} =
   spc() ++ hov 4
     (pr_with_comments ?loc
        (str "| " ++
         hov 0 (prlist_with_sep pr_spcbar
-                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt (pr no_after ltop) no_after ltop) p)) pl
+                 (fun p -> hov 0 (prlist_with_sep sep_v (pr_patt ~flags (pr no_after ltop) no_after ltop) p)) pl
                ++ str " =>") ++
         pr_sep_com spc (pr no_after ltop) rhs))
 
@@ -472,7 +484,7 @@ let pr_binder many pr (nal,r,k,t) =
       let s = prlist_with_sep spc pr_lname nal ++ str " : " ++ r ++ pr t in
       hov 1 (if many then surround_impl b s else surround_implicit b s)
 
-let pr_binder_among_many withquote pr_c = function
+let pr_binder_among_many ~flags withquote pr_c = function
   | CLocalAssum (nal,r,k,t) ->
     pr_binder true pr_c (nal,r,k,t)
   | CLocalDef (na,r,c,topt) ->
@@ -480,29 +492,29 @@ let pr_binder_among_many withquote pr_c = function
               pr_opt_no_spc (fun t -> str " :" ++ ws 1 ++ pr_c t) topt ++
               str" :=" ++ spc() ++ pr_c c)
   | CLocalPattern p ->
-    str (if withquote then "'" else "") ++ pr_patt pr_c no_after lsimplepatt p
+    str (if withquote then "'" else "") ++ pr_patt ~flags pr_c no_after lsimplepatt p
 
-let pr_undelimited_binders sep withquote pr_c =
-  prlist_with_sep sep (pr_binder_among_many withquote pr_c)
+let pr_undelimited_binders ~flags sep withquote pr_c =
+  prlist_with_sep sep (pr_binder_among_many ~flags withquote pr_c)
 
-let pr_delimited_binders kw sep withquote pr_c bl =
+let pr_delimited_binders ~flags kw sep withquote pr_c bl =
   let n = begin_of_binders bl in
   match bl with
   | [CLocalAssum (nal,r,k,t)] ->
     kw n ++ pr_binder false pr_c (nal,r,k,t)
   | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
-    kw n ++ pr_undelimited_binders sep withquote pr_c bdl
+    kw n ++ pr_undelimited_binders ~flags sep withquote pr_c bdl
   | [] -> anomaly (Pp.str "The ast is malformed, found lambda/prod without proper binders.")
 
-let pr_binders_gen pr_c sep is_open withquote =
-  if is_open then pr_delimited_binders pr_com_at sep withquote pr_c
-  else pr_undelimited_binders sep withquote pr_c
+let pr_binders_gen ~flags pr_c sep is_open withquote =
+  if is_open then pr_delimited_binders ~flags pr_com_at sep withquote pr_c
+  else pr_undelimited_binders ~flags sep withquote pr_c
 
-let pr_recursive_decl pr pr_dangling lev_after kw dangling_with_for id bl annot t c =
+let pr_recursive_decl ~flags pr pr_dangling lev_after kw dangling_with_for id bl annot t c =
   let pr_body =
     if dangling_with_for then pr_dangling else pr in
   hov 0 (str kw ++ brk(1,2) ++ pr_id id ++ (if bl = [] then mt () else brk(1,2)) ++
-         hov 0 (pr_undelimited_binders spc true (pr no_after ltop) bl ++ annot) ++
+         hov 0 (pr_undelimited_binders ~flags spc true (pr no_after ltop) bl ++ annot) ++
          pr_opt_type_spc pr t ++ str " :=") ++
   pr_sep_com (fun () -> brk(1,2)) (pr_body lev_after ltop) c
 
@@ -527,12 +539,12 @@ let pr_guard_annot pr_aux bl ro =
       match id with None -> mt() | Some id -> brk (1,1) ++ pr_lident id ++
                                               (match r with None -> mt() | Some r -> str" on " ++ pr_aux r) ++ str"}"
 
-let pr_fixdecl pr prd lev_after kw dangling_with_for ({v=id},_,ro,bl,t,c) =
+let pr_fixdecl ~flags pr prd lev_after kw dangling_with_for ({v=id},_,ro,bl,t,c) =
   let annot = pr_guard_annot (pr no_after lsimpleconstr) bl ro in
-  pr_recursive_decl pr prd lev_after kw dangling_with_for id bl annot t c
+  pr_recursive_decl ~flags pr prd lev_after kw dangling_with_for id bl annot t c
 
-let pr_cofixdecl pr prd lev_after kw dangling_with_for ({v=id},_,bl,t,c) =
-  pr_recursive_decl pr prd lev_after kw dangling_with_for id bl (mt()) t c
+let pr_cofixdecl ~flags pr prd lev_after kw dangling_with_for ({v=id},_,bl,t,c) =
+  pr_recursive_decl ~flags pr prd lev_after kw dangling_with_for id bl (mt()) t c
 
 let pr_recursive lev_after kw pr_decl id = function
   | [] -> anomaly (Pp.str "(co)fixpoint with no definition.")
@@ -543,16 +555,16 @@ let pr_recursive lev_after kw pr_decl id = function
       (pr_decl no_after "with" true) dl ++
     fnl() ++ keyword "for" ++ spc () ++ pr_id id
 
-let pr_as_in pr na indnalopt =
+let pr_as_in ~flags pr na indnalopt =
   (match na with (* Decision of printing "_" or not moved to constrextern.ml *)
    | Some na -> spc () ++ keyword "as" ++ spc () ++  pr_lname na
    | None -> mt ()) ++
   (match indnalopt with
    | None -> mt ()
-   | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt pr no_after ltop t)
+   | Some t -> spc () ++ keyword "in" ++ spc () ++ pr_patt ~flags pr no_after ltop t)
 
-let pr_case_item pr (tm,as_clause, in_clause) =
-  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in (pr no_after ltop) as_clause in_clause)
+let pr_case_item ~flags pr (tm,as_clause, in_clause) =
+  hov 0 (pr no_after (LevelLe lcast) tm ++ pr_as_in ~flags (pr no_after ltop) as_clause in_clause)
 
 let pr_case_type pr po =
   match po with
@@ -645,7 +657,7 @@ let pr_genarg return arg =
   let pp = if String.is_empty name then parg else hov 2 (str name ++ str ":(" ++ parg ++ str ")") in
   return (fun _ -> pp) latom
 
-let pr pr sep lev_after inherited a =
+let pr ~flags pr sep lev_after inherited a =
   let return cmds prec =
     let no_surround = Notation.prec_less prec inherited in
     let lev_after = if no_surround then lev_after else no_after in
@@ -658,24 +670,24 @@ let pr pr sep lev_after inherited a =
   | CFix (id,fix) ->
     return (fun lev_after ->
         hv 0 (pr_recursive lev_after "fix"
-                (pr_fixdecl (pr mt) (pr_dangling_with_for mt pr)) id.v fix))
+                (pr_fixdecl ~flags (pr mt) (pr_dangling_with_for mt pr)) id.v fix))
       lfix
   | CCoFix (id,cofix) ->
     return (fun lev_after ->
         hv 0 (pr_recursive lev_after "cofix"
-                (pr_cofixdecl (pr mt) (pr_dangling_with_for mt pr)) id.v cofix))
+                (pr_cofixdecl ~flags (pr mt) (pr_dangling_with_for mt pr)) id.v cofix))
       lfix
   | CProdN (bl,a) ->
     return (fun lev_after ->
         hov 0 (
-          hov 2 (pr_delimited_binders pr_forall spc true
+          hov 2 (pr_delimited_binders ~flags pr_forall spc true
                    (pr mt no_after ltop) bl) ++
           str "," ++ pr spc lev_after ltop a))
       lprod
   | CLambdaN (bl,a) ->
     return (fun lev_after ->
         hov 0 (
-          hov 2 (pr_delimited_binders pr_fun spc true
+          hov 2 (pr_delimited_binders ~flags pr_fun spc true
                    (pr mt no_after ltop) bl) ++
           pr_fun_sep ++ pr spc lev_after ltop a))
       llambda
@@ -719,8 +731,8 @@ let pr pr sep lev_after inherited a =
     return (fun lev_after ->
         hv 0 (
           keyword "let" ++ spc () ++ str"'" ++
-          hov 0 (pr_patt (pr mt no_after ltop) no_after ltop p ++
-                 pr_as_in (pr mt no_after ltop) as_clause in_clause ++
+          hov 0 (pr_patt ~flags (pr mt no_after ltop) no_after ltop p ++
+                 pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause ++
                  str " :=" ++ pr spc no_after ltop c ++
                  pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
                  spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
@@ -731,10 +743,10 @@ let pr pr sep lev_after inherited a =
           (hv 0 (keyword "match" ++ brk (1,2) ++
                  hov 0 (
                    prlist_with_sep sep_v
-                     (pr_case_item (pr_dangling_with_for mt pr)) c
+                     (pr_case_item ~flags (pr_dangling_with_for mt pr)) c
                    ++ pr_case_type (pr_dangling_with_for mt pr) rtntypopt) ++
                  spc () ++ keyword "with") ++
-           prlist (pr_eqn (pr mt)) eqns ++ spc()
+           prlist (pr_eqn ~flags (pr mt)) eqns ++ spc()
            ++ keyword "end"))
       latom
   | CLetTuple (nal,(na,po),c,b) ->
@@ -784,7 +796,7 @@ let pr pr sep lev_after inherited a =
   | CNotation (which,s,env) ->
     let l_not = (find_notation_printing_rule which s).notation_printing_level in
     let l_not = if overlap_right_left which s lev_after then max_int else l_not in
-    return (fun lev_after -> pr_notation lev_after (pr mt) (pr_patt_binder (pr mt no_after ltop)) (pr_binders_gen (pr mt no_after ltop)) which s env) l_not
+    return (fun lev_after -> pr_notation ~flags lev_after (pr mt) (pr_patt_binder ~flags (pr mt no_after ltop)) (pr_binders_gen ~flags (pr mt no_after ltop)) which s env) l_not
   | CGeneralization (bk,c) ->
     return (fun lev_after -> pr_generalization bk (pr mt no_after ltop c)) latom
   | CPrim p ->
@@ -799,35 +811,39 @@ let pr pr sep lev_after inherited a =
                str " |]" ++ pr_universe_instance u)) 0
 
 type term_pr = {
-  pr_constr_expr   : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
-  pr_lconstr_expr  : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
-  pr_constr_pattern_expr  : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t;
-  pr_lconstr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
+  pr_constr_expr   : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
+  pr_lconstr_expr  : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
+  pr_constr_pattern_expr  : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t;
+  pr_lconstr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
 }
 
 let modular_constr_pr = pr
-let rec fix rf x = rf (fix rf) x
-let pr = fix modular_constr_pr mt
 
-let pr lev_after prec = function
+let rec pr ~flags sep lev_after inherited a : Pp.t =
+  modular_constr_pr ~flags (pr ~flags) sep lev_after inherited a
+
+let pr ~flags lev_after inherited a : Pp.t = pr ~flags mt lev_after inherited a
+
+let pr ~flags lev_after prec = function
   (* A toplevel printer hack mimicking parsing, incidentally meaning
      that we cannot use [pr] correctly anymore in a recursive loop
      if the current expr is followed by other exprs which would be
      interpreted as arguments *)
   | { CAst.v = CAppExpl ((f,us),[]) } -> str "@" ++ pr_cref f us
-  | c -> pr lev_after prec c
+  | c -> pr ~flags lev_after prec c
 
 let transf env sigma c =
   if !Flags.beautify_file then
     let r = Constrintern.intern_gen ~strict_check:false WithoutTypeConstraint env sigma c in
-    Constrextern.(extern_glob_constr (extern_env env sigma)) r
+    let eenv = Constrextern.extern_env env sigma ~flags:(PrintingFlags.Extern.current()) in
+    Constrextern.extern_glob_constr eenv r
   else c
 
-let pr_expr env sigma lev_after prec c =
-  pr lev_after prec (transf env sigma c)
+let pr_expr ~flags env sigma lev_after prec c =
+  pr ~flags lev_after prec (transf env sigma c)
 
-let pr_simpleconstr_env env sigma = pr_expr env sigma no_after lsimpleconstr
-let pr_top_env env sigma = pr_expr env sigma no_after ltop
+let pr_simpleconstr_env ~flags env sigma c = pr_expr ~flags env sigma no_after lsimpleconstr c
+let pr_top_env ~flags env sigma = pr_expr ~flags env sigma no_after ltop
 
 let default_term_pr = {
   pr_constr_expr   = pr_simpleconstr_env;
@@ -843,12 +859,12 @@ let set_term_pr = (:=) term_pr
 let pr_simpleconstr = pr no_after lsimpleconstr
 let pr_top = pr no_after ltop
 
-let pr_constr_expr_n n c = pr_expr n c no_after
-let pr_constr_expr c   = !term_pr.pr_constr_expr   c
-let pr_lconstr_expr c  = !term_pr.pr_lconstr_expr  c
-let pr_constr_pattern_expr c  = !term_pr.pr_constr_pattern_expr  c
-let pr_lconstr_pattern_expr c = !term_pr.pr_lconstr_pattern_expr c
+let pr_constr_expr_n ~flags env sigma n c : Pp.t = pr_expr ~flags env sigma no_after n c
+let pr_constr_expr ~flags env sigma c : Pp.t = !term_pr.pr_constr_expr ~flags env sigma c
+let pr_lconstr_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_expr ~flags env sigma c
+let pr_constr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_constr_pattern_expr ~flags env sigma c
+let pr_lconstr_pattern_expr ~flags env sigma c : Pp.t = !term_pr.pr_lconstr_pattern_expr ~flags env sigma c
 
-let pr_cases_pattern_expr = pr_patt (pr no_after ltop) no_after ltop
+let pr_cases_pattern_expr ~flags c : Pp.t = pr_patt ~flags (pr ~flags no_after ltop) no_after ltop c
 
-let pr_binders env sigma = pr_undelimited_binders spc true (pr_expr env sigma no_after ltop)
+let pr_binders ~flags env sigma l : Pp.t = pr_undelimited_binders ~flags spc true (pr_expr ~flags env sigma no_after ltop) l

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -93,7 +93,7 @@ let prec_of_prim_token = function
 
 let adjust_level side lev_after l_not prec =
   match side with
-  | Some _ when !Constrextern.print_parentheses -> no_after, LevelLe 0
+  | Some _ when !PrintingFlags.print_parentheses -> no_after, LevelLe 0
   | Some Right ->
     (if Notation.may_capture_cont_after lev_after prec then no_after else lev_after), prec
   | Some Left -> Some l_not, prec

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -16,6 +16,12 @@ open Libnames
 open Constrexpr
 open Names
 
+type flags = { parentheses : bool }
+
+val current_flags : unit -> flags
+val of_extern_flags : PrintingFlags.Extern.t -> flags
+val of_printing_flags : PrintingFlags.t -> flags
+
 val pr_tight_coma : unit -> Pp.t
 
 val pr_with_comments : ?loc:Loc.t -> Pp.t -> Pp.t
@@ -41,19 +47,19 @@ val pr_guard_annot
 
 val pr_record : string -> string -> ('a -> Pp.t) -> 'a list -> Pp.t
 val pr_record_body : string -> string -> ('a -> Pp.t) -> (Libnames.qualid * 'a) list -> Pp.t
-val pr_binders : Environ.env -> Evd.evar_map -> local_binder_expr list -> Pp.t
-val pr_constr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
-val pr_lconstr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
-val pr_constr_expr : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t
-val pr_lconstr_expr : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t
-val pr_cases_pattern_expr : cases_pattern_expr -> Pp.t
-val pr_constr_expr_n : Environ.env -> Evd.evar_map -> entry_relative_level -> constr_expr -> Pp.t
+val pr_binders : flags:flags -> Environ.env -> Evd.evar_map -> local_binder_expr list -> Pp.t
+val pr_constr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
+val pr_lconstr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
+val pr_constr_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t
+val pr_lconstr_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t
+val pr_cases_pattern_expr : flags:flags -> cases_pattern_expr -> Pp.t
+val pr_constr_expr_n : flags:flags -> Environ.env -> Evd.evar_map -> entry_relative_level -> constr_expr -> Pp.t
 
 type term_pr = {
-  pr_constr_expr : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
-  pr_lconstr_expr : Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
-  pr_constr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t;
-  pr_lconstr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
+  pr_constr_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
+  pr_lconstr_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_expr -> Pp.t;
+  pr_constr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t;
+  pr_lconstr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
 }
 
 val set_term_pr : term_pr -> unit
@@ -79,12 +85,13 @@ val ltop : entry_relative_level
 
 (* Print at level "simpleconstr"  (applications are surrounded with parentheses)
    ensured not to be overriden, on the contrary of pr_constr_expr *)
-val pr_simpleconstr : constr_expr -> Pp.t
+val pr_simpleconstr : flags:flags -> constr_expr -> Pp.t
 
 (* Print at level "top" (no parentheses)
    ensured not to be overriden, on the contrary of pr_lconstr_expr *)
-val pr_top : constr_expr -> Pp.t
+val pr_top : flags:flags -> constr_expr -> Pp.t
 
 val modular_constr_pr :
+  flags:flags ->
   ((unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t) ->
   (unit->Pp.t) -> int option -> entry_relative_level -> constr_expr -> Pp.t

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -247,13 +247,13 @@ let universe_binders_with_opt_names orig names =
   names
 
 let pr_universe_ctx_set sigma c =
-  if !Detyping.print_universes && not (Univ.ContextSet.is_empty c) then
+  if !PrintingFlags.print_universes && not (Univ.ContextSet.is_empty c) then
     fnl()++pr_in_comment (v 0 (Univ.ContextSet.pr (Termops.pr_evd_level sigma) c))
   else
     mt()
 
 let pr_universe_ctx sigma ?variance c =
-  if !Detyping.print_universes && not (UVars.UContext.is_empty c) then
+  if !PrintingFlags.print_universes && not (UVars.UContext.is_empty c) then
     fnl()++
     pr_in_comment
       (v 0
@@ -266,7 +266,7 @@ let pr_abstract_universe_ctx sigma ?variance ?priv c =
   let open Univ in
   let priv = Option.default Univ.ContextSet.empty priv in
   let has_priv = not (ContextSet.is_empty priv) in
-  if !Detyping.print_universes && (not (UVars.AbstractContext.is_empty c) || has_priv) then
+  if !PrintingFlags.print_universes && (not (UVars.AbstractContext.is_empty c) || has_priv) then
     let prqvar u = Termops.pr_evd_qvar sigma u in
     let prlev u = Termops.pr_evd_level sigma u in
     let pub = (if has_priv then str "Public universes:" ++ fnl() else mt()) ++ v 0 (UVars.pr_abstract_universe_context prqvar prlev ?variance c) in
@@ -303,7 +303,7 @@ let pr_universe_instance evd inst =
   str "@{" ++ UVars.Instance.pr prqvar prlev inst ++ str "}"
 
 let pr_puniverses f env sigma (c,u) =
-  if !Detyping.print_universes
+  if !PrintingFlags.print_universes
   then f env c ++ pr_universe_instance sigma u
   else f env c
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -48,6 +48,9 @@ let { Goptions.get = should_gname } =
 let print_goal_name sigma ev =
   should_gname () || Evd.evar_has_ident ev sigma
 
+let current_combined = PrintingFlags.current
+let current_extern = PrintingFlags.Extern.current
+
 (**********************************************************************)
 (** Terms                                                             *)
 
@@ -59,71 +62,100 @@ let print_goal_name sigma ev =
    and only names of goal/section variables and rel names that do
    _not_ occur in the scope of the binder to be printed are avoided. *)
 
-let pr_econstr_n_env ?inctx ?scope env sigma n t =
-  pr_constr_expr_n env sigma n (extern_constr ?inctx ?scope env sigma t)
-let pr_econstr_env ?inctx ?scope env sigma t =
-  pr_constr_expr env sigma (extern_constr ?inctx ?scope env sigma t)
-let pr_leconstr_env ?inctx ?scope env sigma t =
-  Ppconstr.pr_lconstr_expr env sigma (extern_constr ?inctx ?scope env sigma t)
+let pr_econstr_n_env ?inctx ?scope ?(flags=current_combined()) env sigma n t =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_constr_expr_n ~flags:ppflags env sigma n (extern_constr ?inctx ?scope ~flags env sigma t)
+let pr_econstr_env ?inctx ?scope ?(flags=current_combined()) env sigma t =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_constr_expr ~flags:ppflags env sigma (extern_constr ?inctx ?scope ~flags env sigma t)
+let pr_leconstr_env ?inctx ?scope ?(flags=current_combined()) env sigma t =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  Ppconstr.pr_lconstr_expr ~flags:ppflags env sigma (extern_constr ?inctx ?scope ~flags env sigma t)
 
-let pr_constr_n_env ?inctx ?scope env sigma n c =
-  pr_econstr_n_env ?inctx ?scope env sigma n (EConstr.of_constr c)
-let pr_constr_env ?inctx ?scope env sigma c =
-  pr_econstr_env ?inctx ?scope env sigma (EConstr.of_constr c)
-let pr_lconstr_env ?inctx ?scope env sigma c =
-  pr_leconstr_env ?inctx ?scope env sigma (EConstr.of_constr c)
+let pr_constr_n_env ?inctx ?scope ?flags env sigma n c =
+  pr_econstr_n_env ?inctx ?scope ?flags env sigma n (EConstr.of_constr c)
+let pr_constr_env ?inctx ?scope ?flags env sigma c =
+  pr_econstr_env ?inctx ?scope ?flags env sigma (EConstr.of_constr c)
+let pr_lconstr_env ?inctx ?scope ?flags env sigma c =
+  pr_leconstr_env ?inctx ?scope ?flags env sigma (EConstr.of_constr c)
 
-let pr_constr_under_binders_env_gen pr env sigma (ids,c) =
+let pr_constr_under_binders_env_gen pr ?flags env sigma (ids,c) =
   (* Warning: clashes can occur with variables of same name in env but *)
   (* we also need to preserve the actual names of the patterns *)
   (* So what to do? *)
   let assums = List.map (fun id -> (make_annot (Name id) Sorts.Relevant,(* dummy *) mkProp)) ids in
-  pr (Termops.push_rels_assum assums env) sigma c
+  pr ?inctx:None ?scope:None ?flags (Termops.push_rels_assum assums env) sigma c
 
 let pr_constr_under_binders_env = pr_constr_under_binders_env_gen pr_econstr_env
 let pr_lconstr_under_binders_env = pr_constr_under_binders_env_gen pr_leconstr_env
 
-let pr_etype_env ?goal_concl_style env sigma t =
-  pr_constr_expr env sigma (extern_type ?goal_concl_style env sigma t)
-let pr_letype_env ?goal_concl_style env sigma ?impargs t =
-  pr_lconstr_expr env sigma (extern_type ?goal_concl_style env sigma ?impargs t)
+let pr_etype_env ?goal_concl_style ?(flags=current_combined()) env sigma t =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_constr_expr ~flags:ppflags env sigma (extern_type ?goal_concl_style ~flags env sigma t)
+let pr_letype_env ?goal_concl_style ?(flags=current_combined()) env sigma ?impargs t =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_lconstr_expr ~flags:ppflags env sigma (extern_type ?goal_concl_style ~flags env sigma ?impargs t)
 
-let pr_type_env ?goal_concl_style env sigma c =
-  pr_etype_env ?goal_concl_style env sigma (EConstr.of_constr c)
-let pr_ltype_env ?goal_concl_style env sigma ?impargs c =
-  pr_letype_env ?goal_concl_style env sigma ?impargs (EConstr.of_constr c)
+let pr_type_env ?goal_concl_style ?flags env sigma c =
+  pr_etype_env ?goal_concl_style ?flags env sigma (EConstr.of_constr c)
+let pr_ltype_env ?goal_concl_style ?flags env sigma ?impargs c =
+  pr_letype_env ?goal_concl_style ?flags env sigma ?impargs (EConstr.of_constr c)
 
-let pr_ljudge_env env sigma j =
-  (pr_leconstr_env env sigma j.uj_val, pr_leconstr_env env sigma j.uj_type)
+let pr_ljudge_env ?flags env sigma j =
+  (pr_leconstr_env ?flags env sigma j.uj_val, pr_leconstr_env ?flags env sigma j.uj_type)
 
-let pr_lglob_constr_env env sigma c =
-  pr_lconstr_expr env sigma (extern_glob_constr (extern_env env sigma) c)
-let pr_glob_constr_env env sigma c =
-  pr_constr_expr env sigma (extern_glob_constr (extern_env env sigma) c)
+let pr_lglob_constr_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_lconstr_expr ~flags:ppflags env sigma
+    (extern_glob_constr (extern_env ~flags env sigma) c)
+let pr_glob_constr_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_constr_expr ~flags:ppflags env sigma
+    (extern_glob_constr (extern_env ~flags env sigma) c)
 
-let pr_closed_glob_n_env ?goal_concl_style ?inctx ?scope env sigma n c =
-  pr_constr_expr_n env sigma n (extern_closed_glob ?goal_concl_style ?inctx ?scope env sigma c)
-let pr_closed_glob_env ?goal_concl_style ?inctx ?scope env sigma c =
-  pr_constr_expr env sigma (extern_closed_glob ?goal_concl_style ?inctx ?scope env sigma c)
-let pr_closed_lglob_env ?goal_concl_style ?inctx ?scope env sigma c =
-  pr_lconstr_expr env sigma (extern_closed_glob ?goal_concl_style ?inctx ?scope env sigma c)
+let pr_closed_glob_n_env ?goal_concl_style ?inctx ?scope ?(flags=current_combined()) env sigma n c =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_constr_expr_n ~flags:ppflags env sigma n
+    (extern_closed_glob ?goal_concl_style ?inctx ?scope ~flags env sigma c)
+let pr_closed_glob_env ?goal_concl_style ?inctx ?scope ?(flags=current_combined()) env sigma c =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_constr_expr ~flags:ppflags env sigma
+    (extern_closed_glob ?goal_concl_style ?inctx ?scope ~flags env sigma c)
+let pr_closed_lglob_env ?goal_concl_style ?inctx ?scope ?(flags=current_combined()) env sigma c =
+  let ppflags = Ppconstr.of_printing_flags flags in
+  pr_lconstr_expr ~flags:ppflags env sigma
+    (extern_closed_glob ?goal_concl_style ?inctx ?scope ~flags env sigma c)
 
-let pr_lconstr_pattern_env env sigma c =
-  pr_lconstr_pattern_expr env sigma (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
-let pr_constr_pattern_env env sigma c =
-  pr_constr_pattern_expr env sigma (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
-let pr_uninstantiated_lconstr_pattern_env env sigma c =
-  pr_lconstr_pattern_expr env sigma (extern_uninstantiated_pattern (Termops.names_of_rel_context env) sigma c)
-let pr_uninstantiated_constr_pattern_env env sigma c =
-  pr_constr_pattern_expr env sigma (extern_uninstantiated_pattern (Termops.names_of_rel_context env) sigma c)
+let pr_lconstr_pattern_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_lconstr_pattern_expr ~flags:ppflags env sigma
+    (extern_constr_pattern ~flags (Termops.names_of_rel_context env) sigma c)
+let pr_constr_pattern_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_constr_pattern_expr ~flags:ppflags env sigma
+    (extern_constr_pattern ~flags (Termops.names_of_rel_context env) sigma c)
+let pr_uninstantiated_lconstr_pattern_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_lconstr_pattern_expr ~flags:ppflags env sigma
+    (extern_uninstantiated_pattern ~flags (Termops.names_of_rel_context env) sigma c)
+let pr_uninstantiated_constr_pattern_env ?(flags=current_extern()) env sigma c =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_constr_pattern_expr ~flags:ppflags env sigma
+    (extern_uninstantiated_pattern ~flags (Termops.names_of_rel_context env) sigma c)
 
-let pr_cases_pattern t =
-  pr_cases_pattern_expr (extern_cases_pattern Names.Id.Set.empty t)
+let pr_cases_pattern ?(flags=current_extern()) t =
+  let ppflags = Ppconstr.of_extern_flags flags in
+  pr_cases_pattern_expr ~flags:ppflags
+    (extern_cases_pattern ~flags Names.Id.Set.empty t)
 
-let pr_sort sigma s = pr_sort_expr (extern_sort sigma s)
+let pr_sort ?universes ?qualities sigma s =
+  let flags = PrintingFlags.Detype.current() in
+  let universes = Option.default flags.universes universes in
+  let qualities = Option.default flags.qualities qualities in
+  pr_sort_expr (extern_sort ~universes ~qualities sigma s)
 
 let () = Termops.Internal.set_print_constr
-  (fun env sigma t -> pr_lconstr_expr env sigma (extern_constr env sigma t))
+  (fun env sigma t -> pr_leconstr_env ~flags:(current_combined()) env sigma t)
 
 let pr_in_comment x = str "(* " ++ x ++ str " *)"
 
@@ -180,8 +212,8 @@ let safe_gen f env sigma c = match safe_extern_wrapper f env sigma c with
 | None -> str "??"
 | Some v -> v
 
-let safe_pr_lconstr_env = safe_gen pr_lconstr_env
-let safe_pr_constr_env = safe_gen pr_constr_env
+let safe_pr_lconstr_env ?flags = safe_gen (pr_lconstr_env ?flags)
+let safe_pr_constr_env ?flags = safe_gen (pr_constr_env ?flags)
 
 let q_ident = Id.of_string "α"
 
@@ -308,7 +340,7 @@ let pr_puniverses f env sigma (c,u) =
   else f env c
 
 let pr_existential_key = Termops.pr_existential_key
-let pr_existential env sigma ev = pr_lconstr_env env sigma (mkEvar ev)
+let pr_existential ?flags env sigma ev = pr_lconstr_env ?flags env sigma (mkEvar ev)
 
 let pr_constant env cst = Termops.pr_global_env env (GlobRef.ConstRef cst)
 let pr_inductive env ind = Termops.pr_global_env env (GlobRef.IndRef ind)
@@ -321,12 +353,10 @@ let pr_pconstructor = pr_puniverses pr_constructor
 let pr_evaluable_reference ref =
   pr_global (Tacred.global_of_evaluable_reference ref)
 
+(* XXX inline this in only caller in himsg? *)
 let pr_notation_interpretation_env env sigma c =
-  Constrextern.without_symbols (pr_glob_constr_env env sigma) c
-
-let pr_notation_interpretation c =
-  let env = Global.env () in
-  pr_notation_interpretation_env env (Evd.from_env env) c
+  let flags = { (PrintingFlags.Extern.current()) with notations = false } in
+  pr_glob_constr_env ~flags env sigma c
 
 (*let pr_glob_constr t =
   pr_lconstr (Constrextern.extern_glob_constr Id.Set.empty t)*)
@@ -345,52 +375,52 @@ let get_compact_context,set_compact_context =
   let compact_context = ref false in
   (fun () -> !compact_context),(fun b  -> compact_context := b)
 
-let pr_compacted_decl env sigma decl =
+let pr_compacted_decl ?flags env sigma decl =
   let ids, pbody, typ = match decl with
     | CompactedDecl.LocalAssum (ids, typ) ->
        ids, None, typ
     | CompactedDecl.LocalDef (ids,c,typ) ->
        (* Force evaluation *)
-       let pb = pr_lconstr_env ~inctx:true env sigma c in
+       let pb = pr_lconstr_env ?flags ~inctx:true env sigma c in
        let pb = if isCast c then surround pb else pb in
        ids, Some pb, typ in
   let pids =
     hov 0 (prlist_with_sep pr_comma (fun id -> pr_id id.binder_name) ids) in
-  let pt = pr_ltype_env env sigma typ in
+  let pt = pr_ltype_env ?flags env sigma typ in
   match pbody with
   | None -> hov 2 (pids ++ str" :" ++ spc () ++ pt)
   | Some pbody ->
      hov 2 (pids ++ str" :=" ++ spc () ++ pbody ++ spc () ++ str": " ++ pt)
 
-let pr_ecompacted_decl env sigma (decl:EConstr.compacted_declaration) =
+let pr_ecompacted_decl ?flags env sigma (decl:EConstr.compacted_declaration) =
   let Refl = EConstr.Unsafe.eq in
-  pr_compacted_decl env sigma decl
+  pr_compacted_decl ?flags env sigma decl
 
-let pr_named_decl env sigma decl =
-  decl |> CompactedDecl.of_named_decl |> pr_compacted_decl env sigma
+let pr_named_decl ?flags env sigma decl =
+  decl |> CompactedDecl.of_named_decl |> pr_compacted_decl ?flags env sigma
 
-let pr_enamed_decl env sigma (decl:EConstr.named_declaration) =
+let pr_enamed_decl ?flags env sigma (decl:EConstr.named_declaration) =
   let Refl = EConstr.Unsafe.eq in
-  pr_named_decl env sigma decl
+  pr_named_decl ?flags env sigma decl
 
-let pr_rel_decl env sigma decl =
+let pr_rel_decl ?flags env sigma decl =
   let na = RelDecl.get_name decl in
   let typ = RelDecl.get_type decl in
   let pbody = match decl with
     | RelDecl.LocalAssum _ -> mt ()
     | RelDecl.LocalDef (_,c,_) ->
         (* Force evaluation *)
-        let pb = pr_lconstr_env ~inctx:true env sigma c in
+        let pb = pr_lconstr_env ?flags ~inctx:true env sigma c in
         let pb = if isCast c then surround pb else pb in
         (str":=" ++ spc () ++ pb ++ spc ()) in
-  let ptyp = pr_ltype_env env sigma typ in
+  let ptyp = pr_ltype_env ?flags env sigma typ in
   match na with
   | Anonymous -> hov 2 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
   | Name id -> hov 2 (pr_id id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
 
-let pr_erel_decl env sigma (decl:EConstr.rel_declaration) =
+let pr_erel_decl ?flags env sigma (decl:EConstr.rel_declaration) =
   let Refl = EConstr.Unsafe.eq in
-  pr_rel_decl env sigma decl
+  pr_rel_decl ?flags env sigma decl
 
 
 
@@ -399,47 +429,48 @@ let pr_erel_decl env sigma (decl:EConstr.rel_declaration) =
  * It's printed out from outermost to innermost, so it's readable. *)
 
 (* Prints a signature, all declarations on the same line if possible *)
-let pr_named_context_of env sigma =
-  let make_decl_list env d pps = pr_named_decl env sigma d :: pps in
+let pr_named_context_of ?flags env sigma =
+  let make_decl_list env d pps = pr_named_decl ?flags env sigma d :: pps in
   let psl = List.rev (fold_named_context make_decl_list env ~init:[]) in
   hv 0 (prlist_with_sep (fun _ -> ws 2) (fun x -> x) psl)
 
-let pr_var_list_decl env sigma decl =
-  hov 0 (pr_ecompacted_decl env sigma decl)
+let pr_var_list_decl ?flags env sigma decl =
+  hov 0 (pr_ecompacted_decl ?flags env sigma decl)
 
-let pr_named_context env sigma ne_context =
+let pr_named_context ?flags env sigma ne_context =
   hv 0 (Context.Named.fold_outside
-          (fun d pps -> pps ++ ws 2 ++ pr_named_decl env sigma d)
+          (fun d pps -> pps ++ ws 2 ++ pr_named_decl ?flags env sigma d)
           ne_context ~init:(mt ()))
 
-let pr_rel_context env sigma rel_context =
+let pr_rel_context ?(flags=current_combined()) env sigma rel_context =
+  let ppflags = Ppconstr.of_printing_flags flags in
   let rel_context = EConstr.of_rel_context rel_context in
-  pr_binders env sigma (extern_rel_context env sigma rel_context)
+  pr_binders ~flags:ppflags env sigma (extern_rel_context ~flags env sigma rel_context)
 
-let pr_rel_context_of env sigma =
-  pr_rel_context env sigma (rel_context env)
+let pr_rel_context_of ?flags env sigma =
+  pr_rel_context ?flags env sigma (rel_context env)
 
 (* Prints an env (variables and de Bruijn). Separator: newline *)
-let pr_context_unlimited env sigma =
+let pr_context_unlimited ?flags env sigma =
   let sign_env =
     Context.Compacted.fold
       (fun d pps ->
-         let pidt =  pr_ecompacted_decl env sigma d in
+         let pidt =  pr_ecompacted_decl ?flags env sigma d in
          (pps ++ fnl () ++ pidt))
       (Termops.compact_named_context sigma (EConstr.named_context env)) ~init:(mt ())
   in
   let db_env =
     fold_rel_context
       (fun env d pps ->
-         let pnat = pr_rel_decl env sigma d in (pps ++ fnl () ++ pnat))
+         let pnat = pr_rel_decl ?flags env sigma d in (pps ++ fnl () ++ pnat))
       env ~init:(mt ())
   in
   (sign_env ++ db_env)
 
-let pr_ne_context_of header env sigma =
+let pr_ne_context_of header ?flags env sigma =
   if List.is_empty (Environ.rel_context env) &&
     List.is_empty (Environ.named_context env)  then (mt ())
-  else let penv = pr_context_unlimited env sigma in (header ++ penv ++ fnl ())
+  else let penv = pr_context_unlimited ?flags env sigma in (header ++ penv ++ fnl ())
 
 (* Heuristic for horizontalizing hypothesis that the user probably
    considers as "variables": An hypothesis H:T where T:S and S<>Prop. *)
@@ -452,30 +483,30 @@ let should_compact env sigma typ =
 (* If option Compact Contexts is set, we pack "simple" hypothesis in a
    hov box (with three sapaces as a separator), the global box being a
    v box *)
-let rec bld_sign_env env sigma ctxt pps =
+let rec bld_sign_env ?flags env sigma ctxt pps =
   match ctxt with
   | [] -> pps
   | CompactedDecl.LocalAssum (ids,typ)::ctxt' when should_compact env sigma typ ->
-    let pps',ctxt' = bld_sign_env_id env sigma ctxt (mt ()) true in
+    let pps',ctxt' = bld_sign_env_id ?flags env sigma ctxt (mt ()) true in
     (* putting simple hyps in a more horizontal flavor *)
-    bld_sign_env env sigma ctxt' (pps ++ brk (0,0) ++ hov 0 pps')
+    bld_sign_env ?flags env sigma ctxt' (pps ++ brk (0,0) ++ hov 0 pps')
   | d:: ctxt' ->
-    let pidt = pr_var_list_decl env sigma d in
+    let pidt = pr_var_list_decl ?flags env sigma d in
     let pps' = pps ++ brk (0,0) ++ pidt in
-    bld_sign_env env sigma ctxt' pps'
-and bld_sign_env_id env sigma ctxt pps is_start =
+    bld_sign_env ?flags env sigma ctxt' pps'
+and bld_sign_env_id ?flags env sigma ctxt pps is_start =
   match ctxt with
   | [] -> pps,ctxt
  | CompactedDecl.LocalAssum(ids,typ) as d :: ctxt' when should_compact env sigma typ ->
-    let pidt = pr_var_list_decl env sigma d in
+    let pidt = pr_var_list_decl ?flags env sigma d in
     let pps' = pps ++ (if not is_start then brk (3,0) else (mt ())) ++ pidt in
-    bld_sign_env_id env sigma ctxt' pps' false
+    bld_sign_env_id ?flags env sigma ctxt' pps' false
   | _ -> pps,ctxt
 
 
 (* compact printing an env (variables and de Bruijn). Separator: three
    spaces between simple hyps, and newline otherwise *)
-let pr_context_limit_compact ?n env sigma =
+let pr_context_limit_compact ?n ?flags env sigma =
   let ctxt = EConstr.named_context env in
   let ctxt = Termops.compact_named_context sigma ctxt in
   let lgth = List.length ctxt in
@@ -488,9 +519,9 @@ let pr_context_limit_compact ?n env sigma =
   (* a dot line hinting the number of hidden hyps. *)
   let hidden_dots = String.make (List.length ctxt_hidden) '.' in
   let sign_env = v 0 (str hidden_dots ++ (mt ())
-                 ++ bld_sign_env env sigma (List.rev ctxt_chopped) (mt ())) in
+                 ++ bld_sign_env ?flags env sigma (List.rev ctxt_chopped) (mt ())) in
   let db_env =
-    fold_rel_context (fun env d pps -> pps ++ fnl () ++ pr_rel_decl env sigma d)
+    fold_rel_context (fun env d pps -> pps ++ fnl () ++ pr_rel_decl ?flags env sigma d)
       env ~init:(mt ()) in
   sign_env ++ db_env
 
@@ -502,9 +533,9 @@ let { Goptions.get = print_hyps_limit } =
     ~value:None
     ()
 
-let pr_context_of env sigma = match print_hyps_limit () with
-  | None -> hv 0 (pr_context_limit_compact env sigma)
-  | Some n -> hv 0 (pr_context_limit_compact ~n env sigma)
+let pr_context_of ?flags env sigma = match print_hyps_limit () with
+  | None -> hv 0 (pr_context_limit_compact ?flags env sigma)
+  | Some n -> hv 0 (pr_context_limit_compact ~n ?flags env sigma)
 
 (* display goal parts (Proof mode) *)
 
@@ -545,11 +576,11 @@ let goal_repr sigma g =
  og_s has goal+sigma on the previous proof step for diffs
  g_s has goal+sigma on the current proof step
  *)
-let pr_goal ?(ogoal=None) sigma g =
+let pr_goal ?(flags=current_combined()) ?(ogoal=None) sigma g =
   let goal = match ogoal with
   | Some og_s ->
     let g = Proof_diffs.make_goal (Global.env ()) sigma g in
-    let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ?og_s g in
+    let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal ?og_s ~flags g in
     let hyp_list_to_pp hyps =
       match hyps with
       | h :: tl -> List.fold_left (fun x y -> x ++ cut () ++ y) h tl
@@ -561,9 +592,9 @@ let pr_goal ?(ogoal=None) sigma g =
       concl_pp)
   | None ->
     let env, concl = goal_repr sigma g in
-      pr_context_of env sigma ++ cut () ++
+      pr_context_of ~flags env sigma ++ cut () ++
         str "============================" ++ cut ()  ++
-        hov 0 (pr_letype_env ~goal_concl_style:true env sigma concl)
+        hov 0 (pr_letype_env ~goal_concl_style:true ~flags env sigma concl)
   in
   str "  " ++ v 0 goal
 
@@ -582,21 +613,21 @@ let pr_goal_header nme sigma g =
   ++ (if print_goal_name sigma g then str " " ++ Pp.surround (pr_existential_key (Global.env ()) sigma g) else mt ())
 
 (* display the conclusion of a goal *)
-let pr_concl n ?(ogoal=None) sigma g =
+let pr_concl ?(flags=current_combined()) n ?(ogoal=None) sigma g =
   let env, concl = goal_repr sigma g in
   let pc = match ogoal with
   | Some og_s ->
-      Proof_diffs.diff_concl ?og_s (Proof_diffs.make_goal env sigma g)
+      Proof_diffs.diff_concl ?og_s ~flags (Proof_diffs.make_goal env sigma g)
   | None ->
-      pr_letype_env ~goal_concl_style:true env sigma concl
+      pr_letype_env ~goal_concl_style:true ~flags env sigma concl
   in
   let header = pr_goal_header (int n) sigma g in
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
-let pr_evgl_sign env sigma (evi : undefined evar_info) =
+let pr_evgl_sign ?(flags=current_combined()) env sigma (evi : undefined evar_info) =
   let env = evar_env env evi in
-  let ps = pr_named_context_of env sigma in
+  let ps = pr_named_context_of ~flags env sigma in
   let _, l = match Filter.repr (evar_filter evi) with
   | None -> [], []
   | Some f -> List.filter2 (fun b c -> not b) f (evar_context evi)
@@ -607,13 +638,13 @@ let pr_evgl_sign env sigma (evi : undefined evar_info) =
       (str " (" ++ prlist_with_sep pr_comma pr_id ids ++ str " cannot be used)")
   in
   let concl = Evd.evar_concl evi in
-  let pc = pr_leconstr_env env sigma concl in
+  let pc = pr_leconstr_env ~flags env sigma concl in
   let candidates =
     begin match Evd.evar_candidates evi with
     | None -> mt ()
     | Some l ->
       spc () ++ str "= {" ++
-      prlist_with_sep (fun () -> str "|") (pr_leconstr_env env sigma) l ++ str "}"
+      prlist_with_sep (fun () -> str "|") (pr_leconstr_env ~flags env sigma) l ++ str "}"
     end
   in
   hov 0 (str"[" ++ ps ++ spc () ++ str"|- "  ++ pc ++ str"]" ++
@@ -621,9 +652,9 @@ let pr_evgl_sign env sigma (evi : undefined evar_info) =
 
 (* Print an existential variable *)
 
-let pr_evar sigma (evk, evi) =
+let pr_evar ?(flags=current_combined()) sigma (evk, evi) =
   let env = Global.env () in
-  let pegl = pr_evgl_sign env sigma evi in
+  let pegl = pr_evgl_sign ~flags env sigma evi in
   hov 2 (pr_existential_key env sigma evk ++ str " :" ++ spc () ++ pegl)
 
 (* Print an enumerated list of existential variables *)
@@ -633,7 +664,7 @@ let rec pr_evars_int_hd pr sigma i = function
       (hov 0 (pr i evk evi)) ++
       (match rest with [] -> mt () | _ -> fnl () ++ pr_evars_int_hd pr sigma (i+1) rest)
 
-let pr_evars_int sigma ~shelf ~given_up i evs =
+let pr_evars_int ?(flags=current_combined()) sigma ~shelf ~given_up i evs =
   let pr_status i =
     if List.mem i shelf then str " (shelved)"
     else if List.mem i given_up then str " (given up)"
@@ -641,21 +672,21 @@ let pr_evars_int sigma ~shelf ~given_up i evs =
   pr_evars_int_hd
     (fun i evk evi ->
       str "Existential " ++ int i ++ str " =" ++
-      spc () ++ pr_evar sigma (evk,evi) ++ pr_status evk)
+      spc () ++ pr_evar ~flags sigma (evk,evi) ++ pr_status evk)
     sigma i (Evar.Map.bindings evs)
 
-let pr_evars sigma evs =
-  pr_evars_int_hd (fun i evk evi -> pr_evar sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
+let pr_evars ?(flags=current_combined()) sigma evs =
+  pr_evars_int_hd (fun i evk evi -> pr_evar ~flags sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
 
 (* Display a list of evars given by their name, with a prefix *)
-let pr_ne_evar_set hd tl sigma l =
+let pr_ne_evar_set ?(flags=current_combined()) hd tl sigma l =
   if l != Evar.Set.empty then
     let l = Evar.Map.bind (fun ev ->
         let evi = Evd.find_undefined sigma ev in
         Evarutil.nf_evar_info sigma evi)
         l
     in
-    hd ++ pr_evars sigma l ++ tl
+    hd ++ pr_evars ~flags sigma l ++ tl
   else
     mt ()
 
@@ -678,19 +709,19 @@ let get_ogoal goal_map g =
   in
   Option.map (fun map -> get_ogs map g) goal_map
 
-let pr_selected_subgoal ?(ogoal=None) name sigma g =
-  let pg = pr_goal ~ogoal sigma g in
+let pr_selected_subgoal ?(flags=current_combined()) ?(ogoal=None) name sigma g =
+  let pg = pr_goal ~flags ~ogoal sigma g in
   let header = pr_goal_header name sigma g in
   v 0 (header ++ str " is:" ++ cut () ++ pg)
 
-let pr_subgoal oldp proof n sigma =
+let pr_subgoal ~flags oldp proof n sigma =
   let rec prrec p = function
     | [] -> user_err Pp.(str "No such goal.")
     | g::rest ->
         if Int.equal p 1 then
           let goal_map = get_goal_map oldp proof in
           let ogoal = get_ogoal goal_map g in
-          pr_selected_subgoal ~ogoal (int n) sigma g
+          pr_selected_subgoal ~flags ~ogoal (int n) sigma g
         else
           prrec (p-1) rest
   in
@@ -698,17 +729,17 @@ let pr_subgoal oldp proof n sigma =
 
 let pr_internal_existential_key ev = Evar.print ev
 
-let print_evar_constraints gl sigma =
+let print_evar_constraints ?(flags=current_combined()) gl sigma =
   let pr_env =
     match gl with
-    | None -> fun e' -> pr_context_of e' sigma
+    | None -> fun e' -> pr_context_of e' ~flags sigma
     | Some g ->
        let env, _ = goal_repr sigma g in fun e' ->
        begin
          if Context.Named.equal Sorts.relevance_equal Constr.equal (named_context env) (named_context e') then
            if Context.Rel.equal Sorts.relevance_equal Constr.equal (rel_context env) (rel_context e') then mt ()
-           else pr_rel_context_of e' sigma ++ str " |-" ++ spc ()
-         else pr_context_of e' sigma ++ str " |-" ++ spc ()
+           else pr_rel_context_of ~flags e' sigma ++ str " |-" ++ spc ()
+         else pr_context_of ~flags e' sigma ++ str " |-" ++ spc ()
        end
   in
   let pr_evconstr (pbty,env,t1,t2) =
@@ -723,15 +754,15 @@ let print_evar_constraints gl sigma =
          naming/renaming *)
       Namegen.make_all_name_different env sigma in
     str" " ++
-      hov 2 (pr_env env ++ pr_leconstr_env env sigma t1 ++ spc () ++
+      hov 2 (pr_env env ++ pr_leconstr_env ~flags env sigma t1 ++ spc () ++
              str (match pbty with
                   | Conversion.CONV -> "=="
                   | Conversion.CUMUL -> "<=") ++
-             spc () ++ pr_leconstr_env env sigma t2)
+             spc () ++ pr_leconstr_env ~flags env sigma t2)
   in
   let pr_candidate ev evi (candidates,acc) =
     if Option.has_some (Evd.evar_candidates evi) then
-      (succ candidates, acc ++ pr_evar sigma (ev,evi) ++ fnl ())
+      (succ candidates, acc ++ pr_evar ~flags sigma (ev,evi) ++ fnl ())
     else (candidates, acc)
   in
   let constraints =
@@ -877,7 +908,7 @@ let print_dependent_evars_entry gl sigma = function
    and printed in its entirety. *)
 (* [os_map] is derived from the previous proof step, used for diffs *)
 let pr_subgoals ?(pr_first=true) ?goalmap ?entry
-    sigma ~shelf ~stack ~unfocused ~goals =
+    ~flags sigma ~shelf ~stack ~unfocused ~goals =
 
   (* Printing functions for the extra informations. *)
   let rec print_stack a = function
@@ -916,14 +947,14 @@ let pr_subgoals ?(pr_first=true) ?goalmap ?entry
     | [] -> (mt ())
     | g::rest ->
       let ogoal = get_ogoal goalmap g in
-      let pc = pr_concl n ~ogoal sigma g in
+      let pc = pr_concl ~flags n ~ogoal sigma g in
         let prest = pr_rec (n+1) rest in
         (cut () ++ pc ++ prest)
   in
   let print_multiple_goals g l =
     if pr_first then
       let ogoal = get_ogoal goalmap g in
-      pr_goal ~ogoal sigma g
+      pr_goal ~flags ~ogoal sigma g
       ++ (if l=[] then mt () else cut ())
       ++ pr_rec 2 l
     else
@@ -931,7 +962,7 @@ let pr_subgoals ?(pr_first=true) ?goalmap ?entry
   in
   let pr_evar_info gl =
     let first_goal = if pr_first then gl else None in
-    print_evar_constraints gl sigma ++ print_dependent_evars_entry first_goal sigma entry
+    print_evar_constraints ~flags gl sigma ++ print_dependent_evars_entry first_goal sigma entry
   in
 
   (* Main function *)
@@ -941,7 +972,7 @@ let pr_subgoals ?(pr_first=true) ?goalmap ?entry
     if Evar.Map.is_empty exl then
       v 0 (str "No more goals." ++ pr_evar_info None)
     else
-      let pei = pr_evars_int sigma ~shelf ~given_up:[] 1 exl in
+      let pei = pr_evars_int ~flags sigma ~shelf ~given_up:[] 1 exl in
       v 0 ((str "No more goals,"
           ++ str " but there are non-instantiated existential variables:"
           ++ cut () ++ (hov 0 pei)
@@ -962,7 +993,7 @@ let pr_subgoals ?(pr_first=true) ?goalmap ?entry
         ++ pr_evar_info (Some g1)
       )
 
-let pr_open_subgoals ?(quiet=false) ?(oldp=None) proof =
+let pr_open_subgoals ?(quiet=false) ?(oldp=None) ?(flags=current_combined()) proof =
   (* spiwack: it shouldn't be the job of the printer to look up stuff
      in the [evar_map], I did stuff that way because it was more
      straightforward, but seriously, [Proof.proof] should return
@@ -975,16 +1006,16 @@ let pr_open_subgoals ?(quiet=false) ?(oldp=None) proof =
   begin match goals with
   | [] -> let bgoals = Proof.background_subgoals p in
           begin match bgoals,shelf,given_up with
-          | [] , [] , g when Evar.Set.is_empty g -> pr_subgoals sigma ~entry ~shelf ~stack ~unfocused:[] ~goals
+          | [] , [] , g when Evar.Set.is_empty g -> pr_subgoals ~flags sigma ~entry ~shelf ~stack ~unfocused:[] ~goals
           | [] , [] , _ ->
              Feedback.msg_info (str "No more goals, but there are some goals you gave up:");
              fnl ()
-            ++ pr_subgoals ~pr_first:false sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:(Evar.Set.elements given_up)
+            ++ pr_subgoals ~pr_first:false ~flags sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:(Evar.Set.elements given_up)
             ++ fnl () ++ str "You need to go back and solve them."
           | [] , _ , _ ->
             Feedback.msg_info (str "All the remaining goals are on the shelf.");
             fnl ()
-            ++ pr_subgoals ~pr_first:false sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:shelf
+            ++ pr_subgoals ~pr_first:false ~flags sigma ~entry ~shelf:[] ~stack:[] ~unfocused:[] ~goals:shelf
           | _ , _, _ ->
             let () =
               if quiet then ()
@@ -995,41 +1026,41 @@ let pr_open_subgoals ?(quiet=false) ?(oldp=None) proof =
                  if Pp.ismt s then s else fnl () ++ s) ++
                 fnl ())
             in
-            pr_subgoals ~pr_first:false sigma ~entry ~shelf ~stack:[] ~unfocused:[] ~goals:bgoals
+            pr_subgoals ~pr_first:false ~flags sigma ~entry ~shelf ~stack:[] ~unfocused:[] ~goals:bgoals
           end
   | _ ->
      let bgoals = Proof.background_subgoals p in
      let bgoals_focused, bgoals_unfocused = List.partition (fun x -> List.mem x goals) bgoals in
      let unfocused_if_needed = if should_unfoc() then bgoals_unfocused else [] in
      let goalmap = get_goal_map oldp proof in
-     pr_subgoals ~pr_first:true ?goalmap sigma ~entry ~shelf ~stack:[]
+     pr_subgoals ~flags ~pr_first:true ?goalmap sigma ~entry ~shelf ~stack:[]
         ~unfocused:unfocused_if_needed ~goals:bgoals_focused
   end
 
-let pr_nth_open_subgoal ?(oldp=None) ~proof n =
+let pr_nth_open_subgoal ?(flags=current_combined()) ?(oldp=None) ~proof n =
   let Proof.{goals;sigma} = Proof.data proof in
-  pr_subgoal oldp proof n sigma goals
+  pr_subgoal ~flags oldp proof n sigma goals
 
-let pr_goal_by_id ?(oldp=None) ~proof id =
+let pr_goal_by_id ?(flags=current_combined()) ?(oldp=None) ~proof id =
   try
     let { Proof.sigma } = Proof.data proof in
     let g = Evd.evar_key id sigma in
     let goal_map = get_goal_map oldp proof in
     let ogoal = get_ogoal goal_map g in
-    pr_selected_subgoal ~ogoal (pr_id id) sigma g
+    pr_selected_subgoal ~flags ~ogoal (pr_id id) sigma g
   with Not_found -> user_err Pp.(str "No such goal.")
 
 (** print a goal identified by the goal id as it appears in -emacs mode.
     sid should be the Stm state id corresponding to proof.  Used to support
     the Prooftree tool in Proof General. (https://askra.de/software/prooftree/).
 *)
-let pr_goal_emacs ~proof gid sid =
+let pr_goal_emacs ?(flags=current_combined()) ~proof gid sid =
   match proof with
   | None -> user_err Pp.(str "No proof for that state.")
   | Some proof ->
     let pr sigma gs =
       v 0 ((str "goal ID " ++ (int gid) ++ str " at state " ++ (int sid)) ++ cut ()
-          ++ pr_goal sigma gs)
+          ++ pr_goal ~flags sigma gs)
     in
     try
       let { Proof.sigma } = Proof.data proof in
@@ -1094,7 +1125,7 @@ end
 module ContextObjectSet = Set.Make (OrderedContextObject)
 module ContextObjectMap = Map.Make (OrderedContextObject)
 
-let pr_assumptionset env sigma s =
+let pr_assumptionset ?(flags=current_combined()) env sigma s =
   if ContextObjectMap.is_empty s &&
        not (rewrite_rules_allowed env) &&
        not (is_impredicative_set env) then
@@ -1120,12 +1151,12 @@ let pr_assumptionset env sigma s =
         MutInd.print kn
     in
     let safe_pr_ltype env sigma typ =
-      try str " :" ++ spc () ++ pr_ltype_env env sigma typ
+      try str " :" ++ spc () ++ pr_ltype_env ~flags env sigma typ
       with e when CErrors.noncritical e -> mt ()
     in
     let safe_pr_ltype_relctx (rctx, typ) =
       let env = Environ.push_rel_context rctx env in
-      try str " " ++ pr_ltype_env env sigma typ
+      try str " " ++ pr_ltype_env ~flags env sigma typ
       with e when CErrors.noncritical e -> mt ()
     in
     let pr_axiom env ax typ =
@@ -1145,7 +1176,7 @@ let pr_assumptionset env sigma s =
       let (v, a, o, tr) = accu in
       match t with
       | Variable id ->
-        let var = pr_id id ++ spc() ++ str ": " ++ pr_ltype_env env sigma typ in
+        let var = pr_id id ++ spc() ++ str ": " ++ pr_ltype_env ~flags env sigma typ in
         (var :: v, a, o, tr)
       | Axiom (axiom, []) ->
         let ax = pr_axiom env axiom typ in
@@ -1215,7 +1246,7 @@ let pr_typing_flags flags =
 module Debug =
 struct
 
-let pr_goal gl =
-  pr_goal (Proofview.Goal.sigma gl) (Proofview.Goal.goal gl)
+let pr_goal ?(flags=current_combined()) gl =
+  pr_goal ~flags (Proofview.Goal.sigma gl) (Proofview.Goal.goal gl)
 
 end

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -49,30 +49,38 @@ val print_goal_tag_opt_name : string list
 *)
 
 
-val pr_constr_env          : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> constr -> Pp.t
-val pr_lconstr_env         : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> constr -> Pp.t
+val pr_constr_env : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> constr -> Pp.t
+val pr_lconstr_env : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> constr -> Pp.t
 
-val pr_constr_n_env        : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> Constrexpr.entry_relative_level -> constr -> Pp.t
+val pr_constr_n_env        : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constrexpr.entry_relative_level -> constr -> Pp.t
 
 (** Same, but resilient to [Nametab] errors. Prints fully-qualified
     names when [shortest_qualid_of_global] has failed. Prints "??"
     in case of remaining issues (such as reference not in env). *)
 
-val safe_pr_constr_env  : env -> evar_map -> constr -> Pp.t
-val safe_pr_lconstr_env : env -> evar_map -> constr -> Pp.t
+val safe_pr_constr_env  : ?flags:PrintingFlags.t -> env -> evar_map -> constr -> Pp.t
+val safe_pr_lconstr_env : ?flags:PrintingFlags.t -> env -> evar_map -> constr -> Pp.t
 val safe_extern_wrapper : (env -> evar_map -> 'a -> 'b) -> env -> evar_map -> 'a -> 'b option
 
-val pr_econstr_env      : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> EConstr.t -> Pp.t
-val pr_leconstr_env     : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> EConstr.t -> Pp.t
+val pr_econstr_env : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.t -> Pp.t
+val pr_leconstr_env : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.t -> Pp.t
 
-val pr_econstr_n_env    : ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> Constrexpr.entry_relative_level -> EConstr.t -> Pp.t
+val pr_econstr_n_env : ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constrexpr.entry_relative_level -> EConstr.t -> Pp.t
 
-val pr_etype_env        : ?goal_concl_style:bool -> env -> evar_map -> EConstr.types -> Pp.t
-val pr_letype_env       : ?goal_concl_style:bool -> env -> evar_map -> ?impargs:Glob_term.binding_kind list -> EConstr.types -> Pp.t
+val pr_etype_env : ?goal_concl_style:bool -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.types -> Pp.t
+val pr_letype_env : ?goal_concl_style:bool -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> ?impargs:Glob_term.binding_kind list -> EConstr.types -> Pp.t
 
-val pr_constr_under_binders_env  : env -> evar_map -> constr_under_binders -> Pp.t
+val pr_constr_under_binders_env : ?flags:PrintingFlags.t -> env -> evar_map -> constr_under_binders -> Pp.t
 
-val pr_lconstr_under_binders_env : env -> evar_map -> constr_under_binders -> Pp.t
+val pr_lconstr_under_binders_env : ?flags:PrintingFlags.t -> env -> evar_map -> constr_under_binders -> Pp.t
 
 (** Printers for types. Types are printed in scope "type_scope" and
     under the constraint of being of type a sort.
@@ -95,30 +103,42 @@ val pr_lconstr_under_binders_env : env -> evar_map -> constr_under_binders -> Pp
     scope of the binder to be printed are avoided.
 *)
 
-val pr_ltype_env           : ?goal_concl_style:bool -> env -> evar_map -> ?impargs:Glob_term.binding_kind list -> types -> Pp.t
-val pr_type_env            : ?goal_concl_style:bool -> env -> evar_map -> types -> Pp.t
+val pr_ltype_env : ?goal_concl_style:bool -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> ?impargs:Glob_term.binding_kind list -> types -> Pp.t
+val pr_type_env : ?goal_concl_style:bool -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> types -> Pp.t
 
-val pr_closed_glob_n_env   : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> Constrexpr.entry_relative_level -> closed_glob_constr -> Pp.t
-val pr_closed_glob_env     : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> closed_glob_constr -> Pp.t
-val pr_closed_lglob_env    : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> env -> evar_map -> closed_glob_constr -> Pp.t
+val pr_closed_glob_n_env : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constrexpr.entry_relative_level -> closed_glob_constr -> Pp.t
+val pr_closed_glob_env : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> closed_glob_constr -> Pp.t
+val pr_closed_lglob_env : ?goal_concl_style:bool -> ?inctx:bool -> ?scope:scope_name -> ?flags:PrintingFlags.t ->
+  env -> evar_map -> closed_glob_constr -> Pp.t
 
-val pr_ljudge_env          : env -> evar_map -> EConstr.unsafe_judgment -> Pp.t * Pp.t
+val pr_ljudge_env : ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.unsafe_judgment -> Pp.t * Pp.t
 
-val pr_lglob_constr_env    : env -> evar_map -> 'a glob_constr_g -> Pp.t
+val pr_lglob_constr_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> 'a glob_constr_g -> Pp.t
 
-val pr_glob_constr_env     : env -> evar_map -> 'a glob_constr_g -> Pp.t
+val pr_glob_constr_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> 'a glob_constr_g -> Pp.t
 
-val pr_lconstr_pattern_env : env -> evar_map -> constr_pattern -> Pp.t
+val pr_lconstr_pattern_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> constr_pattern -> Pp.t
 
-val pr_constr_pattern_env  : env -> evar_map -> constr_pattern -> Pp.t
+val pr_constr_pattern_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> constr_pattern -> Pp.t
 
-val pr_uninstantiated_lconstr_pattern_env : env -> evar_map -> uninstantiated_pattern -> Pp.t
+val pr_uninstantiated_lconstr_pattern_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> uninstantiated_pattern -> Pp.t
 
-val pr_uninstantiated_constr_pattern_env  : env -> evar_map -> uninstantiated_pattern -> Pp.t
+val pr_uninstantiated_constr_pattern_env : ?flags:PrintingFlags.Extern.t ->
+  env -> evar_map -> uninstantiated_pattern -> Pp.t
 
-val pr_cases_pattern       : cases_pattern -> Pp.t
+val pr_cases_pattern : ?flags:PrintingFlags.Extern.t -> cases_pattern -> Pp.t
 
-val pr_sort                : evar_map -> Sorts.t -> Pp.t
+val pr_sort : ?universes:bool -> ?qualities:bool -> evar_map -> Sorts.t -> Pp.t
 
 (** Universe constraints *)
 
@@ -152,7 +172,7 @@ val pr_global              : GlobRef.t -> Pp.t
 
 val pr_constant            : env -> Constant.t -> Pp.t
 val pr_existential_key     : env -> evar_map -> Evar.t -> Pp.t
-val pr_existential         : env -> evar_map -> existential -> Pp.t
+val pr_existential : ?flags:PrintingFlags.t -> env -> evar_map -> existential -> Pp.t
 val pr_constructor         : env -> constructor -> Pp.t
 val pr_inductive           : env -> inductive -> Pp.t
 val pr_evaluable_reference : Evaluable.t -> Pp.t
@@ -162,7 +182,6 @@ val pr_pinductive : env -> evar_map -> pinductive -> Pp.t
 val pr_pconstructor : env -> evar_map -> pconstructor -> Pp.t
 
 val pr_notation_interpretation_env : env -> evar_map -> glob_constr -> Pp.t
-val pr_notation_interpretation : glob_constr -> Pp.t
 
 (** Contexts *)
 
@@ -170,22 +189,33 @@ val pr_notation_interpretation : glob_constr -> Pp.t
 val set_compact_context : bool -> unit
 val get_compact_context : unit -> bool
 
-val pr_context_unlimited   : env -> evar_map -> Pp.t
-val pr_ne_context_of       : Pp.t -> env -> evar_map -> Pp.t
+val pr_context_unlimited : ?flags:PrintingFlags.t -> env -> evar_map -> Pp.t
+val pr_ne_context_of : Pp.t -> ?flags:PrintingFlags.t -> env -> evar_map -> Pp.t
 
-val pr_named_decl          : env -> evar_map -> Constr.named_declaration -> Pp.t
-val pr_compacted_decl      : env -> evar_map -> Constr.compacted_declaration -> Pp.t
-val pr_rel_decl            : env -> evar_map -> Constr.rel_declaration -> Pp.t
+val pr_named_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constr.named_declaration -> Pp.t
+val pr_compacted_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constr.compacted_declaration -> Pp.t
+val pr_rel_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constr.rel_declaration -> Pp.t
 
-val pr_enamed_decl          : env -> evar_map -> EConstr.named_declaration -> Pp.t
-val pr_ecompacted_decl      : env -> evar_map -> EConstr.compacted_declaration -> Pp.t
-val pr_erel_decl            : env -> evar_map -> EConstr.rel_declaration -> Pp.t
+val pr_enamed_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.named_declaration -> Pp.t
+val pr_ecompacted_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.compacted_declaration -> Pp.t
+val pr_erel_decl : ?flags:PrintingFlags.t ->
+  env -> evar_map -> EConstr.rel_declaration -> Pp.t
 
-val pr_named_context       : env -> evar_map -> Constr.named_context -> Pp.t
-val pr_named_context_of    : env -> evar_map -> Pp.t
-val pr_rel_context         : env -> evar_map -> Constr.rel_context -> Pp.t
-val pr_rel_context_of      : env -> evar_map -> Pp.t
-val pr_context_of          : env -> evar_map -> Pp.t
+val pr_named_context : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constr.named_context -> Pp.t
+val pr_named_context_of : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Pp.t
+val pr_rel_context : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Constr.rel_context -> Pp.t
+val pr_rel_context_of : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Pp.t
+val pr_context_of : ?flags:PrintingFlags.t ->
+  env -> evar_map -> Pp.t
 
 (** Predicates *)
 
@@ -202,11 +232,16 @@ val pr_transparent_state   : TransparentState.t -> Pp.t
      conclusions.  If [oldp] is [Some oproof], highlight the differences between the old proof [oproof], and [proof].  [quiet]
      disables printing messages as Feedback.
 *)
-val pr_open_subgoals       : ?quiet:bool -> ?oldp:Proof.t option option -> Proof.t -> Pp.t
-val pr_nth_open_subgoal    : ?oldp:Proof.t option option -> proof:Proof.t -> int -> Pp.t
-val pr_evar                : evar_map -> (Evar.t * undefined evar_info) -> Pp.t
-val pr_evars_int           : evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> undefined evar_info Evar.Map.t -> Pp.t
-val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
+val pr_open_subgoals : ?quiet:bool -> ?oldp:Proof.t option option -> ?flags:PrintingFlags.t ->
+  Proof.t -> Pp.t
+val pr_nth_open_subgoal : ?flags:PrintingFlags.t ->
+  ?oldp:Proof.t option option -> proof:Proof.t -> int -> Pp.t
+val pr_evar : ?flags:PrintingFlags.t ->
+  evar_map -> (Evar.t * undefined evar_info) -> Pp.t
+val pr_evars_int : ?flags:PrintingFlags.t ->
+  evar_map -> shelf:Evar.t list -> given_up:Evar.t list -> int -> undefined evar_info Evar.Map.t -> Pp.t
+val pr_ne_evar_set : ?flags:PrintingFlags.t ->
+  Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)
@@ -227,10 +262,13 @@ module ContextObjectSet : CSet.ExtS with type elt = context_object
 module ContextObjectMap : CMap.ExtS
   with type key = context_object and module Set := ContextObjectSet
 
-val pr_assumptionset : env -> evar_map -> types ContextObjectMap.t -> Pp.t
+val pr_assumptionset : ?flags:PrintingFlags.t ->
+  env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
-val pr_goal_by_id : ?oldp:Proof.t option option -> proof:Proof.t -> Id.t -> Pp.t
-val pr_goal_emacs : proof:Proof.t option -> int -> int -> Pp.t
+val pr_goal_by_id : ?flags:PrintingFlags.t ->
+  ?oldp:Proof.t option option -> proof:Proof.t -> Id.t -> Pp.t
+val pr_goal_emacs : ?flags:PrintingFlags.t ->
+  proof:Proof.t option -> int -> int -> Pp.t
 
 val pr_typing_flags : Declarations.typing_flags -> Pp.t
 
@@ -241,7 +279,7 @@ val print_goal_name : evar_map -> Evar.t -> bool
 module Debug :
 sig
 
-val pr_goal : Proofview.Goal.t -> Pp.t
+val pr_goal : ?flags:PrintingFlags.t -> Proofview.Goal.t -> Pp.t
 
 end
 (** Debug printers *)

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -49,13 +49,13 @@ Subgoals XML command to fetch just the conclusion of a goal.  This is useful,
 for example, when an IDE only needs to display the number of admitted goals or
 preview the next unsolved goal.
 *)
-val diff_goal : ?short:bool -> ?og_s:goal -> goal -> Pp.t list * Pp.t
+val diff_goal : ?short:bool -> ?og_s:goal -> flags:PrintingFlags.t -> goal -> Pp.t list * Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
 
 (** Computes diffs for a single conclusion *)
-val diff_concl : ?og_s:goal -> goal -> Pp.t
+val diff_concl : ?og_s:goal -> flags:PrintingFlags.t -> goal -> Pp.t
 
 type goal_map
 
@@ -81,6 +81,6 @@ type hyp_info = {
 
 val diff_hyps : string list list -> hyp_info CString.Map.t -> string list list -> hyp_info CString.Map.t -> Pp.t list
 
-val diff_proofs : diff_opt:diffOpt -> ?old:Proof.t -> Proof.t -> Pp.t
+val diff_proofs : diff_opt:diffOpt -> ?old:Proof.t -> flags:PrintingFlags.t -> Proof.t -> Pp.t
 
 val notify_proof_diff_failure : string -> unit

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1242,7 +1242,7 @@ let resolve_all_evars depth unique env p oevd fail =
         str"fail = " ++ bool fail);
     ppdebug 2 (fun () ->
         str"Initial evar map: " ++
-        Termops.pr_evar_map ~with_univs:!Detyping.print_universes None env oevd)
+        Termops.pr_evar_map ~with_univs:!PrintingFlags.print_universes None env oevd)
   in
   let split = split_evars p env oevd in
   let in_comp comp ev = Evar.Set.mem ev comp in
@@ -1250,7 +1250,7 @@ let resolve_all_evars depth unique env p oevd fail =
     | [] ->
       let () = ppdebug 2 (fun () ->
           str"Final evar map: " ++
-          Termops.pr_evar_map ~with_univs:!Detyping.print_universes None env evd)
+          Termops.pr_evar_map ~with_univs:!PrintingFlags.print_universes None env evd)
       in
       evd
     | comp :: comps ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -765,7 +765,7 @@ let change_of_red_expr_val ?occs redexp =
 let reduce redexp cl =
   let trace env sigma =
     let open Printer in
-    let pr = ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e), pr_evaluable_reference, pr_constr_pattern_env, int, Redexpr.pr_glob_user_red_expr) in
+    let pr = ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e), pr_evaluable_reference, (fun e -> pr_constr_pattern_env e), int, Redexpr.pr_glob_user_red_expr) in
     Pp.(hov 2 (Ppred.pr_red_expr_env env sigma pr str redexp))
   in
   Proofview.Goal.enter begin fun gl ->

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -43,8 +43,8 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
   if copts.Coqcargs.output_context then begin
     let sigma, env = let e = Global.env () in Evd.from_env e, e in
     let access = Library.indirect_accessor[@@warning "-3"] in
-    Feedback.msg_notice Pp.(Flags.(with_option raw_print (fun () ->
-        Prettyp.print_full_pure_context access env sigma) ()) ++ fnl ())
+    Feedback.msg_notice Pp.(Flags.with_option PrintingFlags.raw_print (fun () ->
+        Prettyp.print_full_pure_context access env sigma) () ++ fnl ())
   end;
   ()
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -430,7 +430,7 @@ let show_proof_diff_cmd ~state diff_opt =
   | None -> CErrors.user_err (str "No proofs to diff.")
   | Some proof ->
       let old = Stm.get_prev_proof ~doc:state.doc state.sid in
-      Proof_diffs.diff_proofs ~diff_opt ?old proof
+      Proof_diffs.diff_proofs ~flags:(PrintingFlags.current()) ~diff_opt ?old proof
 
 let ml_toplevel_state = ref None
 let ml_toplevel_include_ran = ref false

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -840,7 +840,7 @@ let explain_differing_params kind (ind,p) (ind',p') =
     | (up,p) ->
       let env = Global.env() in
       let sigma = Evd.from_env env in
-      let pr_binders = Ppconstr.pr_binders env sigma in
+      let pr_binders = Ppconstr.pr_binders ~flags:(Ppconstr.current_flags()) env sigma in
       str "parameters" ++ spc() ++ hov 1 (quote (pr_binders up ++ pr_opt (fun p -> str "|" ++ spc() ++ pr_binders p) p))
   in
   v 0

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -128,9 +128,9 @@ let rec display_expr_eq c1 c2 =
   | _ ->
     Constrexpr_ops.constr_expr_eq_gen display_expr_eq c1 c2
 
-let safe_extern_constr env sigma t =
+let safe_extern_constr ~flags env sigma t =
   Printer.safe_extern_wrapper begin fun env sigma () ->
-    Constrextern.extern_constr env sigma t
+    Constrextern.extern_constr ~flags env sigma t
   end env sigma ()
 
 (** Tries to realize when the two terms, albeit different are printed the same. *)
@@ -138,8 +138,8 @@ let display_eq ~flags env sigma t1 t2 =
   (* terms are canonized, then their externalisation is compared syntactically *)
   let t1 = canonize_constr sigma t1 in
   let t2 = canonize_constr sigma t2 in
-  let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () in
-  let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () in
+  let ct1 = safe_extern_constr ~flags env sigma t1 in
+  let ct2 = safe_extern_constr ~flags env sigma t2 in
   match ct1, ct2 with
   | None, None -> false
   | Some _, None | None, Some _ -> false
@@ -157,22 +157,26 @@ let rec pr_explicit_aux env sigma t1 t2 = function
     (* The two terms are the same from the user point of view *)
     pr_explicit_aux env sigma t1 t2 rem
   else
-    let ct1 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t1) () in
-    let ct2 = Flags.with_options flags (fun () -> safe_extern_constr env sigma t2) () in
+    let ct1 = safe_extern_constr ~flags env sigma t1 in
+    let ct2 = safe_extern_constr ~flags env sigma t2 in
     let pr = function
     | None -> str "??"
-    | Some c -> Ppconstr.pr_lconstr_expr env sigma c
+    | Some c -> Ppconstr.pr_lconstr_expr ~flags:(Ppconstr.of_printing_flags flags) env sigma c
     in
     pr ct1, pr ct2
 
-let explicit_flags =
+let explicit_flags () =
   let open PrintingFlags in
-  [ []; (* First, try with the current flags *)
-    [print_implicits]; (* Then with implicit *)
-    [print_universes]; (* Then with universes *)
-    [print_universes; print_implicits]; (* With universes AND implicits *)
-    [print_implicits; print_coercions; print_no_symbol]; (* Then more! *)
-    [print_universes; print_implicits; print_coercions; print_no_symbol] (* and more! *) ]
+  let with_implicits flags = { flags with extern = { flags.extern with implicits = true } } in
+  let with_universes flags = { flags with detype = { flags.detype with universes = true } } in
+  let with_coe_nosymb flags = { flags with extern = { flags.extern with coercions = true; notations = false } } in
+  let flags = PrintingFlags.current() in
+  [ flags; (* First, try with the current flags *)
+    with_implicits flags; (* Then with implicit *)
+    with_universes flags; (* Then with universes *)
+    with_universes @@ with_implicits flags; (* With universes AND implicits *)
+    with_implicits @@ with_coe_nosymb flags; (* Then more! *)
+    with_universes @@ with_implicits @@ with_coe_nosymb flags (* and more! *) ]
 
 let with_diffs pm pn =
   if not (Proof_diffs.show_diffs ()) then pm, pn else
@@ -187,7 +191,7 @@ let with_diffs pm pn =
     pm, pn
 
 let pr_explicit env sigma t1 t2 =
-  let p1, p2 = pr_explicit_aux env sigma t1 t2 explicit_flags in
+  let p1, p2 = pr_explicit_aux env sigma t1 t2 (explicit_flags()) in
   let p1, p2 = with_diffs p1 p2 in
   quote p1, quote p2
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -167,7 +167,7 @@ let rec pr_explicit_aux env sigma t1 t2 = function
 
 let explicit_flags =
   let open Constrextern in
-  let open Detyping in
+  let open PrintingFlags in
   [ []; (* First, try with the current flags *)
     [print_implicits]; (* Then with implicit *)
     [print_universes]; (* Then with universes *)
@@ -241,7 +241,7 @@ let explain_elim_arity env sigma ind c okinds =
     | None | Some AlwaysSquashed -> pp ()
     | Some (SometimesSquashed _) ->
       (* universe instance matters, so print it regardless of Printing Universes *)
-      Flags.with_option Detyping.print_universes pp ()
+      Flags.with_option PrintingFlags.print_universes pp ()
   in
   let pc = Option.map (pr_leconstr_env env sigma) c in
   let msg = match okinds with
@@ -249,7 +249,7 @@ let explain_elim_arity env sigma ind c okinds =
     | Some sp ->
       let ppt ?(ppunivs=false) () =
         let pp () = pr_leconstr_env env sigma (mkSort (ESorts.make sp)) in
-        if ppunivs then Flags.with_option Detyping.print_universes pp ()
+        if ppunivs then Flags.with_option PrintingFlags.print_universes pp ()
         else pp ()
       in
       let env = Environ.set_qualities (Evd.elim_graph sigma) env in
@@ -561,7 +561,7 @@ let explain_ill_formed_fix_body env sigma names i = function
           | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
      str "Recursive call to " ++ called ++ str " has not enough arguments"
   | FixpointOnNonEliminable (s, s') ->
-  let pr_sort u = quote @@ Flags.with_option Detyping.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = quote @@ Flags.with_option PrintingFlags.print_universes (Printer.pr_sort sigma) u in
     fmt "Cannot define a fixpoint@ with principal argument living in sort %t@ \
          to produce a value in sort %t@ because %t does not eliminate to %t"
       (fun () -> pr_sort s)
@@ -1527,7 +1527,7 @@ let error_large_non_prop_inductive_not_in_type () =
 
 let error_inductive_missing_constraints env (us,ind_univ) =
   let sigma = Evd.from_env env in
-  let pr_sort u = Flags.with_option Detyping.print_universes (Printer.pr_sort sigma) u in
+  let pr_sort u = Flags.with_option PrintingFlags.print_universes (Printer.pr_sort sigma) u in
   str "Missing universe constraint declared for inductive type:" ++ spc()
   ++ v 0 (prlist_with_sep spc (fun u ->
       hov 0 (pr_sort u ++ str " <= " ++ pr_sort ind_univ))

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -166,7 +166,6 @@ let rec pr_explicit_aux env sigma t1 t2 = function
     pr ct1, pr ct2
 
 let explicit_flags =
-  let open Constrextern in
   let open PrintingFlags in
   [ []; (* First, try with the current flags *)
     [print_implicits]; (* Then with implicit *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -2102,7 +2102,10 @@ let add_abbreviation ~local user_warns env ident (vars,c) modl =
 let cache_notation_toggle (local,(on,all,pat)) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  toggle_notations ~on ~all ~verbose:(not !Flags.quiet) (Constrextern.without_symbols (Printer.pr_glob_constr_env env sigma)) pat
+  let flags = PrintingFlags.Extern.current() in
+  let flags = { flags with notations = false } in
+  let prglob c = Printer.pr_glob_constr_env ~flags env sigma c in
+  toggle_notations ~on ~all ~verbose:(not !Flags.quiet) prglob pat
 
 let subst_notation_toggle (subst,(local,(on,all,pat))) =
   let {notation_entry_pattern; interp_rule_key_pattern; use_pattern;

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -36,11 +36,15 @@ let pr_in_global_env f c : Pp.t =
   let sigma = Evd.from_env env in
   f env sigma c
 
+let pr_in_global_env_with_ppflags f c : Pp.t =
+  let flags = Ppconstr.current_flags () in
+  pr_in_global_env (f ~flags) c
+
 (* when not !Flags.beautify_file these just ignore the env/sigma *)
-let pr_constr_expr = pr_in_global_env pr_constr_expr
-let pr_lconstr_expr = pr_in_global_env pr_lconstr_expr
-let pr_binders = pr_in_global_env pr_binders
-let pr_constr_pattern_expr = pr_in_global_env pr_constr_pattern_expr
+let pr_constr_expr = pr_in_global_env_with_ppflags pr_constr_expr
+let pr_lconstr_expr = pr_in_global_env_with_ppflags pr_lconstr_expr
+let pr_binders = pr_in_global_env_with_ppflags pr_binders
+let pr_constr_pattern_expr = pr_in_global_env_with_ppflags pr_constr_pattern_expr
 let pr_user_red_expr = pr_in_global_env Redexpr.pr_raw_user_red_expr
 
 (* In principle this may use the env/sigma, in practice not sure if it

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -226,7 +226,7 @@ let print_polymorphism env ref =
       (if poly then str "universe polymorphic"
        else if template_poly then
          str "template universe polymorphic"
-         ++ if !Detyping.print_universes then h (pr_template_variables env ref) else mt()
+         ++ if !PrintingFlags.print_universes then h (pr_template_variables env ref) else mt()
        else str "not universe polymorphic") ]
 
 let print_squash env ref udecl = match ref with

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -127,7 +127,7 @@ let print_one_inductive env sigma mib ((_,i) as ind) =
   let cstrtypes = Array.map (fun c -> snd (Term.decompose_prod_n_decls nparamdecls c)) cstrtypes in
   let isrecord = match mip.mind_record with
     | NotRecord -> None
-    | FakeRecord -> if !Flags.raw_print then None else Some Anonymous
+    | FakeRecord -> if !PrintingFlags.raw_print then None else Some Anonymous
     | PrimRecord (id,_,_,_) -> Some (Name id)
   in
   if Option.has_some isrecord then assert (Array.length cstrtypes = 1);
@@ -156,7 +156,7 @@ let pr_mutual_inductive_body env mind mib udecl =
     | BiFinite ->
        match mib.mind_packets.(0).mind_record with
        | NotRecord -> "Variant"
-       | FakeRecord -> if !Flags.raw_print then "Variant" else "Record"
+       | FakeRecord -> if !PrintingFlags.raw_print then "Variant" else "Record"
        | PrimRecord l -> "Record"
   in
   let udecl = Option.map (fun x -> GlobRef.IndRef (mind,0), x) udecl in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2000,14 +2000,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"All"];
-      optread  = (fun () -> !Flags.raw_print);
-      optwrite = (fun b -> Flags.raw_print := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Kernel"; "Term"; "Sharing"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.share_reduction);
       optwrite = Global.set_share_reduction }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Notations"];
-      optread  = (fun () -> not !Constrextern.print_no_symbol);
-      optwrite = (fun b ->  Constrextern.print_no_symbol := not b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Raw";"Literals"];
       optread  = (fun () -> !Constrextern.print_raw_literal);
       optwrite = (fun b ->  Constrextern.print_raw_literal := b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Implicit"];
-      optread  = (fun () -> !Constrextern.print_implicits);
-      optwrite = (fun b ->  Constrextern.print_implicits := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Implicit";"Defensive"];
       optread  = (fun () -> !Constrextern.print_implicits_defensive);
       optwrite = (fun b ->  Constrextern.print_implicits_defensive := b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Parentheses"];
-      optread  = (fun () -> !Constrextern.print_parentheses);
-      optwrite = (fun b ->  Constrextern.print_parentheses := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Implicit"];
       optread  = (fun () -> !Constrextern.print_implicits);
       optwrite = (fun b ->  Constrextern.print_implicits := b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Raw";"Literals"];
-      optread  = (fun () -> !Constrextern.print_raw_literal);
-      optwrite = (fun b ->  Constrextern.print_raw_literal := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Kernel"; "Term"; "Sharing"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.share_reduction);
       optwrite = Global.set_share_reduction }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Implicit";"Defensive"];
-      optread  = (fun () -> !Constrextern.print_implicits_defensive);
-      optwrite = (fun b ->  Constrextern.print_implicits_defensive := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Projections"];
       optread  = (fun () -> !Constrextern.print_projections);
       optwrite = (fun b ->  Constrextern.print_projections := b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Projections"];
-      optread  = (fun () -> !Constrextern.print_projections);
-      optwrite = (fun b ->  Constrextern.print_projections := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Notations"];
       optread  = (fun () -> not !Constrextern.print_no_symbol);
       optwrite = (fun b ->  Constrextern.print_no_symbol := not b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1944,14 +1944,6 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
-      optkey   = ["Printing";"Coercions"];
-      optread  = (fun () -> !Constrextern.print_coercions);
-      optwrite = (fun b ->  Constrextern.print_coercions := b) }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
       optkey   = ["Printing";"Parentheses"];
       optread  = (fun () -> !Constrextern.print_parentheses);
       optwrite = (fun b ->  Constrextern.print_parentheses := b) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1864,7 +1864,7 @@ let vernac_reserve bl =
     let env = Global.env() in
     let sigma = Evd.from_env env in
     let t,ctx = Constrintern.interp_type env sigma c in
-    let t = Flags.without_option Detyping.print_universes (fun () ->
+    let t = Flags.without_option PrintingFlags.print_universes (fun () ->
         Detyping.detype Detyping.Now env (Evd.from_ctx ctx) t)
         ()
     in
@@ -2027,14 +2027,6 @@ let () =
       optkey   = ["Printing";"Width"];
       optread  = Topfmt.get_margin;
       optwrite = Topfmt.set_margin }
-
-let () =
-  declare_bool_option
-    { optstage = Summary.Stage.Interp;
-      optdepr  = None;
-      optkey   = ["Printing";"Universes"];
-      optread  = (fun () -> !Detyping.print_universes);
-      optwrite = (fun b -> Detyping.print_universes:=b) }
 
 let () =
   (* no summary: handled as part of the debug state *)


### PR DESCRIPTION
This PR starts with some cleanup commits which have been opened as separate PRs. Then the various printing options are gathered into new file pretyping/PrintingFlags.ml, moving 1 flag per commit. 
The last commit is the biggest and passes the flags functionally in detyping, extern and ppconstr. Direct calls to these functions must provide the flags explicitly (the flags can be gotten from PrintingFlags).
The functions in Printer take flags as optional arguments (defaulting to the current flags according to the global state).

Depends:
- https://github.com/rocq-prover/rocq/pull/21277
- https://github.com/rocq-prover/rocq/pull/21275
- https://github.com/rocq-prover/rocq/pull/21270
- https://github.com/rocq-prover/rocq/pull/21269
- https://github.com/rocq-prover/rocq/pull/21268

Overlays:
- https://github.com/Lysxia/coq-simple-io/pull/85
- https://github.com/uds-psl/autosubst-ocaml/pull/32
- https://github.com/ejgallego/rocq-lsp/pull/1064
- https://github.com/lukaszcz/coqhammer/pull/210
- https://github.com/LPCIC/coq-elpi/pull/929
- https://github.com/mattam82/Coq-Equations/pull/669
- https://github.com/smtcoq/smtcoq/pull/157
- https://github.com/coq-tactician/coq-tactician/pull/118
- https://github.com/rocq-prover/vsrocq/pull/1178
- https://github.com/impermeable/coq-waterproof/pull/216
- https://github.com/QuickChick/QuickChick/pull/419