### PR TITLE
Actually save _build_ci on master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,7 +199,7 @@ before_script:
     - for target in $CI_TARGETS; do dev/ci/ci-wrapper.sh "$target"; done
     - touch ci-success
   after_script:
-    - if { [ "$SAVE_BUILD_CI" ] || [ "$CI_BRANCH" = master ] || ! [ -e ci-success ]; } && [ -d _build_ci ]; then mv _build_ci saved_build_ci; fi
+    - if { [ "$SAVE_BUILD_CI" ] || [ "$CI_COMMIT_REF_NAME" = master ] || ! [ -e ci-success ]; } && [ -d _build_ci ]; then mv _build_ci saved_build_ci; fi
     - dev/tools/list-potential-artifacts.sh > available_artifacts.txt
     - dev/tools/cleanup-artifacts.sh downloaded_artifacts.txt available_artifacts.txt
   artifacts:


### PR DESCRIPTION
CI_BRANCH is the variable name we use in our scripts, it's not available in after_script

