### PR TITLE
Delimiter args to Ltac2 constr synclass may be qualified with "delimiters"

### DIFF
--- a/doc/changelog/06-Ltac2-language/21285-constr-delims-Deprecated.rst
+++ b/doc/changelog/06-Ltac2-language/21285-constr-delims-Deprecated.rst
@@ -1,0 +1,8 @@
+- **Deprecated:**
+  syntactic classes parsing terms (`constr`, `lconstr`, etc.)
+  taking more than one :n:`@scope_key` argument without qualifying it with `delimiters`
+  (e.g. `constr(type, function)` should be `constr(delimiters(type, function))`
+  but a single argument like `constr(type)` is not deprecated).
+  See :n:`@ltac2_constr_synclass_arg`
+  (`#21285 <https://github.com/rocq-prover/rocq/pull/21285>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -1492,28 +1492,41 @@ Metasyntactic operations that can be applied to other syntactic classes are:
 The following classes represent nonterminals with some special handling.  The
 table further down lists the classes that are handled plainly.
 
-  :n:`constr {? ( {+, @scope_key } ) }`
-    Parses a :token:`term`.  If specified, the :token:`scope_key`\s are used to interpret
-    the term (as described in  :ref:`LocalInterpretationRulesForNotations`).  The last
-    :token:`scope_key` is the top of the scope stack that's applied to the :token:`term`.
+.. insertprodn ltac2_constr_synclass_arg ltac2_constr_synclass_arg
 
-  :n:`lconstr {? ( {+, @scope_key } ) }`
+.. prodn::
+   ltac2_constr_synclass_arg ::= @scope_key
+   | delimiters ( {+, @scope_key } )
+
+Syntactic classes parsing terms may specify :token:`scope_key`\s which
+are used to interpret the term (as described in :ref:`LocalInterpretationRulesForNotations`).
+The last :token:`scope_key` is the top of the scope stack that's applied to the
+:token:`term`.
+When more than one :n:`@scope_key` is specified, it should be qualified using `delimiters`.
+
+  :n:`constr {? ( {+, @ltac2_constr_synclass_arg } ) }`
+    Parses a :token:`term`.
+    Typechecking the term runs typeclass resolution, after which no
+    new undefined existential variables may exist.
+
+  :n:`lconstr {? ( {+, @ltac2_constr_synclass_arg } ) }`
      Identical to `constr` but the term is parsed at precedence level 200.
 
-  :n:`open_constr {? ( {+, @scope_key } ) }`
-    Parses an open :token:`term`. Like :n:`constr` above, this class
-    accepts a list of notation scopes with the same effects.
+  :n:`open_constr {? ( {+, @ltac2_constr_synclass_arg } ) }`
+    Parses an open :token:`term`.
+    Typechecking the term may create new undefined existential variables,
+    and does not run typeclass resolution.
 
-  :n:`open_lconstr {? ( {+, @scope_key } ) }`
+  :n:`open_lconstr {? ( {+, @ltac2_constr_synclass_arg } ) }`
      Identical to `open_constr` but the term is parsed at precedence level 200.
 
 .. _preterm:
 
-  :n:`preterm {? ( {+, @scope_key } ) }`
+  :n:`preterm {? ( {+, @ltac2_constr_synclass_arg } ) }`
     Parses a non-typechecked :token:`term`. Like :n:`constr` above, this class
     accepts a list of notation scopes with the same effects.
 
-  :n:`lpreterm {? ( {+, @scope_key } ) }`
+  :n:`lpreterm {? ( {+, @ltac2_constr_synclass_arg } ) }`
      Identical to `preterm` but the term is parsed at precedence level 200.
 
   :n:`ident`

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2127,6 +2127,11 @@ ltac2_induction_clause: [
 | WITH ltac2_destruction_arg ltac2_as_or_and_ipat ltac2_eqn_ipat OPT ltac2_clause  TAG Ltac2
 ]
 
+ltac2_constr_synclass_arg: [
+| scope_key
+| "delimiters" "(" LIST1 scope_key SEP "," ")"
+]
+
 starredidentref: [
 | EDIT identref ADD_OPT "*"
 | EDIT "Type" ADD_OPT "*"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1793,6 +1793,11 @@ ltac2_in_clause: [
 | LIST0 ltac2_hypident_occ SEP "," OPT ( "|-" OPT ltac2_concl_occ )      (* Ltac2 plugin *)
 ]
 
+ltac2_constr_synclass_arg: [
+| scope_key
+| "delimiters" "(" LIST1 scope_key SEP "," ")"
+]
+
 q_occurrences: [
 | OPT ltac2_occs      (* ltac2 plugin *)
 ]


### PR DESCRIPTION

and deprecate having more than 1 arg without using qualification

in preparation for having multiple argument kinds in https://github.com/rocq-prover/rocq/pull/21215
