### PR TITLE
Make the Genredexpr.red_expr_gen type open-ended.

### DIFF
--- a/dev/ci/user-overlays/21287-ppedrot-genredexpr-open-api.sh
+++ b/dev/ci/user-overlays/21287-ppedrot-genredexpr-open-api.sh
@@ -1,0 +1,5 @@
+overlay coq_lsp https://github.com/ppedrot/coq-lsp genredexpr-open-api 21287
+
+overlay elpi https://github.com/ppedrot/coq-elpi genredexpr-open-api 21287
+
+overlay tactician https://github.com/ppedrot/coq-tactician genredexpr-open-api 21287

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -73,11 +73,11 @@ let subst_strategy sub = map_strategy
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
 let pr_raw_strategy env sigma prc prlc _ (s : Tacexpr.raw_strategy) =
-  let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc,Pputils.pr_or_var Pp.int) in
+  let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc,Pputils.pr_or_var Pp.int, Redexpr.pr_raw_user_red_expr) in
   Rewrite.pr_strategy (prc env sigma) prr Pputils.pr_lident s
 let pr_glob_strategy env sigma prc prlc _ (s : Tacexpr.glob_strategy) =
   let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
-  let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prc, Pputils.pr_or_var Pp.int) in
+  let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prc, Pputils.pr_or_var Pp.int, Redexpr.pr_glob_user_red_expr) in
   Rewrite.pr_strategy (prc env sigma) prr Id.print s
 
 }

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -20,7 +20,7 @@ val open_constr : constr_expr Entry.t
 val constr_with_bindings : constr_expr with_bindings Entry.t
 val bindings : constr_expr bindings Entry.t
 val hypident : (Names.lident * Locus.hyp_location_flag) Entry.t
-val constr_eval : (constr_expr,qualid or_by_notation,constr_expr,int Locus.or_var) may_eval Entry.t
+val constr_eval : (constr_expr,qualid or_by_notation,constr_expr,int Locus.or_var, Genarg.rlevel Redexpr.user_red_expr) may_eval Entry.t
 val uconstr : constr_expr Entry.t
 val quantified_hypothesis : quantified_hypothesis Entry.t
 val destruction_arg : constr_expr with_bindings Tactics.destruction_arg Entry.t

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -97,13 +97,15 @@ val pr_red_expr : env -> Evd.evar_map ->
   (env -> Evd.evar_map -> 'a -> Pp.t) *
   ('b -> Pp.t) *
   (env -> Evd.evar_map -> 'c -> Pp.t) *
-  ('occvar -> Pp.t) ->
-  ('a,'b,'c,'occvar) Genredexpr.red_expr_gen -> Pp.t
+  ('occvar -> Pp.t) *
+  (env -> Evd.evar_map -> 'usr -> Pp.t) ->
+  ('a,'b,'c,'occvar,'usr) Genredexpr.red_expr_gen -> Pp.t
 val pr_may_eval :
   env -> Evd.evar_map ->
   (env -> Evd.evar_map -> 'a -> Pp.t) -> (env -> Evd.evar_map -> 'a -> Pp.t) -> ('b -> Pp.t) ->
   (env -> Evd.evar_map -> 'c -> Pp.t) -> ('occvar -> Pp.t) ->
-  ('a,'b,'c,'occvar) may_eval -> Pp.t
+  (env -> Evd.evar_map -> 'usr -> Pp.t) ->
+  ('a,'b,'c,'occvar,'usr) may_eval -> Pp.t
 
 val pr_and_short_name : ('a -> Pp.t) -> 'a Genredexpr.and_short_name -> Pp.t
 

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -122,7 +122,7 @@ type 'a gen_atomic_tactic_expr =
       rec_flag * evars_flag * ('trm,'dtrm,'nam) induction_clause_list
 
   (* Conversion *)
-  | TacReduce of ('trm,'cst,'rpat,'occvar) red_expr_gen * 'nam clause_expr
+  | TacReduce of ('trm,'cst,'rpat,'occvar, 'lev Redexpr.user_red_expr) red_expr_gen * 'nam clause_expr
   | TacChange of check_flag * 'rpat option * 'dtrm * 'nam clause_expr
 
   (* Equality and inversion *)
@@ -152,15 +152,15 @@ constraint 'a = <
 
 (** Possible arguments of a tactic definition *)
 
-type ('a,'b,'c,'occvar) may_eval =
+type ('a,'b,'c,'occvar,'usr) may_eval =
   | ConstrTerm of 'a
-  | ConstrEval of ('a,'b,'c,'occvar) red_expr_gen * 'a
+  | ConstrEval of ('a,'b,'c,'occvar, 'usr) red_expr_gen * 'a
   | ConstrContext of Names.lident * 'a
   | ConstrTypeOf of 'a
 
 type 'a gen_tactic_arg =
   | TacGeneric     of string option * 'lev generic_argument
-  | ConstrMayEval  of ('trm,'cst,'rpat, 'occvar) may_eval
+  | ConstrMayEval  of ('trm,'cst,'rpat, 'occvar, 'lev Redexpr.user_red_expr) may_eval
   | Reference      of 'ref
   | TacCall    of ('ref * 'a gen_tactic_arg list) CAst.t
   | TacFreshId of string or_var list
@@ -378,8 +378,8 @@ type atomic_tactic_expr =
 
 (** Misc *)
 
-type raw_strategy = (constr_expr, Genredexpr.raw_red_expr, lident) Rewrite.strategy_ast
-type glob_strategy = (Genintern.glob_constr_and_expr, Genredexpr.glob_red_expr, Id.t) Rewrite.strategy_ast
+type raw_strategy = (constr_expr, Redexpr.raw_red_expr, lident) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, Redexpr.glob_red_expr, Id.t) Rewrite.strategy_ast
 
 (** Traces *)
 

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -58,6 +58,6 @@ val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 
 (** Reduction expressions *)
 
-val intern_red_expr : glob_sign -> Genredexpr.raw_red_expr -> Genredexpr.glob_red_expr
+val intern_red_expr : glob_sign -> Redexpr.raw_red_expr -> Redexpr.glob_red_expr
 
 val intern_strategy : glob_sign -> raw_strategy -> glob_strategy

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -77,7 +77,7 @@ val val_interp : interp_sign -> glob_tactic_expr -> (value -> unit Proofview.tac
 val interp_ltac_constr : interp_sign -> glob_tactic_expr -> (constr -> unit Proofview.tactic) -> unit Proofview.tactic
 
 (** Interprets redexp arguments *)
-val interp_red_expr : interp_sign -> Environ.env -> Evd.evar_map -> Genredexpr.glob_red_expr -> Evd.evar_map * red_expr
+val interp_red_expr : interp_sign -> Environ.env -> Evd.evar_map -> Redexpr.glob_red_expr -> Evd.evar_map * red_expr
 
 val interp_strategy : interp_sign -> Environ.env -> Evd.evar_map -> glob_strategy -> Rewrite.strategy
 

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -103,6 +103,7 @@ let subst_glob_red_expr subst =
     (subst_glob_constr subst)
     (subst_evaluable subst)
     (subst_glob_constr subst)
+    (Redexpr.subst_user_red_expr subst)
 
 let subst_raw_may_eval subst = function
   | ConstrEval (r,c) -> ConstrEval (subst_glob_red_expr subst r,subst_glob_constr subst c)

--- a/plugins/ltac/tacsubst.mli
+++ b/plugins/ltac/tacsubst.mli
@@ -32,4 +32,4 @@ val subst_glob_with_bindings : substitution ->
   glob_constr_and_expr with_bindings ->
   glob_constr_and_expr with_bindings
 
-val subst_glob_red_expr : substitution -> Genredexpr.glob_red_expr -> Genredexpr.glob_red_expr
+val subst_glob_red_expr : substitution -> Redexpr.glob_red_expr -> Redexpr.glob_red_expr

--- a/tactics/genredexpr.mli
+++ b/tactics/genredexpr.mli
@@ -42,7 +42,7 @@ type 'a glob_red_flag = {
 
 type ('b,'c,'occvar) red_context = ('occvar Locus.occurrences_gen * ('b,'c) Util.union) option
 
-type ('a, 'b, 'c, 'occvar, 'flags) red_expr_gen0 =
+type ('a, 'b, 'c, 'occvar, 'flags, 'usr) red_expr_gen0 =
   | Red
   | Hnf
   | Simpl of 'flags * ('b, 'c, 'occvar) red_context
@@ -55,9 +55,10 @@ type ('a, 'b, 'c, 'occvar, 'flags) red_expr_gen0 =
   | ExtraRedExpr of string
   | CbvVm of ('b, 'c, 'occvar) red_context
   | CbvNative of ('b, 'c, 'occvar) red_context
+  | UserRed of 'usr
 
-type ('a, 'b, 'c, 'occvar) red_expr_gen =
-  ('a, 'b, 'c, 'occvar, 'b glob_red_flag) red_expr_gen0
+type ('a, 'b, 'c, 'occvar, 'usr) red_expr_gen =
+  ('a, 'b, 'c, 'occvar, 'b glob_red_flag, 'usr) red_expr_gen0
 
 open Constrexpr
 
@@ -65,7 +66,7 @@ type r_trm = constr_expr
 type r_pat = constr_pattern_expr
 type r_cst = Libnames.qualid or_by_notation
 
-type raw_red_expr = (r_trm, r_cst, r_pat, int Locus.or_var) red_expr_gen
+type 'usr raw_red_expr = (r_trm, r_cst, r_pat, int Locus.or_var, 'usr) red_expr_gen
 
 type 'a and_short_name = 'a * Names.lident option
 
@@ -73,4 +74,4 @@ type g_trm = Genintern.glob_constr_and_expr
 type g_pat = Genintern.glob_constr_pattern_and_expr
 type g_cst = Evaluable.t and_short_name Locus.or_var
 
-type glob_red_expr = (g_trm, g_cst, g_trm, int Locus.or_var) red_expr_gen
+type 'usr glob_red_expr = (g_trm, g_cst, g_trm, int Locus.or_var, 'usr) red_expr_gen

--- a/tactics/ppred.ml
+++ b/tactics/ppred.ml
@@ -47,7 +47,7 @@ let pr_union pr1 pr2 = function
   | Inl a -> pr1 a
   | Inr b -> pr2 b
 
-let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern,prvar) keyword = function
+let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern,prvar,pruser) keyword = function
   | Red -> keyword "red"
   | Hnf -> keyword "hnf"
   | Simpl (f,o) -> keyword "simpl" ++ (pr_short_red_flag pr_ref f)
@@ -76,6 +76,7 @@ let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern,prvar) keyword = functio
     keyword "vm_compute" ++ pr_opt (pr_with_occurrences prvar (pr_union pr_ref pr_pattern) keyword) o
   | CbvNative o ->
     keyword "native_compute" ++ pr_opt (pr_with_occurrences prvar (pr_union pr_ref pr_pattern) keyword) o
+  | UserRed usr -> pruser usr
 
-let pr_red_expr_env env sigma (pr_constr,pr_lconstr,pr_ref,pr_pattern,prvar) =
-  pr_red_expr (pr_constr env sigma, pr_lconstr env sigma, pr_ref, pr_pattern env sigma,prvar)
+let pr_red_expr_env env sigma (pr_constr,pr_lconstr,pr_ref,pr_pattern,prvar,pruser) =
+  pr_red_expr (pr_constr env sigma, pr_lconstr env sigma, pr_ref, pr_pattern env sigma, prvar,pruser env sigma)

--- a/tactics/ppred.mli
+++ b/tactics/ppred.mli
@@ -6,9 +6,9 @@ val pr_with_occurrences :
 val pr_short_red_flag : ('a -> Pp.t) -> 'a glob_red_flag -> Pp.t
 val pr_red_flag : ('a -> Pp.t) -> 'a glob_red_flag -> Pp.t
 
-val pr_red_expr : ('a -> Pp.t) * ('a -> Pp.t) * ('b -> Pp.t) * ('c -> Pp.t) * ('v -> Pp.t)
+val pr_red_expr : ('a -> Pp.t) * ('a -> Pp.t) * ('b -> Pp.t) * ('c -> Pp.t) * ('v -> Pp.t) * ('usr -> Pp.t)
   -> (string -> Pp.t) ->
-  ('a,'b,'c,'v) red_expr_gen -> Pp.t
+  ('a,'b,'c,'v,'usr) red_expr_gen -> Pp.t
 
 (** Compared to [pr_red_expr], this immediately applied the tuple
    elements to the extra arguments. *)
@@ -17,6 +17,7 @@ val pr_red_expr_env : 'env -> 'sigma ->
   ('env -> 'sigma -> 'a -> Pp.t) *
   ('b -> Pp.t) *
   ('env -> 'sigma -> 'c -> Pp.t) *
-  ('v -> Pp.t) ->
+  ('v -> Pp.t) *
+  ('env -> 'sigma -> 'usr -> Pp.t) ->
   (string -> Pp.t) ->
-  ('a,'b,'c,'v) red_expr_gen -> Pp.t
+  ('a,'b,'c,'v,'usr) red_expr_gen -> Pp.t

--- a/tactics/redexpr.mli
+++ b/tactics/redexpr.mli
@@ -17,7 +17,17 @@ open Genredexpr
 open Reductionops
 open Locus
 
-type red_expr = (constr, Evaluable.t, constr_pattern, int) red_expr_gen
+(** User-defined reductions *)
+type 'l user_red_expr
+
+val subst_user_red_expr : Genarg.glevel user_red_expr Gensubst.subst_fun
+val eval_user_red_expr : Genarg.glevel user_red_expr -> e_reduction_function * cast_kind
+val pr_raw_user_red_expr : Environ.env -> Evd.evar_map -> Genarg.rlevel user_red_expr -> Pp.t
+val pr_glob_user_red_expr : Environ.env -> Evd.evar_map -> Genarg.glevel user_red_expr -> Pp.t
+
+type raw_red_expr = Genarg.rlevel user_red_expr Genredexpr.raw_red_expr
+type glob_red_expr = Genarg.glevel user_red_expr Genredexpr.glob_red_expr
+type red_expr = (constr, Evaluable.t, constr_pattern, int, Genarg.glevel user_red_expr) red_expr_gen
 
 type red_expr_val
 
@@ -75,7 +85,7 @@ module Intern : sig
     pattern_of_glob : Glob_term.glob_constr -> 'pat;
   }
 
-  val intern_red_expr : ('a,'b,'c) intern_env -> raw_red_expr -> ('a,'b,'c, int Locus.or_var) red_expr_gen
+  val intern_red_expr : ('a,'b,'c) intern_env -> raw_red_expr -> ('a,'b,'c, int Locus.or_var, Genarg.glevel user_red_expr) red_expr_gen
 
   val from_env : Environ.env -> (Glob_term.glob_constr, Evaluable.t, Glob_term.glob_constr) intern_env
 
@@ -84,21 +94,44 @@ end
 module Interp : sig
   open Names
 
-  type ('constr,'evref,'pat) interp_env = {
+  type ('constr,'evref,'pat,'usr) interp_env = {
     interp_occurrence_var : lident -> int list;
     interp_constr : Environ.env -> Evd.evar_map -> 'constr -> Evd.evar_map * EConstr.constr;
     interp_constr_list : Environ.env -> Evd.evar_map -> 'constr -> Evd.evar_map * EConstr.constr list;
     interp_evaluable : Environ.env -> Evd.evar_map -> 'evref -> Evaluable.t;
     interp_pattern : Environ.env -> Evd.evar_map -> 'pat -> constr_pattern;
     interp_evaluable_or_pattern : Environ.env -> Evd.evar_map
-      -> 'evref -> (Evaluable.t, constr_pattern) Util.union
+      -> 'evref -> (Evaluable.t, constr_pattern) Util.union;
   }
 
-  val interp_red_expr : ('constr,'evref,'pat) interp_env -> Environ.env -> Evd.evar_map
-    -> ('constr,'evref,'pat, int Locus.or_var) red_expr_gen -> Evd.evar_map * red_expr
+  val interp_red_expr : ('constr,'evref,'pat,'usr) interp_env -> Environ.env -> Evd.evar_map
+    -> ('constr,'evref,'pat, int Locus.or_var, Genarg.glevel user_red_expr) red_expr_gen -> Evd.evar_map * red_expr
 
-  val without_ltac : (Glob_term.glob_constr, Evaluable.t, Glob_term.glob_constr) interp_env
+  val without_ltac : (Glob_term.glob_constr, Evaluable.t, Glob_term.glob_constr, 'usr) interp_env
 
 end
 
 val interp_redexp_no_ltac : Environ.env -> Evd.evar_map -> raw_red_expr -> Evd.evar_map * red_expr
+
+module User :
+sig
+
+type ('raw, 'glb) user_red_spec = {
+  ured_intern : Constrintern.ltac_sign -> 'raw -> 'glb;
+  ured_subst : Mod_subst.substitution -> 'glb -> 'glb;
+  ured_eval : 'glb -> e_reduction_function * cast_kind;
+  ured_rprint : Environ.env -> Evd.evar_map -> 'raw -> Pp.t;
+  ured_gprint : Environ.env -> Evd.evar_map -> 'glb -> Pp.t;
+}
+
+type ('raw, 'glb) user_red
+(** User-defined reductions are indexed by the kind of payload they contain at
+    both raw and glob levels. *)
+
+val create : string -> ('raw, 'glb) user_red_spec -> ('raw, 'glb) user_red
+(** Create a new user-defined reduction. *)
+
+val make : ('raw, 'glb) user_red -> 'raw -> Genarg.rlevel user_red_expr
+(** Inject the required data into a user reduction expression. *)
+
+end

--- a/tactics/redops.ml
+++ b/tactics/redops.ml
@@ -55,7 +55,7 @@ let map_flags f flags =
 
 let map_occs f (occ,e) = (occ,f e)
 
-let map_red_expr_gen f g h = function
+let map_red_expr_gen f g h i = function
   | Fold l -> Fold (List.map f l)
   | Pattern occs_l -> Pattern (List.map (map_occs f) occs_l)
   | Simpl (flags,occs_o) ->
@@ -67,3 +67,4 @@ let map_red_expr_gen f g h = function
   | CbvNative occs_o -> CbvNative (Option.map (map_occs (Util.map_union g h)) occs_o)
   | Cbn flags -> Cbn (map_flags g flags)
   | ExtraRedExpr _ | Red | Hnf as x -> x
+  | UserRed usr -> UserRed (i usr)

--- a/tactics/redops.mli
+++ b/tactics/redops.mli
@@ -16,5 +16,5 @@ val all_flags : 'a glob_red_flag
 
 (** Mapping [red_expr_gen] *)
 
-val map_red_expr_gen : ('a -> 'd) -> ('b -> 'e) -> ('c -> 'f) ->
-  ('a,'b,'c,'occvar) red_expr_gen -> ('d,'e,'f,'occvar) red_expr_gen
+val map_red_expr_gen : ('a1 -> 'a2) -> ('b1 -> 'b2) -> ('c1 -> 'c2) -> ('d1 -> 'd2) ->
+  ('a1, 'b1, 'c1, 'occvar, 'd1) red_expr_gen -> ('a2, 'b2, 'c2, 'occvar, 'd2) red_expr_gen

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -765,7 +765,7 @@ let change_of_red_expr_val ?occs redexp =
 let reduce redexp cl =
   let trace env sigma =
     let open Printer in
-    let pr = ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e), pr_evaluable_reference, pr_constr_pattern_env, int) in
+    let pr = ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e), pr_evaluable_reference, pr_constr_pattern_env, int, Redexpr.pr_glob_user_red_expr) in
     Pp.(hov 2 (Ppred.pr_red_expr_env env sigma pr str redexp))
   in
   Proofview.Goal.enter begin fun gl ->
@@ -782,6 +782,7 @@ let reduce redexp cl =
     if is_local_unfold env flags then LocalHypConv else StableHypConv
   | Red | Hnf | CbvVm _ | CbvNative _ -> StableHypConv
   | ExtraRedExpr _ -> StableHypConv (* Should we be that lenient ?*)
+  | UserRed _ -> AnyHypConv (* TODO: ask it in the API *)
   in
   let redexp = Redexpr.eval_red_expr env redexp in
   Proofview.Trace.name_tactic (fun () -> trace env sigma) begin

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -41,6 +41,7 @@ let pr_constr_expr = pr_in_global_env pr_constr_expr
 let pr_lconstr_expr = pr_in_global_env pr_lconstr_expr
 let pr_binders = pr_in_global_env pr_binders
 let pr_constr_pattern_expr = pr_in_global_env pr_constr_pattern_expr
+let pr_user_red_expr = pr_in_global_env Redexpr.pr_raw_user_red_expr
 
 (* In principle this may use the env/sigma, in practice not sure if it
    does except through pr_constr_expr in beautify mode. *)
@@ -56,7 +57,7 @@ let pr_spc_lconstr =
 
 let pr_red_expr =
   Ppred.pr_red_expr
-    (pr_constr_expr, pr_lconstr_expr, pr_smart_global, pr_constr_expr, pr_or_var int)
+    (pr_constr_expr, pr_lconstr_expr, pr_smart_global, pr_constr_expr, pr_or_var int, pr_user_red_expr)
     keyword
 
 let pr_uconstraint (l, d, r) =

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 open Procq
-open Genredexpr
+open Redexpr
 open Vernacexpr
 
 type proof_mode

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -11,7 +11,7 @@
 val check_may_eval :
   Environ.env ->
   Evd.evar_map ->
-  Genredexpr.raw_red_expr option ->
+  Redexpr.raw_red_expr option ->
   Constrexpr.constr_expr ->
   Pp.t
 

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -152,7 +152,7 @@ type option_setting =
 
 type definition_expr =
   | ProveBody of local_binder_expr list * constr_expr
-  | DefineBody of local_binder_expr list * Genredexpr.raw_red_expr option * constr_expr
+  | DefineBody of local_binder_expr list * Redexpr.raw_red_expr option * constr_expr
       * constr_expr option
 
 type notation_format =
@@ -481,9 +481,9 @@ type nonrec synpure_vernac_expr =
       (Conv_oracle.level * qualid or_by_notation list) list
   | VernacMemOption of Goptions.option_name * Goptions.table_value list
   | VernacPrintOption of Goptions.option_name
-  | VernacCheckMayEval of Genredexpr.raw_red_expr option * Goal_select.t option * constr_expr
+  | VernacCheckMayEval of Redexpr.raw_red_expr option * Goal_select.t option * constr_expr
   | VernacGlobalCheck of constr_expr
-  | VernacDeclareReduction of string * Genredexpr.raw_red_expr
+  | VernacDeclareReduction of string * Redexpr.raw_red_expr
   | VernacPrint of printable
   | VernacSearch of searchable * Goal_select.t option * qualid list search_restriction
   | VernacLocate of locatable


### PR DESCRIPTION
This makes it possible for plugins to extend the user-facing reductions with arbitrary code.

Fixes #20979: Reductions in plugin.

Overlays:
- https://github.com/ejgallego/rocq-lsp/pull/1060
- https://github.com/coq-tactician/coq-tactician/pull/117
- https://github.com/LPCIC/coq-elpi/pull/927