### PR TITLE
Print evars instead of metas in Clenv unification failures

### DIFF
--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -77,6 +77,10 @@ val case_pf : ?with_evars:bool ->
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv
 
+val replace_clenv_metas : env -> evar_map -> clausenv -> evar_map * (EConstr.constr -> EConstr.constr)
+
+exception ClenvCannotUnify of env * evar_map * clausenv * econstr * econstr * Pretype_errors.unification_error option
+
 (** {6 Pretty-print (debug only) } *)
 val pr_clenv : clausenv -> Pp.t
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1738,6 +1738,9 @@ let rec vernac_interp_error_handler = function
     explain_type_error env (Evd.from_env env) te
   | PretypeError(ctx,sigma,te) ->
     explain_pretype_error ctx sigma te
+  | Clenv.ClenvCannotUnify (env, sigma, clenv, t1, t2, reason) ->
+    let sigma, f = Clenv.replace_clenv_metas env sigma clenv in
+    explain_pretype_error env sigma (CannotUnify (f t1, f t2, reason))
   | PrimNotations.PrimTokenNotationError(kind,ctx,sigma,te) ->
     explain_prim_token_notation_error kind ctx sigma te
   | Typeclasses_errors.TypeClassError(env, sigma, te) ->


### PR DESCRIPTION
This is mostly a hack, and is quite probably not addressing all possible ways for metas to still be shown.

Based on #20827

It's intended as a MVPatch, for people who know more about Clenv and Unification to complete.