### PR TITLE
Make the failed-abstract-certificate warning error by default.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -886,7 +886,7 @@ let inline_private_constants env ((body, ctx), side_eff) =
   (body, ctx')
 
 let warn_failed_cert = CWarnings.create ~name:"failed-abstract-certificate"
-    ~category:CWarnings.CoreCategories.tactics ~default:CWarnings.Disabled
+    ~category:CWarnings.CoreCategories.tactics ~default:CWarnings.AsError
     Pp.(fun kn ->
         str "Certificate for private constant " ++
         Id.print (Constant.label kn) ++


### PR DESCRIPTION
Since the purification of the side-effect mechanism, this warning should never be triggered. We could make it into an anomaly, but just for the sake of being able to work around bugs, we just make it error by default from now on, and will eventually turn it into an assertion.