### PR TITLE
Clean up APIs and implementations around tclABSTRACT

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1376,6 +1376,20 @@ let push_side_effects prv senv ?univs ?role effs =
     seff_safeenv = Some senv;
   }
 
+let push_side_effects ?role ?ts name de ctx effs =
+  let univs =
+    if Univ.Level.Set.is_empty (fst ctx) then None
+    else Some (UState.Monomorphic_entry ctx, UnivNames.empty_binders)
+  in
+  let senv = get_senv_side_effects effs in
+  let senv = match ts with
+  | None -> senv
+  | Some ts -> Safe_typing.set_oracle ts senv
+  in
+  let (kn, eff), senv = Safe_typing.add_private_constant name ctx de senv in
+  let effs = push_side_effects eff senv ?univs ?role effs in
+  kn, effs
+
 let seff_mem_label id effs =
   Id.Set.mem id effs.seff_labels
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1349,9 +1349,6 @@ let emit_side_effects eff evd =
   let effects = { effects with seff_safeenv = Some senv } in
   { evd with effects; universes = UState.emit_side_effects eff.seff_private evd.universes }
 
-let drop_side_effects evd =
-  { evd with effects = empty_side_effects; }
-
 let set_side_effects eff evd =
   { evd with effects = eff }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -404,8 +404,10 @@ val emit_side_effects : side_effects -> evar_map -> evar_map
 val eval_side_effects : evar_map -> side_effects
 (** Return the effects contained in the evar map. *)
 
-val push_side_effects : Safe_typing.private_constants -> Safe_typing.safe_environment ->
-  ?univs:UState.named_universes_entry -> ?role:side_effect_role -> side_effects -> side_effects
+val push_side_effects :
+  ?role:side_effect_role -> ?ts:Conv_oracle.oracle ->
+  Id.t -> Safe_typing.side_effect_declaration -> Univ.ContextSet.t ->
+  side_effects -> Constant.t * side_effects
 
 (** {6 Accessors} *)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -396,15 +396,13 @@ val empty_side_effects : side_effects
 val get_senv_side_effects : side_effects -> Safe_typing.safe_environment
 
 val set_side_effects : side_effects -> evar_map -> evar_map
+(** Replaces the side-effects of the evarmap. *)
 
 val emit_side_effects : side_effects -> evar_map -> evar_map
 (** Push a side-effect into the evar map. *)
 
 val eval_side_effects : evar_map -> side_effects
 (** Return the effects contained in the evar map. *)
-
-val drop_side_effects : evar_map -> evar_map
-(** This should not be used. For hacking purposes. *)
 
 val push_side_effects : Safe_typing.private_constants -> Safe_typing.safe_environment ->
   ?univs:UState.named_universes_entry -> ?role:side_effect_role -> side_effects -> side_effects

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1133,7 +1133,7 @@ module Unsafe = struct
 
   let purge_side_effects pv =
     let effs = Evd.eval_side_effects pv.solution in
-    { pv with solution = Evd.drop_side_effects pv.solution }, effs
+    { pv with solution = Evd.set_side_effects Evd.empty_side_effects pv.solution }, effs
 
 end
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -892,8 +892,6 @@ let emit_side_effects eff x =
   { x with solution = Evd.emit_side_effects eff x.solution }
 
 let tclEFFECTS eff =
-  let open Proof in
-  return () >>= fun () -> (* The Global.env should be taken at exec time *)
   Pv.modify (fun initial -> emit_side_effects eff initial)
 
 let mark_as_unsafe = Status.put false

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -887,13 +887,6 @@ let tclENV = Env.get
 
 (** {7 Put-like primitives} *)
 
-
-let emit_side_effects eff x =
-  { x with solution = Evd.emit_side_effects eff x.solution }
-
-let tclEFFECTS eff =
-  Pv.modify (fun initial -> emit_side_effects eff initial)
-
 let mark_as_unsafe = Status.put false
 
 (** Gives up on the goal under focus. Reports an unsafe status. Proofs

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -407,9 +407,6 @@ val tclENV : Environ.env tactic
 
 (** {7 Put-like primitives} *)
 
-(** [tclEFFECTS eff] add the effects [eff] to the current state. *)
-val tclEFFECTS : Evd.side_effects -> unit tactic
-
 (** [mark_as_unsafe] declares the current tactic is unsafe. *)
 val mark_as_unsafe : unit tactic
 

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -86,7 +86,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
         (Tactics.intros_mustbe_force (List.rev_map NamedDecl.get_id sign) <*>
          tac)
     in
-    let effs, sigma, lem, args, safe =
+    let sigma, lem, args, safe =
       !declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl
     in
     let pose_tac = match name_op with
@@ -95,13 +95,13 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
       if opaque then Tactics.pose_proof (Names.Name id) lem
       else Tactics.pose_tac (Names.Name id) lem
     in
-    let solve =
-      Proofview.tclEFFECTS effs <*>
-      pose_tac <*>
-      tacK lem args
-    in
-    let tac = if not safe then Proofview.mark_as_unsafe <*> solve else solve in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) tac
+    let mark = if not safe then Proofview.mark_as_unsafe else tclIDTAC in
+    tclTHENLIST [
+      Proofview.Unsafe.tclEVARS sigma;
+      mark;
+      pose_tac;
+      tacK lem args;
+    ];
   end
 
 let abstract_subproof ~opaque tac =

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -31,4 +31,4 @@ val declare_abstract :
   -> Environ.env
   -> Evd.evar_map
   -> EConstr.t
-  -> Evd.side_effects * Evd.evar_map * EConstr.t * EConstr.t list * bool) ref
+  -> Evd.evar_map * EConstr.t * EConstr.t list * bool) ref

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -108,13 +108,11 @@ let lookup_scheme kind ind =
 
 type schemes = {
   sch_eff : Evd.side_effects;
-  sch_env : Safe_typing.safe_environment;
   sch_reg : (Id.t * Constant.t * Loc.t option * UState.named_universes_entry) list;
 }
 
-let empty_schemes senv = {
-  sch_eff = Evd.empty_side_effects;
-  sch_env = senv;
+let empty_schemes eff = {
+  sch_eff = eff;
   sch_reg = [];
 }
 
@@ -156,11 +154,10 @@ let define ?loc internal role id c poly uctx sch =
   let c = UState.nf_universes uctx c in
   let uctx = UState.restrict uctx (Vars.universes_of_constr c) in
   let univs = UState.univ_entry ~poly uctx in
-  let effs = sch.sch_eff, sch.sch_env in
+  let effs = sch.sch_eff in
   let cst, effs = !declare_definition_scheme ~univs ~role ~name:id ~effs c in
-  let effs, senv = effs in
   let reg = (id, cst, loc, univs) :: sch.sch_reg in
-  cst, { sch_eff = effs; sch_env = senv; sch_reg = reg }
+  cst, { sch_eff = effs; sch_reg = reg }
 
 module Locmap : sig
 
@@ -203,10 +200,10 @@ end = struct
   end
 
 let get_env sch =
-  Safe_typing.env_of_safe_env sch.sch_env
+  Safe_typing.env_of_safe_env (Evd.get_senv_side_effects sch.sch_eff)
 
 let globally_declare_schemes sch =
-  Global.Internal.reset_safe_env sch.sch_env
+  Global.Internal.reset_safe_env (Evd.get_senv_side_effects sch.sch_eff)
 
 (* Assumes that dependencies are already defined *)
 let rec define_individual_scheme_base ?loc kind suff f ~internal idopt (mind,i as ind) eff =
@@ -286,14 +283,14 @@ let force_find_scheme kind (mind,i as ind) =
       | s,IndividualSchemeFunction (f, deps) ->
         let env = Safe_typing.env_of_safe_env senv in
         let deps = match deps with None -> [] | Some deps -> deps env ind in
-        let sch = empty_schemes senv in
+        let sch = empty_schemes eff in
         let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) sch deps in
         let c, eff = define_individual_scheme_base kind s f ~internal:true None ind eff in
         eff, c
       | s,MutualSchemeFunction (f, deps) ->
         let env = Safe_typing.env_of_safe_env senv in
         let deps = match deps with None -> [] | Some deps -> deps env mind in
-        let sch = empty_schemes senv in
+        let sch = empty_schemes eff in
         let eff = List.fold_left (fun eff dep -> declare_scheme_dependence eff dep) sch deps in
         let ca, eff = define_mutual_scheme_base kind s f ~internal:true [] mind eff in
         eff, ca.(i)
@@ -311,14 +308,14 @@ let register_schemes sch =
   List.iter iter (List.rev sch.sch_reg)
 
 let define_individual_scheme ?loc kind names ind =
-  let sch = empty_schemes (Global.safe_env ()) in
+  let sch = empty_schemes Evd.empty_side_effects in
   let eff = define_individual_scheme ?loc kind ~internal:false names ind sch in
   let () = globally_declare_schemes eff in
   let () = register_schemes eff in
   redeclare_schemes eff
 
 let define_mutual_scheme ?locmap kind names mind =
-  let sch = empty_schemes (Global.safe_env ()) in
+  let sch = empty_schemes Evd.empty_side_effects in
   let eff = define_mutual_scheme ?locmap kind ~internal:false names mind sch in
   let () = globally_declare_schemes eff in
   let () = register_schemes eff in

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -102,9 +102,9 @@ val declare_definition_scheme :
   (univs:UState.named_universes_entry
    -> role:Evd.side_effect_role
    -> name:Id.t
-   -> effs:(Evd.side_effects * Safe_typing.safe_environment)
+   -> effs:Evd.side_effects
    -> Constr.t
-   -> Constant.t * (Evd.side_effects * Safe_typing.safe_environment)) ref
+   -> Constant.t * Evd.side_effects) ref
 
 val register_definition_scheme :
   (internal:bool

--- a/test-suite/bugs/bug_21304.v
+++ b/test-suite/bugs/bug_21304.v
@@ -1,0 +1,9 @@
+(* NB this test can be removed once dynamic scheme declaration is removed
+   (ie when warning "missing-scheme" is replaced by an error) *)
+Inductive equal T (x : T) : T -> Type := Equal : equal T x x.
+
+Lemma foo : forall a b, equal nat a b -> a = b.
+Proof.
+intros a b H.
+rewrite <- H, H.
+Abort.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2278,14 +2278,15 @@ let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma con
   let body, typ, args = ProofEntry.shrink_entry sign body const.proof_entry_type in
   let senv = Evd.get_senv_side_effects (Evd.eval_side_effects sigma) in
   let senv = Safe_typing.set_oracle (Environ.oracle env) senv in
-  let cst, effs, senv =
+  let cst, effs, _senv =
     (* No side-effects in the entry, they already exist in the ambient environment *)
     let const = { const with proof_entry_body = body; proof_entry_type = typ } in
     declare_private_constant ~name ~opaque const (Evd.eval_side_effects sigma) senv
   in
+  let sigma = Evd.emit_side_effects effs sigma in
   let inst = instance_of_univs const.proof_entry_universes in
   let lem = EConstr.of_constr (Constr.mkConstU (cst, inst)) in
-  effs, sigma, lem, args, safe
+  sigma, lem, args, safe
 
 let get_goal_context pf i =
   let p = get pf in


### PR DESCRIPTION
After the purification of the tclABSTRACT tactic, some cruft could be removed.