### PR TITLE
Hack debug option for name printing

### DIFF
--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -103,7 +103,7 @@ let make_ident sa = function
 
 let root_of_id id =
   let suffixstart = cut_ident true id in
-  Id.of_string (String.sub (Id.to_string id) 0 suffixstart)
+  Id.of_string_soft (String.sub (Id.to_string id) 0 suffixstart)
 
 (* Return the same identifier as the original one but whose {i subscript} is incremented.
    If the original identifier does not have a suffix, [0] is appended to it.


### PR DESCRIPTION
This adds an option `Printing All Names` off by default which does 2 things when on:

- stop printing `_` for binders of unused variable (eg `forall H:nat, nat` isn't printed as `forall _:nat, nat`)

- print the original name (before renaming to avoid shadowing) in comments so eg `forall x x : Prop, x` prints `forall x (* x *) x0 (* x *) : Prop, x0 (* x *)`

If we ever want to merge the second part should be implemented in a less hacky way, and maybe separate the 2 parts to use separate options.
