### PR TITLE
Fix Derive to handle dependent types correctly by reversing context

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21313-copilot-fix-dependent-types-support-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21313-copilot-fix-dependent-types-support-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Fix Derive command to handle dependent types correctly
+  (`#21313 <https://github.com/rocq-prover/rocq/pull/21313>`_,
+  fixes `#21292 <https://github.com/rocq-prover/rocq/issues/21292>`_,
+  by copilot-swe-agent[bot]).

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -48,6 +48,9 @@ let start_deriving ~atts bl suchthat name : Declare.Proof.t =
   let sigma = Evd.from_env env in
   let () = List.iter check_allowed_binders bl in
   let sigma, (impls_env, ((env', ctx'), _, locs)) = Constrintern.interp_named_context_evars env sigma bl in
+  (* ctx' is in reverse order (last binder first), so reverse it before processing *)
+  let ctx' = List.rev ctx' in
+  let locs = List.rev locs in
   let sigma, env', ctx' = fill_assumptions env sigma ctx' in
   let sigma = Evd.shelve sigma (List.map fst (Evar.Map.bindings (Evd.undefined_map sigma))) in
   let sigma, (suchthat, impargs) = Constrintern.interp_type_evars_impls env' sigma ~impls:impls_env suchthat in

--- a/test-suite/success/Derive.v
+++ b/test-suite/success/Derive.v
@@ -46,3 +46,8 @@ reflexivity.
 Qed.
 
 Check id'@{Set} 0.
+
+(* Test dependent types - issue fix *)
+Derive (X : Type) (l : list X) in (l = l) as foo_dep.
+exact (eq_refl (@nil unit)).
+Defined.


### PR DESCRIPTION

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21292


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->
