### PR TITLE
Do not wrap side-effect certificates in ephemerons.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -416,7 +416,7 @@ let universes c = c.certif_univs
 end
 
 type side_effect = {
-  seff_certif : Certificate.t CEphemeron.key;
+  seff_certif : Certificate.t;
   seff_constant : Constant.t;
   seff_body : HConstr.t option * (Constr.t, Vmemitcodes.body_code option) Declarations.pconstant_body;
   seff_univs : Univ.ContextSet.t;
@@ -898,20 +898,14 @@ let warn_failed_cert = CWarnings.create ~name:"failed-abstract-certificate"
 let check_signatures senv sl =
   match sl with
   | [] -> Ok Univ.ContextSet.empty
-  | (firstkn,first) :: rest ->
-    match CEphemeron.get first with
-    | exception CEphemeron.InvalidKey -> Error None
-    | first ->
-    if not (Certificate.compatible senv first) then Error (Some firstkn)
+  | (firstkn, first) :: rest ->
+    if not (Certificate.compatible senv first) then Error firstkn
     else
       let is_direct_ancestor curmb (kn, mb) =
-        match CEphemeron.get mb with
-        | exception CEphemeron.InvalidKey -> Error None
-        | mb ->
-          let mb = Certificate.safe_extend ~src:curmb ~dst:mb in
-          match mb with
-          | None -> Error (Some kn)
-          | Some mb -> Ok mb
+        let mb = Certificate.safe_extend ~src:curmb ~dst:mb in
+        match mb with
+        | None -> Error kn
+        | Some mb -> Ok mb
       in
       let accu = List.fold_left_error is_direct_ancestor first rest in
       match accu with
@@ -923,10 +917,9 @@ let check_signatures senv sl =
 let check_signatures senv sl =
   match check_signatures senv sl with
   | Ok univs -> Some univs
-  | Error None ->
-    (* don't warn when the issue is an invalid ephemeron *)
+  | Error kn ->
+    let () = warn_failed_cert kn in
     None
-  | Error (Some kn) -> warn_failed_cert kn; None
 
 type side_effect_declaration =
 | DefinitionEff : Entries.definition_entry -> side_effect_declaration
@@ -1189,7 +1182,7 @@ let add_private_constant l uctx decl senv : (Constant.t * private_constants) * s
   in
   let senv = add_constant_aux senv ?hbody (kn, dcb) in
   let eff =
-    let from_env = CEphemeron.create (Certificate.make senv) in
+    let from_env = Certificate.make senv in
     let eff = {
       seff_certif = from_env;
       seff_constant = kn;


### PR DESCRIPTION
The reason we used to do so was likely because at some point safe environments contained futures and thus arbitrary closures, that could not be marshalled safely. Nowadays this datatype is first-order, so there should not be any problem on this front. Note that despite marshalling losing pointer equality, the current implementation of par: is done in a way to ignore abstract wrappers and replay the proof locally without marshalling the certificate, thus preserving its validity.

The only potential issue comes from the huge size of the marshalled environment in async mode, but in theory we already marshal it anyway in the summary, so most of the data should be shared.