### PR TITLE
Fix #4493: [abstract] in a hint extern gives anomaly on [Check].

### DIFF
--- a/test-suite/bugs/bug_4493.v
+++ b/test-suite/bugs/bug_4493.v
@@ -1,0 +1,3 @@
+Class A := a : True.
+Hint Extern 1 A => abstract exact I : typeclass_instances.
+Check _ : A. (* failure with error in 8.4, anomaly in 8.5rc1 *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2204,6 +2204,7 @@ let check_may_eval env sigma redexp rc =
       let env = Environ.push_qualities qs env in
       let env = Environ.push_context_set (us,csts) env in
       let c = EConstr.to_constr sigma c in
+      let env = Safe_typing.push_private_constants env (Evd.seff_private @@ Evd.eval_side_effects sigma) in
       (* OK to call kernel which does not support evars *)
       Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
   in


### PR DESCRIPTION
We simply rectify the environment with the local side-effects before sending the term to the kernel for type-checking.