### PR TITLE
Clean Tacmach API

### DIFF
--- a/dev/ml_toplevel/include_utilities
+++ b/dev/ml_toplevel/include_utilities
@@ -37,4 +37,4 @@ let current_goal () = get_nth_goal 1;;
 *)
 
 let pf_e gl s = 
-  Constrintern.interp_constr (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) (parse_constr s)
+  Constrintern.interp_constr (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) (parse_constr s)

--- a/dev/ml_toplevel/include_utilities
+++ b/dev/ml_toplevel/include_utilities
@@ -37,4 +37,4 @@ let current_goal () = get_nth_goal 1;;
 *)
 
 let pf_e gl s = 
-  Constrintern.interp_constr (Tacmach.pf_env gl) (Tacmach.project gl) (parse_constr s)
+  Constrintern.interp_constr (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) (parse_constr s)

--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -109,7 +109,7 @@ let get_type_of_hyp env id =
 
 let repackage i h_hyps_id = Goal.enter begin fun gl ->
     let env = Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Tacmach.pf_concl gl in
     let (ty1 : EConstr.t) = get_type_of_hyp env i in
     let (packed_ty2 : EConstr.t) = get_type_of_hyp env h_hyps_id in

--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -109,8 +109,8 @@ let get_type_of_hyp env id =
 
 let repackage i h_hyps_id = Goal.enter begin fun gl ->
     let env = Goal.env gl in
-    let sigma = Proofview.Goal.sigma gl in
-    let concl = Tacmach.pf_concl gl in
+    let sigma = Goal.sigma gl in
+    let concl = Goal.concl gl in
     let (ty1 : EConstr.t) = get_type_of_hyp env i in
     let (packed_ty2 : EConstr.t) = get_type_of_hyp env h_hyps_id in
     let ty2 = unpack_type sigma packed_ty2 in

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -231,6 +231,7 @@ module Btauto = struct
     Proofview.Goal.enter begin fun gl ->
       let concl = Proofview.Goal.concl gl in
       let concl = EConstr.Unsafe.to_constr concl in
+      let genv = Proofview.Goal.env gl in
       let sigma = Proofview.Goal.sigma gl in
       let eq = Lazy.force eq in
       let bool = Lazy.force Bool.typ in
@@ -239,8 +240,8 @@ module Btauto = struct
       | App (c, [|typ; tl; tr|])
           when typ === bool && c === eq ->
           let env = Env.empty () in
-          let fl = Bool.quote env (Tacmach.pf_env gl) sigma tl in
-          let fr = Bool.quote env (Tacmach.pf_env gl) sigma tr in
+          let fl = Bool.quote env genv sigma tl in
+          let fr = Bool.quote env genv sigma tr in
           let env = Env.to_list env in
           let fl = reify env fl in
           let fr = reify env fr in

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -216,7 +216,7 @@ module Btauto = struct
       let concl = Proofview.Goal.concl gl in
       let eq = Lazy.force eq in
       let concl = EConstr.Unsafe.to_constr concl in
-      let t = decomp_term (Tacmach.project gl) concl in
+      let t = decomp_term (Proofview.Goal.sigma gl) concl in
       match t with
       | App (c, [|typ; p; _|]) when c === eq ->
       (* should be an equality [@eq poly ?p (Cst false)] *)
@@ -231,7 +231,7 @@ module Btauto = struct
     Proofview.Goal.enter begin fun gl ->
       let concl = Proofview.Goal.concl gl in
       let concl = EConstr.Unsafe.to_constr concl in
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let eq = Lazy.force eq in
       let bool = Lazy.force Bool.typ in
       let t = decomp_term sigma concl in

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -439,7 +439,7 @@ let cc_tactic depth additional_terms b =
       Proofview.tclORELSE (debug_congruence (fun () -> Pp.str "Goal solved, generating proof ...");
       match reason with
         Discrimination (i,ipac,j,jpac) ->
-        let p=build_proof (Tacmach.pf_env gl) sigma uf (`Discr (i,ipac,j,jpac)) in
+        let p=build_proof env sigma uf (`Discr (i,ipac,j,jpac)) in
         let cstr=(get_constructor_info uf ipac.cnode).ci_constr in
         discriminate_tac cstr p
       | Incomplete terms_to_complete ->
@@ -547,11 +547,11 @@ let simple_congruence_tac depth l =
 let mk_eq f c1 c2 k =
   Tacticals.pf_constr_of_global (Lazy.force f) >>= fun fc ->
   Proofview.Goal.enter begin fun gl ->
-    let open Tacmach in
-    let evm, ty = pf_apply type_of gl c1 in
-    let evm, ty = Evarsolve.refresh_universes (Some false) (pf_env gl) evm ty in
+    let env = Proofview.Goal.env gl in
+    let evm, ty = Tacmach.pf_apply type_of gl c1 in
+    let evm, ty = Evarsolve.refresh_universes (Some false) env evm ty in
     let term = mkApp (fc, [| ty; c1; c2 |]) in
-    let evm, _ =  type_of (pf_env gl) evm term in
+    let evm, _ =  type_of env evm term in
     Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm) (k term)
     end
 

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -67,8 +67,9 @@ let gen_ground_tac ist taco ids bases =
       in
       let startseq k =
         Proofview.Goal.enter begin fun gl ->
-        let seq=empty_seq (ground_depth ()) in
-        let seq, sigma = extend_with_ref_list ~flags (pf_env gl) (project gl) ids seq in
+        let sigma = Proofview.Goal.sigma gl in
+        let seq = empty_seq (ground_depth ()) in
+        let seq, sigma = extend_with_ref_list ~flags (pf_env gl) sigma ids seq in
         let seq, sigma = extend_with_auto_hints ~flags (pf_env gl) sigma bases seq in
         tclTHEN (Proofview.Unsafe.tclEVARS sigma) (k seq)
         end

--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -14,7 +14,6 @@ open Ltac_plugin
 open Sequent
 open Ground
 open Goptions
-open Tacmach
 open Tacticals
 open Tacinterp
 open Stdarg
@@ -68,9 +67,10 @@ let gen_ground_tac ist taco ids bases =
       let startseq k =
         Proofview.Goal.enter begin fun gl ->
         let sigma = Proofview.Goal.sigma gl in
+        let env = Proofview.Goal.env gl in
         let seq = empty_seq (ground_depth ()) in
-        let seq, sigma = extend_with_ref_list ~flags (pf_env gl) sigma ids seq in
-        let seq, sigma = extend_with_auto_hints ~flags (pf_env gl) sigma bases seq in
+        let seq, sigma = extend_with_ref_list ~flags env sigma ids seq in
+        let seq, sigma = extend_with_auto_hints ~flags env sigma bases seq in
         tclTHEN (Proofview.Unsafe.tclEVARS sigma) (k seq)
         end
       in

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -30,11 +30,12 @@ let ground_tac ~flags solver startseq =
   Proofview.Goal.enter begin fun gl ->
   let rec toptac skipped seq =
     Proofview.Goal.enter begin fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
     tclORELSE (axiom_tac ~flags seq)
       begin
         try
-          let (hd, seq1) = take_formula (pf_env gl) (project gl) seq
-          and re_add s=re_add_formula_list (project gl) skipped s in
+          let (hd, seq1) = take_formula (pf_env gl) sigma seq
+          and re_add s=re_add_formula_list sigma skipped s in
           let continue=toptac []
           and backtrack =toptac (hd::skipped) seq1 in
           let AnyFormula hd = hd in
@@ -55,7 +56,7 @@ let ground_tac ~flags solver startseq =
                           or_tac ~flags backtrack continue (re_add seq1)
                       | Rfalse->backtrack
                       | Rexists(i,dom,triv)->
-                          let (lfp, seq2) = collect_quantified (pf_env gl) (project gl) seq in
+                          let (lfp, seq2) = collect_quantified (pf_env gl) sigma seq in
                           let backtrack2=toptac (lfp@skipped) seq2 in
                             if Sequent.has_fuel seq then
                               quantified_tac ~flags lfp backtrack2
@@ -75,7 +76,7 @@ let ground_tac ~flags solver startseq =
                           left_or_tac ~flags ind backtrack
                           (get_id hd) continue (re_add seq1)
                       | Lforall (_,_,_)->
-                          let (lfp, seq2) = collect_quantified (pf_env gl) (project gl) seq in
+                          let (lfp, seq2) = collect_quantified (pf_env gl) sigma seq in
                           let backtrack2=toptac (lfp@skipped) seq2 in
                             if Sequent.has_fuel seq then
                               quantified_tac ~flags lfp backtrack2

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -127,8 +127,8 @@ let mk_open_instance env sigma id idc c =
 let left_instance_tac ~flags (inst,id) continue seq=
   let open EConstr in
   Proofview.Goal.enter begin fun gl ->
-  let sigma = project gl in
   let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
   match inst with
       Phantom dom->
         if lookup env sigma (id,None) seq then
@@ -154,7 +154,8 @@ let left_instance_tac ~flags (inst,id) continue seq=
             if not @@ Unify.Item.is_ground c then
               (pf_constr_of_global id >>= fun idc ->
                 Proofview.Goal.enter begin fun gl->
-                  let (evmap, rc, ot) = mk_open_instance (pf_env gl) (project gl) id idc c in
+                  let sigma = Proofview.Goal.sigma gl in
+                  let (evmap, rc, ot) = mk_open_instance (pf_env gl) sigma id idc c in
                   let gt=
                     it_mkLambda_or_LetIn
                       (mkApp(idc,[|ot|])) rc in
@@ -204,7 +205,8 @@ let instance_tac ~flags (hd, AnyId id) = match id with
 let quantified_tac ~flags lf backtrack continue seq =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let insts=give_instances env (project gl) lf seq in
+  let sigma = Proofview.Goal.sigma gl in
+  let insts = give_instances env sigma lf seq in
     tclORELSE
       (tclFIRST (List.map (fun inst->instance_tac ~flags inst continue seq) insts))
       backtrack

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -154,13 +154,14 @@ let left_instance_tac ~flags (inst,id) continue seq=
             if not @@ Unify.Item.is_ground c then
               (pf_constr_of_global id >>= fun idc ->
                 Proofview.Goal.enter begin fun gl->
+                  let env = Proofview.Goal.env gl in
                   let sigma = Proofview.Goal.sigma gl in
-                  let (evmap, rc, ot) = mk_open_instance (pf_env gl) sigma id idc c in
+                  let (evmap, rc, ot) = mk_open_instance env sigma id idc c in
                   let gt=
                     it_mkLambda_or_LetIn
                       (mkApp(idc,[|ot|])) rc in
                   let evmap, _ =
-                    try Typing.type_of (pf_env gl) evmap gt
+                    try Typing.type_of env evmap gt
                     with e when CErrors.noncritical e ->
                       user_err Pp.(str "Untypable instance, maybe higher-order non-prenex quantification") in
                   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evmap)

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -14,7 +14,6 @@ open CErrors
 open Util
 open EConstr
 open Vars
-open Tacmach
 open Tactics
 open Tacticals
 open Proofview.Notations
@@ -139,7 +138,7 @@ let left_instance_tac ~flags (inst,id) continue seq=
                [introf;
                 (pf_constr_of_global id >>= fun idc ->
                 Proofview.Goal.enter begin fun gl ->
-                  let id0 = List.nth (pf_ids_of_hyps gl) 0 in
+                  let id0 = List.nth (Tacmach.pf_ids_of_hyps gl) 0 in
                   Generalize.generalize [mkApp(idc, [|mkVar id0|])]
                 end);
                 introf;
@@ -186,7 +185,7 @@ let right_instance_tac ~flags inst continue seq=
         [tclTHENLIST
            [introf;
             Proofview.Goal.enter begin fun gl ->
-              let id0 = List.nth (pf_ids_of_hyps gl) 0 in
+              let id0 = List.nth (Tacmach.pf_ids_of_hyps gl) 0 in
               split (Tactypes.ImplicitBindings [mkVar id0])
             end;
             tclSOLVE [wrap ~flags 0 true continue (deepen seq)]];

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -13,7 +13,6 @@ open Util
 open Names
 open EConstr
 open Vars
-open Tacmach
 open Tactics
 open Tacticals
 open Proofview.Notations
@@ -245,7 +244,7 @@ let ll_forall_tac ~flags prod backtrack id continue seq=
            (pf_constr_of_global id >>= fun idc ->
            Proofview.Goal.enter begin fun gls->
               let open EConstr in
-              let id0 = List.nth (pf_ids_of_hyps gls) 0 in
+              let id0 = List.nth (Tacmach.pf_ids_of_hyps gls) 0 in
               let term=mkApp(idc,[|mkVar(id0)|]) in
               tclTHEN (Generalize.generalize [term]) (clear [id0])
            end);

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -37,20 +37,21 @@ let wrap ~flags n b continue seq =
   let nc = Proofview.Goal.hyps gls in
   let env = Proofview.Goal.env gls in
   let sigma = Proofview.Goal.sigma gls in
+  let concl = Proofview.Goal.concl gls in
   let rec aux i nc ctx=
     if i<=0 then seq else
       match nc with
           []->anomaly (Pp.str "Not the expected number of hyps.")
         | nd::q->
             let id = NamedDecl.get_id nd in
-            if occur_var env sigma id (pf_concl gls) ||
+            if occur_var env sigma id concl ||
               List.exists (occur_var_in_decl env sigma id) ctx then
                 (aux (i-1) q (nd::ctx))
             else
               add_formula ~flags ~hint:false env sigma (GlobRef.VarRef id) (NamedDecl.get_type nd) (aux (i-1) q (nd::ctx)) in
   let seq1=aux n nc [] in
   let seq2 =
-    if b then add_concl ~flags env sigma (pf_concl gls) seq1 else seq1
+    if b then add_concl ~flags env sigma concl seq1 else seq1
   in
   continue seq2
   end

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -35,7 +35,7 @@ let wrap ~flags n b continue seq =
   Proofview.Goal.enter begin fun gls ->
   Control.check_for_interrupt ();
   let nc = Proofview.Goal.hyps gls in
-  let env = pf_env gls in
+  let env = Proofview.Goal.env gls in
   let sigma = Proofview.Goal.sigma gls in
   let rec aux i nc ctx=
     if i<=0 then seq else
@@ -133,7 +133,8 @@ let arrow_tac ~flags backtrack continue seq=
 
 let left_and_tac ~flags ind backtrack id continue seq =
   Proofview.Goal.enter begin fun gl ->
-  let n=(construct_nhyps (pf_env gl) ind).(0) in
+  let env = Proofview.Goal.env gl in
+  let n = (construct_nhyps env ind).(0) in
    tclIFTHENELSE
      (tclTHENLIST
       [(pf_constr_of_global id >>= simplest_elim);
@@ -145,7 +146,8 @@ let left_and_tac ~flags ind backtrack id continue seq =
 
 let left_or_tac ~flags ind backtrack id continue seq =
   Proofview.Goal.enter begin fun gl ->
-  let v=construct_nhyps (pf_env gl) ind in
+  let env = Proofview.Goal.env gl in
+  let v = construct_nhyps env ind in
   let f n=
     tclTHENLIST
       [clear_global id;
@@ -166,8 +168,9 @@ let left_false_tac id=
 
 let ll_ind_tac ~flags (ind,u as indu) largs backtrack id continue seq =
   Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-     let rcs=ind_hyps (pf_env gl) sigma 0 indu largs in
+    let rcs = ind_hyps env sigma 0 indu largs in
      let vargs=Array.of_list largs in
              (* construire le terme  H->B, le generaliser etc *)
      let myterm idc i=
@@ -223,7 +226,8 @@ let forall_tac ~flags backtrack continue seq=
 
 let left_exists_tac ~flags ind backtrack id continue seq =
   Proofview.Goal.enter begin fun gl ->
-  let n=(construct_nhyps (pf_env gl) ind).(0) in
+  let env = Proofview.Goal.env gl in
+  let n = (construct_nhyps env ind).(0) in
     tclIFTHENELSE
       (Tacticals.pf_constr_of_global id >>= simplest_elim)
       (tclTHENLIST [clear_global id;

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -35,8 +35,8 @@ let wrap ~flags n b continue seq =
   Proofview.Goal.enter begin fun gls ->
   Control.check_for_interrupt ();
   let nc = Proofview.Goal.hyps gls in
-  let env=pf_env gls in
-  let sigma = project gls in
+  let env = pf_env gls in
+  let sigma = Proofview.Goal.sigma gls in
   let rec aux i nc ctx=
     if i<=0 then seq else
       match nc with
@@ -166,7 +166,8 @@ let left_false_tac id=
 
 let ll_ind_tac ~flags (ind,u as indu) largs backtrack id continue seq =
   Proofview.Goal.enter begin fun gl ->
-     let rcs=ind_hyps (pf_env gl) (project gl) 0 indu largs in
+    let sigma = Proofview.Goal.sigma gl in
+     let rcs=ind_hyps (pf_env gl) sigma 0 indu largs in
      let vargs=Array.of_list largs in
              (* construire le terme  H->B, le generaliser etc *)
      let myterm idc i=

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -258,10 +258,9 @@ let change_eq env sigma hyp_id (context : rel_context) x t end_of_type =
   in
   let prove_new_hyp =
     let open Tacticals in
-    let open Tacmach in
     tclTHEN (tclDO ctxt_size intro)
       (Proofview.Goal.enter (fun g ->
-           let all_ids = pf_ids_of_hyps g in
+           let all_ids = Tacmach.pf_ids_of_hyps g in
            let new_ids, _ = list_chop ctxt_size all_ids in
            let to_refine = applist (witness_fun, List.rev_map mkVar new_ids) in
            let evm, _ =

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -14,7 +14,6 @@ open CErrors
 open Names
 open Constr
 open EConstr
-open Tacmach
 open Tacticals
 open Tactics
 open Induction
@@ -100,7 +99,7 @@ let functional_induction with_clean c princl pat =
           CErrors.user_err
             (str "functional induction must be used with a function") )
       | Some (princ, binding) ->
-        let sigma, princt = pf_type_of gl princ in
+        let sigma, princt = Tacmach.pf_type_of gl princ in
         Proofview.Unsafe.tclEVARS sigma
         <*> Proofview.tclUNIT (princ, binding, princt, args))
   >>= fun (princ, bindings, princ_type, args) ->
@@ -131,7 +130,7 @@ let functional_induction with_clean c princl pat =
           args Id.Set.empty
       in
       let old_idl =
-        List.fold_right Id.Set.add (pf_ids_of_hyps gl) Id.Set.empty
+        List.fold_right Id.Set.add (Tacmach.pf_ids_of_hyps gl) Id.Set.empty
       in
       let old_idl = Id.Set.diff old_idl princ_vars in
       let subst_and_reduce gl =
@@ -139,7 +138,7 @@ let functional_induction with_clean c princl pat =
           let idl =
             List.filter
               (fun id -> not (Id.Set.mem id old_idl))
-              (pf_ids_of_hyps gl)
+              (Tacmach.pf_ids_of_hyps gl)
           in
           let flag =
             Genredexpr.Cbv {Redops.all_flags with Genredexpr.rDelta = false}

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -42,7 +42,7 @@ let choose_dest_or_ind scheme_info args =
 let functional_induction with_clean c princl pat =
   let open Proofview.Notations in
   Proofview.Goal.enter_one (fun gl ->
-      let sigma = project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let f, args = decompose_app_list sigma c in
       match princl with
       | None -> (
@@ -69,7 +69,7 @@ let functional_induction with_clean c princl pat =
             (* then we get the principle *)
             match princ_option with
             | Some princ ->
-              Evd.fresh_global (pf_env gl) (project gl) (GlobRef.ConstRef princ)
+              Evd.fresh_global (pf_env gl) sigma (GlobRef.ConstRef princ)
             | None ->
               (*i If there is not default lemma defined then,
                       we cross our finger and try to find a lemma named f_ind
@@ -90,7 +90,7 @@ let functional_induction with_clean c princl pat =
                     ( str "Cannot find induction principle for "
                     ++ Termops.pr_global_env (pf_env gl) (ConstRef c') )
               in
-              Evd.fresh_global (pf_env gl) (project gl) princ_ref
+              Evd.fresh_global (pf_env gl) sigma princ_ref
           in
           let princt = Retyping.get_type_of (pf_env gl) sigma princ in
           Proofview.Unsafe.tclEVARS sigma
@@ -104,8 +104,8 @@ let functional_induction with_clean c princl pat =
         <*> Proofview.tclUNIT (princ, binding, princt, args))
   >>= fun (princ, bindings, princ_type, args) ->
   Proofview.Goal.enter (fun gl ->
-      let sigma = project gl in
-      let princ_infos = compute_elim_sig (project gl) princ_type in
+      let sigma = Proofview.Goal.sigma gl in
+      let princ_infos = compute_elim_sig sigma princ_type in
       let args_as_induction_constr =
         let c_list = if princ_infos.farg_in_concl then [c] else [] in
         if List.length args + List.length c_list = 0 then

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -42,6 +42,7 @@ let choose_dest_or_ind scheme_info args =
 let functional_induction with_clean c princl pat =
   let open Proofview.Notations in
   Proofview.Goal.enter_one (fun gl ->
+      let env = Proofview.Goal.env gl in
       let sigma = Proofview.Goal.sigma gl in
       let f, args = decompose_app_list sigma c in
       match princl with
@@ -57,7 +58,7 @@ let functional_induction with_clean c princl pat =
               | None ->
                 user_err
                   ( str "Cannot find induction information on "
-                  ++ Termops.pr_global_env (pf_env gl) (ConstRef c') )
+                  ++ Termops.pr_global_env env (ConstRef c') )
             in
             match elimination_sort_of_goal gl with
             | Qual (QConstant QSProp) -> finfo.sprop_lemma
@@ -69,7 +70,7 @@ let functional_induction with_clean c princl pat =
             (* then we get the principle *)
             match princ_option with
             | Some princ ->
-              Evd.fresh_global (pf_env gl) sigma (GlobRef.ConstRef princ)
+              Evd.fresh_global env sigma (GlobRef.ConstRef princ)
             | None ->
               (*i If there is not default lemma defined then,
                       we cross our finger and try to find a lemma named f_ind
@@ -88,11 +89,11 @@ let functional_induction with_clean c princl pat =
                 | None ->
                   user_err
                     ( str "Cannot find induction principle for "
-                    ++ Termops.pr_global_env (pf_env gl) (ConstRef c') )
+                    ++ Termops.pr_global_env env (ConstRef c') )
               in
-              Evd.fresh_global (pf_env gl) sigma princ_ref
+              Evd.fresh_global env sigma princ_ref
           in
-          let princt = Retyping.get_type_of (pf_env gl) sigma princ in
+          let princt = Retyping.get_type_of env sigma princ in
           Proofview.Unsafe.tclEVARS sigma
           <*> Proofview.tclUNIT (princ, Tactypes.NoBindings, princt, args)
         | _ ->

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -12,7 +12,6 @@ open Util
 open Names
 open Constr
 open EConstr
-open Tacmach
 open Tactics
 open Tacticals
 open Indfun_common
@@ -32,7 +31,7 @@ let revert_graph kn post_tac hid =
   Proofview.Goal.enter (fun gl ->
       let env = Proofview.Goal.env gl in
       let sigma = Proofview.Goal.sigma gl in
-      let typ = pf_get_hyp_typ hid gl in
+      let typ = Tacmach.pf_get_hyp_typ hid gl in
       match EConstr.kind sigma typ with
       | App (i, args) when isInd sigma i ->
         let ((kn', num) as ind'), u = destInd sigma i in
@@ -84,10 +83,10 @@ let revert_graph kn post_tac hid =
 let functional_inversion kn hid fconst f_correct =
   Proofview.Goal.enter (fun gl ->
       let old_ids =
-        List.fold_right Id.Set.add (pf_ids_of_hyps gl) Id.Set.empty
+        List.fold_right Id.Set.add (Tacmach.pf_ids_of_hyps gl) Id.Set.empty
       in
       let sigma = Proofview.Goal.sigma gl in
-      let type_of_h = pf_get_hyp_typ hid gl in
+      let type_of_h = Tacmach.pf_get_hyp_typ hid gl in
       match EConstr.kind sigma type_of_h with
       | App (eq, args) when EConstr.eq_constr sigma eq (make_eq ()) ->
         let pre_tac, f_args, res =
@@ -109,7 +108,7 @@ let functional_inversion kn hid fconst f_correct =
                 let new_ids =
                   List.filter
                     (fun id -> not (Id.Set.mem id old_ids))
-                    (pf_ids_of_hyps gl)
+                    (Tacmach.pf_ids_of_hyps gl)
                 in
                 tclMAP (revert_graph kn pre_tac) (hid :: new_ids)) ]
       | _ -> tclFAILn 1 Pp.(mt ()))
@@ -139,7 +138,7 @@ let invfun qhyp f =
     let tac_action hid =
       Proofview.Goal.enter begin fun gl ->
       let sigma = Proofview.Goal.sigma gl in
-      let hyp_typ = pf_get_hyp_typ hid gl in
+      let hyp_typ = Tacmach.pf_get_hyp_typ hid gl in
       match EConstr.kind sigma hyp_typ with
       | App (eq, args) when EConstr.eq_constr sigma eq (make_eq ()) -> (
         let f1, _ = decompose_app sigma args.(1) in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1437,11 +1437,11 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
                          tclIDTAC))) ])
     in
     let end_tac =
-      let open Tacmach in
       let open Tacticals in
       Proofview.Goal.enter (fun gl ->
           let sigma = Proofview.Goal.sigma gl in
-          match EConstr.kind sigma (pf_concl gl) with
+          let concl = Proofview.Goal.concl gl in
+          match EConstr.kind sigma concl with
           | App (f, _) when EConstr.eq_constr sigma f (well_founded ()) ->
             Auto.gen_auto None [] (Some [])
           | _ ->

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1440,7 +1440,7 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
       let open Tacmach in
       let open Tacticals in
       Proofview.Goal.enter (fun gl ->
-          let sigma = project gl in
+          let sigma = Proofview.Goal.sigma gl in
           match EConstr.kind sigma (pf_concl gl) with
           | App (f, _) when EConstr.eq_constr sigma f (well_founded ()) ->
             Auto.gen_auto None [] (Some [])

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1418,20 +1418,19 @@ let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
     let h_num = ref (-1) in
     let env = Global.env () in
     let start_tac =
-      let open Tacmach in
       let open Tacticals in
       Proofview.Goal.enter (fun gl ->
-          let hid = next_ident_away_in_goal h_id (pf_ids_of_hyps gl) in
+          let hid = next_ident_away_in_goal h_id (Tacmach.pf_ids_of_hyps gl) in
           observe_tclTHENLIST
             (fun _ _ -> mt ())
             [ Generalize.generalize [lemma]
             ; Simple.intro hid
             ; Proofview.Goal.enter (fun gl ->
-                  let ids = pf_ids_of_hyps gl in
+                  let ids = Tacmach.pf_ids_of_hyps gl in
                   tclTHEN
                     (Elim.h_decompose_and (mkVar hid))
                     (Proofview.Goal.enter (fun gl ->
-                         let ids' = pf_ids_of_hyps gl in
+                         let ids' = Tacmach.pf_ids_of_hyps gl in
                          lid := List.rev (List.subtract Id.equal ids' ids);
                          if List.is_empty !lid then lid := [hid];
                          tclIDTAC))) ])

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -26,7 +26,7 @@ let assert_succeeds tac =
 
 let mytclWithHoles tac with_evars c =
   Proofview.Goal.enter begin fun gl ->
-    let env = Tacmach.pf_env gl in
+    let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     let sigma',c = Tactics.force_destruction_arg with_evars env sigma c in
     Tacticals.tclWITHHOLES with_evars (tac with_evars (Some c)) sigma'
@@ -191,9 +191,10 @@ let decompose l c =
 let exact ist (c : Ltac_pretype.closed_glob_constr) =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let expected_type = Pretyping.OfType (pf_concl gl) in
-  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) sigma in
+  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c env sigma in
   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
   end
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -27,7 +27,7 @@ let assert_succeeds tac =
 let mytclWithHoles tac with_evars c =
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.pf_env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let sigma',c = Tactics.force_destruction_arg with_evars env sigma c in
     Tacticals.tclWITHHOLES with_evars (tac with_evars (Some c)) sigma'
   end
@@ -179,7 +179,7 @@ let onSomeWithHoles tac = function
 
 let decompose l c =
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let to_ind c =
       if isInd sigma c then fst (destInd sigma c)
       else user_err Pp.(str "not an inductive type")
@@ -191,8 +191,9 @@ let decompose l c =
 let exact ist (c : Ltac_pretype.closed_glob_constr) =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
+  let sigma = Proofview.Goal.sigma gl in
   let expected_type = Pretyping.OfType (pf_concl gl) in
-  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) (project gl) in
+  let sigma, c = Tacinterp.type_uconstr ~expected_type ist c (pf_env gl) sigma in
   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
   end
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -189,11 +189,11 @@ let decompose l c =
   end
 
 let exact ist (c : Ltac_pretype.closed_glob_constr) =
-  let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
-  let expected_type = Pretyping.OfType (pf_concl gl) in
+  let concl = Proofview.Goal.concl gl in
+  let expected_type = Pretyping.OfType concl in
   let sigma, c = Tacinterp.type_uconstr ~expected_type ist c env sigma in
   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Tactics.exact_no_check c)
   end

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -261,7 +261,7 @@ let lemInv id c =
   let mv = let mvs = Clenv.clenv_arguments clause in
     if List.is_empty mvs then
       CErrors.user_err
-        Pp.(hov 0 (pr_econstr_env (pf_env gls) sigma c ++ spc ()
+        Pp.(hov 0 (pr_econstr_env env sigma c ++ spc ()
                    ++ str "does not refer to an inversion lemma."))
     else List.last mvs
   in
@@ -272,7 +272,7 @@ let lemInv id c =
     | Failure _ | UserError _ ->
          user_err
            (str "Cannot refine current goal with the lemma " ++
-              pr_leconstr_env (pf_env gls) sigma c ++ str ".")
+              pr_leconstr_env env sigma c ++ str ".")
   end
 
 let lemInv_gen id c = try_intros_until (fun id -> lemInv id c) id

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -23,7 +23,6 @@ open Evd
 open Printer
 open Reductionops
 open Inductiveops
-open Tacmach
 open Tacticals
 open Tactics
 open Context.Named.Declaration
@@ -257,7 +256,7 @@ let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   let env = Proofview.Goal.env gls in
   let sigma = Proofview.Goal.sigma gls in
-  let clause = Clenv.mk_clenv_from env sigma (c, pf_get_type_of gls c) in
+  let clause = Clenv.mk_clenv_from env sigma (c, Tacmach.pf_get_type_of gls c) in
   let mv = let mvs = Clenv.clenv_arguments clause in
     if List.is_empty mvs then
       CErrors.user_err
@@ -279,7 +278,7 @@ let lemInv_gen id c = try_intros_until (fun id -> lemInv id c) id
 
 let lemInvIn id c ids =
   Proofview.Goal.enter begin fun gl ->
-    let hyps = List.map (fun id -> pf_get_hyp id gl) ids in
+    let hyps = List.map (fun id -> Tacmach.pf_get_hyp id gl) ids in
     let intros_replace_ids =
       let concl = Proofview.Goal.concl gl in
       let sigma = Proofview.Goal.sigma gl in

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -256,11 +256,12 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
 let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   let env = Proofview.Goal.env gls in
-  let clause = Clenv.mk_clenv_from env (project gls) (c, pf_get_type_of gls c) in
+  let sigma = Proofview.Goal.sigma gls in
+  let clause = Clenv.mk_clenv_from env sigma (c, pf_get_type_of gls c) in
   let mv = let mvs = Clenv.clenv_arguments clause in
     if List.is_empty mvs then
       CErrors.user_err
-        Pp.(hov 0 (pr_econstr_env (pf_env gls) (project gls) c ++ spc ()
+        Pp.(hov 0 (pr_econstr_env (pf_env gls) sigma c ++ spc ()
                    ++ str "does not refer to an inversion lemma."))
     else List.last mvs
   in
@@ -271,7 +272,7 @@ let lemInv id c =
     | Failure _ | UserError _ ->
          user_err
            (str "Cannot refine current goal with the lemma " ++
-              pr_leconstr_env (pf_env gls) (project gls) c ++ str ".")
+              pr_leconstr_env (pf_env gls) sigma c ++ str ".")
   end
 
 let lemInv_gen id c = try_intros_until (fun id -> lemInv id c) id
@@ -281,7 +282,7 @@ let lemInvIn id c ids =
     let hyps = List.map (fun id -> pf_get_hyp id gl) ids in
     let intros_replace_ids =
       let concl = Proofview.Goal.concl gl in
-      let sigma = project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let nb_of_new_hyp = nb_prod sigma concl - List.length ids in
       if nb_of_new_hyp < 1  then
         intros_replacing ids

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -256,7 +256,7 @@ let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   let env = Proofview.Goal.env gls in
   let sigma = Proofview.Goal.sigma gls in
-  let clause = Clenv.mk_clenv_from env sigma (c, Tacmach.pf_get_type_of gls c) in
+  let clause = Clenv.mk_clenv_from env sigma (c, Retyping.get_type_of env sigma c) in
   let mv = let mvs = Clenv.clenv_arguments clause in
     if List.is_empty mvs then
       CErrors.user_err

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -703,7 +703,7 @@ let dummy_id = Id.of_string "_"
 let lift_constr_tac_to_ml_tac vars tac =
   let tac _ ist = Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let map = function
     | Anonymous -> None
     | Name id ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -812,7 +812,11 @@ let interp_constr_may_eval ist env sigma c =
 (** TODO: should use dedicated printers *)
 let message_of_value v =
   let pr_with_env pr =
-    Ftactic.enter begin fun gl -> Ftactic.return (pr (pf_env gl) (project gl)) end in
+    Ftactic.enter begin fun gl ->
+      let sigma = Proofview.Goal.sigma gl in
+      Ftactic.return (pr (pf_env gl) sigma)
+    end
+  in
   let open Genprint in
   match generic_val_print v with
   | TopPrinterBasic pr -> Ftactic.return (pr ())
@@ -1146,8 +1150,10 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
       let (stack,_) = push_trace(None,call) ist in
       do_profile stack
         (catch_error_tac stack begin
-      Proofview.Goal.enter begin fun gl -> Abstract.tclABSTRACT
-        (Option.map (interp_ident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
+      Proofview.Goal.enter begin fun gl ->
+        let sigma = Proofview.Goal.sigma gl in
+        Abstract.tclABSTRACT
+        (Option.map (interp_ident ist (pf_env gl) sigma) ido) (interp_tactic ist t)
       end end)
   | TacThen (t1,t) ->
       Tacticals.tclTHEN (interp_tactic ist t1) (interp_tactic ist t)
@@ -1273,7 +1279,7 @@ and interp_tacarg ist arg : Val.t Ftactic.t =
   | Reference r -> interp_ltac_reference false ist r
   | ConstrMayEval c ->
       Ftactic.enter begin fun gl ->
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let env = Proofview.Goal.env gl in
         let (sigma,c_interp) = interp_constr_may_eval ist env sigma c in
         Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
@@ -1288,7 +1294,8 @@ and interp_tacarg ist arg : Val.t Ftactic.t =
       interp_app loc ist fv largs
   | TacFreshId l ->
       Ftactic.enter begin fun gl ->
-        let id = interp_fresh_id ist (pf_env gl) (project gl) l in
+        let sigma = Proofview.Goal.sigma gl in
+        let id = interp_fresh_id ist (pf_env gl) sigma l in
         Ftactic.return (in_gen (topwit wit_intro_pattern) (CAst.make @@ IntroNaming (IntroIdentifier id)))
       end
   | TacPretype c ->
@@ -1355,7 +1362,7 @@ and interp_app loc ist fv largs : Val.t Ftactic.t =
         match generic_val_print v with
         | TopPrinterBasic _ -> call_debug None
         | TopPrinterNeedsContext _ | TopPrinterNeedsContextAndLevel _ ->
-          Proofview.Goal.enter (fun gl -> call_debug (Some (pf_env gl,project gl)))
+          Proofview.Goal.enter (fun gl -> call_debug (Some (pf_env gl, Proofview.Goal.sigma gl)))
       end <*>
       if List.is_empty lval then Ftactic.return v else interp_app loc ist v lval
     else
@@ -1522,8 +1529,8 @@ and interp_match ist lz constr lmr =
     end
   end >>= fun constr ->
   Ftactic.enter begin fun gl ->
-    let sigma = project gl in
     let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ilr = read_match_rule ist env sigma lmr in
     interp_match_successes lz ist (Tactic_matching.match_term env sigma constr ilr)
   end
@@ -1531,8 +1538,8 @@ and interp_match ist lz constr lmr =
 (* Interprets the Match Context expressions *)
 and interp_match_goal ist lz lr lmr =
     Ftactic.enter begin fun gl ->
-      let sigma = project gl in
       let env = Proofview.Goal.env gl in
+      let sigma = Proofview.Goal.sigma gl in
       let hyps = Proofview.Goal.hyps gl in
       let hyps = if lr then List.rev hyps else hyps in
       let concl = Proofview.Goal.concl gl in
@@ -1616,7 +1623,7 @@ and interp_ltac_constr ist e : EConstr.t Ftactic.t =
   end >>= fun result ->
   Ftactic.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = project gl in
+  let sigma = Proofview.Goal.sigma gl in
   try
     let cresult = coerce_to_closed_constr env result in
     Proofview.tclLIFT begin
@@ -1656,7 +1663,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacIntroPattern (ev,l) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let l' = interp_intro_pattern_list_as_list ist env sigma l in
         name_atomic ~env
           (TacIntroPattern (ev,l))
@@ -1669,7 +1676,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       Proofview.Trace.name_tactic (fun () -> Pp.str"<apply>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let l = List.map (fun (k,c) ->
             let loc, f = interp_open_constr_with_bindings_loc ist c in
             let f = Tacticals.tactic_of_delayed f in
@@ -1686,7 +1693,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacElim (ev,(keep,cb),cbo) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let sigma, cb = interp_open_constr_with_bindings ist env sigma cb in
         let sigma, cbo = Option.fold_left_map (interp_open_constr_with_bindings ist env) sigma cbo in
         let named_tac =
@@ -1697,8 +1704,8 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacCase (ev,(keep,cb)) ->
       Proofview.Goal.enter begin fun gl ->
-        let sigma = project gl in
         let env = Proofview.Goal.env gl in
+        let sigma = Proofview.Goal.sigma gl in
         let sigma, cb = interp_open_constr_with_bindings ist env sigma cb in
         let named_tac =
           let tac = Tactics.general_case_analysis ev keep cb in
@@ -1711,11 +1718,12 @@ and interp_atomic ist tac : unit Proofview.tactic =
       Proofview.Trace.name_tactic (fun () -> Pp.str"<mutual fix>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = pf_env gl in
+        let sigma = Proofview.Goal.sigma gl in
         let f sigma (id,n,c) =
           let (sigma,c_interp) = interp_type ist env sigma c in
           sigma , (interp_ident ist env sigma id,n,c_interp) in
         let (sigma,l_interp) =
-          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
+          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l sigma
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (FixTactics.mutual_fix (interp_ident ist env sigma id) n l_interp)
@@ -1726,11 +1734,12 @@ and interp_atomic ist tac : unit Proofview.tactic =
       Proofview.Trace.name_tactic (fun () -> Pp.str"<mutual cofix>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = pf_env gl in
+        let sigma = Proofview.Goal.sigma gl in
         let f sigma (id,c) =
           let (sigma,c_interp) = interp_type ist env sigma c in
           sigma , (interp_ident ist env sigma id,c_interp) in
         let (sigma,l_interp) =
-          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
+          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l sigma
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (FixTactics.mutual_cofix (interp_ident ist env sigma id) l_interp)
@@ -1739,7 +1748,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacAssert (ev,b,t,ipat,c) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let (sigma,c) =
           let expected_type =
             if Option.is_empty t then WithoutTypeConstraint else IsType in
@@ -1755,7 +1764,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       end
   | TacGeneralize cl ->
       Proofview.Goal.enter begin fun gl ->
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let env = Proofview.Goal.env gl in
         let sigma, cl = interp_constr_with_occurrences_and_name_as_list ist env sigma cl in
         Tacticals.tclWITHHOLES false
@@ -1766,7 +1775,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacLetTac (ev,na,c,clp,b,eqpat) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let clp = interp_clause ist env sigma clp in
         let eqpat = interp_intro_pattern_naming_option ist env sigma eqpat in
         if Locusops.is_nowhere clp (* typically "pose" *) then
@@ -1806,7 +1815,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
          prenormalised. *)
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let l =
           List.map begin fun (c,(ipato,ipats),cls) ->
             (* TODO: move sigma as a side-effect *)
@@ -1832,14 +1841,16 @@ and interp_atomic ist tac : unit Proofview.tactic =
   (* Conversion *)
   | TacReduce (r,cl) ->
       Proofview.Goal.enter begin fun gl ->
-        let (sigma,r_interp) = interp_red_expr ist (pf_env gl) (project gl) r in
+        let sigma = Proofview.Goal.sigma gl in
+        let (sigma,r_interp) = interp_red_expr ist (pf_env gl) sigma r in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.reduce r_interp (interp_clause ist (pf_env gl) (project gl) cl))
+        (Tactics.reduce r_interp (interp_clause ist (pf_env gl) sigma cl))
       end
   | TacChange (check,None,c,cl) ->
       (* spiwack: until the tactic is in the monad *)
       Proofview.Trace.name_tactic (fun () -> Pp.str"<change>") begin
       Proofview.Goal.enter begin fun gl ->
+        let sigma = Proofview.Goal.sigma gl in
         let is_onhyps = match cl.onhyps with
           | None | Some [] -> true
           | _ -> false
@@ -1858,7 +1869,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
             then Changed (interp_type ist env sigma c)
             else Changed (interp_constr ist env sigma c)
         in
-        Tactics.change ~check None c_interp (interp_clause ist (pf_env gl) (project gl) cl)
+        Tactics.change ~check None c_interp (interp_clause ist (pf_env gl) sigma cl)
       end
       end
   | TacChange (check,Some op,c,cl) ->
@@ -1866,7 +1877,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
       Proofview.Trace.name_tactic (fun () -> Pp.str"<change>") begin
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let op = interp_typed_pattern ist env sigma op in
         let to_catch = function Not_found -> true | e -> CErrors.is_sync_anomaly e in
         let c_interp patvars env sigma =
@@ -1895,7 +1906,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           in
           (b,m,keep,f)) l in
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let cl = interp_clause ist env sigma cl in
         name_atomic ~env
           (TacRewrite (ev,l,cl,Option.map ignore by))
@@ -1907,7 +1918,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacInversion (DepInversion (k,c,ids),hyp) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let (sigma,c_interp) =
           match c with
           | None -> sigma , None
@@ -1925,7 +1936,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacInversion (NonDepInversion (k,idl,ids),hyp) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let hyps = interp_hyp_list ist env sigma idl in
         let dqhyps = interp_declared_or_quantified_hypothesis ist env sigma hyp in
         let ids_interp = interp_or_and_intro_pattern_option ist env sigma ids in
@@ -1936,7 +1947,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
   | TacInversion (InversionUsing (c,idl),hyp) ->
       Proofview.Goal.enter begin fun gl ->
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let (sigma,c_interp) = interp_constr ist env sigma c in
         let dqhyps = interp_declared_or_quantified_hypothesis ist env sigma hyp in
         let hyps = interp_hyp_list ist env sigma idl in
@@ -2137,7 +2148,7 @@ let () =
 
 let () =
   register_interp0 wit_uconstr (fun ist c -> Ftactic.enter begin fun gl ->
-    Ftactic.return (interp_uconstr ist (Proofview.Goal.env gl) (Tacmach.project gl) c)
+    Ftactic.return (interp_uconstr ist (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) c)
   end)
 
 (***************************************************************************)

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -315,7 +315,7 @@ let defer_output = Comm.defer_output
 
 let db_pr_goal gl =
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let penv = Termops.Internal.print_named_context env sigma in
   let pc = Printer.pr_econstr_env env sigma concl in

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -173,7 +173,7 @@ let pf_apply ?(catch_exceptions=false) f =
     f env sigma
   | [gl] ->
     gl >>= fun gl ->
-    f (Proofview.Goal.env gl) (Tacmach.project gl)
+    f (Proofview.Goal.env gl) (Proofview.Goal.sigma gl)
   | _ :: _ :: _ ->
     throw Tac2ffi.err_notfocussed
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1892,10 +1892,10 @@ let fresh_id avoid id gl =
 
 let clear_all_no_check =
   Proofview.Goal.enter (fun gl ->
+      let env = Proofview.Goal.env gl in
       let concl = Tacmach.pf_concl gl in
       let env =
-        Environ.reset_with_named_context Environ.empty_named_context_val
-          (Tacmach.pf_env gl)
+        Environ.reset_with_named_context Environ.empty_named_context_val env
       in
       Refine.refine_with_principal ~typecheck:false (fun sigma ->
           let sigma, ev = Evarutil.new_evar env sigma concl in
@@ -1904,7 +1904,7 @@ let clear_all_no_check =
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Proofview.Goal.enter (fun gl ->
       let sigma = Proofview.Goal.sigma gl in
-      let genv = Tacmach.pf_env gl in
+      let genv = Proofview.Goal.env gl in
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       try
@@ -2036,7 +2036,7 @@ let micromega_genr prover tac =
   in
   Proofview.Goal.enter (fun gl ->
       let sigma = Proofview.Goal.sigma gl in
-      let genv = Tacmach.pf_env gl in
+      let genv = Proofview.Goal.env gl in
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       try
@@ -2433,10 +2433,9 @@ let nlinear_Z =
 let exfalso_if_concl_not_Prop =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
-      Tacmach.(
-        if is_prop (pf_env gl) sigma (pf_concl gl) then
-          Tacticals.tclIDTAC
-        else Tactics.exfalso)
+    let env = Proofview.Goal.env gl in
+    if is_prop env sigma (Tacmach.pf_concl gl) then Tacticals.tclIDTAC
+    else Tactics.exfalso
   end
 
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1903,7 +1903,7 @@ let clear_all_no_check =
 
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Proofview.Goal.enter (fun gl ->
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let genv = Tacmach.pf_env gl in
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
@@ -1975,7 +1975,7 @@ Tacticals.tclTHEN
 
 let micromega_wit_gen pre_process cnf spec prover wit_id ff =
   Proofview.Goal.enter (fun gl ->
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       try
         let spec = Lazy.force spec in
         let undump_cstr = undump_cstr spec.undump_coeff in
@@ -2035,7 +2035,7 @@ let micromega_genr prover tac =
       ; coeff_eq = Mc.qeq_bool }
   in
   Proofview.Goal.enter (fun gl ->
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let genv = Tacmach.pf_env gl in
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
@@ -2431,11 +2431,13 @@ let nlinear_Z =
   *)
 
 let exfalso_if_concl_not_Prop =
-  Proofview.Goal.enter (fun gl ->
+  Proofview.Goal.enter begin fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
       Tacmach.(
-        if is_prop (pf_env gl) (project gl) (pf_concl gl) then
+        if is_prop (pf_env gl) sigma (pf_concl gl) then
           Tacticals.tclIDTAC
-        else Tactics.exfalso))
+        else Tactics.exfalso)
+  end
 
 let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Tacticals.tclTHEN exfalso_if_concl_not_Prop

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1536,6 +1536,7 @@ let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
   (* todo : directly generate the proof term - or generalize before conversion? *)
   Proofview.Goal.enter (fun gl ->
     let sigma = Proofview.Goal.sigma gl in
+    let concl = Proofview.Goal.concl gl in
       Tacticals.tclTHENLIST
         [ Tactics.change_concl
             (set sigma
@@ -1547,8 +1548,7 @@ let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
                ; ( "__varmap"
                  , vm
                  , EConstr.mkApp (Lazy.force rocq_VarMap, [|spec.typ|]) )
-               ; ("__wit", cert, cert_typ) ]
-               (Tacmach.pf_concl gl)) ])
+               ; ("__wit", cert, cert_typ) ] concl) ])
 
 (**
   * The datastructures that aggregate prover attributes.
@@ -1893,7 +1893,7 @@ let fresh_id avoid id gl =
 let clear_all_no_check =
   Proofview.Goal.enter (fun gl ->
       let env = Proofview.Goal.env gl in
-      let concl = Tacmach.pf_concl gl in
+      let concl = Proofview.Goal.concl gl in
       let env =
         Environ.reset_with_named_context Environ.empty_named_context_val env
       in
@@ -1905,7 +1905,7 @@ let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
   Proofview.Goal.enter (fun gl ->
       let sigma = Proofview.Goal.sigma gl in
       let genv = Proofview.Goal.env gl in
-      let concl = Tacmach.pf_concl gl in
+      let concl = Proofview.Goal.concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       try
         let hyps, concl, env =
@@ -2008,6 +2008,7 @@ let micromega_order_changer cert env ff =
   let vm = dump_varmap typ (vm_of_list env) in
   Proofview.Goal.enter (fun gl ->
     let sigma = Proofview.Goal.sigma gl in
+    let concl = Proofview.Goal.concl gl in
       Tacticals.tclTHENLIST
         [ Tactics.change_concl
             (set sigma
@@ -2017,8 +2018,7 @@ let micromega_order_changer cert env ff =
                      ( Lazy.force rocq_Formula
                      , [|formula_typ; Lazy.force rocq_IsProp|] ) )
                ; ("__varmap", vm, EConstr.mkApp (Lazy.force rocq_VarMap, [|typ|]))
-               ; ("__wit", cert, cert_typ) ]
-               (Tacmach.pf_concl gl))
+               ; ("__wit", cert, cert_typ) ] concl)
           (*      Tacticals.tclTHENLIST (List.map (fun id ->  (Tactics.introduction id)) ids)*)
         ])
 
@@ -2037,7 +2037,7 @@ let micromega_genr prover tac =
   Proofview.Goal.enter (fun gl ->
       let sigma = Proofview.Goal.sigma gl in
       let genv = Proofview.Goal.env gl in
-      let concl = Tacmach.pf_concl gl in
+      let concl = Proofview.Goal.concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       try
         let hyps, concl, env =
@@ -2434,7 +2434,8 @@ let exfalso_if_concl_not_Prop =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
-    if is_prop env sigma (Tacmach.pf_concl gl) then Tacticals.tclIDTAC
+    let concl = Proofview.Goal.concl gl in
+    if is_prop env sigma concl then Tacticals.tclIDTAC
     else Tactics.exfalso
   end
 

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -816,7 +816,7 @@ module CstrTable = struct
         (* Add the constraint (cstr k) if it is not already present *)
         let gen k cstr =
           Proofview.Goal.enter (fun gl ->
-              let env = Tacmach.pf_env gl in
+              let env = Proofview.Goal.env gl in
               let term = EConstr.mkApp (cstr, [|k|]) in
               let types = get_type_of env evd term in
               if has_hyp types then Tacticals.tclIDTAC
@@ -1346,7 +1346,7 @@ let trans_hyp h t0 prfp =
   | IProof -> Tacticals.tclIDTAC (* Should detect before *)
   | CProof t' ->
     Proofview.Goal.enter (fun gl ->
-        let env = Tacmach.pf_env gl in
+        let env = Proofview.Goal.env gl in
         let evd = Proofview.Goal.sigma gl in
         let t' = Reductionops.nf_betaiota env evd t' in
         Tactics.change_in_hyp ~check:true None
@@ -1355,7 +1355,7 @@ let trans_hyp h t0 prfp =
   | TProof (t', prf) ->
     Tacticals.(
       Proofview.Goal.enter (fun gl ->
-          let env = Tacmach.pf_env gl in
+          let env = Proofview.Goal.env gl in
           let evd = Proofview.Goal.sigma gl in
           let target = Reductionops.nf_betaiota env evd t' in
           let h' = Tactics.fresh_id_in_env Id.Set.empty h env in
@@ -1373,13 +1373,13 @@ let trans_concl prfp =
   | IProof -> Tacticals.tclIDTAC
   | CProof t ->
     Proofview.Goal.enter (fun gl ->
-        let env = Tacmach.pf_env gl in
+        let env = Proofview.Goal.env gl in
         let evd = Proofview.Goal.sigma gl in
         let t' = Reductionops.nf_betaiota env evd t in
         Tactics.change_concl t')
   | TProof (t, prf) ->
     Proofview.Goal.enter (fun gl ->
-        let env = Tacmach.pf_env gl in
+        let env = Proofview.Goal.env gl in
         let evd = Proofview.Goal.sigma gl in
         let typ = get_type_of env evd prf in
         match EConstr.kind evd typ with
@@ -1394,7 +1394,7 @@ let tclTHENOpt e tac tac' =
 
 let elim_binding x t ty =
   Proofview.Goal.enter (fun gl ->
-      let env = Tacmach.pf_env gl in
+      let env = Proofview.Goal.env gl in
       let h =
         Tactics.fresh_id_in_env Id.Set.empty (Nameops.add_prefix "heq_" x) env
       in
@@ -1407,7 +1407,7 @@ let do_let tac (h : Constr.named_declaration) =
   | Context.Named.Declaration.LocalAssum _ -> Tacticals.tclIDTAC
   | Context.Named.Declaration.LocalDef (id, t, ty) ->
     Proofview.Goal.enter (fun gl ->
-        let env = Tacmach.pf_env gl in
+        let env = Proofview.Goal.env gl in
         let evd = Proofview.Goal.sigma gl in
         try
           let x = id.Context.binder_name in
@@ -1422,7 +1422,7 @@ let do_let tac (h : Constr.named_declaration) =
 
 let iter_let_aux tac =
   Proofview.Goal.enter (fun gl ->
-      let env = Tacmach.pf_env gl in
+      let env = Proofview.Goal.env gl in
       let sign = Environ.named_context env in
       init_cache ();
       Tacticals.tclMAP (do_let tac) sign)
@@ -1442,7 +1442,7 @@ let zify_tac =
       Rocqlib.check_required_library ["Stdlib"; "micromega"; "ZifyInst"];
       init_cache ();
       let evd = Proofview.Goal.sigma gl in
-      let env = Tacmach.pf_env gl in
+      let env = Proofview.Goal.env gl in
       let sign = Environ.named_context env in
       let evd, concl = trans_check_prop env evd (Tacmach.pf_concl gl) in
       let evd, hyps = trans_hyps env evd sign in
@@ -1537,7 +1537,7 @@ let spec_of_hyps =
       let terms =
         Tacmach.pf_concl gl :: List.map snd (Tacmach.pf_hyps_types gl)
       in
-      let env = Tacmach.pf_env gl in
+      let env = Proofview.Goal.env gl in
       let evd = Proofview.Goal.sigma gl in
       let s = fresh_subscript env in
       let env =
@@ -1611,7 +1611,7 @@ let saturate =
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       let evd = Proofview.Goal.sigma gl in
-      let env = Tacmach.pf_env gl in
+      let env = Proofview.Goal.env gl in
       let rec sat t =
         match EConstr.kind evd t with
         | App (c, args) ->

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -801,7 +801,7 @@ module CstrTable = struct
      *)
   let gen_cstr table =
     Proofview.Goal.enter (fun gl ->
-        let evd = Tacmach.project gl in
+        let evd = Proofview.Goal.sigma gl in
         (* Build the table of existing hypotheses *)
         let has_hyp =
           let hyps_table = HConstr.create 20 in
@@ -1347,7 +1347,7 @@ let trans_hyp h t0 prfp =
   | CProof t' ->
     Proofview.Goal.enter (fun gl ->
         let env = Tacmach.pf_env gl in
-        let evd = Tacmach.project gl in
+        let evd = Proofview.Goal.sigma gl in
         let t' = Reductionops.nf_betaiota env evd t' in
         Tactics.change_in_hyp ~check:true None
           (Tactics.make_change_arg t')
@@ -1356,7 +1356,7 @@ let trans_hyp h t0 prfp =
     Tacticals.(
       Proofview.Goal.enter (fun gl ->
           let env = Tacmach.pf_env gl in
-          let evd = Tacmach.project gl in
+          let evd = Proofview.Goal.sigma gl in
           let target = Reductionops.nf_betaiota env evd t' in
           let h' = Tactics.fresh_id_in_env Id.Set.empty h env in
           let prf =
@@ -1374,13 +1374,13 @@ let trans_concl prfp =
   | CProof t ->
     Proofview.Goal.enter (fun gl ->
         let env = Tacmach.pf_env gl in
-        let evd = Tacmach.project gl in
+        let evd = Proofview.Goal.sigma gl in
         let t' = Reductionops.nf_betaiota env evd t in
         Tactics.change_concl t')
   | TProof (t, prf) ->
     Proofview.Goal.enter (fun gl ->
         let env = Tacmach.pf_env gl in
-        let evd = Tacmach.project gl in
+        let evd = Proofview.Goal.sigma gl in
         let typ = get_type_of env evd prf in
         match EConstr.kind evd typ with
         | App (c, a) when Array.length a = 2 ->
@@ -1408,7 +1408,7 @@ let do_let tac (h : Constr.named_declaration) =
   | Context.Named.Declaration.LocalDef (id, t, ty) ->
     Proofview.Goal.enter (fun gl ->
         let env = Tacmach.pf_env gl in
-        let evd = Tacmach.project gl in
+        let evd = Proofview.Goal.sigma gl in
         try
           let x = id.Context.binder_name in
           ignore
@@ -1441,7 +1441,7 @@ let zify_tac =
       Rocqlib.check_required_library ["Stdlib"; "micromega"; "ZifyClasses"];
       Rocqlib.check_required_library ["Stdlib"; "micromega"; "ZifyInst"];
       init_cache ();
-      let evd = Tacmach.project gl in
+      let evd = Proofview.Goal.sigma gl in
       let env = Tacmach.pf_env gl in
       let sign = Environ.named_context env in
       let evd, concl = trans_check_prop env evd (Tacmach.pf_concl gl) in
@@ -1538,7 +1538,7 @@ let spec_of_hyps =
         Tacmach.pf_concl gl :: List.map snd (Tacmach.pf_hyps_types gl)
       in
       let env = Tacmach.pf_env gl in
-      let evd = Tacmach.project gl in
+      let evd = Proofview.Goal.sigma gl in
       let s = fresh_subscript env in
       let env =
         List.fold_left
@@ -1610,7 +1610,7 @@ let saturate =
       let table = CstrTable.HConstr.create 20 in
       let concl = Tacmach.pf_concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
-      let evd = Tacmach.project gl in
+      let evd = Proofview.Goal.sigma gl in
       let env = Tacmach.pf_env gl in
       let rec sat t =
         match EConstr.kind evd t with

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1444,7 +1444,8 @@ let zify_tac =
       let evd = Proofview.Goal.sigma gl in
       let env = Proofview.Goal.env gl in
       let sign = Environ.named_context env in
-      let evd, concl = trans_check_prop env evd (Tacmach.pf_concl gl) in
+      let concl = Proofview.Goal.concl gl in
+      let evd, concl = trans_check_prop env evd concl in
       let evd, hyps = trans_hyps env evd sign in
       let l = CstrTable.get () in
       Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evd)
@@ -1534,9 +1535,8 @@ let rec interp_pscripts l =
 
 let spec_of_hyps =
   Proofview.Goal.enter (fun gl ->
-      let terms =
-        Tacmach.pf_concl gl :: List.map snd (Tacmach.pf_hyps_types gl)
-      in
+      let concl = Proofview.Goal.concl gl in
+      let terms = concl :: List.map snd (Tacmach.pf_hyps_types gl) in
       let env = Proofview.Goal.env gl in
       let evd = Proofview.Goal.sigma gl in
       let s = fresh_subscript env in
@@ -1608,7 +1608,7 @@ let saturate =
   Proofview.Goal.enter (fun gl ->
       init_cache ();
       let table = CstrTable.HConstr.create 20 in
-      let concl = Tacmach.pf_concl gl in
+      let concl = Proofview.Goal.concl gl in
       let hyps = Tacmach.pf_hyps_types gl in
       let evd = Proofview.Goal.sigma gl in
       let env = Proofview.Goal.env gl in

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -689,7 +689,7 @@ let ltac_ring_structure e =
 
 let ring_lookup (f : Value.t) lH rl t =
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let rl = make_args_list sigma rl t in
     let e = find_ring_structure env sigma rl in
@@ -968,7 +968,7 @@ let ltac_field_structure e =
 
 let field_lookup (f : Value.t) lH rl t =
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let rl = make_args_list sigma rl t in
     let e = find_field_structure env sigma rl in

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -93,12 +93,13 @@ let mkRAppView ist env sigma rv gv =
 let refine_interp_apply_view dbl ist gv =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
+  let sigma = Proofview.Goal.sigma gl in
   let pair i = List.map (fun x -> i, x) in
   let rv = intern_term ist (pf_env gl) gv in
-  let v = mkRAppView ist (pf_env gl) (project gl) rv gv in
+  let v = mkRAppView ist (pf_env gl) sigma rv gv in
   let interp_with (dbl, hint) =
     let i = if dbl = Ssrview.AdaptorDb.Equivalence then 2 else 1 in
-    interp_refine (pf_env gl) (project gl) ist ~concl:(pf_concl gl) (mkRApp hint (v :: mkRHoles i)) in
+    interp_refine (pf_env gl) sigma ist ~concl:(pf_concl gl) (mkRApp hint (v :: mkRHoles i)) in
   let rec loop = function
   | [] -> Proofview.tclORELSE (apply_rconstr ~ist rv) (fun _ -> view_error "apply" gv)
   | h :: hs ->
@@ -124,8 +125,8 @@ let apply_top_tac =
 let inner_ssrapplytac gviews (ggenl, gclr) ist =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
-
- let clr = interp_hyps ist (pf_env gl) (project gl) gclr in
+  let sigma = Proofview.Goal.sigma gl in
+ let clr = interp_hyps ist (pf_env gl) sigma gclr in
  let vtac gv i = refine_interp_apply_view i ist gv in
  let ggenl, tclGENTAC =
    if gviews <> [] && ggenl <> [] then

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -91,16 +91,16 @@ let mkRAppView ist env sigma rv gv =
   mkRApp rv (mkRHoles (abs nb_view_imps))
 
 let refine_interp_apply_view dbl ist gv =
-  let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let env = Proofview.Goal.env gl in
+  let concl = Proofview.Goal.concl gl in
   let pair i = List.map (fun x -> i, x) in
   let rv = intern_term ist env gv in
   let v = mkRAppView ist env sigma rv gv in
   let interp_with (dbl, hint) =
     let i = if dbl = Ssrview.AdaptorDb.Equivalence then 2 else 1 in
-    interp_refine env sigma ist ~concl:(pf_concl gl) (mkRApp hint (v :: mkRHoles i)) in
+    interp_refine env sigma ist ~concl (mkRApp hint (v :: mkRHoles i)) in
   let rec loop = function
   | [] -> Proofview.tclORELSE (apply_rconstr ~ist rv) (fun _ -> view_error "apply" gv)
   | h :: hs ->
@@ -135,7 +135,6 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist =
      [], Tacticals.tclTHEN (genstac (ggenl,[]))
    else ggenl, (fun tac -> tac) in
  tclGENTAC (Proofview.Goal.enter (fun gl ->
- let open Tacmach in
   match gviews, ggenl with
   | v :: tl, [] ->
     let dbl =
@@ -150,7 +149,8 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist =
   | [], [agens] ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
-    let clr', lemma = interp_agens ist env sigma ~concl:(pf_concl gl) agens in
+    let concl = Proofview.Goal.concl gl in
+    let clr', lemma = interp_agens ist env sigma ~concl agens in
     let sigma = Evd.merge_universe_context sigma (Evd.ustate (fst lemma)) in
     Tacticals.tclTHENLIST [Proofview.Unsafe.tclEVARS sigma; cleartac clr; refine_with ~beta:true lemma; cleartac clr']
   | _, _ ->

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -645,7 +645,8 @@ let discharge_hyp (id', (id, mode)) =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
-  let cl' = Vars.subst_var sigma id (Tacmach.pf_concl gl) in
+  let concl = Proofview.Goal.concl gl in
+  let cl' = Vars.subst_var sigma id concl in
   let decl = pf_get_hyp id gl in
   match decl, mode with
   | NamedDecl.LocalAssum _, _ | NamedDecl.LocalDef _, "(" ->
@@ -963,11 +964,11 @@ let anontac decl =
   end
 
 let rec intro_anon () =
-  let open Tacmach in
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
-  let d = List.hd (fst (EConstr.decompose_prod_n_decls sigma 1 (pf_concl gl))) in
+  let concl = Proofview.Goal.concl gl in
+  let d = List.hd (fst (EConstr.decompose_prod_n_decls sigma 1 concl)) in
   Proofview.tclORELSE (anontac d)
     (fun (err0, info) -> Proofview.tclORELSE
         (Tactics.red_in_concl <*> intro_anon ()) (fun _ -> Proofview.tclZERO ~info err0))

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -642,12 +642,11 @@ let mkRefl env sigma t c =
 
 let discharge_hyp (id', (id, mode)) =
   let open EConstr in
-  let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let cl' = Vars.subst_var sigma id concl in
-  let decl = pf_get_hyp id gl in
+  let decl = Tacmach.pf_get_hyp id gl in
   match decl, mode with
   | NamedDecl.LocalAssum _, _ | NamedDecl.LocalDef _, "(" ->
     let id' = {(NamedDecl.get_annot decl) with binder_name = Name id'} in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -966,7 +966,8 @@ let rec intro_anon () =
   let open Tacmach in
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
-  let d = List.hd (fst (EConstr.decompose_prod_n_decls (project gl) 1 (pf_concl gl))) in
+  let sigma = Proofview.Goal.sigma gl in
+  let d = List.hd (fst (EConstr.decompose_prod_n_decls sigma 1 (pf_concl gl))) in
   Proofview.tclORELSE (anontac d)
     (fun (err0, info) -> Proofview.tclORELSE
         (Tactics.red_in_concl <*> intro_anon ()) (fun _ -> Proofview.tclZERO ~info err0))

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -477,6 +477,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma0 = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
   let sigma = resolve_typeclasses ~where:r ~fail:false env sigma in
   let r_n, evs, ucst = abs_evars env sigma0 (sigma, r) in
   let sigma0 = Evd.set_universe_context sigma0 ucst in
@@ -527,7 +528,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
       let error = Option.cata (fun (env, sigma, te) ->
           Pp.(fnl () ++ str "Type error was: " ++ Himsg.explain_pretype_error env sigma te))
           (Pp.mt ()) e in
-      if occur_existential sigma0 (Tacmach.pf_concl gl)
+      if occur_existential sigma0 concl
       then Tacticals.tclZEROMSG Pp.(str "Rewriting impacts evars" ++ error)
       else Tacticals.tclZEROMSG Pp.(str "Dependent type error in rewrite of "
         ++ pr_econstr_env env sigma0

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -380,11 +380,10 @@ let id_map_redex _ sigma ~before:_ ~after = sigma, after
     ⊢ c_ty ≡ EQN rdx_ty rdx new_rdx
 *)
 let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty new_rdx dir (sigma, c) c_ty =
-  let open Tacmach in
   let open Tacticals in
   Proofview.Goal.enter begin fun gl ->
 (*   ppdebug(lazy(str"sigma@pirrel_rewrite=" ++ pr_evar_map None sigma)); *)
-  let env = pf_env gl in
+  let env = Proofview.Goal.env gl in
   let beta = Reductionops.clos_norm_flags RedFlags.beta env sigma in
   let sigma, new_rdx = map_redex env sigma ~before:rdx ~after:new_rdx in
   let sigma, elim =

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -111,7 +111,7 @@ let basecuttac k c =
   let open EConstr in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
     match Typing.sort_of env sigma c with
     | exception e when CErrors.noncritical e ->
@@ -213,7 +213,7 @@ let assert_is_conv (ctx, concl) =
   Proofview.Goal.enter begin fun gl ->
     Proofview.tclORELSE (convert_concl ~check:true (EConstr.it_mkProd_or_LetIn concl ctx))
     (fun _ -> Tacticals.tclZEROMSG (str "Given proof term is not of type " ++
-      pr_econstr_env (Tacmach.pf_env gl) (Tacmach.project gl) (EConstr.mkArrow (EConstr.mkVar (Id.of_string "_")) ERelevance.relevant concl)))
+      pr_econstr_env (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) (EConstr.mkArrow (EConstr.mkVar (Id.of_string "_")) ERelevance.relevant concl)))
   end
 
 let push_goals gs =
@@ -435,7 +435,8 @@ let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
   let ctac =
     let open Tacmach in
     Proofview.Goal.enter begin fun gl ->
-    let sigma, _, ty, _ = pf_interp_ty (pf_env gl) (project gl) ist c in
+    let sigma = Proofview.Goal.sigma gl in
+    let sigma, _, ty, _ = pf_interp_ty (pf_env gl) sigma ist c in
     Proofview.Unsafe.tclEVARS sigma <*> basesufftac ty
   end in
   Tacticals.tclTHENS ctac [htac; Tacticals.tclTHEN (cleartac clr) (introstac (binders@simpl))]

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -213,7 +213,7 @@ let assert_is_conv (ctx, concl) =
   Proofview.Goal.enter begin fun gl ->
     Proofview.tclORELSE (convert_concl ~check:true (EConstr.it_mkProd_or_LetIn concl ctx))
     (fun _ -> Tacticals.tclZEROMSG (str "Given proof term is not of type " ++
-      pr_econstr_env (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) (EConstr.mkArrow (EConstr.mkVar (Id.of_string "_")) ERelevance.relevant concl)))
+      pr_econstr_env (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) (EConstr.mkArrow (EConstr.mkVar (Id.of_string "_")) ERelevance.relevant concl)))
   end
 
 let push_goals gs =
@@ -433,10 +433,10 @@ let sufftac ist ((((clr, pats),binders),simpl), ((_, c), hint)) =
     end
   in
   let ctac =
-    let open Tacmach in
     Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
-    let sigma, _, ty, _ = pf_interp_ty (pf_env gl) sigma ist c in
+    let env = Proofview.Goal.env gl in
+    let sigma, _, ty, _ = pf_interp_ty env sigma ist c in
     Proofview.Unsafe.tclEVARS sigma <*> basesufftac ty
   end in
   Tacticals.tclTHENS ctac [htac; Tacticals.tclTHEN (cleartac clr) (introstac (binders@simpl))]

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -996,10 +996,10 @@ let ssrabstract dgens =
     ] in
   let interp_gens { gens } ~conclusion = Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
+    let env = Proofview.Goal.env gl in
      let open Ssrmatching in
-     let open Tacmach in
      let ipats = List.map (fun (_,cp) ->
-       match id_of_pattern sigma (interp_cpattern (pf_env gl) sigma cp None) with
+       match id_of_pattern sigma (interp_cpattern env sigma cp None) with
        | None -> IPatAnon (One None)
        | Some id -> IPatId id)
        (List.tl gens) in

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -995,10 +995,11 @@ let ssrabstract dgens =
       Ssrcommon.unfold[abstract;abstract_key]
     ] in
   let interp_gens { gens } ~conclusion = Goal.enter begin fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
      let open Ssrmatching in
      let open Tacmach in
      let ipats = List.map (fun (_,cp) ->
-       match id_of_pattern (project gl) (interp_cpattern (pf_env gl) (project gl) cp None) with
+       match id_of_pattern sigma (interp_cpattern (pf_env gl) sigma cp None) with
        | None -> IPatAnon (One None)
        | Some id -> IPatId id)
        (List.tl gens) in

--- a/plugins/ssr/ssrtacs.mlg
+++ b/plugins/ssr/ssrtacs.mlg
@@ -561,7 +561,8 @@ END
 
 let vmexacttac pf =
   Goal.enter begin fun gl ->
-  exact_no_check (EConstr.mkCast (pf, vmCast, Tacmach.pf_concl gl))
+  let concl = Proofview.Goal.concl gl in
+  exact_no_check (EConstr.mkCast (pf, vmCast, concl))
   end
 
 }

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -91,7 +91,6 @@ let hidetacs clseq idhide cl0 =
    convert_concl_no_check (EConstr.mkVar idhide)]
 
 let endclausestac id_map clseq gl_id cl0 =
-  let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
@@ -128,7 +127,7 @@ let endclausestac id_map clseq gl_id cl0 =
   let mktac itacs = Tacticals.tclTHENLIST (itacs @ utacs @ ugtac :: ctacs) in
   let itac (_, id) = Tactics.introduction id in
   if fits false (id_map, List.rev dc) then mktac (List.map itac id_map) else
-  let all_ids = ids_of_rel_context dc @ pf_ids_of_hyps gl in
+  let all_ids = ids_of_rel_context dc @ Tacmach.pf_ids_of_hyps gl in
   if List.for_all not_hyp' all_ids && not c_hidden then mktac [] else
   errorstrm Pp.(str "tampering with discharged assumptions of \"in\" tactical")
   end

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -94,9 +94,10 @@ let endclausestac id_map clseq gl_id cl0 =
   let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
   let not_hyp' id = not (List.mem_assoc id id_map) in
   let orig_id id = try List.assoc id id_map with Not_found -> id in
-  let dc, c = EConstr.decompose_prod_decls sigma (pf_concl gl) in
+  let dc, c = EConstr.decompose_prod_decls sigma concl in
   let hide_goal = hidden_clseq clseq in
   let c_hidden =
     hide_goal && EConstr.eq_constr sigma c (EConstr.mkVar gl_id) in
@@ -117,7 +118,8 @@ let endclausestac id_map clseq gl_id cl0 =
   let utacs = List.map utac (Proofview.Goal.hyps gl) in
   let ugtac =
     Proofview.Goal.enter begin fun gl ->
-      convert_concl_no_check (unmark (pf_concl gl))
+      let concl = Proofview.Goal.concl gl in
+      convert_concl_no_check (unmark concl)
     end
   in
   let ctacs =

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -1074,9 +1074,9 @@ let unify ?(flags=fail_quick_unif_flags) ~cv_pb m =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let n = Tacmach.pf_concl gl in
+    let concl = Proofview.Goal.concl gl in
     try
-      let _, sigma = w_unify ~metas:Meta.empty env sigma cv_pb ~flags m n in
+      let _, sigma = w_unify ~metas:Meta.empty env sigma cv_pb ~flags m concl in
       Proofview.Unsafe.tclEVARSADVANCE sigma
     with e when CErrors.noncritical e ->
       let info = Exninfo.reify () in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -1072,7 +1072,7 @@ let fail_quick_unif_flags = {
 (* let unifyTerms m n = walking (fun wc -> fst (w_Unify CONV m n [] wc)) *)
 let unify ?(flags=fail_quick_unif_flags) ~cv_pb m =
   Proofview.Goal.enter begin fun gl ->
-    let env = Tacmach.pf_env gl in
+    let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     let n = Tacmach.pf_concl gl in
     try

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -24,6 +24,8 @@ val project : Proofview.Goal.t -> Evd.evar_map
 [@@ocaml.deprecated "(9.2) Use Proofview.Goal.sigma"]
 
 val pf_env : Proofview.Goal.t -> Environ.env
+[@@ocaml.deprecated "(9.2) Use Proofview.Goal.env"]
+
 val pf_concl : Proofview.Goal.t -> types
 
 (** This function does no type inference and expects an already well-typed term.

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -32,6 +32,7 @@ val pf_concl : Proofview.Goal.t -> types
 (** This function does no type inference and expects an already well-typed term.
     It recomputes its type in the fastest way possible (no conversion is ever involved) *)
 val pf_get_type_of : Proofview.Goal.t -> constr -> types
+[@@ocaml.deprecated "(9.2) Use Retyping.get_type_of"]
 
 (** This function entirely type-checks the term and computes its type
     and the implied universe constraints. *)

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -21,6 +21,8 @@ open Evd
 val pf_apply : (env -> evar_map -> 'a) -> Proofview.Goal.t -> 'a
 
 val project : Proofview.Goal.t -> Evd.evar_map
+[@@ocaml.deprecated "(9.2) Use Proofview.Goal.sigma"]
+
 val pf_env : Proofview.Goal.t -> Environ.env
 val pf_concl : Proofview.Goal.t -> types
 

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -27,6 +27,7 @@ val pf_env : Proofview.Goal.t -> Environ.env
 [@@ocaml.deprecated "(9.2) Use Proofview.Goal.env"]
 
 val pf_concl : Proofview.Goal.t -> types
+[@@ocaml.deprecated "(9.2) Use Proofview.Goal.concl"]
 
 (** This function does no type inference and expects an already well-typed term.
     It recomputes its type in the fastest way possible (no conversion is ever involved) *)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -239,13 +239,12 @@ type hint_v = {
 (** Hack to properly solve dependent evars that are typeclasses *)
 let rec e_trivial_fail_db db_list local_db secvars =
   let open Tacticals in
-  let open Tacmach in
   let trivial_fail =
     Proofview.Goal.enter
     begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let d = NamedDecl.get_id @@ pf_last_hyp gl in
+    let d = NamedDecl.get_id @@ Tacmach.pf_last_hyp gl in
     let hints = push_resolve_hyp env sigma d local_db in
       e_trivial_fail_db db_list hints secvars
       end

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -155,12 +155,11 @@ let auto_unif_flags ?(allowed_evars = Evarsolve.AllowedEvars.all) st =
 }
 
 let e_give_exact flags h =
-  let open Tacmach in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let sigma, c = Hints.fresh_hint env sigma h in
-  let (sigma, t1) = Typing.type_of (pf_env gl) sigma c in
+  let (sigma, t1) = Typing.type_of env sigma c in
   Proofview.Unsafe.tclEVARS sigma <*>
   Clenv.unify ~flags ~cv_pb:CUMUL t1 <*> exact_no_check c
   end
@@ -253,10 +252,10 @@ let rec e_trivial_fail_db db_list local_db secvars =
   in
   let trivial_resolve =
     Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let tacs = e_trivial_resolve db_list local_db secvars
-                                 (pf_env gl) sigma (pf_concl gl) in
-      tclFIRST (List.map (fun h -> h.hint_tac) tacs)
+    let tacs = e_trivial_resolve db_list local_db secvars env sigma (pf_concl gl) in
+    tclFIRST (List.map (fun h -> h.hint_tac) tacs)
     end
   in
   let tacl =

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -254,7 +254,8 @@ let rec e_trivial_fail_db db_list local_db secvars =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let tacs = e_trivial_resolve db_list local_db secvars env sigma (pf_concl gl) in
+    let concl = Proofview.Goal.concl gl in
+    let tacs = e_trivial_resolve db_list local_db secvars env sigma concl in
     tclFIRST (List.map (fun h -> h.hint_tac) tacs)
     end
   in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1376,9 +1376,9 @@ let autoapply c i =
   in
   let flags = auto_unif_flags
     (Hints.Hint_db.transparent_state hintdb) in
-  let cty = Tacmach.pf_get_type_of gl c in
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
+  let cty = Retyping.get_type_of env sigma c in
   let ce = Clenv.mk_clenv_from env sigma (c,cty) in
   Clenv.res_pf ~with_evars:true ~with_classes:false ~flags ce <*>
       Proofview.tclEVARMAP >>= (fun sigma ->

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -58,7 +58,7 @@ let filter_hyp f tac =
 
 let contradiction_context =
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let rec seek_neg l = match l with
       | [] ->
@@ -110,7 +110,7 @@ let is_negation_of env sigma typ t =
 
 let contradiction_term (c,lbind as cl) =
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let typ = Tacmach.pf_get_type_of gl c in
     let _, ccl = whd_decompose_prod env sigma typ in

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -112,7 +112,7 @@ let contradiction_term (c,lbind as cl) =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
-    let typ = Tacmach.pf_get_type_of gl c in
+    let typ = Retyping.get_type_of env sigma c in
     let _, ccl = whd_decompose_prod env sigma typ in
     if is_empty_type env sigma ccl then
       Tacticals.tclTHEN

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -102,7 +102,7 @@ let e_exact flags h =
 let rec e_trivial_fail_db db_list local_db =
   let next = Proofview.Goal.enter begin fun gl ->
     let d = NamedDecl.get_id @@ Tacmach.pf_last_hyp gl in
-    let local_db = push_resolve_hyp (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) d local_db in
+    let local_db = push_resolve_hyp (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) d local_db in
     e_trivial_fail_db db_list local_db
   end in
   Proofview.Goal.enter begin fun gl ->
@@ -110,7 +110,7 @@ let rec e_trivial_fail_db db_list local_db =
   let tacl =
     e_assumption ::
     (Tacticals.tclTHEN Tactics.intro next) ::
-    (e_trivial_resolve (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) db_list local_db secvars (Tacmach.pf_concl gl))
+    (e_trivial_resolve (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) db_list local_db secvars (Tacmach.pf_concl gl))
   in
   Tacticals.tclSOLVE tacl
   end
@@ -381,7 +381,7 @@ let gen_eauto ?debug ?depth lems dbs =
 
 let autounfolds ids csts prjs gl cls =
   let hyps = Tacmach.pf_ids_of_hyps gl in
-  let env = Tacmach.pf_env gl in
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let ids = List.filter (fun id -> List.mem id hyps && Tacred.is_evaluable env sigma (EvalVarRef id)) ids in
   let csts = List.filter (fun cst -> Tacred.is_evaluable env sigma (EvalConstRef cst)) csts in

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -102,7 +102,7 @@ let e_exact flags h =
 let rec e_trivial_fail_db db_list local_db =
   let next = Proofview.Goal.enter begin fun gl ->
     let d = NamedDecl.get_id @@ Tacmach.pf_last_hyp gl in
-    let local_db = push_resolve_hyp (Tacmach.pf_env gl) (Tacmach.project gl) d local_db in
+    let local_db = push_resolve_hyp (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) d local_db in
     e_trivial_fail_db db_list local_db
   end in
   Proofview.Goal.enter begin fun gl ->
@@ -110,7 +110,7 @@ let rec e_trivial_fail_db db_list local_db =
   let tacl =
     e_assumption ::
     (Tacticals.tclTHEN Tactics.intro next) ::
-    (e_trivial_resolve (Tacmach.pf_env gl) (Tacmach.project gl) db_list local_db secvars (Tacmach.pf_concl gl))
+    (e_trivial_resolve (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) db_list local_db secvars (Tacmach.pf_concl gl))
   in
   Tacticals.tclSOLVE tacl
   end
@@ -467,7 +467,7 @@ let unfold_head env sigma (ids, csts, prjs) c =
 let autounfold_one db cl =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let st =
     List.fold_left (fun (i,c,p) dbname ->

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -14,7 +14,6 @@ open Termops
 open EConstr
 open Inductiveops
 open Hipattern
-open Tacmach
 open Tacticals
 open Tactics
 
@@ -95,7 +94,7 @@ let rec general_decompose_aux recognizer id =
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let ((ind, u), t) = pf_apply Tacred.reduce_to_atomic_ind gl (pf_get_type_of gl (mkVar id)) in
+  let ((ind, u), t) = Tacmach.pf_apply Tacred.reduce_to_atomic_ind gl (Tacmach.pf_get_type_of gl (mkVar id)) in
   let _, args = decompose_app (Proofview.Goal.sigma gl) t in
   let rec_flag, mkelim =
     match (Environ.lookup_mind (fst ind) env).mind_packets.(snd ind).mind_record with
@@ -125,7 +124,7 @@ let tmphyp_name = Id.of_string "_TmpHyp"
 
 let general_decompose recognizer c =
   Proofview.Goal.enter begin fun gl ->
-  let typc = pf_get_type_of gl c in
+  let typc = Tacmach.pf_get_type_of gl c in
   tclTHENS (cut typc)
     [ intro_using_then tmphyp_name (fun id ->
           ifOnHyp recognizer (general_decompose_aux recognizer)

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -94,8 +94,9 @@ let rec general_decompose_aux recognizer id =
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let ((ind, u), t) = Tacmach.pf_apply Tacred.reduce_to_atomic_ind gl (Tacmach.pf_get_type_of gl (mkVar id)) in
-  let _, args = decompose_app (Proofview.Goal.sigma gl) t in
+  let sigma = Proofview.Goal.sigma gl in
+  let ((ind, u), t) = Tacred.reduce_to_atomic_ind env sigma (Retyping.get_type_of env sigma (mkVar id)) in
+  let _, args = decompose_app sigma t in
   let rec_flag, mkelim =
     match (Environ.lookup_mind (fst ind) env).mind_packets.(snd ind).mind_record with
     | NotRecord -> true, Elim
@@ -124,7 +125,9 @@ let tmphyp_name = Id.of_string "_TmpHyp"
 
 let general_decompose recognizer c =
   Proofview.Goal.enter begin fun gl ->
-  let typc = Tacmach.pf_get_type_of gl c in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let typc = Retyping.get_type_of env sigma c in
   tclTHENS (cut typc)
     [ intro_using_then tmphyp_name (fun id ->
           ifOnHyp recognizer (general_decompose_aux recognizer)

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -136,7 +136,7 @@ let general_decompose recognizer c =
 
 let head_in indl t gl =
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   try
     let ity,_ = extract_mrectype sigma t in
     List.exists (fun i -> Environ.QInd.equal env (fst i) (fst ity)) indl

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -243,7 +243,7 @@ let solveEqBranch rectype =
       Proofview.Goal.enter begin fun gl ->
         let concl = pf_concl gl in
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         match_eqdec env sigma concl >>= fun (dty, lhs, rhs,_) ->
           let (mib,mip) = Inductive.lookup_mind_specif env rectype in
           let nparams   = mib.mind_nparams in
@@ -271,7 +271,7 @@ let decideGralEquality =
       Proofview.Goal.enter begin fun gl ->
         let concl = pf_concl gl in
         let env = Proofview.Goal.env gl in
-        let sigma = project gl in
+        let sigma = Proofview.Goal.sigma gl in
         match_eqdec env sigma concl >>= fun (dty, c1, c2, typ as data) ->
         let headtyp = hd_app sigma (pf_whd_compute gl typ) in
         begin match EConstr.kind sigma headtyp with

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -241,9 +241,9 @@ let solveEqBranch rectype =
   Proofview.tclORELSE
     begin
       Proofview.Goal.enter begin fun gl ->
-        let concl = pf_concl gl in
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
+        let concl = Proofview.Goal.concl gl in
         match_eqdec env sigma concl >>= fun (dty, lhs, rhs,_) ->
           let (mib,mip) = Inductive.lookup_mind_specif env rectype in
           let nparams   = mib.mind_nparams in
@@ -269,9 +269,9 @@ let decideGralEquality =
   Proofview.tclORELSE
     begin
       Proofview.Goal.enter begin fun gl ->
-        let concl = pf_concl gl in
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
+        let concl = Proofview.Goal.concl gl in
         match_eqdec env sigma concl >>= fun (dty, c1, c2, typ as data) ->
         let headtyp = hd_app sigma (pf_whd_compute gl typ) in
         begin match EConstr.kind sigma headtyp with

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -27,7 +27,6 @@ open Auto
 open Constr_matching
 open Hipattern
 open Proofview.Notations
-open Tacmach
 open Tactypes
 
 (* This file contains the implementation of the tactics ``Decide
@@ -135,7 +134,7 @@ let idy = Id.of_string "y"
 
 let mkGenDecideEqGoal rectype ops g =
   let sigma = Proofview.Goal.sigma g in
-  let hypnames = pf_ids_set_of_hyps g in
+  let hypnames = Tacmach.pf_ids_set_of_hyps g in
   let xname    = next_ident_away idx hypnames in
   let yname    = next_ident_away idy (Id.Set.add xname hypnames) in
   (mkNamedProd sigma (make_annot xname ERelevance.relevant) rectype
@@ -228,7 +227,7 @@ let rec solveArg hyps dty largs rargs = match largs, rargs with
   ]
 | a1 :: largs, a2 :: rargs ->
   Proofview.Goal.enter begin fun gl ->
-  let sigma, rectype = pf_type_of gl a1 in
+  let sigma, rectype = Tacmach.pf_type_of gl a1 in
   let tac hyp = solveArg (hyp :: hyps) dty largs rargs in
   let subtacs =
     if dty.eqonleft then [eqCase tac;diseqCase hyps dty.eqonleft;default_auto]
@@ -273,7 +272,7 @@ let decideGralEquality =
         let sigma = Proofview.Goal.sigma gl in
         let concl = Proofview.Goal.concl gl in
         match_eqdec env sigma concl >>= fun (dty, c1, c2, typ as data) ->
-        let headtyp = hd_app sigma (pf_whd_compute gl typ) in
+        let headtyp = hd_app sigma (Tacmach.pf_whd_compute gl typ) in
         begin match EConstr.kind sigma headtyp with
         | Ind (mi,_) -> Proofview.tclUNIT mi
         | _ -> tclZEROMSG (Pp.str"This decision procedure only works for inductive objects.")
@@ -306,7 +305,7 @@ let compare c1 c2 =
   pf_constr_of_global (lib_ref "core.eq.type") >>= fun eqc ->
   pf_constr_of_global (lib_ref "core.not.type") >>= fun notc ->
   Proofview.Goal.enter begin fun gl ->
-  let sigma, rectype = pf_type_of gl c1 in
+  let sigma, rectype = Tacmach.pf_type_of gl c1 in
   let ops = (opc,eqc,notc) in
   let decide = mkDecideEqGoal true ops rectype c1 c2 in
   tclTHEN (Proofview.Unsafe.tclEVARS sigma)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -278,8 +278,9 @@ let general_elim_clause with_evars frzevars tac cls c (ctx, eqn, args) l l2r eli
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
+    let concl = Proofview.Goal.concl gl in
     let typ = match cls with
-    | None -> pf_concl gl
+    | None -> concl
     | Some id -> pf_get_hyp_typ id gl
     in
     let ty = it_mkProd_or_LetIn (applist (eqn, args)) ctx in
@@ -1551,10 +1552,10 @@ let cutSubstInConcl l2r eqn =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
   let (lbeq,u,(t,e1,e2)) = pf_apply find_eq_data_decompose gl eqn in
-  let typ = pf_concl gl in
   let (e1,e2) = if l2r then (e1,e2) else (e2,e1) in
-  let (sigma, (typ, expected)) = subst_tuple_term env sigma e1 e2 typ in
+  let (sigma, (typ, expected)) = subst_tuple_term env sigma e1 e2 concl in
   tclTHEN (Proofview.Unsafe.tclEVARS sigma)
   (tclTHENFIRST
     (tclTHENLIST [

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1267,7 +1267,7 @@ let inject_if_homogenous_dependent_pair ty =
         raise_notrace Exit
       | Some v -> v
     in
-    let new_eq_args = [|Tacmach.pf_get_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
+    let new_eq_args = [|Retyping.get_type_of env sigma ar1.(3);ar1.(3);ar2.(3)|] in
     find_scheme Equality (!eq_dec_scheme_kind_name()) ind >>= fun c ->
     let sigma, c = fresh_global env sigma c in
     (* cut with the good equality and prove the requested goal *)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1023,7 +1023,7 @@ let rec build_discriminator env sigma true_0 false_0 pos c = function
 
 let gen_absurdity id =
   Proofview.Goal.enter begin fun gl ->
-  let env = pf_env gl in
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let hyp_typ = pf_get_hyp_typ id gl in
   if is_empty_type env sigma hyp_typ

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -128,7 +128,7 @@ let instantiate_tac_by_name id c =
 let let_evar name typ =
   let src = (Loc.tag Evar_kinds.GoalEvar) in
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let sigma, _ = Typing.sort_of env sigma typ in
     let id = match name with

--- a/tactics/fixTactics.ml
+++ b/tactics/fixTactics.ml
@@ -39,7 +39,7 @@ let rec check_mutind env sigma k cl = match EConstr.kind sigma (strip_outer_cast
 
 let mutual_fix f n others = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let () = check_mutind env sigma n concl in
   let all = (f, n, concl) :: others in
@@ -87,7 +87,7 @@ let rec check_is_mutcoind env sigma cl =
 
 let mutual_cofix f others = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let all = (f, concl) :: others in
   List.iter (fun (_, c) -> check_is_mutcoind env sigma c) all;

--- a/tactics/generalize.ml
+++ b/tactics/generalize.ml
@@ -146,9 +146,9 @@ let generalize_goal_gen env sigma ids i ((occs,c,b),na) t cl =
   in
   mkProd_or_LetIn decl cl', sigma'
 
-let generalize_goal gl i ((occs,c,b),na as o) (cl,sigma) =
+let generalize_goal gl i ((occs,c,b),na as o) (cl,sigma) = (* XXX do not take gl *)
   let open Tacmach in
-  let env = pf_env gl in
+  let env = Proofview.Goal.env gl in
   let ids = pf_ids_of_hyps gl in
   let sigma, t = Typing.type_of env sigma c in
   generalize_goal_gen env sigma ids i o t cl
@@ -157,9 +157,9 @@ let generalize_dep ?(with_let=false) c =
   let open Tacmach in
   let open Tacticals in
   Proofview.Goal.enter begin fun gl ->
-  let env = pf_env gl in
-  let sign = named_context_val env in
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
+  let sign = named_context_val env in
   let init_ids = ids_of_named_context (Global.named_context()) in
   let seek (d:named_declaration) (toquant:named_context) =
     if List.exists (fun d' -> occur_var_in_decl env sigma (NamedDecl.get_id d') d) toquant
@@ -408,7 +408,7 @@ let is_defined_variable env id =
 let abstract_args gl generalize_vars dep id defined f args =
   let open Context.Rel.Declaration in
   let sigma = Proofview.Goal.sigma gl in
-  let env = Tacmach.pf_env gl in
+  let env = Proofview.Goal.env gl in
   let concl = Tacmach.pf_concl gl in
   let hyps = Proofview.Goal.hyps gl in
   let dep = dep || local_occur_var sigma id concl in

--- a/tactics/generalize.ml
+++ b/tactics/generalize.ml
@@ -147,14 +147,12 @@ let generalize_goal_gen env sigma ids i ((occs,c,b),na) t cl =
   mkProd_or_LetIn decl cl', sigma'
 
 let generalize_goal gl i ((occs,c,b),na as o) (cl,sigma) = (* XXX do not take gl *)
-  let open Tacmach in
   let env = Proofview.Goal.env gl in
-  let ids = pf_ids_of_hyps gl in
+  let ids = Tacmach.pf_ids_of_hyps gl in
   let sigma, t = Typing.type_of env sigma c in
   generalize_goal_gen env sigma ids i o t cl
 
 let generalize_dep ?(with_let=false) c =
-  let open Tacmach in
   let open Tacticals in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
@@ -180,7 +178,7 @@ let generalize_dep ?(with_let=false) c =
   let cl' = it_mkNamedProd_or_LetIn sigma concl to_quantify in
   let is_var, body = match EConstr.kind sigma c with
   | Var id ->
-    let body = NamedDecl.get_value (pf_get_hyp id gl) in
+    let body = NamedDecl.get_value (Tacmach.pf_get_hyp id gl) in
     let is_var = Option.is_empty body && not (List.mem id init_ids) in
     if with_let then is_var, body else is_var, None
   | _ -> false, None

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -153,7 +153,7 @@ let onOpenInductionArg env sigma tac = function
         (Tacticals.onLastHyp
            (fun c ->
              Proofview.Goal.enter begin fun gl ->
-             let sigma = Tacmach.project gl in
+             let sigma = Proofview.Goal.sigma gl in
              tac clear_flag (Some sigma,(c,NoBindings))
              end))
   | clear_flag,ElimOnIdent {CAst.v=id} ->
@@ -161,7 +161,7 @@ let onOpenInductionArg env sigma tac = function
       Tacticals.tclTHEN
         (try_intros_until_id_check id)
         (Proofview.Goal.enter begin fun gl ->
-         let sigma = Tacmach.project gl in
+         let sigma = Proofview.Goal.sigma gl in
          tac clear_flag (Some sigma,(mkVar id,NoBindings))
         end)
 
@@ -1027,7 +1027,7 @@ let find_induction_type env sigma isrec elim hyp0 sort = match elim with
   sigma, (hd, params, indices), ElimUsing (hyp0, (e, elimt, indsign))
 
 let is_functional_induction elimc gl =
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let scheme = compute_elim_sig sigma (Tacmach.pf_get_type_of gl (fst elimc)) in
   (* The test is not safe: with non-functional induction on non-standard
      induction scheme, this may fail *)
@@ -1060,7 +1060,7 @@ let recolle_clenv i params args elimclause gl =
 let induction_tac with_evars params indvars (elim, elimt) =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let clause, bindings, index = match elim with
   | ElimConstant c ->
     let i = index_of_ind_arg sigma elimt in
@@ -1226,7 +1226,7 @@ let induction_without_atomization isrec with_evars elim names lid =
 (* assume that no occurrences are selected *)
 let clear_unselected_context id inhyps cls =
   Proofview.Goal.enter begin fun gl ->
-  if occur_var (Tacmach.pf_env gl) (Tacmach.project gl) id (Tacmach.pf_concl gl) &&
+  if occur_var (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) id (Tacmach.pf_concl gl) &&
     cls.concl_occs == NoOccurrences
   then error (MentionConclusionDependentOn id);
   match cls.onhyps with
@@ -1236,7 +1236,7 @@ let clear_unselected_context id inhyps cls =
         if Id.List.mem id' inhyps then (* if selected, do not erase *) None
         else
           (* erase if not selected and dependent on id or selected hyps *)
-          let test id = occur_var_in_decl (Tacmach.pf_env gl) (Tacmach.project gl) id d in
+          let test id = occur_var_in_decl (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) id d in
           if List.exists test (id::inhyps) then Some id' else None in
       let ids = List.map_filter to_erase (Proofview.Goal.hyps gl) in
       clear ids
@@ -1483,7 +1483,7 @@ let induction_destruct isrec with_evars (lc,elim) =
   | [c,(eqname,names as allnames),cls] ->
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     match elim with
     | Some elim when is_functional_induction elim gl ->
       (* Standard induction on non-standard induction schemes *)
@@ -1502,7 +1502,7 @@ let induction_destruct isrec with_evars (lc,elim) =
   | _ ->
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     match elim with
     | None ->
       (* Several arguments, without "using" clause *)
@@ -1518,7 +1518,7 @@ let induction_destruct isrec with_evars (lc,elim) =
         (Tacticals.tclMAP (fun (a,b,cl) ->
           Proofview.Goal.enter begin fun gl ->
           let env = Proofview.Goal.env gl in
-          let sigma = Tacmach.project gl in
+          let sigma = Proofview.Goal.sigma gl in
           onOpenInductionArg env sigma (fun clear_flag a ->
             induction_gen ~clear_flag ~isrec:false ~with_evars None (a,b) cl) a
           end) l)

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -26,7 +26,6 @@ open Declarations
 open Reductionops
 open Tacred
 open Genredexpr
-open Tacmach
 open Logic
 open Clenv
 open Tacticals
@@ -1047,7 +1046,7 @@ let recolle_clenv i params args elimclause gl =
   List.fold_right
     (fun e acc ->
       let x, i = e in
-      let y = pf_get_hyp_typ x gl in
+      let y = Tacmach.pf_get_hyp_typ x gl in
       let elimclause' = clenv_instantiate i acc (mkVar x, y) in
       elimclause')
     (List.rev clauses)
@@ -1456,7 +1455,7 @@ let induction_gen_l isrec with_evars elim names lc =
 
             | _ ->
                 Proofview.Goal.enter begin fun gl ->
-                let sigma, t = pf_apply Typing.type_of gl c in
+                let sigma, t = Tacmach.pf_apply Typing.type_of gl c in
                 let x = id_of_name_using_hdchar (Proofview.Goal.env gl) sigma t Anonymous in
                 let id = new_fresh_id Id.Set.empty x gl in
                 let newl' = List.map (fun r -> replace_term sigma c (mkVar id) r) l' in

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1226,7 +1226,9 @@ let induction_without_atomization isrec with_evars elim names lid =
 (* assume that no occurrences are selected *)
 let clear_unselected_context id inhyps cls =
   Proofview.Goal.enter begin fun gl ->
-  if occur_var (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) id (Tacmach.pf_concl gl) &&
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  if occur_var env sigma id (Tacmach.pf_concl gl) &&
     cls.concl_occs == NoOccurrences
   then error (MentionConclusionDependentOn id);
   match cls.onhyps with
@@ -1236,7 +1238,7 @@ let clear_unselected_context id inhyps cls =
         if Id.List.mem id' inhyps then (* if selected, do not erase *) None
         else
           (* erase if not selected and dependent on id or selected hyps *)
-          let test id = occur_var_in_decl (Tacmach.pf_env gl) (Proofview.Goal.sigma gl) id d in
+          let test id = occur_var_in_decl env sigma id d in
           if List.exists test (id::inhyps) then Some id' else None in
       let ids = List.map_filter to_erase (Proofview.Goal.hyps gl) in
       clear ids

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1090,7 +1090,7 @@ let apply_induction_in_context with_evars inhyps elim indvars names =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
-    let concl = Tacmach.pf_concl gl in
+    let concl = Proofview.Goal.concl gl in
     let hyp0 = match elim with
     | ElimUsing (hyp0, _) | ElimOver (hyp0, _) | CaseOver (hyp0, _) -> Some hyp0
     | ElimUsingList _ -> None
@@ -1228,8 +1228,8 @@ let clear_unselected_context id inhyps cls =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
-  if occur_var env sigma id (Tacmach.pf_concl gl) &&
-    cls.concl_occs == NoOccurrences
+  let concl = Proofview.Goal.concl gl in
+  if occur_var env sigma id concl && cls.concl_occs == NoOccurrences
   then error (MentionConclusionDependentOn id);
   match cls.onhyps with
   | Some hyps ->

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1025,9 +1025,10 @@ let find_induction_type env sigma isrec elim hyp0 sort = match elim with
   let (params, indices) = List.chop scheme.nparams args in
   sigma, (hd, params, indices), ElimUsing (hyp0, (e, elimt, indsign))
 
-let is_functional_induction elimc gl =
+let is_functional_induction elimc gl = (* XXX don't take a gl *)
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
-  let scheme = compute_elim_sig sigma (Tacmach.pf_get_type_of gl (fst elimc)) in
+  let scheme = compute_elim_sig sigma (Retyping.get_type_of env sigma (fst elimc)) in
   (* The test is not safe: with non-functional induction on non-standard
      induction scheme, this may fail *)
   Option.is_empty scheme.indarg
@@ -1035,7 +1036,7 @@ let is_functional_induction elimc gl =
 (* Instantiate all meta variables of elimclause using lid, some elts
    of lid are parameters (first ones), the other are
    arguments. Returns the clause obtained.  *)
-let recolle_clenv i params args elimclause gl =
+let recolle_clenv i params args elimclause gl = (* XXX don't take a gl *)
   let lindmv = Array.of_list (clenv_arguments elimclause) in
   let k = match i with None -> Array.length lindmv - List.length args | Some i -> i in
   (* parameters correspond to first elts of lid. *)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -569,8 +569,8 @@ let invIn k names ids id =
     let nb_prod_init = nb_prod sigma concl in
     let intros_replace_ids =
       Proofview.Goal.enter begin fun gl ->
-        let concl = pf_concl gl in
         let sigma = Proofview.Goal.sigma gl in
+        let concl = Proofview.Goal.concl gl in
         let nb_of_new_hyp =
           nb_prod sigma concl - (List.length hyps + nb_prod_init)
         in

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -389,10 +389,11 @@ let projectAndApply as_mode thin avoid id eqname names depids =
   in
   let substHypIfVariable tac id =
     Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     (* We only look at the type of hypothesis "id" *)
     let hyp = pf_nf_evar gl (pf_get_hyp_typ id gl) in
-    let (t,t1,t2) = dest_nf_eq (pf_env gl) sigma hyp in
+    let (t,t1,t2) = dest_nf_eq env sigma hyp in
     match (EConstr.kind sigma t1, EConstr.kind sigma t2) with
     | Var id1, _ -> generalizeRewriteIntros as_mode (subst_hyp true id) depids id1
     | _, Var id2 -> generalizeRewriteIntros as_mode (subst_hyp false id) depids id2

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -22,7 +22,6 @@ open Namegen
 open Inductiveops
 open Printer
 open Retyping
-open Tacmach
 open Tacticals
 open Tactics
 open Elim
@@ -392,7 +391,7 @@ let projectAndApply as_mode thin avoid id eqname names depids =
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     (* We only look at the type of hypothesis "id" *)
-    let hyp = pf_nf_evar gl (pf_get_hyp_typ id gl) in
+    let hyp = Tacmach.pf_nf_evar gl (Tacmach.pf_get_hyp_typ id gl) in
     let (t,t1,t2) = dest_nf_eq env sigma hyp in
     match (EConstr.kind sigma t1, EConstr.kind sigma t2) with
     | Var id1, _ -> generalizeRewriteIntros as_mode (subst_hyp true id) depids id1
@@ -488,7 +487,7 @@ let raw_inversion inv_kind id status names =
     let concl = Proofview.Goal.concl gl in
     let c = mkVar id in
     let ((ind, u), t) =
-      try pf_apply Tacred.reduce_to_atomic_ind gl (pf_get_type_of gl c)
+      try Tacmach.pf_apply Tacred.reduce_to_atomic_ind gl (Tacmach.pf_get_type_of gl c)
       with UserError _ ->
         let msg = str "The type of " ++ Id.print id ++ str " is not inductive." in
         CErrors.user_err  msg
@@ -563,7 +562,7 @@ let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp (CAst.make i
 
 let invIn k names ids id =
   Proofview.Goal.enter begin fun gl ->
-    let hyps = List.map (fun id -> pf_get_hyp id gl) ids in
+    let hyps = List.map (fun id -> Tacmach.pf_get_hyp id gl) ids in
     let concl = Proofview.Goal.concl gl in
     let sigma = Proofview.Goal.sigma gl in
     let nb_prod_init = nb_prod sigma concl in

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -487,7 +487,7 @@ let raw_inversion inv_kind id status names =
     let concl = Proofview.Goal.concl gl in
     let c = mkVar id in
     let ((ind, u), t) =
-      try Tacmach.pf_apply Tacred.reduce_to_atomic_ind gl (Tacmach.pf_get_type_of gl c)
+      try Tacred.reduce_to_atomic_ind env sigma (Retyping.get_type_of env sigma c)
       with UserError _ ->
         let msg = str "The type of " ++ Id.print id ++ str " is not inductive." in
         CErrors.user_err  msg

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1904,8 +1904,8 @@ let unification_rewrite l2r c1 c2 sigma prf car rel but env =
   abs, sigma, res, Sorts.is_prop sort
 
 let get_hyp gl (c,l) clause l2r =
+  let env = Proofview.Goal.env gl in
   let evars = Proofview.Goal.sigma gl in
-  let env = Tacmach.pf_env gl in
   let sigma, hi = decompose_applied_relation env evars (c,l) in
   let but = match clause with
     | Some id -> Tacmach.pf_get_hyp_typ id gl

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1636,7 +1636,7 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
     let concl = Proofview.Goal.concl gl in
     let env = Proofview.Goal.env gl in
     let state = Proofview.Goal.state gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ty = match clause with
     | None -> concl
     | Some id -> EConstr.of_constr (Environ.named_type id env)
@@ -1904,7 +1904,7 @@ let unification_rewrite l2r c1 c2 sigma prf car rel but env =
   abs, sigma, res, Sorts.is_prop sort
 
 let get_hyp gl (c,l) clause l2r =
-  let evars = Tacmach.project gl in
+  let evars = Proofview.Goal.sigma gl in
   let env = Tacmach.pf_env gl in
   let sigma, hi = decompose_applied_relation env evars (c,l) in
   let but = match clause with
@@ -1929,7 +1929,7 @@ let general_s_rewrite cl l2r occs (c,l) ~new_goals =
     (), res
               }
   in
-  let origsigma = Tacmach.project gl in
+  let origsigma = Proofview.Goal.sigma gl in
   tactic_init_rewrite () <*>
     Proofview.tclOR
       (tclPROGRESS
@@ -1960,7 +1960,7 @@ let not_declared ~info env sigma ty concl =
 let setoid_proof ty fn fallback =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
     Proofview.tclORELSE
       begin

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1905,11 +1905,12 @@ let unification_rewrite l2r c1 c2 sigma prf car rel but env =
 
 let get_hyp gl (c,l) clause l2r =
   let env = Proofview.Goal.env gl in
-  let evars = Proofview.Goal.sigma gl in
-  let sigma, hi = decompose_applied_relation env evars (c,l) in
+  let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
+  let sigma, hi = decompose_applied_relation env sigma (c, l) in
   let but = match clause with
     | Some id -> Tacmach.pf_get_hyp_typ id gl
-    | None -> Reductionops.nf_evar evars (Tacmach.pf_concl gl)
+    | None -> Reductionops.nf_evar sigma concl
   in
   unification_rewrite l2r hi.c1 hi.c2 sigma hi.prf hi.car hi.rel but env
 

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -18,7 +18,6 @@ open Declarations
 open Tactypes
 open Proofview
 open Proofview.Notations
-open Tacmach
 
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
@@ -468,7 +467,7 @@ let tclWITHHOLES accept_unresolved_holes tac sigma =
 
 let tactic_of_delayed d =
   Proofview.Goal.enter_one ~__LOC__ @@ fun gl ->
-  let sigma, v = pf_apply d gl in
+  let sigma, v = Tacmach.pf_apply d gl in
   Proofview.Unsafe.tclEVARS sigma <*>
   tclUNIT v
 
@@ -529,7 +528,7 @@ let nLastHyps gl n = List.map mkVar (nLastHypsId gl n)
 let ifOnHyp pred tac1 tac2 id =
   Proofview.Goal.enter begin fun gl ->
   let typ = Tacmach.pf_get_hyp_typ id gl in
-  if pf_apply pred gl (id,typ) then
+  if Tacmach.pf_apply pred gl (id,typ) then
     tac1 id
   else
     tac2 id
@@ -581,12 +580,12 @@ let onAllHypsAndConcl tac =
 let elimination_sort_of_goal gl =
   (* Retyping will expand evars anyway. *)
   let c = Proofview.Goal.concl gl in
-  pf_apply Retyping.get_sort_quality_of gl c
+  Tacmach.pf_apply Retyping.get_sort_quality_of gl c
 
 let elimination_sort_of_hyp id gl =
   (* Retyping will expand evars anyway. *)
-  let c = pf_get_hyp_typ id gl in
-  pf_apply Retyping.get_sort_quality_of gl c
+  let c = Tacmach.pf_get_hyp_typ id gl in
+  Tacmach.pf_apply Retyping.get_sort_quality_of gl c
 
 let elimination_sort_of_clause id gl = match id with
 | None -> elimination_sort_of_goal gl

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2561,8 +2561,9 @@ let forward b usetac ipat c =
   match usetac with
   | None ->
       Proofview.Goal.enter begin fun gl ->
-      let t = Tacmach.pf_get_type_of gl c in
+      let env = Proofview.Goal.env gl in
       let sigma = Proofview.Goal.sigma gl in
+      let t = Retyping.get_type_of env sigma c in
       let hd = head_ident sigma c in
       let assert_as =
         let naming,tac = prepare_intros_opt false IntroAnonymous MoveLast ipat in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -94,7 +94,7 @@ let introduction id =
   Proofview.Goal.enter begin fun gl ->
     let concl = Proofview.Goal.concl gl in
     let relevance = Proofview.Goal.relevance gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let hyps = named_context_val (Proofview.Goal.env gl) in
     let env = Proofview.Goal.env gl in
     let () = if mem_named_context_val id hyps then
@@ -130,7 +130,7 @@ let convert_concl ~cast ~check ty k =
 let convert_hyp ~check ~reorder d =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ty = Proofview.Goal.concl gl in
     let sign = convert_hyp ~check ~reorder env sigma d in
     let env = reset_with_named_context sign env in
@@ -161,7 +161,7 @@ let clear_gen fail = function
     let ids = List.fold_right Id.Set.add ids Id.Set.empty in
     (* clear_hyps_in_evi does not require nf terms *)
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
     let (sigma, hyps, concl) =
       try clear_hyps_in_evi env sigma (named_context_val env) concl ids
@@ -204,7 +204,7 @@ let apply_clear_request clear_flag dft c =
 let move_hyp id dest =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ty = Proofview.Goal.concl gl in
     let sign = named_context_val env in
     let sign' = move_hyp_in_named_context env sigma id dest sign in
@@ -320,7 +320,7 @@ let find_name mayrepl decl naming gl = match naming with
   | NamingAvoid idl ->
       (* This case must be compatible with [find_intro_names] below. *)
       let env = Proofview.Goal.env gl in
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       new_fresh_id idl (default_id env sigma decl) gl
   | NamingBasedOn (id,idl) -> new_fresh_id idl id gl
   | NamingMustBe {CAst.loc;v=id} ->
@@ -367,7 +367,7 @@ let clear_hyps2 env sigma ids sign t cl =
 let internal_cut ?(check=true) replace id t =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
     let sign = named_context_val env in
     let r = Retyping.relevance_of_type env sigma t in
@@ -513,7 +513,7 @@ let e_change_in_hyps ~check ~reorder f args = match args with
 | _ :: _ ->
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let (env, sigma) = match reorder with
     | LocalHypConv ->
       (* If the reduction function is known not to depend on the named
@@ -835,7 +835,7 @@ let build_intro_tac id dest tac = match dest with
 let rec intro_then_gen name_flag move_flag ~force ~dep tac =
   let open Context.Rel.Declaration in
   Proofview.Goal.enter begin fun gl ->
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Tacmach.pf_env gl in
     let concl = Proofview.Goal.concl gl in
     match EConstr.kind sigma concl with
@@ -1049,7 +1049,7 @@ let lookup_hypothesis_as_renamed env sigma ccl = function
 let lookup_hypothesis_as_renamed_gen red h gl =
   let env = Proofview.Goal.env gl in
   let rec aux ccl =
-    match lookup_hypothesis_as_renamed env (Tacmach.project gl) ccl h with
+    match lookup_hypothesis_as_renamed env (Proofview.Goal.sigma gl) ccl h with
       | None when red ->
         begin match red_product env (Proofview.Goal.sigma gl) ccl with
         | None -> None
@@ -1173,7 +1173,7 @@ let force_destruction_arg with_evars env sigma c =
 let cut c =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
     (* Backward compat: ensure that [c] is well-typed. Plus we need to
        know the relevance *)
@@ -1296,7 +1296,7 @@ let general_elim_clause0 with_evars flags (submetas, c, ty) elim =
 let general_elim_clause_in0 with_evars flags id (submetas, c, ty) elimc =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let elimt = Retyping.get_type_of env sigma elimc in
   let i = index_of_ind_arg sigma elimt in
   let elimclause = mk_clenv_from env sigma (elimc, elimt) in
@@ -1328,7 +1328,7 @@ let general_elim_clause_in0 with_evars flags id (submetas, c, ty) elimc =
 let general_elim with_evars clear_flag (c, lbindc) elim =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let ct = Retyping.get_type_of env sigma c in
   let id = try Some (destVar sigma c) with DestKO -> None in
   let t = try snd (reduce_to_quantified_ind env sigma ct) with UserError _ -> ct in
@@ -1524,7 +1524,7 @@ let make_projection env sigma params cstr sign elim i n c (ind, u) =
 let descend_in_conjunctions avoid tac (err, info) c =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   try
     let t = Retyping.get_type_of env sigma c in
     let ((ind,u),t) = reduce_to_quantified_ind env sigma t in
@@ -1546,7 +1546,7 @@ let descend_in_conjunctions avoid tac (err, info) c =
           (List.init n (fun i (err, info) ->
             Proofview.Goal.enter begin fun gl ->
             let env = Proofview.Goal.env gl in
-            let sigma = Tacmach.project gl in
+            let sigma = Proofview.Goal.sigma gl in
             match make_projection env sigma params cstr sign elim i n c (ind, u) with
             | None ->
               Proofview.tclZERO ~info err
@@ -1576,13 +1576,13 @@ let general_apply ?(with_classes=true) ?(respect_opaque=false) with_delta with_d
     clear_flag {CAst.loc;v=(c,lbind : EConstr.constr with_bindings)} =
   Proofview.Goal.enter begin fun gl ->
   let concl = Proofview.Goal.concl gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let id = try Some (destVar sigma c) with DestKO -> None in
   let concl_nprod = nb_prod_modulo_zeta sigma concl in
   let rec try_main_apply with_destruct c =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ts =
       if respect_opaque then Conv_oracle.get_transp_state (oracle env)
       else TransparentState.full
@@ -1735,8 +1735,8 @@ let apply_in_once ?(respect_opaque = false) with_delta
   let rec aux ?err idstoclear with_destruct c =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
-    let idc = try Some (destVar (Tacmach.project gl) c) with DestKO -> None in
+    let sigma = Proofview.Goal.sigma gl in
+    let idc = try Some (destVar (Proofview.Goal.sigma gl) c) with DestKO -> None in
     let ts =
       if respect_opaque then Conv_oracle.get_transp_state (oracle env)
       else TransparentState.full
@@ -1850,7 +1850,7 @@ let assumption =
   | decl::rest ->
     let t = NamedDecl.get_type decl in
     let concl = Proofview.Goal.concl gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ans =
       if only_eq then
         if EConstr.eq_constr sigma t concl then Some sigma
@@ -1901,7 +1901,7 @@ let clear_body idl =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let ctx = named_context env in
     let ids = Id.Set.of_list idl in
     (* We assume the context to respect dependencies *)
@@ -1971,7 +1971,7 @@ let keep hyps =
   Proofview.Goal.enter begin fun gl ->
   Proofview.tclENV >>= fun env ->
   let ccl = Proofview.Goal.concl gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   let cl,_ =
     fold_named_context_reverse (fun (clear,keep) decl ->
       let decl = EConstr.of_named_decl decl in
@@ -2151,7 +2151,7 @@ let rewrite_hyp_then with_evars thin l2r id tac =
     List.filter (fun {CAst.v=id} -> not (Id.equal id id')) thin in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let {uj_type=t} = Typing.judge_of_variable env id in
     let t = whd_all env sigma t in
     let eqtac, thin = match match_with_equality_type env sigma t with
@@ -2559,7 +2559,7 @@ let forward b usetac ipat c =
   | None ->
       Proofview.Goal.enter begin fun gl ->
       let t = Tacmach.pf_get_type_of gl c in
-      let sigma = Tacmach.project gl in
+      let sigma = Proofview.Goal.sigma gl in
       let hd = head_ident sigma c in
       let assert_as =
         let naming,tac = prepare_intros_opt false IntroAnonymous MoveLast ipat in
@@ -2923,7 +2923,7 @@ let (forward_setoid_reflexivity, setoid_reflexivity) = Hook.make ()
 
 let maybe_betadeltaiota_concl allowred gl =
   let concl = Tacmach.pf_concl gl in
-  let sigma = Tacmach.project gl in
+  let sigma = Proofview.Goal.sigma gl in
   if not allowred then concl
   else
     let env = Proofview.Goal.env gl in
@@ -2935,7 +2935,7 @@ let reflexivity_red allowred =
      for an equality, but we may need to do some when called back from
      inside setoid_reflexivity (see Optimize cases in setoid_replace.ml). *)
     let env = Tacmach.pf_env gl in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = maybe_betadeltaiota_concl allowred gl in
     match match_with_equality_type env sigma concl with
     | None ->
@@ -3066,7 +3066,7 @@ let prove_transitivity hdcncl eq_kind t =
         mkApp (hdcncl, [| typ; c1; t |]), mkApp (hdcncl, [| typ; t; c2 |])
       | HeterogenousEq (typ1,c1,typ2,c2) ->
         let env = Proofview.Goal.env gl in
-        let sigma = Tacmach.project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let typt = Retyping.get_type_of env sigma t in
         mkApp(hdcncl, [| typ1; c1; typt ;t |]),
         mkApp(hdcncl, [| typt; t; typ2; c2 |])
@@ -3119,7 +3119,7 @@ let constr_eq ~strict x y =
   let fail_universes ~info = Tacticals.tclFAIL ~info (str "Not equal (due to universes)") in
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.pf_env gl in
-    let evd = Tacmach.project gl in
+    let evd = Proofview.Goal.sigma gl in
       match EConstr.eq_constr_universes env evd x y with
       | Some csts ->
         if strict then

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -929,7 +929,7 @@ let do_replace_lb handle aavoid narg p q =
   Proofview.Goal.enter begin fun gl ->
     let type_of_pq = Tacmach.pf_get_type_of gl p in
     let sigma = Proofview.Goal.sigma gl in
-    let env = Tacmach.pf_env gl in
+    let env = Proofview.Goal.env gl in
     let (ind,u as indu),v = destruct_ind env sigma type_of_pq in
     let c = get_scheme handle (!lb_scheme_kind_aux ()) ind in
     let sigma , lb_type_of_p = Evd.fresh_global env sigma c in
@@ -977,8 +977,8 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
     match (l1,l2) with
     | (t1::q1,t2::q2) ->
         Proofview.Goal.enter begin fun gl ->
+        let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
-        let env = Tacmach.pf_env gl in
         if EConstr.eq_constr sigma t1 t2 then aux q1 q2
         else (
           let tt1 = Tacmach.pf_get_type_of gl t1 in

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -927,9 +927,9 @@ let do_replace_lb handle aavoid narg p q =
 
   in
   Proofview.Goal.enter begin fun gl ->
-    let type_of_pq = Tacmach.pf_get_type_of gl p in
     let sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
+    let type_of_pq = Retyping.get_type_of env sigma p in
     let (ind,u as indu),v = destruct_ind env sigma type_of_pq in
     let c = get_scheme handle (!lb_scheme_kind_aux ()) ind in
     let sigma , lb_type_of_p = Evd.fresh_global env sigma c in
@@ -981,7 +981,7 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
         let sigma = Proofview.Goal.sigma gl in
         if EConstr.eq_constr sigma t1 t2 then aux q1 q2
         else (
-          let tt1 = Tacmach.pf_get_type_of gl t1 in
+          let tt1 = Retyping.get_type_of env sigma t1 in
           let (ind',u as indu),v = try destruct_ind env sigma tt1
           (* trick so that the good sequence is returned*)
                 with e when CErrors.noncritical e -> indu,[||]

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -928,7 +928,7 @@ let do_replace_lb handle aavoid narg p q =
   in
   Proofview.Goal.enter begin fun gl ->
     let type_of_pq = Tacmach.pf_get_type_of gl p in
-    let sigma = Tacmach.project gl in
+    let sigma = Proofview.Goal.sigma gl in
     let env = Tacmach.pf_env gl in
     let (ind,u as indu),v = destruct_ind env sigma type_of_pq in
     let c = get_scheme handle (!lb_scheme_kind_aux ()) ind in
@@ -977,7 +977,7 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
     match (l1,l2) with
     | (t1::q1,t2::q2) ->
         Proofview.Goal.enter begin fun gl ->
-        let sigma = Tacmach.project gl in
+        let sigma = Proofview.Goal.sigma gl in
         let env = Tacmach.pf_env gl in
         if EConstr.eq_constr sigma t1 t2 then aux q1 q2
         else (
@@ -1150,7 +1150,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
               Proofview.Goal.enter begin fun gl ->
                 let env = Proofview.Goal.env gl in
                 let concl = Proofview.Goal.concl gl in
-                let sigma = Tacmach.project gl in
+                let sigma = Proofview.Goal.sigma gl in
                 match EConstr.kind sigma concl with
                 | App (c,ca) -> (
                   match EConstr.kind sigma c with
@@ -1287,7 +1287,7 @@ let compute_lb_tact handle ind lnamesparrec nparrec =
                 );
               Proofview.Goal.enter begin fun gls ->
                 let concl = Proofview.Goal.concl gls in
-                let sigma = Tacmach.project gls in
+                let sigma = Proofview.Goal.sigma gls in
                 (* assume the goal to be eq (eq_type ...) = true *)
                 match EConstr.kind sigma concl with
                 | App(c,ca) -> (match (EConstr.kind sigma ca.(1)) with


### PR DESCRIPTION
We deprecate the usual (env, sigma, concl) trio that ought to have been replaced by their Proofview.Goal equivalent a long time ago. We also clean up a bit some of the callers along the way.