### PR TITLE
Revert #21328: Do not wrap side-effect certificates in ephemerons.

### DIFF
--- a/test-suite/stm/abstract.v
+++ b/test-suite/stm/abstract.v
@@ -1,0 +1,8 @@
+(* -*- coq-prog-args: ("-async-proofs" "on"); -*- *)
+
+Definition dummy := tt.
+
+Definition delayed_abstract : unit.
+Proof.
+abstract constructor.
+Qed.


### PR DESCRIPTION
The CI was green, but only because this PR was not properly tested above the other PR turning the certificate warning into an error. Merging both in parallel resulted in a CI failure reaching master.

For good measure we also add a test.