### PR TITLE
Stop directly checking Printing All while printing constr

### DIFF
--- a/dev/ci/user-overlays/21342-SkySkimmer-print-raw.sh
+++ b/dev/ci/user-overlays/21342-SkySkimmer-print-raw.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi print-raw 21342

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1232,14 +1232,9 @@ and extern_local_binder depth scopes eenv = function
          (na::assums,na::ids,
           CLocalAssum([CAst.make na],extern_relevance_info eenv.uvars r,Default bk,ty) :: l))
 
-    | GLocalPattern ((p,_),_,bk,ty) ->
-      let ty =
-        if eenv.flags.raw then Some (extern_typ depth scopes eenv ty) else None in
+    | GLocalPattern ((p,_),_,bk,_) ->
       let p = mkCPatOr (List.map (extern_cases_pattern ~flags:eenv.flags eenv.vars) p) in
       let (assums,ids,l) = extern_local_binder depth scopes eenv l in
-      let p = match ty with
-        | None -> p
-        | Some ty -> CAst.make @@ (CPatCast (p,ty)) in
       (assums,ids, CLocalPattern p :: l)
 
 and extern_eqn depth inctx scopes eenv {CAst.loc;v=(ids,pll,c)} =

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -99,7 +99,7 @@ let without_implicit_declarations f () =
 
 let full_detype_flags () =
   let flags = PrintingFlags.Detype.current() in
-  { flags with raw = true; universes = true; }
+  PrintingFlags.Detype.make_raw { flags with universes = true; }
 
 let full_extern_flags () =
   let flags = PrintingFlags.Extern.current() in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -103,9 +103,7 @@ let full_detype_flags () =
 
 let full_extern_flags () =
   let flags = PrintingFlags.Extern.current() in
-  { flags with raw = true; factorize_eqns = {
-        flags.factorize_eqns with
-        allow_match_default_clause = false } }
+  PrintingFlags.Extern.make_raw flags
 
 let extern_env_full_printing () =
   Constrextern.empty_extern_env ~flags:(full_extern_flags())

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -615,7 +615,7 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
         DAst.make @@ GCast (tomatch, None, detype t)
   in
   let alias, aliastyp, pred =
-    if (not flags.flg.raw) && synth_type && computable && not (Int.equal (Array.length bl) 0)
+    if synth_type && computable && not (Int.equal (Array.length bl) 0)
     then
       Anonymous, None, None
     else
@@ -635,7 +635,7 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
   let constructs = Array.init (Array.length bl) (fun i -> (ci.ci_ind,i+1)) in
   let tag = let st = ci.ci_pp_info.style in
     try
-      if flags.flg.raw then
+      if flags.flg.always_regular_match_style then
         RegularStyle
       else if st == LetPatternStyle then
         st
@@ -948,7 +948,7 @@ and detype_r d flags avoid env sigma t =
 
 and detype_eqns d flags avoid env sigma computable constructs bl =
   try
-    if flags.flg.raw || not flags.flg.matching then raise_notrace Exit;
+    if not flags.flg.matching then raise_notrace Exit;
     let mat = build_tree ~flags Anonymous flags (avoid,env) sigma bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))
@@ -1010,9 +1010,12 @@ and detype_binder d flags bk avoid env sigma decl c =
           try Retyping.get_sort_quality_of (snd env) sigma ty
           with Retyping.RetypeError _ -> UnivGen.QualityOrSet.qtype
       in
-      let t = if not (UnivGen.QualityOrSet.is_prop s) && not flags.flg.raw
-              then None
-              else Some (detype d (nongoal flags) avoid env sigma ty) in
+      let t =
+        (* XXX also sprop? *)
+        if flags.flg.nonpropositional_letin_types || UnivGen.QualityOrSet.is_prop s
+        then Some (detype d (nongoal flags) avoid env sigma ty)
+        else None
+      in
       GLetIn (na', rinfo, c, t, r)
 
 let detype_rel_context d flags avoid env sigma sign =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -24,7 +24,6 @@ open Glob_term
 open Glob_ops
 open Termops
 open Namegen
-open Libnames
 open Globnames
 open Mod_subst
 open Context.Rel.Declaration
@@ -244,28 +243,8 @@ let encode_tuple env ({CAst.loc} as r) =
       (str "This type cannot be seen as a tuple type.");
   x
 
-module PrintingInductiveMake =
-  functor (Test : sig
-     val encode : Environ.env -> qualid -> inductive
-     val member_message : Pp.t -> bool -> Pp.t
-     val field : string
-     val title : string
-  end) ->
-  struct
-    type t = inductive
-    module Set = Indset_env
-    let encode env ind = Environ.QInd.canonize env (Test.encode env ind)
-    let subst subst obj = subst_ind subst obj
-    let check_local _ _ = ()
-    let discharge (i:t) = i
-    let printer ind = Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef ind)
-    let key = ["Printing";Test.field]
-    let title = Test.title
-    let member_message x = Test.member_message (printer x)
-  end
-
 module PrintingCasesIf =
-  PrintingInductiveMake (struct
+  PrintingFlags.PrintingInductiveMake (struct
     let encode = encode_bool
     let field = "If"
     let title = "Types leading to pretty-printing of Cases using a `if' form:"
@@ -277,7 +256,7 @@ module PrintingCasesIf =
   end)
 
 module PrintingCasesLet =
-  PrintingInductiveMake (struct
+  PrintingFlags.PrintingInductiveMake (struct
     let encode = encode_tuple
     let field = "Let"
     let title =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -408,7 +408,7 @@ let lookup_index_as_renamed env sigma t n =
 let rec join_eqns ~flags (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
     let open ExternFlags.FactorizeEqns in
-     if not flags.raw && flags.factorize_match_patterns &&
+     if flags.factorize_match_patterns &&
         List.eq_set Id.equal ids ids' && glob_constr_eq rhs rhs'
      then
        join_eqns  ~flags x (patl'::patll) rest
@@ -455,7 +455,7 @@ let factorize_eqns ~flags eqns =
   let mk_anon patl = List.map (fun _ -> DAst.make @@ PatVar Anonymous) patl in
   let open CAst in
   let open ExternFlags.FactorizeEqns in
-  if not flags.raw && flags.allow_match_default_clause && eqns <> [] then
+  if flags.allow_match_default_clause && eqns <> [] then
     match select_default_clause eqns with
     (* At least two clauses and the last one is disjunctive with no variables *)
     | Some {loc=gloc;v=([],patl::_::_,rhs)}, (_::_ as eqns) ->

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -56,11 +56,3 @@ val detype_closed_glob : flags:PrintingFlags.Detype.t -> ?isgoal:bool ->
 (** look for the index of a named var or a nondep var as it is renamed *)
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option
 val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
-
-module PrintingInductiveMake :
-  functor (_ : sig
-    val encode : Environ.env -> Libnames.qualid -> Names.inductive
-    val member_message : Pp.t -> bool -> Pp.t
-    val field : string
-    val title : string
-  end) -> Goptions.RefConvertArg with type t = inductive

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -162,7 +162,6 @@ let { Goptions.get = print_float } =
 
 module Detype = struct
   type t = {
-    raw : bool;
     universes : bool;
     qualities : bool;
     relevances : bool;
@@ -174,10 +173,12 @@ module Detype = struct
     primproj_params : bool;
     unfolded_primproj_as_match : bool;
     match_paramunivs : bool;
+    always_regular_match_style : bool;
+    (* XXX is there a better word than "nonpropositional"? *)
+    nonpropositional_letin_types : bool;
   }
 
-  let current () = {
-    raw = !raw_print;
+  let current_ignore_raw () = {
     universes = !print_universes;
     qualities = print_sort_quality();
     relevances = print_relevances();
@@ -189,7 +190,24 @@ module Detype = struct
     primproj_params = print_primproj_params();
     unfolded_primproj_as_match = print_unfolded_primproj_asmatch();
     match_paramunivs = print_match_paramunivs();
+
+    (* not yet exposed (except through Printing All) *)
+    always_regular_match_style = false;
+    nonpropositional_letin_types = false;
   }
+
+  let make_raw flags = {
+    flags with
+    synth_match_return = false;
+    always_regular_match_style = true;
+    matching = false;
+    nonpropositional_letin_types = true;
+  }
+
+  let current () =
+    let flags = current_ignore_raw () in
+    if !raw_print then make_raw flags else flags
+
 end
 
 module Extern = struct

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -160,6 +160,64 @@ let { Goptions.get = print_float } =
     ~value:true
     ()
 
+module PrintingInductiveMake (Test : sig
+    val encode : Environ.env -> Libnames.qualid -> Names.inductive
+    val member_message : Pp.t -> bool -> Pp.t
+    val field : string
+    val title : string
+  end) =
+struct
+  type t = Names.inductive
+  module Set = Names.Indset_env
+  let encode env ind = Environ.QInd.canonize env (Test.encode env ind)
+  let subst subst obj = Mod_subst.subst_ind subst obj
+  let check_local _ _ = ()
+  let discharge (i:t) = i
+  let printer ind = Nametab.pr_global_env Names.Id.Set.empty (IndRef ind)
+  let key = ["Printing";Test.field]
+  let title = Test.title
+  let member_message x = Test.member_message (printer x)
+end
+
+(**********************************************************************)
+(* Control printing of records *)
+
+let encode_record env r =
+  let indsp = Nametab.global_inductive r in
+  if not (Structures.Structure.mem env indsp) then
+    CErrors.user_err ?loc:r.CAst.loc
+      Pp.(str "This type is not a structure type.");
+  indsp
+
+module PrintingRecordRecord =
+  PrintingInductiveMake (struct
+    let encode = encode_record
+    let field = "Record"
+    let title = "Types leading to pretty-printing using record notation: "
+    let member_message s b =
+      let open Pp in
+      str "Terms of " ++ s ++
+      str
+        (if b then " are printed using record notation"
+         else " are not printed using record notation")
+  end)
+
+module PrintingRecordConstructor =
+  PrintingInductiveMake (struct
+    let encode = encode_record
+    let field = "Constructor"
+    let title = "Types leading to pretty-printing using constructor form: "
+    let member_message s b =
+      let open Pp in
+      str "Terms of " ++ s ++
+      str
+        (if b then " are printed using constructor form"
+         else " are not printed using constructor form")
+  end)
+
+module PrintingRecord = Goptions.MakeRefTable(PrintingRecordRecord)
+module PrintingConstructor = Goptions.MakeRefTable(PrintingRecordConstructor)
+
 module Detype = struct
   type t = {
     universes : bool;
@@ -234,12 +292,40 @@ module Extern = struct
       if !raw_print then make_raw flags else flags
   end
 
+  module Records = struct
+    open Names
+
+    type t = {
+      default : bool;
+      force_record : Indset_env.t;
+      force_constructor : Indset_env.t;
+    }
+
+    let current_ignore_raw () = {
+      default = get_record_print();
+      force_record = PrintingRecord.v();
+      force_constructor = PrintingConstructor.v();
+    }
+
+    let make_raw _flags = {
+      default = false;
+      force_record = Indset_env.empty;
+      force_constructor = Indset_env.empty;
+    }
+
+    let current () =
+      let flags = current_ignore_raw() in
+      if !raw_print then make_raw flags else flags
+
+    let use_record_syntax flags r =
+      (flags.default && not (Indset_env.mem r flags.force_constructor)) ||
+      Indset_env.mem r flags.force_record
+
+  end
+
   type t = {
     use_implicit_types : bool;
-    records : bool;
-    (* XXX include the Printing Record & Printing Constructor tables
-       here instead of force_record_constructors? *)
-    force_record_constructors : bool;
+    records : Records.t;
     implicits : bool;
     implicits_explicit_args : bool;
     implicits_defensive : bool;
@@ -255,7 +341,7 @@ module Extern = struct
 
   let current_ignore_raw () = {
     use_implicit_types = print_use_implicit_types();
-    records = get_record_print();
+    records = Records.current_ignore_raw();
     implicits = !print_implicits;
     implicits_explicit_args = print_implicits_explicit_args();
     implicits_defensive = !print_implicits_defensive;
@@ -266,18 +352,15 @@ module Extern = struct
     projections = !print_projections;
     float = print_float();
     factorize_eqns = FactorizeEqns.current_ignore_raw();
-
-    (* not yet exposed (except through Printing All) *)
-    force_record_constructors = false;
   }
 
   let make_raw flags = {
     flags with
+    records = Records.make_raw flags.records;
     use_implicit_types = false;
     implicits = true;
     implicits_explicit_args = false;
     coercions = true;
-    force_record_constructors = true;
     raw_literals = true;
     notations = false;
     projections = false;

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -53,11 +53,24 @@ module Extern : sig
     val current_ignore_raw : unit -> t
   end
 
+  module Records : sig
+    type t
+
+    val make_raw : t -> t
+
+    val current : unit -> t
+
+    val current_ignore_raw : unit -> t
+
+    (** Tells whether record syntax should be used for some record. If
+        the inductive is not a record, the result is meaningless. *)
+    val use_record_syntax : t -> Names.inductive -> bool
+  end
+
   type t = {
     (* This tells to skip types if a variable has this type by default *)
     use_implicit_types : bool;
-    records : bool;
-    force_record_constructors : bool;
+    records : Records.t;
     implicits : bool;
     (** When [implicits] is on then [implicits_explicit_args] tells
         how implicit args are printed. If on, implicit args are
@@ -104,3 +117,13 @@ val current_ignore_raw : unit -> t
 val raw_print : bool ref
 
 val print_universes : bool ref
+
+module PrintingInductiveMake (_ : sig
+    val encode : Environ.env -> Libnames.qualid -> Names.inductive
+    val member_message : Pp.t -> bool -> Pp.t
+    val field : string
+    val title : string
+  end)
+  : Goptions.RefConvertArg
+    with type t = Names.inductive
+     and module Set = Names.Indset_env

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -10,7 +10,6 @@
 
 module Detype : sig
   type t = {
-    raw : bool;
     universes : bool;
     (** Should we print hidden sort quality variables? *)
     qualities : bool;
@@ -24,9 +23,15 @@ module Detype : sig
     primproj_params : bool;
     unfolded_primproj_as_match : bool;
     match_paramunivs : bool;
+    always_regular_match_style : bool;
+    nonpropositional_letin_types : bool;
   }
 
+  val make_raw : t -> t
+
   val current : unit -> t
+
+  val current_ignore_raw : unit -> t
 end
 
 module Extern : sig

--- a/pretyping/printingFlags.mli
+++ b/pretyping/printingFlags.mli
@@ -37,46 +37,53 @@ end
 module Extern : sig
   module FactorizeEqns : sig
     type t = {
-      raw : bool;
-      (** If true, contract branches with same r.h.s. and same matching
+      (* If true, contract branches with same r.h.s. and same matching
           variables in a disjunctive pattern *)
       factorize_match_patterns : bool;
-      (** If this flag is true and the last non unique clause of a
+      (* If this flag is true and the last non unique clause of a
           "match" is a variable-free disjunctive pattern, turn it into a
           catch-call case *)
       allow_match_default_clause : bool;
     }
 
+    val make_raw : t -> t
+
     val current : unit -> t
+
+    val current_ignore_raw : unit -> t
   end
 
   type t = {
-    raw : bool;
-    (** This tells to skip types if a variable has this type by default *)
+    (* This tells to skip types if a variable has this type by default *)
     use_implicit_types : bool;
     records : bool;
+    force_record_constructors : bool;
     implicits : bool;
     (** When [implicits] is on then [implicits_explicit_args] tells
         how implicit args are printed. If on, implicit args are
         printed with the form (id:=arg) otherwise arguments are
         printed normally and the function is prefixed by "@". *)
     implicits_explicit_args : bool;
-    (** Tells if implicit arguments not known to be inferable from a rigid
+    (* Tells if implicit arguments not known to be inferable from a rigid
         position are systematically printed *)
     implicits_defensive : bool;
     coercions : bool;
     parentheses : bool;
     notations : bool;
-    (** primitive tokens, like strings *)
+    (* primitive tokens, like strings *)
     raw_literals : bool;
-    (** This governs printing of projections using the dot notation symbols *)
+    (* This governs printing of projections using the dot notation symbols *)
     projections : bool;
     float : bool;
     factorize_eqns : FactorizeEqns.t;
     (* XXX depth? *)
   }
 
+  val make_raw : t -> t
+
   val current : unit -> t
+
+  val current_ignore_raw : unit -> t
 end
 
 (** Combined detyping and extern flags. *)
@@ -85,7 +92,11 @@ type t = {
   extern : Extern.t;
 }
 
+val make_raw : t -> t
+
 val current : unit -> t
+
+val current_ignore_raw : unit -> t
 
 (** The following flags are still accessed directly, but not when printing constr. *)
 

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -86,6 +86,8 @@ let rebuild env s =
   let nparams = mib.Declarations.mind_nparams in
   { s with nparams }
 
+let mem env ind = Environ.QInd.Map.mem env ind !structure_table
+
 let find env indsp = Environ.QInd.Map.find env indsp !structure_table
 
 let find_projections env indsp =

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -35,6 +35,9 @@ val subst : Mod_subst.substitution -> t -> t
 (** refreshes nparams, e.g. after section discharging *)
 val rebuild : Environ.env -> t -> t
 
+(** Tells whether the inductive corresponds to a structure. *)
+val mem : Environ.env -> Names.inductive -> bool
+
 (** [find isp] returns the Structure.t associated to the
    inductive path [isp] if it corresponds to a structure, otherwise
    it fails with [Not_found] *)


### PR DESCRIPTION
Instead Printing All overrides the values of other printing flags.

To make this work a couple new flags were added (not yet exposed to the user except through Printing All):
~~~ocaml
    always_regular_match_style : bool;
    nonpropositional_letin_types : bool;
~~~

(feel free to bikeshed the name of the second one as I'm not entirely satisfied with `nonpropositional_letin_types`:
by default ·`false`, Printing All makes it `true`, when `false` the types of letins not in Prop are not printed (Prop letins are always printed), eg `Check let x := 0 in let y := I in tt.` prints `let x := 0 in let y : True := I in tt`)

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/932