### PR TITLE
Print on non primitive record always prints as record

### DIFF
--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -127,7 +127,7 @@ let print_one_inductive env sigma mib ((_,i) as ind) =
   let cstrtypes = Array.map (fun c -> snd (Term.decompose_prod_n_decls nparamdecls c)) cstrtypes in
   let isrecord = match mip.mind_record with
     | NotRecord -> None
-    | FakeRecord -> if !PrintingFlags.raw_print then None else Some Anonymous
+    | FakeRecord -> Some Anonymous
     | PrimRecord (id,_,_,_) -> Some (Name id)
   in
   if Option.has_some isrecord then assert (Array.length cstrtypes = 1);
@@ -156,7 +156,7 @@ let pr_mutual_inductive_body env mind mib udecl =
     | BiFinite ->
        match mib.mind_packets.(0).mind_record with
        | NotRecord -> "Variant"
-       | FakeRecord -> if !PrintingFlags.raw_print then "Variant" else "Record"
+       | FakeRecord -> "Record"
        | PrimRecord l -> "Record"
   in
   let udecl = Option.map (fun x -> GlobRef.IndRef (mind,0), x) udecl in


### PR DESCRIPTION
instead of printing as Variant when Printing All is on. That was a IMO dubious and anyways undocumented behaviour.
