### PR TITLE
Stop using Printing All in coqc -output-context

### DIFF
--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -43,8 +43,8 @@ let coqc_main ((copts,_),stm_opts) injections ~opts =
   if copts.Coqcargs.output_context then begin
     let sigma, env = let e = Global.env () in Evd.from_env e, e in
     let access = Library.indirect_accessor[@@warning "-3"] in
-    Feedback.msg_notice Pp.(Flags.with_option PrintingFlags.raw_print (fun () ->
-        Prettyp.print_full_pure_context access env sigma) () ++ fnl ())
+    Feedback.msg_notice Pp.(
+        Prettyp.print_full_pure_context access env sigma ++ fnl ())
   end;
   ()
 


### PR DESCRIPTION
TBH this command line option isn't even documented AFAICT so maybe we should just remove it.
