### PR TITLE
Separate unsynchronized and synchronized grammar states in procq

### DIFF
--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -292,4 +292,4 @@ val unfreeze : frozen_t -> unit
 
 val get_keyword_state : unit -> CLexer.keyword_state
 
-val modify_keyword_state : (CLexer.keyword_state -> CLexer.keyword_state) -> unit
+val extend_keywords : string list -> unit

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -22,7 +22,7 @@ let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpac
 
 let () =
    Mltop.add_init_function "rocq-runtime.plugins.derive" (fun () ->
-     Procq.modify_keyword_state (fun kw -> CLexer.add_keyword_tok kw (Tok.PKEYWORD "SuchThat")))
+     Procq.modify_keyword_state (fun kw -> CLexer.add_keyword kw  "SuchThat"))
 
 let warn_deprecated_derive_suchthat =
    CWarnings.create ~name:"deprecated-derive-suchthat" ~category:Deprecation.Version.v9_0

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -22,7 +22,7 @@ let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpac
 
 let () =
    Mltop.add_init_function "rocq-runtime.plugins.derive" (fun () ->
-     Procq.modify_keyword_state (fun kw -> CLexer.add_keyword kw  "SuchThat"))
+     Procq.extend_keywords ["SuchThat"])
 
 let warn_deprecated_derive_suchthat =
    CWarnings.create ~name:"deprecated-derive-suchthat" ~category:Deprecation.Version.v9_0


### PR DESCRIPTION
The unsynchronized part is shared over the whole process, but in
principle we could have multiple synchronized parsing states (eg with
multicore, or a more functional style summary)
