### PR TITLE
Fixes #21176 (effect keyword in ocaml extraction)

### DIFF
--- a/doc/changelog/13-extraction/21350-issue-21176-Fixed.rst
+++ b/doc/changelog/13-extraction/21350-issue-21176-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Added "effect" as a recognized keyword for ocaml extraction
+  (`#21350 <https://github.com/rocq-prover/rocq/pull/21350>`_,
+  fixes `#21176 <https://github.com/rocq-prover/rocq/issues/21176>`_,
+  by Dan Rostovtsev).

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -46,8 +46,8 @@ let pp_letin pat def body =
 
 let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))
-  [ "and"; "as"; "assert"; "begin"; "class"; "constraint"; "do";
-    "done"; "downto"; "else"; "end"; "exception"; "external"; "false";
+  [ "and"; "as"; "assert"; "begin"; "class"; "constraint"; "do"; "done";
+    "downto"; "effect"; "else"; "end"; "exception"; "external"; "false";
     "for"; "fun"; "function"; "functor"; "if"; "in"; "include";
     "inherit"; "initializer"; "lazy"; "let"; "match"; "method";
     "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or";

--- a/test-suite/output/bug_21176.out
+++ b/test-suite/output/bug_21176.out
@@ -1,0 +1,4 @@
+(** val effect0 : nat -> nat **)
+
+let effect0 x =
+  x

--- a/test-suite/output/bug_21176.v
+++ b/test-suite/output/bug_21176.v
@@ -1,0 +1,5 @@
+Require Import Extraction.
+
+Definition effect (x : nat) := x.
+
+Extraction effect.


### PR DESCRIPTION
Fixes #21176. 

Extraction now handles 'effect' keyword in OCaml 5.3.0 and higher.
