### PR TITLE
Manipulate lists rather than qualified identifiers in Evarnames.

### DIFF
--- a/dev/ci/user-overlays/21366-ppedrot-evar-names-use-full-path.sh
+++ b/dev/ci/user-overlays/21366-ppedrot-evar-names-use-full-path.sh
@@ -1,0 +1,3 @@
+overlay equations https://github.com/ppedrot/Coq-Equations evar-names-use-full-path 21366
+
+overlay tactician https://github.com/ppedrot/coq-tactician evar-names-use-full-path 21366

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1340,8 +1340,8 @@ command: [
 
 | DELETE "Show"
 | DELETE "Show" natural
-| DELETE "Show" fullyqualid
-| "Show" OPT [ fullyqualid | natural ]
+| DELETE "Show" qualid
+| "Show" OPT [ qualid | natural ]
 | DELETE "Show" "Ltac" "Profile"
 | REPLACE "Show" "Ltac" "Profile" "CutOff" integer
 | WITH "Show" "Ltac" "Profile" OPT [ "CutOff" integer | string ]
@@ -1561,7 +1561,7 @@ vernac_toplevel: [
 | DELETE vernac_control
 | DELETE "Show" "."
 | DELETE "Show" natural "."
-| REPLACE "Show" "Diffs" ident "."
+| REPLACE "Show" "Diffs" qualid "."
 | WITH "Show" "Diffs" ident
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -496,7 +496,7 @@ vernac_toplevel: [
 | "Show" "Proof" "Diffs" OPT "removed" "."
 | "Show" "."
 | test_show_natural "Show" natural "."
-| "Show" "Diffs" ident "."
+| "Show" "Diffs" qualid "."
 | Pvernac.Vernac_.main_entry
 ]
 
@@ -530,7 +530,7 @@ command: [
 | "Unfocused"
 | "Show"
 | "Show" natural
-| "Show" fullyqualid
+| "Show" qualid
 | "Show" "Existentials"
 | "Show" "Universes"
 | "Show" "Conjectures"
@@ -1383,7 +1383,7 @@ simple_reserv: [
 range_selector: [
 | natural "-" natural
 | natural
-| test_bracket_ident "[" fullyqualid "]"
+| test_bracket_ident "[" qualid "]"
 ]
 
 goal_selector: [

--- a/engine/evarnames.ml
+++ b/engine/evarnames.ml
@@ -31,7 +31,7 @@ sig
   type t =
     { basename: Id.t;
       path: Id.t list }
-  val make : Libnames.full_path -> t
+  val make : Libnames.qualid -> t
   val repr : t -> Libnames.full_path
 end =
 struct
@@ -40,7 +40,7 @@ struct
       path: Id.t list }
 
   let make path =
-    let (dp, id) = Libnames.repr_path path in
+    let (dp, id) = Libnames.repr_qualid path in
     { basename = id; path = DirPath.repr dp }
 
   let repr { basename; path } =
@@ -382,4 +382,4 @@ let resolve fp evn =
      if EvSet.mem ev evn.removed_evars then raise Not_found
      else ev
   | _ :: _ :: _ ->
-    CErrors.user_err (str "Ambiguous evar name " ++ Libnames.pr_path fp)
+    CErrors.user_err ?loc:fp.loc (str "Ambiguous evar name " ++ Libnames.pr_qualid fp ++ str ".")

--- a/engine/evarnames.ml
+++ b/engine/evarnames.ml
@@ -25,40 +25,28 @@ let { Goptions.get = generate_goal_names } =
 
 (** Internal representation of qualified evar names.
 
-    Example: "x.y.z" is represented as [{ basename: "z"; path: ["y"; "x"] }]
-
-    To convert to and from [Id.t] (with dots), use [EvarQualid.to_id] and [EvarQualid.of_id]. *)
+    Example: "x.y.z" is represented as [{ basename: "z"; path: ["y"; "x"] }] *)
 module EvarQualid :
 sig
   type t =
     { basename: Id.t;
       path: Id.t list }
-
-  val of_list : Id.t list -> t
-  val of_id : Id.t -> t
-
-  val to_id : t -> Id.t
+  val make : Libnames.full_path -> t
+  val repr : t -> Libnames.full_path
 end =
 struct
   type t =
     { basename: Id.t;
       path: Id.t list }
 
-  let of_list l =
-    match List.rev l with
-    | basename :: path -> { basename; path }
-    | [] -> failwith "of_list"
+  let make path =
+    let (dp, id) = Libnames.repr_path path in
+    { basename = id; path = DirPath.repr dp }
 
-  let of_id id =
-    let parts = String.split_on_char '.' (Id.to_string id) in
-    of_list (List.map Id.of_string parts)
+  let repr { basename; path } =
+    Libnames.make_path (DirPath.make path) basename
 
-  let to_id { basename; path } =
-    let parts = List.rev_map Id.to_string (basename :: path) in
-    Id.of_string_soft (String.concat "." parts)
 end
-
-let of_list l = EvarQualid.to_id (EvarQualid.of_list l)
 
 (** Module for evar name resolution, using a reversed trie.
 
@@ -359,12 +347,16 @@ let name_of ev evn =
   | Some name ->
      let conflicts = NameResolution.find name evn.name_resolution in
      begin match conflicts with
-     | [_] -> Some (EvarQualid.to_id name)
+     | [_] -> Some (EvarQualid.repr name)
      | _ ->
         (* If the qualified name is ambiguous, we append a suffix corresponding to the insertion index in the list. *)
+        let { EvarQualid.basename; path } = name in
         let i = CList.length conflicts - CList.index Evar.equal ev conflicts - 1 in
-        if i == -1 then Some (EvarQualid.to_id name)
-        else Some (EvarQualid.to_id EvarQualid.{ name with basename = Id.of_string @@ (Id.to_string name.basename) ^ (string_of_int i) })
+        let basename =
+          if Int.equal i (-1) then basename
+          else Id.of_string ((Id.to_string name.basename) ^ (string_of_int i))
+        in
+        Some (Libnames.make_path (DirPath.make path) basename)
      end
   | None -> None
 
@@ -380,8 +372,8 @@ let has_unambiguous_name ev evn =
      end
   | None -> false
 
-let resolve id evn =
-  let qualid = EvarQualid.of_id id in
+let resolve fp evn =
+  let qualid = EvarQualid.make fp in
   let evs = NameResolution.find qualid evn.name_resolution in
   let open Pp in
   match evs with
@@ -389,4 +381,5 @@ let resolve id evn =
   | [ev] ->
      if EvSet.mem ev evn.removed_evars then raise Not_found
      else ev
-  | _ :: _ :: _ -> CErrors.user_err (str "Ambiguous name " ++ Id.print id )
+  | _ :: _ :: _ ->
+    CErrors.user_err (str "Ambiguous evar name " ++ Libnames.pr_path fp)

--- a/engine/evarnames.mli
+++ b/engine/evarnames.mli
@@ -13,9 +13,6 @@ open Names
 (** Whether the [Generate Goal Names] option is enabled. *)
 val generate_goal_names : unit -> bool
 
-(** Creates a qualified name from a list of identifiers. *)
-val of_list : Id.t list -> Id.t
-
 (** Represents an evar name map. *)
 type t
 
@@ -39,7 +36,7 @@ val remove : Evar.t -> t -> t
 val transfer_name : Evar.t -> Evar.t -> t -> t
 
 (** Returns the qualified name associated to the evar, if any. *)
-val name_of : Evar.t -> t -> Id.t option
+val name_of : Evar.t -> t -> Libnames.full_path option
 
 (** Returns [true] if the evar has a name.
     Equivalent to [name_of ev <> None] but faster since it does not compute the
@@ -51,4 +48,4 @@ val has_unambiguous_name : Evar.t -> t -> bool
 
 (** Resolves the given (partially) qualified name to an evar.
     If the name resolution failed, raises [Not_found]. *)
-val resolve : Id.t -> t -> Evar.t
+val resolve : Libnames.full_path -> t -> Evar.t

--- a/engine/evarnames.mli
+++ b/engine/evarnames.mli
@@ -48,4 +48,4 @@ val has_unambiguous_name : Evar.t -> t -> bool
 
 (** Resolves the given (partially) qualified name to an evar.
     If the name resolution failed, raises [Not_found]. *)
-val resolve : Libnames.full_path -> t -> Evar.t
+val resolve : Libnames.qualid -> t -> Evar.t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -377,7 +377,7 @@ val downcast : Evar.t-> etypes -> evar_map -> evar_map
 
 (** {6 Evar names} *)
 
-val evar_ident : Evar.t -> evar_map -> Id.t option
+val evar_ident : Evar.t -> evar_map -> Libnames.full_path option
 
 val evar_has_name : Evar.t -> evar_map -> bool
 
@@ -387,7 +387,7 @@ val add_name : Evar.t -> Id.t -> ?parent:Evar.t -> evar_map -> evar_map
 
 val transfer_name : Evar.t -> Evar.t -> evar_map -> evar_map
 
-val evar_key : Id.t -> evar_map -> Evar.t
+val evar_key : Libnames.full_path -> evar_map -> Evar.t
 
 val dependent_evar_ident : Evar.t -> evar_map -> Id.t
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -387,7 +387,7 @@ val add_name : Evar.t -> Id.t -> ?parent:Evar.t -> evar_map -> evar_map
 
 val transfer_name : Evar.t -> Evar.t -> evar_map -> evar_map
 
-val evar_key : Libnames.full_path -> evar_map -> Evar.t
+val evar_key : Libnames.qualid -> evar_map -> Evar.t
 
 val dependent_evar_ident : Evar.t -> evar_map -> Id.t
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -365,7 +365,7 @@ let tclBREAK = Proof.break
 type goal_range_selector =
   | NthSelector of int
   | RangeSelector of (int * int)
-  | IdSelector of Libnames.full_path
+  | IdSelector of Libnames.qualid
 
 exception NoSuchGoals of int
 exception CannotSelectShelvedAndFocused

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -365,7 +365,7 @@ let tclBREAK = Proof.break
 type goal_range_selector =
   | NthSelector of int
   | RangeSelector of (int * int)
-  | IdSelector of Names.Id.t
+  | IdSelector of Libnames.full_path
 
 exception NoSuchGoals of int
 exception CannotSelectShelvedAndFocused

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -248,7 +248,7 @@ val tclBREAK : (Exninfo.iexn -> Exninfo.iexn option) -> 'a tactic -> 'a tactic
 type goal_range_selector =
   | NthSelector of int
   | RangeSelector of (int * int)
-  | IdSelector of Libnames.full_path
+  | IdSelector of Libnames.qualid
 
 exception NoSuchGoals of int
 exception CannotSelectShelvedAndFocused
@@ -293,7 +293,7 @@ val tclFOCUSSELECTORLIST : ?nosuchgoal:'a tactic -> goal_range_selector list -> 
 (** [tclFOCUSID x t] applies [t] on a (single) focused goal like
     {!tclFOCUS}. The goal is found by its name rather than its
     number. Fails with [nosuchgoal], by default raising [NoSuchGoals 1]. *)
-val tclFOCUSID : ?nosuchgoal:'a tactic -> Libnames.full_path -> 'a tactic -> 'a tactic
+val tclFOCUSID : ?nosuchgoal:'a tactic -> Libnames.qualid -> 'a tactic -> 'a tactic
 
 (** [tclTRYFOCUS i j t] behaves like {!tclFOCUS}, except that if the
     specified range doesn't correspond to existing goals, behaves like

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -248,7 +248,7 @@ val tclBREAK : (Exninfo.iexn -> Exninfo.iexn option) -> 'a tactic -> 'a tactic
 type goal_range_selector =
   | NthSelector of int
   | RangeSelector of (int * int)
-  | IdSelector of Names.Id.t
+  | IdSelector of Libnames.full_path
 
 exception NoSuchGoals of int
 exception CannotSelectShelvedAndFocused
@@ -293,7 +293,7 @@ val tclFOCUSSELECTORLIST : ?nosuchgoal:'a tactic -> goal_range_selector list -> 
 (** [tclFOCUSID x t] applies [t] on a (single) focused goal like
     {!tclFOCUS}. The goal is found by its name rather than its
     number. Fails with [nosuchgoal], by default raising [NoSuchGoals 1]. *)
-val tclFOCUSID : ?nosuchgoal:'a tactic -> Names.Id.t -> 'a tactic -> 'a tactic
+val tclFOCUSID : ?nosuchgoal:'a tactic -> Libnames.full_path -> 'a tactic -> 'a tactic
 
 (** [tclTRYFOCUS i j t] behaves like {!tclFOCUS}, except that if the
     specified range doesn't correspond to existing goals, behaves like

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -111,7 +111,7 @@ let evar_suggested_name env sigma evk =
   let open Evd in
   let base_id evk' evi =
   match evar_ident evk' sigma with
-  | Some id -> id
+  | Some id -> Libnames.basename id
   | None -> match Evd.evar_source evi with
   | _,Evar_kinds.ImplicitArg (c,(n,id),b) -> id
   | _,Evar_kinds.VarInstance id -> id
@@ -138,7 +138,7 @@ match evar_ident evk sigma with
 | None ->
   str "?" ++ Id.print (evar_suggested_name env sigma evk)
 | Some id ->
-  str "?" ++ Id.print id
+  str "?" ++ Libnames.pr_path id
 
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1419,9 +1419,10 @@ let rec glob_of_pat
       let map decl pat = NamedDecl.get_id decl, pat in
       let l = List.filter filter @@ List.map2 map hyps l in
       let id = match Evd.evar_ident evk sigma with
-      | None -> Id.of_string "__"
-      | Some id -> id
+      | None -> "__"
+      | Some id -> Libnames.string_of_path id
       in
+      let id = Id.of_string_soft id in
       GEvar (CAst.make id,List.map (fun (id,c) -> (CAst.make id, glob_of_pat of_extra avoid env sigma c)) l)
   | PRel n ->
       let id = try match lookup_name_of_rel n env with

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -254,7 +254,9 @@ let coerce_to_ident_not_fresh sigma v =
        | Evar (kn,_) ->
         begin match Evd.evar_ident kn sigma with
         | None -> fail ()
-        | Some id -> id
+        | Some id ->
+          let (dp, id) = Libnames.repr_path id in
+          if DirPath.is_empty dp then id else fail ()
         end
        | Const (cst,_) -> Constant.label cst
        | Construct (cstr,_) ->

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -864,7 +864,7 @@ and detype_r d flags avoid env sigma t =
         try
           let id = match Evd.evar_ident evk sigma with
           | None -> Termops.evar_suggested_name (snd env) sigma evk
-          | Some id -> id
+          | Some id -> Libnames.basename id (* XXX: is this reasonable? *)
           in
           let info = Evd.find_undefined sigma evk in
           let cl = Evd.expand_existential sigma (evk, cl) in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -774,7 +774,7 @@ struct
          sous-contexte du contexte courant, et qu'il n'y a pas de Rel "caché" *)
       let id = interp_ltac_id env id in
       let sigma, evk =
-        match Evd.evar_key (Libnames.make_path DirPath.empty id) sigma (* XXX: handle qualids *) with
+        match Evd.evar_key (Libnames.make_qualid DirPath.empty id) sigma (* XXX: handle qualids *) with
         | evk -> sigma, evk
         | exception Not_found ->
             if flags.undeclared_evars_rr then

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -601,7 +601,7 @@ let new_typed_evar env sigma ?naming ?rrpat ~src tycon =
     let sigma, ty = new_type_evar env sigma ~src in
     let sigma, c = new_evar env sigma ~src ?rrpat ?naming ty in
     let evk = fst (destEvar sigma c) in
-    let ido = Evd.evar_ident evk sigma in
+    let ido = Option.map Libnames.basename (Evd.evar_ident evk sigma) in
     let src = (fst src,Evar_kinds.EvarType (ido,evk)) in
     let sigma = update_source sigma (fst (destEvar sigma ty)) src in
     sigma, c, ty
@@ -774,7 +774,7 @@ struct
          sous-contexte du contexte courant, et qu'il n'y a pas de Rel "caché" *)
       let id = interp_ltac_id env id in
       let sigma, evk =
-        match Evd.evar_key id sigma with
+        match Evd.evar_key (Libnames.make_path DirPath.empty id) sigma (* XXX: handle qualids *) with
         | evk -> sigma, evk
         | exception Not_found ->
             if flags.undeclared_evars_rr then

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1057,7 +1057,7 @@ let pr_goal_by_id ?(flags=current_combined()) ?(oldp=None) ~proof id =
     let g = Evd.evar_key id sigma in
     let goal_map = get_goal_map oldp proof in
     let ogoal = get_ogoal goal_map g in
-    pr_selected_subgoal ~flags ~ogoal (Libnames.pr_path id) sigma g
+    pr_selected_subgoal ~flags ~ogoal (Libnames.pr_qualid id) sigma g
   with Not_found -> user_err Pp.(str "No such goal.")
 
 (** print a goal identified by the goal id as it appears in -emacs mode.

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1057,7 +1057,7 @@ let pr_goal_by_id ?(flags=current_combined()) ?(oldp=None) ~proof id =
     let g = Evd.evar_key id sigma in
     let goal_map = get_goal_map oldp proof in
     let ogoal = get_ogoal goal_map g in
-    pr_selected_subgoal ~flags ~ogoal (pr_id id) sigma g
+    pr_selected_subgoal ~flags ~ogoal (Libnames.pr_path id) sigma g
   with Not_found -> user_err Pp.(str "No such goal.")
 
 (** print a goal identified by the goal id as it appears in -emacs mode.

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -266,7 +266,7 @@ val pr_assumptionset : ?flags:PrintingFlags.t ->
   env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
 val pr_goal_by_id : ?flags:PrintingFlags.t ->
-  ?oldp:Proof.t option option -> proof:Proof.t -> Libnames.full_path -> Pp.t
+  ?oldp:Proof.t option option -> proof:Proof.t -> Libnames.qualid -> Pp.t
 val pr_goal_emacs : ?flags:PrintingFlags.t ->
   proof:Proof.t option -> int -> int -> Pp.t
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -266,7 +266,7 @@ val pr_assumptionset : ?flags:PrintingFlags.t ->
   env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
 val pr_goal_by_id : ?flags:PrintingFlags.t ->
-  ?oldp:Proof.t option option -> proof:Proof.t -> Id.t -> Pp.t
+  ?oldp:Proof.t option option -> proof:Proof.t -> Libnames.full_path -> Pp.t
 val pr_goal_emacs : ?flags:PrintingFlags.t ->
   proof:Proof.t option -> int -> int -> Pp.t
 

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -21,7 +21,7 @@ type t =
 let select_nth n = SelectList [NthSelector n]
 
 let pr_id_selector id =
-  Pp.(str "[" ++ Libnames.pr_path id ++ str "]")
+  Pp.(str "[" ++ Libnames.pr_qualid id ++ str "]")
 
 let pr_range_selector = let open Proofview in function
   | NthSelector i -> Pp.int i

--- a/proofs/goal_select.ml
+++ b/proofs/goal_select.ml
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
-
 (* spiwack: I'm choosing, for now, to have [goal_selector] be a
    different type than [goal_reference] mostly because if it makes sense
    to print a goal that is out of focus (or already solved) it doesn't
@@ -23,7 +21,7 @@ type t =
 let select_nth n = SelectList [NthSelector n]
 
 let pr_id_selector id =
-  Pp.(str "[" ++ Id.print id ++ str "]")
+  Pp.(str "[" ++ Libnames.pr_path id ++ str "]")
 
 let pr_range_selector = let open Proofview in function
   | NthSelector i -> Pp.int i

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -217,7 +217,8 @@ let focus_id cond inf id pr =
           raise CannotUnfocusThisWay
      end
   | None ->
-     raise (NoSuchGoal (Some id))
+    let id = Libnames.basename id in
+    raise (NoSuchGoal (Some id))
   end
 
 let rec unfocus kind pr () =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -56,7 +56,7 @@ exception CannotUnfocusThisWay
 (* Cannot focus on non-existing subgoals *)
 exception NoSuchGoals of int * int
 
-exception NoSuchGoal of Names.Id.t option
+exception NoSuchGoal of Libnames.qualid option
 
 exception FullyUnfocused
 
@@ -68,7 +68,7 @@ let _ = CErrors.register_handler begin function
   | NoSuchGoals (i,j) ->
     Some Pp.(str "[Focus] Not every goal in range ["++ int i ++ str","++int j++str"] exist.")
   | NoSuchGoal (Some id) ->
-    Some Pp.(str "[Focus] No such goal: " ++ str (Names.Id.to_string id) ++ str ".")
+    Some Pp.(str "[Focus] No such goal: " ++ Libnames.pr_qualid id ++ str ".")
   | NoSuchGoal None ->
     Some Pp.(str "[Focus] No such goal.")
   | FullyUnfocused ->
@@ -217,7 +217,6 @@ let focus_id cond inf id pr =
           raise CannotUnfocusThisWay
      end
   | None ->
-    let id = Libnames.basename id in
     raise (NoSuchGoal (Some id))
   end
 

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -117,7 +117,7 @@ val done_cond : ?loose_end:bool -> 'a focus_kind -> 'a focus_condition
 val focus : 'a focus_condition -> 'a -> int -> t -> t
 
 (* focus on goal named id *)
-val focus_id : 'a focus_condition -> 'a -> Libnames.full_path -> t -> t
+val focus_id : 'a focus_condition -> 'a -> Libnames.qualid -> t -> t
 
 exception FullyUnfocused
 exception CannotUnfocusThisWay
@@ -129,7 +129,7 @@ exception CannotUnfocusThisWay
    Bullet.push. *)
 exception NoSuchGoals of int * int
 
-exception NoSuchGoal of Names.Id.t option
+exception NoSuchGoal of Libnames.qualid option
 
 (* Unfocusing command.
    Raises [FullyUnfocused] if the proof is not focused.

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -117,7 +117,7 @@ val done_cond : ?loose_end:bool -> 'a focus_kind -> 'a focus_condition
 val focus : 'a focus_condition -> 'a -> int -> t -> t
 
 (* focus on goal named id *)
-val focus_id : 'a focus_condition -> 'a -> Names.Id.t -> t -> t
+val focus_id : 'a focus_condition -> 'a -> Libnames.full_path -> t -> t
 
 exception FullyUnfocused
 exception CannotUnfocusThisWay

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -119,7 +119,7 @@ let instantiate_tac n c ido =
 let instantiate_tac_by_name id c =
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
-  let id = Libnames.make_path DirPath.empty id in
+  let id = Libnames.make_qualid DirPath.empty id in
   let evk =
     try Evd.evar_key id sigma
     with Not_found -> user_err Pp.(str "Unknown existential variable.") in

--- a/tactics/evar_tactics.ml
+++ b/tactics/evar_tactics.ml
@@ -119,6 +119,7 @@ let instantiate_tac n c ido =
 let instantiate_tac_by_name id c =
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
+  let id = Libnames.make_path DirPath.empty id in
   let evk =
     try Evd.evar_key id sigma
     with Not_found -> user_err Pp.(str "Unknown existential variable.") in

--- a/toplevel/g_toplevel.mlg
+++ b/toplevel/g_toplevel.mlg
@@ -56,7 +56,7 @@ GRAMMAR EXTEND Gram
           (if removed = None then Proof_diffs.DiffOn else Proof_diffs.DiffRemoved)) }
       | IDENT "Show"; "."-> { Some (VernacShowGoal OpenSubgoals) }
       | test_show_natural; IDENT "Show"; n = natural; "." -> { Some (VernacShowGoal (NthGoal n)) }
-      | IDENT "Show"; IDENT "Diffs"; id = ident; "." -> { Some (VernacShowGoal (GoalId id)) }
+      | IDENT "Show"; IDENT "Diffs"; id = qualid; "." -> { Some (VernacShowGoal (GoalId id)) }
       | cmd = Pvernac.Vernac_.main_entry ->
               { match cmd with
               | None -> None

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2358,8 +2358,12 @@ let finish_proved_equations ~pm ~kind ~hook i entries types sigma0 =
     CList.fold_left2_map (fun sigma (_evar_env, ev, _evi, local_context, _type) entry ->
         let id =
           match Evd.evar_ident ev sigma0 with
-          | Some id -> id
-          | None -> let n = !obls in incr obls; Nameops.add_suffix i ("_obligation_" ^ string_of_int n)
+          | Some id -> Libnames.basename id (* XXX: should deambiguate somehow *)
+          | None ->
+            let n = !obls in
+            let () = incr obls in
+            let id = Nameops.add_suffix i ("_obligation_" ^ string_of_int n) in
+            id
         in
         let body, opaque = match entry.proof_entry_body with Default { body; opaque } -> body, opaque | _ -> assert false in
         let body, typ, args = ProofEntry.shrink_entry local_context body entry.proof_entry_type in

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -90,8 +90,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Unfocused" -> { VernacSynPure VernacUnfocused }
       | IDENT "Show" -> { VernacSynPure (VernacShow (ShowGoal OpenSubgoals)) }
       | IDENT "Show"; n = natural -> { VernacSynPure (VernacShow (ShowGoal (NthGoal n))) }
-      | IDENT "Show"; id = fullyqualid -> {
-      let id = Evarnames.of_list id.CAst.v in VernacSynPure (VernacShow (ShowGoal (GoalId id))) }
+      | IDENT "Show"; id = qualid -> { VernacSynPure (VernacShow (ShowGoal (GoalId id))) }
       | IDENT "Show"; IDENT "Existentials" -> { VernacSynPure (VernacShow ShowExistentials) }
       | IDENT "Show"; IDENT "Universes" -> { VernacSynPure (VernacShow ShowUniverses) }
       | IDENT "Show"; IDENT "Conjectures" -> { VernacSynPure (VernacShow ShowProofNames) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1044,7 +1044,7 @@ GRAMMAR EXTEND Gram
   range_selector:
     [ [ n = natural ; "-" ; m = natural -> { Proofview.RangeSelector (n, m) }
       | n = natural -> { Proofview.NthSelector n }
-      | test_bracket_ident; "["; id = qualid; "]" -> { Proofview.IdSelector Libnames.(make_path (qualid_path id) (qualid_basename id)) } ] ]
+      | test_bracket_ident; "["; id = qualid; "]" -> { Proofview.IdSelector id } ] ]
   ;
   goal_selector:
   [ [ l = LIST1 range_selector SEP "," -> { Goal_select.SelectList l } ] ]

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1044,8 +1044,7 @@ GRAMMAR EXTEND Gram
   range_selector:
     [ [ n = natural ; "-" ; m = natural -> { Proofview.RangeSelector (n, m) }
       | n = natural -> { Proofview.NthSelector n }
-      | test_bracket_ident; "["; id = fullyqualid; "]" -> {
-      let id = Evarnames.of_list id.CAst.v in Proofview.IdSelector id } ] ]
+      | test_bracket_ident; "["; id = qualid; "]" -> { Proofview.IdSelector Libnames.(make_path (qualid_path id) (qualid_basename id)) } ] ]
   ;
   goal_selector:
   [ [ l = LIST1 range_selector SEP "," -> { Goal_select.SelectList l } ] ]

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -775,7 +775,7 @@ let pr_synpure_vernac_expr v =
     let pr_goal_reference = function
       | OpenSubgoals -> mt ()
       | NthGoal n -> spc () ++ int n
-      | GoalId id -> spc () ++ pr_id id
+      | GoalId id -> spc () ++ pr_qualid id
     in
     let pr_showable = function
       | ShowGoal n -> keyword "Show" ++ pr_goal_reference n

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2427,8 +2427,7 @@ let show_goal goalref proof oldp =
     | OpenSubgoals -> pr_open_subgoals ~oldp proof
     | NthGoal n -> pr_nth_open_subgoal ~oldp ~proof n
     | GoalId qid ->
-      let fp = Libnames.(make_path (qualid_path qid) (qualid_basename qid)) in
-      pr_goal_by_id ~oldp ~proof fp
+      pr_goal_by_id ~oldp ~proof qid
 
 (* Stack is needed due to show proof names, should deprecate / remove
    and take pstate *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2426,7 +2426,9 @@ let show_goal goalref proof oldp =
   match goalref with
     | OpenSubgoals -> pr_open_subgoals ~oldp proof
     | NthGoal n -> pr_nth_open_subgoal ~oldp ~proof n
-    | GoalId id -> pr_goal_by_id ~oldp ~proof id
+    | GoalId qid ->
+      let fp = Libnames.(make_path (qualid_path qid) (qualid_basename qid)) in
+      pr_goal_by_id ~oldp ~proof fp
 
 (* Stack is needed due to show proof names, should deprecate / remove
    and take pstate *)

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -23,7 +23,7 @@ type scope_delimiter = delimiter_depth * scope_name
 type goal_reference =
   | OpenSubgoals
   | NthGoal of int
-  | GoalId of Id.t
+  | GoalId of qualid
 
 type debug_univ_name =
   | NamedUniv of qualid


### PR DESCRIPTION
This is a much better API, at the cost of slight backwards incompatibilities. Note that we use full_path rather than qualid despite the names being potentially not fully qualified, because the former does not store the locations while the latter does.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/671
- https://github.com/coq-tactician/coq-tactician/pull/122