### PR TITLE
Deprecate a good chunk of the Tacmach API

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -260,9 +260,10 @@ let app_global f args k =
 
 let assert_before n c =
   Proofview.Goal.enter begin fun gl ->
-    let evm, _ = Tacmach.pf_apply type_of gl c in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm)
-    (assert_before n c)
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let sigma, _ = type_of env sigma c in
+    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (assert_before n c)
   end
 
 let refresh_type env evm ty =
@@ -376,8 +377,10 @@ let refute_tac c t1 t2 p =
 
 let refine_exact_check c =
   Proofview.Goal.enter begin fun gl ->
-    let evm, _ = Tacmach.pf_apply type_of gl c in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm) (exact_check c)
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let sigma, _ = type_of env sigma c in
+    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (exact_check c)
   end
 
 let convert_to_goal_tac c t1 t2 p =
@@ -548,11 +551,12 @@ let mk_eq f c1 c2 k =
   Tacticals.pf_constr_of_global (Lazy.force f) >>= fun fc ->
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let evm, ty = Tacmach.pf_apply type_of gl c1 in
-    let evm, ty = Evarsolve.refresh_universes (Some false) env evm ty in
+    let sigma = Proofview.Goal.sigma gl in
+    let sigma, ty = type_of env sigma c1 in
+    let sigma, ty = Evarsolve.refresh_universes (Some false) env sigma ty in
     let term = mkApp (fc, [| ty; c1; c2 |]) in
-    let evm, _ =  type_of env evm term in
-    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evm) (k term)
+    let sigma, _ =  type_of env sigma term in
+    Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (k term)
     end
 
 let f_equal =

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -644,12 +644,12 @@ let build_proof (interactive_proof : bool) (fnames : Constant.t list) ptes_infos
           | Prod _ ->
             tclTHEN intro
               (Proofview.Goal.enter (fun g' ->
+                   let env = Proofview.Goal.env g' in
+                   let sigma = Proofview.Goal.sigma g' in
                    let open Context.Named.Declaration in
-                   let id = Tacmach.pf_last_hyp g' |> get_id in
+                   let id = get_id @@ List.hd @@ Environ.named_context env in
                    let new_term =
-                     Reductionops.nf_betaiota (Proofview.Goal.env g')
-                       (Proofview.Goal.sigma g')
-                       (mkApp (dyn_infos.info, [|mkVar id|]))
+                     Reductionops.nf_betaiota env sigma (mkApp (dyn_infos.info, [|mkVar id|]))
                    in
                    let new_infos = {dyn_infos with info = new_term} in
                    let do_prove new_hyps =

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -511,6 +511,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
                     (Proofview.Goal.enter (fun g' ->
                          let env = Proofview.Goal.env g' in
                          let sigma = Proofview.Goal.sigma g' in
+                         let concl = Proofview.Goal.concl g' in
                          (* We get infos on the equations introduced*)
                          let new_term_value_eq =
                            Tacmach.pf_get_hyp_typ heq_id g'
@@ -522,7 +523,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
                            | _ ->
                              observe
                                (fun () -> str "cannot compute new term value : "
-                               ++ Tacmach.pr_gls g' ++ fnl ()
+                               ++ Termops.Internal.print_constr_env env sigma concl ++ fnl ()
                                ++ str "last hyp is"
                                ++ pr_leconstr_env env sigma new_term_value_eq );
                              anomaly (Pp.str "cannot compute new term value.")

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -99,7 +99,7 @@ let functional_induction with_clean c princl pat =
           CErrors.user_err
             (str "functional induction must be used with a function") )
       | Some (princ, binding) ->
-        let sigma, princt = Tacmach.pf_type_of gl princ in
+        let sigma, princt = Typing.type_of env sigma princ in
         Proofview.Unsafe.tclEVARS sigma
         <*> Proofview.tclUNIT (princ, binding, princt, args))
   >>= fun (princ, bindings, princ_type, args) ->

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -1091,7 +1091,10 @@ let () =
 let () =
   define "goal" (unit @-> tac constr) @@ fun _ ->
   assert_focussed >>= fun () ->
-  Proofview.Goal.enter_one @@ fun gl -> return (Tacmach.pf_nf_concl gl)
+  Proofview.Goal.enter_one @@ fun gl ->
+  let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
+  return (Reductionops.nf_evar sigma concl)
 
 (** ident -> constr *)
 let () =

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -57,6 +57,8 @@ val pf_hnf_constr : Proofview.Goal.t -> constr -> types
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types
 
 val pf_compute : Proofview.Goal.t -> constr -> constr
+[@@ocaml.deprecated "(9.2) Use Tacred.pf_compute"]
+
 val pf_whd_compute : Proofview.Goal.t -> constr -> constr
 [@@ocaml.deprecated "(9.2) Use Tacred.whd_compute"]
 

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -60,5 +60,6 @@ val pf_compute : Proofview.Goal.t -> constr -> constr
 val pf_whd_compute : Proofview.Goal.t -> constr -> constr
 
 val pf_nf_evar : Proofview.Goal.t -> constr -> constr
+[@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]
 
 val pr_gls : Proofview.Goal.t -> Pp.t

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -69,3 +69,4 @@ val pf_nf_evar : Proofview.Goal.t -> constr -> constr
 [@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]
 
 val pr_gls : Proofview.Goal.t -> Pp.t
+[@@ocaml.deprecated "(9.2) Use Printer.pr_evar"]

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -51,6 +51,7 @@ val pf_get_hyp_typ        : Id.t -> Proofview.Goal.t -> types
 val pf_last_hyp           : Proofview.Goal.t -> named_declaration
 
 val pf_nf_concl : Proofview.Goal.t -> types
+[@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]
 
 val pf_hnf_constr : Proofview.Goal.t -> constr -> types
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -52,6 +52,7 @@ val pf_hyps_types : Proofview.Goal.t -> (Id.t * types) list
 val pf_get_hyp : Id.t -> Proofview.Goal.t -> named_declaration
 val pf_get_hyp_typ        : Id.t -> Proofview.Goal.t -> types
 val pf_last_hyp           : Proofview.Goal.t -> named_declaration
+[@@ocaml.deprecated "(9.2) Use EConstr.named_context"]
 
 val pf_nf_concl : Proofview.Goal.t -> types
 [@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -40,6 +40,7 @@ val pf_type_of : Proofview.Goal.t -> constr -> evar_map * types
 [@@ocaml.deprecated "(9.2) Use Typing.type_of"]
 
 val pf_conv_x : Proofview.Goal.t -> t -> t -> bool
+[@@ocaml.deprecated "(9.2) Use Reductionops.is_conv"]
 
 val pf_get_new_id  : Id.t -> Proofview.Goal.t -> Id.t
 val pf_ids_of_hyps : Proofview.Goal.t -> Id.t list

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -54,7 +54,9 @@ val pf_nf_concl : Proofview.Goal.t -> types
 [@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]
 
 val pf_hnf_constr : Proofview.Goal.t -> constr -> types
+
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types
+[@@ocaml.deprecated "(9.2) Use Reductionops.whd_all and Retyping.get_type_of"]
 
 val pf_compute : Proofview.Goal.t -> constr -> constr
 [@@ocaml.deprecated "(9.2) Use Tacred.pf_compute"]

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -37,6 +37,8 @@ val pf_get_type_of : Proofview.Goal.t -> constr -> types
 (** This function entirely type-checks the term and computes its type
     and the implied universe constraints. *)
 val pf_type_of : Proofview.Goal.t -> constr -> evar_map * types
+[@@ocaml.deprecated "(9.2) Use Typing.type_of"]
+
 val pf_conv_x : Proofview.Goal.t -> t -> t -> bool
 
 val pf_get_new_id  : Id.t -> Proofview.Goal.t -> Id.t

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -54,6 +54,7 @@ val pf_nf_concl : Proofview.Goal.t -> types
 [@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]
 
 val pf_hnf_constr : Proofview.Goal.t -> constr -> types
+[@@ocaml.deprecated "(9.2) Use Tacred.hnf_constr"]
 
 val pf_hnf_type_of : Proofview.Goal.t -> constr -> types
 [@@ocaml.deprecated "(9.2) Use Reductionops.whd_all and Retyping.get_type_of"]

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -45,7 +45,9 @@ val pf_conv_x : Proofview.Goal.t -> t -> t -> bool
 val pf_get_new_id  : Id.t -> Proofview.Goal.t -> Id.t
 val pf_ids_of_hyps : Proofview.Goal.t -> Id.t list
 val pf_ids_set_of_hyps : Proofview.Goal.t -> Id.Set.t
+
 val pf_hyps_types : Proofview.Goal.t -> (Id.t * types) list
+[@@ocaml.deprecated "(9.2) Use EConstr.named_context"]
 
 val pf_get_hyp : Id.t -> Proofview.Goal.t -> named_declaration
 val pf_get_hyp_typ        : Id.t -> Proofview.Goal.t -> types

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -58,6 +58,7 @@ val pf_hnf_type_of : Proofview.Goal.t -> constr -> types
 
 val pf_compute : Proofview.Goal.t -> constr -> constr
 val pf_whd_compute : Proofview.Goal.t -> constr -> constr
+[@@ocaml.deprecated "(9.2) Use Tacred.whd_compute"]
 
 val pf_nf_evar : Proofview.Goal.t -> constr -> constr
 [@@ocaml.deprecated "(9.2) Use Reductionops.nf_evar"]

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -244,10 +244,13 @@ let rec e_trivial_fail_db db_list local_db secvars =
     begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let d = NamedDecl.get_id @@ Tacmach.pf_last_hyp gl in
+    let d = match EConstr.named_context env with
+    | [] -> assert false
+    | d :: _ -> NamedDecl.get_id d
+    in
     let hints = push_resolve_hyp env sigma d local_db in
-      e_trivial_fail_db db_list hints secvars
-      end
+    e_trivial_fail_db db_list hints secvars
+    end
   in
   let trivial_resolve =
     Proofview.Goal.enter begin fun gl ->
@@ -882,7 +885,10 @@ module Search = struct
     let open Proofview in
     let env = Goal.env gl in
     let sigma = Goal.sigma gl in
-    let decl = Tacmach.pf_last_hyp gl in
+    let decl = match EConstr.named_context env with
+    | [] -> assert false
+    | decl :: _ -> decl
+    in
     let ldb =
       make_resolve_hyp env sigma (Hint_db.transparent_state info.search_hints)
                        info.search_only_classes decl info.search_hints in

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -88,8 +88,9 @@ let contradiction_context =
                  Tacticals.tclZEROMSG ~info (Pp.str"Not a negated unit type."))
               (Proofview.tclORELSE
                  (Proofview.Goal.enter begin fun gl ->
-                   let is_conv_leq = Tacmach.pf_apply is_conv_leq gl in
-                   filter_hyp (fun typ -> is_conv_leq typ t)
+                   let sigma = Proofview.Goal.sigma gl in
+                   let env = Proofview.Goal.env gl in
+                   filter_hyp (fun typ -> is_conv_leq env sigma typ t)
                      (fun id' -> simplest_elim (mkApp (mkVar id,[|mkVar id'|])))
                  end)
                  begin function (e, info) -> match e with

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -103,8 +103,13 @@ let e_exact flags h =
 
 let rec e_trivial_fail_db db_list local_db =
   let next = Proofview.Goal.enter begin fun gl ->
-    let d = NamedDecl.get_id @@ Tacmach.pf_last_hyp gl in
-    let local_db = push_resolve_hyp (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) d local_db in
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let d = match EConstr.named_context env with
+    | [] -> assert false
+    | d :: _ -> NamedDecl.get_id d
+    in
+    let local_db = push_resolve_hyp env sigma d local_db in
     e_trivial_fail_db db_list local_db
   end in
   Proofview.Goal.enter begin fun gl ->

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -29,8 +29,10 @@ let eauto_unif_flags = auto_flags_of_state TransparentState.full
 
 let e_give_exact ?(flags=eauto_unif_flags) c =
   Proofview.Goal.enter begin fun gl ->
-  let sigma, t1 = Tacmach.pf_type_of gl c in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
+  let sigma, t1 = Typing.type_of env sigma c in
   if occur_existential sigma t1 || occur_existential sigma concl then
     Tacticals.tclTHENLIST
       [Proofview.Unsafe.tclEVARS sigma;

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -227,7 +227,9 @@ let rec solveArg hyps dty largs rargs = match largs, rargs with
   ]
 | a1 :: largs, a2 :: rargs ->
   Proofview.Goal.enter begin fun gl ->
-  let sigma, rectype = Tacmach.pf_type_of gl a1 in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let sigma, rectype = Typing.type_of env sigma a1 in
   let tac hyp = solveArg (hyp :: hyps) dty largs rargs in
   let subtacs =
     if dty.eqonleft then [eqCase tac;diseqCase hyps dty.eqonleft;default_auto]
@@ -305,7 +307,9 @@ let compare c1 c2 =
   pf_constr_of_global (lib_ref "core.eq.type") >>= fun eqc ->
   pf_constr_of_global (lib_ref "core.not.type") >>= fun notc ->
   Proofview.Goal.enter begin fun gl ->
-  let sigma, rectype = Tacmach.pf_type_of gl c1 in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let sigma, rectype = Typing.type_of env sigma c1 in
   let ops = (opc,eqc,notc) in
   let decide = mkDecideEqGoal true ops rectype c1 c2 in
   tclTHEN (Proofview.Unsafe.tclEVARS sigma)

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -274,7 +274,7 @@ let decideGralEquality =
         let sigma = Proofview.Goal.sigma gl in
         let concl = Proofview.Goal.concl gl in
         match_eqdec env sigma concl >>= fun (dty, c1, c2, typ as data) ->
-        let headtyp = hd_app sigma (Tacmach.pf_whd_compute gl typ) in
+        let headtyp = hd_app sigma (Tacred.whd_compute env sigma typ) in
         begin match EConstr.kind sigma headtyp with
         | Ind (mi,_) -> Proofview.tclUNIT mi
         | _ -> tclZEROMSG (Pp.str"This decision procedure only works for inductive objects.")

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -730,13 +730,14 @@ let replace_core clause l2r eq =
 
 let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   Proofview.Goal.enter begin fun gl ->
-  let get_type_of = Tacmach.pf_apply get_type_of gl in
-  let t1 = get_type_of c1
-  and t2 = get_type_of c2 in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let t1 = get_type_of env sigma c1 in
+  let t2 = get_type_of env sigma c2 in
   let evd =
-    if unsafe then Some (Proofview.Goal.sigma gl)
+    if unsafe then Some sigma
     else
-      try Some (Evarconv.unify_delay (Proofview.Goal.env gl) (Proofview.Goal.sigma gl) t1 t2)
+      try Some (Evarconv.unify_delay env sigma t1 t2)
       with Evarconv.UnableToUnify _ -> None
   in
   match evd with
@@ -1338,7 +1339,7 @@ let inject_if_homogenous_dependent_pair ty =
   try
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let eq,u,(t,t1,t2) = Tacmach.pf_apply find_this_eq_data_decompose gl ty in
+    let eq,u,(t,t1,t2) = find_this_eq_data_decompose env sigma ty in
     (* fetch the informations of the  pair *)
     let sigTconstr   = Rocqlib.(lib_ref "core.sigT.type") in
     let existTconstr = Rocqlib.lib_ref    "core.sigT.intro" in
@@ -1349,13 +1350,13 @@ let inject_if_homogenous_dependent_pair ty =
         hd2,ar2 = decompose_app sigma t2 in
     if not (isRefX env sigma existTconstr hd1) then raise_notrace Exit;
     if not (isRefX env sigma existTconstr hd2) then raise_notrace Exit;
-    let (ind, _), _ = try Tacmach.pf_apply find_mrectype gl ar1.(0) with Not_found -> raise_notrace Exit in
+    let (ind, _), _ = try find_mrectype env sigma ar1.(0) with Not_found -> raise_notrace Exit in
     (* check if the user has declared the dec principle *)
     (* and compare the fst arguments of the dep pair *)
     (* Note: should work even if not an inductive type, but the table only *)
     (* knows inductive types *)
     if not (Option.has_some (Ind_tables.lookup_scheme (!eq_dec_scheme_kind_name()) ind) &&
-            Tacmach.pf_apply is_conv gl ar1.(2) ar2.(2)) then raise_notrace Exit;
+            is_conv env sigma ar1.(2) ar2.(2)) then raise_notrace Exit;
     let inj2 = match lib_ref_opt "core.eqdep_dec.inj_pair2" with
       | None ->
         warn_inject_no_eqdep_dec (env,ind);
@@ -1647,7 +1648,7 @@ let cutSubstInConcl l2r eqn =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
-  let (lbeq,u,(t,e1,e2)) = Tacmach.pf_apply find_eq_data_decompose gl eqn in
+  let (lbeq,u,(t,e1,e2)) = find_eq_data_decompose env sigma eqn in
   let (e1,e2) = if l2r then (e1,e2) else (e2,e1) in
   let (sigma, (typ, expected)) = subst_tuple_term env sigma e1 e2 concl in
   tclTHEN (Proofview.Unsafe.tclEVARS sigma)
@@ -1663,7 +1664,7 @@ let cutSubstInHyp l2r eqn id =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
-  let (lbeq,u,(t,e1,e2)) = Tacmach.pf_apply find_eq_data_decompose gl eqn in
+  let (lbeq,u,(t,e1,e2)) = find_eq_data_decompose env sigma eqn in
   let typ = Tacmach.pf_get_hyp_typ id gl in
   let (e1,e2) = if l2r then (e1,e2) else (e2,e1) in
   let (sigma, (typ, expected)) = subst_tuple_term env sigma e1 e2 typ in
@@ -1693,7 +1694,9 @@ let cutSubstClause l2r eqn cls =
 
 let substClause l2r c cls =
   Proofview.Goal.enter begin fun gl ->
-  let eq = Tacmach.pf_apply get_type_of gl c in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let eq = get_type_of env sigma c in
   tclTHENS (cutSubstClause l2r eq cls)
     [Proofview.tclUNIT (); exact_no_check c]
   end
@@ -1867,7 +1870,7 @@ let subst_all ?(flags=default_subst_tactic_flags) () =
     let sigma = Proofview.Goal.sigma gl in
     let c = Tacmach.pf_get_hyp hyp gl |> NamedDecl.get_type in
     try
-      let lbeq,u,(_,x,y) = Tacmach.pf_apply find_eq_data_decompose gl c in
+      let lbeq,u,(_,x,y) = find_eq_data_decompose env sigma c in
       if flags.only_leibniz then restrict_to_eq_and_identity env lbeq.eq;
       match EConstr.kind sigma x, EConstr.kind sigma y with
       | Var x, Var y when Id.equal x y ->

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1454,8 +1454,10 @@ let induction_gen_l isrec with_evars elim names lc =
 
             | _ ->
                 Proofview.Goal.enter begin fun gl ->
-                let sigma, t = Tacmach.pf_apply Typing.type_of gl c in
-                let x = id_of_name_using_hdchar (Proofview.Goal.env gl) sigma t Anonymous in
+                let env = Proofview.Goal.env gl in
+                let sigma = Proofview.Goal.sigma gl in
+                let sigma, t = Typing.type_of env sigma c in
+                let x = id_of_name_using_hdchar env sigma t Anonymous in
                 let id = new_fresh_id Id.Set.empty x gl in
                 let newl' = List.map (fun r -> replace_term sigma c (mkVar id) r) l' in
                 let () = newlc:=id::!newlc in

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -391,7 +391,7 @@ let projectAndApply as_mode thin avoid id eqname names depids =
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
     (* We only look at the type of hypothesis "id" *)
-    let hyp = Tacmach.pf_nf_evar gl (Tacmach.pf_get_hyp_typ id gl) in
+    let hyp = Reductionops.nf_evar sigma (Tacmach.pf_get_hyp_typ id gl) in
     let (t,t1,t2) = dest_nf_eq env sigma hyp in
     match (EConstr.kind sigma t1, EConstr.kind sigma t2) with
     | Var id1, _ -> generalizeRewriteIntros as_mode (subst_hyp true id) depids id1

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -467,7 +467,9 @@ let tclWITHHOLES accept_unresolved_holes tac sigma =
 
 let tactic_of_delayed d =
   Proofview.Goal.enter_one ~__LOC__ @@ fun gl ->
-  let sigma, v = Tacmach.pf_apply d gl in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let sigma, v = d env sigma in
   Proofview.Unsafe.tclEVARS sigma <*>
   tclUNIT v
 
@@ -527,8 +529,10 @@ let nLastHyps gl n = List.map mkVar (nLastHypsId gl n)
 
 let ifOnHyp pred tac1 tac2 id =
   Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
   let typ = Tacmach.pf_get_hyp_typ id gl in
-  if Tacmach.pf_apply pred gl (id,typ) then
+  if pred env sigma (id, typ) then
     tac1 id
   else
     tac2 id

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -142,7 +142,9 @@ let convert_hyp ~check ~reorder d =
 
 let convert_gen pb x y =
   Proofview.Goal.enter begin fun gl ->
-    match Tacmach.pf_apply (Reductionops.infer_conv ~pb) gl x y with
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    match Reductionops.infer_conv ~pb env sigma x y with
     | Some sigma -> Proofview.Unsafe.tclEVARS sigma
     | None -> TacticErrors.not_convertible ()
     | exception e when CErrors.noncritical e ->
@@ -2045,8 +2047,9 @@ let constructor_core with_evars cstr lbind =
 let constructor_tac with_evars expctdnumopt i lbind =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
-    let ((ind,_),redcl) = Tacmach.pf_apply Tacred.reduce_to_quantified_ind gl concl in
+    let ((ind, _), redcl) = Tacred.reduce_to_quantified_ind env sigma concl in
     let nconstr = Array.length (snd (Inductive.lookup_mind_specif env ind)).mind_consnames in
     check_number_of_constructors expctdnumopt i nconstr;
     Tacticals.tclTHENLIST [
@@ -2074,8 +2077,9 @@ let any_constructor with_evars tacopt =
     else Tacticals.tclORD (one_constr (ind,i)) (any_constr ind n (i + 1)) in
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
     let concl = Proofview.Goal.concl gl in
-    let (ind,_),redcl = Tacmach.pf_apply Tacred.reduce_to_quantified_ind gl concl in
+    let (ind, _), redcl = Tacred.reduce_to_quantified_ind env sigma concl in
     let nconstr =
       Array.length (snd (Inductive.lookup_mind_specif env ind)).mind_consnames in
     if Int.equal nconstr 0 then TacticErrors.no_constructors ();

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3029,7 +3029,9 @@ let (forward_setoid_symmetry_in, setoid_symmetry_in) = Hook.make ()
 
 let symmetry_in id =
   Proofview.Goal.enter begin fun gl ->
-    let sigma, ctype = Tacmach.pf_type_of gl (mkVar id) in
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let sigma, ctype = Typing.type_of env sigma (mkVar id) in
     let sign,t = decompose_prod_decls sigma ctype in
     tclEVARSTHEN sigma
       (Proofview.tclORELSE


### PR DESCRIPTION
This API is very error-prone. Taking goals as argument is a recipe for mismatched evarmaps, so this code should go away. Most of the fixed up code is in dubious parts of the implementation...