### PR TITLE
Deprecate the Tacticals.elimination_sort_of_* functions.

### DIFF
--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -43,6 +43,7 @@ let functional_induction with_clean c princl pat =
   Proofview.Goal.enter_one (fun gl ->
       let env = Proofview.Goal.env gl in
       let sigma = Proofview.Goal.sigma gl in
+      let concl = Proofview.Goal.concl gl in
       let f, args = decompose_app_list sigma c in
       match princl with
       | None -> (
@@ -59,7 +60,7 @@ let functional_induction with_clean c princl pat =
                   ( str "Cannot find induction information on "
                   ++ Termops.pr_global_env env (ConstRef c') )
             in
-            match elimination_sort_of_goal gl with
+            match Retyping.get_sort_quality_of env sigma concl with
             | Qual (QConstant QSProp) -> finfo.sprop_lemma
             | Qual (QConstant QProp) -> finfo.prop_lemma
             | Set -> finfo.rec_lemma
@@ -77,7 +78,7 @@ let functional_induction with_clean c princl pat =
               let princ_name =
                 Elimschemes.make_elimination_ident
                   (Constant.label c')
-                  (elimination_sort_of_goal gl)
+                  (Retyping.get_sort_quality_of env sigma concl)
               in
               let princ_ref =
                 match

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -201,8 +201,9 @@ let elim_type dty rectype a1 a2 =
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
+  let concl = Proofview.Goal.concl gl in
   let (ind, _) = Tacred.reduce_to_atomic_ind env sigma dty.op in
-  let s = Tacticals.elimination_sort_of_goal gl in
+  let s = Retyping.get_sort_quality_of env sigma concl in
   let elimc = Elimschemes.lookup_eliminator env (fst ind) s in
   (* Eliminator type is expected to have (potentially non-dependent) shape
       [forall A B (P : I A B -> Type), P _ -> P _ -> forall (s : I A B), P s ] *)

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1157,7 +1157,8 @@ let induction_with_atomization_of_ind_arg isrec with_evars elim names hyp0 inhyp
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
-  let sort = Tacticals.elimination_sort_of_goal gl in
+  let concl = Proofview.Goal.concl gl in
+  let sort = Retyping.get_sort_quality_of env sigma concl in
   let sigma, ty, elim_info = find_induction_type env sigma isrec elim hyp0 sort in
   let letins, avoid, t = atomize_param_of_ind env sigma ty in
   let letins = tclMAP (fun (na, c) -> Tactics.letin_tac None (Name na) c None allHypsAndConcl) letins in

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -159,8 +159,11 @@ val onAllHyps           : (Id.t -> unit tactic) -> unit tactic
 val onAllHypsAndConcl   : (Id.t option -> unit tactic) -> unit tactic
 
 val elimination_sort_of_goal : Proofview.Goal.t -> UnivGen.QualityOrSet.t
+[@@ocaml.deprecated "(9.2) Use Retyping.get_sort_quality_of"]
 val elimination_sort_of_hyp  : Id.t -> Proofview.Goal.t -> UnivGen.QualityOrSet.t
+[@@ocaml.deprecated "(9.2) Use Retyping.get_sort_quality_of"]
 val elimination_sort_of_clause : Id.t option -> Proofview.Goal.t -> UnivGen.QualityOrSet.t
+[@@ocaml.deprecated "(9.2) Use Retyping.get_sort_quality_of"]
 
 val pf_constr_of_global : GlobRef.t -> constr Proofview.tactic
 


### PR DESCRIPTION
Two of these functions were not even used, and the remaining one was very infrequently used in dubious bits of code.