### PR TITLE
Remove APIs that have been deprecated before 9.0.

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -1,5 +1,5 @@
 open Format
-open Term
+open Sorts
 open Names
 open Vmemitcodes
 open Values

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -1143,8 +1143,6 @@ let mkNamedProd_wo_LetIn sigma decl c =
 let it_mkProd init = List.fold_left (fun c (n,t)  -> mkProd (n, t, c)) init
 let it_mkLambda init = List.fold_left (fun c (n,t)  -> mkLambda (n, t, c)) init
 
-let compose_lam l b = it_mkLambda b l
-
 let it_mkProd_or_LetIn t ctx = List.fold_left (fun c d -> mkProd_or_LetIn d c) t ctx
 let it_mkLambda_or_LetIn t ctx = List.fold_left (fun c d -> mkLambda_or_LetIn d c) t ctx
 
@@ -1222,8 +1220,6 @@ let fresh_global ?loc ?rigid ?names env sigma reference =
   let (evd,t) = Evd.fresh_global ?loc ?rigid ?names env sigma reference in
   evd, t
 
-let is_global = isRefX
-
 let lookup_constant = Evd.MiniEConstr.lookup_constant
 
 let constant_value_in env sigma (kn, u) =
@@ -1292,16 +1288,5 @@ module UnsafeMonomorphic = struct
   let mkInd i = of_kind (Ind (in_punivs i))
   let mkConstruct c = of_kind (Construct (in_punivs c))
 end
-
-(* deprecated *)
-
-let decompose_lambda_assum = decompose_lambda_decls
-let decompose_prod_assum = decompose_prod_decls
-let decompose_prod_n_assum = decompose_prod_n_decls
-let prod_assum = prod_decls
-let decompose_lam = decompose_lambda
-let decompose_lam_n_assum = decompose_lambda_n_assum
-let decompose_lam_n_decls = decompose_lambda_n_decls
-let decompose_lam_assum = decompose_lambda_assum
 
 include UnsafeMonomorphic

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -191,15 +191,6 @@ module UnsafeMonomorphic : sig
   val mkConstruct : constructor -> t
 end
 
-val mkConst : Constant.t -> t
-[@@deprecated "(8.18) Use [mkConstU] or if truly needed [UnsafeMonomorphic.mkConst]"]
-
-val mkInd : inductive -> t
-[@@deprecated "(8.18) Use [mkIndU] or if truly needed [UnsafeMonomorphic.mkInd]"]
-
-val mkConstruct : constructor -> t
-[@@deprecated "(8.18) Use [mkConstructU] or if truly needed [UnsafeMonomorphic.mkConstruct]"]
-
 val mkRef : GlobRef.t * EInstance.t -> t
 
 val type1 : t
@@ -324,9 +315,6 @@ val decompose_lambda_n_assum : Evd.evar_map -> int -> t -> rel_context * t
 val decompose_lambda_n_decls : Evd.evar_map -> int -> t -> rel_context * t
 
 val prod_decls : Evd.evar_map -> t -> rel_context
-
-val compose_lam : (Name.t binder_annot * t) list -> t -> t
-[@@ocaml.deprecated "(8.17) Use [it_mkLambda] instead."]
 
 val to_lambda : Evd.evar_map -> int -> t -> t
 
@@ -459,9 +447,6 @@ val fresh_global :
   ?loc:Loc.t -> ?rigid:Evd.rigid -> ?names:EInstance.t -> Environ.env ->
   Evd.evar_map -> GlobRef.t -> Evd.evar_map * t
 
-val is_global : Environ.env -> Evd.evar_map -> GlobRef.t -> t -> bool
-[@@ocaml.deprecated "(8.12) Use [EConstr.isRefX] instead."]
-
 val expand_case : Environ.env -> Evd.evar_map ->
   case -> (t,t,ERelevance.t) Inductive.pexpanded_case
 
@@ -571,23 +556,3 @@ val iter_with_binders : Evd.evar_map ->
   ('a -> 'a) -> ('a -> handle -> t -> unit) -> 'a -> handle -> kind -> unit
 
 end
-
-(** Deprecated *)
-
-val decompose_lambda_assum : Evd.evar_map -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_decls] instead."]
-val decompose_prod_assum : Evd.evar_map -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_prod_decls] instead."]
-val decompose_prod_n_assum : Evd.evar_map -> int -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_prod_n_decls] instead."]
-val prod_assum : Evd.evar_map -> t -> rel_context
-[@@ocaml.deprecated "(8.18) Use [prod_decls] instead."]
-
-val decompose_lam : Evd.evar_map -> t -> (Name.t binder_annot * t) list * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda] instead."]
-val decompose_lam_n_assum : Evd.evar_map -> int -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_n_assum] instead."]
-val decompose_lam_n_decls : Evd.evar_map -> int -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_n_decls] instead."]
-val decompose_lam_assum : Evd.evar_map -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_assum] instead."]

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -16,7 +16,7 @@
 
 open Util
 open Names
-open Term
+open Sorts
 open Constr
 open Context
 open Environ

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -31,35 +31,6 @@ val lookup_rel_id : Id.t -> ('c, 't, 'r) Context.Rel.pt -> int * 'c option * 't
 val rel_vect : int -> int -> Constr.constr array
 val rel_list : int -> int -> constr list
 
-(** Prod/Lambda/LetIn destructors on econstr *)
-
-val mkProd_or_LetIn : rel_declaration -> types -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.mkProd_or_LetIn]."]
-
-val mkProd_wo_LetIn : rel_declaration -> types -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.mkProd_wo_LetIn]."]
-
-val it_mkProd : types -> (Name.t EConstr.binder_annot * types) list -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkProd]."]
-
-val it_mkLambda : constr -> (Name.t EConstr.binder_annot * types) list -> constr
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkLambda]."]
-
-val it_mkProd_or_LetIn : types -> rel_context -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkProd_or_LetIn]."]
-
-val it_mkProd_wo_LetIn : types -> rel_context -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkProd_wo_LetIn]."]
-
-val it_mkLambda_or_LetIn : Constr.constr -> Constr.rel_context -> Constr.constr
-  [@@ocaml.deprecated "(8.17) Use synonymous [Term.it_mkLambda_or_LetIn]."]
-
-val it_mkNamedProd_or_LetIn : Evd.evar_map -> types -> named_context -> types
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkNamedProd_or_LetIn]."]
-
-val it_mkNamedLambda_or_LetIn : Evd.evar_map -> constr -> named_context -> constr
-  [@@ocaml.deprecated "(8.17) Use synonymous [EConstr.it_mkNamedLambda_or_LetIn]."]
-
 (** Prod/Lambda/LetIn destructors on constr *)
 
 val it_mkNamedProd_wo_LetIn : Constr.types -> Constr.named_context -> Constr.types
@@ -205,12 +176,6 @@ val ids_of_named_context : ('c, 't, 'r) Context.Named.pt -> Id.t list
 val ids_of_context : env -> Id.t list
 val names_of_rel_context : env -> names_context
 
-(* [context_chop n Γ] returns (Γ₁,Γ₂) such that [Γ]=[Γ₂Γ₁], [Γ₁] has
-   [n] hypotheses, excluding local definitions, and [Γ₁], if not empty,
-   starts with an hypothesis (i.e. [Γ₁] has the form empty or [x:A;Γ₁'] *)
-val context_chop : int -> Constr.rel_context -> Constr.rel_context * Constr.rel_context
-  [@@ocaml.deprecated "(8.16) Use synonymous [Context.Rel.chop_nhyps]."]
-
 (* [env_rel_context_chop n env] extracts out the [n] top declarations
    of the rel_context part of [env], counting both local definitions and
    hypotheses *)
@@ -224,16 +189,6 @@ val add_vname : Id.Set.t -> Name.t -> Id.Set.t
 val process_rel_context : (rel_declaration -> env -> env) -> env -> env
 val assums_of_rel_context : ('c, 't, 'r) Context.Rel.pt -> ((Name.t,'r) Context.pbinder_annot * 't) list
 
-val lift_rel_context : int -> Constr.rel_context -> Constr.rel_context
-  [@@ocaml.deprecated "(8.15) Use synonymous [Vars.lift_rel_context]."]
-val substl_rel_context : Constr.constr list -> Constr.rel_context -> Constr.rel_context
-  [@@ocaml.deprecated "(8.15) Use synonymous [Vars.substl_rel_context]."]
-val smash_rel_context : Constr.rel_context -> Constr.rel_context
-  [@@ocaml.deprecated "(8.15) Use synonymous [Vars.smash_rel_context]."]
-val map_rel_context_with_binders :
-  (int -> 'c -> 'c) -> ('c, 'c, 'r) Context.Rel.pt -> ('c, 'c, 'r) Context.Rel.pt
-  [@@ocaml.deprecated "(8.15) Use synonymous [Context.Rel.map_with_binders]."]
-
 val map_rel_context_in_env :
   (env -> Constr.constr -> Constr.constr) -> env -> Constr.rel_context -> Constr.rel_context
 val fold_named_context_both_sides :
@@ -241,12 +196,6 @@ val fold_named_context_both_sides :
     Constr.named_context -> init:'a -> 'a
 val mem_named_context_val : Id.t -> named_context_val -> bool
 val compact_named_context : Evd.evar_map -> EConstr.named_context -> EConstr.compacted_context
-
-val map_rel_decl : ('r1 -> 'r2 ) -> ('a -> 'b) -> ('a, 'a, 'r1) Context.Rel.Declaration.pt -> ('b, 'b, 'r2) Context.Rel.Declaration.pt
-[@@deprecated "(8.20) Use [Context.Rel.Declaration.map_constr_het]"]
-
-val map_named_decl : ('r1 -> 'r2 ) -> ('a -> 'b) -> ('a, 'a, 'r1) Context.Named.Declaration.pt -> ('b, 'b, 'r2) Context.Named.Declaration.pt
-[@@deprecated "(8.20) Use [Context.Named.Declaration.map_constr_het]"]
 
 val clear_named_body : Id.t -> env -> env
 
@@ -260,15 +209,6 @@ val dependency_closure : env -> Evd.evar_map -> named_context -> Id.Set.t -> Id.
 
 (** Test if an identifier is the basename of a global reference *)
 val is_section_variable : env -> Id.t -> bool
-
-val global_of_constr : Evd.evar_map -> constr -> GlobRef.t * EInstance.t
-[@@ocaml.deprecated "(8.12) Use [EConstr.destRef] instead (throws DestKO instead of Not_found)."]
-
-val is_global : Environ.env -> Evd.evar_map -> GlobRef.t -> constr -> bool
-[@@ocaml.deprecated "(8.12) Use [EConstr.isRefX] instead."]
-
-val isGlobalRef : Evd.evar_map -> constr -> bool
-[@@ocaml.deprecated "(8.12) Use [EConstr.isRef] instead."]
 
 val is_template_polymorphic_ref : env -> Evd.evar_map -> constr -> bool
 val is_template_polymorphic_ind : env -> Evd.evar_map -> constr -> bool

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -565,10 +565,6 @@ module KerPair = struct
     let hash x = KerName.hash (canonical x)
   end
 
-  (** Default (logical) comparison and hash is on the canonical part *)
-  let equal = CanOrd.equal
-  let hash = CanOrd.hash
-
   module Self_Hashcons =
     struct
       type t = kernel_pair
@@ -813,9 +809,6 @@ struct
 
     let arg c = c.proj_arg
 
-    let hash p =
-      Hashset.Combine.combinesmall p.proj_arg (Ind.CanOrd.hash p.proj_ind)
-
     let compare_gen a b =
       let c = Int.compare a.proj_arg b.proj_arg in
       if c <> 0 then c
@@ -851,9 +844,6 @@ struct
       let hash p =
         Hashset.Combine.combinesmall p.proj_arg (Ind.UserOrd.hash p.proj_ind)
     end
-
-    let equal = CanOrd.equal
-    let compare = CanOrd.compare
 
     let canonize p =
       let { proj_ind; proj_npars; proj_arg; proj_name } = p in
@@ -911,12 +901,6 @@ struct
   let unfolded = snd
   let unfold (c, b as p) = if b then p else (c, true)
 
-  let equal (c, b) (c', b') = Repr.equal c c' && b == b'
-
-  let repr_equal p p' = Repr.equal (repr p) (repr p')
-
-  let hash (c, b) = (if b then 1 else 0) + Repr.hash c
-
   module CanOrd = struct
     type nonrec t = t
     let compare (p, b) (p', b') =
@@ -954,10 +938,6 @@ struct
 
   let hcons = Hashcons.simple_hcons HashProjection.generate HashProjection.hcons ()
 
-  let compare (p, b) (p', b') =
-    let c = Bool.compare b b' in
-    if c <> 0 then c else Repr.compare p p'
-
   let map f (c, b as x) =
     let c' = Repr.map f c in
     if c' == c then x else (c', b)
@@ -988,14 +968,6 @@ module GlobRefInternal = struct
     | ConstRef of Constant.t       (** A reference to the environment. *)
     | IndRef of inductive          (** A reference to an inductive type. *)
     | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
-
-  let equal gr1 gr2 =
-    gr1 == gr2 || match gr1,gr2 with
-    | ConstRef con1, ConstRef con2 -> Constant.equal con1 con2
-    | IndRef kn1, IndRef kn2 -> Ind.CanOrd.equal kn1 kn2
-    | ConstructRef kn1, ConstructRef kn2 -> Construct.CanOrd.equal kn1 kn2
-    | VarRef v1, VarRef v2 -> Id.equal v1 v2
-    | (ConstRef _ | IndRef _ | ConstructRef _ | VarRef _), _ -> false
 
   let global_eq_gen eq_cst eq_ind eq_cons x y =
     x == y ||
@@ -1037,8 +1009,6 @@ module GlobRef = struct
     | ConstRef of Constant.t       (** A reference to the environment. *)
     | IndRef of inductive          (** A reference to an inductive type. *)
     | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
-
-  let equal = GlobRefInternal.equal
 
   (* By default, [global_reference] are ordered on their canonical part *)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -373,12 +373,6 @@ sig
 
   include QNameS with type t := t
 
-  val equal : t -> t -> bool [@@ocaml.deprecated "(8.13) Use QConstant.equal"]
-  (** Default comparison, alias for [CanOrd.equal] *)
-
-  val hash : t -> int [@@ocaml.deprecated "(8.13) Use QConstant.hash"]
-  (** Hashing function *)
-
   val change_label : t -> Id.t -> t
   (** Builds a new constant name with a different label *)
 
@@ -443,11 +437,6 @@ sig
   (** Comparisons *)
 
   include QNameS with type t := t
-
-  val equal : t -> t -> bool [@@ocaml.deprecated "(8.13) Use QMutInd.equal"]
- (** Default comparison, alias for [CanOrd.equal] *)
-
-  val hash : t -> int [@@ocaml.deprecated "(8.13) Use QMutInd.hash"]
 
   (** Displaying *)
 
@@ -582,10 +571,6 @@ module Projection : sig
     val arg : t -> int
     val label : t -> Id.t
 
-    val equal : t -> t -> bool [@@ocaml.deprecated "(8.13) Use QProjection.equal"]
-    val hash : t -> int [@@ocaml.deprecated "(8.13) Use QProjection.hash"]
-    val compare : t -> t -> int [@@ocaml.deprecated "(8.13) Use QProjection.compare"]
-
     val map : (MutInd.t -> MutInd.t) -> t -> t
     val map_npars : (int -> int) -> t -> t
 
@@ -612,19 +597,8 @@ module Projection : sig
   val unfolded : t -> bool
   val unfold : t -> t
 
-  val equal : t -> t -> bool
-  [@@ocaml.deprecated "(8.13) Use QProjection.equal"]
-  val hash : t -> int
-  [@@ocaml.deprecated "(8.13) Use QProjection.hash"]
   val hcons : t Hashcons.f
   (** Hashconsing of projections. *)
-
-  val repr_equal : t -> t -> bool
-  [@@ocaml.deprecated "(8.13) Use an explicit projection of Repr"]
-  (** Ignoring the unfolding boolean. *)
-
-  val compare : t -> t -> int
-  [@@ocaml.deprecated "(8.13) Use QProjection.compare"]
 
   val map : (MutInd.t -> MutInd.t) -> t -> t
   val map_npars : (int -> int) -> t -> t
@@ -658,9 +632,6 @@ module GlobRef : sig
     | ConstRef of Constant.t       (** A reference to the environment. *)
     | IndRef of inductive          (** A reference to an inductive type. *)
     | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
-
-  val equal : t -> t -> bool
-  [@@ocaml.deprecated "(8.18) Use QGlobRef.equal"]
 
   val is_bound : t -> bool
 

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -371,23 +371,3 @@ let rec isArity c =
   | Cast (c,_,_)      -> isArity c
   | Sort _          -> true
   | _               -> false
-
-(* Deprecated *)
-
-let decompose_prod_assum = decompose_prod_decls
-let decompose_lam_assum = decompose_lambda_decls
-let decompose_prod_n_assum = decompose_prod_n_decls
-let prod_assum = prod_decls
-let lam_assum = lambda_decls
-let prod_n_assum = prod_n_decls
-let strip_prod_assum = strip_prod_decls
-let strip_lam_assum = strip_lambda_decls
-let decompose_lam = decompose_lambda
-let decompose_lam_n = decompose_lambda_n
-let decompose_lam_n_assum = decompose_lambda_n_assum
-let decompose_lam_n_decls = decompose_lambda_n_decls
-
-type sorts = Sorts.t = private
-  | SProp | Prop | Set
-  | Type of Univ.Universe.t  (** Type *)
-  | QSort of Sorts.QVar.t * Univ.Universe.t

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -188,37 +188,3 @@ val destArity : types -> arity
 
 (** Tell if a term has the form of an arity *)
 val isArity : types -> bool
-
-(* Deprecated *)
-
-type sorts = Sorts.t = private
-  | SProp | Prop | Set
-  | Type of Univ.Universe.t  (** Type *)
-  | QSort of Sorts.QVar.t * Univ.Universe.t
-[@@ocaml.deprecated "(8.8) Alias for Sorts.t"]
-
-val decompose_prod_assum : types -> Constr.rel_context * types
-[@@ocaml.deprecated "(8.18) Use [decompose_prod_decls] instead."]
-val decompose_lam_assum : constr -> Constr.rel_context * constr
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_decls] instead."]
-val decompose_prod_n_assum : int -> types -> Constr.rel_context * types
-[@@ocaml.deprecated "(8.18) Use [decompose_prod_n_decls] instead."]
-val prod_assum : types -> Constr.rel_context
-[@@ocaml.deprecated "(8.18) Use [prod_decls] instead."]
-val lam_assum : constr -> Constr.rel_context
-[@@ocaml.deprecated "(8.18) Use [lambda_decls] instead."]
-val prod_n_assum : int -> types -> Constr.rel_context
-[@@ocaml.deprecated "(8.18) Use [prod_n_decls] instead."]
-val strip_prod_assum : types -> types
-[@@ocaml.deprecated "(8.18) Use [strip_prod_decls] instead."]
-val strip_lam_assum : constr -> constr
-[@@ocaml.deprecated "(8.18) Use [strip_lambda_decls] instead."]
-
-val decompose_lam : t -> (Name.t binder_annot * t) list * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda] instead."]
-val decompose_lam_n : int -> t -> (Name.t binder_annot * t) list * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_n] instead."]
-val decompose_lam_n_assum : int -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_n_assum] instead."]
-val decompose_lam_n_decls : int -> t -> rel_context * t
-[@@ocaml.deprecated "(8.18) Use [decompose_lambda_n_decls] instead."]

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -12,6 +12,7 @@ open CErrors
 open Util
 open Names
 open Univ
+open Sorts
 open Term
 open Constr
 open Context

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -10,10 +10,6 @@
 
 open Pp
 
-(** Aliases *)
-
-let push = Exninfo.capture
-
 (* Errors *)
 
 exception Anomaly of string option * Pp.t (* System errors *)

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -11,11 +11,6 @@
 (** This modules implements basic manipulations of errors for use
     throughout Rocq's code. *)
 
-(** {6 Error handling} *)
-
-val push : exn -> Exninfo.iexn
-[@@ocaml.deprecated "(8.12) please use [Exninfo.capture]"]
-
 (** {6 Generic errors.}
 
  [Anomaly] is used for system errors and [UserError] for the

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -66,10 +66,6 @@ let get_warning name =
 
 let warning_status w = w.current
 
-let get_status ~name = match get_warning name with
-  | There w -> warning_status w
-  | NotThere | OtherType -> assert false
-
 type _ tag = ..
 
 type w = W : Loc.t option * 'a tag * 'a -> w

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -84,9 +84,6 @@ val get_warning : string -> warning elt
 val warning_status : warning -> status
 (** Current status of the warning. *)
 
-val get_status : name:string -> status
-(* [@@ocaml.deprecated "(8.18) Use [CWarnings.warning_status]"] *)
-
 val normalize_flags_string : string -> string
 (** Cleans up a user provided warnings status string, e.g. removing unknown
     warnings (in which case a warning is emitted) or subsumed warnings . *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -199,10 +199,6 @@ end
 
 let map_union = Union.map
 
-type iexn = Exninfo.iexn
-
-let iraise = Exninfo.iraise
-
 let open_utf8_file_in fname =
   let is_bom s =
     Int.equal (Char.code (Bytes.get s 0)) 0xEF &&

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -124,14 +124,6 @@ val protect_state : freeze:(unit -> 'st) -> unfreeze:('st ->unit) -> scope:(unit
 
 val atomify : ('a -> 'b) -> 'a -> 'b
 
-(** {6 Enriched exceptions} *)
-
-type iexn = Exninfo.iexn
-[@@ocaml.deprecated "(8.12) please use [Exninfo.iexn]"]
-
-val iraise : Exninfo.iexn -> 'a
-[@@ocaml.deprecated "(8.12) please use [Exninfo.iraise]"]
-
 (** {6 Misc. } *)
 
 type ('a, 'b) union = ('a, 'b) CSig.union = Inl of 'a | Inr of 'b

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -333,7 +333,6 @@ module Prim =
 
     (* parsed like ident but interpreted as a term *)
     let hyp = Entry.make "hyp"
-    let var = hyp
 
     let name = Entry.make "name"
     let identref = Entry.make "identref"

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -169,7 +169,6 @@ module Prim :
     val ne_string : string Entry.t
     val ne_lstring : lstring Entry.t
     val hyp : lident Entry.t
-    val var : lident Entry.t [@@ocaml.deprecated "(8.13) Use Prim.hyp"]
     val bar_cbrace : unit Entry.t
     val strategy_level : Conv_oracle.level Entry.t
   end

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -19,7 +19,6 @@
 open CErrors
 open Util
 open Names
-open Term
 open Constr
 open Context
 open Environ

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -16,7 +16,7 @@ open Util
 open Names
 open Constr
 open Context
-open Term
+open Sorts
 open EConstr
 open Vars
 open Inductiveops

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -133,13 +133,6 @@ let rec head_pattern_bound (t:constr_pattern) =
       anomaly ~label:"head_pattern_bound" (Pp.str "not a type.")
     | PExtra e -> Util.Empty.abort e
 
-let head_of_constr_reference sigma c = match EConstr.kind sigma c with
-  | Const (sp,_) -> GlobRef.ConstRef sp
-  | Construct (sp,_) -> GlobRef.ConstructRef sp
-  | Ind (sp,_) -> GlobRef.IndRef sp
-  | Var id -> GlobRef.VarRef id
-  | _ -> anomaly (Pp.str "Not a rigid reference.")
-
 let mkPRef env gr =
   PRef (Environ.QGlobRef.canonize env gr)
 

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -12,7 +12,6 @@ open Names
 open Mod_subst
 open Glob_term
 open Pattern
-open EConstr
 
 (** {5 Functions on patterns} *)
 
@@ -30,12 +29,6 @@ exception BoundPattern
    if [t] is an abstraction *)
 
 val head_pattern_bound : constr_pattern -> GlobRef.t
-
-(** [head_of_constr_reference c] assumes [r] denotes a reference and
-   returns its label; raises an anomaly otherwise *)
-
-val head_of_constr_reference : Evd.evar_map -> constr -> GlobRef.t
-[@@ocaml.deprecated "(8.12) use [EConstr.destRef]"]
 
 (** [pattern_of_constr c] translates a term [c] with metavariables into
    a pattern; currently, no destructor (Cases, Fix, Cofix) and no

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1260,8 +1260,6 @@ let is_conv ?(reds=TransparentState.full) env sigma x y =
   is_fconv ~reds Conversion.CONV env sigma x y
 let is_conv_leq ?(reds=TransparentState.full) env sigma x y =
   is_fconv ~reds Conversion.CUMUL env sigma x y
-let check_conv ?(pb=Conversion.CUMUL) ?(ts=TransparentState.full) env sigma x y =
-  is_fconv ~reds:ts pb env sigma x y
 
 let sigma_compare_sorts pb s0 s1 sigma =
   match pb with
@@ -1524,28 +1522,6 @@ let dest_arity env sigma c =
 
 let sort_of_arity env sigma c = snd (dest_arity env sigma c)
 
-(* deprecated (wrong behavior)  *)
-let hnf_decompose_prod_n_decls env sigma n =
-  let rec decrec env m ln c = if Int.equal m 0 then (ln,c) else
-    match EConstr.kind sigma (whd_all env sigma c) with
-      | Prod (n,a,c0) ->
-          decrec (push_rel (LocalAssum (n,a)) env)
-            (m-1) (Context.Rel.add (LocalAssum (n,a)) ln) c0
-      | _                      -> invalid_arg "whd_decompose_prod_n_decls"
-  in
-  decrec env n Context.Rel.empty
-
-(* deprecated (wrong behavior) *)
-let hnf_decompose_lambda_n_assum env sigma n =
-  let rec decrec env m ln c = if Int.equal m 0 then (ln,c) else
-    match EConstr.kind sigma (whd_all env sigma c) with
-      | Lambda (n,a,c0) ->
-          decrec (push_rel (LocalAssum (n,a)) env)
-            (m-1) (Context.Rel.add (LocalAssum (n,a)) ln) c0
-      | _                      -> invalid_arg "whd_decompose_lambda_n_assum"
-  in
-  decrec env n Context.Rel.empty
-
 let whd_decompose_prod_n_assum env sigma n =
   let rec decrec env m ctx c = if Int.equal m 0 then (ctx,c) else
     match EConstr.kind sigma (whd_allnolet env sigma c) with
@@ -1740,15 +1716,3 @@ let inferred_universes elims =
 end
 
 let inferred_universes env = Infer.inferred_universes (Environ.qualities env)
-
-(* Deprecated *)
-
-let splay_prod = whd_decompose_prod
-let splay_lam = whd_decompose_lambda
-let splay_prod_assum = whd_decompose_prod_decls
-let splay_prod_n = hnf_decompose_prod_n_decls
-let splay_lam_n = hnf_decompose_lambda_n_assum
-
-let hnf_decompose_prod = whd_decompose_prod
-let hnf_decompose_lambda = whd_decompose_lambda
-let hnf_decompose_prod_decls = whd_decompose_prod_decls

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -255,12 +255,6 @@ val is_conv : ?reds:TransparentState.t -> env -> evar_map -> constr -> constr ->
 val is_conv_leq : ?reds:TransparentState.t -> env -> evar_map -> constr -> constr -> bool
 val is_fconv : ?reds:TransparentState.t -> conv_pb -> env -> evar_map -> constr -> constr -> bool
 
-(** [check_conv] Checks universe constraints only.
-    pb defaults to CUMUL and ts to a full transparent state.
- *)
-val check_conv : ?pb:conv_pb -> ?ts:TransparentState.t -> env -> evar_map -> constr -> constr -> bool
-[@@ocaml.deprecated "(8.18) Use Reductionops.is_fconv instead"]
-
 (** [infer_conv] Adds necessary universe constraints to the evar map.
     pb defaults to CUMUL and ts to a full transparent state.
     @raise UniverseInconsistency iff catch_incon is set to false,
@@ -317,29 +311,3 @@ exception AnomalyInConversion of exn
 
 (* inferred_universes just gathers the constraints. *)
 val inferred_universes : env -> (UGraph.t * Univ.UnivConstraints.t, Conversion.graph_inconsistency) Conversion.universe_compare
-
-(** Deprecated *)
-
-val splay_prod : env -> evar_map -> constr -> (Name.t EConstr.binder_annot * constr) list * constr
-[@@ocaml.deprecated "(8.18) Use [whd_decompose_prod] instead."]
-val splay_lam : env -> evar_map -> constr -> (Name.t EConstr.binder_annot * constr) list * constr
-[@@ocaml.deprecated "(8.18) Use [whd_decompose_lambda] instead."]
-val splay_prod_assum : env -> evar_map -> constr -> rel_context * constr
-[@@ocaml.deprecated "(8.18) Use [whd_decompose_prod_decls] instead."]
-val splay_prod_n : env -> evar_map -> int -> constr -> rel_context * constr
-[@@ocaml.deprecated "(8.18) This function contracts let-ins. Replace either with whd_decompose_prod_n (if only products are expected, then returning only a list of assumptions), whd_decompose_prod_n_assum (if let-ins are expected to be preserved, returning a rel_context), or whd_decompose_prod_n_decls (if let-ins are expected to be preserved and counted, returning also a rel_context)"]
-val splay_lam_n : env -> evar_map -> int -> constr -> rel_context * constr
-[@@ocaml.deprecated "(8.18) This function contracts let-ins. Replace either with whd_decompose_lambda_n (if only lambdas are expected, then returning only a list of assumptions) or whd_decompose_lambda_n_assum (if let-ins are expected to be preserved, returning a rel_context)"]
-
-(** Re-deprecated in 8.19 *)
-
-val hnf_decompose_prod : env -> evar_map -> types -> (Name.t EConstr.binder_annot * constr) list * types
-[@@ocaml.deprecated "(8.19) Use [whd_decompose_prod] instead."]
-val hnf_decompose_lambda : env -> evar_map -> constr -> (Name.t EConstr.binder_annot * constr) list * constr
-[@@ocaml.deprecated "(8.19) Use [whd_decompose_lambda] instead."]
-val hnf_decompose_prod_decls : env -> evar_map -> types -> rel_context * types
-[@@ocaml.deprecated "(8.19) Use [whd_decompose_prod_decls] instead."]
-val hnf_decompose_prod_n_decls : env -> evar_map -> int -> types -> rel_context * types
-[@@ocaml.deprecated "(8.19) This function contracts let-ins. Replace either with whd_decompose_prod_n (if only products are expected, then returning only a list of assumptions), whd_decompose_prod_n_assum (if let-ins are expected to be preserved, returning a rel_context), or whd_decompose_prod_n_decls (if let-ins are expected to be preserved and counted, returning also a rel_context)"]
-val hnf_decompose_lambda_n_assum : env -> evar_map -> int -> constr -> rel_context * constr
-[@@ocaml.deprecated "(8.19) This function contracts let-ins. Replace either with whd_decompose_lambda_n (if only lambdas are expected, then returning only a list of assumptions) or whd_decompose_lambda_n_assum (if let-ins are expected to be preserved, returning a rel_context)"]

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -13,7 +13,6 @@ module CVars = Vars
 open Pp
 open CErrors
 open Util
-open Term
 open Constr
 open Context
 open Inductiveops

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -12,7 +12,6 @@ module CVars = Vars
 
 open CErrors
 open Util
-open Term
 open Constr
 open Context
 open Environ

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -11,7 +11,6 @@
 open Pp
 open Util
 open Names
-open Term
 open Constr
 open Termops
 open EConstr

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -12,7 +12,6 @@ open Pp
 open CErrors
 open Util
 open Names
-open Term
 open Termops
 open Constr
 open Context

--- a/tactics/stdarg.ml
+++ b/tactics/stdarg.ml
@@ -49,8 +49,6 @@ let wit_identref =
 let wit_hyp =
   make0 ~dyn:(val_tag (topwit wit_ident)) "hyp"
 
-let wit_var = wit_hyp
-
 let wit_ref = make0 "ref"
 
 let wit_smart_global = make0 ~dyn:(val_tag (topwit wit_ref)) "smart_global"

--- a/tactics/stdarg.mli
+++ b/tactics/stdarg.mli
@@ -43,9 +43,6 @@ val wit_identref : (lident, lident, Id.t) genarg_type
 
 val wit_hyp : (lident, lident, Id.t) genarg_type
 
-val wit_var : (lident, lident, Id.t) genarg_type
-[@@ocaml.deprecated "(8.13) Use Stdarg.wit_hyp"]
-
 val wit_ref : (qualid, GlobRef.t located or_var, GlobRef.t) genarg_type
 
 val wit_smart_global : (qualid or_by_notation, GlobRef.t located or_var, GlobRef.t) genarg_type

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -607,5 +607,3 @@ let tclTYPEOFTHEN ?refresh c tac =
     let sigma = Proofview.Goal.sigma gl in
     let (sigma, t) = Typing.type_of ?refresh env sigma c in
     Proofview.Unsafe.tclEVARS sigma <*> tac sigma t)
-
-let tclSELECT = Goal_select.tclSELECT

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -169,9 +169,6 @@ val pf_constr_of_global : GlobRef.t -> constr Proofview.tactic
 
 val tclTYPEOFTHEN : ?refresh:bool -> constr -> (evar_map -> types -> unit Proofview.tactic) -> unit Proofview.tactic
 
-val tclSELECT : ?nosuchgoal:'a tactic -> Goal_select.t -> 'a tactic -> 'a tactic
-[@@ocaml.deprecated "(8.14) Use [Goal_select.tclSELECT]"]
-
 (** {6 Elimination tacticals. } *)
 
 (** [get_and_check_or_and_pattern loc pats branchsign] returns an appropriate

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -896,10 +896,6 @@ let intro_move idopt hto = intro_move_avoid idopt Id.Set.empty hto
 
 (**** Multiple introduction tactics ****)
 
-let rec intros_using = function
-  | []     -> Proofview.tclUNIT()
-  | str::l -> Tacticals.tclTHEN (intro_using str) (intros_using l)
-
 let rec intros_mustbe_force = function
   | []     -> Proofview.tclUNIT()
   | str::l -> Tacticals.tclTHEN (intro_mustbe_force str) (intros_mustbe_force l)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -105,10 +105,6 @@ val intro_avoiding : Id.Set.t -> unit Proofview.tactic
     Fails if [id] is not already in the context. *)
 val intro_replacing : Id.t -> unit Proofview.tactic
 
-(** Deprecated version of [intro_using_then] kept for backwards compatibility. *)
-val intro_using : Id.t -> unit Proofview.tactic
-[@@ocaml.deprecated "(8.13) Prefer [intro_using_then] to avoid renaming issues."]
-
 (** [intro_using_then id tac] introduces a single variable named [id]. It refreshes the name [id] if needed,
     and applies [tac] to the resulting identifier. *)
 val intro_using_then : Id.t -> (Id.t -> unit Proofview.tactic) -> unit Proofview.tactic
@@ -123,10 +119,6 @@ val intros_mustbe_force : Id.t list -> unit Proofview.tactic
 (** [intro_then tac] introduces a single variable with an automatically-generated name,
     and applies [tac] to the resulting identifier. *)
 val intro_then : (Id.t -> unit Proofview.tactic) -> unit Proofview.tactic
-
-(** Deprecated variant of [intros_using_then] kept for backwards compatibility. *)
-val intros_using : Id.t list -> unit Proofview.tactic
-[@@ocaml.deprecated "(8.13) Prefer [intros_using_then] to avoid renaming issues."]
 
 (** Generalization of [intro_using_then] to a list of variables (processed from left to right). *)
 val intros_using_then : Id.t list -> (Id.t list -> unit Proofview.tactic) -> unit Proofview.tactic


### PR DESCRIPTION
There are still a few that are actually used in the code. I left them around, for the lack of a better alternative.

Backwards compatible overlays:
- https://github.com/unicoq/unicoq/pull/105
- https://github.com/Mtac2/Mtac2/pull/416
- https://github.com/mattam82/Coq-Equations/pull/672
- https://github.com/lukaszcz/coqhammer/pull/211
- https://github.com/damien-pous/relation-algebra/pull/52
- https://github.com/mit-plv/rewriter/pull/183