### PR TITLE
Change the semantics of the deprecated intropattern genarg.

### DIFF
--- a/dev/ci/user-overlays/21381-ppedrot-rm-deprecated-intro-pattern.sh
+++ b/dev/ci/user-overlays/21381-ppedrot-rm-deprecated-intro-pattern.sh
@@ -1,0 +1,3 @@
+overlay equations https://github.com/ppedrot/Coq-Equations rm-deprecated-intro-pattern 21381
+
+overlay tactician https://github.com/ppedrot/coq-tactician rm-deprecated-intro-pattern 21381

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -290,19 +290,8 @@ end
 
 module Grammar = Register(GrammarObj)
 
-let warn_deprecated_intropattern =
-  CWarnings.create ~name:"deprecated-intropattern-entry" ~category:Deprecation.Version.v8_11
-  (fun () -> Pp.strbrk "Entry name intropattern has been renamed in order \
-  to be consistent with the documented grammar of tactics. Use \
-  \"simple_intropattern\" instead.")
-
-let check_compatibility = function
-  | Genarg.ExtraArg s when ArgT.repr s = "intropattern" -> warn_deprecated_intropattern ()
-  | _ -> ()
-
 let register_grammar = Grammar.register0
 let genarg_grammar x =
-  check_compatibility x;
   Grammar.obj x
 
 let create_generic_entry2 (type a) s (etyp : a raw_abstract_argument_type) : a Entry.t =

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -83,7 +83,7 @@ let out_disjunctive = CAst.map (function
 
 }
 
-ARGUMENT EXTEND with_names TYPED AS intro_pattern option
+ARGUMENT EXTEND with_names TYPED AS intropattern option
   PRINTED BY { fun prc _ _ -> pr_intro_as_pat (fun c -> prc env sigma @@ snd @@ c env sigma) }
   RAW_PRINTED BY { fun prc _ _ -> pr_intro_as_pat (prc env sigma) }
   GLOB_PRINTED BY { fun prc _ _ -> pr_intro_as_pat (prc env sigma) }

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -206,7 +206,8 @@ let deprecated_conversion_at_with =
 GRAMMAR EXTEND Gram
   GLOBAL: simple_tactic constr_with_bindings quantified_hypothesis
   bindings open_constr uconstr
-  simple_intropattern in_clause clause_dft_concl hypident destruction_arg;
+  intropattern simple_intropattern
+  in_clause clause_dft_concl hypident destruction_arg;
 
   (* An identifier or a quotation meta-variable *)
   id_or_meta:

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -28,6 +28,8 @@ let quantified_hypothesis =
   Entry.make "quantified_hypothesis"
 let destruction_arg = Entry.make "destruction_arg"
 let nat_or_var = G_redexpr.nat_or_var
+let intropattern =
+  Entry.make "intropattern"
 let simple_intropattern =
   Entry.make "simple_intropattern"
 let in_clause = Entry.make "in_clause"
@@ -50,8 +52,7 @@ let () =
   let open G_redexpr in
   register_grammar wit_int_or_var (int_or_var);
   register_grammar wit_nat_or_var (nat_or_var);
-  register_grammar wit_intro_pattern (simple_intropattern); (* To remove at end of deprecation phase *)
-(* register_grammar wit_intropattern (intropattern); *) (* To be added at end of deprecation phase *)
+  register_grammar wit_intropattern (intropattern);
   register_grammar wit_simple_intropattern (simple_intropattern);
   register_grammar wit_quant_hyp (quantified_hypothesis);
   register_grammar wit_uconstr (uconstr);

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -26,6 +26,7 @@ val quantified_hypothesis : quantified_hypothesis Entry.t
 val destruction_arg : constr_expr with_bindings Tactics.destruction_arg Entry.t
 val nat_or_var : int Locus.or_var Entry.t
 val simple_tactic : raw_tactic_expr Entry.t
+val intropattern : constr_expr intro_pattern_expr CAst.t Entry.t
 val simple_intropattern : constr_expr intro_pattern_expr CAst.t Entry.t
 val in_clause : Names.lident Locus.clause_expr Entry.t
 val clause_dft_concl : Names.lident Locus.clause_expr Entry.t

--- a/plugins/ltac/tacarg.ml
+++ b/plugins/ltac/tacarg.ml
@@ -27,12 +27,6 @@ let wit_open_constr_with_bindings = make0 "open_constr_with_bindings"
 let wit_bindings = make0 "bindings"
 let wit_quantified_hypothesis = wit_quant_hyp
 
-(* A convenient common part to simple_intropattern and intropattern
-   usable when no parsing rule is concerned: indeed
-   simple_intropattern and intropattern are in the same type and have
-   the same interp/intern/subst methods *)
-let wit_intro_pattern = wit_intropattern
-
 let wit_tactic : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
   make0 "tactic"
 

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -16,13 +16,10 @@ open Tactypes
 open Tacexpr
 
 (** Tactic related witnesses, could also live in tactics/ if other users *)
-(* To keep after deprecation phase but it will get a different parsing semantics in pltac.ml *)
+
 val wit_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
-[@@ocaml.deprecated "(8.11) Use wit_simple_intropattern"]
 
 val wit_simple_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
-
-val wit_intro_pattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
 val wit_quant_hyp : quantified_hypothesis uniform_genarg_type
 

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -206,8 +206,8 @@ let coerce_to_constr_context v =
   | None -> raise (CannotCoerceTo "a term context")
 
 let is_intro_pattern v =
-  if has_type v (topwit wit_intro_pattern) then
-    Some (out_gen (topwit wit_intro_pattern) v).CAst.v
+  if has_type v (topwit wit_intropattern) then
+    Some (out_gen (topwit wit_intropattern) v).CAst.v
   else
     None
 
@@ -218,8 +218,8 @@ let coerce_var_to_ident fresh env sigma v =
   | Some (IntroNaming (IntroIdentifier id)) -> id
   | Some _ -> fail ()
   | None ->
-  if has_type v (topwit wit_intro_pattern) then
-    match out_gen (topwit wit_intro_pattern) v with
+  if has_type v (topwit wit_intropattern) then
+    match out_gen (topwit wit_intropattern) v with
     | { CAst.v=IntroNaming (IntroIdentifier id)} -> id
     | _ -> fail ()
   else if has_type v (topwit wit_hyp) then

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -190,7 +190,7 @@ let intern_non_tactic_reference ist qid =
   (* By convention, use IntroIdentifier for unbound ident, when not in a def *)
   if qualid_is_ident qid && not ist.strict_check then
     let id = qualid_basename qid in
-    let ipat = in_gen (glbwit wit_intro_pattern) (make ?loc:qid.CAst.loc @@ IntroNaming (IntroIdentifier id)) in
+    let ipat = in_gen (glbwit wit_intropattern) (make ?loc:qid.CAst.loc @@ IntroNaming (IntroIdentifier id)) in
     TacGeneric (None,ipat)
   else
     (* Reference not found *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -302,7 +302,7 @@ let coerce_to_tactic loc id v =
 
 let intro_pattern_of_ident id = CAst.make @@ IntroNaming (IntroIdentifier id)
 let value_of_ident id =
-  in_gen (topwit wit_intro_pattern) (intro_pattern_of_ident id)
+  in_gen (topwit wit_intropattern) (intro_pattern_of_ident id)
 
 let (+++) lfun1 lfun2 = Id.Map.fold Id.Map.add lfun1 lfun2
 
@@ -502,8 +502,8 @@ let rec intropattern_ids accu {loc;v=pat} = match pat with
 
 let extract_ids ids lfun accu =
   let fold id v accu =
-    if has_type v (topwit wit_intro_pattern) then
-      let {v=ipat} = out_gen (topwit wit_intro_pattern) v in
+    if has_type v (topwit wit_intropattern) then
+      let {v=ipat} = out_gen (topwit wit_intropattern) v in
       if Id.List.mem id ids then accu
       else intropattern_ids accu (CAst.make ipat)
     else accu
@@ -986,8 +986,8 @@ let interp_destruction_arg ist gl arg =
       try
         (* FIXME: should be moved to taccoerce *)
         let v = Id.Map.find id ist.lfun in
-        if has_type v (topwit wit_intro_pattern) then
-          let v = out_gen (topwit wit_intro_pattern) v in
+        if has_type v (topwit wit_intropattern) then
+          let v = out_gen (topwit wit_intropattern) v in
           match v with
           | {v=IntroNaming (IntroIdentifier id)} -> try_cast_id id
           | _ -> error ()
@@ -1298,7 +1298,7 @@ and interp_tacarg ist arg : Val.t Ftactic.t =
         let env = Proofview.Goal.env gl in
         let sigma = Proofview.Goal.sigma gl in
         let id = interp_fresh_id ist env sigma l in
-        Ftactic.return (in_gen (topwit wit_intro_pattern) (CAst.make @@ IntroNaming (IntroIdentifier id)))
+        Ftactic.return (in_gen (topwit wit_intropattern) (CAst.make @@ IntroNaming (IntroIdentifier id)))
       end
   | TacPretype c ->
       Ftactic.enter begin fun gl ->

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -240,7 +240,7 @@ let warn_auto_with_star_tac _ _ =
 let val_of_id id =
   let open Geninterp in
   let id = CAst.make @@ Tactypes.IntroNaming (IntroIdentifier id) in
-  Val.inject (val_tag @@ Genarg.topwit Tacarg.wit_intro_pattern) id
+  Val.inject (val_tag @@ Genarg.topwit Tacarg.wit_intropattern) id
 
 let find_cut _ ist =
   let k = Id.Map.find (Names.Id.of_string "k") ist.lfun in


### PR DESCRIPTION
This is the conclusion of PR #10239 that originally introduced the deprecation in Coq 8.11. After this commit, the "intropattern" Ltac notation entry parses the same thing as what the refman calls "intropattern".

We also remove the alias wit_intro_pattern, which is now just fueling further confusion.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/673
- https://github.com/coq-tactician/coq-tactician/pull/123