### PR TITLE
Correctly use the goal-local evarmap to check toplevel TC unifiability.

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -919,7 +919,7 @@ module Search = struct
     let tac sigma gls i =
       Goal.enter begin fun gl ->
         let i = succ i in
-        let dep = dep || Proofview.unifiable sigma (Goal.goal gl) gls in
+        let dep = dep || Proofview.unifiable (Goal.sigma gl) (Goal.goal gl) gls in
         let info = make_autogoal mst only_classes dep (cut_of_hints hints) best_effort i gl in
         search_tac hints depth 1 info
       end


### PR DESCRIPTION
The code for toplevel unifiability was not performing the check in the same evarmap as the one performed during resolution. The former was using the evarmap from the point where the goals depended upon were fetched, while the latter used the evarmap from the current goal being solved.

According to the oracle @mattam82, we should look at unifiability in the current goal, so we fix the toplevel check.