### PR TITLE
[ci] Disable rocq-lsp from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1294,11 +1294,13 @@ library:ci-rupicola:
   - library:ci-bedrock2
   stage: build-3+
 
-plugin:ci-coq_lsp:
-  extends: .ci-template-flambda
-  needs:
-  - build:edge+flambda
-  - library:ci-stdlib+flambda
+# Disabled until a new maintainer is available
+#
+# plugin:ci-coq_lsp:
+#   extends: .ci-template-flambda
+#   needs:
+#   - build:edge+flambda
+#   - library:ci-stdlib+flambda
 
 plugin:ci-vsrocq:
   extends: .ci-template-flambda


### PR DESCRIPTION
I won't be able to keep maintaining rocq-lsp anymore.

I propose to disable it from CI until a new maintainer is found.

c.f. https://rocq-prover.zulipchat.com/#narrow/channel/329642-rocq-lsp/topic/Release.200.2E2.2E5/with/561250824

