### PR TITLE
Remove cruft in Declare

### DIFF
--- a/dev/ci/user-overlays/21384-ppedrot-declare-clear-cruft.sh
+++ b/dev/ci/user-overlays/21384-ppedrot-declare-clear-cruft.sh
@@ -1,0 +1,3 @@
+overlay equations https://github.com/ppedrot/Coq-Equations declare-clear-cruft 21384
+
+overlay metarocq https://github.com/ppedrot/metarocq declare-clear-cruft 21384

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -210,7 +210,10 @@ let exact ist (c : Ltac_pretype.closed_glob_constr) =
    NOTE: some tactics delete hypothesis and reuse names (induction,
    destruct), this is not detected by this tactical. *)
 let infoH ~pstate (tac : raw_tactic_expr) : unit =
-  let (_, oldhyps) = Declare.Proof.get_current_goal_context pstate in
+  let oldhyps =
+    try snd @@ Declare.Proof.get_goal_context pstate 1
+    with Proof.NoSuchGoal _ -> Global.env ()
+  in
   let oldhyps = List.map Context.Named.Declaration.get_id @@ Environ.named_context oldhyps in
   let tac = Tacinterp.interp tac in
   let tac =

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -353,9 +353,7 @@ let declare_instance_program pm env sigma ~locality ~poly {CAst.v=name;loc} pri 
   let kind = Decls.IsDefinition Decls.Instance in
   let cinfo = Declare.CInfo.make ?loc ~name ~typ ~impargs () in
   let info = Declare.Info.make ~udecl ~poly ~kind ~hook () in
-  let pm, _ =
-    Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~uctx ~body obls
-  in pm
+  Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~uctx ~body obls
 
 let declare_instance_open sigma ?hook ~tac ~locality ~poly (id:lident) pri impargs udecl ids term termtype =
   (* spiwack: it is hard to reorder the actions to do

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -142,12 +142,10 @@ let do_definition_program ?loc ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_f
     interp_definition ~program_mode:true env evd empty_internalization_env bl red_option c ctypopt
   in
   let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name ~body ?types env evd in
-  Evd.check_sort_poly_decl_early ~poly ~with_obls:true evd udecl [body; typ];
-  let pm, _ =
-    let cinfo = Declare.CInfo.make ?loc ~name ~typ ~impargs () in
-    let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
-    Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls
-  in pm
+  let () = Evd.check_sort_poly_decl_early ~poly ~with_obls:true evd udecl [body; typ] in
+  let cinfo = Declare.CInfo.make ?loc ~name ~typ ~impargs () in
+  let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
+  Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls
 
 let do_definition_interactive ?loc ~program_mode ?hook ~name ~scope ?clearbody ~poly ~typing_flags ~kind ?using ?user_warns udecl bl t =
   let env = Global.env () in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -596,7 +596,7 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
     (match fixwfs, bodies, cinfo, obls with
     | [Some _], [body], [cinfo], [obls] ->
       (* Program Fixpoint wf/measure *)
-      let pm, _ = Declare.Obls.add_definition ~pm ~cinfo ~info ~opaque:false ~body ~uctx ?using obls in
+      let pm = Declare.Obls.add_definition ~pm ~cinfo ~info ~opaque:false ~body ~uctx ?using obls in
       Some pm, None
     | _ ->
       let possible_guard = (possible_guard, fixrs) in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2200,14 +2200,12 @@ let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate (proof : t) : 
   ; pinfo = proof.pinfo
   }) ()
 
-let close_proof_delayed ~feedback_id proof (fpl : closed_proof_output Future.computation) : Proof_object.t =
+let close_future_proof ~feedback_id proof (fpl : closed_proof_output Future.computation) : Proof_object.t =
   { Proof_object.proof_object =
       DeferredOpaqueProof { deferred_proof = fpl; using = proof.using; initial_proof_data = Proof.data proof.proof;
                           feedback_id; initial_euctx = proof.initial_euctx }
   ; pinfo = proof.pinfo
   }
-
-let close_future_proof = close_proof_delayed
 
 let update_sigma_univs ugraph p =
   map ~f:(Proof.update_sigma_univs ugraph) p

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2284,17 +2284,6 @@ let get_goal_context pf i =
   let p = get pf in
   Proof.get_goal_context_gen p i
 
-let get_current_goal_context pf =
-  let p = get pf in
-  try Proof.get_goal_context_gen p 1
-  with
-  | Proof.NoSuchGoal _ ->
-    (* spiwack: returning empty evar_map, since if there is no goal,
-       under focus, there is no accessible evar either. EJGA: this
-       seems strange, as we have pf *)
-    let env = Global.env () in
-    Evd.from_env env, env
-
 let get_current_context pf =
   let p = get pf in
   Proof.get_proof_context p

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2201,12 +2201,11 @@ let close_proof ?warn_incomplete ~opaque ~keep_body_ucst_separate (proof : t) : 
   }) ()
 
 let close_proof_delayed ~feedback_id proof (fpl : closed_proof_output Future.computation) : Proof_object.t =
-  NewProfile.profile "close_proof_delayed" (fun () ->
   { Proof_object.proof_object =
       DeferredOpaqueProof { deferred_proof = fpl; using = proof.using; initial_proof_data = Proof.data proof.proof;
                           feedback_id; initial_euctx = proof.initial_euctx }
   ; pinfo = proof.pinfo
-  }) ()
+  }
 
 let close_future_proof = close_proof_delayed
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -544,12 +544,6 @@ type fixpoint_kind = IsFixpoint of lident option list | IsCoFixpoint
 val check_solved_obligations : pm:OblState.t -> what_for:Pp.t -> unit
 val default_tactic : unit Proofview.tactic ref
 
-(** Resolution status of a program *)
-type progress =
-  | Remain of int  (** n obligations remaining *)
-  | Dependent  (** Dependent on other definitions *)
-  | Defined of GlobRef.t  (** Defined as id *)
-
 (** Prepare API, to be removed once we provide the corresponding 1-step API *)
 val prepare_obligations
   :  name:Id.t
@@ -576,7 +570,7 @@ val add_definition :
   -> ?using:Vernacexpr.section_subset_expr
   -> ?obl_hook: OblState.t Hook.g
   -> RetrieveObl.obligation_info
-  -> OblState.t * progress
+  -> OblState.t
 
 (* XXX: unify with MutualEntry *)
 
@@ -610,8 +604,6 @@ val next_obligation :
 
 (** Implementation of the [Solve Obligations of id with tac] command *)
 val solve_obligations :
-  pm:OblState.t -> Names.Id.t option -> unit Proofview.tactic option -> OblState.t * progress
-val try_solve_obligations :
   pm:OblState.t -> Names.Id.t option -> unit Proofview.tactic option -> OblState.t
 
 (** Implementation of the [Solve All Obligations with tac] command *)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -474,8 +474,6 @@ val definition_message : Id.t -> unit
 val assumption_message : Id.t -> unit
 val fixpoint_message : int array option -> Id.t list -> unit
 
-val check_exists : Id.t -> unit
-
 (** Semantics of this function is a bit dubious, use with care *)
 val build_by_tactic
   :  Environ.env

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -298,9 +298,6 @@ module Proof : sig
 
   val get_goal_context : t -> int -> Evd.evar_map * Environ.env
 
-  (** [get_current_goal_context ()] works as [get_goal_context 1] *)
-  val get_current_goal_context : t -> Evd.evar_map * Environ.env
-
   (** [get_current_context ()] returns the context of the
       current focused goal. If there is no focused goal but there
       is a proof in progress, it returns the corresponding evar_map.

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -127,9 +127,13 @@ let declare_mind ?typing_flags ~indlocs mie =
     (typ, consl)
   in
   let names = List.mapi map_names mie.mind_entry_inds in
+  let check_exists id =
+    if Decls.variable_exists id || Global.exists_objlabel id then
+      raise (DeclareUniv.AlreadyDeclared (None, id))
+  in
   List.iter (fun ({CAst.v=typ}, cons) ->
-      Declare.check_exists typ;
-      List.iter (fun {CAst.v} -> Declare.check_exists v) cons) names;
+      check_exists typ;
+      List.iter (fun {CAst.v} -> check_exists v) cons) names;
   let mind, why_not_prim_record = Global.add_mind ?typing_flags id mie in
   let () = Lib.add_leaf (inInductive (id, { ind_names = names })) in
   let () = UState.add_template_default_univs (Global.env ()) mind in

--- a/vernac/g_obligations.mlg
+++ b/vernac/g_obligations.mlg
@@ -82,9 +82,9 @@ END
 
 VERNAC COMMAND EXTEND Solve_Obligations CLASSIFIED AS SIDEFF STATE program
 | [ "Solve" "Obligations" "of" identref(name) withtac(t) ] ->
-    { try_solve_obligations (Some name.CAst.v) (Option.map interp_gen t) }
+    { solve_obligations (Some name.CAst.v) (Option.map interp_gen t) }
 | [ "Solve" "Obligations" withtac(t) ] ->
-    { try_solve_obligations None (Option.map interp_gen t) }
+    { solve_obligations None (Option.map interp_gen t) }
 END
 
 VERNAC COMMAND EXTEND Solve_All_Obligations CLASSIFIED AS SIDEFF STATE program


### PR DESCRIPTION
We remove small bits of legacy or dead code in Declare. Nothing serious, but it doesn't hurt either.

Overlays:
- https://github.com/MetaRocq/metarocq/pull/1220
- https://github.com/mattam82/Coq-Equations/pull/676