### PR TITLE
CLexer.terminal does not check keyword state

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -573,7 +573,7 @@ struct
 let terminal s =
   let p =
     if s <> "" && s.[0] >= '0' && s.[0] <= '9' then "CLexer.terminal_number"
-    else "Procq.terminal" in
+    else "CLexer.terminal" in
   let c = Printf.sprintf "Procq.Symbol.token (%s \"%s\")" p s in
   SymbQuote c
 

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -72,7 +72,7 @@ module type S = sig
     type 'a parser_fun = { parser_fun : keyword_state -> (keyword_state,te) LStream.t -> 'a parser_v }
     val of_parser : string -> 'a parser_fun -> 'a t mod_estate
     val parse_token_stream : 'a t -> (keyword_state,te) LStream.t -> 'a parser_v with_gstate
-    val print : Format.formatter -> 'a t -> unit with_estate
+    val print : Format.formatter -> 'a t -> unit with_kwstate with_estate
     val is_empty : 'a t -> bool with_estate
 
     type any_t = Any : 'a t -> any_t

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -15,7 +15,8 @@ module type S = sig
   type te
   type 'c pattern
   val tok_pattern_eq : 'a pattern -> 'b pattern -> ('a, 'b) Util.eq option
-  val tok_pattern_strings : 'c pattern -> string * string option
+  val tok_pattern_exact : _ pattern -> bool
+  val tok_pattern_strings : keyword_state -> 'c pattern -> string * string option
 
   (** Returning a stream equipped with a location function *)
   val tok_func : ?loc:Loc.t -> (unit,char) Stream.t -> (keyword_state,te) LStream.t

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -804,9 +804,6 @@ module LexerDiff = MakeLexer (struct let mode = true end)
 
 (** Terminal symbols interpretation *)
 
-let is_ident_not_keyword ttree s =
-  is_ident s && not (is_keyword ttree s)
-
 let strip s =
   let len =
     let rec loop i len =
@@ -826,10 +823,10 @@ let strip s =
     in
     Bytes.to_string (loop 0 0)
 
-let terminal ttree s =
+let terminal s =
   let s = strip s in
   let () = match s with "" -> failwith "empty token." | _ -> () in
-  if is_ident_not_keyword ttree s then PIDENT (Some s)
+  if is_ident s then PIDENT (Some s)
   else PKEYWORD s
 
 (* Precondition: the input is a number (c.f. [NumTok.t]) *)

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -47,8 +47,11 @@ val check_keyword : string -> unit
 
 val add_keyword_tok : keyword_state -> 'c Tok.p -> keyword_state
 
-(** When string is not an ident, returns a keyword. *)
-val terminal : keyword_state -> string -> string Tok.p
+(** When string is not an ident, returns a keyword.
+    (returns [PIDENT (Some _)] for idents which have been declared as keywords,
+    as the keyword state is not checked)
+*)
+val terminal : string -> string Tok.p
 
 (** Precondition: the input is a number (c.f. [NumTok.t]) *)
 val terminal_number : string -> NumTok.Unsigned.t Tok.p

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -193,7 +193,7 @@ module Entry = struct
       (fun estate e -> Unsafe.existing_of_parser estate e p)
       ()
   let parse_token_stream e strm = parse_token_stream e strm (gstate())
-  let print fmt e = print fmt e (gstate()).estate
+  let print fmt e = let gstate = gstate() in print fmt e gstate.estate gstate.kwstate
   let is_empty e = is_empty e (gstate()).estate
   let accumulate_in e = accumulate_in e (gstate()).estate
   let all_in () = all_in () (gstate()).estate

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -64,8 +64,6 @@ let gstate () = (!state).current_state
 
 let get_keyword_state () = (gstate()).kwstate
 
-let terminal s = CLexer.terminal (get_keyword_state()) s
-
 let reset_to_base state = {
   base_state = state.base_state;
   current_state = state.base_state;

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -43,9 +43,6 @@ module Lookahead : sig
   val lk_ident_list : t
 end
 
-(** When string is not an ident, returns a keyword. *)
-val terminal : string -> string Tok.p
-
 (** The parser of Rocq is built from three kinds of rule declarations:
 
    - dynamic rules declared at the evaluation of Rocq files (using

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -23,18 +23,16 @@ type 'c p =
   | PQUOTATION : string -> string p
   | PEOI : unit p
 
-let pattern_strings : type c. c p -> string * string option =
-  function
-  | PKEYWORD s -> "", Some s
-  | PIDENT s -> "IDENT", s
-  | PFIELD s -> "FIELD", s
-  | PNUMBER None -> "NUMBER", None
-  | PNUMBER (Some n) -> "NUMBER", Some (NumTok.Unsigned.sprint n)
-  | PSTRING s -> "STRING", s
-  | PLEFTQMARK -> "LEFTQMARK", None
-  | PBULLET s -> "BULLET", s
-  | PQUOTATION lbl -> "QUOTATION", Some lbl
-  | PEOI -> "EOI", None
+let pattern_exact : type c. c p -> bool = function
+  | PKEYWORD _ -> true
+  | PIDENT id -> Option.has_some id
+  | PFIELD s -> Option.has_some s
+  | PNUMBER n -> Option.has_some n
+  | PSTRING s -> Option.has_some s
+  | PLEFTQMARK -> false
+  | PBULLET s -> Option.has_some s
+  | PQUOTATION _ -> true
+  | PEOI -> false
 
 type t =
   | KEYWORD of string

--- a/parsing/tok.mli
+++ b/parsing/tok.mli
@@ -21,7 +21,7 @@ type 'c p =
   | PQUOTATION : string -> string p
   | PEOI : unit p
 
-val pattern_strings : 'c p -> string * string option
+val pattern_exact : _ p -> bool
 
 type t =
   | KEYWORD of string

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -139,10 +139,10 @@ let rec prod_item_of_symbol lev = function
   EntryName (Rawwit (ListArg typ), Procq.Symbol.list0 e)
 | Extend.Ulist1sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Procq.Symbol.list1sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]))
+  EntryName (Rawwit (ListArg typ), Procq.Symbol.list1sep e (Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal sep)]))
 | Extend.Ulist0sep (s, sep) ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
-  EntryName (Rawwit (ListArg typ), Procq.Symbol.list0sep e (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal sep)]))
+  EntryName (Rawwit (ListArg typ), Procq.Symbol.list0sep e (Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal sep)]))
 | Extend.Uopt s ->
   let EntryName (Rawwit typ, e) = prod_item_of_symbol lev s in
   EntryName (Rawwit (OptArg typ), Procq.Symbol.opt e)
@@ -443,11 +443,11 @@ let create_ltac_quotation ~plugin name cast (e, l) : unit =
               (Rule.next
                  (Rule.next
                     Rule.stop
-                    (Symbol.token (Procq.terminal name)))
-                 (Symbol.token (Procq.terminal ":")))
-              (Symbol.token (Procq.terminal "(")))
+                    (Symbol.token (CLexer.terminal name)))
+                 (Symbol.token (CLexer.terminal ":")))
+              (Symbol.token (CLexer.terminal "(")))
            entry)
-        (Symbol.token (Procq.terminal ")")))
+        (Symbol.token (CLexer.terminal ")")))
   in
   let action _ v _ _ _ loc = cast (Some loc, v) in
   let gram = [Procq.Production.make rule action] in

--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -873,7 +873,7 @@ let rec get_rule (tok : SynclassDyn.t token list) : krule = match tok with
   KRule (rule, act)
 | TacTerm t :: tok ->
   let KRule (rule, act) = get_rule tok in
-  let rule = Procq.(Rule.next rule (Symbol.token (Procq.terminal t))) in
+  let rule = Procq.(Rule.next rule (Symbol.token (CLexer.terminal t))) in
   let act k _ = act k in
   KRule (rule, act)
 

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -458,7 +458,7 @@ let () = add_syntax_class "terminal" begin function
 | [SexprStr {loc;v=s}] -> s
 | arg -> syntax_class_fail "terminal" arg
   end begin fun s ->
-    let syntax_class = Procq.Symbol.token (Procq.terminal s) in
+    let syntax_class = Procq.Symbol.token (CLexer.terminal s) in
     Tac2entries.SyntaxRule (syntax_class, (fun _ -> q_unit))
   end
 
@@ -480,7 +480,7 @@ let () = add_syntax_class_full "list0" {
     Tac2entries.SyntaxRule (syntax_class, act)
   | subclass, Some str ->
     let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.interp_syntax_class subclass in
-    let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
+    let sep = Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal str)] in
     let syntax_class = Procq.Symbol.list0sep syntax_class sep in
     let act l = Tac2quote.of_list act l in
     Tac2entries.SyntaxRule (syntax_class, act)
@@ -505,7 +505,7 @@ let () = add_syntax_class_full "list1" {
     Tac2entries.SyntaxRule (syntax_class, act)
   | subclass, Some str ->
     let Tac2entries.SyntaxRule (syntax_class, act) = Tac2entries.interp_syntax_class subclass in
-    let sep = Procq.Symbol.tokens [Procq.TPattern (Procq.terminal str)] in
+    let sep = Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal str)] in
     let syntax_class = Procq.Symbol.list1sep syntax_class sep in
     let act l = Tac2quote.of_list act l in
     Tac2entries.SyntaxRule (syntax_class, act)

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -35,7 +35,7 @@ let rec ty_rule_of_gram = function
 | [] -> AnyTyRule TyStop
 | GramTerminal s :: rem ->
   let AnyTyRule rem = ty_rule_of_gram rem in
-  let tok = Procq.Symbol.token (Procq.terminal s) in
+  let tok = Procq.Symbol.token (CLexer.terminal s) in
   let r = TyNext (rem, tok, None) in
   AnyTyRule r
 | GramNonTerminal (_, (t, tok)) :: rem ->

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -785,7 +785,7 @@ let prod_entry_type = function
 
 let keyword_needed need s =
   (* Ensure that IDENT articulation terminal symbols are keywords *)
-  match Procq.terminal s with
+  match CLexer.terminal s with
   | Tok.PIDENT (Some k) ->
     if need then
       Flags.if_verbose Feedback.msg_info (str "Identifier '" ++ str k ++ str "' now a keyword");

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -168,9 +168,9 @@ let rec untype_command : type r s. (r, s) ty_sig -> r -> plugin_args -> vernac_c
 let rec untype_user_symbol : type s a b c. (a, b, c) Extend.ty_user_symbol -> (s, Gramlib.Grammar.norec, a) Procq.Symbol.t =
   let open Extend in function
   | TUlist1 l -> Procq.Symbol.list1 (untype_user_symbol l)
-  | TUlist1sep (l, s) -> Procq.Symbol.list1sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)])
+  | TUlist1sep (l, s) -> Procq.Symbol.list1sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal s)])
   | TUlist0 l -> Procq.Symbol.list0 (untype_user_symbol l)
-  | TUlist0sep (l, s) -> Procq.Symbol.list0sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (Procq.terminal s)])
+  | TUlist0sep (l, s) -> Procq.Symbol.list0sep (untype_user_symbol l) (Procq.Symbol.tokens [Procq.TPattern (CLexer.terminal s)])
   | TUopt o -> Procq.Symbol.opt (untype_user_symbol o)
   | TUentry a -> Procq.Symbol.nterm (Procq.genarg_grammar (Genarg.ExtraArg a))
   | TUentryl (a, i) -> Procq.Symbol.nterml (Procq.genarg_grammar (Genarg.ExtraArg a)) (string_of_int i)


### PR DESCRIPTION
CLexer.terminal is called in places where there is no associated
keyword state (typically plugin dynlinking), so it shouldn't depend on
whatever arbitrary state is currently installed.

For instance if we do (with -noinit):
~~~coq
(* make "into" a keyword *)
Notation "'into' x" := (x x) (at level 42).
Require Ltac.
~~~
then backtrack, remove the notation and replay the Require, "into" will
still be a keyword.

For idents which have been declared as keywords, producing PIDENT
instead of PKEYWORD should only change the behaviour of Print Grammar,
to avoid this we change it to check the keyword state when printing `PIDENT (Some _)`.
