### PR TITLE
Use regular goption to test if SSR is loaded instead of checking keywords

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -511,14 +511,13 @@ let string_of_genarg_arg (ArgumentType arg) =
            (fun id -> spc () ++ pr_hyp_location pr_id id) l ++ pr_occs)
 
 
-  (* When the [ssreflect.SsrSynax] module is imported, ssreflect operates
-     in reduced compatibility mode. During printing, we try to account for
-     this when this module is imported. See [plugins/ssr/ssrparser.mlg] for
-     the code that enables the reduced compatibility mode. *)
-  let ssr_loaded = ref (fun () -> false)
-  let ssr_loaded_hook f = ssr_loaded := f
+(* When the [ssreflect.SsrSynax] module is imported, ssreflect
+   operates in reduced compatibility mode. During printing, we try to
+   account for this when this module is imported. *)
+let { Goptions.get = ssr_loaded } =
+  Goptions.declare_bool_option_and_ref ~stage:Synterp ~key:["SSR";"Loaded"] ~value:false ()
 
-  let pr_orient b = if b then if !ssr_loaded () then str "-> " else mt () else str "<- "
+  let pr_orient b = if b then if ssr_loaded () then str "-> " else mt () else str "<- "
 
   let pr_multi = let open Equality in function
     | Precisely 1 -> mt ()

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -162,4 +162,4 @@ val ltop : entry_relative_level
 val make_constr_printer : (env -> Evd.evar_map -> entry_relative_level -> 'a -> Pp.t) ->
   'a Genprint.top_printer
 
-val ssr_loaded_hook : (unit -> bool) -> unit
+val ssr_loaded : unit -> bool

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -51,12 +51,8 @@ open Libobject
 (* some caching, repeating the test only when the environment changes.  *)
 (*   We check for protect_term because it is the first constant loaded; *)
 (* ssr_have would ultimately be a better choice.                        *)
-let ssr_loaded = Summary.ref ~name:"SSR:loaded" false
-let is_ssr_loaded () =
-  !ssr_loaded ||
-  (if CLexer.is_keyword (Procq.get_keyword_state()) "SsrSyntax_is_Imported" then ssr_loaded:=true;
-   !ssr_loaded)
-let () = Pptactic.ssr_loaded_hook is_ssr_loaded
+
+let is_ssr_loaded = Pptactic.ssr_loaded
 
 }
 

--- a/theories/Corelib/ssr/ssreflect.v
+++ b/theories/Corelib/ssr/ssreflect.v
@@ -86,8 +86,8 @@ Module SsrSyntax.
 
 Reserved Notation "(* x 'is' y 'of' z 'isn't' // /= //= *)".
 
-(**  Non ambiguous keyword to check if the SsrSyntax module is imported  **)
-Reserved Notation "(* Use to test if 'SsrSyntax_is_Imported' *)".
+(** Enable SSR features **)
+#[export] Set SSR Loaded.
 
 Reserved Notation "<hidden n >" (at level 0, n at level 0,
   format "<hidden  n >").


### PR DESCRIPTION

I guess this check was introduced before Export Set.
