### PR TITLE
Mitigate #2939: injection overly reduces in subterms.

### DIFF
--- a/dev/ci/user-overlays/21392-ppedrot-fix-2939.sh
+++ b/dev/ci/user-overlays/21392-ppedrot-fix-2939.sh
@@ -1,0 +1,1 @@
+overlay stdlib https://github.com/ppedrot/stdlib fix-2939 21392


### PR DESCRIPTION
The new code still has to fully head reduce terms to try to find a constructor, including δ-reduction, but it preserves the original shape of the term when it does not evaluate to a constructor.