### PR TITLE
Fix ind_tables minimization

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -74,7 +74,6 @@ module QState : sig
   val collapse_above_prop : to_prop:bool -> t -> t
   val collapse : ?except:QVar.Set.t -> t -> t
   val pr : (QVar.t -> Libnames.qualid option) -> t -> Pp.t
-  val of_set : QVar.Set.t -> t
   val of_elims : QGraph.t -> t
   val elims : t -> QGraph.t
   val set_elims : QGraph.t -> t -> t
@@ -228,12 +227,6 @@ let add ~check_fresh ~rigid q m =
     above_prop = m.above_prop;
     elims = add_quality m.elims;
     initial_elims = add_quality m.initial_elims }
-
-let of_set qs =
-  let empty_qmap = QMap.bind (fun _ -> None) qs in
-  let g = QVar.Set.fold (fun v -> QGraph.add_quality (QVar v)) qs QGraph.initial_graph in
-  { rigid = QSet.empty; qmap = empty_qmap; above_prop = QSet.empty;
-    elims = g; initial_elims = g }
 
 let of_elims elims =
   let qs = QGraph.qvar_domain elims in
@@ -485,12 +478,6 @@ let univ_entry ~poly uctx =
     if poly then Polymorphic_entry (context uctx)
     else Monomorphic_entry (context_set uctx) in
   entry, binders
-
-let of_context_set ((qs,us),csts) =
-  let sort_variables = QState.of_set qs in
-  { empty with
-    local = (us,csts);
-    sort_variables;}
 
 type universe_opt_subst = UnivFlex.t
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -45,9 +45,6 @@ val from_env : ?binders:lident list -> Environ.env -> t
 val of_names : (UnivNames.universe_binders * UnivNames.rev_binders) -> t
 (** Main entry point when only names matter, e.g. for printing. *)
 
-val of_context_set : UnivGen.sort_context_set -> t
-(** Main entry point when starting from the instance of a global
-    reference, e.g. when building a scheme. *)
 
 (** Misc *)
 

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -76,6 +76,9 @@ let fresh env id avoid =
 let with_context_set ctx (b, ctx') =
   (b, UnivGen.sort_context_union ctx ctx')
 
+let of_context_set env ctx =
+  UState.merge_sort_context ~sideff:false UnivRigid QGraph.Internal (UState.from_env env) ctx
+
 let build_dependent_inductive ind (mib,mip) =
   let realargs,_ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
   applist
@@ -230,7 +233,7 @@ let build_sym_scheme env _handle ind =
             mkRel 1 (* varH *),
             [|cstr (nrealargs+1)|])))))
   in
-  c, UState.of_context_set ctx
+  c, of_context_set env ctx
 
 let sym_scheme_kind =
   declare_individual_scheme_object "sym"
@@ -301,7 +304,7 @@ let build_sym_involutive_scheme env handle ind =
                NoInvert,
                mkRel 1 (* varH *),
                [|mkApp(eqrefl,[|applied_ind_C;cstr (nrealargs+1)|])|])))))
-  in (c, UState.of_context_set ctx)
+  in (c, of_context_set env ctx)
 
 let sym_involutive_scheme_kind =
   declare_individual_scheme_object "sym_involutive"
@@ -461,7 +464,7 @@ let build_l2r_rew_scheme dep env handle ind kind =
        [|main_body|]))
    else
      main_body))))))
-  in (c, UState.of_context_set ctx)
+  in (c, of_context_set env ctx)
 
 (**********************************************************************)
 (* Build the left-to-right rewriting lemma for hypotheses associated  *)
@@ -554,7 +557,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
           (if dep then realsign_ind_P 1 applied_ind_P' else realsign_P 2) s)
       (mkNamedLambda (make_annot varHC sr) applied_PC'
         (mkVar varHC))|]))))))
-  in c, UState.of_context_set ctx
+  in c, of_context_set env ctx
 
 (**********************************************************************)
 (* Build the right-to-left rewriting lemma for hypotheses associated  *)
@@ -641,7 +644,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
            lift (nrealargs+3) applied_PC,
            mkRel 1)|])),
     [|mkVar varHC|]))))))
-  in c, UState.of_context_set ctx
+  in c, of_context_set env ctx
 
 (**********************************************************************)
 (* This function "repairs" the non-dependent r2l forward rewriting    *)
@@ -859,7 +862,7 @@ let build_congr env (eq,refl,ctx) ind =
        [|mkApp (refl,
           [|mkVar varB;
             mkApp (mkVar varf, [|lift (mip.mind_nrealargs+3) b|])|])|])))))))
-  in c, UState.of_context_set ctx
+  in c, of_context_set env ctx
 
 let congr_scheme_kind = declare_individual_scheme_object "congr"
   (fun env _ ind ->

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -150,6 +150,7 @@ let define ?loc internal role id c poly uctx sch =
   let avoid = Id.Set.of_list @@ List.map (fun cst -> Constant.label cst) avoid in
   let id = compute_name internal id avoid in
   let uctx = UState.collapse_above_prop_sort_variables ~to_prop:true uctx in
+  let uctx = UState.normalize_variables uctx in
   let uctx = UState.minimize uctx in
   let c = UState.nf_universes uctx c in
   let uctx = UState.restrict uctx (Vars.universes_of_constr c) in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -375,14 +375,9 @@ let name_and_process_scheme env = function
     (newref, sch_isdep sch_type, ind, sch_sort)
 
 let do_mutual_induction_scheme ~register ?(force_mutual=false) env ?(isrec=true) l =
-  let sigma, inst =
-    let _,_,ind,_ = match l with | x::_ -> x | [] -> assert false in
-    let _, ctx = Typeops.type_of_global_in_context env (Names.GlobRef.IndRef ind) in
-    let u, ctx = UnivGen.fresh_instance_from ctx None in
-    let u = EConstr.EInstance.make u in
-    let sigma = Evd.from_ctx (UState.of_context_set ctx) in
-    sigma, u
-  in
+  let sigma = Evd.from_env env in
+  let _,_,ind,_ = match l with | x::_ -> x | [] -> assert false in
+  let sigma, (ind, inst) = Evd.fresh_inductive_instance env sigma ~rigid:UnivRigid ind in
   let sigma, lrecspec =
     List.fold_left_map (fun sigma (_,dep,ind,sort) ->
         let sigma, sort = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma sort in


### PR DESCRIPTION
All other calls to `UState.minimize` happen through `Evd.minimize_universes`, which also calls `UState.normalize_variables`.
It's still unclear to me why this is needed, but this should be fine either way.