### PR TITLE
Reduce the reliance on PConstraints.ContextSet.t in upper layers

### DIFF
--- a/dev/ci/user-overlays/21394-ppedrot-reduce-pcontext-api.sh
+++ b/dev/ci/user-overlays/21394-ppedrot-reduce-pcontext-api.sh
@@ -1,0 +1,11 @@
+overlay elpi https://github.com/ppedrot/coq-elpi reduce-pcontext-api 21394
+
+overlay equations https://github.com/ppedrot/Coq-Equations reduce-pcontext-api 21394
+
+overlay mtac2 https://github.com/ppedrot/Mtac2 reduce-pcontext-api 21394
+
+overlay paramcoq https://github.com/ppedrot/paramcoq reduce-pcontext-api 21394
+
+overlay rewriter https://github.com/ppedrot/rewriter reduce-pcontext-api 21394
+
+overlay metarocq https://github.com/ppedrot/metarocq reduce-pcontext-api 21394

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1298,7 +1298,6 @@ let push_side_effects ?role ?ts name de ctx effs =
   let seff_univs =
     if Univ.Level.Set.is_empty (fst ctx) then effs.seff_univs
     else
-      let ctx = PConstraints.ContextSet.of_univ_context_set ctx in (* XXX *)
       Cmap_env.add kn (UState.Monomorphic_entry ctx, UnivNames.empty_binders) effs.seff_univs
   in
   let seff_roles = match role with

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -274,6 +274,8 @@ val check_mono_sort_poly_decl : t -> sort_poly_decl -> Univ.ContextSet.t
 
 val check_template_sort_poly_decl : t -> template_qvars:QVar.Set.t -> sort_poly_decl -> PConstraints.ContextSet.t
 
+val check_mono_sort_constraints : PConstraints.ContextSet.t -> Univ.ContextSet.t
+
 (** {5 TODO: Document me} *)
 
 val update_sigma_univs : t -> UGraph.t -> t

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -17,7 +17,7 @@ open Univ
 open Sorts
 
 type universes_entry =
-| Monomorphic_entry of PConstraints.ContextSet.t
+| Monomorphic_entry of Univ.ContextSet.t
 | Polymorphic_entry of UVars.UContext.t
 
 exception UniversesDiffer

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -208,10 +208,6 @@ let fresh_sort_in_quality =
      let u = fresh_level () in
      sort_of_univ (Univ.Universe.make u), ((QVar.Set.empty,Level.Set.singleton u), PConstraints.empty)
 
-let new_global_univ () =
-  let u = fresh_level () in
-  (Univ.Universe.make u, ContextSet.singleton_lvl u)
-
 let fresh_universe_context_set_instance ctx =
   if ContextSet.is_empty ctx then Level.Map.empty, ctx
   else

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -60,8 +60,6 @@ val new_sort_global : Id.t -> Sorts.QGlobal.t
 val fresh_level : unit -> Level.t
 val fresh_sort_quality : unit -> Sorts.QVar.t
 
-val new_global_univ : unit -> Universe.t in_poly_context_set
-
 (** Build a fresh instance for a given context, its associated substitution and
     the instantiated constraints. *)
 

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -131,7 +131,7 @@ let rec intern_module_ast kind m = match m with
       (MEwith(me,decl), base, kind)
 
 let interp_with_decl env base kind = function
-  | WithMod (fqid,mp) -> WithMod (fqid,mp), PConstraints.ContextSet.empty
+  | WithMod (fqid,mp) -> WithMod (fqid,mp), Univ.ContextSet.empty
   | WithDef(fqid,(udecl,c)) ->
     let sigma, udecl = interp_sort_poly_decl_opt env udecl in
     let c, ectx = interp_constr env sigma c in
@@ -141,7 +141,7 @@ let interp_with_decl env base kind = function
         let inst, ctx = UVars.abstract_universes ctx in
         let c = EConstr.Vars.subst_univs_level_constr (UVars.make_instance_subst inst) c in
         let c = EConstr.to_constr sigma c in
-        WithDef (fqid,(c, Some ctx)), PConstraints.ContextSet.empty
+        WithDef (fqid,(c, Some ctx)), Univ.ContextSet.empty
       | UState.Monomorphic_entry ctx ->
         let c = EConstr.to_constr sigma c in
         WithDef (fqid,(c, None)), ctx
@@ -156,8 +156,8 @@ let rec interp_module_ast env kind base m cst = match m with
 | MEwith(me,decl) ->
   let me, cst = interp_module_ast env kind base me cst in
   let decl, cst' = interp_with_decl env base kind decl in
-  let cst = PConstraints.ContextSet.union cst cst' in
+  let cst = Univ.ContextSet.union cst cst' in
   MEwith(me,decl), cst
 
 let interp_module_ast env kind base m =
-  interp_module_ast env kind base m PConstraints.ContextSet.empty
+  interp_module_ast env kind base m Univ.ContextSet.empty

--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -42,4 +42,4 @@ val intern_module_ast :
 
 (** Module interpretation, i.e. from module expression to typed module entry *)
 val interp_module_ast :
-  env -> module_kind -> ModPath.t -> module_struct_expr -> module_struct_entry * PConstraints.ContextSet.t
+  env -> module_kind -> ModPath.t -> module_struct_expr -> module_struct_entry * Univ.ContextSet.t

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -183,7 +183,7 @@ let decl_constant name univs c =
   let () = Global.push_qualities QGraph.Static (PConstraints.ContextSet.sort_context_set univs) in (* XXX *)
   let () = Global.push_context_set (PConstraints.ContextSet.univ_context_set univs) in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
-  let univs = UState.Monomorphic_entry PConstraints.ContextSet.empty, UnivNames.empty_binders in
+  let univs = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in
   (* UnsafeMonomorphic: we always do poly:false *)
   UnsafeMonomorphic.mkConst
     (declare_constant ~name

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -825,11 +825,12 @@ let build_congr env (eq,refl,ctx) ind =
   let varf,avoid = fresh env (Id.of_string "f") avoid in
   let rci = Sorts.Relevant in (* TODO relevance *)
   let ci = make_case_info env ind RegularStyle in
-  let uni, ctx' = UnivGen.new_global_univ () in
+  let lvl = UnivGen.fresh_level () in
+  let uni = Univ.Universe.make lvl in
   let ctx =
-    let (qs,us),csts = ctx in
-    let us, (elim_csts,univ_csts) = PConstraints.ContextSet.union (us,csts) ctx' in
-    ((qs, us), (elim_csts,UnivSubst.enforce_leq uni (univ_of_eq env eq) univ_csts)) in
+    let (qs, us), (qcst, ucst) = ctx in
+    let us = Univ.Level.Set.add lvl us in
+    ((qs, us), (qcst, UnivSubst.enforce_leq uni (univ_of_eq env eq) ucst)) in
   let c =
   my_it_mkLambda_or_LetIn paramsctxt
      (mkNamedLambda (make_annot varB Sorts.Relevant) (mkType uni)

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -2,14 +2,13 @@ open Names
 
 let evil name name_f =
   let open Univ in
-  let open PConstraints in
   let open UVars in
   let open Constr in
   let kind = Decls.(IsDefinition Definition) in
   let u = Level.var 0 in
   let tu = mkType (Universe.make u) in
   let te = Declare.definition_entry
-      ~univs:(UState.Monomorphic_entry (ContextSet.singleton_lvl u), UnivNames.empty_binders) tu
+      ~univs:(UState.Monomorphic_entry (Univ.ContextSet.singleton u), UnivNames.empty_binders) tu
   in
   let tc = Declare.declare_constant ~name ~kind (Declare.DefinitionEntry te) in
   let tc = mkConst tc in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -101,7 +101,7 @@ let interp_assumption ~program_mode env sigma impl_env bl c =
   sigma, ty, impls1@impls2
 
 let empty_poly_univ_entry = UState.Polymorphic_entry UVars.UContext.empty, UnivNames.empty_binders
-let empty_mono_univ_entry = UState.Monomorphic_entry PConstraints.ContextSet.empty, UnivNames.empty_binders
+let empty_mono_univ_entry = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders
 let empty_univ_entry poly = if poly then empty_poly_univ_entry else empty_mono_univ_entry
 
 let clear_univs scope univ =

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -56,7 +56,7 @@ type t = {
   nuparams : int option;
   univ_binders : UState.named_universes_entry;
   implicits : DeclareInd.one_inductive_impls list;
-  uctx : PConstraints.ContextSet.t;
+  uctx : Univ.ContextSet.t;
   where_notations : Metasyntax.notation_interpretation_decl list;
   coercions : Libnames.qualid list;
   indlocs : DeclareInd.indlocs;
@@ -99,7 +99,7 @@ val interp_mutual_inductive_constr
      * (* for global universe names, used by DeclareInd *)
      UState.named_universes_entry
      * (* global universes to declare before the inductive (ie without the template univs) *)
-     PConstraints.ContextSet.t
+     Univ.ContextSet.t
 
 (************************************************************************)
 (** Internal API, exported for Record                                   *)

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -283,7 +283,7 @@ let constraint_obj =
    main issue is the filtering or redundant constraints (needed for perf / smaller vo file sizes) *)
 let add_constraint_source x ctx =
   let _, csts = ctx in
-  if PConstraints.is_empty csts then ()
+  if Univ.UnivConstraints.is_empty csts then ()
   else
     let v = x, csts in
     Lib.add_leaf (constraint_obj v)

--- a/vernac/declareUniv.mli
+++ b/vernac/declareUniv.mli
@@ -27,9 +27,9 @@ val do_universe : poly:bool -> lident list -> unit
 (** Command [Constraint]. *)
 val do_constraint : poly:bool -> Constrexpr.sort_poly_constraint_expr list -> unit
 
-val add_constraint_source : GlobRef.t -> PConstraints.ContextSet.t -> unit
+val add_constraint_source : GlobRef.t -> Univ.ContextSet.t -> unit
 
-val constraint_sources : unit -> (GlobRef.t * PConstraints.t) list
+val constraint_sources : unit -> (GlobRef.t * Univ.UnivConstraints.t) list
 (** Returns constraints associated to globrefs, newest first. *)
 
 (** Command [Sort]. *)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -215,7 +215,7 @@ module RecordEntry = struct
     }
 
   type t = {
-    global_univs : PConstraints.ContextSet.t;
+    global_univs : Univ.ContextSet.t;
     ubinders : UState.named_universes_entry;
     mie : Entries.mutual_inductive_entry;
     ind_infos : one_ind_info list;
@@ -645,7 +645,7 @@ let declare_projections indsp ~kind ~inhabitant_id flags ?fieldlocs fieldimpls =
     Declareops.inductive_polymorphic_context mib
   in
   let univs = match mib.mind_universes with
-    | Monomorphic -> UState.Monomorphic_entry PConstraints.ContextSet.empty
+    | Monomorphic -> UState.Monomorphic_entry Univ.ContextSet.empty
     | Polymorphic auctx -> UState.Polymorphic_entry (UVars.AbstractContext.repr auctx)
   in
   let univs = univs, UnivNames.empty_binders in
@@ -835,8 +835,7 @@ module Declared = struct
 end
 
 let declare_structure (decl:Record_decl.t) ~schemes =
-  let () = Global.push_qualities QGraph.Rigid (PConstraints.ContextSet.sort_context_set decl.entry.global_univs) in (* XXX *)
-  let () = Global.push_context_set (PConstraints.ContextSet.univ_context_set decl.entry.global_univs) in
+  let () = Global.push_context_set decl.entry.global_univs in
   (* XXX no implicit arguments for constructors? *)
   let impls = List.make (List.length decl.entry.mie.mind_entry_inds) (decl.entry.param_impls, []) in
   let default_dep_elim = List.map (fun x -> x.RecordEntry.default_dep_elim) decl.entry.ind_infos in
@@ -893,7 +892,7 @@ let declare_class_constant entry (data:Data.t) =
   in
   let inst, univs = match univs with
     | UState.Monomorphic_entry _, ubinders ->
-      UVars.Instance.empty, (UState.Monomorphic_entry PConstraints.ContextSet.empty, ubinders)
+      UVars.Instance.empty, (UState.Monomorphic_entry Univ.ContextSet.empty, ubinders)
     | UState.Polymorphic_entry uctx, _ ->
       UVars.UContext.instance uctx, univs
   in

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -65,7 +65,7 @@ module RecordEntry : sig
   }
 
   type t = {
-    global_univs : PConstraints.ContextSet.t;
+    global_univs : Univ.ContextSet.t;
     ubinders : UState.named_universes_entry;
     mie : Entries.mutual_inductive_entry;
     ind_infos : one_ind_info list;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -560,7 +560,7 @@ let mk_sources () =
       edges libs
   in
   let edges =
-    List.fold_left (fun edges (ref,(_,csts)) ->
+    List.fold_left (fun edges (ref, csts) ->
         UnivConstraints.fold (fun cst edges -> add_edge cst (GlobRef ref) edges)
           csts edges)
       edges srcs


### PR DESCRIPTION
We reinstate Univ.ContextSet.t where it should have been left and add several assertions where we drop the elimination constraints.

Weirdly enough, just asserting that the set of elimination constraint is empty in monomorphic definitions is enough to pass the test-suite. If you ask me this is fishy, as it means we never really generate any constraint in this mode. At best we should generate constraints on local sort variables and then collapse them to trivially true ground constraints. This probably means somebody will have to fix things up when we really start using sort polymorphism.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/675
- https://github.com/LPCIC/coq-elpi/pull/939
- https://github.com/rocq-community/paramcoq/pull/146
- https://github.com/mit-plv/rewriter/pull/185
- https://github.com/MetaRocq/metarocq/pull/1219
- https://github.com/Mtac2/Mtac2/pull/418