### PR TITLE
Remove the last call to Evd.undefine in ssreflect

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -720,16 +720,6 @@ let remove d e =
   { d with undf_evars; defn_evars; future_goals;
            evar_flags; candidate_evars }
 
-let undefine sigma e concl =
-  let EvarInfo evi = find sigma e in
-  let evi = { evi with
-    evar_body = Evar_empty;
-    evar_concl = Undefined concl;
-    evar_candidates = Undefined None;
-    evar_abstract_arguments = Undefined Abstraction.identity;
-  } in
-  add (remove sigma e) e evi
-
 let find_defined d e = EvMap.find_opt e d.defn_evars
 
 let find_undefined d e = EvMap.find e d.undf_evars

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -225,9 +225,6 @@ val find_undefined : evar_map -> Evar.t -> undefined evar_info
 val remove : evar_map -> Evar.t -> evar_map
 (** Remove an evar from an evar map. Use with caution. *)
 
-val undefine : evar_map -> Evar.t -> etypes -> evar_map [@@ocaml.deprecated]
-(** Remove the body of an evar. Only there for backward compat, do not use. *)
-
 val mem : evar_map -> Evar.t -> bool
 (** Whether an evar is present in an evarmap. *)
 

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -156,7 +156,7 @@ let unif_redex env sigma0 nsigma p t = (* t is a hint for the redex of p *)
   let t, _, _, sigma = saturate ~beta:true env p.pat_sigma t (List.length evs) in
   let sigma = Evd.merge_universe_context sigma ucst in
   match p.pat_pat with
-  | X_In_T (e, p) -> { pat_sigma = sigma; pat_pat = E_As_X_In_T (t, e, p) }
+  | X_In_T p -> { pat_sigma = sigma; pat_pat = E_As_X_In_T (t, p) }
   | _ ->
     try { p with pat_sigma = unify_HO env sigma t (fst (redex_of_pattern env p)) }
     with e when CErrors.noncritical e -> p

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -45,9 +45,9 @@ ARGUMENT EXTEND rpattern
   | [ "in" lconstr(x) "in" lconstr(c) ] ->
     { mk_rpattern (In_X_In_T (mk_lterm x None, mk_lterm c None)) }
   | [ lconstr(e) "in" lconstr(x) "in" lconstr(c) ] ->
-    { mk_rpattern (E_In_X_In_T (mk_lterm e None, mk_lterm x None, mk_lterm c None)) }
+    { mk_rpattern (E_In_X_In_T (mk_lterm e None, (mk_lterm x None, mk_lterm c None))) }
   | [ lconstr(e) "as" lconstr(x) "in" lconstr(c) ] ->
-    { mk_rpattern (E_As_X_In_T (mk_lterm e None, mk_lterm x None, mk_lterm c None)) }
+    { mk_rpattern (E_As_X_In_T (mk_lterm e None, (mk_lterm x None, mk_lterm c None))) }
 END
 
 {

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1334,7 +1334,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
           str "in the pattern?") in
     let ty = Retyping.get_type_of (Evd.evar_filtered_env env0 e_def) sigma (EConstr.mkEvar (e, Evd.evar_identity_subst e_def)) in
     let sigma = Evd.undefine sigma e ty [@@ocaml.warning "-3"] in
-    sigma, e_body in
+    Reductionops.nf_evar sigma p, e_body
+  in
   let mk_upat_for ?hack ~rigid (sigma, t) =
     mk_tpattern ?hack ~rigid env0 t L2R (fs sigma t) (empty_tpatterns sigma)
   in
@@ -1361,8 +1362,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
     let find_X, end_X = mk_tpattern_matcher ?raise_NoMatch sigma occ holep in
     let concl = find_T env0 concl0 1 ~k:(fun env c _ h ->
       let p_sigma = unify_HO env (create_evar_defs sigma) c p in
-      let sigma, e_body = pop_evar p_sigma ex p in
-      fs p_sigma (find_X env (fs sigma p) h
+      let p, e_body = pop_evar p_sigma ex p in
+      fs p_sigma (find_X env p h
         ~k:(fun env _ -> do_subst env e_body))) in
     let _ = end_X () in let _, _, (_, _, us, _) = end_T () in
     concl, us
@@ -1378,8 +1379,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
     let find_E, end_E = mk_tpattern_matcher ?raise_NoMatch sigma0 occ re in
     let concl = find_T env0 concl0 1 ~k:(fun env c _ h ->
       let p_sigma = unify_HO env (create_evar_defs sigma) c p in
-      let sigma, e_body = pop_evar p_sigma ex p in
-      fs p_sigma (find_X env (fs sigma p) h ~k:(fun env c _ h ->
+      let p, e_body = pop_evar p_sigma ex p in
+      fs p_sigma (find_X env p h ~k:(fun env c _ h ->
         find_E env e_body h ~k:do_subst))) in
     let _, _, (_, _, us, _) = end_E () in
     let _ = end_X () in let _ = end_T () in
@@ -1397,8 +1398,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
     let find_X, end_X = mk_tpattern_matcher sigma occ holep in
     let concl = find_TE env0 concl0 1 ~k:(fun env c _ h ->
       let p_sigma = unify_HO env (create_evar_defs sigma) c p in
-      let sigma, e_body = pop_evar p_sigma ex p in
-      fs p_sigma (find_X env (fs sigma p) h ~k:(fun env c _ h ->
+      let p, e_body = pop_evar p_sigma ex p in
+      fs p_sigma (find_X env p h ~k:(fun env c _ h ->
         let e_sigma = unify_HO env sigma e_body e in
         let e_body = fs e_sigma e in
         do_subst env e_body e_body h))) in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -977,7 +977,12 @@ let pr_pattern pr_ident pr_term = function
 
 let pr_hole pr_constr e = pr_constr (EConstr.mkEvar e)
 
-let pr_in_pattern_aux pr_constr (x, t) =
+type in_pattern = {
+  in_hole : EConstr.existential;
+  in_patt : EConstr.t;
+}
+
+let pr_in_pattern_aux pr_constr { in_hole = x; in_patt = t} =
   pr_hole pr_constr x ++ str " in " ++ pr_constr t
 
 let pr_pattern_aux pr_constr = function
@@ -989,8 +994,6 @@ let pr_pattern_aux pr_constr = function
       pr_constr e ++ str " in " ++ pr_in_pattern_aux pr_constr p
   | E_As_X_In_T (e, p) ->
       pr_constr e ++ str " as " ++ pr_in_pattern_aux pr_constr p
-
-type in_pattern = EConstr.existential * EConstr.t
 
 type pattern = {
   pat_sigma : Evd.evar_map;
@@ -1314,15 +1317,16 @@ let interp_pattern ?wit_ssrpatternarg env sigma0 red redty =
     let h = EConstr.destEvar sigma h in
     let sigma = cleanup_XinE env sigma0 h x rp sigma in
     let rp = EConstr.Vars.subst1 (EConstr.mkEvar h) (Evarutil.nf_evar sigma rp) in
+    let in_pat = { in_hole = h; in_patt = rp } in
     let sigma, p = match red with
-      | X_In_T _ -> sigma, X_In_T (h,rp)
-      | In_X_In_T _ -> sigma, In_X_In_T (h,rp)
+      | X_In_T _ -> sigma, X_In_T in_pat
+      | In_X_In_T _ -> sigma, In_X_In_T in_pat
       | E_In_X_In_T (e, _) ->
         let sigma, e = interp_term env sigma e in
-        sigma, E_In_X_In_T (e, (h, rp))
+        sigma, E_In_X_In_T (e, in_pat)
       | E_As_X_In_T (e, _) ->
         let sigma, e = interp_term env sigma e in
-        sigma, E_As_X_In_T (e, (h, rp))
+        sigma, E_As_X_In_T (e, in_pat)
       | T _ | In_T _ -> assert false
     in
     { pat_sigma = sigma; pat_pat = p }
@@ -1366,7 +1370,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
     let concl = find_T env0 concl0 1 ~k:do_subst in
     let _, _, (_, _, us, _) = end_T () in
     concl, us
-  | Some { pat_sigma = sigma; pat_pat = (X_In_T (hole, p) | In_X_In_T (hole, p)) } ->
+  | Some { pat_sigma = sigma; pat_pat = (X_In_T p | In_X_In_T p) } ->
+    let { in_hole = hole; in_patt = p } = p in
     let p = fs sigma p in
     let occ = match pattern with Some { pat_pat = X_In_T _ } -> occ | _ -> noindex in
     let ex = fst hole in
@@ -1383,7 +1388,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
         ~k:(fun env _ -> do_subst env e_body))) in
     let _ = end_X () in let _, _, (_, _, us, _) = end_T () in
     concl, us
-  | Some { pat_sigma = sigma; pat_pat = E_In_X_In_T (e, (hole, p)) } ->
+  | Some { pat_sigma = sigma; pat_pat = E_In_X_In_T (e, p) } ->
+    let { in_hole = hole; in_patt = p } = p in
     let p, e = fs sigma p, fs sigma e in
     let ex = fst hole in
     let hole = EConstr.mkEvar hole in
@@ -1401,7 +1407,8 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
     let _, _, (_, _, us, _) = end_E () in
     let _ = end_X () in let _ = end_T () in
     concl, us
-  | Some { pat_sigma = sigma; pat_pat = E_As_X_In_T (e, (hole, p)) } ->
+  | Some { pat_sigma = sigma; pat_pat = E_As_X_In_T (e, p) } ->
+    let { in_hole = hole; in_patt = p } = p in
     let p, e = fs sigma p, fs sigma e in
     let ex = fst hole in
     let hole = EConstr.mkEvar hole in
@@ -1424,7 +1431,7 @@ let eval_pattern ?raise_NoMatch env0 sigma0 concl0 pattern occ (do_subst : subst
 
 let redex_of_pattern { pat_sigma = sigma; pat_pat = p } = match p with
 | In_T _ | In_X_In_T _ -> None
-| X_In_T (e, _) -> Some (sigma, EConstr.mkEvar e)
+| X_In_T { in_hole = e } -> Some (sigma, EConstr.mkEvar e)
 | T e | E_As_X_In_T (e, _) | E_In_X_In_T (e, _) -> Some (sigma, e)
 
 let redex_of_pattern_nf env p =

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -35,17 +35,19 @@ exception NoMatch
 exception NoProgress
 
 (** AST for [rpattern] (and consequently [cpattern]) *)
-type ('ident, 'term) ssrpattern =
+type ('inpat, 'term) ssrpattern =
   | T of 'term
   | In_T of 'term
-  | X_In_T of 'ident * 'term
-  | In_X_In_T of 'ident * 'term
-  | E_In_X_In_T of 'term * 'ident * 'term
-  | E_As_X_In_T of 'term * 'ident * 'term
+  | X_In_T of 'inpat
+  | In_X_In_T of 'inpat
+  | E_In_X_In_T of 'term * 'inpat
+  | E_As_X_In_T of 'term * 'inpat
+
+type in_pattern
 
 type pattern = {
   pat_sigma : Evd.evar_map;
-  pat_pat : (EConstr.existential, EConstr.t) ssrpattern;
+  pat_pat : (in_pattern, EConstr.t) ssrpattern;
 }
 
 val pp_pattern : env -> pattern -> Pp.t
@@ -53,7 +55,7 @@ val pp_pattern : env -> pattern -> Pp.t
 (** The type of rewrite patterns, the patterns of the [rewrite] tactic.
     These patterns also include patterns that identify all the subterms
     of a context (i.e. "in" prefix) *)
-type rpattern = (cpattern, cpattern) ssrpattern
+type rpattern = (cpattern * cpattern, cpattern) ssrpattern
 val pr_rpattern : rpattern -> Pp.t
 
 (** Extracts the redex and applies to it the substitution part of the pattern.
@@ -251,7 +253,7 @@ sig
   val subst_rpattern : Mod_subst.substitution -> rpattern -> rpattern
   val interp_rpattern : Geninterp.interp_sign -> env -> evar_map -> rpattern -> rpattern
   val pr_rpattern : rpattern -> Pp.t
-  val mk_rpattern : (cpattern, cpattern) ssrpattern -> rpattern
+  val mk_rpattern : (cpattern * cpattern, cpattern) ssrpattern -> rpattern
   val mk_lterm : Constrexpr.constr_expr -> Geninterp.interp_sign option -> cpattern
   val mk_term : ssrtermkind -> Constrexpr.constr_expr -> Geninterp.interp_sign option -> cpattern
 


### PR DESCRIPTION
This code was making a little belly dance to lock the expansion of an evar `?e` in a term, but the term was actually generated as `t{x := ?e}` so it was easy to just work directly on `t`. We made this explicit by adding a little bit more abstraction on the data types manipulated in the function. The resulting code should be equivalent to the previous one, but it is still semantically dubious as we should not care about evar expansion in the EConstr.t type. It may be a remnant of the era where we would not expand on sight, but for the time being I'm leaving this as is as my main goal was to get rid of `Evd.undefined`.