### PR TITLE
Remove Safe_typing.add_constraints and its Global counterpart.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -554,9 +554,6 @@ let push_context_set ~strict cst senv =
       univ = Univ.ContextSet.union cst senv.univ;
       sections }
 
-let add_constraints cst senv =
-  push_context_set ~strict:true cst senv
-
 let push_qualities src qs senv =
   if Sorts.QVar.Set.is_empty (fst qs) && Sorts.ElimConstraints.is_empty (snd qs) then senv
   else
@@ -1147,7 +1144,7 @@ let fill_opaque { opq_univs = ctx; opq_handle = i; opq_nonce = n; _ } senv =
   (* TODO: Drop the the monomorphic constraints, they should really be internal
      but the higher levels use them haphazardly. *)
   let senv = match ctx with
-  | Opaqueproof.PrivateMonomorphic ctx -> add_constraints ctx senv
+  | Opaqueproof.PrivateMonomorphic ctx -> push_context_set ~strict:true ctx senv
   | Opaqueproof.PrivatePolymorphic _ -> senv
   in
   (* Mark the constant as having been checked *)
@@ -1820,9 +1817,6 @@ let register_inductive ind prim senv =
   check_register_ind ind prim senv.env;
   let action = Retroknowledge.Register_ind(prim,ind) in
   add_retroknowledge action senv
-
-let add_constraints c =
-  add_constraints (Univ.Level.Set.empty, c)
 
 (* NB: The next old comment probably refers to [propagate_loads] above.
    When a Require is done inside a module, we'll redo this require

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -155,9 +155,6 @@ val add_modtype :
 val push_context_set :
   strict:bool -> Univ.ContextSet.t -> safe_transformer0
 
-val add_constraints :
-  Univ.UnivConstraints.t -> safe_transformer0
-
 (** Adding global sort qualities *)
 
 val push_qualities : QGraph.constraint_source -> Sorts.QContextSet.t -> safe_transformer0

--- a/library/global.ml
+++ b/library/global.ml
@@ -81,8 +81,7 @@ let globalize_with_summary fs f =
 let push_named_assum a = globalize0 (Safe_typing.push_named_assum a)
 let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let push_section_context c = globalize0 (Safe_typing.push_section_context c)
-let add_constraints c = globalize0 (Safe_typing.add_constraints c)
-let add_univ_constraints c = globalize0 (Safe_typing.add_constraints c)
+let add_univ_constraints c = globalize0 (Safe_typing.push_context_set ~strict:true (Univ.Level.Set.empty, c))
 let push_context_set c = globalize0 (Safe_typing.push_context_set ~strict:true c)
 let push_qualities src c = globalize0 (Safe_typing.push_qualities src c)
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -64,7 +64,6 @@ val add_mind :
   MutInd.t * IndTyping.NotPrimRecordReason.t option
 
 (** Extra universe constraints *)
-val add_constraints : Univ.UnivConstraints.t -> unit
 val add_univ_constraints : Univ.UnivConstraints.t -> unit
 
 val push_context_set : Univ.ContextSet.t -> unit


### PR DESCRIPTION
This API is redundant and has a rather generic name, it is better to use directly the underlying API.