### PR TITLE
Remove build_case_analysis_scheme 

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -2203,10 +2203,8 @@ let build_case_scheme fa =
     let ind = (first_fun_kn, funs_indexes) in
     ((ind, EConstr.EInstance.empty) (*FIXME*), EConstr.ESorts.prop)
   in
-  let sigma, scheme =
-    Indrec.build_case_analysis_scheme_default env sigma ind sf
-  in
-  let scheme, scheme_type = Indrec.eval_case_analysis scheme in
+  let dep = Elimschemes.default_case_analysis_dependence env (fst ind) in
+  let sigma, scheme, scheme_type = Indrec.build_case_analysis_scheme env sigma ind dep sf in
   let sorts = (fun (_, _, x) ->
       EConstr.ESorts.make @@ fst @@ UnivGen.fresh_sort_in_quality x) fa in
   let princ_name = (fun (x, _, _) -> x) fa in

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -210,9 +210,7 @@ let find_eliminator env sigma ~concl ~is_case ?elim oc c_gen =
         let elimty = Retyping.get_type_of env sigma elim in
         sigma, elim, elimty
       else
-        let sigma, case = Indrec.build_case_analysis_scheme env sigma indu true sort in
-        let (ind, indty) = Indrec.eval_case_analysis case in
-        (sigma, ind, indty)
+        Indrec.build_case_analysis_scheme env sigma indu true sort
     in
     let pred_id,n_elim_args,is_rec,elim_is_dep,n_pred_args,ctx_concl =
       analyze_eliminator elimty env sigma in

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -16,15 +16,11 @@ open Pp
 open CErrors
 open Util
 open Names
-open Nameops
 open Constr
 open EConstr
 open Declarations
 open Context
-open Vars
-open Namegen
 open Inductive
-open Inductiveops
 open Environ
 open LibBinding
 open State
@@ -41,109 +37,6 @@ type recursion_scheme_error =
   | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
 exception RecursionSchemeError of env * recursion_scheme_error
-
-let ident_hd env ids t na =
-  let na = named_hd env (Evd.from_env env) t na in
-  next_name_away na ids
-
-module RelEnv =
-struct
-  type t = { env : Environ.env; avoid : Id.Set.t }
-
-  let make env =
-    let avoid = Id.Set.of_list (Termops.ids_of_rel_context (rel_context env)) in
-    { env; avoid }
-
-  let avoid_decl avoid decl = match get_name decl with
-  | Anonymous -> avoid
-  | Name id -> Id.Set.add id avoid
-
-  let push_rel decl env =
-    { env = EConstr.push_rel decl env.env; avoid = avoid_decl env.avoid decl }
-
-  let push_rel_context ctx env =
-    let avoid = List.fold_left avoid_decl env.avoid ctx in
-    { env = EConstr.push_rel_context ctx env.env; avoid }
-
-end
-
-let (!!) env = env.RelEnv.env
-
-let set_names env l =
-  let ids = env.RelEnv.avoid in
-  let fold d (ids, l) =
-    let id = ident_hd !!env ids (get_type d) (get_name d) in
-    (Id.Set.add id ids, set_name (Name id) d :: l)
-  in
-  snd (List.fold_right fold l (ids,[]))
-
-let make_name env s r =
-  let id = next_ident_away (Id.of_string s) env.RelEnv.avoid in
-  make_annot (Name id) r
-
-
-(*******************************************)
-(* Building curryfied elimination          *)
-(*******************************************)
-
-let check_privacy_block specif =
-  if Inductive.is_private specif then
-    user_err (str"case analysis on a private inductive type")
-
-(**********************************************************************)
-(* Building case analysis schemes *)
-(* Christine Paulin, 1996 *)
-
-type case_analysis = {
-  case_params : EConstr.rel_context;
-  case_pred : Name.t EConstr.binder_annot * EConstr.types;
-  case_branches : EConstr.rel_context;
-  case_arity : EConstr.rel_context;
-  case_body : EConstr.t;
-  case_type : EConstr.t;
-}
-
-let eval_case_analysis case =
-  let open EConstr in
-  let body = it_mkLambda_or_LetIn case.case_body case.case_arity in
-  (* Expand let bindings in the type for backwards compatibility *)
-  let bodyT = it_mkProd_wo_LetIn case.case_type case.case_arity in
-  let body = it_mkLambda_or_LetIn body case.case_branches in
-  let bodyT = it_mkProd_or_LetIn bodyT case.case_branches in
-  let (nameP, typP) = case.case_pred in
-  let body = mkLambda (nameP, typP, body) in
-  let bodyT = mkProd (nameP, typP, bodyT) in
-  let c = it_mkLambda_or_LetIn body case.case_params in
-  let cT = it_mkProd_or_LetIn bodyT case.case_params in
-  (c, cT)
-
-(* [p] is the predicate and [cs] a constructor summary *)
-let build_branch_type env sigma dep p cs =
-  let open EConstr in
-  let open EConstr.Vars in
-  let base = mkApp (lift cs.cs_nargs p, cs.cs_concl_realargs) in
-  if dep then
-    Namegen.it_mkProd_or_LetIn_name env sigma
-      (applist (base,[build_dependent_constructor cs]))
-      cs.cs_args
-  else
-    it_mkProd_or_LetIn base cs.cs_args
-
-let check_valid_elimination env sigma (ind, u as pind) ~dep s =
-  let specif = Inductive.lookup_mind_specif env ind in
-  let () =
-    if dep && not (Inductiveops.has_dependent_elim specif) then
-      raise (RecursionSchemeError (env, NotAllowedDependentAnalysis (false, ind)))
-  in
-  let () = check_privacy_block specif in
-  match Inductiveops.make_allowed_elimination sigma (specif,u) s with
-  | Some sigma -> sigma
-  | None ->
-    let s = EConstr.ESorts.kind sigma s in
-    let pind = on_snd EConstr.Unsafe.to_instance pind in
-    raise
-      (RecursionSchemeError
-         (env, NotAllowedCaseAnalysis (sigma, false, s, pind)))
 
 let paramdecls_fresh_template sigma (mib,u) =
   match mib.mind_template with
@@ -169,152 +62,6 @@ let paramdecls_fresh_template sigma (mib,u) =
     let sigma = Evd.add_poly_constraints QGraph.Internal sigma csts in
     sigma, EConstr.of_rel_context params
 
-let mis_make_case_com dep env sigma (ind, u as pind) (mib, mip) s =
-  let open EConstr in
-  let sigma = check_valid_elimination env sigma pind ~dep s in
-  let sigma, lnamespar = paramdecls_fresh_template sigma (mib, u) in
-  let indf = make_ind_family(pind, Context.Rel.instance_list mkRel 0 lnamespar) in
-  let constrs = get_constructors env indf in
-  let projs = get_projections env ind in
-  let relevance = Retyping.relevance_of_sort s in
-  let ndepar = mip.mind_nrealdecls + 1 in
-
-  (* Pas génant car env ne sert pas à typer mais juste à renommer les Anonym *)
-  (* mais pas très joli ... (mais manque get_sort_of à ce niveau) *)
-  let env = RelEnv.make env in
-  let env' = RelEnv.push_rel_context lnamespar env in
-
-  let typP = make_arity !!env' sigma dep indf s in
-  let nameP = make_name env' "P" ERelevance.relevant in
-
-  let rec get_branches env k accu =
-    if Int.equal k (Array.length mip.mind_consnames) then accu
-    else
-      let cs = lift_constructor (k+1) constrs.(k) in
-      let t = build_branch_type !!env sigma dep (mkRel (k+1)) cs in
-      let branch_name = make_annot (Name cs.cs_name) relevance in
-      let decl = LocalAssum (branch_name, t) in
-      get_branches (RelEnv.push_rel decl env) (k + 1) (decl :: accu)
-  in
-
-  let env' = RelEnv.push_rel (LocalAssum (nameP,typP)) env' in
-  let branches = get_branches env' 0 [] in
-
-  let arity, body, bodyT =
-    let env = RelEnv.push_rel_context branches env' in
-    let nbprod = Array.length mip.mind_consnames + 1 in
-
-    let indf' = lift_inductive_family nbprod indf in
-    let arsign = get_arity !!env indf' in
-    let r = Inductiveops.relevance_of_inductive_family !!env indf' in
-    let depind = build_dependent_inductive !!env indf' in
-    let deparsign = LocalAssum (make_annot Anonymous r,depind) :: arsign in
-
-    let ci = make_case_info !!env (fst pind) RegularStyle in
-    let pbody =
-      mkApp
-        (mkRel (ndepar + nbprod),
-          if dep then Context.Rel.instance mkRel 0 deparsign
-          else Context.Rel.instance mkRel 1 arsign) in
-    let deparsign = set_names env deparsign in
-    let pctx =
-      if dep then deparsign
-      else LocalAssum (make_annot Anonymous r, depind) :: List.tl deparsign
-    in
-    let obj, objT =
-      match projs with
-      | None ->
-        let pms = Context.Rel.instance mkRel (ndepar + nbprod) lnamespar in
-        let iv =
-          if Typeops.should_invert_case !!env (ERelevance.kind sigma relevance) ci then
-            CaseInvert { indices = Context.Rel.instance mkRel 1 arsign }
-          else NoInvert
-        in
-        let ncons = Array.length mip.mind_consnames in
-        let mk_branch i =
-          (* we need that to get the generated names for the branch *)
-          let ft = get_type (lookup_rel (ncons - i) !!env) in
-          let (ctx, _) = EConstr.decompose_prod_decls sigma ft in
-          let brnas = Array.of_list (List.rev_map get_annot ctx) in
-          let n = mkRel (List.length ctx + ndepar + ncons - i) in
-          let args = Context.Rel.instance mkRel 0 ctx in
-          (brnas, mkApp (n, args))
-        in
-        let br = Array.init ncons mk_branch in
-        let pnas = Array.of_list (List.rev_map get_annot pctx) in
-        let obj = mkCase (ci, u, pms, ((pnas, liftn ndepar (ndepar + 1) pbody), relevance), iv, mkRel 1, br) in
-        obj, pbody
-      | Some ps ->
-        let term =
-          mkApp (mkRel 2,
-                  Array.map
-                    (fun (p,r) ->
-                       let r = EConstr.Vars.subst_instance_relevance u (ERelevance.make r) in
-                       mkProj (Projection.make p true, r, mkRel 1))
-                    ps)
-        in
-        if dep then
-          let ty = mkApp (mkRel 3, [| mkRel 1 |]) in
-          mkCast (term, DEFAULTcast, ty), ty
-        else
-          term, mkRel 3
-    in
-    (deparsign, obj, objT)
-  in
-  let params = set_names env lnamespar in
-  let case = {
-    case_params = params;
-    case_pred = (nameP, typP);
-    case_branches = branches;
-    case_arity = arity;
-    case_body = body;
-    case_type = bodyT;
-  } in
-  (sigma, case)
-
-(**********************************************************************)
-(* This builds elimination predicate for Case tactic *)
-
-let build_case_analysis_scheme env sigma pity dep kind =
-  let specif = lookup_mind_specif env (fst pity) in
-  mis_make_case_com dep env sigma pity specif kind
-
-let prop_but_default_dependent_elim =
-  Summary.ref ~name:"prop_but_default_dependent_elim" Indset_env.empty
-
-let inPropButDefaultDepElim : inductive -> Libobject.obj =
-  Libobject.declare_object @@
-  Libobject.superglobal_object "prop_but_default_dependent_elim"
-    ~cache:(fun i ->
-        prop_but_default_dependent_elim := Indset_env.add i !prop_but_default_dependent_elim)
-    ~subst:(Some (fun (subst,i) -> Mod_subst.subst_ind subst i))
-    ~discharge:(fun i -> Some i)
-
-let declare_prop_but_default_dependent_elim i =
-  Lib.add_leaf (inPropButDefaultDepElim i)
-
-let is_prop_but_default_dependent_elim i = Indset_env.mem i !prop_but_default_dependent_elim
-
-let pseudo_sort_quality_for_elim ind mip =
-  let s = mip.mind_sort in
-  if Sorts.is_prop s && is_prop_but_default_dependent_elim ind
-  then Sorts.Quality.qtype
-  else Sorts.quality s
-
-let is_in_prop mip =
-  let s = mip.mind_sort in
-  Sorts.is_prop s
-
-let default_case_analysis_dependence env ind =
-  let _, mip as specif = lookup_mind_specif env ind in
-  Inductiveops.has_dependent_elim specif
-  && (not (is_in_prop mip) || is_prop_but_default_dependent_elim ind)
-
-let build_case_analysis_scheme_default env sigma pity kind =
-  let dep = default_case_analysis_dependence env (fst pity) in
-  build_case_analysis_scheme env sigma pity dep kind
-
-
 (* ************************************************************************** *)
 (*                              Generate Recursors                            *)
 (* ************************************************************************** *)
@@ -336,8 +83,7 @@ type arg =
   (* constant context, hd, args (maybe empty) *)
   | ArgIsCst of rel_context * constr * constr array
 
-(* Decompose the argument in [it_Prod_or_LetIn local, X]
-  where [X] is Ind, nested or a constant *)
+(** Decompose the argument in [it_Prod_or_LetIn local, X] where [X] is Ind, nested or a constant *)
 let view_arg kname mdecl t : arg State.t =
   let* env = get_env in
   let* sigma = get_sigma in
@@ -371,18 +117,30 @@ let chop_letin n l =
   in
   goto n [] l
 
+(** Generalize parameters for template and univ poly, and split uniform and non-uniform parameters *)
 let get_params_sep sigma mdecl u =
   let (sigma, up_params) = paramdecls_fresh_template sigma (mdecl, u) in
   let (uparams, nuparams) = chop_letin mdecl.mind_nparams_rec @@ List.rev up_params in
   (sigma, List.rev uparams, List.rev nuparams)
 
-let closure_uparams binder s uparams = closure_context_sep binder Old s uparams
-let closure_nuparams binder s nuparams = closure_context_sep binder Old s nuparams
+(** Closure of uniform parameters forgetting letins *)
+let closure_uparams binder naming_scheme uparams cc =
+  closure_context_sep binder Old naming_scheme uparams (fun (x,_,_) -> cc x)
 
+(** Closure of non-uniform parameters if [b], forgetting letins  *)
+let closure_nuparams_opt b binder naming_scheme nuparams =
+    if b
+    then fun cc -> closure_context_sep binder Old naming_scheme nuparams (fun (x,_,_) -> cc (Some x))
+    else fun cc -> cc None
 
+(** Closure of non-uniform parameters if [key_uparams_opt = None], forgetting letins  *)
+let closure_nuparams binder naming_scheme nuparams key_uparams_opt cc =
+  let@ key_uparams_opt' = closure_nuparams_opt (Option.is_empty key_uparams_opt) binder naming_scheme nuparams in
+  match key_uparams_opt, key_uparams_opt' with
+  | Some z, None | None, Some z -> cc z
+  | _, _ -> assert false
 
-
-(* get the position in ind_bodies out of the position of mind_packets *)
+(** get the position in ind_bodies out of the position of mind_packets *)
 let find_opt_pos p l =
   let rec aux i l = match l with
   | [] -> None
@@ -390,10 +148,10 @@ let find_opt_pos p l =
   | _::t -> aux (1+i) t
   in aux 0 l
 
-(* relevance *)
+(** Compute relevance of an inductive block *)
 let ind_relevance ind u = ERelevance.make @@ relevance_of_ind_body ind (EConstr.Unsafe.to_instance u)
 
-(* Closure for indices must be fresh as it is not in the context of the arguments *)
+(** Closure for indices. They are considered as [Fresh] as tey are not in the context of the arguments *)
 let closure_indices binder naming_scheme indb u f =
   let* i = get_indices indb u in
   closure_context_sep binder Fresh naming_scheme i f
@@ -404,12 +162,12 @@ let closure_indices binder naming_scheme indb u f =
   - i0 ... il : indices
 *)
 
-(* Builds the type of the predicate for the i-th block
+(** Builds the type of the predicate for the i-th block
     forall (B0 ... Bm : nuparams),
     forall (i1 ... tl : indices),
     (Ind A1 ... An B0 ... Bm i1 ... il) -> U)  *)
-let make_type_pred kn u (pos_ind, ind, dep, sort) key_uparams nuparams =
-  let@ (key_nuparams, _, _) = closure_nuparams Prod naming_hd_fresh nuparams in
+let make_type_pred kn u (pos_ind, ind, dep, sort) key_uparams nuparams key_nuparams_opt =
+  let@ key_nuparams = closure_nuparams Prod naming_hd_fresh nuparams key_nuparams_opt in
   let@ (key_indices , _, _) = closure_indices  Prod (naming_hd_fresh_dep dep) ind u in
   (* NOT DEP: return the sort *)
   if not dep then return  @@ mkSort sort else
@@ -419,15 +177,25 @@ let make_type_pred kn u (pos_ind, ind, dep, sort) key_uparams nuparams =
   let@ _ = make_binder Prod naming_hd_fresh name_ind tind in
   return @@ mkSort sort
 
-(* Closure Predicates *)
-let closure_preds kn u ind_bodies binder key_uparams nuparams cc =
+(** Closure Predicates *)
+let closure_preds kn u ind_bodies binder key_uparams nuparams key_nuparams_opt cc =
   fold_right_state (fun a l -> a :: l) ind_bodies (fun _ ind cc ->
     let name_pred = make_annot (Name (Id.of_string "P")) ERelevance.relevant in
-    let* ty_pred = make_type_pred kn u ind key_uparams nuparams in
+    let* ty_pred = make_type_pred kn u ind key_uparams nuparams key_nuparams_opt in
     make_binder binder naming_hd_fresh name_pred ty_pred cc
   ) cc
 
-(* This function computes the type of the recursive call *)
+ (** Make the predicate P B0 ... Bm i0 ... il t *)
+let make_pred rec_hyp key_preds focus dep inst_nuparams inst_indices t =
+  let* z = geti_term key_preds focus in
+  let pred =
+    if rec_hyp
+    then mkApp (z, Array.concat [inst_nuparams; inst_indices])
+    else mkApp (z, inst_indices) in
+  if not dep then return pred else
+  return @@ mkApp (pred, [| t |])
+
+(** Compute the type of the recursive call *)
 let make_rec_call kn mdecl ind_bodies key_preds key_arg ty =
   let* v = view_arg kn mdecl ty in
   match v with
@@ -440,92 +208,107 @@ let make_rec_call kn mdecl ind_bodies key_preds key_arg ty =
         relevance_of_sort sort,
         (* Pi B0 ... Bm i0 ... il (x a0 ... an) *)
         let@ (key_locals, _, _) = closure_context_sep Prod Fresh naming_id loc in
-        let* i = geti_term key_preds pred_pos in
-        let pred = mkApp (i, (Array.append inst_nuparams inst_indices)) in
-        (* NOT DEP: return the predicate *)
-        if not pred_dep then return pred else
-        (* DEP: Apply the predicate to the argument *)
         let* arg = get_term key_arg in
         let* loc = get_terms key_locals in
         let arg = mkApp (arg , Array.of_list loc) in
-        return @@ mkApp (pred, [| arg |])
+        make_pred true key_preds pred_pos pred_dep inst_nuparams inst_indices arg
       )
     end
   | _ -> return None
 
-(* Create and bind the recursive call *)
-let make_rec_call_cc kn mdecl ind_bodies key_preds _ key_arg cc =
+(** Create and bind the recursive call, if [rec_hyp] and if any *)
+let make_rec_call_cc rec_hyp kn mdecl ind_bodies key_preds _ key_arg cc =
   let* arg = LibBinding.State.get_type key_arg in
-  let* rec_call = make_rec_call kn mdecl ind_bodies key_preds key_arg arg in
-  match rec_call with
-  | Some (rec_hyp_rev, rec_hyp_ty) ->
-      let name_rec_hyp = make_annot Anonymous rec_hyp_rev in
-      let* rec_hyp_ty = rec_hyp_ty in
-      let@ _ = make_binder Prod naming_id name_rec_hyp rec_hyp_ty in
-      cc [key_arg]
-  | _ -> cc [key_arg]
+  if rec_hyp then
+    let* rec_call = make_rec_call kn mdecl ind_bodies key_preds key_arg arg in
+    match rec_call with
+    | Some (rec_hyp_rev, rec_hyp_ty) ->
+        let name_rec_hyp = make_annot Anonymous rec_hyp_rev in
+        let* rec_hyp_ty = rec_hyp_ty in
+        let@ _ = make_binder Prod naming_id name_rec_hyp rec_hyp_ty in
+        cc [key_arg]
+    | _ -> cc [key_arg]
+  else cc [key_arg]
 
-(* Generates the type associated to a constructor *)
-(* forall (B0 ... Bm : nuparams),
+(** Closure of the args, and of the rec call if [rec_hyp], and if any *)
+let closure_args_and_rec_call rec_hyp kn u mdecl ind_bodies dep key_preds args =
+  read_by_decl args
+    (build_binder Prod Old (naming_hd_dep dep))
+    (fun _ _ cc -> cc [])
+    (make_rec_call_cc rec_hyp kn mdecl ind_bodies key_preds)
+
+(** Generates the type associated to a constructor
+    forall (B0 ... Bm : nuparams),
     forall x0 : arg0, [P x0], ..., xn : argn, [P n],
     P B0 ... Bm f0 ... fl (cst A0 ... An B0 ... Bm x0 ... xl) *)
-let make_type_ctor kn u mdecl ind_bodies pos_list (pos_ind, ind, dep, sort) pos_ctor ctor key_uparams nuparams key_preds =
-  let@ (key_nuparams, _, _) = closure_nuparams Prod naming_id nuparams in
-  let (args, indices) = ctor in
-  let@ key_args = read_by_decl args (build_binder Prod Old (naming_hd_dep dep))
-                        (fun _ _ cc -> cc []) (make_rec_call_cc kn mdecl ind_bodies key_preds) in
-  let* state = get_state in
-  let weaken a = weaken a state in
-  let indices = Array.map weaken indices in
-  let* x = geti_term key_preds pos_list in
-  let* y = get_terms key_nuparams in
-  let pred = mkApp (x, Array.append (Array.of_list y) indices) in
-  (* NOT DEP: return the predicate *)
-  if not dep then return pred else
-  (* DEP: return the predicate applied to the constructor *)
+let make_type_ctor kn u mdecl ind_bodies pos_list (pos_ind, ind, dep, sort) pos_ctor (args, indices) key_uparams nuparams key_nuparams_opt key_preds =
+  let rec_hyp = Option.is_empty key_nuparams_opt in
+  let@ key_nuparams = closure_nuparams Prod naming_id nuparams key_nuparams_opt in
+  let@ key_args = closure_args_and_rec_call rec_hyp kn u mdecl ind_bodies dep key_preds args in
+  (* make cst *)
   let* k = get_terms key_args in
   let* cst = make_cst ((kn, pos_ind), u) pos_ctor key_uparams key_nuparams k in
-  return @@ mkApp (pred, [| cst |])
+  (* make pred cst *)
+  let* inst_nuparams = get_terms key_nuparams in
+  let* state = get_state in
+  let weaken a = weaken a state in
+  let inst_indices = Array.map weaken indices in
+  make_pred rec_hyp key_preds pos_list dep (Array.of_list inst_nuparams) inst_indices cst
 
-(* closure assumptions functions over all the ctors *)
-let closure_ctors kn mdecl u ind_bodies binder key_uparams nuparams key_preds =
+(** Closure assumptions functions over all the ctors *)
+let closure_ctors rec_hyp kn mdecl u ind_bodies binder key_uparams nuparams key_nuparams_opt key_preds =
   fold_right_state (fun a l -> a :: l) ind_bodies (
     fun pos_list (pos_ind, ind, dep, sort) cc ->
     iterate_ctors mdecl ind u (
       fun pos_ctor ctor cc ->
       let name_assumption = make_annot (Name ind.mind_consnames.(pos_ctor)) (relevance_of_sort sort) in
-      let* fct = make_type_ctor kn u mdecl ind_bodies pos_list (pos_ind, ind, dep, sort) pos_ctor ctor key_uparams nuparams key_preds in
+      let* fct = make_type_ctor kn u mdecl ind_bodies pos_list (pos_ind, ind, dep, sort) pos_ctor ctor key_uparams nuparams key_nuparams_opt key_preds in
       make_binder binder naming_hd_fresh name_assumption fct cc
     ) cc
   )
 
-(* Make the type of the conclusion *)
-(* P B0 ... Bm i0 ... il x *)
-let make_ccl key_preds focus dep key_nuparams key_indices key_VarMatch =
+(** Make the type of the conclusion
+    P B0 ... Bm i0 ... il x *)
+let make_ccl rec_hyp key_preds focus dep key_nuparams key_indices key_VarMatch =
   let* x = get_terms key_nuparams in
   let* y = get_terms key_indices in
-  let args = Array.of_list (x @ y) in
-  let* z = geti_term key_preds focus in
-  let pred = mkApp (z, args) in
-  if not dep then return pred else
-  let* km = get_term key_VarMatch in
-  return @@ mkApp (pred, [| km |])
+  let* var = get_term key_VarMatch in
+  make_pred rec_hyp key_preds focus dep (Array.of_list x) (Array.of_list y) var
 
-(* Make the return type *)
-(* forall (B0 ... Bm : nuparams),
+(** Make the return type
+    forall (B0 ... Bm : nuparams),
     forall (i1 ... il : indices),
     forall (x : Ind A0 ... An B0 ... Bm i0 ... il),
     P B0 ... Bm i0 ... il x *)
-let make_return_type kn u ind_bodies focus key_uparams nuparams key_preds =
+let make_return_type kn u ind_bodies focus key_uparams nuparams key_nuparams_opt key_preds =
   let (pos_ind, ind, dep, sort) = List.nth ind_bodies focus in
-  let@ (key_nuparams, _, _) = closure_nuparams Prod naming_hd_fresh nuparams in
+  let@ key_nuparams = closure_nuparams Prod naming_hd_fresh nuparams key_nuparams_opt in
   let@ (key_indices , _, _) = closure_indices Prod naming_hd_fresh ind u in
   let name_ind = make_annot Anonymous (ind_relevance ind u) in
   let* tind = make_ind ((kn, pos_ind), u) key_uparams key_nuparams key_indices in
   let@ (key_VarMatch) = make_binder Prod naming_hd_fresh name_ind tind in
-  make_ccl key_preds focus dep key_nuparams key_indices key_VarMatch
+  let rec_hyp = Option.is_empty key_nuparams_opt in
+  make_ccl rec_hyp key_preds focus dep key_nuparams key_indices key_VarMatch
 
-(* ty is well-formed in s *)
+(** Generate the type of the recursor, useful for debugging *)
+let gen_elim_type print_constr rec_hyp env sigma kn u mdecl uparams nuparams (ind_bodies : elim_info list) (focus : int) =
+
+  dbg Pp.(fun () -> str "\n------------------------------------------------------------- \n"
+    ++ str (MutInd.to_string kn) ++ str " ## pos_ind = " ++ int focus
+    ++ str " ## rec_hyp = " ++ bool rec_hyp ++ str "\n") ;
+
+  let t =
+    let@ key_uparams = closure_uparams Prod naming_hd_fresh uparams in
+    let@ key_nuparams_opt = closure_nuparams_opt (not rec_hyp) Prod naming_hd_fresh nuparams in
+    let@ key_preds = closure_preds kn u ind_bodies Prod key_uparams nuparams key_nuparams_opt in
+    let@ key_ctors = closure_ctors rec_hyp kn mdecl u ind_bodies Prod key_uparams nuparams key_nuparams_opt key_preds in
+    make_return_type kn u ind_bodies focus key_uparams nuparams key_nuparams_opt key_preds
+  in
+  let x = t @@ State.make env sigma in
+  dbg Pp.(fun () -> print_constr env sigma x ++ str "\n");
+  x
+
+(** Compute the recursive call *)
 let make_rec_call kn mdecl ind_bodies key_fixs key_arg ty : ((constr State.t) option) State.t =
   let* v = view_arg kn mdecl ty in
   match v with
@@ -547,7 +330,7 @@ let make_rec_call kn mdecl ind_bodies key_fixs key_arg ty : ((constr State.t) op
     end
   | _ -> return None
 
-(* Compute the arguments of the rec call *)
+(** Compute the arguments of the rec call *)
 let compute_args_fix kn mdecl ind_bodies pos_list key_fixs key_args =
   CList.fold_right_i (fun pos_arg key_arg t ->
     let* karg = LibBinding.State.get_type key_arg in
@@ -560,30 +343,29 @@ let compute_args_fix kn mdecl ind_bodies pos_list key_fixs key_args =
       | None -> return @@ karg' :: t
   ) 0 key_args (return [])
 
-let gen_elim print_constr env sigma kn u mdecl uparams nuparams (ind_bodies : elim_info list) (focus : int) =
-
-  dbg Pp.(fun () -> str "\n------------------------------------------------------------- \n"
-    ++ str (MutInd.to_string kn) ++ str " ## pos_ind : " ++ str (string_of_int focus) ++ str "\n") ;
+let gen_elim_term print_constr (rec_hyp : bool) env sigma kn u mdecl uparams nuparams (ind_bodies : elim_info list) (focus : int) =
 
   let t =
 
   (* 1. Closure Uparams / preds / ctors *)
-  let@ (key_uparams, _, _) = closure_uparams Lambda naming_hd_fresh uparams in
-  let@ key_preds = closure_preds kn u ind_bodies Lambda key_uparams nuparams in
-  let@ key_ctors = closure_ctors kn mdecl u ind_bodies Lambda key_uparams nuparams key_preds in
+  let@ key_uparams = closure_uparams Lambda naming_hd_fresh uparams in
+  let@ key_nuparams_opt = closure_nuparams_opt (not rec_hyp) Lambda naming_hd_fresh nuparams in
+  let@ key_preds = closure_preds kn u ind_bodies Lambda key_uparams nuparams key_nuparams_opt in
+  let@ key_ctors = closure_ctors rec_hyp kn mdecl u ind_bodies Lambda key_uparams nuparams key_nuparams_opt key_preds in
   (* 2. Fixpoint *)
   let fix_name pos_list (_,_,_,sort) = make_annot (Name (Id.of_string "F")) (relevance_of_sort sort) in
-  let fix_type pos_list _ = make_return_type  kn u ind_bodies pos_list key_uparams nuparams key_preds in
+  let fix_type pos_list _ = make_return_type kn u ind_bodies pos_list key_uparams nuparams key_nuparams_opt key_preds in
   let fix_rarg pos_list (_,ind,_,_) = (mdecl.mind_nparams - mdecl.mind_nparams_rec) + ind.mind_nrealargs in
   let is_rec = let (_, ind, _, _) = List.hd ind_bodies in
-    List.length ind_bodies > 1 || Inductiveops.mis_is_recursive env ((kn, focus), mdecl, ind) in
+    List.length ind_bodies > 1 ||
+    (rec_hyp && Inductiveops.mis_is_recursive env ((kn, focus), mdecl, ind)) in
   let@ (key_fixs, pos_list, (pos_ind, ind, dep, sort)) =
     (* Doe not create a fix if it is not-recursive and only has one inductive body *)
     if is_rec
     then make_fix ind_bodies focus fix_rarg fix_name fix_type
     else fun cc -> cc ([], 0, List.hd ind_bodies) in
   (* 3. Closure Nuparams / Indices / Var *)
-  let@ (key_nuparams, _, _) = closure_nuparams Lambda naming_hd_fresh nuparams in
+  let@ key_nuparams = closure_nuparams Lambda naming_hd_fresh nuparams key_nuparams_opt in
   let@ (key_indices , _, _) = closure_indices Lambda naming_hd_fresh ind u in
   let name_ind = make_annot Anonymous (ind_relevance ind u) in
   let* tind = make_ind ((kn, pos_ind), u) key_uparams key_nuparams key_indices in
@@ -593,7 +375,7 @@ let gen_elim print_constr env sigma kn u mdecl uparams nuparams (ind_bodies : el
     let* xup = get_terms key_uparams in
     let* xnup = get_terms key_nuparams in
     let params = Array.of_list (xup @ xnup) in
-    let case_pred = make_ccl key_preds pos_list dep key_nuparams in
+    let case_pred = make_ccl rec_hyp key_preds pos_list dep key_nuparams in
     let* xmatch = get_term key_VarMatch in
     let* xind = get_terms key_indices in
     let@ (key_args, _, _, pos_ctor) =
@@ -601,16 +383,21 @@ let gen_elim print_constr env sigma kn u mdecl uparams nuparams (ind_bodies : el
         xind case_pred (relevance_of_sort sort) (xmatch) in
     (* 5 Body of the branch *)
     let* hyp = getij_term key_ctors pos_list pos_ctor in
-    let* cfix = compute_args_fix kn mdecl ind_bodies pos_list key_fixs key_args in
     let* xnup = get_terms key_nuparams in
-    let args = xnup @ cfix in
-    return @@ mkApp (hyp, Array.of_list args)
+    if rec_hyp
+    (* REC: apply to nuparams + args + rec call *)
+    then let* cfix = compute_args_fix kn mdecl ind_bodies pos_list key_fixs key_args in
+          return @@ mkApp (hyp, Array.of_list (xnup @ cfix))
+    (* NOT REC : apply to args *)
+    else let* args = get_terms key_args in
+          return @@ mkApp (hyp, Array.of_list args)
+
   in
   (* 6. If it is not-recursive, has primitive projections and is dependent => add a cast *)
   let* env = get_env in
   let projs = Environ.get_projections env (kn, pos_ind) in
   if is_rec || Option.is_empty projs || not dep then ccl else
-  let* ty = make_ccl key_preds pos_list dep key_nuparams key_indices key_VarMatch in
+  let* ty = make_ccl rec_hyp key_preds pos_list dep key_nuparams key_indices key_VarMatch in
   let* ccl = ccl in
   return @@ mkCast (ccl, DEFAULTcast, ty)
 
@@ -623,20 +410,23 @@ let gen_elim print_constr env sigma kn u mdecl uparams nuparams (ind_bodies : el
 (**********************************************************************)
 (* build the eliminators mutual and individual *)
 
-(* Check all dependent eliminations are allowed*)
-let check_elim env sigma (kn, n) mib u lrecspec =
+(** Check all dependent eliminations are allowed *)
+let check_valid_elimination env sigma (kn, n) mib u lrecspec =
+  (* Check the mutual can be eliminated. *)
+  if mib.mind_private = Some true
+  then user_err (str "case analysis on a private inductive type is not allowed");
+  (* Check all the blocks can be eliminated *)
   List.iter (fun ((kni, ni),dep,s) ->
     (* Check that all the blocks can be eliminated to s *)
-    let elim_allowed = Inductiveops.is_allowed_elimination sigma ((mib,mib.mind_packets.(ni)),u) s in
-    if not elim_allowed
+    if not @@ Inductiveops.is_allowed_elimination sigma ((mib,mib.mind_packets.(ni)),u) s
     then raise (RecursionSchemeError (env, NotAllowedCaseAnalysis (sigma, true, ESorts.kind sigma s, ((kn, ni), EInstance.kind sigma u))));
     (* Check if dep elim is allowed: rec (co)ind records with prim proj can not be eliminated dependently *)
     if dep && not (Inductiveops.has_dependent_elim (mib, mib.mind_packets.(ni)))
     then raise (RecursionSchemeError (env, NotAllowedDependentAnalysis (true, (kni, ni))));
   ) lrecspec
 
-(* Check all the blocks are mutual, and not given twice *)
-let check_mut env sigma (kn, n) mib u lrecspec =
+(** Check all the blocks are mutual, and not given twice *)
+let check_valid_mutual env sigma (kn, n) mib u lrecspec =
   let _ : int list =
     List.fold_left (fun ln ((kni, ni),dep,s) ->
         (* Check all the blocks are mutual  *)
@@ -650,21 +440,33 @@ let check_mut env sigma (kn, n) mib u lrecspec =
   in
   ()
 
-let build_mutual_induction_scheme env sigma ?(force_mutual=false) lrecspec u =
+let build_mutual_induction_scheme_gen rec_hyp env sigma lrecspec u =
   match lrecspec with
   | (mind,dep,s)::tail ->
       let mib, mip = lookup_mind_specif env mind in
       (* Check the blocks are all mutual, different, and can be eliminated dependently *)
-      let () = check_mut env sigma mind mib u tail in
-      let () = check_elim env sigma mind mib u lrecspec in
+      let () = check_valid_mutual env sigma mind mib u tail in
+      let () = check_valid_elimination env sigma mind mib u lrecspec in
       (* Compute values for gen_elim *)
       let listdepkind = (snd mind, mip, dep, s) :: List.map (fun ((_,ni), dep, s) -> (ni, mib.mind_packets.(ni), dep, s)) tail in
       (* Get parameters, and generalized them for UnivPoly + TemplatePoly *)
       let (sigma, uparams, nuparams) = get_params_sep sigma mib u in
-      (* Compute eliminators *)
-      let recs = List.init (List.length listdepkind) (gen_elim Termops.Internal.print_constr_env env sigma (fst mind) u mib uparams nuparams listdepkind) in
-      (sigma, recs)
+      (* Compute eliminators' types and terms *)
+      let recs_ty = List.init (List.length listdepkind)
+        (gen_elim_type Termops.Internal.print_constr_env rec_hyp env sigma (fst mind) u mib uparams nuparams listdepkind) in
+      let recs_tm = List.init (List.length listdepkind)
+        (gen_elim_term Termops.Internal.print_constr_env rec_hyp env sigma (fst mind) u mib uparams nuparams listdepkind) in
+      (sigma, recs_ty, recs_tm)
   | _ -> anomaly (Pp.str "build_mutual_induction_scheme expects a non empty list of inductive types.")
 
+let build_mutual_induction_scheme env sigma ?(force_mutual=false) lrecspec u =
+  let (sigma, _, recs_tm) = build_mutual_induction_scheme_gen true env sigma lrecspec u in
+  sigma, recs_tm
+
 let build_induction_scheme env sigma (ind, u) dep kind =
-  on_snd List.hd @@ build_mutual_induction_scheme env sigma [(ind, dep, kind)] u
+  let (sigma, _, recs_tm) = build_mutual_induction_scheme_gen true env sigma [(ind, dep, kind)] u in
+  (sigma, List.hd recs_tm)
+
+let build_case_analysis_scheme env sigma (ind, u) dep kind =
+  let (sigma, recs_ty, recs_tm) = build_mutual_induction_scheme_gen false env sigma [(ind, dep, kind)] u in
+  (sigma, List.hd recs_tm, List.hd recs_ty)

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -13,8 +13,10 @@ open EConstr
 open Environ
 open Evd
 
-(** Errors related to recursors building *)
+(** Eliminations *)
+type dep_flag = bool
 
+(** Errors related to recursors building *)
 type recursion_scheme_error =
   | NotAllowedCaseAnalysis of evar_map * (*isrec:*) bool * Sorts.t * Constr.pinductive
   | NotMutualInScheme of inductive * inductive
@@ -23,51 +25,14 @@ type recursion_scheme_error =
 
 exception RecursionSchemeError of env * recursion_scheme_error
 
-(** Eliminations *)
-
-type dep_flag = bool
-
-(** Build a case analysis elimination scheme in some sort *)
-
-type case_analysis = private {
-  case_params : EConstr.rel_context;
-  case_pred : Name.t EConstr.binder_annot * EConstr.types;
-  case_branches : EConstr.rel_context;
-  case_arity : EConstr.rel_context;
-  case_body : EConstr.t;
-  case_type : EConstr.t;
-}
-
-val check_valid_elimination : env -> evar_map -> inductive puniverses -> dep:bool -> ESorts.t -> evar_map
-
-val eval_case_analysis : case_analysis -> EConstr.t * EConstr.types
-
-val default_case_analysis_dependence : env -> inductive -> bool
-
 val build_case_analysis_scheme : env -> Evd.evar_map -> inductive puniverses ->
-  dep_flag -> ESorts.t -> evar_map * case_analysis
-
-(** Build a dependent case elimination predicate unless type is in Prop
-   or is a recursive record with primitive projections. *)
-
-val build_case_analysis_scheme_default : env -> evar_map -> inductive puniverses ->
-  ESorts.t -> evar_map * case_analysis
+  dep_flag -> ESorts.t -> evar_map * constr * constr
 
 (** Builds a recursive induction scheme (Peano-induction style) in the given sort.  *)
-
 val build_induction_scheme : env -> evar_map -> inductive puniverses ->
   dep_flag -> ESorts.t -> evar_map * constr
 
 (** Builds mutual (recursive) induction schemes *)
-
 val build_mutual_induction_scheme :
   env -> evar_map -> ?force_mutual:bool ->
   (inductive * dep_flag * EConstr.ESorts.t) list -> einstance -> evar_map * constr list
-
-(** Default dependence of eliminations for Prop inductives *)
-
-val declare_prop_but_default_dependent_elim : inductive -> unit
-
-val is_prop_but_default_dependent_elim : inductive -> bool
-
-val pseudo_sort_quality_for_elim : inductive -> Declarations.one_inductive_body -> Sorts.Quality.t

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1401,7 +1401,7 @@ let pattern_occs loccs_trm = begin fun env sigma c ->
 let check_privacy env ind =
   let spec = Inductive.lookup_mind_specif env ind in
   if Inductive.is_private spec then
-    user_err Pp.(str "case analysis on a private type.")
+    user_err Pp.(str "case analysis on a private type is not allowed.")
 
 (* put t as t'=(x1:A1)..(xn:An)B with B an inductive definition of name name
    return name, B and t' *)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -319,8 +319,7 @@ let check_allowed_sort env sigma ind c p =
   in
   match Inductiveops.make_allowed_elimination sigma (specif, (snd ind)) sort with
   | Some sigma -> sigma, ESorts.relevance_of_sort sort
-  | None ->
-    error_elim_arity env sigma ind c (Some sort)
+  | None -> error_elim_arity env sigma ind c (Some sort)
 
 let check_actual_type env sigma cj t =
   try Evarconv.unify_leq_delay env sigma cj.uj_type t

--- a/tactics/elimschemes.mli
+++ b/tactics/elimschemes.mli
@@ -9,9 +9,27 @@
 (************************************************************************)
 
 open Ind_tables
+open Names
+open Environ
+
+(* -------------------------------------------------------------------------- *)
+
+(** Declare an inductive block can be eliminated dependently *)
+val declare_prop_but_default_dependent_elim : inductive -> unit
+
+(** Check if an inductive block can be eliminated dependently *)
+val is_prop_but_default_dependent_elim : inductive -> bool
+
+(** Returns [QType] if the inductive block can be eliminated dependently,
+    the sort of the inductive block otherwise   *)
+val pseudo_sort_quality_for_elim : inductive -> Declarations.one_inductive_body -> Sorts.Quality.t
+
+(** Check that an inductive block can be eliminated dependently, and is declared to be so if in Prop *)
+val default_case_analysis_dependence : env -> inductive -> bool
+
+(* -------------------------------------------------------------------------- *)
 
 (** Induction/recursion schemes *)
-
 val elim_scheme : dep:bool -> to_kind:UnivGen.QualityOrSet.t -> individual scheme_kind
 
 (** Case analysis schemes *)

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -202,7 +202,7 @@ let build_sym_scheme env _handle ind =
     get_sym_eq_data env indu in
   let cstr n =
     mkApp (mkConstructUi(indu,1),Context.Rel.instance mkRel n mib.mind_params_ctxt) in
-  let inds = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let inds = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let varH,_ = fresh env (default_id_of_sort inds) Id.Set.empty in
   let applied_ind = build_dependent_inductive indu specif in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
@@ -263,7 +263,7 @@ let build_sym_involutive_scheme env handle ind =
   let eq,eqrefl,ctx = get_rocq_eq env ctx in
   let sym, ctx = const_of_scheme sym_scheme_kind env handle ind ctx in
   let cstr n = mkApp (mkConstructUi (indu,1),Context.Rel.instance mkRel n paramsctxt) in
-  let inds = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let inds = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,_ = fresh env (default_id_of_sort inds) Id.Set.empty in
   let applied_ind = build_dependent_inductive indu specif in
@@ -379,7 +379,7 @@ let build_l2r_rew_scheme dep env handle ind kind =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.instance mkRel n paramsctxt1;
                     rel_vect p nrealargs]) in
-  let inds = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let inds = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
@@ -497,7 +497,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.instance mkRel n paramsctxt1;
                     rel_vect p nrealargs]) in
-  let inds = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let inds = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let indr = UVars.subst_instance_relevance u mip.mind_relevance in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
@@ -593,7 +593,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
   let cstr n =
     mkApp (mkConstructUi(indu,1),Context.Rel.instance mkRel n mib.mind_params_ctxt) in
   let constrargs_cstr = constrargs@[cstr 0] in
-  let inds = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let inds = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let indr = Inductive.relevance_of_ind_body mip u in
   let varH,avoid = fresh env (default_id_of_sort inds) Id.Set.empty in
   let varHC,avoid = fresh env (Id.of_string "HC") avoid in
@@ -702,8 +702,7 @@ let build_r2l_rew_scheme dep env ind k =
   let sigma = Evd.from_env env in
   let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
   let sigma, k = Evd.fresh_sort_in_quality ~rigid:UnivRigid sigma k in
-  let (sigma, c) = build_case_analysis_scheme env sigma indu dep k in
-  let (c, _) = Indrec.eval_case_analysis c in
+  let (sigma, c, _) = build_case_analysis_scheme env sigma indu dep k in
   EConstr.Unsafe.to_constr c, Evd.ustate sigma
 
 (**********************************************************************)

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -31,7 +31,7 @@ open Clenv
 open Tacticals
 open Rocqlib
 open Evarutil
-open Indrec
+open Elimschemes
 open Unification
 open Locus
 open Locusops

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -32,7 +32,7 @@ open Tacticals
 open Hipattern
 open Rocqlib
 open Evarutil
-open Indrec
+open Elimschemes
 open Pretype_errors
 open Unification
 open Locus

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -230,21 +230,22 @@ let declare_mutual_inductive_with_eliminations
              (GlobRef.ConstructRef (ind, succ j)) impls)
         constrimpls)
     impls;
+  (* Compute which inductive blocks can be eliminated dependently, and store it *)
   let () = match default_dep_elim with
     | None -> ()
     | Some defaults ->
       List.iteri (fun i default ->
-          let ind = (mind, i) in
-          let prop_but_default_dep_elim = match default with
+          let prop_but_default_dep_elim =
+            match default with
             | PropButDepElim -> true
             | DefaultElim ->
               default_prop_dep_elim () &&
-              let _, mip = Global.lookup_inductive ind in
+              let _, mip = Global.lookup_inductive (mind, i) in
               Sorts.is_prop mip.mind_sort
           in
-          if prop_but_default_dep_elim then
-            Indrec.declare_prop_but_default_dependent_elim ind)
-        defaults
+          if prop_but_default_dep_elim
+          then Elimschemes.declare_prop_but_default_dependent_elim (mind, i)
+        ) defaults
   in
   Flags.if_verbose Feedback.msg_info (minductive_message names);
   let indlocs = List.map fst indlocs in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -325,7 +325,8 @@ let explain_case_not_inductive env sigma cj =
           str "which is not a (co-)inductive type."
 
 let explain_case_on_private_ind env sigma ind =
-  str "Case analysis on private inductive "++pr_inductive env ind
+  str "Case analysis on private inductive "++ pr_inductive env ind
+  ++ str " is not allowed."
 
 let explain_number_branches env sigma cj expn =
   let env = make_all_name_different env sigma in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -198,7 +198,7 @@ let declare_beq_scheme ?locmap mi = declare_beq_scheme_with ?locmap [] mi
 (* Case analysis schemes *)
 let declare_one_case_analysis_scheme ?loc ind =
   let (mib, mip) as specif = Global.lookup_inductive ind in
-  let kind = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let kind = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let dep, suff =
     if Sorts.Quality.is_qprop kind then case_nodep, Some "case"
     else if not (Inductiveops.has_dependent_elim specif) then
@@ -218,7 +218,7 @@ let declare_one_case_analysis_scheme ?loc ind =
 
 let declare_one_induction_scheme ?loc ind =
   let (mib,mip) as specif = Global.lookup_inductive ind in
-  let kind = Indrec.pseudo_sort_quality_for_elim ind mip in
+  let kind = Elimschemes.pseudo_sort_quality_for_elim ind mip in
   let from_prop = Sorts.Quality.is_qprop kind in
   let depelim = Inductiveops.has_dependent_elim specif in
   let kelim mip = Inductiveops.constant_sorts_below
@@ -366,7 +366,7 @@ let name_and_process_scheme env = function
     (* If no name has been provided, we build one from the types of the ind requested *)
     let ind = smart_ind sch_qualid in
     let sort_of_ind =
-      Indrec.pseudo_sort_quality_for_elim ind
+      Elimschemes.pseudo_sort_quality_for_elim ind
         (snd (Inductive.lookup_mind_specif env ind))
     in
     let suffix = scheme_suffix_gen sch sort_of_ind in
@@ -394,8 +394,7 @@ let do_mutual_induction_scheme ~register ?(force_mutual=false) env ?(isrec=true)
     if isrec then Indrec.build_mutual_induction_scheme env sigma ~force_mutual lrecspec inst
     else
       List.fold_left_map (fun sigma (ind,dep,sort) ->
-          let sigma, c = Indrec.build_case_analysis_scheme env sigma (ind, inst) dep sort in
-          let c, _ = Indrec.eval_case_analysis c in
+          let sigma, c, _ = Indrec.build_case_analysis_scheme env sigma (ind, inst) dep sort in
           sigma, c)
         sigma lrecspec
   in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -283,7 +283,7 @@ let print_squash env ref udecl = match ref with
 let print_prop_but_default_dep_elim ref =
   match ref with
   | GlobRef.IndRef ind ->
-    if Indrec.is_prop_but_default_dependent_elim ind
+    if Elimschemes.is_prop_but_default_dependent_elim ind
     then [pr_global ref ++ str " is in Prop but its eliminators are declared dependent by default"]
     else []
   | _ -> []


### PR DESCRIPTION
The goal of this pull request is to remove the implementation of `build_case_analysis_scheme` and related functions by unifying it with the implementation of  `gen_elim`.

The advantages are to:
1. Only have one implementation to maintain and understand. 
2. From a high point of view, this is relatively simple, the differences are:
    - non uniform parameters are not quantified in predicates
    - we do not create recursion hypothesis
3. Remove the old code manipulating debruijn variables by hand that is hard to understand, for the new one using LibBinding.ml for that making it less prone to mistakes and easier to maintain

It also moves the `prop_but_default_dependent_elim` API from `indrec.ml` to `elimschemes.ml` since it not used to define the functions generating the eliminator `gen_elim` but only to instantiate it dependently or not.

Doing so, I added a few comments, and made small improvements to the code quality
