### PR TITLE
Perform kernel typing after universe abstraction for polymorphic code.

### DIFF
--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -13,9 +13,8 @@ open Constr
 open Declarations
 open Environ
 
-(** Should only be used for monomorphic terms *)
 val compile :
-  fail_on_error:bool -> ?universes:int*int ->
+  fail_on_error:bool ->
   env -> Genlambda.evars -> constr ->
   (bool array * to_patch * patches) option
 

--- a/test-suite/bugs/bug_21405.v
+++ b/test-suite/bugs/bug_21405.v
@@ -1,0 +1,7 @@
+Set Universe Polymorphism.
+
+Definition T@{u} : Set := unit.
+Definition U@{u} : Type@{u+1} := Type@{u}.
+
+Definition anomaly := (tt <: T).
+Definition anomaly' := (Type <: U).


### PR DESCRIPTION
This is safer and will make it possible to simplify the code that pushes bound levels and sorts in the environment. We also share more hashconsing for polymorphic entries this way.

This also probably fixes a bug with the relevance computation for definitions. The environment passed to the function was the one with the concrete levels, but the term argument was expected to live in the abstracted context.