### PR TITLE
Fix native conversion of polymorphic code after #21405.

### DIFF
--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -162,8 +162,12 @@ let mk_constant_accu kn u = mk_accu (Aconstant (kn,u))
 let mk_ind_accu ind u = mk_accu (Aind (ind,u))
 
 let mk_sort_accu s u =
-  let s = UVars.subst_instance_sort u s in
-  mk_accu (Asort s)
+  if UVars.Instance.is_empty u then
+    (* Prevents array index failure when not required to substitute *)
+    mk_accu (Asort s)
+  else
+    let s = UVars.subst_instance_sort u s in
+    mk_accu (Asort s)
 
 let mk_var_accu id =
   mk_accu (Avar id)

--- a/test-suite/bugs/bug_21405.v
+++ b/test-suite/bugs/bug_21405.v
@@ -5,3 +5,6 @@ Definition U@{u} : Type@{u+1} := Type@{u}.
 
 Definition anomaly := (tt <: T).
 Definition anomaly' := (Type <: U).
+
+Definition native_anomaly := (tt <<: T).
+Definition native_anomaly' := (Type <<: U).


### PR DESCRIPTION
The code for the VM was correctly adapted in that PR, but not the native one. It was suffering from the same problem, i.e. raising assertion failures when faced with level variables. We adapt the code in the same way, by discriminating between toplevel and constant compilation.

(It seems we had no code in the CI testing for native compilation within universe polymorphic code, this is now in the test-suite...)