### PR TITLE
Split sort substitution from accumulator construction in native compilation

### DIFF
--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -161,13 +161,8 @@ let mk_constant_accu kn u = mk_accu (Aconstant (kn,u))
 
 let mk_ind_accu ind u = mk_accu (Aind (ind,u))
 
-let mk_sort_accu s u =
-  if UVars.Instance.is_empty u then
-    (* Prevents array index failure when not required to substitute *)
-    mk_accu (Asort s)
-  else
-    let s = UVars.subst_instance_sort u s in
-    mk_accu (Asort s)
+let mk_sort_accu s =
+  mk_accu (Asort s)
 
 let mk_var_accu id =
   mk_accu (Avar id)

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -81,7 +81,7 @@ val mk_rel_accu : int -> t
 val mk_rels_accu : int -> int -> t array
 val mk_constant_accu : Constant.t -> UVars.Instance.t -> t
 val mk_ind_accu : inductive -> UVars.Instance.t -> t
-val mk_sort_accu : Sorts.t -> UVars.Instance.t -> t
+val mk_sort_accu : Sorts.t -> t
 val mk_var_accu : Id.t -> t
 val mk_sw_accu : annot_sw -> accumulator -> t -> (t -> t)
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t


### PR DESCRIPTION
This removes a dubious runtime check in mk_sort_accu, which ensures more invariants and is slightly faster.