### PR TITLE
Clean up exceptions of recursion_scheme_error and pretype_errors

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -313,7 +313,7 @@ let explain_exn = function
       | UnsatisfiedUnivConstraints _ -> str"UnsatisfiedUnivConstraints"
       | UnsatisfiedQUConstraints _ -> str"UnsatisfiedQUConstraints"
       | UnsatisfiedPConstraints _ -> str"UnsatisfiedPConstraints"
-      | DisallowedSProp -> str"DisallowedSProp"
+      | NotAllowedSProp -> str"NotAllowedSProp"
       | BadBinderRelevance _ -> str"BadBinderRelevance"
       | BadCaseRelevance _ -> str"BadCaseRelevance"
       | BadInvert -> str"BadInvert"

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -90,7 +90,7 @@ let check_constant_declaration env opac kn cb opacify =
 let check_quality_mask env qmask lincheck =
   let open Sorts.Quality in
   match qmask with
-  | PQConstant QSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_disallowed_sprop env
+  | PQConstant QSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_not_allowed_sprop env
   | PQConstant (QProp | QType) -> lincheck
   | PQVar qio -> Partial_subst.maybe_add_quality qio () lincheck
 
@@ -139,7 +139,7 @@ and get_holes_profiles_head env nargs ndecls lincheck = function
       let (mib, _) = Inductive.lookup_mind_specif env ind in
       check_instance_mask env mib.mind_universes u lincheck
   | PHInt _  | PHFloat _ | PHString _ -> lincheck
-  | PHSort PSSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_disallowed_sprop env
+  | PHSort PSSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_not_allowed_sprop env
   | PHSort PSType io -> Partial_subst.maybe_add_univ io () lincheck
   | PHSort PSQSort (qio, uio) ->
       lincheck

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -78,7 +78,7 @@ type ('constr, 'types, 'r) ptype_error =
   | UnsatisfiedPConstraints of PConstraints.t
   | UndeclaredQualities of Sorts.QVar.Set.t
   | UndeclaredUniverses of Level.Set.t
-  | DisallowedSProp
+  | NotAllowedSProp
   | BadBinderRelevance of 'r * ('constr, 'types, 'r) Context.Rel.Declaration.pt
   | BadCaseRelevance of 'r * 'constr
   | BadInvert
@@ -181,8 +181,8 @@ let error_undeclared_qualities env l =
 let error_undeclared_universes env l =
   raise (TypeError (env, UndeclaredUniverses l))
 
-let error_disallowed_sprop env =
-  raise (TypeError (env, DisallowedSProp))
+let error_not_allowed_sprop env =
+  raise (TypeError (env, NotAllowedSProp))
 
 let error_bad_binder_relevance env rlv decl =
   raise (TypeError (env, BadBinderRelevance (rlv, decl)))
@@ -230,7 +230,7 @@ let map_pguard_error f = function
 
 let map_ptype_error fr f = function
 | UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _ | IllFormedCaseParams
-| UndeclaredQualities _ | UndeclaredUniverses _ | DisallowedSProp
+| UndeclaredQualities _ | UndeclaredUniverses _ | NotAllowedSProp
 | UnsatisfiedElimConstraints _ | UnsatisfiedUnivConstraints _ | UnsatisfiedQCumulConstraints _
 | UnsatisfiedQUConstraints _ | UnsatisfiedPConstraints _
 | ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ | IllFormedConstant _ | IllFormedInductive _ as e -> e

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -80,7 +80,7 @@ type ('constr, 'types, 'r) ptype_error =
   | UnsatisfiedPConstraints of PConstraints.t
   | UndeclaredQualities of Sorts.QVar.Set.t
   | UndeclaredUniverses of Level.Set.t
-  | DisallowedSProp
+  | NotAllowedSProp
   | BadBinderRelevance of 'r * ('constr, 'types, 'r) Context.Rel.Declaration.pt
   | BadCaseRelevance of 'r * 'constr
   | BadInvert
@@ -169,7 +169,7 @@ val error_undeclared_qualities : env -> Sorts.QVar.Set.t -> 'a
 
 val error_undeclared_universes : env -> Level.Set.t -> 'a
 
-val error_disallowed_sprop : env -> 'a
+val error_not_allowed_sprop : env -> 'a
 
 val error_bad_binder_relevance : env -> Sorts.relevance -> rel_declaration -> 'a
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -670,7 +670,7 @@ and execute_aux tbl env cstr =
     (* Atomic terms *)
     | Sort s ->
       let () = match s with
-      | SProp -> if not (Environ.sprop_allowed env) then error_disallowed_sprop env
+      | SProp -> if not (Environ.sprop_allowed env) then error_not_allowed_sprop env
       | QSort _ | Prop | Set | Type _ -> ()
       in
       type_of_sort s

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -18,10 +18,8 @@ type dep_flag = bool
 
 (** Errors related to recursors building *)
 type recursion_scheme_error =
-  | NotAllowedCaseAnalysis of evar_map * (*isrec:*) bool * Sorts.t * Constr.pinductive
   | NotMutualInScheme of inductive * inductive
   | DuplicateInductiveBlock of inductive
-  | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
 exception RecursionSchemeError of env * recursion_scheme_error
 

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -468,12 +468,6 @@ let make_case_invert env sigma (IndType (((ind,u),params),indices)) ~case_releva
   then Constr.CaseInvert {indices=Array.of_list indices}
   else Constr.NoInvert
 
-let error_not_allowed_dependent_analysis env isrec i =
-  let open Pp in
-  str "Dependent " ++ str (if isrec then "induction" else "case analysis") ++
-  strbrk " is not allowed for " ++ Termops.pr_global_env env (IndRef i) ++ str "." ++
-  str "Primitive records must have eta conversion to allow dependent elimination."
-
 let make_project env sigma ind pred c branches ps =
   assert(Array.length branches == 1);
   let na, ty, t = destLambda sigma pred in
@@ -481,7 +475,7 @@ let make_project env sigma ind pred c branches ps =
   let () =
     if (* dependent *) not (Vars.noccurn sigma 1 t) &&
          not (has_dependent_elim specif) then
-      user_err (error_not_allowed_dependent_analysis env false ind)
+      Pretype_errors.error_not_allowed_dependent_elimination env sigma false ind
   in
   let branch = branches.(0) in
   let ctx, br = decompose_lambda_n_decls sigma mip.mind_consnrealdecls.(0) branch in

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -230,8 +230,6 @@ val compute_projections : Environ.env -> inductive -> (constr * types) array
 (********************)
 val control_only_guard : env -> Evd.evar_map -> EConstr.types -> unit
 
-val error_not_allowed_dependent_analysis : Environ.env -> bool -> Names.inductive -> Pp.t
-
 module Internal : sig
   (* FIXME hack for the [QVar]s, see the implementation for more information. *)
   val nf_relevance : Evd.evar_map -> Sorts.relevance -> Sorts.relevance

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -599,7 +599,7 @@ let rec execute env sigma cstr =
       begin match ESorts.kind sigma s with
         | SProp ->
           if Environ.sprop_allowed env then sigma, judge_of_sprop
-          else error_disallowed_sprop env sigma
+          else error_not_allowed_sprop env sigma
         | Prop -> sigma, judge_of_prop
         | Set -> sigma, judge_of_set
         | Type u -> sigma, judge_of_type u

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1057,7 +1057,7 @@ let expand_projection_with_metas ~metas env sigma pr c args =
   let ty = get_type_of_with_metas ~metas ~lax:true env sigma c in
   let (i,u), ind_args =
     try Inductiveops.find_mrectype env sigma ty
-    with Not_found -> error_disallowed_sprop env sigma (* dummy, caught immediately *)
+    with Not_found -> error_not_allowed_sprop env sigma (* dummy, caught immediately *)
   in
     mkApp (mkConstU (Projection.constant pr,u),
            Array.of_list (ind_args @ (c :: args)))


### PR DESCRIPTION
- Move the exception from indrec to pretype_errors to remove dep from indrec and clenv
- rename the errors to align them on the functions 
- clean up pretype_errors.ml and pretype_errors.mli