### PR TITLE
feat: Allow primitive projections with postponed eta (sort poly)

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -438,7 +438,7 @@ let v_wfp =
 
 let v_squash_info = v_sum "squash_info" 1 [|[|v_set v_quality|]|]
 
-let v_has_eta = v_enum "has_eta" 2
+let v_has_eta = v_enum "has_eta" 3
 let v_record_info =
   v_sum "record_info" 2
     [| [| v_id; v_array v_id; v_array v_relevance; v_array v_constr; v_has_eta |] |]

--- a/doc/changelog/01-kernel/21416-record-postponed-eta-Changed.rst
+++ b/doc/changelog/01-kernel/21416-record-postponed-eta-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Sort-polymorphic records can now have primitive projections
+  with eta conversion depending on instantiation,
+  which is checked at runtime
+  (`#21416 <https://github.com/rocq-prover/rocq/pull/21416>`_,
+  by Tomas Diaz).

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -145,6 +145,31 @@ are allowed and have η-conversion.
                 s = {| spr1 := s.(spr1 A P); spr2 := s.(spr2 A P) |}.
    Proof. intros A P s. reflexivity. Qed.
 
+Sort polymorphic primitive records are allowed and η-conversion depends on
+the actual instantiation of sorts.
+
+.. rocqdoc::
+    Inductive eq@{s; u} (A : Type@{s;u}) (a : A) : A -> Prop :=
+      eq_refl : eq A a a.
+
+    Arguments eq {_}.
+    Arguments eq_refl {_ _}.
+
+   Record RSToS'@{s s'; u u'| s' -> s +} (A : Type@{s;u}): Type@{s';u'} := {
+     rsprj : A
+   }.
+
+   (* Conversion when record is in Type and field in SProp fails correctly *)
+   Goal forall (A:SProp) (rs : RSToS'@{SProp Type; 0 0} A),
+                  eq rs {| rsprj := rs.(rsprj A) |}.
+   Proof. intros A rs. Fail reflexivity. Abort.
+
+   (* Conversion when record and field are instantiated to SProp checks correctly *)
+   Goal forall (A:SProp) (rs : RSToS'@{SProp SProp; 0 0} A),
+                  eq rs {| rsprj := rs.(rsprj A) |}.
+   Proof. intros A rs. reflexivity. Qed.
+
+
 Encodings for strict propositions
 ---------------------------------
 

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -134,6 +134,8 @@ non-:math:`\SProp` sorts (through record η-extensionality).
    Goal forall (A : SProp) (r : rBox A), r = {| runbox := r.(runbox A) |}.
    Proof. intros A r. Fail reflexivity. Abort.
 
+.. _record-eta-restriction:
+
 In contrast, primitive records in relevant sorts with at least one relevant field
 are allowed and have η-conversion.
 
@@ -148,7 +150,10 @@ are allowed and have η-conversion.
 Sort polymorphic primitive records are allowed and η-conversion depends on
 the actual instantiation of sorts.
 
-.. rocqdoc::
+.. rocqtop:: in
+
+    Set Universe Polymorphism.
+
     Inductive eq@{s; u} (A : Type@{s;u}) (a : A) : A -> Prop :=
       eq_refl : eq A a a.
 
@@ -168,6 +173,8 @@ the actual instantiation of sorts.
    Goal forall (A:SProp) (rs : RSToS'@{SProp SProp; 0 0} A),
                   eq rs {| rsprj := rs.(rsprj A) |}.
    Proof. intros A rs. reflexivity. Qed.
+
+   Unset Universe Polymorphism.
 
 
 Encodings for strict propositions

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -406,7 +406,7 @@ flag.
 There are currently two ways to introduce primitive records types:
 
 #. Through the :cmd:`Record` command, in which case the type has to be
-   non-recursive. The defined type enjoys eta-conversion definitionally,
+   non-recursive. The defined type enjoys eta-conversion definitionally, in most cases (See :ref:`sprop` for exceptions),
    that is the generalized form of surjective pairing for records:
    `r` ``= Build_``\ `R` ``(``\ `r`\ ``.(``\ |p_1|\ ``) …`` `r`\ ``.(``\ |p_n|\ ``))``.
    Eta-conversion allows to define dependent elimination for these types as well.

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -406,7 +406,7 @@ flag.
 There are currently two ways to introduce primitive records types:
 
 #. Through the :cmd:`Record` command, in which case the type has to be
-   non-recursive. The defined type enjoys eta-conversion definitionally, in most cases (See :ref:`sprop` for exceptions),
+   non-recursive. The defined type has eta-conversion definitionally, in most cases (See :ref:`sprop <record-eta-restriction>` for exceptions),
    that is the generalized form of surjective pairing for records:
    `r` ``= Build_``\ `R` ``(``\ `r`\ ``.(``\ |p_1|\ ``) …`` `r`\ ``.(``\ |p_n|\ ``))``.
    Eta-conversion allows to define dependent elimination for these types as well.

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -157,7 +157,7 @@ v}
     [FakeRecord]. It is mostly used by extraction, and should be extruded from
     the kernel at some point.
 *)
-type has_eta = AlwaysEta | NoEta
+type has_eta = AlwaysEta | MaybeEta | NoEta
 
 type record_info =
 | NotRecord

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -261,7 +261,7 @@ let check_record data =
               match info.ind_univ with
               | SProp -> Result.Ok AlwaysEta
               | Set | Type _ | Prop -> Result.Ok NoEta (* Set, Type and Prop don't have eta *)
-              | QSort _ ->  Result.Ok NoEta (* For sort variables it now defaults to not having eta *)
+              | QSort _ ->  Result.Ok MaybeEta (* For sort variables it depends on the instantiation *)
     )
     (Result.Ok NoEta)
     data

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -511,6 +511,10 @@ let relevance_of_sort = function
   | Prop | Set | Type _ -> Relevant
   | QSort (q, _) -> RelevanceVar q
 
+let is_relevant = function
+  | Relevant -> true
+  | Irrelevant | RelevanceVar _ -> false
+
 let debug_print = function
   | SProp -> Pp.(str "SProp")
   | Prop -> Pp.(str "Prop")

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -210,6 +210,8 @@ val relevance_subst_fn : (QVar.t -> Quality.t) -> relevance -> relevance
 
 val relevance_of_sort : t -> relevance
 
+val is_relevant : relevance -> bool
+
 val debug_print : t -> Pp.t
 val pr : (QVar.t -> Pp.t) -> (Univ.Universe.t -> Pp.t) -> t -> Pp.t
 val raw_pr : t -> Pp.t

--- a/test-suite/success/record_postponed_eta.v
+++ b/test-suite/success/record_postponed_eta.v
@@ -47,7 +47,6 @@ Proof. intros A r2. Fail reflexivity. Abort.
     r2 : RSToProp A
     Unable to unify "{| f3 := f3 _ r2 |}" with "r2". *)
 
-Set Debug "cClosure".
 (* Conversion when record and field are instantiated to SProp checks correctly *)
 Goal forall (A:SProp) (r2 : RSToSProp@{SProp;0} A), eq r2 {| f3 := r2.(f3 A) |}.
 Proof. intros A r2. reflexivity. Qed.
@@ -78,17 +77,17 @@ Proof. intros A r2. Fail reflexivity. Abort.
 Goal forall (A:SProp) (r2 : RSToS'@{SProp SProp;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
 Proof. intros A r2. reflexivity. Qed.
 
-(* Conversion when record and field are instantiated to the same sort (Type) still fails correctly because we haven't implemented it *)
+(* Conversion when record and field are instantiated to the same sort (Type) checks correctly *)
 Goal forall (A:Set) (r2 : RSToS'@{Type Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
-Proof. intros A r2. Fail reflexivity. Abort.
+Proof. intros A r2. reflexivity. Qed.
 
-(* Conversion when record and field are instantiated to the same sort (Prop) still fails correctly because we haven't implemented it *)
+(* Conversion when record and field are instantiated to the same sort (Prop) checks correctly *)
 Goal forall (A:Prop) (r2 : RSToS'@{Prop Prop;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
-Proof. intros A r2. Fail reflexivity. Abort.
+Proof. intros A r2. reflexivity. Qed.
 
-(* Conversion when record is in Type and field is in Prop still fails correctly because we haven't implemented it *)
+(* Conversion when record is in Type and field is in Prop checks correctly *)
 Goal forall (A:Prop) (r2 : RSToS'@{Prop Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
-Proof. intros A r2. Fail reflexivity. Abort.
+Proof. intros A r2. reflexivity. Qed.
 
 Section Sorts.
   Sort s s'.
@@ -115,7 +114,7 @@ Section Sorts.
     r2 : RSToS' A
     Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)
 
-  (* Conversion when record and field are instantiated to the same sort (Type) still fails correctly because we haven't implemented it *)
+  (* Conversion when record and field are instantiated to the same sort (Type) checks correctly *)
   Goal forall (A:Type@{s;0}) (r2 : RSToS'@{s s;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
-  Proof. intros A r2. Fail reflexivity. Abort.
+  Proof. intros A r2. reflexivity. Qed.
 End Sorts.

--- a/test-suite/success/sort_poly.v
+++ b/test-suite/success/sort_poly.v
@@ -86,7 +86,7 @@ Module Inference.
   (* implicit instance of zog gets a variable which then gets unified with s from the type of A *)
   Definition zag@{s; |} (A:Type@{s;Set}) := zog A.
 
-  (* implicit type of A gets unified to Type@{s|Set} *)
+  (* implicit type of A gets unified to Type@{s;Set} *)
   Definition zig@{s; |} A := zog@{s;} A.
 
   (* Unfortunately casting a hole to a sort (while typing A on the

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -322,6 +322,7 @@ let print_primitive_record recflag mipv =
       | CoFinite | Finite -> str " without eta conversion"
       | BiFinite -> match has_eta with
                     | NoEta -> str " without eta conversion"
+                    | MaybeEta -> str " with eta conversion depending on sort instantiation"
                     | AlwaysEta -> str " with eta conversion"
     in
     [Id.print mip.mind_typename ++ str" has primitive projections" ++ eta ++ str"."]


### PR DESCRIPTION
This PR depends on #21438. It extends it to consider eta for sort polymorphic records with primitive projections, resolving the `MaybeEta` check during conversion.
- Records defined at some sort `s` with fields only in `SProp` are allowed but rechecked during eta.
- Records defined at some sort `s` with fields in other sorts are allowed but rechecked during eta. 

Associated RFC : https://github.com/rocq-prover/rfcs/pull/111.

### Examples
Test cases adjusted in **success/record_postponed_eta.v**

```coq
Set Universe Polymorphism.

Inductive eq@{s s'; u} (A : Type@{s;u}) (a : A) : A -> Prop :=
  eq_refl : eq A a a.

Record RSToS'@{s1 s2;u1 u2| s2 -> s1 +} (A : Type@{s1;u1}): Type@{s2;u2} := { f4 : A }.

(* Conversion when record is in Type and field in SProp fails correctly *)
Goal forall (A:SProp) (r2 : RSToS'@{SProp Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
Proof. intros A r2. Fail reflexivity. Abort.
(* Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)
  
(* Conversion when record is in Prop and field in SProp fails correctly *)
Goal forall (A:SProp) (r2 : RSToS'@{SProp Prop;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
Proof. intros A r2. Fail reflexivity. Abort.
(* Unable to unify "{| f4 := f4 _ r2 |}" with "r2". *)

(* Conversion when record and field are instantiated to the same sort (Type) checks correctly *)
Goal forall (A:Set) (r2 : RSToS'@{Type Type;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
Proof. intros A r2. reflexivity. Qed.

(* Conversion when record and field are instantiated to the same sort (Prop) checks correctly *)
Goal forall (A:Prop) (r2 : RSToS'@{Prop Prop;0 0} A), eq r2 {| f4 := r2.(f4 A) |}.
Proof. intros A r2. reflexivity. Qed.
```

----
<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

- [ ] Opened **overlay** pull requests.
