### PR TITLE
feat: Add elaboration of elimination constraints

### DIFF
--- a/dev/ci/user-overlays/21417-mattam82-elab-elim-constraints.sh
+++ b/dev/ci/user-overlays/21417-mattam82-elab-elim-constraints.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/mattam82/coq-elpi elab-elim-constraints 21417

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -73,6 +73,7 @@ install_printer Top_printers.pperelevance
 install_printer Top_printers.ppqvar
 install_printer Top_printers.ppuni_level
 install_printer Top_printers.ppqvarset
+install_printer Top_printers.ppqset
 install_printer Top_printers.ppuniverse_set
 install_printer Top_printers.ppuniverse_instance
 install_printer Top_printers.ppuniverse_einstance
@@ -90,6 +91,8 @@ install_printer Top_printers.ppuniverseconstraints
 install_printer Top_printers.ppuniverse_context_future
 install_printer Top_printers.ppuniverses
 install_printer Top_printers.ppqualities
+install_printer Top_printers.ppqgraph
+install_printer Top_printers.ppelim_constraints
 install_printer Top_printers.pp_partialfsubst
 install_printer Top_printers.pp_partialsubst
 install_printer Top_printers.ppnamedcontextval

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -91,7 +91,6 @@ install_printer Top_printers.ppuniverseconstraints
 install_printer Top_printers.ppuniverse_context_future
 install_printer Top_printers.ppuniverses
 install_printer Top_printers.ppqualities
-install_printer Top_printers.ppqgraph
 install_printer Top_printers.ppelim_constraints
 install_printer Top_printers.pp_partialfsubst
 install_printer Top_printers.pp_partialsubst

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -290,6 +290,7 @@ let pperelevance r = pprelevance (EConstr.Unsafe.to_relevance r)
 let prlev l = UnivNames.pr_level_with_global_universes l
 let prqvar q = UnivNames.pr_quality_with_global_universes q
 let ppqvarset l = pp (hov 1 (str "{" ++ prlist_with_sep spc prqvar (QVar.Set.elements l) ++ str "}"))
+let ppqset qs = pp (hov 1 (str "{" ++ prlist_with_sep spc (Quality.pr prqvar) (Quality.Set.elements qs) ++ str "}"))
 let ppuniverse_set l = pp (Level.Set.pr prlev l)
 let ppuniverse_instance l = pp (Instance.pr prqvar prlev l)
 let ppuniverse_einstance l = ppuniverse_instance (EConstr.Unsafe.to_instance l)
@@ -308,6 +309,8 @@ let ppuniverse_context_future c =
     ppuniverse_context ctx
 let ppuniverses u = pp (UGraph.pr_universes Level.raw_pr (UGraph.repr u))
 let ppqualities q = pp (QGraph.pr_qualities Quality.raw_pr q)
+let ppqgraph q = pp (QGraph.pr Sorts.QVar.raw_pr q)
+let ppelim_constraints cstrs = pp (Sorts.ElimConstraints.pr Sorts.QVar.raw_pr cstrs)
 let ppnamedcontextval e =
   let env = Global.env () in
   let sigma = Evd.from_env env in

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -309,8 +309,7 @@ let ppuniverse_context_future c =
     ppuniverse_context ctx
 let ppuniverses u = pp (UGraph.pr_universes Level.raw_pr (UGraph.repr u))
 let ppqualities q = pp (QGraph.pr_qualities Quality.raw_pr q)
-let ppqgraph q = pp (QGraph.pr Sorts.QVar.raw_pr q)
-let ppelim_constraints cstrs = pp (Sorts.ElimConstraints.pr Sorts.QVar.raw_pr cstrs)
+let ppelim_constraints cstrs = pp (Sorts.ElimConstraints.pr prqvar cstrs)
 let ppnamedcontextval e =
   let env = Global.env () in
   let sigma = Evd.from_env env in

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -154,6 +154,7 @@ val ppesorts : EConstr.ESorts.t -> unit
 val pperelevance : EConstr.ERelevance.t -> unit
 val prlev : Univ.Level.t -> Pp.t (* with global names (does this work?) *)
 val ppqvarset : Sorts.QVar.Set.t -> unit
+val ppqset : Sorts.Quality.Set.t -> unit
 val ppuniverse_set : Univ.Level.Set.t -> unit
 val ppuniverse_instance : UVars.Instance.t -> unit
 val ppuniverse_einstance : EConstr.EInstance.t -> unit
@@ -171,6 +172,8 @@ val ppuniverseconstraints : UnivProblem.Set.t -> unit
 val ppuniverse_context_future : UVars.UContext.t Future.computation -> unit
 val ppuniverses : UGraph.t -> unit
 val ppqualities : QGraph.t -> unit
+val ppqgraph : QGraph.t -> unit
+val ppelim_constraints : Sorts.ElimConstraints.t -> unit
 
 val pp_partialfsubst : (CClosure.fconstr, Sorts.Quality.t, Univ.Universe.t) Partial_subst.t -> unit
 val pp_partialsubst : (EConstr.constr, Sorts.Quality.t, Univ.Universe.t) Partial_subst.t -> unit

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -172,7 +172,6 @@ val ppuniverseconstraints : UnivProblem.Set.t -> unit
 val ppuniverse_context_future : UVars.UContext.t Future.computation -> unit
 val ppuniverses : UGraph.t -> unit
 val ppqualities : QGraph.t -> unit
-val ppqgraph : QGraph.t -> unit
 val ppelim_constraints : Sorts.ElimConstraints.t -> unit
 
 val pp_partialfsubst : (CClosure.fconstr, Sorts.Quality.t, Univ.Universe.t) Partial_subst.t -> unit

--- a/doc/changelog/02-specification-language/21417-elab-elim-constraints-Added.rst
+++ b/doc/changelog/02-specification-language/21417-elab-elim-constraints-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  implicit elaboration of :ref:`elimination constraints <elim-constraints>`
+  (`#21417 <https://github.com/rocq-prover/rocq/pull/21417>`_,
+  by Tomas Diaz).

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -331,6 +331,8 @@ val whd_evar : Evd.evar_map -> constr -> constr
 val eq_constr : Evd.evar_map -> t -> t -> bool
 val eq_constr_nounivs : Evd.evar_map -> t -> t -> bool
 val eq_constr_universes : Environ.env -> Evd.evar_map -> ?nargs:int -> t -> t -> UnivProblem.Set.t option
+(** Does not produce QLeq nor QElimTo constraints *)
+
 val leq_constr_universes : Environ.env -> Evd.evar_map -> ?nargs:int -> t -> t -> UnivProblem.Set.t option
 val eq_existential : Evd.evar_map ->  (t -> t -> bool) -> existential -> existential -> bool
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1176,6 +1176,9 @@ let set_above_prop evd q =
   add_constraints evd @@
     UnivProblem.Set.singleton (QLeq (Sorts.Quality.qprop, q))
 
+let set_elim_to evd q1 q2 =
+  add_constraints evd @@ UnivProblem.Set.singleton (QElimTo (q1, q2))
+
 let check_eq evd s s' =
   let quals = elim_graph evd in
   let ustate = evd.universes in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -597,6 +597,7 @@ val set_eq_instances : ?flex:bool ->
   evar_map -> einstance -> einstance -> evar_map
 
 val set_eq_qualities : evar_map -> Sorts.Quality.t -> Sorts.Quality.t -> evar_map
+val set_elim_to : evar_map -> Sorts.Quality.t -> Sorts.Quality.t -> evar_map
 val set_above_prop : evar_map -> Sorts.Quality.t -> evar_map
 
 val check_eq : evar_map -> esorts -> esorts -> bool

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -303,7 +303,7 @@ let pr prqvar_opt ({ qmap; elims; rigid } as m) =
     | None -> mt()
     | Some qid -> str " (named " ++ Libnames.pr_qualid qid ++ str ")"
   in
-  h (prlist_with_sep fnl (fun (u, v) -> QVar.raw_pr u ++ prbody u v ++ prqvar_name u) (QMap.bindings qmap))
+  h (prlist_with_sep fnl (fun (u, v) -> QVar.raw_pr u ++ prbody u v ++ prqvar_name u) (QMap.bindings qmap) ++ str " |= " ++ QGraph.pr prqvar elims)
 
 let elims m = m.elims
 

--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -14,6 +14,7 @@ open Sorts
 type t =
   | QEq of Quality.t * Quality.t
   | QLeq of Quality.t * Quality.t
+  | QElimTo of Quality.t * Quality.t
   | ULe of Sorts.t * Sorts.t
   | UEq of Sorts.t * Sorts.t
   | ULub of Level.t * Level.t
@@ -21,12 +22,13 @@ type t =
 
 let is_trivial = function
   | QLeq (a,b) -> Inductive.raw_eliminates_to a b
+  | QElimTo (a, b) -> Inductive.raw_eliminates_to a b
   | QEq (a, b) -> Quality.equal a b
   | ULe (u, v) | UEq (u, v) -> Sorts.equal u v
   | ULub (u, v) | UWeak (u, v) -> Level.equal u v
 
 let force = function
-  | QEq _ | QLeq _ | ULe _ | UEq _ | UWeak _ as cst -> cst
+  | QEq _ | QElimTo _ | QLeq _ | ULe _ | UEq _ | UWeak _ as cst -> cst
   | ULub (u,v) -> UEq (Sorts.sort_of_univ @@ Universe.make u, Sorts.sort_of_univ @@ Universe.make v)
 
 let check_eq_level g u v = UGraph.check_eq_level g u v
@@ -37,12 +39,15 @@ module Set = struct
     type nonrec t = t
 
     let compare x y =
-      match x, y with
-      | (QEq (a, b) | QLeq (a, b)),
-        (QEq (a', b') | QLeq (a', b')) ->
+      let compare_qualities (a, b) (a', b') =
         let i = Quality.compare a a' in
         if i <> 0 then i
         else Quality.compare b b'
+      in
+      match x, y with
+      | QEq (a, b), QEq (a', b')
+      | QLeq (a, b), QLeq (a', b')
+      | QElimTo (a, b), QElimTo (a', b') -> compare_qualities (a, b) (a', b')
       | ULe (u, v), ULe (u', v') ->
         let i = Sorts.compare u u' in
         if Int.equal i 0 then Sorts.compare v v'
@@ -61,6 +66,8 @@ module Set = struct
       | _, QEq _ -> 1
       | QLeq _, _ -> -1
       | _, QLeq _ -> 1
+      | QElimTo _, _ -> -1
+      | _, QElimTo _ -> 1
       | ULe _, _ -> -1
       | _, ULe _ -> 1
       | UEq _, _ -> -1
@@ -78,6 +85,7 @@ module Set = struct
   let pr_one = let open Pp in function
     | QEq (a, b) -> Quality.raw_pr a ++ str " = " ++ Quality.raw_pr b
     | QLeq (a, b) -> Quality.raw_pr a ++ str " <= " ++ Quality.raw_pr b
+    | QElimTo (a, b) -> Quality.raw_pr a ++ str " -> " ++ Quality.raw_pr b
     | ULe (u, v) -> Sorts.debug_print u ++ str " <= " ++ Sorts.debug_print v
     | UEq (u, v) -> Sorts.debug_print u ++ str " = " ++ Sorts.debug_print v
     | ULub (u, v) -> Level.raw_pr u ++ str " /\\ " ++ Level.raw_pr v

--- a/engine/univProblem.mli
+++ b/engine/univProblem.mli
@@ -23,6 +23,7 @@ open UVars
 type t =
   | QEq of Sorts.Quality.t * Sorts.Quality.t
   | QLeq of Sorts.Quality.t * Sorts.Quality.t
+  | QElimTo of Sorts.Quality.t * Sorts.Quality.t
   | ULe of Sorts.t * Sorts.t
   | UEq of Sorts.t * Sorts.t
   | ULub of Level.t * Level.t

--- a/kernel/pConstraints.ml
+++ b/kernel/pConstraints.ml
@@ -61,9 +61,10 @@ let filter_univs f (qc, lc) =
 
 let pr prv prl (qc, lc) =
   let open Pp in
-  let ppelim = if ElimConstraints.is_empty qc then mt()
-               else ElimConstraints.pr prv qc ++ str"," in
-  v 0 (ppelim ++ UnivConstraints.pr prl lc)
+  let sep = if ElimConstraints.is_empty qc || UnivConstraints.is_empty lc
+            then mt()
+            else str ", " in
+  v 0 (ElimConstraints.pr prv qc ++ sep ++ UnivConstraints.pr prl lc)
 
 module HPConstraints =
   Hashcons.Make(

--- a/kernel/pConstraints.ml
+++ b/kernel/pConstraints.ml
@@ -62,8 +62,8 @@ let filter_univs f (qc, lc) =
 let pr prv prl (qc, lc) =
   let open Pp in
   let sep = if ElimConstraints.is_empty qc || UnivConstraints.is_empty lc
-            then mt()
-            else str ", " in
+            then mt ()
+            else pr_comma () in
   v 0 (ElimConstraints.pr prv qc ++ sep ++ UnivConstraints.pr prl lc)
 
 module HPConstraints =

--- a/kernel/qGraph.mli
+++ b/kernel/qGraph.mli
@@ -35,7 +35,7 @@ type quality_inconsistency =
     (ElimConstraint.kind * Quality.t * Quality.t * explanation option)
 
 type elimination_error =
-  | IllegalConstraint
+  | IllegalConstraint of Quality.t * Quality.t
   | CreatesForbiddenPath of Quality.t * Quality.t
   | MultipleDominance of Quality.t * Quality.t * Quality.t
   | QualityInconsistency of quality_inconsistency
@@ -103,3 +103,5 @@ val pr_qualities : (Quality.t -> Pp.t) -> t -> Pp.t
 val explain_quality_inconsistency : (QVar.t -> Pp.t) -> explanation option -> Pp.t
 
 val explain_elimination_error : (QVar.t -> Pp.t) -> elimination_error -> Pp.t
+
+val pr : (QVar.t -> Pp.t) -> t -> Pp.t

--- a/kernel/qGraph.mli
+++ b/kernel/qGraph.mli
@@ -35,7 +35,8 @@ type quality_inconsistency =
     (ElimConstraint.kind * Quality.t * Quality.t * explanation option)
 
 type elimination_error =
-  | IllegalConstraint of Quality.t * Quality.t
+  | IllegalConstraintFromSProp of Quality.t
+  | IllegalConstantConstraint of Quality.constant * Quality.constant
   | CreatesForbiddenPath of Quality.t * Quality.t
   | MultipleDominance of Quality.t * Quality.t * Quality.t
   | QualityInconsistency of quality_inconsistency
@@ -103,5 +104,3 @@ val pr_qualities : (Quality.t -> Pp.t) -> t -> Pp.t
 val explain_quality_inconsistency : (QVar.t -> Pp.t) -> explanation option -> Pp.t
 
 val explain_elimination_error : (QVar.t -> Pp.t) -> elimination_error -> Pp.t
-
-val pr : (QVar.t -> Pp.t) -> t -> Pp.t

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -316,7 +316,7 @@ module ElimConstraints = struct include Stdlib.Set.Make(ElimConstraint)
   let pr prq c =
     let open Pp in
     v 0 (prlist_with_sep spc (fun (u1,op,u2) ->
-      hov 0 (Quality.pr prq u1 ++ ElimConstraint.pr_kind op ++ Quality.pr prq u2))
+      hov 0 (Quality.pr prq u1 ++ spc() ++ ElimConstraint.pr_kind op ++ spc() ++ Quality.pr prq u2))
        (elements c))
 
   module HConstraints = CSet.Hashcons(ElimConstraint)(struct

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2171,7 +2171,7 @@ let prepare_predicate ?loc ~program_mode typing_fun env sigma tomatchs arsign ty
       let sigma, predcclj = typing_fun (Some (mkSort rtnsort)) envar sigma rtntyp in
       let check_elim_sort sigma squash =
         try Inductiveops.squash_elim_sort sigma squash rtnsort
-        with UGraph.UniverseInconsistency _ ->
+        with QGraph.EliminationError _ | UGraph.UniverseInconsistency _ ->
           (* Incompatible constraints are ignored and handled later
              when typing the pattern-matching. *)
           sigma

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -283,20 +283,19 @@ let is_allowed_elimination sigma ((_,mip) as specif,u) s =
       s
 
 let make_allowed_elimination_actions sigma s =
-  Inductive.
-  { not_squashed = Some sigma
+  Inductive.{
+    not_squashed = Some sigma
   ; squashed_to_set_below = Some sigma
   ; squashed_to_set_above = (
     try Some (Evd.set_leq_sort sigma s ESorts.set)
     with UGraph.UniverseInconsistency _ -> None)
-  ; squashed_to_quality =
-      fun indq -> let sq = EConstr.ESorts.quality sigma s in
-               if Inductive.eliminates_to (Evd.elim_graph sigma) indq sq
-               then Some sigma
-               else
-                 let mk q = ESorts.make @@ Sorts.make q Univ.Universe.type0 in
-                 try Some (Evd.set_leq_sort sigma (mk sq) (mk indq))
-                 with UGraph.UniverseInconsistency _ -> None }
+  ; squashed_to_quality = fun indq ->
+      let sq = EConstr.ESorts.quality sigma s in
+      if Inductive.eliminates_to (Evd.elim_graph sigma) indq sq
+      then Some sigma
+      else
+        try Some (Evd.set_elim_to sigma indq sq)
+        with QGraph.EliminationError _ | UGraph.UniverseInconsistency _ -> None }
 
 let make_allowed_elimination sigma ((_,mip) as specif,u) s =
   match mip.mind_record with

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -449,7 +449,8 @@ let magically_constant_of_fixbody env sigma (reference, params) bd = function
             let addus l r (qs,us) = qs, Univ.Level.Map.add l r us in
             let subst = Set.fold (fun cst acc ->
                 match cst with
-                | QEq (a,b) | QLeq (a,b) ->
+                | QLeq _ | QElimTo _ -> assert false (* eq_constr_universes cannot produce QLeq nor QElimTo constraints *)
+                | QEq (a, b) ->
                   let a = match a with
                     | QVar q -> q
                     | _ -> assert false

--- a/test-suite/output/ShowUnivs.out
+++ b/test-suite/output/ShowUnivs.out
@@ -6,7 +6,10 @@ ALGEBRAIC UNIVERSES:
 FLEXIBLE UNIVERSES:
  
 SORTS:
-  |= Prop -> SProp , Type -> Prop , Type -> SProp
+  |= Prop -> SProp
+     Type -> Prop
+          -> SProp
+     
 WEAK CONSTRAINTS:
  
 
@@ -30,7 +33,14 @@ FLEXIBLE UNIVERSES:
 SORTS:
  α1 := Type
  α2 := Type
- α3 := α1 |= α1 -> α2 , α1 -> α3 , α1 -> Prop , α1 -> SProp , α1 -> Type , α2 -> α1 , α2 -> α3 , α2 -> Prop , α2 -> SProp , α2 -> Type , α3 -> α1 , α3 -> α2 , α3 -> Prop , α3 -> SProp , α3 -> Type , Prop -> SProp , Type -> α1 , Type -> α2 , Type -> α3 , Type -> Prop , Type -> SProp
+ α3 := α1 |=
+   α1 <-> Type
+   α2 <-> Type
+   α3 <-> α1
+   Prop -> SProp
+   Type -> Prop
+        -> SProp
+   
 WEAK CONSTRAINTS:
  
 

--- a/test-suite/output/ShowUnivs.out
+++ b/test-suite/output/ShowUnivs.out
@@ -6,7 +6,7 @@ ALGEBRAIC UNIVERSES:
 FLEXIBLE UNIVERSES:
  
 SORTS:
- 
+  |= Prop -> SProp , Type -> Prop , Type -> SProp
 WEAK CONSTRAINTS:
  
 
@@ -30,7 +30,7 @@ FLEXIBLE UNIVERSES:
 SORTS:
  α1 := Type
  α2 := Type
- α3 := α1
+ α3 := α1 |= α1 -> α2 , α1 -> α3 , α1 -> Prop , α1 -> SProp , α1 -> Type , α2 -> α1 , α2 -> α3 , α2 -> Prop , α2 -> SProp , α2 -> Type , α3 -> α1 , α3 -> α2 , α3 -> Prop , α3 -> SProp , α3 -> Type , Prop -> SProp , Type -> α1 , Type -> α2 , Type -> α3 , Type -> Prop , Type -> SProp
 WEAK CONSTRAINTS:
  
 

--- a/test-suite/output/sort_poly_elim_error.out
+++ b/test-suite/output/sort_poly_elim_error.out
@@ -6,14 +6,11 @@ the return type has sort "Type" while it should be SProp or Prop.
 Elimination of an inductive object of sort Prop
 is not allowed on a predicate in sort "Type"
 because proofs can be eliminated only to build proofs.
-File "./output/sort_poly_elim_error.v", line 19, characters 0-106:
+File "./output/sort_poly_elim_error.v", line 17, characters 0-106:
 The command has indeed failed with message:
-Incorrect elimination of "x" in the inductive type "sBox@{s s' ; u}":
-the return type has sort "Type@{s ; u}"
-while it should be in a sort s' eliminates to.
-Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
-is only allowed on itself or with an explicit elimination constraint to the target sort.
-File "./output/sort_poly_elim_error.v", line 24, characters 0-37:
+Elimination constraints are not implied by the ones declared: 
+s' -> s
+File "./output/sort_poly_elim_error.v", line 23, characters 0-37:
 The command has indeed failed with message:
 Incorrect elimination of "sC" in the inductive type "sP":
 the return type has sort "Prop" while it should be SProp.

--- a/test-suite/output/sort_poly_elim_error.v
+++ b/test-suite/output/sort_poly_elim_error.v
@@ -7,10 +7,8 @@ Arguments inr {A B}.
 
 Fail Check (fun p : sum@{Prop;_ _} True False => match p return Set with inl a => unit | inr b => bool end).
 (*
-Error: Incorrect elimination of "p" in the inductive type "sum":
-the return type has sort "Type@{Set+1}" while it should be at some variable quality.
-Elimination of an inductive object of sort Type is not allowed on a predicate in sort Type
-because wrong arity.
+Error: The quality constraints are inconsistent: cannot enforce Prop -> Type because it would identify Type and Prop which is inconsistent.
+This is introduced by the constraints Prop -> Type
 *)
 
 
@@ -18,7 +16,12 @@ Inductive sBox@{s s';u|} (A:Type@{s;u}) : Type@{s';u} := sbox (_:A).
 
 Fail Definition elim@{s s';u|} (A:Type@{s;u}) (x:sBox@{s s';u} A) : A :=
   match x with sbox _ v => v end.
+(* Error: Elimination constraints are not implied by the ones declared: s' -> s *)
 
 Inductive sP : SProp := sC.
 
 Fail Check match sC with sC => I end.
+(*
+Error: The quality constraints are inconsistent: cannot enforce SProp -> Prop because it would identify Prop and SProp which is inconsistent.
+This is introduced by the constraints SProp -> Prop
+*)

--- a/test-suite/success/sort_poly_elab.v
+++ b/test-suite/success/sort_poly_elab.v
@@ -1,0 +1,175 @@
+Set Universe Polymorphism.
+
+Inductive sum@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) : Type@{s;max(ul,ur)} :=
+| inl : A -> sum A B
+| inr : B -> sum A B.
+
+Arguments inl {A B} _ , [A] B _.
+Arguments inr {A B} _ , A [B] _.
+
+(* Elimination constraint left explicitly empty. Definition fails because of missing constraint. *)
+Fail Definition sum_elim@{sl sr s0 s0';ul ur v|}
+  (A : Type@{sl;ul}) (B : Type@{sr;ur}) (P : sum@{sl sr s0;ul ur} A B -> Type@{s0';v})
+  (fl : forall a, P (inl a)) (fr : forall b, P (inr b)) (x : sum@{sl sr s0;ul ur} A B) :=
+    match x with
+    | inl a => fl a
+    | inr b => fr b
+    end.
+(* The command has indeed failed with message:
+Elimination constraints are not implied by the ones declared: s0->s0' *)
+
+(* Using + to elaborate missing constraints. Definition passes *)
+Definition sum_elim@{sl sr s0 s0';ul ur v|+}
+  (A : Type@{sl;ul}) (B : Type@{sr;ur}) (P : sum@{sl sr s0;ul ur} A B -> Type@{s0';v})
+  (fl : forall a, P (inl a)) (fr : forall b, P (inr b)) (x : sum@{sl sr s0;ul ur} A B) :=
+    match x with
+    | inl a => fl a
+    | inr b => fr b
+    end.
+(* sl sr s0 s0' ; ul ur v |= s0->s0' *)
+
+Definition sum_sind := sum_elim@{Type Type Type SProp;_ _ _}.
+Definition sum_rect := sum_elim@{Type Type Type Type;_ _ _}.
+Definition sum_ind := sum_elim@{Type Type Type Prop;_ _ _}.
+
+Definition or_ind := sum_elim@{Prop Prop Prop Prop;_ _ _}.
+Definition or_sind := sum_elim@{Prop Prop Prop SProp;_ _ _}.
+Fail Definition or_rect := sum_elim@{Prop Prop Prop Type;_ _ _}.
+(* The command has indeed failed with message:
+The quality constraints are inconsistent: cannot enforce Prop -> Type because it would identifyType and Prop which is inconsistent.
+This is introduced by the constraints Type -> Prop *)
+
+Definition sumor := sum@{Type Prop Type;_ _}.
+
+Definition sumor_sind := sum_elim@{Type Prop Type SProp;_ _ _}.
+Definition sumor_rect := sum_elim@{Type Prop Type Type;_ _ _}.
+Definition sumor_ind := sum_elim@{Type Prop Type Prop;_ _ _}.
+
+(* Implicit constraints are elaborated *)
+Definition idT@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+  : sum@{sl sr Type;ul ur} A B :=
+  match x return sum@{sl sr Type;ul ur} A B with
+  | inl a => inl a
+  | inr b => inr b
+  end.
+(* sl sr s ; ul ur |= s->Type *)
+
+(* Implicit constraints are elaborated *)
+Definition idP@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+  : sum@{sl sr Prop;ul ur} A B :=
+  match x return sum@{sl sr Prop;ul ur} A B with
+  | inl a => inl a
+  | inr b => inr b
+  end.
+(* sl sr s ; ul ur |= s->Prop *)
+
+(* Implicit constraints are elaborated *)
+Definition idS@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+  : sum@{sl sr SProp;ul ur} A B :=
+  match x return sum@{sl sr SProp;ul ur} A B with
+  | inl a => inl a
+  | inr b => inr b
+  end.
+(* sl sr s ; ul ur |= s->SProp *)
+
+(* Implicit constraints are elaborated *)
+Definition idV@{sl sr s s';ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+  : sum@{sl sr s';ul ur} A B :=
+  match x return sum@{sl sr s';ul ur} A B with
+  | inl a => inl a
+  | inr b => inr b
+  end.
+(* sl sr s s' ; ul ur |= s->s' *)
+
+Inductive List'@{s s';l} (A : Type@{s;l}) : Type@{s';l} :=
+| nil' : List' A
+| cons' : A -> List' A -> List' A.
+
+Arguments nil' {A}.
+Arguments cons' {A} _ _.
+
+Definition list'_elim@{s s0 s';l l'}
+  (A : Type@{s;l}) (P : List'@{s s0;l} A -> Type@{s';l'})
+  (fn : P nil') (fc : forall (x : A) (l : List' A), P l -> P (cons' x l)) :=
+  fix F (l : List'@{s s0;l} A) : P l :=
+    match l with
+    | nil' => fn
+    | cons' x l => fc x l (F l)
+    end.
+(* s s0 s' ; l l' |= s0->s' *)
+
+Fixpoint list'_idT@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Type;l} A :=
+  match l with
+  | nil' => nil'
+  | cons' x l => cons' x (list'_idT l)
+  end.
+(* s s' ; l |= s'->Type *)
+
+Fixpoint list'_idP@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Prop;l} A :=
+  match l with
+  | nil' => nil'
+  | cons' x l => cons' x (list'_idP l)
+  end.
+(* s s' ; l |= s'->Prop *)
+
+Fixpoint list'_idS@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s SProp;l} A :=
+  match l with
+  | nil' => nil'
+  | cons' x l => cons' x (list'_idS l)
+  end.
+(* s s' ; l |= s'->SProp *)
+
+(* Elimination constraint left explicitly empty. Definition fails because of missing constraint. *)
+Fail Fixpoint list'_idV@{s s0 s';l l'|l <= l'} {A : Type@{s;l}} (l : List'@{s s0;l} A) : List'@{s s';l'} A :=
+  match l with
+  | nil' => nil'
+  | cons' x l => cons' x (list'_idV l)
+  end.
+(* The command has indeed failed with message:
+Elimination constraints are not implied by the ones declared: s0->s' *)
+
+(* Using + to elaborate missing constraints. Definition passes *)
+Fixpoint list'_idV@{s s0 s';l l'|l <= l' + } {A : Type@{s;l}} (l : List'@{s s0;l} A) : List'@{s s';l'} A :=
+  match l with
+  | nil' => nil'
+  | cons' x l => cons' x (list'_idV l)
+  end.
+(* s s0 s' ; l l' |= s0->s', l <= l' *)
+
+
+Inductive False'@{s;u} : Type@{s;u} :=.
+
+Definition False'_False@{s; +|+} (x : False'@{s;_}) : False := match x return False with end.
+(* s ; u |= s->Prop *)
+
+Inductive bool@{s;u} : Type@{s;u} := true | false.
+
+Definition bool_to_Prop@{s;u} (b : bool@{s;u}) : Prop.
+Proof.
+  destruct b.
+  - exact True.
+  - exact False.
+Defined.
+(* s ; u |= s->Type *)
+
+Definition bool_to_True_conj@{s;u} (b : bool@{s;u}) : True \/ True.
+Proof.
+  destruct b.
+  - exact (or_introl I).
+  - exact (or_intror I).
+Defined.
+(* s ; u |= s->Prop *)
+
+Program Definition bool_to_Prop'@{s;u} (b : bool@{s;u}) : Prop := _.
+Next Obligation.
+  intro b; destruct b.
+  - exact True.
+  - exact False.
+Defined.
+(* s ; u |= s->Type *)
+
+Inductive unit@{s;u} : Type@{s;u} := tt.
+
+#[universes(polymorphic=no)]
+Sort Test.
+Check (match true@{Test;Set} return ?[P] with true => tt | false => tt end).

--- a/test-suite/success/sort_poly_elim_csts.v
+++ b/test-suite/success/sort_poly_elim_csts.v
@@ -73,28 +73,28 @@ Definition sumor_sind := sum_elim@{Type Prop Type SProp;_ _ _}.
 Definition sumor_rect := sum_elim@{Type Prop Type Type;_ _ _}.
 Definition sumor_ind := sum_elim@{Type Prop Type Prop;_ _ _}.
 
-Fail Definition idT@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+Fail Definition idT@{sl sr s;ul ur|} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
   : sum@{sl sr Type;ul ur} A B :=
   match x return sum@{sl sr Type;ul ur} A B with
   | inl a => inl a
   | inr b => inr b
   end.
 
-Fail Definition idP@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+Fail Definition idP@{sl sr s;ul ur|} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
   : sum@{sl sr Prop;ul ur} A B :=
   match x return sum@{sl sr Prop;ul ur} A B with
   | inl a => inl a
   | inr b => inr b
   end.
 
-Fail Definition idS@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+Fail Definition idS@{sl sr s;ul ur|} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
   : sum@{sl sr SProp;ul ur} A B :=
   match x return sum@{sl sr SProp;ul ur} A B with
   | inl a => inl a
   | inr b => inr b
   end.
 
-Fail Definition idV@{sl sr s s';ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
+Fail Definition idV@{sl sr s s';ul ur|} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
   : sum@{sl sr s';ul ur} A B :=
   match x return sum@{sl sr s';ul ur} A B with
   | inl a => inl a
@@ -145,19 +145,19 @@ Definition list'_elim@{s s0 s';l l'|s0 -> s'}
     | cons' x l => fc x l (F l)
     end.
 
-Fail Fixpoint list'_idT@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Type;l} A :=
+Fail Fixpoint list'_idT@{s s';l|} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Type;l} A :=
   match l with
   | nil' => nil'
   | cons' x l => cons' x (list'_idT l)
   end.
 
-Fail Fixpoint list'_idP@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Prop;l} A :=
+Fail Fixpoint list'_idP@{s s';l|} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s Prop;l} A :=
   match l with
   | nil' => nil'
   | cons' x l => cons' x (list'_idP l)
   end.
 
-Fail Fixpoint list'_idS@{s s';l} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s SProp;l} A :=
+Fail Fixpoint list'_idS@{s s';l|} {A : Type@{s;l}} (l : List'@{s s';l} A) : List'@{s SProp;l} A :=
   match l with
   | nil' => nil'
   | cons' x l => cons' x (list'_idS l)


### PR DESCRIPTION
This PR adds implicit elaboration of elimination constraints. Only elimination constraints, not qualities.
(Also some fixes in printing + some refactoring/renaming that don't change the API)

Associated RFC : https://github.com/rocq-prover/rfcs/pull/111.

### Examples 
```coq 
Set Universe Polymorphism.

Inductive sum@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) : Type@{s;max(ul,ur)} :=
| inl : A -> sum A B
| inr : B -> sum A B.

(* Elimination constraint left explicitly empty. Definition fails because of missing constraint. *)
Fail Definition sum_elim@{sl sr s0 s0';ul ur v|}
  (A : Type@{sl;ul}) (B : Type@{sr;ur}) (P : sum@{sl sr s0;ul ur} A B -> Type@{s0';v})
  (fl : forall a, P (inl a)) (fr : forall b, P (inr b)) (x : sum@{sl sr s0;ul ur} A B) :=
    match x with
    | inl a => fl a
    | inr b => fr b
    end.
(* The command has indeed failed with message:
Elimination constraints are not implied by the ones declared: s0->s0' *)

(* Using + to elaborate missing constraints. Definition passes *)
Definition sum_elim@{sl sr s0 s0';ul ur v|+}
  (A : Type@{sl;ul}) (B : Type@{sr;ur}) (P : sum@{sl sr s0;ul ur} A B -> Type@{s0';v})
  (fl : forall a, P (inl a)) (fr : forall b, P (inr b)) (x : sum@{sl sr s0;ul ur} A B) :=
    match x with
    | inl a => fl a
    | inr b => fr b
    end.
(* sl sr s0 s0' ; ul ur v |= s0->s0' *)

(* Implicit constraints are elaborated *)
Definition idT@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
  : sum@{sl sr Type;ul ur} A B :=
  match x return sum@{sl sr Type;ul ur} A B with
  | inl a => inl a
  | inr b => inr b
  end.
(* sl sr s ; ul ur |= s->Type *)

(* Implicit constraints are elaborated *)
Definition idP@{sl sr s;ul ur} (A : Type@{sl;ul}) (B : Type@{sr;ur}) (x : sum@{sl sr s;ul ur} A B)
  : sum@{sl sr Prop;ul ur} A B :=
  match x return sum@{sl sr Prop;ul ur} A B with
  | inl a => inl a
  | inr b => inr b
  end.
(* sl sr s ; ul ur |= s->Prop *)
```

### Main API Changes
- `univProblem.mli` : Extending constraints to include `QElimTo`
- `evd.mli` : Adding a `set_elim_to` function

### Overlays
- https://github.com/LPCIC/coq-elpi/pull/946
- https://github.com/math-comp/hierarchy-builder/pull/569