### PR TITLE
Freshen monomorphic constraints in Declare.build_constant_by_tactic.

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -204,10 +204,10 @@ let build_functional_principle env (sigma : Evd.evar_map) old_princ_type sorts f
   let ftac = proof_tac funs mutr_nparams in
   let uctx = Evd.ustate sigma in
   let typ = EConstr.of_constr new_principle_type in
-  let body, typ, univs, _safe, _uctx =
+  let body, typ, univs, _safe, uctx =
     Subproof.build_by_tactic env ~uctx ~poly:PolyFlags.default ~typ ftac
   in
-  (* uctx was ignored before *)
+  let sigma = Evd.set_universe_context sigma uctx in
   let hook = Declare.Hook.make (hook new_principle_type) in
   (body, typ, univs, hook, sigma)
 

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -109,20 +109,10 @@ let shrink_entry sign body typ =
 
 let freshen_instance univs = match univs with
 | UState.Monomorphic_entry uctx, unames ->
-  (* Freshen the universe levels *)
-  let (us, ucst) = uctx in
-  let uctx = (Sorts.QVar.Set.empty, us), (Sorts.ElimConstraints.empty, ucst) in
-  let usubst, ((_qs, us), (_qcst, ucst)) = UnivGen.fresh_sort_context_instance uctx in
-  let uctx = us, ucst in
-  (* Add equality constraints between the local universes and the fresh ones *)
-  let fold u v accu =
-    let cst = Univ.UnivConstraints.singleton (u, Eq, v) in
-    Univ.ContextSet.add_constraints cst accu
-  in
-  let guctx = Univ.Level.Map.fold fold (snd usubst) uctx in
-  guctx, (UState.Monomorphic_entry uctx, unames), usubst
+  let guctx = (Univ.Level.Set.empty, snd uctx) in
+  guctx, (UState.Monomorphic_entry uctx, unames)
 | UState.Polymorphic_entry _, _ ->
-  Univ.ContextSet.empty, univs, UVars.empty_sort_subst
+  Univ.ContextSet.empty, univs
 
 let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
   let proof = Proof.start ~name ~poly sigma [Global.env_of_context sign, typ] in
@@ -149,9 +139,7 @@ let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly (typ : EConstr.t) tac
     UState.check_univ_decl ~poly uctx UState.default_univ_decl
   in
   (* TODO: uctx levels are almost immediately demoted, we should do this directly instead *)
-  let uctx, univs, usubst = freshen_instance univs in
-  let body  = Vars.subst_univs_level_constr usubst body in
-  let typ = Vars.subst_univs_level_constr usubst typ in
+  let uctx, univs = freshen_instance univs in
   let { Proof.sigma } = Proof.data proof in
   let sigma =
     (* XXX overwriting the context in polymorphic mode breaks a lot of invariants,

--- a/test-suite/bugs/bug_15795.v
+++ b/test-suite/bugs/bug_15795.v
@@ -1,0 +1,15 @@
+Lemma bla : True * Type.
+Proof.
+  assert (H:Type@{_}) by admit.
+  let t' := constr:(Type) in let t := type of H in unify t' t.
+  (* type of H is typ@{u}, ustate has {u u'} |= u = u', u := u' (with u' rigid) *)
+
+  split.
+  1: abstract exact I.
+  (* abstract ran UState.minimize so ustate has {u'} |=, u := u'
+     update_sigma_univs then drops u from the ustate's ugraph *)
+
+  Fail match goal with H : ?t |- ?t => idtac end.
+  (* conversion uses the ustate's ugraph to check universes without normalizing them, so dies *)
+
+Admitted.


### PR DESCRIPTION
This prevents relying on the pervasive confusion between the global universes introduced by side-effects and their local counterpart in the evarmap. We generate a fresh instance for the constant entry and add equality constraints with the original levels in the evarmap.

As usual, the funind code makes no sense so we fix it in the most local way so as to make the test-suite pass.

Fixes #15795: Conversion test raised an anomaly.

Backwards compatible overlays:
- https://github.com/mit-plv/rewriter/pull/187

Depends on:
- #21420.