### PR TITLE
Fix rocqwc on tactics that end in Proof

### DIFF
--- a/doc/changelog/09-cli-tools/21423-rocq-wc-Proof-Fixed.rst
+++ b/doc/changelog/09-cli-tools/21423-rocq-wc-Proof-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``rocq wc`` now handles tactics containing the word ``Proof`` correctly.
+  (`#21423 <https://github.com/rocq-prover/rocq/pull/21423>`_,
+  fixes `#21422 <https://github.com/rocq-prover/rocq/issues/21422>`_,
+  by Johannes Hostert).

--- a/test-suite/coqwc/tactic-named-proof.out
+++ b/test-suite/coqwc/tactic-named-proof.out
@@ -1,0 +1,2 @@
+     spec    proof comments
+        2       10        1 coqwc/tactic-named-proof.v

--- a/test-suite/coqwc/tactic-named-proof.out
+++ b/test-suite/coqwc/tactic-named-proof.out
@@ -1,2 +1,2 @@
      spec    proof comments
-        2       10        1 coqwc/tactic-named-proof.v
+        2       10        2 coqwc/tactic-named-proof.v

--- a/test-suite/coqwc/tactic-named-proof.v
+++ b/test-suite/coqwc/tactic-named-proof.v
@@ -1,0 +1,13 @@
+  Lemma inv_acc_strong E N P :
+    ↑N ⊆ E → inv N P ={E,E∖↑N}=∗ ▷ P ∗ ∀ E', ▷ P ={E',↑N ∪ E'}=∗ True.
+  Proof.
+    iIntros (?) "Hinv".
+    (* `rocq wc` got confused by tactics like these, ending in "Proof" *)
+    iPoseProof (inv_acc (↑ N) N with "Hinv") as "H"; first done.
+    rewrite difference_diag_L.
+    iPoseProof (fupd_mask_frame_r _ _ (E ∖ ↑ N) with "H") as "H"; first set_solver.
+    rewrite left_id_L -union_difference_L //. iMod "H" as "[$ H]"; iModIntro.
+    iIntros (E') "HP".
+    iPoseProof (fupd_mask_frame_r _ _ E' with "(H HP)") as "H"; first set_solver.
+    by rewrite left_id_L.
+  Qed.

--- a/test-suite/coqwc/tactic-named-proof.v
+++ b/test-suite/coqwc/tactic-named-proof.v
@@ -8,6 +8,7 @@
     iPoseProof (fupd_mask_frame_r _ _ (E ∖ ↑ N) with "H") as "H"; first set_solver.
     rewrite left_id_L -union_difference_L //. iMod "H" as "[$ H]"; iModIntro.
     iIntros (E') "HP".
-    iPoseProof (fupd_mask_frame_r _ _ E' with "(H HP)") as "H"; first set_solver.
+    (* also works with non-ascii names: *)
+    iPoseΔProof (fupd_mask_frame_r _ _ E' with "(H HP)") as "H"; first set_solver.
     by rewrite left_id_L.
   Qed.

--- a/tools/rocqwc.mll
+++ b/tools/rocqwc.mll
@@ -161,13 +161,28 @@ and proof = parse
   | "Proof" space* '.'
   | "Proof" space+ "with"
   | "Proof" space+ "using"
-           { seen_proof := true; proof lexbuf }
+           { seen_proof := true; started_proof lexbuf }
   | "Proof" space
            { proof_term lexbuf }
   | proof_end
            { seen_proof := true; spec lexbuf }
   | character | _
-           { seen_proof := true; proof lexbuf }
+           { seen_proof := true; started_proof lexbuf }
+  | eof    { () }
+
+(*s Scans the proof after the "Proof" keyword, without again giving special treatment to that keyword. See issue #21422. *)
+
+and started_proof = parse
+  | "(*"   { comment lexbuf; started_proof lexbuf }
+  | '"'    { let n = string lexbuf in plines := !plines + n;
+             seen_proof := true; started_proof lexbuf }
+  | space+ | stars
+           { started_proof lexbuf }
+  | '\n'   { newline (); started_proof lexbuf }
+  | proof_end
+           { seen_proof := true; spec lexbuf }
+  | character | _
+           { seen_proof := true; started_proof lexbuf }
   | eof    { () }
 
 and proof_term = parse


### PR DESCRIPTION
The issue is fixed by making sure to not give any special treatment to the "Proof" keyword after seeing it the first time.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #21422 

I think that `rocq wc` is mostly undocumented, so I am not sure how to handle the yet-unchecked boxes. I am also not sure this requires adding to the changelog.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
