### PR TITLE
Reduce the API reliance on PConstraints.ContextSet.t

### DIFF
--- a/dev/ci/user-overlays/21424-ppedrot-chase-pconstraint-context-set.sh
+++ b/dev/ci/user-overlays/21424-ppedrot-chase-pconstraint-context-set.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/ppedrot/coq-elpi chase-pconstraint-context-set 21424

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -473,7 +473,7 @@ let context uctx =
 type named_universes_entry = universes_entry * UnivNames.universe_binders
 
 let check_mono_sort_constraints uctx =
-  let (uvar, (qcst, ucst)) = uctx in
+  let (uvar, (qcst, ucst)) = uctx.local in
   (* This looks very stringent but it passes nonetheless all the tests? *)
   let () = assert (Sorts.ElimConstraints.is_empty qcst) in
   (uvar, ucst)
@@ -483,7 +483,7 @@ let univ_entry ~poly uctx =
   let entry =
     if poly then Polymorphic_entry (context uctx)
     else
-      let uctx = check_mono_sort_constraints (context_set uctx) in
+      let uctx = check_mono_sort_constraints uctx in
       Monomorphic_entry uctx
   in
   entry, binders
@@ -1117,7 +1117,7 @@ let check_mono_univ_decl uctx decl =
     if not decl.univdecl_extensible_instance
     then check_universe_context_set ~prefix levels uctx.names
   in
-  if decl.univdecl_extensible_constraints then check_mono_sort_constraints uctx.local
+  if decl.univdecl_extensible_constraints then check_mono_sort_constraints uctx
   else
     let () = assert (Sorts.ElimConstraints.is_empty (fst csts)) in
     let () = check_implication uctx (univ_decl_csts decl) csts in

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -267,7 +267,7 @@ val check_uctx_impl : fail:(Pp.t -> unit) -> t -> t -> unit
 
 val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
 
-val check_template_univ_decl : t -> template_qvars:QVar.Set.t -> universe_decl -> PConstraints.ContextSet.t
+val check_template_univ_decl : t -> template_qvars:QVar.Set.t -> universe_decl -> Univ.ContextSet.t
 
 val check_mono_sort_constraints : t -> Univ.ContextSet.t
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -269,7 +269,7 @@ val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
 
 val check_template_univ_decl : t -> template_qvars:QVar.Set.t -> universe_decl -> PConstraints.ContextSet.t
 
-val check_mono_sort_constraints : PConstraints.ContextSet.t -> Univ.ContextSet.t
+val check_mono_sort_constraints : t -> Univ.ContextSet.t
 
 (** {5 TODO: Document me} *)
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -155,7 +155,7 @@ val name_level : Univ.Level.t -> Id.t -> t -> t
    the universes in [keep]. The constraints [csts] are adjusted so
    that transitive constraints between remaining universes (those in
    [keep] and those not in [univs]) are preserved. *)
-val restrict_universe_context : PConstraints.ContextSet.t -> Level.Set.t -> PConstraints.ContextSet.t
+val restrict_universe_context : Univ.ContextSet.t -> Level.Set.t -> Univ.ContextSet.t
 
 (** [restrict uctx ctx] restricts the local universes of [uctx] to
    [ctx] extended by local named universes and side effect universes

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -180,8 +180,7 @@ let decl_constant name univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
   let univs = UState.restrict_universe_context univs vars in
-  let () = Global.push_qualities QGraph.Static (PConstraints.ContextSet.sort_context_set univs) in (* XXX *)
-  let () = Global.push_context_set (PConstraints.ContextSet.univ_context_set univs) in
+  let () = Global.push_context_set univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
   let univs = UState.Monomorphic_entry Univ.ContextSet.empty, UnivNames.empty_binders in
   (* UnsafeMonomorphic: we always do poly:false *)
@@ -236,7 +235,8 @@ let exec_tactic env sigma n f args =
   let ((), pv, _, _, _) = Proofview.apply ~name:(Id.of_string "ring") ~poly:false (Global.env ()) tac pv in
   let sigma = Evd.minimize_universes (Proofview.return pv) in
   let nf c = constr_of sigma c in
-  Array.map nf !tactic_res, Evd.universe_context_set sigma
+  let uctx = UState.check_mono_univ_decl (Evd.ustate sigma) UState.default_univ_decl in
+  Array.map nf !tactic_res, uctx
 
 let gen_constant n = (); fun () -> (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref n)))
 let gen_reference n = (); fun () -> (Rocqlib.lib_ref n)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -535,15 +535,12 @@ let template_univ_entry sigma udecl ~template_univs pseudo_sort_poly =
   let uctx =
     UState.check_template_univ_decl (Evd.ustate sigma) ~template_qvars udecl
   in
-  (* XXX: it should be fine to drop the sort constraints but it should be reflected in the API *)
-  let elim_constraints = PConstraints.ContextSet.elim_constraints uctx in
-  let uctx = PConstraints.ContextSet.univ_context_set uctx in
   let ubinders = UState.Monomorphic_entry uctx, Evd.universe_binders sigma in
   let template_univs, global = split_universe_context template_univs uctx in
   let uctx =
     UVars.UContext.of_context_set
       (UState.compute_instance_binders @@ Evd.ustate sigma)
-      ((template_qvars, elim_constraints), template_univs)
+      ((template_qvars, Sorts.ElimConstraints.empty), template_univs)
   in
   let default_univs =
     let inst = UVars.UContext.instance uctx in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2914,7 +2914,7 @@ let declare_entry ?loc ~name ?scope ~kind ?user_warns ?hook ~impargs ~uctx entry
 
 let declare_definition_full ~info ~cinfo ~opaque ~body ?using sigma =
   let c, uctx = declare_definition ~obls:[] ~info ~cinfo ~opaque ~body ?using sigma in
-  c, if info.poly then PConstraints.ContextSet.empty else UState.context_set uctx
+  c, if info.poly then Univ.ContextSet.empty else PConstraints.ContextSet.univ_context_set @@ UState.context_set uctx
 
 let declare_definition ~info ~cinfo ~opaque ~body ?using sigma =
   declare_definition ~obls:[] ~info ~cinfo ~opaque ~body ?using sigma |> fst

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -465,7 +465,7 @@ val declare_definition_full
   -> body:EConstr.t
   -> ?using:Vernacexpr.section_subset_expr
   -> Evd.evar_map
-  -> GlobRef.t * PConstraints.ContextSet.t
+  -> GlobRef.t * Univ.ContextSet.t
 
 (** Declaration messages, for internal use *)
 


### PR DESCRIPTION
There are still quite a few offending APIs, but their number is going down.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/943