### PR TITLE
Inline Evd.universe_rigidity in its only caller (refresh univs)

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1140,14 +1140,6 @@ let is_eq_sort s1 s2 =
   if Sorts.equal s1 s2 then None
   else Some (s1, s2)
 
-(* Precondition: l is not defined in the substitution *)
-let universe_rigidity evd l =
-  let uctx = evd.universes in
-  (* XXX why are we considering all locals to be flexible here? *)
-  if Univ.Level.Set.mem l (fst (UState.universe_context_set uctx)) then
-    UnivFlexible (UState.is_algebraic l uctx)
-  else UnivRigid
-
 let normalize_universe_instance evd l =
   UState.nf_instance evd.universes l
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -584,8 +584,6 @@ val new_sort_variable : ?loc:Loc.t -> rigid -> evar_map -> evar_map * esorts
 
 val add_forgotten_univ : evar_map -> Univ.Level.t -> evar_map
 
-val universe_rigidity : evar_map -> Univ.Level.t -> rigid
-
 val make_nonalgebraic_variable : evar_map -> Univ.Level.t -> evar_map
 (** See [UState.make_nonalgebraic_variable]. *)
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -140,15 +140,14 @@ let refresh_universes ?(allowed_evars=AllowedEvars.all) ?(status=univ_rigid) ?(o
         (match Univ.Universe.level u with
         | None -> refresh_sort status ~direction s
         | Some l ->
-           (match Evd.universe_rigidity !evdref l with
-            | UnivRigid ->
-              if not onlyalg && (not (Univ.Level.is_set l) || (refreshset && not direction))
-              then refresh_sort status ~direction s
-               else t
-            | UnivFlexible alg ->
-               (if alg then
-                  evdref := Evd.make_nonalgebraic_variable !evdref l);
-               t))
+          (if Univ.Level.Set.mem l (fst @@ Evd.universe_context_set !evdref) then
+             let () = if UState.is_algebraic l (Evd.ustate !evdref) then
+                 evdref := Evd.make_nonalgebraic_variable !evdref l
+             in
+             t
+           else if not onlyalg && (not (Univ.Level.is_set l) || (refreshset && not direction))
+           then refresh_sort status ~direction s
+           else t))
       | Set when refreshset && not direction ->
        (* Cannot make a universe "lower" than "Set",
           only refreshing when we want higher universes. *)


### PR DESCRIPTION
This lets us avoid producing UnivFlexible for local but rigid univs.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/684 (backwards compatible)
