### PR TITLE
Remove most of the uses of UState.merge in the code.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1047,8 +1047,7 @@ let merge_context_set ?loc ?(sideff=false) rigid evd uctx' =
   {evd with universes = UState.merge ?loc ~sideff rigid evd.universes uctx'}
 
 let merge_universe_context_set ?loc ?(sideff=false) rigid evd uctx' =
-  let uctx' = PConstraints.ContextSet.of_univ_context_set uctx' in
-  {evd with universes = UState.merge ?loc ~sideff rigid evd.universes uctx'}
+  {evd with universes = UState.merge_universe_context ?loc ~sideff rigid evd.universes uctx'}
 
 let merge_sort_context_set ?loc ?(sideff=false) rigid src evd ctx' =
   {evd with universes = UState.merge_sort_context ?loc ~sideff rigid src evd.universes ctx'}

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1274,6 +1274,9 @@ let merge_sort_variables ?loc ~sideff uctx src qvars csts =
   let sort_variables = QState.merge_constraints (merge_elim_constraints src uctx csts) sort_variables in
   { uctx with sort_variables; names }
 
+let merge_universe_context ?loc ~sideff rigid uctx (us, ucst) =
+  merge ?loc ~sideff rigid uctx (us, (Sorts.ElimConstraints.empty, ucst))
+
 let merge_sort_context ?loc ~sideff rigid src uctx ((qvars,levels),csts) =
   let uctx = merge_sort_variables ?loc ~sideff uctx src qvars (PConstraints.qualities csts) in
   merge ?loc ~sideff rigid uctx (levels,csts)

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -184,6 +184,7 @@ val univ_flexible_alg : rigid
 val merge : ?loc:Loc.t -> sideff:bool -> rigid -> t -> PConstraints.ContextSet.t -> t
 val merge_sort_variables : ?loc:Loc.t -> sideff:bool -> t -> QGraph.constraint_source -> Sorts.QVar.Set.t -> Sorts.ElimConstraints.t -> t
 val merge_sort_context : ?loc:Loc.t -> sideff:bool -> rigid -> QGraph.constraint_source -> t -> UnivGen.sort_context_set -> t
+val merge_universe_context : ?loc:Loc.t -> sideff:bool -> rigid -> t -> Univ.ContextSet.t -> t
 
 val demote_global_univs : Univ.ContextSet.t -> t -> t
 (** After declaring global universes, call this if you want to keep using the UState.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -737,7 +737,7 @@ let declare_private_constant ?role ?ts ~name ~opaque de effs =
 
 let inline_private_constants ~uctx env (body, eff) =
   let body, ctx = Safe_typing.inline_private_constants env (body, SideEff.get eff) in
-  let uctx = UState.merge ~sideff:true Evd.univ_rigid uctx (PConstraints.ContextSet.of_univ_context_set ctx) in
+  let uctx = UState.merge_universe_context ~sideff:true Evd.univ_rigid uctx ctx in
   body, uctx
 
 (** Declaration of section variables and local definitions *)


### PR DESCRIPTION
The last user in the Rocq code base is Evd.merge_context_set, which is very broken but sensitive. This commit sanitizes the parts that can be, and we will fix the remaining callers of the above function one by one.