### PR TITLE
Add `Printing Fully Qualified` flag to print constants with full module paths

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21443-copilot-add-fully-qualified-identifiers-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21443-copilot-add-fully-qualified-identifiers-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :flag:`Printing Fully Qualified` to print all names (global references, modules,
+  module types, universes, etc) using fully qualified paths
+  (`#21443 <https://github.com/rocq-prover/rocq/pull/21443>`_,
+  fixes `#11852 <https://github.com/rocq-prover/rocq/issues/11852>`_,
+  by Jason Gross).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1097,6 +1097,21 @@ Printing constructions in full
 
       .. see a contrived example here: https://github.com/rocq-prover/rocq/pull/11718#discussion_r415481854
 
+.. flag:: Printing Fully Qualified
+
+   When this :term:`flag` is turned on, all names (global references such as constants,
+   inductives, constructors, and section variables, as well as modules, module types,
+   universes, etc) are printed using their fully qualified paths. This is useful when
+   there are multiple objects with the same short name in different modules, and you
+   want to clearly distinguish them.
+
+   For example, if you have both ``Foo.ax`` and ``Bar.ax`` defined, turning on this
+   flag will ensure they are printed as ``Module.Foo.ax`` and ``Module.Bar.ax``
+   respectively (where ``Module`` is the top-level module name), rather than
+   potentially ambiguous short names.
+
+   This flag is off by default.
+
 .. _controlling-typing-flags:
 
 Controlling Typing Flags

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -339,7 +339,7 @@ let visible_ids sigma (nenv, c) =
     let g = global_of_constr c in
     if not (GlobRef.Set_env.mem g gseen) then
       let gseen = GlobRef.Set_env.add g gseen in
-      let ids = match Nametab.shortest_qualid_of_global Id.Set.empty g with
+      let ids = match Nametab.shortest_qualid_of_global ~force_short:true Id.Set.empty g with
       | short ->
         let dir, id = repr_qualid short in
         if DirPath.is_empty dir then Id.Set.add id ids else ids

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -843,7 +843,7 @@ let free_rels_and_unqualified_refs sigma t =
       if not (GlobRef.Set_env.mem g gseen) then begin
         try
           let gseen = GlobRef.Set_env.add g gseen in
-          let short = Nametab.shortest_qualid_of_global Id.Set.empty g in
+          let short = Nametab.shortest_qualid_of_global ~force_short:true Id.Set.empty g in
           let dir, id = Libnames.repr_qualid short in
           let ids = if DirPath.is_empty dir then Id.Set.add id ids else ids in
           (gseen, vseen, ids)

--- a/interp/abbreviation.ml
+++ b/interp/abbreviation.ml
@@ -67,7 +67,7 @@ let toggle_if ~on ~use filter =
 
 let is_alias_of_already_visible_name sp = function
   | _,Notation_term.NRef (ref,None) ->
-      let (dir,id) = repr_qualid (Nametab.shortest_qualid_of_global Id.Set.empty ref) in
+      let (dir,id) = repr_qualid (Nametab.shortest_qualid_of_global ~force_short:true Id.Set.empty ref) in
       DirPath.is_empty dir && Id.equal id (basename sp)
   | _ ->
       false

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -101,16 +101,18 @@ module type NAMETAB = sig
   val remove : full_path -> elt -> unit
   (** Remove an element. *)
 
-  val shortest_qualid_gen : ?loc:Loc.t -> (Id.t -> bool) -> elt -> qualid
+  val shortest_qualid_gen : ?loc:Loc.t -> ?force_short:bool -> (Id.t -> bool) -> elt -> qualid
   (** [shortest_qualid_gen avoid v]: given an object [v] with full
       name Mylib.A.B.x, try to find the shortest among x, B.x, A.B.x
       and Mylib.A.B.x that denotes the same object.
       If [avoid] is [true] on [x] it is assumed to denote something else
       (so B.x is the shortest qualid that could be returned).
+      If [~force_short:true] is passed, always returns the shortest qualid.
+      Otherwise, respects the "Printing Fully Qualified" flag.
 
       @raise Not_found for unknown objects. *)
 
-  val shortest_qualid : ?loc:Loc.t -> Id.Set.t -> elt -> qualid
+  val shortest_qualid : ?loc:Loc.t -> ?force_short:bool -> Id.Set.t -> elt -> qualid
   (** Like [shortest_qualid_gen] but using an id set instead of a closure. *)
 
   val pr : elt -> Pp.t
@@ -213,12 +215,23 @@ val path_of_global : GlobRef.t -> full_path
 
 val path_of_abbreviation : Globnames.abbreviation -> full_path
 
-val shortest_qualid_of_global : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val shortest_qualid_of_abbreviation : ?loc:Loc.t -> Id.Set.t -> Globnames.abbreviation -> qualid
+val shortest_qualid_of_global : ?loc:Loc.t -> ?force_short:bool -> Id.Set.t -> GlobRef.t -> qualid
+(** Returns a qualid for the given global reference. If [~force_short:true] is
+    passed, always returns the shortest qualid. Otherwise (default), respects
+    the "Printing Fully Qualified" flag: when the flag is set, returns the fully
+    qualified name; when unset, returns the shortest qualid. *)
+
+val shortest_qualid_of_abbreviation : ?loc:Loc.t -> ?force_short:bool -> Id.Set.t -> Globnames.abbreviation -> qualid
 
 (** Printing of global references using names as short as possible.
     @raise Not_found when the reference is not in the global tables. *)
 val pr_global_env : Id.Set.t -> GlobRef.t -> Pp.t
+
+(** Fully qualified printing control. When enabled, [pr_global_env] uses
+    fully qualified names instead of shortest names. The flag is controlled
+    by the "Printing Fully Qualified" option declared in printer.ml. *)
+val print_fully_qualified : unit -> bool
+val set_print_fully_qualified : bool -> unit
 
 (** Returns in particular the dirpath or the basename of the full path
    associated to global reference *)
@@ -371,9 +384,9 @@ val path_of_universe : Univ.UGlobal.t -> full_path
    Mylib.A.B.x that denotes the same object.
    @raise Not_found for unknown objects. *)
 
-val shortest_qualid_of_modtype : ?loc:Loc.t -> ModPath.t -> qualid
-val shortest_qualid_of_module : ?loc:Loc.t -> ModPath.t -> qualid
-val shortest_qualid_of_dir : ?loc:Loc.t -> GlobDirRef.t -> qualid
+val shortest_qualid_of_modtype : ?loc:Loc.t -> ?force_short:bool -> ModPath.t -> qualid
+val shortest_qualid_of_module : ?loc:Loc.t -> ?force_short:bool -> ModPath.t -> qualid
+val shortest_qualid_of_dir : ?loc:Loc.t -> ?force_short:bool -> GlobDirRef.t -> qualid
 
 (** In general we have a [UnivNames.universe_binders] around rather than a [Id.Set.t] *)
-val shortest_qualid_of_universe : ?loc:Loc.t -> 'u Id.Map.t -> Univ.UGlobal.t -> qualid
+val shortest_qualid_of_universe : ?loc:Loc.t -> ?force_short:bool -> 'u Id.Map.t -> Univ.UGlobal.t -> qualid

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -114,7 +114,7 @@ val interp_notation : ltac_notation -> notation_data
 val push_ltac : visibility -> full_path -> tacref -> unit
 val locate_ltac : qualid -> tacref
 val locate_extended_all_ltac : qualid -> tacref list
-val shortest_qualid_of_ltac : ?loc:Loc.t -> Id.Set.t -> tacref -> qualid
+val shortest_qualid_of_ltac : ?loc:Loc.t -> ?force_short:bool -> Id.Set.t -> tacref -> qualid
 val path_of_ltac : tacref -> full_path
 
 val push_constructor : ?user_warns:UserWarn.t -> visibility -> full_path -> ltac_constructor -> unit

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -405,7 +405,7 @@ let free_glob_vars =
 let glob_visible_short_qualid c =
   let rec aux acc c = match DAst.get c with
     | GRef (c,_) ->
-        let qualid = Nametab.shortest_qualid_of_global Id.Set.empty c in
+        let qualid = Nametab.shortest_qualid_of_global ~force_short:true Id.Set.empty c in
         let dir,id = Libnames.repr_qualid  qualid in
         if DirPath.is_empty dir then Id.Set.add id acc else acc
     | _ ->

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -45,6 +45,14 @@ let { Goptions.get = should_gname } =
     ~value:false
     ()
 
+let () =
+  Goptions.declare_bool_option
+    { Goptions.optstage = Summary.Stage.Interp;
+      Goptions.optdepr  = None;
+      Goptions.optkey   = ["Printing";"Fully";"Qualified"];
+      Goptions.optread  = Nametab.print_fully_qualified;
+      Goptions.optwrite = Nametab.set_print_fully_qualified }
+
 let print_goal_name sigma ev =
   should_gname () || Evd.evar_has_unambiguous_name ev sigma
 

--- a/test-suite/output/PrintFullyQualified.out
+++ b/test-suite/output/PrintFullyQualified.out
@@ -1,0 +1,6 @@
+use_foo
+use_bar
+use_nested
+PrintFullyQualified.use_foo
+PrintFullyQualified.use_bar
+PrintFullyQualified.use_nested

--- a/test-suite/output/PrintFullyQualified.v
+++ b/test-suite/output/PrintFullyQualified.v
@@ -1,0 +1,35 @@
+(* Test file for Printing Fully Qualified option *)
+
+Module Foo.
+  Axiom ax : False.
+End Foo.
+
+Module Bar.
+  Axiom ax : False.
+End Bar.
+
+Definition use_foo := Foo.ax.
+Definition use_bar := Bar.ax.
+
+(* Test with nested modules *)
+Module Outer.
+  Module Inner.
+    Definition def := 0.
+  End Inner.
+End Outer.
+
+Definition use_nested := Outer.Inner.def.
+
+(* Search with name-only output - default (shortest names) *)
+Set Search Output Name Only.
+Search "use_foo".
+Search "use_bar".
+Search "use_nested".
+
+(* Search with name-only output - fully qualified *)
+Set Printing Fully Qualified.
+Search "use_foo".
+Search "use_bar".
+Search "use_nested".
+
+Unset Printing Fully Qualified.


### PR DESCRIPTION

Fixes / closes #11852


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
