### PR TITLE
Fix #21434: coqchk gives fatal error on module subtyping.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -225,7 +225,13 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
     let state = ((Environ.qualities env, Environ.universes env), Conversion.checked_universes) in
     let _ : QGraph.t * UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
-    let subst = Mod_subst.map_mbid farg_id mp (Mod_subst.empty_delta_resolver mp) in
+    let mp_delta =
+      let mb = lookup_module mp env in
+      match mod_type mb with
+      | NoFunctor _ -> mod_delta mb
+      | MoreFunctor _ -> Mod_subst.empty_delta_resolver mp
+    in
+    let subst = Mod_subst.map_mbid farg_id mp mp_delta in
     Modops.subst_signature subst mp_mse fbody_b, Mod_subst.subst_codom_delta_resolver subst delta
   | MEwith _ -> CErrors.user_err Pp.(str "Unsupported 'with' constraint in module implementation")
 

--- a/test-suite/bugs/bug_21434.v
+++ b/test-suite/bugs/bug_21434.v
@@ -1,0 +1,36 @@
+Module Type Alphs.
+End Alphs.
+
+Module Symbol(Import A:Alphs).
+
+  Inductive symbol :=.
+
+End Symbol.
+
+Module Type Grammar_T.
+  Include Symbol.
+End Grammar_T.
+
+Module Type Automaton_T.
+  Declare Module Gram:Grammar_T.
+End Automaton_T.
+
+Module Validator_safe(Import A:Automaton_T).
+
+Definition head_symbs_of_state := A.Gram.symbol.
+
+End Validator_safe.
+
+Module Gram.
+
+Include Symbol.
+
+End Gram.
+
+Module Aut.
+
+Module Gram := Gram.
+
+End Aut.
+
+Module Boom := Validator_safe Aut.


### PR DESCRIPTION
The checker was incorrectly ignoring the δ-resolver associated to the argument of a functor application when recomputing the signature of an algebraic expression, leading to ill-formed kernel pairs. We fix it by doing basically the same thing as the kernel, up to the fact that we do not try to perform inlining. It should not matter as typing is stable by conversion.