### PR TITLE
Centralize the Nativenorm global state in a reference-passed record

### DIFF
--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -66,7 +66,7 @@ val is_loaded_native_file : string -> bool
 val compile_constant_field : cenv -> env -> Constant.t ->
   global list -> constant_body -> global list
 
-val compile_mind_field : ModPath.t -> Id.t ->
+val compile_mind_field : cenv -> ModPath.t -> Id.t ->
   global list -> mutual_inductive_body -> global list
 
 val compile_rewrite_rules : env -> Id.t ->

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -20,6 +20,7 @@ to OCaml code. *)
 type cenv
 
 val make_cenv : unit -> cenv
+val get_cenv_symbols : cenv -> symbols
 
 type global
 
@@ -30,9 +31,6 @@ val keep_debug_files : unit -> bool
 val pp_global : Format.formatter -> global -> unit
 
 val mk_open : string -> global
-
-(* Precomputed values for a compilation unit *)
-val clear_symbols : unit -> unit
 
 val get_value : symbols -> int -> Nativevalues.t
 
@@ -52,10 +50,8 @@ val get_instance : symbols -> int -> UVars.Instance.t
 
 val get_proj : symbols -> int -> inductive * int
 
-val get_symbols : unit -> symbols
-
 type code_location_updates
-type linkable_code = global list * code_location_updates
+type linkable_code = global list * symbols * code_location_updates
 
 val empty_updates : code_location_updates
 

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -17,6 +17,10 @@ open Nativevalues
 compiler. mllambda represents a fragment of ML, and can easily be printed
 to OCaml code. *)
 
+type cenv
+
+val make_cenv : unit -> cenv
+
 type global
 
 val debug_native_compiler : CDebug.t
@@ -53,15 +57,13 @@ val get_symbols : unit -> symbols
 type code_location_updates
 type linkable_code = global list * code_location_updates
 
-val clear_global_tbl : unit -> unit
-
 val empty_updates : code_location_updates
 
 val register_native_file : string -> unit
 
 val is_loaded_native_file : string -> bool
 
-val compile_constant_field : env -> Constant.t ->
+val compile_constant_field : cenv -> env -> Constant.t ->
   global list -> constant_body -> global list
 
 val compile_mind_field : ModPath.t -> Id.t ->

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -176,11 +176,11 @@ let warn_no_native_compiler =
 let native_conv_gen (type err) pb sigma env (state, check) t1 t2 =
   Nativelib.link_libraries ();
   let ml_filename, prefix = Nativelib.get_ml_filename () in
-  let code, upds = mk_conv_code env sigma prefix t1 t2 in
+  let code, symbols, upds = mk_conv_code env sigma prefix t1 t2 in
   let fn = Nativelib.compile ml_filename code ~profile:false in
   debug_native_compiler (fun () -> Pp.str "Running test...");
   let t0 = Sys.time () in
-  let (rt1, rt2) = Nativelib.execute_library ~prefix fn upds in
+  let (rt1, rt2) = Nativelib.execute_library ~prefix fn symbols upds in
   let rt1 = Option.get rt1 and rt2 = Option.get rt2 in
   let t1 = Sys.time () in
   let time_info = Format.sprintf "Evaluation done in %.5f@." (t1 -. t0) in

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -74,8 +74,11 @@ let get_include_dirs () =
 (* Pointer to the function linking an ML object into Rocq's toplevel *)
 let load_obj = ref (fun _x -> () : string -> unit)
 
+let rsymbols = ref Nativevalues.empty_symbols
 let rt1 = ref None
 let rt2 = ref None
+
+let get_symbols () = !rsymbols
 
 let get_ml_filename () =
   let temp_dir = Lazy.force my_temp_dir in
@@ -176,9 +179,10 @@ let compile_library (code, symb) fn =
   let _ = call_compiler fn in
   delay_cleanup_file fn
 
-let execute_library ~prefix f upds =
-  rt1 := None;
-  rt2 := None;
+let execute_library ~prefix f symbols upds =
+  let () = rt1 := None in
+  let () = rt2 := None in
+  let () = rsymbols := symbols in
   if not (Sys.file_exists f) then
     CErrors.user_err Pp.(str "Cannot find native compiler file " ++ str f);
   if Dynlink.is_native then Dynlink.loadfile f else !load_obj f;

--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -39,7 +39,7 @@ val compile_library : native_library -> string -> unit
     updates the library locations [upds], and returns the values stored
     in [rt1] and [rt2] *)
 val execute_library :
-  prefix:string -> string -> Nativecode.code_location_updates ->
+  prefix:string -> string -> Nativevalues.symbols -> Nativecode.code_location_updates ->
   Nativevalues.t option * Nativevalues.t option
 
 (** [enable_library] marks the given library for dynamic loading
@@ -49,5 +49,6 @@ val enable_library : string -> Names.DirPath.t -> unit
 val link_libraries : unit -> unit
 
 (* used for communication with the loaded libraries *)
+val get_symbols : unit -> Nativevalues.symbols
 val rt1 : Nativevalues.t option ref
 val rt2 : Nativevalues.t option ref

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -44,7 +44,7 @@ and translate_field mp cenv env acc (l,x) =
         let id = mb.mind_packets.(0).mind_typename in
         let msg = Printf.sprintf "Compiling inductive %s..." (Id.to_string id) in
         Pp.str msg));
-     compile_mind_field mp l acc mb
+     compile_mind_field cenv mp l acc mb
   | SFBrules rrb ->
      (debug_native_compiler (fun () ->
         let msg = Printf.sprintf "Not Compiling rules %s..." (Id.to_string l) in

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -17,28 +17,28 @@ open Nativecode
 (** This file implements separate compilation for libraries in the native
 compiler *)
 
-let rec translate_mod mp env mod_expr acc =
+let rec translate_mod mp cenv env mod_expr acc =
   match mod_expr with
   | NoFunctor struc ->
-    List.fold_left (translate_field mp env) acc struc
+    List.fold_left (translate_field mp cenv env) acc struc
   | MoreFunctor _ -> acc
 
 (* XXX I believe it makes no sense to extract module types *)
-and translate_modtype mp env mod_expr reso acc =
+and translate_modtype mp cenv env mod_expr reso acc =
   match mod_expr with
   | NoFunctor struc ->
     let env' = add_structure mp struc reso env in
-    List.fold_left (translate_field mp env') acc struc
+    List.fold_left (translate_field mp cenv env') acc struc
   | MoreFunctor _ -> acc
 
-and translate_field mp env acc (l,x) =
+and translate_field mp cenv env acc (l,x) =
   match x with
   | SFBconst cb ->
      let con = Constant.make2 mp l in
      (debug_native_compiler (fun () ->
         let msg = Printf.sprintf "Compiling constant %s..." (Constant.to_string con) in
         Pp.str msg));
-     compile_constant_field env con acc cb
+     compile_constant_field cenv env con acc cb
   | SFBmind mb ->
      (debug_native_compiler (fun () ->
         let id = mb.mind_packets.(0).mind_typename in
@@ -57,7 +57,7 @@ and translate_field mp env acc (l,x) =
           Printf.sprintf "Compiling module %s..." (ModPath.to_string mp)
         in
         Pp.str msg));
-     translate_mod mp env (mod_type md) acc
+     translate_mod mp cenv env (mod_type md) acc
   | SFBmodtype mdtyp ->
      let mp = MPdot (mp, l) in
      (debug_native_compiler (fun () ->
@@ -65,7 +65,7 @@ and translate_field mp env acc (l,x) =
           Printf.sprintf "Compiling module type %s..." (ModPath.to_string mp)
         in
         Pp.str msg));
-     translate_modtype mp env (mod_type mdtyp) (mod_delta mdtyp) acc
+     translate_modtype mp cenv env (mod_type mdtyp) (mod_delta mdtyp) acc
 
 (* This function expects the contents of the module to be part of [env] already *)
 let dump_library mp env mod_expr =
@@ -73,10 +73,10 @@ let dump_library mp env mod_expr =
   match mod_expr with
   | NoFunctor struc ->
       let t0 = Sys.time () in
-      clear_global_tbl ();
       clear_symbols ();
+      let cenv = Nativecode.make_cenv () in
       let mlcode =
-        List.fold_left (translate_field mp env) [] struc
+        List.fold_left (translate_field mp cenv env) [] struc
       in
       let t1 = Sys.time () in
       let time_info = Format.sprintf "Time spent generating this code: %.5fs" (t1-.t0) in

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -73,7 +73,6 @@ let dump_library mp env mod_expr =
   match mod_expr with
   | NoFunctor struc ->
       let t0 = Sys.time () in
-      clear_symbols ();
       let cenv = Nativecode.make_cenv () in
       let mlcode =
         List.fold_left (translate_field mp cenv env) [] struc
@@ -81,5 +80,6 @@ let dump_library mp env mod_expr =
       let t1 = Sys.time () in
       let time_info = Format.sprintf "Time spent generating this code: %.5fs" (t1-.t0) in
       let mlcode = add_header_comment (List.rev mlcode) time_info in
-      mlcode, get_symbols ()
+      let symbols = Nativecode.get_cenv_symbols cenv in
+      mlcode, symbols
   | _ -> assert false

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -494,7 +494,7 @@ let native_norm env sigma c ty =
     let print_timing = get_timing_enabled () in
     let ml_filename, prefix = Nativelib.get_ml_filename () in
     let tnc0 = Unix.gettimeofday () in
-    let code, upd = mk_norm_code env (evars_of_evar_map sigma) prefix c in
+    let code, symbols, upd = mk_norm_code env (evars_of_evar_map sigma) prefix c in
     let tnc1 = Unix.gettimeofday () in
     let time_info = Format.sprintf "native_compute: Conversion to native code done in %.5f" (tnc1 -. tnc0) in
     if print_timing then Feedback.msg_info (Pp.str time_info);
@@ -505,7 +505,7 @@ let native_norm env sigma c ty =
     if print_timing then Feedback.msg_info (Pp.str time_info);
     let profiler_pid = if profile then start_profiler () else None in
     let t0 = Unix.gettimeofday () in
-    let (rt1, _) = Nativelib.execute_library ~prefix fn upd in
+    let (rt1, _) = Nativelib.execute_library ~prefix fn symbols upd in
     let rt1 = Option.get rt1 in
     let t1 = Unix.gettimeofday () in
     if profile then stop_profiler profiler_pid;


### PR DESCRIPTION
This was a very bad implementation that is, for some reason, common in the OCaml compiler world. Rather than haphazardly mutating some global references, with pass instead a locally mutable state along and ask toplevel callers to provide one.

We had to tweak a little bit the native runtime to fetch the symbol table from Nativelib rather than Nativecode, but this is rather transparent as both are implicitly opened by the generated native code.