### PR TITLE
feat: Remove Type eliminates to any sort by default

### DIFF
--- a/doc/changelog/01-kernel/21453-remove-type-to-sorts-Changed.rst
+++ b/doc/changelog/01-kernel/21453-remove-type-to-sorts-Changed.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  `Type` does not eliminate to every sort by default
+  (`#21453 <https://github.com/rocq-prover/rocq/pull/21453>`_,
+  by Tomas Diaz).

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -135,7 +135,13 @@ let compute_elim_squash ?(is_real_arg=false) env u info =
     | QSort (q, _), (SProp | Prop) ->
         if Environ.Internal.is_above_prop env q then info
         else add_squash (Sorts.quality u) info
-    | _, _ -> { info with ind_squashed = Some AlwaysSquashed }
+    | (Type _ | Set), QSort (q, _) -> add_squash (QVar q) info
+    | SProp, (Prop | Type _ | Set) ->
+        { info with ind_squashed = Some AlwaysSquashed }
+    | Prop, (Type _ | Set) -> { info with ind_squashed = Some AlwaysSquashed }
+    (* These cases should not happen because `eliminates_to` above should be true,
+      * e.g., Type -> (S)Prop, SProp -> SProp, etc. *)
+    | (Type _ | Set | SProp | Prop), _ -> assert false
 
 let check_context_univs ~ctor env info ctx =
   let check_one d (info,env) =

--- a/test-suite/output/sort_poly_elab.v
+++ b/test-suite/output/sort_poly_elab.v
@@ -440,6 +440,13 @@ Module Inductives.
   (* α α0 ; u |= α -> SProp *)
   About list_idS.
 
+  Fixpoint list_idTS {A : Type} (l : list@{_ Type;_} A) : list A :=
+    match l with
+    | nil => nil
+    | cons x l => cons x (list_idTS l)
+    end.
+  About list_idTS.
+
   Fixpoint map A B f (l : list A) : list B :=
     match l with
     | nil => nil
@@ -495,6 +502,13 @@ Module Inductives.
   Defined.
   (* α ;  |= α -> Type *)
   About bool_to_Prop'.
+
+  Definition bool_idTS (b : bool@{Type;}) : bool :=
+    match b with
+    | true => true
+    | false => false
+    end.
+  About bool_idTS.
 
   #[universes(polymorphic=no)]
   Sort Test.

--- a/test-suite/success/sort_poly.v
+++ b/test-suite/success/sort_poly.v
@@ -213,7 +213,9 @@ Module Inductives.
   Definition R5f1_sprop (A:SProp) (r:R5 A) : A := let (f) := r in f.
   Fail Definition R5f1_prop (A:Prop) (r:R5 A) : A := let (f) := r in f.
 
-  Record R6@{s; |} (A:Type@{s;Set}) := { R6f1 : A; R6f2 : nat }.
+  (* This is now invalid since Type does not eliminate to arbitrary sorts by default *)
+  Fail Record R6@{s; |} (A:Type@{s;Set}) := { R6f1 : A; R6f2 : nat }.
+  Record R6@{s; |Type->s} (A:Type@{s;Set}) := { R6f1 : A; R6f2 : nat }.
   Check fun (A:SProp) (x y : R6 A) =>
           eq_refl : Conversion.box _ x.(R6f1 _) = Conversion.box _ y.(R6f1 _).
   Fail Check fun (A:Prop) (x y : R6 A) =>
@@ -286,7 +288,10 @@ Module Inductives.
 
   Arguments exist3 {_ _}.
 
-  Definition π1@{s s';u v|} {A:Type@{s;u}} {P:A -> Type@{s';v}} (p : sigma3@{_ _ Type;_ _} A P) : A :=
+  (* This is now invalid since Type does not eliminate to arbitrary sorts by default *)
+  Fail Definition π1@{s s';u v|} {A:Type@{s;u}} {P:A -> Type@{s';v}} (p : sigma3@{_ _ Type;_ _} A P) : A :=
     match p return A with exist3 a _ => a end.
-
+  Definition π1@{s s';u v|Type -> s} {A:Type@{s;u}} {P:A -> Type@{s';v}} (p : sigma3@{_ _ Type;_ _} A P) : A :=
+    match p return A with exist3 a _ => a end.
+  (* s s' ; u v |= Type -> s *)
 End Inductives.

--- a/test-suite/success/sort_poly_elim_csts.v
+++ b/test-suite/success/sort_poly_elim_csts.v
@@ -192,3 +192,17 @@ Fixpoint list'_idV@{s s0 s';l l'|l <= l', s0 -> s'} {A : Type@{s;l}} (l : List'@
   | nil' => nil'
   | cons' x l => cons' x (list'_idV l)
   end.
+
+Inductive bool@{s;} : Type@{s;Set} := true | false.
+
+Fail Definition bool_idTS@{s;} (b : bool@{Type;}) : bool@{s;} :=
+  match b with
+  | true => true
+  | false => false
+  end.
+
+Definition bool_idTS@{s;| Type -> s} (b : bool@{Type;}) : bool@{s;} :=
+  match b with
+  | true => true
+  | false => false
+  end.


### PR DESCRIPTION
This PR depends on #21417 . 

This PR removes the default behavior of `Type` eliminating to any sort.

Associated RFC : https://github.com/rocq-prover/rfcs/pull/111.

----
- [x] Added / updated **test-suite**.
<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
- [ ] Opened **overlay** pull requests.