### PR TITLE
Do not query unfocused goals when the printing option is unset in RocqIDE

### DIFF
--- a/ide/rocqide/rocqOps.ml
+++ b/ide/rocqide/rocqOps.ml
@@ -475,7 +475,8 @@ object(self)
         script#recenter_insert
       end
     end;
-    let flags = { gf_mode = "full"; gf_fg = true; gf_bg = true; gf_shelved = false; gf_given_up = false } in
+    let gf_bg = PrintOpt.printing_unfocused () in
+    let flags = { gf_mode = "full"; gf_fg = true; gf_bg; gf_shelved = false; gf_given_up = false } in
     let return x = RocqDriver.return (Good x) in
     let (>>=) m f = RocqDriver.bind m (function
     | Fail x -> RocqDriver.return (Fail x)


### PR DESCRIPTION
This is potentially very expensive when there are many goals open in the background, but completely useless as this data is never accessed if the flag is unset. See Wg_ProofView.mode_tactic for the only client of the returned data.