### PR TITLE
Remove a footgun in UState API.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -844,7 +844,7 @@ let add_quconstraints d c =
   { d with universes = UState.add_quconstraints d.universes c }
 
 let add_constraints d c =
-  { d with universes = UState.add_constraints QGraph.Internal d.universes c Sorts.ElimConstraints.empty }
+  { d with universes = UState.add_constraints QGraph.Internal d.universes c }
 
 (*** /Lifting... ***)
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -126,7 +126,7 @@ val add_poly_constraints : QGraph.constraint_source -> t -> PConstraints.t -> t
 
 val add_quconstraints : t -> Sorts.QUConstraints.t -> t
 
-val add_constraints : QGraph.constraint_source -> t -> UnivProblem.Set.t -> ElimConstraints.t -> t
+val add_constraints : QGraph.constraint_source -> t -> UnivProblem.Set.t -> t
 (**
   @raise UniversesDiffer when universes differ
 *)


### PR DESCRIPTION
The UState.add_constraints function was mostly ignoring its elimination constraint argument, simply pushing it into the local state without checking anything. This argument is morally redundant with the universe problem set, especially when we allow to have elimination constraints in unification.

Unfortunately, some callers were not really aware of that issue, the most prominent example being UState.add_poly_constraints, resulting in a potential loss of constraint tracking when adding sort equality constraints rather than just sort elimination constraints.