### PR TITLE
Improve error messages around module typing issues

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -49,6 +49,7 @@ Ali Caglayan <alizter@gmail.com>                   Alizter <Alizter@users.norepl
 Arthur Charguéraud <arthur@chargueraud.org>        charguer <arthur@chargueraud.org>
 chluebi <42419603+chluebi@users.noreply.github.com>  chluebi <42419603+chluebi@users.noreply.github.com>
 Tej Chajed <tchajed@mit.edu>                       tchajed
+Jeffrey Chang <72239159+JeffreyChang12@users.noreply.github.com>  JeffreyChang12 <72239159+JeffreyChang12@users.noreply.github.com>
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xclerc@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xavier.clerc@inria.fr>
 Cyril Cohen <cyril.cohen@crans.org>                Cyril Cohen <cohen@crans.org>

--- a/doc/changelog/01-kernel/21465-better-mod-type-errors-Changed.rst
+++ b/doc/changelog/01-kernel/21465-better-mod-type-errors-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Error messages for module signature mismatches and "with Definition"
+  constraint failures are now more detailed
+  (`#21465 <https://github.com/rocq-prover/rocq/pull/21465>`_,
+  fixes `#21464 <https://github.com/rocq-prover/rocq/issues/21464>`_,
+  by Jason Gross).

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -33,26 +33,31 @@ type signature_mismatch_error =
   | DefinitionFieldExpected
   | ModuleFieldExpected
   | ModuleTypeFieldExpected
-  | NotConvertibleInductiveField of Id.t
-  | NotConvertibleConstructorField of Id.t
-  | NotConvertibleBodyField
+  | NotConvertibleInductiveField of Id.t * (env * types * types) option
+  | NotConvertibleConstructorField of Id.t * (env * types * types) option
+  | NotConvertibleBodyField of (env * constr * constr) option
   | NotConvertibleTypeField of env * types * types
   | CumulativeStatusExpected of bool
   | PolymorphicStatusExpected of bool
-  | NotSameConstructorNamesField
-  | NotSameInductiveNameInBlockField
+  | NotSameConstructorNamesField of Id.t array * Id.t array
+  | NotSameInductiveNameInBlockField of Id.t * Id.t
   | FiniteInductiveFieldExpected of bool
-  | InductiveNumbersFieldExpected of int
-  | InductiveParamsNumberField of int
+  | InductiveNumbersFieldExpected of { got : int; expected : int }
+  | InductiveParamsNumberField of { got : int; expected : int }
   | RecordFieldExpected of bool
-  | RecordProjectionsExpected of Name.t list
-  | NotEqualInductiveAliases
-  | IncompatibleUniverses of UGraph.univ_inconsistency
-  | IncompatibleQualities of QGraph.elimination_error
+  | RecordProjectionsExpected of { expected : Name.t list; got : Name.t list }
+  | NotEqualInductiveAliases of MutInd.t * MutInd.t
+  | IncompatibleUniverses of { err : UGraph.univ_inconsistency; env : env; t1 : types; t2 : types }
+  | IncompatibleQualities of { err : QGraph.elimination_error; env : env; t1 : types; t2 : types }
   | IncompatiblePolymorphism of env * types * types
   | IncompatibleUnivConstraints of { got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
   | IncompatibleVariance
   | NoRewriteRulesSubtyping
+
+type with_constraint_error =
+  | WithSignatureMismatch of signature_mismatch_error
+  | WithCannotConstrainPrimitive
+  | WithCannotConstrainSymbol
 
 type subtyping_trace_elt =
   | Submodule of Id.t
@@ -68,7 +73,7 @@ type module_typing_error =
   | NoSuchLabel of Id.t * ModPath.t
   | NotAModuleLabel of Id.t
   | NotAConstant of Id.t
-  | IncorrectWithConstraint of Id.t
+  | IncorrectWithConstraint of Id.t * with_constraint_error
   | GenerativeModuleExpected of Id.t
   | LabelMissing of Id.t * string
   | IncludeRestrictedFunctor of ModPath.t
@@ -102,8 +107,8 @@ let error_not_a_module_label s =
 let error_not_a_constant l =
   raise (ModuleTypingError (NotAConstant l))
 
-let error_incorrect_with_constraint l =
-  raise (ModuleTypingError (IncorrectWithConstraint l))
+let error_incorrect_with_constraint l err =
+  raise (ModuleTypingError (IncorrectWithConstraint (l, err)))
 
 let error_generative_module_expected l =
   raise (ModuleTypingError (GenerativeModuleExpected l))

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -87,26 +87,31 @@ type signature_mismatch_error =
   | DefinitionFieldExpected
   | ModuleFieldExpected
   | ModuleTypeFieldExpected
-  | NotConvertibleInductiveField of Id.t
-  | NotConvertibleConstructorField of Id.t
-  | NotConvertibleBodyField
+  | NotConvertibleInductiveField of Id.t * (env * types * types) option
+  | NotConvertibleConstructorField of Id.t * (env * types * types) option
+  | NotConvertibleBodyField of (env * constr * constr) option
   | NotConvertibleTypeField of env * types * types
   | CumulativeStatusExpected of bool
   | PolymorphicStatusExpected of bool
-  | NotSameConstructorNamesField
-  | NotSameInductiveNameInBlockField
+  | NotSameConstructorNamesField of Id.t array * Id.t array
+  | NotSameInductiveNameInBlockField of Id.t * Id.t
   | FiniteInductiveFieldExpected of bool
-  | InductiveNumbersFieldExpected of int
-  | InductiveParamsNumberField of int
+  | InductiveNumbersFieldExpected of { got : int; expected : int }
+  | InductiveParamsNumberField of { got : int; expected : int }
   | RecordFieldExpected of bool
-  | RecordProjectionsExpected of Name.t list
-  | NotEqualInductiveAliases
-  | IncompatibleUniverses of UGraph.univ_inconsistency
-  | IncompatibleQualities of QGraph.elimination_error
+  | RecordProjectionsExpected of { expected : Name.t list; got : Name.t list }
+  | NotEqualInductiveAliases of MutInd.t * MutInd.t
+  | IncompatibleUniverses of { err : UGraph.univ_inconsistency; env : env; t1 : types; t2 : types }
+  | IncompatibleQualities of { err : QGraph.elimination_error; env : env; t1 : types; t2 : types }
   | IncompatiblePolymorphism of env * types * types
   | IncompatibleUnivConstraints of { got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
   | IncompatibleVariance
   | NoRewriteRulesSubtyping
+
+type with_constraint_error =
+  | WithSignatureMismatch of signature_mismatch_error
+  | WithCannotConstrainPrimitive
+  | WithCannotConstrainSymbol
 
 type subtyping_trace_elt =
   | Submodule of Id.t
@@ -122,7 +127,7 @@ type module_typing_error =
   | NoSuchLabel of Id.t * ModPath.t
   | NotAModuleLabel of Id.t
   | NotAConstant of Id.t
-  | IncorrectWithConstraint of Id.t
+  | IncorrectWithConstraint of Id.t * with_constraint_error
   | GenerativeModuleExpected of Id.t
   | LabelMissing of Id.t * string
   | IncludeRestrictedFunctor of ModPath.t
@@ -143,7 +148,7 @@ val error_not_a_module_label : Id.t -> 'a
 
 val error_not_a_constant : Id.t -> 'a
 
-val error_incorrect_with_constraint : Id.t -> 'a
+val error_incorrect_with_constraint : Id.t -> with_constraint_error -> 'a
 
 val error_generative_module_expected : Id.t -> 'a
 

--- a/test-suite/output/ModuleErrors.out
+++ b/test-suite/output/ModuleErrors.out
@@ -1,0 +1,60 @@
+File "./output/ModuleErrors.v", line 10, characters 0-43:
+The command has indeed failed with message:
+Signature components for field I do not match:
+types given to constructor c differ: expected
+"nat -> ModuleErrors.IndTest1.I" but found "bool -> ModuleErrors.IndTest1.I".
+File "./output/ModuleErrors.v", line 19, characters 0-46:
+The command has indeed failed with message:
+Signature components for field I do not match:
+types given to constructor c1 differ: expected
+"nat -> ModuleErrors.ConsTest1.I" but found
+"bool -> ModuleErrors.ConsTest1.I".
+File "./output/ModuleErrors.v", line 28, characters 0-55:
+The command has indeed failed with message:
+Signature components for field I do not match: constructor names differ:
+expected foo, bar but found baz, qux.
+File "./output/ModuleErrors.v", line 39, characters 0-52:
+The command has indeed failed with message:
+Signature components for field Foo do not match: inductive type names differ:
+expected Bar but found Baz.
+File "./output/ModuleErrors.v", line 49, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I1 do not match:
+number of inductive types differs: expected 2 but found 1.
+File "./output/ModuleErrors.v", line 58, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I do not match: number of parameters differs:
+expected 2 but found 1.
+File "./output/ModuleErrors.v", line 67, characters 0-43:
+The command has indeed failed with message:
+Signature components for field x do not match:
+the body of definitions differs: expected "42" but found 
+"0".
+File "./output/ModuleErrors.v", line 76, characters 0-58:
+The command has indeed failed with message:
+Signature components for field x do not match: expected type 
+"nat" but found type "bool".
+File "./output/ModuleErrors.v", line 83, characters 0-99:
+The command has indeed failed with message:
+Incorrect constraint for label "b": expected type
+"ModuleErrors.WithParamType.a" but found type "bool"
+File "./output/ModuleErrors.v", line 92, characters 0-82:
+The command has indeed failed with message:
+Incorrect constraint for label "x": expected type 
+"nat" but found type "bool"
+File "./output/ModuleErrors.v", line 101, characters 0-40:
+The command has indeed failed with message:
+Signature components for field R do not match: constructor names differ:
+expected Build_R but found mkR.
+File "./output/ModuleErrors.v", line 110, characters 0-52:
+The command has indeed failed with message:
+Signature components for field R do not match: projection names differ:
+expected foo and bar but found baz and qux.
+File "./output/ModuleErrors.v", line 119, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I do not match:
+type is expected to be coinductive.
+File "./output/ModuleErrors.v", line 125, characters 0-70:
+The command has indeed failed with message:
+Incorrect constraint for label "x": the body of definitions differs: expected
+"5" but found "10"

--- a/test-suite/output/ModuleErrors.v
+++ b/test-suite/output/ModuleErrors.v
@@ -1,0 +1,125 @@
+(* Test improved error messages for module type errors *)
+
+(* Test 1: NotConvertibleInductiveField - types given to inductive differ *)
+Module Type IndType1.
+  Inductive I : Type := c : nat -> I.
+End IndType1.
+Module IndMod1.
+  Inductive I : Type := c : bool -> I.
+End IndMod1.
+Fail Module IndTest1 : IndType1 := IndMod1.
+
+(* Test 2: NotConvertibleConstructorField - constructor types differ *)
+Module Type ConsType1.
+  Inductive I : Type := c1 : nat -> I | c2 : I.
+End ConsType1.
+Module ConsMod1.
+  Inductive I : Type := c1 : bool -> I | c2 : I.
+End ConsMod1.
+Fail Module ConsTest1 : ConsType1 := ConsMod1.
+
+(* Test 3: NotSameConstructorNamesField - constructor names differ *)
+Module Type ConsNameType.
+  Inductive I : Type := foo : I | bar : I.
+End ConsNameType.
+Module ConsNameMod.
+  Inductive I : Type := baz : I | qux : I.
+End ConsNameMod.
+Fail Module ConsNameTest : ConsNameType := ConsNameMod.
+
+(* Test 4: NotSameInductiveNameInBlockField - mutual inductive type names differ *)
+Module Type IndNameType.
+  Inductive Foo : Type := mkFoo : Bar -> Foo
+  with Bar : Type := mkBar : Foo -> Bar.
+End IndNameType.
+Module IndNameMod.
+  Inductive Foo : Type := mkFoo : Baz -> Foo
+  with Baz : Type := mkBar : Foo -> Baz.
+End IndNameMod.
+Fail Module IndNameTest : IndNameType := IndNameMod.
+
+(* Test 5: InductiveNumbersFieldExpected - number of inductives differs *)
+Module Type NumIndType.
+  Inductive I1 : Type := c1 : I1
+  with I2 : Type := c2 : I2.
+End NumIndType.
+Module NumIndMod.
+  Inductive I1 : Type := c1 : I1.
+End NumIndMod.
+Fail Module NumIndTest : NumIndType := NumIndMod.
+
+(* Test 6: InductiveParamsNumberField - number of parameters differs *)
+Module Type ParamsType.
+  Inductive I (A B : Type) : Type := c : A -> B -> I A B.
+End ParamsType.
+Module ParamsMod.
+  Inductive I (A : Type) : Type := c : A -> A -> I A.
+End ParamsMod.
+Fail Module ParamsTest : ParamsType := ParamsMod.
+
+(* Test 7: NotConvertibleBodyField - body of definitions differs *)
+Module Type BodyType.
+  Definition x := 42.
+End BodyType.
+Module BodyMod.
+  Definition x := 0.
+End BodyMod.
+Fail Module BodyTest : BodyType := BodyMod.
+
+(* Test 8: NotConvertibleTypeField - type of definitions differs *)
+Module Type TypeFieldType.
+  Definition x : nat := 0.
+End TypeFieldType.
+Module TypeFieldMod.
+  Definition x : bool := true.
+End TypeFieldMod.
+Fail Module TypeFieldTest : TypeFieldType := TypeFieldMod.
+
+(* Test 9: With Definition type mismatch with complex types from module *)
+Module Type WithParamType.
+  Parameter a : Type.
+  Parameter b : a.
+End WithParamType.
+Fail Module Type WithParamTest := WithParamType with Definition a := nat with Definition b := true.
+
+(* Test 10: Nested with definition error - type mismatch in submodule *)
+Module Type InnerType.
+  Parameter x : nat.
+End InnerType.
+Module Type NestedWithType.
+  Declare Module Inner : InnerType.
+End NestedWithType.
+Fail Module Type NestedWithTest := NestedWithType with Definition Inner.x := true.
+
+(* Test 11: RecordFieldExpected - expected record but got non-record *)
+Module Type RecType.
+  Record R := { field : nat }.
+End RecType.
+Module RecMod.
+  Inductive R := mkR : nat -> R.
+End RecMod.
+Fail Module RecTest : RecType := RecMod.
+
+(* Test 12: RecordProjectionsExpected - projection names differ *)
+Module Type RecProjType.
+  Record R := { foo : nat; bar : bool }.
+End RecProjType.
+Module RecProjMod.
+  Record R := { baz : nat; qux : bool }.
+End RecProjMod.
+Fail Module RecProjTest : RecProjType := RecProjMod.
+
+(* Test 13: FiniteInductiveFieldExpected - inductive vs coinductive *)
+Module Type FiniteType.
+  Inductive I := c : I.
+End FiniteType.
+Module FiniteMod.
+  CoInductive I := c : I.
+End FiniteMod.
+Fail Module FiniteTest : FiniteType := FiniteMod.
+
+(* Test 14: With Definition body mismatch *)
+Module Type WithBodyType.
+  Definition x := 5.
+End WithBodyType.
+Fail Module Type WithBodyTest := WithBodyType with Definition x := 10.

--- a/test-suite/output/ModuleErrorsComprehensive.out
+++ b/test-suite/output/ModuleErrorsComprehensive.out
@@ -1,0 +1,111 @@
+File "./output/ModuleErrorsComprehensive.v", line 12, characters 0-64:
+The command has indeed failed with message:
+Signature components for field I do not match: an inductive definition is
+expected.
+File "./output/ModuleErrorsComprehensive.v", line 21, characters 0-64:
+The command has indeed failed with message:
+Signature components for field x do not match: a definition is expected.
+Hint: you can rename the inductive or constructor and add a definition
+mapping the old name to the new name.
+File "./output/ModuleErrorsComprehensive.v", line 34, characters 0-64:
+The command has indeed failed with message:
+Signature components for field M.x do not match: a definition is expected.
+Hint: you can rename the inductive or constructor and add a definition
+mapping the old name to the new name.
+File "./output/ModuleErrorsComprehensive.v", line 47, characters 0-76:
+The command has indeed failed with message:
+Signature components for field T do not match: a module type is expected.
+File "./output/ModuleErrorsComprehensive.v", line 56, characters 0-61:
+The command has indeed failed with message:
+Signature components for field I do not match:
+types given to constructor c differ: expected
+"nat -> ModuleErrorsComprehensive.NotConvIndTest.I" but found
+"bool -> ModuleErrorsComprehensive.NotConvIndTest.I".
+File "./output/ModuleErrorsComprehensive.v", line 65, characters 0-64:
+The command has indeed failed with message:
+Signature components for field I do not match:
+types given to constructor c1 differ: expected
+"nat -> ModuleErrorsComprehensive.NotConvConsTest.I" but found
+"bool -> ModuleErrorsComprehensive.NotConvConsTest.I".
+File "./output/ModuleErrorsComprehensive.v", line 74, characters 0-64:
+The command has indeed failed with message:
+Signature components for field x do not match:
+the body of definitions differs: expected "42" but found 
+"0".
+File "./output/ModuleErrorsComprehensive.v", line 83, characters 0-64:
+The command has indeed failed with message:
+Signature components for field x do not match: expected type 
+"nat" but found type "bool".
+File "./output/ModuleErrorsComprehensive.v", line 92, characters 0-55:
+The command has indeed failed with message:
+Signature components for field I do not match:
+a cumulative declaration was expected, but a non-cumulative declaration was found.
+File "./output/ModuleErrorsComprehensive.v", line 101, characters 0-52:
+The command has indeed failed with message:
+Signature components for field x do not match:
+a polymorphic declaration was expected, but a monomorphic declaration was found.
+File "./output/ModuleErrorsComprehensive.v", line 110, characters 0-58:
+The command has indeed failed with message:
+Signature components for field I do not match: constructor names differ:
+expected foo, bar but found baz, qux.
+File "./output/ModuleErrorsComprehensive.v", line 121, characters 0-55:
+The command has indeed failed with message:
+Signature components for field A do not match: inductive type names differ:
+expected B but found C.
+File "./output/ModuleErrorsComprehensive.v", line 130, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I do not match:
+type is expected to be coinductive.
+File "./output/ModuleErrorsComprehensive.v", line 140, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I1 do not match:
+number of inductive types differs: expected 2 but found 1.
+File "./output/ModuleErrorsComprehensive.v", line 149, characters 0-49:
+The command has indeed failed with message:
+Signature components for field I do not match: number of parameters differs:
+expected 2 but found 1.
+File "./output/ModuleErrorsComprehensive.v", line 158, characters 0-49:
+The command has indeed failed with message:
+Signature components for field R do not match:
+type is expected to be a record.
+File "./output/ModuleErrorsComprehensive.v", line 167, characters 0-52:
+The command has indeed failed with message:
+Signature components for field R do not match: projection names differ:
+expected foo and bar but found baz and qux.
+File "./output/ModuleErrorsComprehensive.v", line 176, characters 0-67:
+The command has indeed failed with message:
+Signature components for field f do not match:
+incompatible polymorphic binders: got @{u v | u <= v} but expected 
+@{u}.
+File "./output/ModuleErrorsComprehensive.v", line 185, characters 0-55:
+The command has indeed failed with message:
+Signature components for field f do not match:
+incompatible polymorphic binders: got @{u v | v < u} but expected
+@{u v | u < v}
+(incompatible constraints).
+File "./output/ModuleErrorsComprehensive.v", line 197, characters 0-55:
+The command has indeed failed with message:
+Signature components for field I do not match:
+incompatible variance information.
+File "./output/ModuleErrorsComprehensive.v", line 214, characters 0-72:
+The command has indeed failed with message:
+Incorrect constraint for label "x": expected type 
+"nat" but found type "bool"
+File "./output/ModuleErrorsComprehensive.v", line 220, characters 0-70:
+The command has indeed failed with message:
+Incorrect constraint for label "x": the body of definitions differs: expected
+"5" but found "10"
+File "./output/ModuleErrorsComprehensive.v", line 227, characters 0-76:
+The command has indeed failed with message:
+Incorrect constraint for label "x": the universe constraints are inconsistent:
+Cannot enforce big_type.u0 < Set because Set < big_type.u0 when comparing
+"Type" and "Set"
+File "./output/ModuleErrorsComprehensive.v", line 233, characters 0-71:
+The command has indeed failed with message:
+Incorrect constraint for label "p": incompatible polymorphic binders: got 
+@{} but expected @{u}
+File "./output/ModuleErrorsComprehensive.v", line 240, characters 0-95:
+The command has indeed failed with message:
+Incorrect constraint for label "b": expected type
+"ModuleErrorsComprehensive.WithAbsType.a" but found type 
+"bool"

--- a/test-suite/output/ModuleErrorsComprehensive.v
+++ b/test-suite/output/ModuleErrorsComprehensive.v
@@ -1,0 +1,240 @@
+(* Comprehensive tests for all module signature and constraint mismatch errors *)
+
+(* ========== signature_mismatch_error tests ========== *)
+
+(* 1. InductiveFieldExpected - expected inductive but found definition *)
+Module Type IndFieldExpType.
+  Inductive I : Type := c : I.
+End IndFieldExpType.
+Module IndFieldExpMod.
+  Definition I : Type := nat.
+End IndFieldExpMod.
+Fail Module IndFieldExpTest : IndFieldExpType := IndFieldExpMod.
+
+(* 2. DefinitionFieldExpected - expected definition but found inductive *)
+Module Type DefFieldExpType.
+  Definition x : Type := nat.
+End DefFieldExpType.
+Module DefFieldExpMod.
+  Inductive x : Type := c : x.
+End DefFieldExpMod.
+Fail Module DefFieldExpTest : DefFieldExpType := DefFieldExpMod.
+
+(* 3. ModuleFieldExpected - expected module but found definition *)
+Module Type ModFieldExpType.
+  Module M.
+    Definition x := 0.
+  End M.
+End ModFieldExpType.
+Module ModFieldExpMod.
+  Module M.
+    Inductive x : Type := c : x.
+  End M.
+End ModFieldExpMod.
+Fail Module ModFieldExpTest : ModFieldExpType := ModFieldExpMod.
+
+(* 4. ModuleTypeFieldExpected - expected module type but found module *)
+Module Type ModTypeFieldExpType.
+  Module Type T.
+    Definition x := 0.
+  End T.
+End ModTypeFieldExpType.
+Module ModTypeFieldExpMod.
+  Module T.
+    Definition x := 0.
+  End T.
+End ModTypeFieldExpMod.
+Fail Module ModTypeFieldExpTest : ModTypeFieldExpType := ModTypeFieldExpMod.
+
+(* 5. NotConvertibleInductiveField - inductive types differ *)
+Module Type NotConvIndType.
+  Inductive I : Type := c : nat -> I.
+End NotConvIndType.
+Module NotConvIndMod.
+  Inductive I : Type := c : bool -> I.
+End NotConvIndMod.
+Fail Module NotConvIndTest : NotConvIndType := NotConvIndMod.
+
+(* 6. NotConvertibleConstructorField - constructor types differ *)
+Module Type NotConvConsType.
+  Inductive I : Type := c1 : nat -> I | c2 : I.
+End NotConvConsType.
+Module NotConvConsMod.
+  Inductive I : Type := c1 : bool -> I | c2 : I.
+End NotConvConsMod.
+Fail Module NotConvConsTest : NotConvConsType := NotConvConsMod.
+
+(* 7. NotConvertibleBodyField - definition bodies differ *)
+Module Type NotConvBodyType.
+  Definition x := 42.
+End NotConvBodyType.
+Module NotConvBodyMod.
+  Definition x := 0.
+End NotConvBodyMod.
+Fail Module NotConvBodyTest : NotConvBodyType := NotConvBodyMod.
+
+(* 8. NotConvertibleTypeField - definition types differ *)
+Module Type NotConvTypeType.
+  Definition x : nat := 0.
+End NotConvTypeType.
+Module NotConvTypeMod.
+  Definition x : bool := true.
+End NotConvTypeMod.
+Fail Module NotConvTypeTest : NotConvTypeType := NotConvTypeMod.
+
+(* 9. CumulativeStatusExpected - expected cumulative but got non-cumulative *)
+Module Type CumulExpType.
+  Polymorphic Cumulative Inductive I@{u} : Type@{u} := c : I.
+End CumulExpType.
+Module CumulExpMod.
+  Polymorphic Inductive I@{u} : Type@{u} := c : I.
+End CumulExpMod.
+Fail Module CumulExpTest : CumulExpType := CumulExpMod.
+
+(* 10. PolymorphicStatusExpected - expected polymorphic but got monomorphic *)
+Module Type PolyExpType.
+  Polymorphic Definition x : Type := nat.
+End PolyExpType.
+Module PolyExpMod.
+  Definition x : Type := nat.
+End PolyExpMod.
+Fail Module PolyExpTest : PolyExpType := PolyExpMod.
+
+(* 11. NotSameConstructorNamesField - constructor names differ *)
+Module Type ConsNamesType.
+  Inductive I : Type := foo : I | bar : I.
+End ConsNamesType.
+Module ConsNamesMod.
+  Inductive I : Type := baz : I | qux : I.
+End ConsNamesMod.
+Fail Module ConsNamesTest : ConsNamesType := ConsNamesMod.
+
+(* 12. NotSameInductiveNameInBlockField - mutual inductive names differ *)
+Module Type IndNamesType.
+  Inductive A : Type := mkA : B -> A
+  with B : Type := mkB : A -> B.
+End IndNamesType.
+Module IndNamesMod.
+  Inductive A : Type := mkA : C -> A
+  with C : Type := mkB : A -> C.
+End IndNamesMod.
+Fail Module IndNamesTest : IndNamesType := IndNamesMod.
+
+(* 13. FiniteInductiveFieldExpected - expected inductive but got coinductive *)
+Module Type FiniteType.
+  Inductive I : Type := c : I.
+End FiniteType.
+Module FiniteMod.
+  CoInductive I : Type := c : I.
+End FiniteMod.
+Fail Module FiniteTest : FiniteType := FiniteMod.
+
+(* 14. InductiveNumbersFieldExpected - number of mutual inductives differs *)
+Module Type NumIndType.
+  Inductive I1 : Type := c1 : I1
+  with I2 : Type := c2 : I2.
+End NumIndType.
+Module NumIndMod.
+  Inductive I1 : Type := c1 : I1.
+End NumIndMod.
+Fail Module NumIndTest : NumIndType := NumIndMod.
+
+(* 15. InductiveParamsNumberField - number of parameters differs *)
+Module Type ParamsType.
+  Inductive I (A B : Type) : Type := c : A -> B -> I A B.
+End ParamsType.
+Module ParamsMod.
+  Inductive I (A : Type) : Type := c : A -> A -> I A.
+End ParamsMod.
+Fail Module ParamsTest : ParamsType := ParamsMod.
+
+(* 16. RecordFieldExpected - expected record but got non-record *)
+Module Type RecExpType.
+  Record R := { field : nat }.
+End RecExpType.
+Module RecExpMod.
+  Inductive R := Build_R : nat -> R.
+End RecExpMod.
+Fail Module RecExpTest : RecExpType := RecExpMod.
+
+(* 17. RecordProjectionsExpected - projection names differ *)
+Module Type RecProjType.
+  Record R := { foo : nat; bar : bool }.
+End RecProjType.
+Module RecProjMod.
+  Record R := { baz : nat; qux : bool }.
+End RecProjMod.
+Fail Module RecProjTest : RecProjType := RecProjMod.
+
+(* 18. IncompatiblePolymorphism - polymorphic conversion generates constraints *)
+Module Type IncompatPolyType.
+  Polymorphic Definition f@{u} : Type@{u} -> Type@{u} := fun x => x.
+End IncompatPolyType.
+Module IncompatPolyMod.
+  Polymorphic Definition f@{u v} : Type@{u} -> Type@{v} := fun x => x.
+End IncompatPolyMod.
+Fail Module IncompatPolyTest : IncompatPolyType := IncompatPolyMod.
+
+(* 19. IncompatibleUnivConstraints - universe constraints incompatible *)
+Module Type UnivConsType.
+  Polymorphic Definition f@{u v|u < v} : Type@{u} := nat.
+End UnivConsType.
+Module UnivConsMod.
+  Polymorphic Definition f@{u v|v < u} : Type@{u} := nat.
+End UnivConsMod.
+Fail Module UnivConsTest : UnivConsType := UnivConsMod.
+
+(* 20. IncompatibleVariance - variance information incompatible
+   Note: Variance subtyping is v1 <= v2 (module variance <= expected).
+   Covariant (+) is more restrictive than Invariant (=).
+   To trigger: module has Invariant but type expects Covariant. *)
+Module Type VarianceType.
+  Polymorphic Cumulative Inductive I@{+u} : Type@{u} := c : I.
+End VarianceType.
+Module VarianceMod.
+  Polymorphic Cumulative Inductive I@{=u} : Type@{u} := c : I.
+End VarianceMod.
+Fail Module VarianceTest : VarianceType := VarianceMod.
+
+(* NOTE: Some errors are not easily triggerable from this test file:
+   - NoRewriteRulesSubtyping: requires -allow-rewrite-rules flag
+   - NotEqualInductiveAliases: this error checks inductive aliasing through module resolvers;
+     it may be dead code or only triggerable in very specific module functor contexts
+   - IncompatibleUniverses in subtyping: tested above with Set/Type mismatch (Test4 in WithDefErrors)
+   - IncompatibleQualities in subtyping: requires quality constraint conflicts during conversion
+   - WithCannotConstrainPrimitive/Symbol: module types export primitives/symbols as Parameters,
+     so "with Definition" finds a Parameter, not Primitive/Symbol *)
+
+(* ========== with_constraint_error tests ========== *)
+
+(* 22. WithTypeMismatch - type mismatch in with Definition *)
+Module Type WithTypeType.
+  Parameter x : nat.
+End WithTypeType.
+Fail Module Type WithTypeTest := WithTypeType with Definition x := true.
+
+(* 23. WithBodyMismatch - body mismatch in with Definition *)
+Module Type WithBodyType.
+  Definition x := 5.
+End WithBodyType.
+Fail Module Type WithBodyTest := WithBodyType with Definition x := 10.
+
+(* 24. WithUniverseMismatch - universe mismatch in with Definition *)
+Module Type WithUnivType.
+  Parameter x : Set.
+End WithUnivType.
+Definition big_type := Type.
+Fail Module Type WithUnivTest := WithUnivType with Definition x := big_type.
+
+(* 25. WithConstraintsMismatch - polymorphic binders mismatch *)
+Module Type WithConsType.
+  Polymorphic Parameter p@{u} : Type@{u}.
+End WithConsType.
+Fail Module Type WithConsTest := WithConsType with Definition p := nat.
+
+(* 26. WithTypeMismatch with abstract type - test where expected type references module *)
+Module Type WithAbsType.
+  Parameter a : Type.
+  Parameter b : a.
+End WithAbsType.
+Fail Module Type WithAbsTest := WithAbsType with Definition a := nat with Definition b := true.

--- a/test-suite/output/ModuleSubtyping.out
+++ b/test-suite/output/ModuleSubtyping.out
@@ -1,19 +1,23 @@
 File "./output/ModuleSubtyping.v", line 8, characters 2-41:
 The command has indeed failed with message:
 Signature components for field x do not match:
-the body of definitions differs.
+the body of definitions differs: expected "0" but found 
+"1".
 File "./output/ModuleSubtyping.v", line 14, characters 2-30:
 The command has indeed failed with message:
 Signature components for field B.C.x do not match:
-the body of definitions differs.
+the body of definitions differs: expected "0" but found 
+"1".
 File "./output/ModuleSubtyping.v", line 20, characters 2-31:
 The command has indeed failed with message:
 Signature components for field B.C.x in the 1st functor argument do not match:
-the body of definitions differs.
+the body of definitions differs: expected "1" but found 
+"0".
 File "./output/ModuleSubtyping.v", line 30, characters 2-34:
 The command has indeed failed with message:
 Signature components for field B.C.x in the 1st functor argument
-of F do not match: the body of definitions differs.
+of F do not match: the body of definitions differs: expected 
+"1" but found "0".
 File "./output/ModuleSubtyping.v", line 46, characters 2-38:
 The command has indeed failed with message:
 Signature components for field v do not match: expected type 

--- a/test-suite/output/WithDefErrors.out
+++ b/test-suite/output/WithDefErrors.out
@@ -1,0 +1,17 @@
+File "./output/WithDefErrors.v", line 8, characters 0-51:
+The command has indeed failed with message:
+Incorrect constraint for label "x": expected type 
+"nat" but found type "bool"
+File "./output/WithDefErrors.v", line 15, characters 0-51:
+The command has indeed failed with message:
+Incorrect constraint for label "x": the body of definitions differs: expected
+"0" but found "y2"
+File "./output/WithDefErrors.v", line 21, characters 0-52:
+The command has indeed failed with message:
+Incorrect constraint for label "p": incompatible polymorphic binders: got 
+@{} but expected @{u}
+File "./output/WithDefErrors.v", line 28, characters 0-51:
+The command has indeed failed with message:
+Incorrect constraint for label "x": the universe constraints are inconsistent:
+Cannot enforce y4.u0 < Set because Set < y4.u0 when comparing 
+"Type" and "Set"

--- a/test-suite/output/WithDefErrors.v
+++ b/test-suite/output/WithDefErrors.v
@@ -1,0 +1,32 @@
+(* Test improved error messages for "with Definition" constraints *)
+
+(* Test 1: Type mismatch - expected nat but got bool *)
+Module Type T1.
+  Parameter x : nat.
+End T1.
+Definition y1 : bool := true.
+Fail Module Type T1' := T1 with Definition x := y1.
+
+(* Test 2: Body mismatch - definitions with different values *)
+Module Type T2.
+  Definition x := 0.
+End T2.
+Definition y2 : nat := 1.
+Fail Module Type T2' := T2 with Definition x := y2.
+
+(* Test 3: Polymorphic constraint mismatch *)
+Module Type T3.
+  Polymorphic Parameter p : Type.
+End T3.
+Fail Module Type T3' := T3 with Definition p := nat.
+
+(* Test 4: Universe constraint issues *)
+Module Type T4.
+  Parameter x : Set.
+End T4.
+Definition y4 := Type.
+Fail Module Type T4' := T4 with Definition x := y4.
+
+(* NOTE: WithCannotConstrainPrimitive and WithCannotConstrainSymbol errors
+   cannot be triggered from user code because module types export primitives
+   and symbols as parameters. These errors exist for internal consistency. *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1221,36 +1221,66 @@ let explain_not_match_error = function
     strbrk "a module is expected"
   | ModuleTypeFieldExpected ->
     strbrk "a module type is expected"
-  | NotConvertibleInductiveField id | NotConvertibleConstructorField id ->
+  | NotConvertibleInductiveField (id, None) ->
     str "types given to " ++ Id.print id ++ str " differ"
-  | NotConvertibleBodyField ->
+  | NotConvertibleInductiveField (id, Some (env, typ1, typ2)) ->
+    let typ1, typ2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr typ1) (EConstr.of_constr typ2) in
+    str "types given to " ++ Id.print id ++ str " differ:" ++ spc () ++
+    str "expected" ++ spc () ++ typ2 ++ spc () ++
+    str "but found" ++ spc () ++ typ1
+  | NotConvertibleConstructorField (id, None) ->
+    str "types given to constructor " ++ Id.print id ++ str " differ"
+  | NotConvertibleConstructorField (id, Some (env, typ1, typ2)) ->
+    let typ1, typ2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr typ1) (EConstr.of_constr typ2) in
+    str "types given to constructor " ++ Id.print id ++ str " differ:" ++ spc () ++
+    str "expected" ++ spc () ++ typ2 ++ spc () ++
+    str "but found" ++ spc () ++ typ1
+  | NotConvertibleBodyField None ->
     str "the body of definitions differs"
+  | NotConvertibleBodyField (Some (env, c1, c2)) ->
+    let sigma = Evd.from_env env in
+    let c1, c2 = pr_explicit env sigma (EConstr.of_constr c1) (EConstr.of_constr c2) in
+    str "the body of definitions differs:" ++ spc () ++
+    str "expected" ++ spc () ++ c2 ++ spc () ++
+    str "but found" ++ spc () ++ c1
   | NotConvertibleTypeField (env, typ1, typ2) ->
     let typ1, typ2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr typ1) (EConstr.of_constr typ2) in
     str "expected type" ++ spc ()  ++
     typ2 ++ spc () ++
     str "but found type" ++ spc () ++
     typ1
-  | NotSameConstructorNamesField ->
-    str "constructor names differ"
-  | NotSameInductiveNameInBlockField ->
-    str "inductive types names differ"
+  | NotSameConstructorNamesField (got, expected) ->
+    let pr_names arr = prlist_with_sep pr_comma Id.print (Array.to_list arr) in
+    str "constructor names differ:" ++ spc () ++
+    str "expected" ++ spc () ++ pr_names expected ++ spc () ++
+    str "but found" ++ spc () ++ pr_names got
+  | NotSameInductiveNameInBlockField (got, expected) ->
+    str "inductive type names differ:" ++ spc () ++
+    str "expected" ++ spc () ++ Id.print expected ++ spc () ++
+    str "but found" ++ spc () ++ Id.print got
   | FiniteInductiveFieldExpected isfinite ->
     str "type is expected to be " ++
     str (if isfinite then "coinductive" else "inductive")
-  | InductiveNumbersFieldExpected n ->
-    str "number of inductive types differs"
-  | InductiveParamsNumberField n ->
-    str "inductive type has not the right number of parameters"
+  | InductiveNumbersFieldExpected { got; expected } ->
+    str "number of inductive types differs:" ++ spc () ++
+    str "expected" ++ spc () ++ int expected ++ spc () ++
+    str "but found" ++ spc () ++ int got
+  | InductiveParamsNumberField { got; expected } ->
+    str "number of parameters differs:" ++ spc () ++
+    str "expected" ++ spc () ++ int expected ++ spc () ++
+    str "but found" ++ spc () ++ int got
   | RecordFieldExpected isrecord ->
     str "type is expected " ++ str (if isrecord then "" else "not ") ++
     str "to be a record"
-  | RecordProjectionsExpected nal ->
-    (if List.length nal >= 2 then str "expected projection names are "
-     else str "expected projection name is ") ++
-    pr_enum (function Name id -> Id.print id | _ -> str "_") nal
-  | NotEqualInductiveAliases ->
-    str "Aliases to inductive types do not match"
+  | RecordProjectionsExpected { expected; got } ->
+    let pr_names nal = pr_enum (function Name id -> Id.print id | _ -> str "_") nal in
+    str "projection names differ:" ++ spc () ++
+    str "expected" ++ spc () ++ pr_names expected ++ spc () ++
+    str "but found" ++ spc () ++ pr_names got
+  | NotEqualInductiveAliases (got, expected) ->
+    str "aliases to inductive types do not match:" ++ spc () ++
+    str "expected" ++ spc () ++ MutInd.print expected ++ spc () ++
+    str "but found" ++ spc () ++ MutInd.print got
   | CumulativeStatusExpected b ->
     let status b = if b then str"cumulative" else str"non-cumulative" in
       str "a " ++ status b ++ str" declaration was expected, but a " ++
@@ -1259,14 +1289,22 @@ let explain_not_match_error = function
     let status b = if b then str"polymorphic" else str"monomorphic" in
       str "a " ++ status b ++ str" declaration was expected, but a " ++
         status (not b) ++ str" declaration was found"
-  | IncompatibleUniverses incon ->
-    str"the universe constraints are inconsistent: " ++
+  | IncompatibleUniverses { err; env; t1; t2 } ->
+    let sigma = Evd.from_env env in
+    let t1, t2 = pr_explicit env sigma (EConstr.of_constr t1) (EConstr.of_constr t2) in
+    str"the universe constraints are inconsistent:" ++ spc () ++
     UGraph.explain_universe_inconsistency
       Sorts.QVar.raw_pr
       UnivNames.pr_level_with_global_universes
-      incon
-  | IncompatibleQualities incon ->
-     QGraph.explain_elimination_error Sorts.QVar.raw_pr incon
+      err ++ spc () ++
+    str "when comparing" ++ spc () ++ t1 ++ spc () ++
+    str "and" ++ spc () ++ t2
+  | IncompatibleQualities { err; env; t1; t2 } ->
+    let sigma = Evd.from_env env in
+    let t1, t2 = pr_explicit env sigma (EConstr.of_constr t1) (EConstr.of_constr t2) in
+    QGraph.explain_elimination_error Sorts.QVar.raw_pr err ++ spc () ++
+    str "when comparing" ++ spc () ++ t1 ++ spc () ++
+    str "and" ++ spc () ++ t2
   | IncompatiblePolymorphism (env, t1, t2) ->
     let t1, t2 = pr_explicit env (Evd.from_env env) (EConstr.of_constr t1) (EConstr.of_constr t2) in
     str "conversion of polymorphic values generates additional constraints: " ++
@@ -1357,9 +1395,16 @@ let explain_not_a_module_label l =
 let explain_not_a_constant l =
   quote (Id.print l) ++ str " is not a constant."
 
-let explain_incorrect_label_constraint l =
-  str "Incorrect constraint for label " ++
-  quote (Id.print l) ++ str "."
+let explain_with_constraint_error = function
+  | WithSignatureMismatch sig_err -> explain_not_match_error sig_err
+  | WithCannotConstrainPrimitive ->
+      str "cannot constrain a primitive"
+  | WithCannotConstrainSymbol ->
+      str "cannot constrain a symbol"
+
+let explain_incorrect_with_constraint l err =
+  str "Incorrect constraint for label " ++ quote (Id.print l) ++ str ": " ++
+  explain_with_constraint_error err
 
 let explain_generative_module_expected l =
   str "The module " ++ Id.print l ++ str " is not generative." ++
@@ -1385,7 +1430,7 @@ let explain_module_error = function
   | NoSuchLabel (l,mp) -> explain_no_such_label l mp
   | NotAModuleLabel l -> explain_not_a_module_label l
   | NotAConstant l -> explain_not_a_constant l
-  | IncorrectWithConstraint l -> explain_incorrect_label_constraint l
+  | IncorrectWithConstraint (l, err) -> explain_incorrect_with_constraint l err
   | GenerativeModuleExpected l -> explain_generative_module_expected l
   | LabelMissing (l,s) -> explain_label_missing l s
   | IncludeRestrictedFunctor mp -> explain_include_restricted_functor mp


### PR DESCRIPTION
Improve error messages for module signature mismatches and "with Definition" constraint failures, including:
  - Type mismatches showing expected and actual types
  - Body mismatches showing expected and actual definitions
  - Constructor type mismatches with specific constructor names
  - Constructor name differences (expected vs found)
  - Inductive type name differences in mutual blocks
  - Record projection name differences (expected vs found)
  - Universe/quality constraint inconsistencies with details
  - Polymorphic/cumulative status mismatches
  - Incompatible polymorphic binders and variance information
  - Number of parameters/inductive types differences
  - Fix bug where inductive types printed as `<inductive:I:0>` instead of proper names
  - Unify error handling by routing with_constraint_error through signature_mismatch_error
  - Add comprehensive test coverage for module error messages

Fixes #21464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Added / updated **test-suite**.

- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  - [ ] Documented any new / changed **user messages**.

