### PR TITLE
Move all the abstract internals into a new Subproof module.

### DIFF
--- a/dev/ci/user-overlays/21467-ppedrot-centralize-declare-build-by-tactic.sh
+++ b/dev/ci/user-overlays/21467-ppedrot-centralize-declare-build-by-tactic.sh
@@ -1,0 +1,3 @@
+overlay mtac2 https://github.com/ppedrot/Mtac2 centralize-declare-build-by-tactic 21467
+
+overlay rewriter https://github.com/ppedrot/rewriter centralize-declare-build-by-tactic 21467

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -307,7 +307,7 @@ let generate_functional_principle (evd : Evd.evar_map ref) old_princ_type sorts
        Don't forget to close the goal if an error is raised !!!!
     *)
     let uctx = Evd.ustate sigma in
-    let entry = Declare.definition_entry ~univs ?types body in
+    let entry = Declare.definition_entry ~univs ~types body in
     let (_ : Names.GlobRef.t) =
       Declare.declare_entry ~name:new_princ_name ~hook
         ~kind:Decls.(IsProof Theorem)
@@ -1411,7 +1411,7 @@ let make_scheme evd (fas : (Constant.t EConstr.puniverses * UnivGen.QualityOrSet
             let princ_body =
               Term.it_mkLambda_or_LetIn (Constr.mkFix ((idxs, i), decl)) ctxt
             in
-            (princ_body, Some scheme_type, univs, opaque))
+            (princ_body, scheme_type, univs, opaque))
         other_fun_princ_types
     in
     (body, typ, univs, opaque) :: other_result
@@ -1467,7 +1467,7 @@ let derive_correctness (funs : Constant.t EConstr.puniverses list) (graphs : ind
           Array.of_list
             (List.map
                (fun (body, typ, _opaque, _univs) ->
-                 (EConstr.of_constr body, EConstr.of_constr (Option.get typ)))
+                 (EConstr.of_constr body, EConstr.of_constr typ))
                (make_scheme evd
                   (Array.map_to_list (fun const -> (const, UnivGen.QualityOrSet.qtype)) funs)))
       in
@@ -2159,7 +2159,7 @@ let build_scheme fas =
     (fun (princ_id, _, _) (body, types, univs, opaque) ->
       let (_ : Constant.t) =
         let opaque = if opaque = Vernacexpr.Opaque then true else false in
-        let def_entry = Declare.definition_entry ~univs ~opaque ?types body in
+        let def_entry = Declare.definition_entry ~univs ~opaque ~types body in
         Declare.declare_constant ?loc:princ_id.CAst.loc ~name:princ_id.CAst.v
           ~kind:Decls.(IsProof Theorem)
           (Declare.DefinitionEntry def_entry)

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -205,7 +205,7 @@ let build_functional_principle env (sigma : Evd.evar_map) old_princ_type sorts f
   let uctx = Evd.ustate sigma in
   let typ = EConstr.of_constr new_principle_type in
   let body, typ, univs, _safe, _uctx =
-    Declare.build_by_tactic env ~uctx ~poly:PolyFlags.default ~typ ftac
+    Subproof.build_by_tactic env ~uctx ~poly:PolyFlags.default ~typ ftac
   in
   (* uctx was ignored before *)
   let hook = Declare.Hook.make (hook new_principle_type) in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2180,7 +2180,7 @@ let () =
     | Some ty -> sigma, ty
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
-    let (c, sigma) = Proof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma ty tac in
+    let (c, sigma) = Subproof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma ty tac in
     let j = { Environ.uj_val = c; uj_type = ty } in
     (j, sigma)
   in

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -238,7 +238,7 @@ let () =
     | Some ty -> sigma, ty
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
-    let c, sigma = Proof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma concl tac in
+    let c, sigma = Subproof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma concl tac in
     let j = { Environ.uj_val = c; Environ.uj_type = concl } in
     (j, sigma)
   in

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -453,53 +453,6 @@ let solve ?with_end_tac env gi info_lvl tac pr =
     in
     (p, status)
 
-(**********************************************************************)
-(* Shortcut to build a term using tactics *)
-
-let refine_by_tactic ~name ~poly env sigma ty tac =
-  (* Save the initial side-effects to restore them afterwards. *)
-  let eff = Evd.eval_side_effects sigma in
-  let old_len = Safe_typing.length_private @@ Evd.seff_private eff in
-  (* Save the existing goals *)
-  let sigma = Evd.push_future_goals sigma in
-  (* Start a proof *)
-  let prf = start ~name ~poly sigma [env, ty] in
-  let (prf, _, ()) =
-    try run_tactic env tac prf
-    with Logic_monad.TacticFailure e as src ->
-      (* Catch the inner error of the monad tactic *)
-      let (_, info) = Exninfo.capture src in
-      Exninfo.iraise (e, info)
-  in
-  (* Plug back the retrieved sigma *)
-  let { goals; stack; sigma; entry } = data prf in
-  assert (stack = []);
-  let ans = match Proofview.initial_goals entry with
-  | [_, c, _] -> c
-  | _ -> assert false
-  in
-  let ans = EConstr.to_constr ~abort_on_undefined_evars:false sigma ans in
-  (* [neff] contains the freshly generated side-effects *)
-  let neff = Evd.seff_private @@ Evd.eval_side_effects sigma in
-  let new_len = Safe_typing.length_private neff in
-  let neff, _ = Safe_typing.pop_private neff (new_len - old_len) in
-  (* Reset the old side-effects *)
-  let sigma = Evd.set_side_effects eff sigma in
-  (* Restore former goals *)
-  let _goals, sigma = Evd.pop_future_goals sigma in
-  (* Push remaining goals as future_goals which is the only way we
-     have to inform the caller that there are goals to collect while
-     not being encapsulated in the monad *)
-  let sigma = List.fold_right Evd.declare_future_goal goals sigma in
-  (* Get rid of the fresh side-effects by internalizing them in the term
-     itself. Note that this is unsound, because the tactic may have solved
-     other goals that were already present during its invocation, so that
-     those goals rely on effects that are not present anymore. Hopefully,
-     this hack will work in most cases. *)
-  let (ans, uctx) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
-  let sigma = Evd.merge_universe_context_set ~sideff:true UState.UnivRigid sigma uctx in
-  EConstr.of_constr ans, sigma
-
 let get_goal_context_gen pf i =
   let { sigma; goals } = data pf in
   let goal = try List.nth goals (i-1) with Failure _ -> raise (NoSuchGoal None) in

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -199,20 +199,6 @@ val solve :
 (** Option telling if unification heuristics should be used. *)
 val use_unification_heuristics : unit -> bool
 
-val refine_by_tactic
-  :  name:Names.Id.t
-  -> poly:PolyFlags.t
-  -> Environ.env
-  -> Evd.evar_map
-  -> EConstr.types
-  -> unit Proofview.tactic
-  -> EConstr.constr * Evd.evar_map
-(** A variant of the above function that handles open terms as well.
-    Caveat: all effects are purged in the returned term at the end, but other
-    evars solved by side-effects are NOT purged, so that unexpected failures may
-    occur. Ideally all code using this function should be rewritten in the
-    monad. *)
-
 exception SuggestNoSuchGoals of int * t
 
 (** {6 Helpers to obtain proof state when in an interactive proof } *)

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -1,0 +1,58 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Proof
+
+(**********************************************************************)
+(* Shortcut to build a term using tactics *)
+
+let refine_by_tactic ~name ~poly env sigma ty tac =
+  (* Save the initial side-effects to restore them afterwards. *)
+  let eff = Evd.eval_side_effects sigma in
+  let old_len = Safe_typing.length_private @@ Evd.seff_private eff in
+  (* Save the existing goals *)
+  let sigma = Evd.push_future_goals sigma in
+  (* Start a proof *)
+  let prf = start ~name ~poly sigma [env, ty] in
+  let (prf, _, ()) =
+    try run_tactic env tac prf
+    with Logic_monad.TacticFailure e as src ->
+      (* Catch the inner error of the monad tactic *)
+      let (_, info) = Exninfo.capture src in
+      Exninfo.iraise (e, info)
+  in
+  (* Plug back the retrieved sigma *)
+  let { goals; stack; sigma; entry } = data prf in
+  assert (stack = []);
+  let ans = match Proofview.initial_goals entry with
+  | [_, c, _] -> c
+  | _ -> assert false
+  in
+  let ans = EConstr.to_constr ~abort_on_undefined_evars:false sigma ans in
+  (* [neff] contains the freshly generated side-effects *)
+  let neff = Evd.seff_private @@ Evd.eval_side_effects sigma in
+  let new_len = Safe_typing.length_private neff in
+  let neff, _ = Safe_typing.pop_private neff (new_len - old_len) in
+  (* Reset the old side-effects *)
+  let sigma = Evd.set_side_effects eff sigma in
+  (* Restore former goals *)
+  let _goals, sigma = Evd.pop_future_goals sigma in
+  (* Push remaining goals as future_goals which is the only way we
+     have to inform the caller that there are goals to collect while
+     not being encapsulated in the monad *)
+  let sigma = List.fold_right Evd.declare_future_goal goals sigma in
+  (* Get rid of the fresh side-effects by internalizing them in the term
+     itself. Note that this is unsound, because the tactic may have solved
+     other goals that were already present during its invocation, so that
+     those goals rely on effects that are not present anymore. Hopefully,
+     this hack will work in most cases. *)
+  let (ans, uctx) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
+  let sigma = Evd.merge_universe_context_set ~sideff:true UState.UnivRigid sigma uctx in
+  EConstr.of_constr ans, sigma

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -8,7 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Util
+open Names
 open Proof
+
+module NamedDecl = Context.Named.Declaration
 
 (**********************************************************************)
 (* Shortcut to build a term using tactics *)
@@ -56,3 +60,161 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
   let (ans, uctx) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
   let sigma = Evd.merge_universe_context_set ~sideff:true UState.UnivRigid sigma uctx in
   EConstr.of_constr ans, sigma
+
+(* Abstract internals *)
+
+exception OpenProof of Id.t
+
+let () = CErrors.register_handler begin function
+| OpenProof pid ->
+  let open Pp in
+  Some (str " (in proof " ++ Names.Id.print pid ++ str "): " ++
+        str "Attempt to save an incomplete proof.")
+| _ -> None
+end
+
+let universes_of_body_type ~used_univs body typ =
+  let used_univs_typ = Option.cata (Vars.universes_of_constr ~init:used_univs) used_univs typ in
+  let used_univs = Vars.universes_of_constr body ~init:used_univs_typ in
+  used_univs_typ, used_univs
+
+let rec shrink ctx sign c t accu =
+  let open Constr in
+  let open Vars in
+  match ctx, sign with
+  | [], [] -> (c, t, accu)
+  | p :: ctx, decl :: sign ->
+    if noccurn 1 c && noccurn 1 t then
+      let c = subst1 mkProp c in
+      let t = subst1 mkProp t in
+      shrink ctx sign c t accu
+    else
+      let c = Term.mkLambda_or_LetIn p c in
+      let t = Term.mkProd_or_LetIn p t in
+      let accu = if Context.Rel.Declaration.is_local_assum p
+        then EConstr.mkVar (NamedDecl.get_id decl) :: accu
+        else accu
+      in
+      shrink ctx sign c t accu
+  | _ -> assert false
+
+(* If [sign] is [x1:T1..xn:Tn], [c] is [fun x1:T1..xn:Tn => c']
+    and [t] is [forall x1:T1..xn:Tn, t'], returns a new [c'] and [t'],
+    where all non-dependent [xi] are removed, as well as a
+    restriction [args] of [x1..xn] such that [c' args] = [c x1..xn] *)
+let shrink_entry sign body typ =
+  let (ctx, body, typ) = Term.decompose_lambda_prod_n_decls (List.length sign) body typ in
+  let (body, typ, args) = shrink ctx sign body typ [] in
+  body, typ, args
+
+let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
+  let proof = Proof.start ~name ~poly sigma [Global.env_of_context sign, typ] in
+  let proof, status = Proof.solve env (Goal_select.select_nth 1) None tac proof in
+  let (body, typ, output_ustate) =
+    let Proof.{ entry; sigma = evd } = Proof.data proof in
+    let body, typ = match Proofview.initial_goals entry with
+    | [_, body, typ] -> body, typ
+    | _ -> assert false
+    in
+    let () = if not @@ Proof.is_done proof then raise (OpenProof name) in
+    let evd = Evd.minimize_universes evd in
+    let to_constr c = match EConstr.to_constr_opt evd c with
+    | Some p -> p
+    | None -> raise (OpenProof name)
+    in
+    let body = to_constr body in
+    let typ = to_constr typ in
+    (body, typ, Evd.ustate evd)
+  in
+  let univs =
+    let _, used_univs = universes_of_body_type ~used_univs:Univ.Level.Set.empty body (Some typ) in
+    let uctx = UState.restrict output_ustate used_univs in
+    UState.check_univ_decl ~poly uctx UState.default_univ_decl
+  in
+  (* FIXME: return the locally introduced effects *)
+  let { Proof.sigma } = Proof.data proof in
+  let sigma = Evd.set_universe_context sigma output_ustate in
+  (univs, body, typ), status, sigma
+
+let next = let n = ref 0 in fun () -> incr n; !n
+
+let build_by_tactic env ~uctx ~poly ~typ tac =
+  let name = Id.of_string ("temporary_proof"^string_of_int (next())) in
+  let sign = Environ.(val_of_named_context (named_context env)) in
+  let sigma = Evd.from_ctx uctx in
+  let (univs, body, typ), status, sigma = build_constant_by_tactic ~name ~env ~sigma ~sign ~poly typ tac in
+  let uctx = Evd.ustate sigma in
+  (* ignore side effect universes:
+     we don't reset the global env in this code path so the side effects are still present
+     cf #13271 and discussion in #18874
+     (but due to #13324 we still want to inline them) *)
+  let effs = Evd.seff_private @@ Evd.eval_side_effects sigma in
+  let body, ctx = Safe_typing.inline_private_constants env ((body, Univ.ContextSet.empty), effs) in
+  let _uctx = UState.merge_universe_context ~sideff:true Evd.univ_rigid uctx ctx in
+  body, typ, univs, status, uctx
+
+let extract_monomorphic = function
+  | UState.Monomorphic_entry ctx ->
+    Entries.Monomorphic_entry, ctx
+  | UState.Polymorphic_entry uctx -> Entries.Polymorphic_entry uctx, Univ.ContextSet.empty
+
+let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl =
+  let (const, safe, sigma') =
+    try build_constant_by_tactic ~name ~poly ~env ~sigma ~sign:secsign concl solve_tac
+    with Logic_monad.TacticFailure e as src ->
+    (* if the tactic [tac] fails, it reports a [TacticFailure e],
+       which is an error irrelevant to the proof system (in fact it
+       means that [e] comes from [tac] failing to yield enough
+       success). Hence it reraises [e]. *)
+    let (_, info) = Exninfo.capture src in
+    Exninfo.iraise (e, info)
+  in
+  let (univs, body, typ) = const in
+  let sigma = Evd.drop_new_defined ~original:sigma sigma' in
+  (* EJGA: Hack related to the above call to
+     `build_constant_by_tactic` with `~opaque:Transparent`. Even if
+     the abstracted term is destined to be opaque, if we trigger the
+     `if poly && opaque && private_poly_univs ()` in `close_proof`
+     kernel will boom. This deserves more investigation. *)
+  let body, typ, args = shrink_entry sign body typ in
+  let ts = Environ.oracle env in
+  let cst, effs =
+    (* No side-effects in the entry, they already exist in the ambient environment *)
+    let effs = Evd.eval_side_effects sigma in
+    let de, ctx =
+      let univ_entry, ctx = extract_monomorphic (fst univs) in
+      if not opaque then
+        Safe_typing.DefinitionEff { Entries.definition_entry_body = body;
+          definition_entry_secctx = None;
+          definition_entry_type = Some typ;
+          definition_entry_universes = univ_entry;
+          definition_entry_inline_code = false;
+        }, ctx
+      else
+        let secctx =
+          let env = Global.env () in
+          let hyps =
+            if List.is_empty (Environ.named_context env) then Id.Set.empty
+            else
+              let ids_typ = Environ.global_vars_set env typ in
+              let vars = Environ.global_vars_set env body in
+              Id.Set.union ids_typ vars
+          in
+          Environ.really_needed env hyps
+        in
+        Safe_typing.OpaqueEff { Entries.opaque_entry_body = body;
+          opaque_entry_secctx = secctx;
+          opaque_entry_type = typ;
+          opaque_entry_universes = univ_entry;
+        },
+        ctx
+    in
+    Evd.push_side_effects ~ts name de ctx effs
+  in
+  let sigma = Evd.emit_side_effects effs sigma in
+  let inst = match univs with
+  | UState.Monomorphic_entry _, _ -> UVars.Instance.empty
+  | UState.Polymorphic_entry uctx, _ -> UVars.UContext.instance uctx
+  in
+  let lem = EConstr.of_constr (Constr.mkConstU (cst, inst)) in
+  sigma, lem, args, safe

--- a/proofs/subproof.mli
+++ b/proofs/subproof.mli
@@ -1,0 +1,23 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val refine_by_tactic
+  :  name:Names.Id.t
+  -> poly:PolyFlags.t
+  -> Environ.env
+  -> Evd.evar_map
+  -> EConstr.types
+  -> unit Proofview.tactic
+  -> EConstr.constr * Evd.evar_map
+(** A variant of {!Proof.solve} that handles open terms as well.
+    Caveat: all effects are purged in the returned term at the end, but other
+    evars solved by side-effects are NOT purged, so that unexpected failures may
+    occur. Ideally all code using this function should be rewritten in the
+    monad. *)

--- a/proofs/subproof.mli
+++ b/proofs/subproof.mli
@@ -21,3 +21,30 @@ val refine_by_tactic
     evars solved by side-effects are NOT purged, so that unexpected failures may
     occur. Ideally all code using this function should be rewritten in the
     monad. *)
+
+exception OpenProof of Names.Id.t
+(** XXX This can be raised by {!build_by_tactic}, but you shouldn't rely on it *)
+
+val build_by_tactic :
+  Environ.env ->
+  uctx:UState.t -> poly:PolyFlags.t ->
+  typ:EConstr.types ->
+  unit Proofview.tactic ->
+  Constr.constr * Constr.types * UState.named_universes_entry * bool * UState.t
+(** Semantics of this function is a bit dubious, use with care *)
+
+val declare_abstract :
+  name:Names.Id.t ->
+  poly:PolyFlags.t ->
+  sign:EConstr.named_context ->
+  secsign:Environ.named_context_val ->
+  opaque:bool ->
+  solve_tac:unit Proofview.tactic ->
+  Environ.env ->
+  Evd.evar_map ->
+  EConstr.t -> Evd.evar_map * EConstr.t * EConstr.t list * bool
+
+val shrink_entry :
+  ('a, 'b, 'c) Context.Named.Declaration.pt list ->
+  Constr.constr ->
+  Constr.types -> Constr.constr * Constr.constr * EConstr.t list

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -40,9 +40,6 @@ let name_op_to_name ~name_op ~name suffix =
   | Some s -> s
   | None -> Nameops.add_suffix name suffix
 
-let declare_abstract = ref (fun ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl ->
-  CErrors.anomaly (Pp.str "Abstract declaration hook not registered"))
-
 let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
   let open Tacticals in
   let open Proofview.Notations in
@@ -87,7 +84,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
          tac)
     in
     let sigma, lem, args, safe =
-      !declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl
+      Subproof.declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl
     in
     let pose_tac = match name_op with
     | None -> Proofview.tclUNIT ()

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -20,15 +20,3 @@ val cache_term_by_tactic_then
   -> unit Proofview.tactic
 
 val tclABSTRACT : ?opaque:bool -> Id.t option -> unit Proofview.tactic -> unit Proofview.tactic
-
-val declare_abstract :
-  (  name:Names.Id.t
-  -> poly:PolyFlags.t
-  -> sign:EConstr.named_context
-  -> secsign:Environ.named_context_val
-  -> opaque:bool
-  -> solve_tac:unit Proofview.tactic
-  -> Environ.env
-  -> Evd.evar_map
-  -> EConstr.t
-  -> Evd.evar_map * EConstr.t * EConstr.t list * bool) ref

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -635,7 +635,7 @@ let solve_remaining_by env sigma holes by =
         let env = Evd.evar_env env evi in
         let ty = Evd.evar_concl evi in
         let name, poly = Id.of_string "rewrite", PolyFlags.default in
-        let c, sigma = Proof.refine_by_tactic ~name ~poly env sigma ty solve_tac in
+        let c, sigma = Subproof.refine_by_tactic ~name ~poly env sigma ty solve_tac in
         Evd.define evk c sigma
     in
     List.fold_left solve sigma indep

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -1195,7 +1195,7 @@ let make_bl_scheme env handle mind =
   let univ_poly = Declareops.inductive_is_polymorphic mib in
   let poly = PolyFlags.of_univ_poly univ_poly in (* FIXME cumulativity not handled *)
   let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) bl_goal)) else uctx in
-  let (ans, _, _, _, uctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:bl_goal
+  let (ans, _, _, _, uctx) = Subproof.build_by_tactic ~poly env ~uctx ~typ:bl_goal
     (compute_bl_tact handle (ind, EConstr.EInstance.make u) lnamesparrec nparrec)
   in
   ([|ans|], uctx)
@@ -1329,7 +1329,7 @@ let make_lb_scheme env handle mind =
   let poly = Declareops.inductive_is_polymorphic mib in
   let uctx = if poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) lb_goal)) else uctx in
   let poly = PolyFlags.of_univ_poly poly (* FIXME cumulativity not handled *) in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx ~typ:lb_goal
+  let (ans, _, _, _, ctx) = Subproof.build_by_tactic ~poly env ~uctx ~typ:lb_goal
     (compute_lb_tact handle ind lnamesparrec nparrec)
   in
   ([|ans|], ctx)
@@ -1524,7 +1524,7 @@ let make_eq_decidability env handle mind =
   (* FIXME: cumulativity not handled *)
   let poly = PolyFlags.of_univ_poly univ_poly in
   let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) dec_goal)) else uctx in
-  let (ans, _, _, _, ctx) = Declare.build_by_tactic ~poly env ~uctx
+  let (ans, _, _, _, ctx) = Subproof.build_by_tactic ~poly env ~uctx
       ~typ:dec_goal (compute_dec_tact handle (ind,u) lnamesparrec nparrec)
   in
   ([|ans|], ctx)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1803,8 +1803,6 @@ module Proof_object = struct
 
 end
 
-(* Alias *)
-module Proof_ = Proof
 module Proof = struct
 
 type nonrec closed_proof_output = closed_proof_output
@@ -2929,7 +2927,7 @@ let program_inference_hook env sigma ev =
     then None
     else
       let c, sigma =
-        Proof_.refine_by_tactic ~name:(Id.of_string "program_subproof")
+        Subproof.refine_by_tactic ~name:(Id.of_string "program_subproof")
           ~poly:PolyFlags.default env sigma concl (Tacticals.tclSOLVE [tac])
       in
       Some (sigma, c)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -395,39 +395,6 @@ module ProofEntry = struct
     | Default { body; opaque = Opaque (uctx, eff) } -> ((body, uctx), eff), true, None
     | DeferredOpaque { body; feedback_id } -> Future.force body, true, feedback_id
 
-  let rec shrink ctx sign c t accu =
-    let open Constr in
-    let open Vars in
-    match ctx, sign with
-    | [], [] -> (c, t, accu)
-    | p :: ctx, decl :: sign ->
-      if noccurn 1 c && noccurn 1 t then
-        let c = subst1 mkProp c in
-        let t = subst1 mkProp t in
-        shrink ctx sign c t accu
-      else
-        let c = Term.mkLambda_or_LetIn p c in
-        let t = Term.mkProd_or_LetIn p t in
-        let accu = if Context.Rel.Declaration.is_local_assum p
-          then EConstr.mkVar (NamedDecl.get_id decl) :: accu
-          else accu
-        in
-        shrink ctx sign c t accu
-    | _ -> assert false
-
-  (* If [sign] is [x1:T1..xn:Tn], [c] is [fun x1:T1..xn:Tn => c']
-     and [t] is [forall x1:T1..xn:Tn, t'], returns a new [c'] and [t'],
-     where all non-dependent [xi] are removed, as well as a
-     restriction [args] of [x1..xn] such that [c' args] = [c x1..xn] *)
-  let shrink_entry sign body typ =
-    let typ = match typ with
-      | None -> assert false
-      | Some t -> t
-    in
-    let (ctx, body, typ) = Term.decompose_lambda_prod_n_decls (List.length sign) body typ in
-    let (body, typ, args) = shrink ctx sign body typ [] in
-    body, typ, args
-
 end
 
 let local_csts = Summary.ref ~name:"local-csts" Cset_env.empty
@@ -2203,118 +2170,11 @@ let close_future_proof ~feedback_id proof (fpl : closed_proof_output Future.comp
 let update_sigma_univs ugraph p =
   map ~f:(Proof.update_sigma_univs ugraph) p
 
-let next = let n = ref 0 in fun () -> incr n; !n
-
 let by env tac pf =
   let pf, safe = map_fold ~f:(Proof.solve env (Goal_select.select_nth 1) None tac) pf in
   let proof, eff = register_side_effects pf.proof in
   let sideff = SideEff.concat eff pf.sideff in
   { pf with proof; sideff }, safe
-
-let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
-  let proof = Proof.start ~name ~poly sigma [Global.env_of_context sign, typ] in
-  let proof, status = Proof.solve env (Goal_select.select_nth 1) None tac proof in
-  let (body, typ, output_ustate) =
-    let Proof.{ entry; sigma = evd } = Proof.data proof in
-    let body, typ = match Proofview.initial_goals entry with
-    | [_, body, typ] -> body, typ
-    | _ -> assert false
-    in
-    let () = if not @@ Proof.is_done proof then raise (OpenProof (name, OpenGoals)) in
-    let evd = Evd.minimize_universes evd in
-    let to_constr c = match EConstr.to_constr_opt evd c with
-    | Some p -> p
-    | None -> raise_non_ground_proof evd name c
-    in
-    let body = to_constr body in
-    let typ = to_constr typ in
-    (body, typ, Evd.ustate evd)
-  in
-  let univs =
-    let _, used_univs = universes_of_body_type ~used_univs:Univ.Level.Set.empty body (Some typ) in
-    let uctx = UState.restrict output_ustate used_univs in
-    UState.check_univ_decl ~poly uctx UState.default_univ_decl
-  in
-  (* FIXME: return the locally introduced effects *)
-  let { Proof.sigma } = Proof.data proof in
-  let sigma = Evd.set_universe_context sigma output_ustate in
-  (univs, body, typ), status, sigma
-
-let build_by_tactic env ~uctx ~poly ~typ tac =
-  let name = Id.of_string ("temporary_proof"^string_of_int (next())) in
-  let sign = Environ.(val_of_named_context (named_context env)) in
-  let sigma = Evd.from_ctx uctx in
-  let (univs, body, typ), status, sigma = build_constant_by_tactic ~name ~env ~sigma ~sign ~poly typ tac in
-  let uctx = Evd.ustate sigma in
-  (* ignore side effect universes:
-     we don't reset the global env in this code path so the side effects are still present
-     cf #13271 and discussion in #18874
-     (but due to #13324 we still want to inline them) *)
-  let effs = Evd.seff_private @@ Evd.eval_side_effects sigma in
-  let body, ctx = Safe_typing.inline_private_constants env ((body, Univ.ContextSet.empty), effs) in
-  let _uctx = UState.merge_universe_context ~sideff:true Evd.univ_rigid uctx ctx in
-  body, typ, univs, status, uctx
-
-let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl =
-  let (const, safe, sigma') =
-    try build_constant_by_tactic ~name ~poly ~env ~sigma ~sign:secsign concl solve_tac
-    with Logic_monad.TacticFailure e as src ->
-    (* if the tactic [tac] fails, it reports a [TacticFailure e],
-       which is an error irrelevant to the proof system (in fact it
-       means that [e] comes from [tac] failing to yield enough
-       success). Hence it reraises [e]. *)
-    let (_, info) = Exninfo.capture src in
-    Exninfo.iraise (e, info)
-  in
-  let (univs, body, typ) = const in
-  let sigma = Evd.drop_new_defined ~original:sigma sigma' in
-  (* EJGA: Hack related to the above call to
-     `build_constant_by_tactic` with `~opaque:Transparent`. Even if
-     the abstracted term is destined to be opaque, if we trigger the
-     `if poly && opaque && private_poly_univs ()` in `close_proof`
-     kernel will boom. This deserves more investigation. *)
-  let body, typ, args = ProofEntry.shrink_entry sign body (Some typ) in
-  let ts = Environ.oracle env in
-  let cst, effs =
-    (* No side-effects in the entry, they already exist in the ambient environment *)
-    let effs = Evd.eval_side_effects sigma in
-    let de, ctx =
-      let univ_entry, ctx = extract_monomorphic (fst univs) in
-      if not opaque then
-        DefinitionEff { Entries.definition_entry_body = body;
-          definition_entry_secctx = None;
-          definition_entry_type = Some typ;
-          definition_entry_universes = univ_entry;
-          definition_entry_inline_code = false;
-        }, ctx
-      else
-        let secctx =
-          let env = Global.env () in
-          let hyps =
-            if List.is_empty (Environ.named_context env) then Id.Set.empty
-            else
-              let ids_typ = Environ.global_vars_set env typ in
-              let vars = Environ.global_vars_set env body in
-              Id.Set.union ids_typ vars
-          in
-          Environ.really_needed env hyps
-        in
-        OpaqueEff { Entries.opaque_entry_body = body;
-          opaque_entry_secctx = secctx;
-          opaque_entry_type = typ;
-          opaque_entry_universes = univ_entry;
-        },
-        ctx
-    in
-    Evd.push_side_effects ~ts name de ctx effs
-  in
-  let sigma = Evd.emit_side_effects effs sigma in
-  let inst = match univs with
-  | UState.Monomorphic_entry _, _ -> UVars.Instance.empty
-  | UState.Polymorphic_entry uctx, _ -> UVars.UContext.instance uctx
-  in
-  let lem = EConstr.of_constr (Constr.mkConstU (cst, inst)) in
-  sigma, lem, args, safe
 
 let get_goal_context pf i =
   let p = get pf in
@@ -2406,7 +2266,8 @@ let finish_proved_equations ~pm ~kind ~hook i entries types sigma0 =
             id
         in
         let body, opaque = match entry.proof_entry_body with Default { body; opaque } -> body, opaque | _ -> assert false in
-        let body, typ, args = ProofEntry.shrink_entry local_context body entry.proof_entry_type in
+        let typ = match entry.proof_entry_type with None -> assert false | Some typ -> typ in
+        let body, typ, args = Subproof.shrink_entry local_context body typ in
         let entry = { entry with proof_entry_body = Default { body; opaque }; proof_entry_type = Some typ } in
         let cst = declare_constant ~loc:None ~name:id ~kind ~typing_flags:None (DefinitionEntry entry) in
         let sigma, app = Evd.fresh_global (Global.env ()) sigma (GlobRef.ConstRef cst) in
@@ -2500,9 +2361,6 @@ end (* Proof module *)
 
 let _ = Ind_tables.declare_definition_scheme := declare_definition_scheme
 let _ = Ind_tables.register_definition_scheme := register_definition_scheme
-let _ = Abstract.declare_abstract := Proof.declare_abstract
-
-let build_by_tactic = Proof.build_by_tactic
 
 module Internal = struct
 
@@ -2613,7 +2471,7 @@ let solve_by_tac prg obls i tac =
   try
     let env = Global.env () in
     let body, types, _univs, _, uctx =
-      build_by_tactic env ~uctx ~poly ~typ:(EConstr.of_constr obl.obl_type) tac in
+      Subproof.build_by_tactic env ~uctx ~poly ~typ:(EConstr.of_constr obl.obl_type) tac in
     Inductiveops.control_only_guard env (Evd.from_ctx uctx) (EConstr.of_constr body);
     Some (body, types, uctx)
   with
@@ -2622,7 +2480,7 @@ let solve_by_tac prg obls i tac =
     let loc = fst obl.obl_location in
     CErrors.user_err ?loc (Lazy.force s)
   (* If the proof is open we absorb the error and leave the obligation open *)
-  | Proof.OpenProof _ ->
+  | Proof.OpenProof _ | Subproof.OpenProof _ ->
     None
   | e when CErrors.noncritical e ->
     let err = CErrors.print e in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2213,7 +2213,7 @@ let by env tac pf =
   let sideff = SideEff.concat eff pf.sideff in
   { pf with proof; sideff }, safe
 
-let build_constant_by_tactic ~name ?(warn_incomplete = true) ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
+let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly (typ : EConstr.t) tac =
   let proof = Proof.start ~name ~poly sigma [Global.env_of_context sign, typ] in
   let proof, status = Proof.solve env (Goal_select.select_nth 1) None tac proof in
   let (body, typ, output_ustate) =
@@ -2230,7 +2230,6 @@ let build_constant_by_tactic ~name ?(warn_incomplete = true) ~sigma ~env ~sign ~
     in
     let body = to_constr body in
     let typ = to_constr typ in
-    let () = if warn_incomplete then check_incomplete_proof evd in
     (body, typ, Evd.ustate evd)
   in
   let univs =
@@ -2261,7 +2260,7 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
 
 let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl =
   let (const, safe, sigma') =
-    try build_constant_by_tactic ~warn_incomplete:false ~name ~poly ~env ~sigma ~sign:secsign concl solve_tac
+    try build_constant_by_tactic ~name ~poly ~env ~sigma ~sign:secsign concl solve_tac
     with Logic_monad.TacticFailure e as src ->
     (* if the tactic [tac] fails, it reports a [TacticFailure e],
        which is an error irrelevant to the proof system (in fact it

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -481,7 +481,7 @@ val build_by_tactic
   -> poly:PolyFlags.t
   -> typ:EConstr.types
   -> unit Proofview.tactic
-  -> Constr.constr * Constr.types option * UState.named_universes_entry * bool * UState.t
+  -> Constr.constr * Constr.types * UState.named_universes_entry * bool * UState.t
 
 (** {2 Program mode API} *)
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -474,15 +474,6 @@ val definition_message : Id.t -> unit
 val assumption_message : Id.t -> unit
 val fixpoint_message : int array option -> Id.t list -> unit
 
-(** Semantics of this function is a bit dubious, use with care *)
-val build_by_tactic
-  :  Environ.env
-  -> uctx:UState.t
-  -> poly:PolyFlags.t
-  -> typ:EConstr.types
-  -> unit Proofview.tactic
-  -> Constr.constr * Constr.types * UState.named_universes_entry * bool * UState.t
-
 (** {2 Program mode API} *)
 
 (** Rocq's Program mode support. This mode extends declarations of


### PR DESCRIPTION
We first make explicit that this code does not depend on Declare anymore after the change of implementation of abstract. This allows putting this code in a new module `Subproof` where it belongs, i.e. in the `proofs/` folder, thus also removing disgracious hooks. The code is basically the same code as the refine_by_tactic function, up to tricky details, so we also move this function there for good measure. Some factoring and cleanup are now in order.

Overlays:
- https://github.com/Mtac2/Mtac2/pull/420
- https://github.com/mit-plv/rewriter/pull/189