### PR TITLE
Don't exit in partac on_marshal_error (and only print when debug is on)

### DIFF
--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -11,6 +11,7 @@
 open Pp
 
 let stm_pr_err s  = Format.eprintf "%s] %s\n%!"     (Spawned.process_id ()) s
+let stm_prerr_endline s = if CDebug.(get_flag misc) then begin stm_pr_err s end else ()
 
 type response =
   | RespBuiltSubProof of (Constr.constr * UState.t)
@@ -87,8 +88,8 @@ end = struct (* {{{ *)
     `Stay ((),[])
 
   let on_marshal_error err { t_name } =
-    stm_pr_err ("Fatal marshal error (task " ^ t_name ^ "): " ^ err);
-    flush_all (); exit 1
+    stm_prerr_endline ("Fatal marshal error (task " ^ t_name ^ "): " ^ err);
+    flush_all ()
 
   let on_task_cancellation_or_expiration_or_slave_death = function
     | Some { t_goalno; t_assign; t_kill } ->


### PR DESCRIPTION
IIUC marshal errors can happen in the following scenario:
- goal 1 fails (with a regular error)
- the worker for goal 2 gets killed during marshalling

This seems to happen semi regularly in CI leading to red CI (in Partac test, saying eg "Fatal marshal error (task 4): marshal_request: Bad file descriptor").

Testing with artificial marshal errors shows that this works correctly when 1 goal has a regular error and 1 goal has a marshal error (ie prints the regular error with no noise about marshal errors), and produces "Missing results" anomaly if 1 goal succeeds and 1 goal has a marshal error, which IMO is reasonable.
