### PR TITLE
Nameops.root_of_id don't fail on invalid idents

### DIFF
--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -103,7 +103,7 @@ let make_ident sa = function
 
 let root_of_id id =
   let suffixstart = cut_ident true id in
-  Id.of_string (String.sub (Id.to_string id) 0 suffixstart)
+  Id.of_string_soft (String.sub (Id.to_string id) 0 suffixstart)
 
 (* Return the same identifier as the original one but whose {i subscript} is incremented.
    If the original identifier does not have a suffix, [0] is appended to it.


### PR DESCRIPTION
ie if an ident built with of_string_soft is passed to this function it shouldn't cause a failure.
