### PR TITLE
Fix off-by-one error in qualid_of_global for inductive printing

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21473-fix-printing-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21473-fix-printing-Fixed.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  ``qualid_of_global`` now prints inductives without ``<inductive`` and ``>``
+  in more cases (`#21473 <https://github.com/rocq-prover/rocq/pull/21473>`_,
+  by Jason Gross).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -94,10 +94,10 @@ let qualid_of_global = function
   (* We rely on the tacite invariant that the label of a constant is used to build its internal name *)
   | GlobRef.ConstRef cst -> Libnames.make_qualid (dirpath_of_modpath (Constant.modpath cst)) (Constant.label cst)
   (* We rely on the tacite invariant that an inductive block inherits the name of its first type *)
-  | GlobRef.IndRef (ind,1) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (MutInd.label ind)
+  | GlobRef.IndRef (ind,0) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (MutInd.label ind)
   (* These are hacks *)
   | GlobRef.IndRef (ind,n) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<inductive:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ">"))
-  | GlobRef.ConstructRef ((ind,1),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
+  | GlobRef.ConstructRef ((ind,0),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int (p+1) ^ ">"))
   | GlobRef.ConstructRef ((ind,n),p) -> Libnames.make_qualid (dirpath_of_modpath (MutInd.modpath ind)) (Id.of_string_soft ("<constructor:" ^ Id.to_string (MutInd.label ind) ^ ":" ^ string_of_int n ^ ":" ^ string_of_int (p+1) ^ ">"))
 
 let default_extern_reference ?loc vars r =


### PR DESCRIPTION
The first inductive in a mutual block has index 0, not 1. This fixes the pattern matching for IndRef and ConstructRef to use the correct index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes / closes #????

Extracted from #21465

- [ ] Added / updated **test-suite**.

- [x] Added **changelog**.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
