### PR TITLE
Make Print Assumptions commands accept a list of globals

### DIFF
--- a/dev/ci/user-overlays/21477-JasonGross-print-assumptions-list.sh
+++ b/dev/ci/user-overlays/21477-JasonGross-print-assumptions-list.sh
@@ -1,0 +1,3 @@
+overlay paramcoq https://github.com/JasonGross/paramcoq print-assumptions-list 21477
+
+overlay metarocq https://github.com/JasonGross/metacoq print-assumptions-list 21477

--- a/doc/changelog/08-vernac-commands-and-options/21477-print-assumptions-list-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21477-print-assumptions-list-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  :cmd:`Print Assumptions`, :cmd:`Print Opaque Dependencies`, :cmd:`Print
+  Transparent Dependencies`, and :cmd:`Print All Dependencies` now accept lists
+  of globals instead of single references
+  (`#21477 <https://github.com/rocq-prover/rocq/pull/21477>`_,
+  by Jason Gross).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -429,23 +429,23 @@ described elsewhere
 Requests to the environment
 -------------------------------
 
-.. cmd:: Print Assumptions @reference
+.. cmd:: Print Assumptions {+ @reference }
 
    Displays all the assumptions (axioms, parameters and
-   variables) a theorem or definition depends on.
+   variables) one or more theorems or definitions depends on.
 
-   The message "Closed under the global context" indicates that the theorem or
-   definition has no dependencies.
+   The message "Closed under the global context" indicates that all the theorems and
+   definitions have no dependencies.
 
-.. cmd:: Print Opaque Dependencies @reference
+.. cmd:: Print Opaque Dependencies {+ @reference }
 
    Displays the assumptions and opaque constants that :n:`@reference` depends on.
 
-.. cmd:: Print Transparent Dependencies @reference
+.. cmd:: Print Transparent Dependencies {+ @reference }
 
-   Displays the assumptions and  transparent constants that :n:`@reference` depends on.
+   Displays the assumptions and transparent constants that :n:`@reference` depends on.
 
-.. cmd:: Print All Dependencies @reference
+.. cmd:: Print All Dependencies {+ @reference }
 
    Displays all the assumptions and constants :n:`@reference` depends on.
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1440,10 +1440,10 @@ printable: [
 | "Implicit" smart_global
 | [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT ne_string
 | "Sorts"
-| "Assumptions" smart_global
-| "Opaque" "Dependencies" smart_global
-| "Transparent" "Dependencies" smart_global
-| "All" "Dependencies" smart_global
+| "Assumptions" LIST1 smart_global
+| "Opaque" "Dependencies" LIST1 smart_global
+| "Transparent" "Dependencies" LIST1 smart_global
+| "All" "Dependencies" LIST1 smart_global
 | "Strategy" smart_global
 | "Strategies"
 | "Registered"

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -782,10 +782,10 @@ command: [
 | "Print" "Implicit" reference
 | "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 debug_univ_name ")" ) OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT string
 | "Print" "Sorts"
-| "Print" "Assumptions" reference
-| "Print" "Opaque" "Dependencies" reference
-| "Print" "Transparent" "Dependencies" reference
-| "Print" "All" "Dependencies" reference
+| "Print" "Assumptions" LIST1 reference
+| "Print" "Opaque" "Dependencies" LIST1 reference
+| "Print" "Transparent" "Dependencies" LIST1 reference
+| "Print" "All" "Dependencies" LIST1 reference
 | "Print" "Strategy" reference
 | "Print" "Strategies"
 | "Print" "Registered"

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -12,23 +12,23 @@ open Names
 open Constr
 open Printer
 
-(** Collects all the objects on which a term directly relies, bypassing kernel
+(** Collects all the objects on which terms directly rely, bypassing kernel
     opacity, together with the recursive dependence DAG of objects.
 
     WARNING: some terms may not make sense in the environment, because they are
     sealed inside opaque modules. Do not try to do anything fancy with those
     terms apart from printing them, otherwise demons may fly out of your nose.
 
-    NOTE: this function is used in the plugin paramcoq.
+    NOTE: this function is used in the plugins paramcoq and metarocq.
 *)
 val traverse :
-  Global.indirect_accessor -> GlobRef.t -> constr ->
+  Global.indirect_accessor -> GlobRef.t list ->
     (GlobRef.Set_env.t * GlobRef.Set_env.t option GlobRef.Map_env.t *
      (GlobRef.t * Constr.rel_context * types) list GlobRef.Map_env.t)
 
 (** Collects all the assumptions (optionally including opaque definitions)
-   on which a term relies (together with their type). The above warning of
+   on which terms rely (together with their type). The above warning of
    {!traverse} also applies. *)
 val assumptions :
   ?add_opaque:bool -> ?add_transparent:bool -> Global.indirect_accessor ->
-  TransparentState.t -> GlobRef.t -> constr -> types ContextObjectMap.t
+  TransparentState.t -> GlobRef.t list -> types ContextObjectMap.t

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1206,10 +1206,10 @@ GRAMMAR EXTEND Gram
         fopt = OPT ne_string ->
         { PrintUniverses {sort=b; subgraph=g; with_sources; file=fopt;} }
       | IDENT "Sorts" -> { PrintSorts }
-      | IDENT "Assumptions"; qid = smart_global -> { PrintAssumptions (false, false, qid) }
-      | IDENT "Opaque"; IDENT "Dependencies"; qid = smart_global -> { PrintAssumptions (true, false, qid) }
-      | IDENT "Transparent"; IDENT "Dependencies"; qid = smart_global -> { PrintAssumptions (false, true, qid) }
-      | IDENT "All"; IDENT "Dependencies"; qid = smart_global -> { PrintAssumptions (true, true, qid) }
+      | IDENT "Assumptions"; qids = LIST1 smart_global -> { PrintAssumptions (false, false, qids) }
+      | IDENT "Opaque"; IDENT "Dependencies"; qids = LIST1 smart_global -> { PrintAssumptions (true, false, qids) }
+      | IDENT "Transparent"; IDENT "Dependencies"; qids = LIST1 smart_global -> { PrintAssumptions (false, true, qids) }
+      | IDENT "All"; IDENT "Dependencies"; qids = LIST1 smart_global -> { PrintAssumptions (true, true, qids) }
       | IDENT "Strategy"; qid = smart_global -> { PrintStrategy (Some qid) }
       | IDENT "Strategies" -> { PrintStrategy None }
       | IDENT "Registered" -> { PrintRegistered }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -698,14 +698,14 @@ let pr_printable = function
     keyword "Print Implicit" ++ spc()  ++ pr_smart_global qid
   (* spiwack: command printing all the axioms and section variables used in a
      term *)
-  | PrintAssumptions (b, t, qid) ->
+  | PrintAssumptions (b, t, qids) ->
     let cmd = match b, t with
       | true, true -> "Print All Dependencies"
       | true, false -> "Print Opaque Dependencies"
       | false, true -> "Print Transparent Dependencies"
       | false, false -> "Print Assumptions"
     in
-    keyword cmd ++ spc() ++ pr_smart_global qid
+    keyword cmd ++ spc() ++ prlist_with_sep spc pr_smart_global qids
   | PrintNamespace dp ->
     keyword "Print Namespace" ++ DirPath.print dp
   | PrintStrategy None ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2276,13 +2276,12 @@ let vernac_print =
     print_about_hyp_globs ref_or_by_not udecl glnumopt
   | PrintImplicit qid -> with_proof_env @@ fun env _sigma ->
     Prettyp.print_impargs env (smart_global qid)
-  | PrintAssumptions (o,t,r) -> with_proof_env_and_opaques @@ fun ~opaque_access env sigma ->
+  | PrintAssumptions (o,t,rs) -> with_proof_env_and_opaques @@ fun ~opaque_access env sigma ->
     (* Prints all the axioms and section variables used by a term *)
-    let gr = smart_global r in
-    let cstr, _ = UnivGen.fresh_global_instance env gr in
     let st = Conv_oracle.get_transp_state (Environ.oracle env) in
+    let grs = List.map smart_global rs in
     let nassums =
-      Assumptions.assumptions opaque_access st ~add_opaque:o ~add_transparent:t gr cstr in
+      Assumptions.assumptions opaque_access st ~add_opaque:o ~add_transparent:t grs in
     Printer.pr_assumptionset env sigma nassums
   | PrintStrategy r -> no_state @@ fun () -> print_strategy r
   | PrintRegistered -> no_state print_registered

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -72,7 +72,7 @@ type printable =
   | PrintVisibility of string option
   | PrintAbout of qualid or_by_notation * UnivNames.full_name_list option * Goal_select.t option
   | PrintImplicit of qualid or_by_notation
-  | PrintAssumptions of bool * bool * qualid or_by_notation
+  | PrintAssumptions of bool * bool * qualid or_by_notation list
   | PrintStrategy of qualid or_by_notation option
   | PrintRegistered
   | PrintRegisteredSchemes


### PR DESCRIPTION
Print Assumptions, Print Opaque Dependencies, Print Transparent Dependencies, and Print All Dependencies now accept LIST1 smart_global instead of a single reference. This allows an asymptotic speedup in checking assumptions for multiple definitions at once, with results combined.

The Assumptions.traverse and Assumptions.assumptions functions now take a list of (GlobRef.t * constr) pairs instead of a single pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #5639

- [ ] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

- [x] Opened **overlay** pull requests.

Overlays:
- https://github.com/rocq-community/paramcoq/pull/149
- https://github.com/MetaRocq/metarocq/pull/1231

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
