### PR TITLE
extern_reference only fallback for constants from the current module

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21473-fix-printing-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21473-fix-printing-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:** fallback printing of inductives using
+  ``<inductive:Foo:0>`` now prints correctly
+  (though with possibly more qualification than needed)
+  (it should in any case only happen rarely from module errors)
+  (`#21484 <https://github.com/rocq-prover/rocq/pull/21484>`_, by Gaëtan Gilbert).

--- a/test-suite/bugs/bug_2995.v
+++ b/test-suite/bugs/bug_2995.v
@@ -5,9 +5,24 @@ End Interface.
 Module Implementation <: Interface.
   Definition t := bool.
   Definition error: t := false.
-Fail End Implementation.
+  Fail End Implementation.
 (* A UserError here is expected, not an uncaught Not_found *)
 
  Reset error.
  Definition error := 0.
 End Implementation.
+
+
+Module Implementation2 <: Interface.
+  Definition t := bool.
+  Inductive x := X with y := Y.
+  Definition error := X.
+  Fail End Implementation2.
+
+  Reset error.
+  Definition error := Y.
+  Fail End Implementation2.
+
+  Reset error.
+  Definition error := 0.
+End Implementation2.

--- a/test-suite/output-coqtop/bug_16462.out
+++ b/test-suite/output-coqtop/bug_16462.out
@@ -11,8 +11,8 @@ Rocq < 1 goal
   ============================
   True
 
-Unnamed_thm < Top.Unnamed_thm_subproof
-Top.Unnamed_thm_subproof
+Unnamed_thm < Unnamed_thm_subproof
+Unnamed_thm_subproof
 Toplevel input, characters 2-7:
 >   baz I.
 >   ^^^^^
@@ -22,9 +22,8 @@ In nested Ltac calls to "baz", "f" (bound to fun f x y => idtac v; f x),
 "f" (bound to
 fun _ => let v' := v in
          constr:((fun _ => ltac:(idtac v'; fail 1)))) and
-"(fun _ => ltac:(idtac v'; fail 1))" (with x:=I,
-v':=Top.Unnamed_thm_subproof, v:=Top.Unnamed_thm_subproof, H:=H), last term
-evaluation failed.
+"(fun _ => ltac:(idtac v'; fail 1))" (with x:=I, v':=Unnamed_thm_subproof,
+v:=Unnamed_thm_subproof, H:=H), last term evaluation failed.
 
 
 Unnamed_thm < 

--- a/test-suite/output-coqtop/bug_16745.out
+++ b/test-suite/output-coqtop/bug_16745.out
@@ -10,8 +10,8 @@ Unnamed_thm < Unnamed_thm < Unnamed_thm < Toplevel input, characters 111-112:
 >                                             ^
 Error:
 In environment
-x := Top.Unnamed_thm_subproof : nat
-The term "Top.Unnamed_thm_subproof" has type "nat"
+x := Unnamed_thm_subproof : nat
+The term "Unnamed_thm_subproof" has type "nat"
 while it is expected to have type "True".
 
 Unnamed_thm < 


### PR DESCRIPTION
(assuming them to be not-in-nametab side effects)

This lets us print them with a short name instead of pointlessly fully qualified.

It also makes the wrapping of extern_reference in
Printer.safe_extern_wrapper actually useful (since it does `try orig_extern_ref r with e -> fallback` it would not be useful when orig_extern_ref could not raise exceptions).

That wrapper is what now handles unknown inductives from module errors (see eg the expanded test for #2995) so we print a fully qualified but syntactically correct inductive name instead of `<inductive:foo:n>`.
