### PR TITLE
Add Ltac2 `Env.assumptions` exposing assumptions.ml

### DIFF
--- a/doc/changelog/06-Ltac2-language/21488-ltac2-print-assumptions-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21488-ltac2-print-assumptions-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  ``Env.assumptions`` gets the data returned by :cmd:`Print
+  Assumptions`, :cmd:`Print Opaque Dependencies`, :cmd:`Print Transparent
+  Dependencies`, :cmd:`Print All Dependencies` (`#21488
+  <https://github.com/rocq-prover/rocq/pull/21488>`_, fixes `#21487
+  <https://github.com/rocq-prover/rocq/issues/21487>`_, by Jason Gross).

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -61,6 +61,7 @@ let val_pretype_flags = Val.create "pretype_flags"
 let val_expected_type = Val.create "expected_type"
 let val_reduction = Val.create "reduction"
 let val_rewstrategy = Val.create "rewstrategy"
+let val_assumption_data : Printer.context_object Val.tag = Val.create "assumption_data"
 
 let extract_val (type a) (type b) (tag : a Val.tag) (tag' : b Val.tag) (v : b) : a =
 match Val.eq tag tag' with
@@ -479,3 +480,7 @@ let reference = {
   r_of = of_reference;
   r_to = to_reference;
 }
+
+let of_assumption_data c = of_ext val_assumption_data c
+let to_assumption_data c = to_ext val_assumption_data c
+let assumption_data = repr_ext val_assumption_data

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -216,6 +216,10 @@ val of_reference : GlobRef.t -> valexpr
 val to_reference : valexpr -> GlobRef.t
 val reference : GlobRef.t repr
 
+val of_assumption_data : Printer.context_object -> valexpr
+val to_assumption_data : valexpr -> Printer.context_object
+val assumption_data : Printer.context_object repr
+
 val of_ext : 'a Val.tag -> 'a -> valexpr
 val to_ext : 'a Val.tag -> valexpr -> 'a
 val repr_ext : 'a Val.tag -> 'a repr

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -752,3 +752,117 @@ let () =
 
 let () = define "f_equal" (unit @-> tac unit) @@ fun () ->
     Tac2tactics.f_equal
+
+(** Assumptions *)
+
+let tac_assumptions add_opaque add_transparent st refs =
+  Tac2core.pf_apply @@ fun env _sigma ->
+  let access = Library.indirect_accessor [@@warning "-3"] in
+  let result = Assumptions.assumptions ~add_opaque ~add_transparent access st refs in
+  let bindings = Printer.ContextObjectMap.bindings result in
+  let converted = List.map (fun (obj, typ) ->
+    (obj, EConstr.of_constr typ)
+  ) bindings in
+  return converted
+
+let () =
+  define "env_assumptions"
+    (bool @-> bool @-> transparent_state @-> list reference @-> tac (list (pair assumption_data constr)))
+    tac_assumptions
+
+(** Assumption accessors *)
+
+let assumption_reference obj =
+  let open Printer in
+  let open Names.GlobRef in
+  match obj with
+  | Variable id -> VarRef id
+  | Axiom (Constant kn, _) -> ConstRef kn
+  | Axiom (Positive m, _) -> IndRef (m, 0)
+  | Axiom (Guarded gr, _) -> gr
+  | Axiom (TypeInType gr, _) -> gr
+  | Axiom (UIP m, _) -> IndRef (m, 0)
+  | Opaque kn -> ConstRef kn
+  | Transparent kn -> ConstRef kn
+
+let () =
+  define "env_assumption_reference"
+    (assumption_data @-> ret reference)
+    assumption_reference
+
+let assumption_is_axiom obj =
+  let open Printer in
+  match obj with
+  | Axiom (Constant _, _) -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_is_axiom"
+    (assumption_data @-> ret bool)
+    assumption_is_axiom
+
+let assumption_is_opaque obj =
+  let open Printer in
+  match obj with
+  | Opaque _ -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_is_opaque"
+    (assumption_data @-> ret bool)
+    assumption_is_opaque
+
+let assumption_is_transparent obj =
+  let open Printer in
+  match obj with
+  | Transparent _ -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_is_transparent"
+    (assumption_data @-> ret bool)
+    assumption_is_transparent
+
+let assumption_assumes_positive obj =
+  let open Printer in
+  match obj with
+  | Axiom (Positive _, _) -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_assumes_positive"
+    (assumption_data @-> ret bool)
+    assumption_assumes_positive
+
+let assumption_assumes_guarded obj =
+  let open Printer in
+  match obj with
+  | Axiom (Guarded _, _) -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_assumes_guarded"
+    (assumption_data @-> ret bool)
+    assumption_assumes_guarded
+
+let assumption_assumes_type_in_type obj =
+  let open Printer in
+  match obj with
+  | Axiom (TypeInType _, _) -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_assumes_type_in_type"
+    (assumption_data @-> ret bool)
+    assumption_assumes_type_in_type
+
+let assumption_assumes_uip obj =
+  let open Printer in
+  match obj with
+  | Axiom (UIP _, _) -> true
+  | _ -> false
+
+let () =
+  define "env_assumption_assumes_uip"
+    (assumption_data @-> ret bool)
+    assumption_assumes_uip

--- a/test-suite/ltac2/assumptions.v
+++ b/test-suite/ltac2/assumptions.v
@@ -1,0 +1,88 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Env.
+Require Import Ltac2.TransparentState.
+
+(* Test axiom *)
+Axiom test_axiom : nat.
+
+(* Test opaque definition *)
+Definition test_opaque : nat. Proof. exact 0. Qed.
+
+(* Test transparent definition *)
+Definition test_transparent : nat := 0.
+
+(* Test definition that depends on an axiom *)
+Definition depends_on_axiom : nat := test_axiom.
+
+(* Basic test: assumptions on an axiom returns itself *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(test_axiom)] in
+  Control.assert_true (Int.equal (List.length asms) 1).
+
+(* Test: assumptions on transparent definition with no axioms returns empty *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(test_transparent)] in
+  Control.assert_true (Int.equal (List.length asms) 0).
+
+(* Test: assumptions on definition depending on axiom finds the axiom *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(depends_on_axiom)] in
+  Control.assert_true (Int.equal (List.length asms) 1).
+
+(* Test: is_axiom accessor *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(test_axiom)] in
+  match asms with
+  | (a, _) :: _ => Control.assert_true (Env.Assumption.is_axiom a)
+  | [] => Control.throw Assertion_failure
+  end.
+
+(* Test: is_opaque accessor with add_opaque=true *)
+Ltac2 Eval
+  let asms := Env.assumptions true false TransparentState.full [reference:(test_opaque)] in
+  Control.assert_true (Int.equal (List.length asms) 1).
+
+Ltac2 Eval
+  let asms := Env.assumptions true false TransparentState.full [reference:(test_opaque)] in
+  match asms with
+  | (a, _) :: _ => Control.assert_true (Env.Assumption.is_opaque a)
+  | [] => Control.throw Assertion_failure
+  end.
+
+(* Test: is_transparent accessor with add_transparent=true *)
+Ltac2 Eval
+  let asms := Env.assumptions false true TransparentState.full [reference:(test_transparent)] in
+  Control.assert_true (Int.equal (List.length asms) 1).
+
+Ltac2 Eval
+  let asms := Env.assumptions false true TransparentState.full [reference:(test_transparent)] in
+  match asms with
+  | (a, _) :: _ => Control.assert_true (Env.Assumption.is_transparent a)
+  | [] => Control.throw Assertion_failure
+  end.
+
+(* Test: reference accessor *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(test_axiom)] in
+  match asms with
+  | (a, _) :: _ =>
+    match Env.Assumption.reference a with
+    | Std.ConstRef _ => ()
+    | _ => Control.throw Assertion_failure
+    end
+  | [] => Control.throw Assertion_failure
+  end.
+
+(* Test: other accessors return false for plain axiom *)
+Ltac2 Eval
+  let asms := Env.assumptions false false TransparentState.full [reference:(test_axiom)] in
+  match asms with
+  | (a, _) :: _ =>
+    Control.assert_false (Env.Assumption.is_opaque a);
+    Control.assert_false (Env.Assumption.is_transparent a);
+    Control.assert_false (Env.Assumption.assumes_positive a);
+    Control.assert_false (Env.Assumption.assumes_guarded a);
+    Control.assert_false (Env.Assumption.assumes_type_in_type a);
+    Control.assert_false (Env.Assumption.assumes_uip a)
+  | [] => Control.throw Assertion_failure
+  end.

--- a/theories/Ltac2/Env.v
+++ b/theories/Ltac2/Env.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-From Ltac2 Require Import Init Std.
+From Ltac2 Require Import Init Std TransparentState.
 
 Ltac2 @ external get : ident list -> Std.reference option := "rocq-runtime.plugins.ltac2" "env_get".
 (** Returns the global reference corresponding to the absolute name given as
@@ -26,3 +26,49 @@ Ltac2 @ external instantiate : Std.reference -> constr := "rocq-runtime.plugins.
 (** Returns a fresh instance of the corresponding reference, in particular
     generating fresh universe variables and constraints when this reference is
     universe-polymorphic. *)
+
+Module Assumption.
+(** Assumption analysis (as used by Print Assumptions) *)
+
+  Ltac2 Type t.
+  (** Opaque type representing an assumption (axiom, opaque constant, etc.) *)
+
+  Ltac2 @external reference : t -> Std.reference :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_reference".
+  (** Get the reference associated with an assumption *)
+
+  Ltac2 @external is_axiom : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_is_axiom".
+  (** Returns true if the assumption is an axiom (constant without body) *)
+
+  Ltac2 @external is_opaque : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_is_opaque".
+  (** Returns true if the assumption is an opaque constant *)
+
+  Ltac2 @external is_transparent : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_is_transparent".
+  (** Returns true if the assumption is a transparent constant *)
+
+  Ltac2 @external assumes_positive : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_assumes_positive".
+  (** Returns true if the assumption relies on a positivity assumption *)
+
+  Ltac2 @external assumes_guarded : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_assumes_guarded".
+  (** Returns true if the assumption relies on a guardedness assumption *)
+
+  Ltac2 @external assumes_type_in_type : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_assumes_type_in_type".
+  (** Returns true if the assumption relies on Type-in-Type *)
+
+  Ltac2 @external assumes_uip : t -> bool :=
+    "rocq-runtime.plugins.ltac2" "env_assumption_assumes_uip".
+  (** Returns true if the assumption relies on definitional UIP *)
+End Assumption.
+
+Ltac2 @external assumptions : bool -> bool -> TransparentState.t -> Std.reference list -> (Assumption.t * constr) list :=
+  "rocq-runtime.plugins.ltac2" "env_assumptions".
+(** Returns the list of assumptions that a list of references depend on.
+    The first bool enables including opaque constants.
+    The second bool enables including transparent constants.
+    The transparent_state controls which constants are considered transparent. *)


### PR DESCRIPTION
Add Ltac2 `Env.assumptions` module exposes assumptions.ml
    
This adds an Ltac2 interface to the assumptions analysis used by `Print Assumptions`. The new `Env.Assumptions` module provides:
    
- `Env.assumptions`: compute assumptions for a list of references
- `t`: opaque type representing an assumption
- Accessor functions: `reference`, `is_axiom`, `is_opaque`, `is_transparent`, `assumes_positive`, `assumes_guarded`, `assumes_type_in_type`, `assumes_uip`; this ensures that code is future-proof against extensions to the datatype
    
The function takes a `TransparentState.t` argument to control which constants are considered transparent during the analysis.
    
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

On top of https://github.com/rocq-prover/rocq/pull/21477
Fixes #21487

- [x] Added / updated **test-suite**.

- [x] Added **changelog**.
- [ ] Added / updated **documentation**.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
