### PR TITLE
Simplify squashed_gen / allowed_elimination_gen API

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -419,10 +419,11 @@ let is_squashed_gen g indsort_to_quality squashed_to_quality ((_,mip),u) =
   | Some squash ->
      let indq = indsort_to_quality u s in
      match squash with
-     | AlwaysSquashed -> begin match s with
-                         | Set -> Some SquashToSet
-                         | _ -> Some (SquashToQuality indq)
-                         end
+     | AlwaysSquashed ->
+       begin match s with
+       | Set -> Some SquashToSet
+       | _ -> Some (SquashToQuality indq)
+       end
      | SometimesSquashed squash ->
         (* impredicative set squashes are always quashed,
            so here if inds=Set it is a sort poly squash (see "foo6" in test sort_poly.v) *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -412,29 +412,29 @@ type 'a allow_elimination_actions =
   ; squashed_to_set_above : 'a
   ; squashed_to_quality : Quality.t -> 'a }
 
-let is_squashed_gen g indsort_to_quality squashed_to_quality ((_,mip),u) =
+let is_squashed_gen g nf_quality ((_,mip),u) =
   let s = mip.mind_sort in
   match mip.mind_squashed with
   | None -> None
   | Some squash ->
-     let indq = indsort_to_quality u s in
-     match squash with
-     | AlwaysSquashed ->
-       begin match s with
-       | Set -> Some SquashToSet
-       | _ -> Some (SquashToQuality indq)
-       end
-     | SometimesSquashed squash ->
-        (* impredicative set squashes are always quashed,
-           so here if inds=Set it is a sort poly squash (see "foo6" in test sort_poly.v) *)
-        if Quality.Set.for_all
-             (fun q -> eliminates_to g indq (squashed_to_quality u q))
-             squash && not @@ Quality.is_qvar indq
-        then None
-        else Some (SquashToQuality indq)
+    let indq = nf_quality (UVars.subst_instance_quality u @@ Sorts.quality s) in
+    match squash with
+    | AlwaysSquashed ->
+      begin match s with
+      | Set -> Some SquashToSet
+      | _ -> Some (SquashToQuality indq)
+      end
+    | SometimesSquashed squash ->
+      (* impredicative set squashes are always quashed,
+         so here if inds=Set it is a sort poly squash (see "foo6" in test sort_poly.v) *)
+      if Quality.Set.for_all
+          (fun q -> eliminates_to g indq (nf_quality (UVars.subst_instance_quality u q)))
+          squash && not @@ Quality.is_qvar indq
+      then None
+      else Some (SquashToQuality indq)
 
-let allowed_elimination_gen g indsort_to_quality squashed_to_quality actions specifu s =
-  match is_squashed_gen g indsort_to_quality squashed_to_quality specifu with
+let allowed_elimination_gen g nf_quality actions specifu s =
+  match is_squashed_gen g nf_quality specifu with
   | None -> actions.not_squashed
   | Some SquashToSet ->
     begin match s with
@@ -443,14 +443,8 @@ let allowed_elimination_gen g indsort_to_quality squashed_to_quality actions spe
     end
   | Some (SquashToQuality indq) -> actions.squashed_to_quality indq
 
-let loc_indsort_to_quality u s = Sorts.quality (UVars.subst_instance_sort u s)
-let loc_squashed_to_quality = UVars.subst_instance_quality
-
-let is_squashed env =
-  is_squashed_gen
-    (Environ.qualities env)
-    loc_indsort_to_quality
-    loc_squashed_to_quality
+let is_squashed env specif =
+  is_squashed_gen (Environ.qualities env) Fun.id specif
 
 let is_allowed_elimination_actions g s =
   { not_squashed = true
@@ -463,8 +457,7 @@ let is_allowed_elimination_actions g s =
 let is_allowed_elimination env specifu s =
   let g = Environ.qualities env in
   allowed_elimination_gen g
-    loc_indsort_to_quality
-    loc_squashed_to_quality
+    Fun.id
     (is_allowed_elimination_actions g s)
     specifu s
 

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -98,13 +98,12 @@ type 'a allow_elimination_actions =
   ; squashed_to_set_above : 'a
   ; squashed_to_quality : Sorts.Quality.t -> 'a }
 
-val is_squashed_gen : QGraph.t -> ('a -> Sorts.t -> Sorts.Quality.t)
-  -> ('a -> Sorts.Quality.t -> Sorts.Quality.t) -> (mind_specif * 'a)
+val is_squashed_gen : QGraph.t -> (Sorts.Quality.t -> Sorts.Quality.t)
+  -> mind_specif puniverses
   -> squash option
 
-val allowed_elimination_gen : QGraph.t -> ('a -> Sorts.t -> Sorts.Quality.t)
-  -> ('a -> Sorts.Quality.t -> Sorts.Quality.t)
-  -> 'b allow_elimination_actions -> (mind_specif * 'a) -> Sorts.t -> 'b
+val allowed_elimination_gen : QGraph.t -> (Sorts.Quality.t -> Sorts.Quality.t)
+  -> 'b allow_elimination_actions -> mind_specif puniverses -> Sorts.t -> 'b
 
 val is_squashed : env -> mind_specif puniverses -> squash option
 

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -99,11 +99,11 @@ type 'a allow_elimination_actions =
   ; squashed_to_quality : Sorts.Quality.t -> 'a }
 
 val is_squashed_gen : QGraph.t -> ('a -> Sorts.t -> Sorts.Quality.t)
-  -> ('a -> Sorts.Quality.Set.elt -> Sorts.Quality.t) -> (mind_specif * 'a)
+  -> ('a -> Sorts.Quality.t -> Sorts.Quality.t) -> (mind_specif * 'a)
   -> squash option
 
 val allowed_elimination_gen : QGraph.t -> ('a -> Sorts.t -> Sorts.Quality.t)
-  -> ('a -> Sorts.Quality.Set.elt -> Sorts.Quality.t)
+  -> ('a -> Sorts.Quality.t -> Sorts.Quality.t)
   -> 'b allow_elimination_actions -> (mind_specif * 'a) -> Sorts.t -> 'b
 
 val is_squashed : env -> mind_specif puniverses -> squash option

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -267,9 +267,7 @@ let squash_elim_sort sigma squash rtnsort =
 (* [s] is the sort of an inductive definition. *)
 let loc_indsort_to_quality sigma u s =
   let u = (EConstr.Unsafe.to_instance u) in
-  Sorts.quality
-    (EConstr.ESorts.kind sigma
-        (EConstr.ESorts.make @@ UVars.subst_instance_sort u s))
+  ESorts.quality sigma (EConstr.ESorts.make @@ UVars.subst_instance_sort u s)
 
 (* [q] is a quality an inductive has to be squashed to. *)
 let loc_squashed_to_quality sigma u q =


### PR DESCRIPTION
The only higher-layer information we need is quality normalization.