### PR TITLE
change computation of uniform parameters

### DIFF
--- a/dev/ci/user-overlays/21498-thomas-lamiaux-uparams.sh
+++ b/dev/ci/user-overlays/21498-thomas-lamiaux-uparams.sh
@@ -1,0 +1,1 @@
+overlay metarocq https://github.com/thomas-lamiaux/metacoq adapt21498 21498

--- a/doc/changelog/01-kernel/21498-uparams-Changed.rst
+++ b/doc/changelog/01-kernel/21498-uparams-Changed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Change computation of uniform-parameters for nested inductive types.
+  Inductive types now need to be fully applied when nesting in order for
+  parameters to be considered as uniform
+  (`#21498 <https://github.com/rocq-prover/rocq/pull/21498>`_,
+  fixes `#21497 <https://github.com/rocq-prover/rocq/issues/21497>`_,
+  by Thomas Lamiaux).

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1164,22 +1164,6 @@ let rec eta_reduce_head sigma c =
            | _ -> c)
     | _ -> c
 
-let eta_expand_instantiation ?evars env inst ctxt =
-  let open Context.Rel.Declaration in
-  let eta_inst = Array.make (Array.length inst) mkProp in
-  let rec fold subst i = function
-  | [] -> assert (Array.length inst = i)
-  | LocalAssum (_, ty) :: ctx ->
-    let ty = substl subst ty in
-    let eta_t = Reduction.eta_expand ?evars env inst.(i) ty in
-    let () = eta_inst.(i) <- eta_t in
-    fold (eta_t :: subst) (i + 1) ctx
-  | LocalDef (_, bd, _) :: ctx ->
-    fold (bd :: subst) i ctx
-  in
-  let () = fold [] 0 (List.rev ctxt) in
-  eta_inst
-
 (* iterator on rel context *)
 let process_rel_context f env =
   let sign = named_context_val env in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -130,10 +130,6 @@ val eq_constr : Environ.env -> Evd.evar_map -> constr -> constr -> bool (* FIXME
 
 val eta_reduce_head : Evd.evar_map -> constr -> constr
 
-(* Eta expand the instantiation of a context *)
-val eta_expand_instantiation : ?evars:CClosure.evar_handler -> env ->
-  Constr.constr array -> Constr.rel_context -> Constr.constr array
-
 (** [prod_applist] [forall (x1:B1;...;xn:Bn), B] [a1...an] @return [B[a1...an]] *)
 val prod_applist : Evd.evar_map -> constr -> constr list -> constr
 

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -62,3 +62,5 @@ val dest_arity : ?evars:evar_handler -> env -> types -> Term.arity (* raises Not
 val is_arity : ?evars:evar_handler -> env -> types -> bool
 
 val eta_expand : ?evars:evar_handler -> env -> constr -> types -> constr
+(* Eta expand the instantiation of a context *)
+val eta_expand_instantiation : ?evars:evar_handler -> env -> constr array -> rel_context -> constr array

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1783,5 +1783,5 @@ let eta_expand env sigma t ty =
 let eta_expand_instantiation env sigma inst ctxt =
   let inst = Array.map (EConstr.Unsafe.to_constr) inst in
   let ctxt =  List.map (EConstr.Unsafe.to_rel_decl) ctxt in
-  let eta_inst = Termops.eta_expand_instantiation ~evars:(Evd.evar_handler sigma) env inst ctxt in
+  let eta_inst = Reduction.eta_expand_instantiation ~evars:(Evd.evar_handler sigma) env inst ctxt in
   Array.map of_constr eta_inst

--- a/tactics/allScheme.ml
+++ b/tactics/allScheme.ml
@@ -106,7 +106,7 @@ let rec compute_params_rec_strpos_arg compute_params_rec_strpos env kn uparams
           let uparams_nested = List.rev @@ fst @@
                 Context.Rel.chop_nhyps mib_nested.mind_nparams_rec @@
                 List.rev mib_nested.mind_params_ctxt in
-          let inst_uparams = Termops.eta_expand_instantiation env inst_uparams uparams_nested in
+          let inst_uparams = Reduction.eta_expand_instantiation env inst_uparams uparams_nested in
           (* - appear strictly positively in the instantiation of the uniform parameters
                that are strictly postive themselves
              - not appear in uniform parameters that are not strictly postive *)

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -80,3 +80,51 @@ BoxP@{q ; a} may only be eliminated to produce values whose type is SProp or Pro
 Arguments BoxP A%_type_scope
 Expands to: Inductive Inductive.BoxP
 Declared in library Inductive, line 56, characters 22-26
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+File "./output/Inductive.v", line 62, characters 0-74:
+Warning: Cut is nested using Box. No scheme for Box is registered as All.
+[register-all,automation,default]
+Cut_ind@{u} :
+forall P : forall x : unit, Cut@{u} x -> Prop,
+(forall (x : unit) (b : Box@{u u} (fun n : unit => Cut@{u} n)),
+ P x (triv@{u} x b)) ->
+forall (x : unit) (c : Cut@{u} x), P x c
+(* u |=  *)
+
+Cut_ind is universe polymorphic
+Arguments Cut_ind (P triv)%_function_scope x c
+Cut_ind is transparent
+Expands to: Constant Inductive.Cut_ind
+Declared in library Inductive, line 62, characters 0-74

--- a/test-suite/output/Inductive.v
+++ b/test-suite/output/Inductive.v
@@ -56,3 +56,10 @@ About ssig.
 Polymorphic Inductive BoxP@{q;a|} (A:Type@{q;a}) : Prop := boxP (_:A).
 
 About BoxP.
+
+Variant Box (F  : unit -> Type) := .
+
+Inductive Cut (x : unit) : Type :=
+| triv : Box (fun n => Cut n) -> Cut x.
+
+About Cut_ind.


### PR DESCRIPTION
Change the computation of the uniform-parameters in the nested case 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21497 


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [X] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [X] Added **changelog**.
- [ ] Added / updated **documentation**.

<!-- If this breaks external libraries or plugins in CI: -->
- [X] Opened **overlay** pull requests.
https://github.com/MetaRocq/metarocq/pull/1233

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
