### PR TITLE
Delete Termops.free_rels_and_unqualified_refs

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -835,34 +835,6 @@ let free_rels sigma m =
   in
   frec 1 Int.Set.empty m
 
-let free_rels_and_unqualified_refs sigma t =
-  let rec aux k (gseen, vseen, ids as accu) t =
-    match EConstr.kind sigma t with
-    | Const _ | Ind _ | Construct _ | Var _ ->
-      let g, _ = EConstr.destRef sigma t in
-      if not (GlobRef.Set_env.mem g gseen) then begin
-        try
-          let gseen = GlobRef.Set_env.add g gseen in
-          let short = Nametab.shortest_qualid_of_global ~force_short:true Id.Set.empty g in
-          let dir, id = Libnames.repr_qualid short in
-          let ids = if DirPath.is_empty dir then Id.Set.add id ids else ids in
-          (gseen, vseen, ids)
-        with Not_found when !Flags.in_debugger || !Flags.in_ml_toplevel ->
-          accu
-      end else
-        accu
-    | Rel p ->
-      if p > k && not (Int.Set.mem (p - k) vseen) then
-        let vseen = Int.Set.add (p - k) vseen in
-        (gseen, vseen, ids)
-      else
-        accu
-    | _ ->
-      EConstr.fold_with_binders sigma succ aux k accu t in
-  let accu = (GlobRef.Set_env.empty, Int.Set.empty, Id.Set.empty) in
-  let (_, rels, ids) = aux 0 accu t in
-  rels, ids
-
 (* collects all metavar occurrences, in left-to-right order, preserving
  * repetitions and all. *)
 

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -81,10 +81,6 @@ val local_occur_var_in_decl : Evd.evar_map -> Id.t -> named_declaration -> bool
 
 val free_rels : Evd.evar_map -> constr -> Int.Set.t
 
-(* Return the list of unbound rels and unqualified reference (same
-   strategy as in Namegen) *)
-val free_rels_and_unqualified_refs : Evd.evar_map -> constr -> Int.Set.t * Id.Set.t
-
 (** [dependent m t] tests whether [m] is a subterm of [t] *)
 val dependent : Evd.evar_map -> constr -> constr -> bool
 val dependent_no_evar : Evd.evar_map -> constr -> constr -> bool

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -254,18 +254,18 @@ let compute_implicits_names env sigma t =
   let open Context.Rel.Declaration in
   let rec aux env names t = match whd_prod env sigma t with
   | Some (na, a, b) ->
-    let rels,ids = Termops.free_rels_and_unqualified_refs sigma a in
-    aux (push_rel (LocalAssum (na,a)) env) ((na.Context.binder_name,rels,ids)::names) b
+    let rels = Termops.free_rels sigma a in
+    aux (push_rel (LocalAssum (na,a)) env) ((na.Context.binder_name,rels)::names) b
   | None ->
-    let rels,ids = Termops.free_rels_and_unqualified_refs sigma t in
-    let rec set_names (allrels,ids) = function
+    let rels = Termops.free_rels sigma t in
+    let rec set_names allrels = function
     | [] -> (1,1,[])
-    | (na,rels',ids')::names ->
-      let (absolute_pos,nnondep,names) = set_names (rels'::allrels,Id.Set.union ids ids') names in
+    | (na,rels')::names ->
+      let (absolute_pos,nnondep,names) = set_names (rels'::allrels) names in
       let isdep = List.exists_i (fun i rels -> Int.Set.mem i rels) 1 allrels in
       let nnondep',dep_pos = if isdep then nnondep, None else nnondep + 1, Some nnondep in
       (absolute_pos+1,nnondep',(na,absolute_pos,dep_pos)::names) in
-    let _,_,names = set_names ([rels],ids) names in
+    let _,_,names = set_names [rels] names in
     List.rev names
   in
   NewProfile.profile "compute_implicits_names" (fun () -> aux env [] t) ()


### PR DESCRIPTION
The only caller (Impargs.compute_implicits_names) doesn't actually use the idents this returns, so it can just use free_rels.
