### PR TITLE
Various fixes around bound universe instances in kernel and checker

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -45,7 +45,7 @@ let check_constant_declaration env opac kn cb opacify =
     | Polymorphic auctx ->
       let ctx = UVars.AbstractContext.repr auctx in
       (* [env] contains De Bruijn universe variables *)
-      (* FIXME: check validity of the sort context *)
+      let () = check_ucontext ctx env in
       let env = push_context ~strict:false ctx env in
       true, env
   in

--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -16,7 +16,11 @@ let import senv opac clib vmtab digest =
   let mb = Safe_typing.module_of_library clib in
   let env = Safe_typing.env_of_safe_env senv in
   let qualities, univs = Safe_typing.univs_of_library clib in
-  let () = assert (Sorts.QVar.Set.for_all Sorts.QVar.is_global (fst qualities)) in
+  let check_quality q =
+    Sorts.QVar.is_global q &&
+    not (QGraph.is_declared (Sorts.Quality.QVar q) (Environ.qualities env))
+  in
+  let () = assert (Sorts.QVar.Set.for_all check_quality (fst qualities)) in
   let env = push_qualities ~rigid:true qualities env in
   let env = push_context_set ~strict:true univs env in
   let env = Modops.add_retroknowledge (Mod_declarations.mod_retroknowledge mb) env in

--- a/kernel/constant_typing.ml
+++ b/kernel/constant_typing.ml
@@ -103,8 +103,9 @@ let process_universes env = function
     (** [ctx] must contain local universes, such that it has no impact
         on the rest of the graph (up to transitivity). *)
     let inst, auctx = UVars.abstract_universes uctx in
-    (* FIXME: check validity of the sort context *)
-    let env = Environ.push_context ~strict:false (AbstractContext.repr auctx) env in
+    let ctx = AbstractContext.repr auctx in
+    let () = check_ucontext ctx env in
+    let env = Environ.push_context ~strict:false ctx env in
     let usubst = UVars.make_instance_subst inst in
     env, usubst, UVars.make_abstract_instance auctx, Polymorphic auctx
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -485,9 +485,9 @@ let push_context ?(strict=false) ctx env =
 
 (* TODO: a bit wasteful, we typically call this before pushing the sort context *)
 let check_ucontext ctx env =
-  let env = push_context ~strict:false ctx env in
+  let qgraph = add_qualities ctx (qualities env) in
   if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints ctx) then
-    QGraph.check_rigid_paths (qualities env)
+    QGraph.check_rigid_paths qgraph
 
 let add_universes_set ~strict (lvl, cstr) g =
   let g = Univ.Level.Set.fold

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -483,6 +483,12 @@ let push_context ?(strict=false) ctx env =
   let env = map_qualities (add_qualities ctx) env in
   map_universes (add_universes ~strict ctx) env
 
+(* TODO: a bit wasteful, we typically call this before pushing the sort context *)
+let check_ucontext ctx env =
+  let env = push_context ~strict:false ctx env in
+  if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints ctx) then
+    QGraph.check_rigid_paths (qualities env)
+
 let add_universes_set ~strict (lvl, cstr) g =
   let g = Univ.Level.Set.fold
             (* Be lenient, module typing reintroduces universes and constraints due to includes *)
@@ -1067,11 +1073,8 @@ module QGlobRef = HackQ(GlobRef)(GlobRef.Map_env)
 
 module Internal = struct
   let push_template_context uctx env =
+    let () = check_ucontext uctx env in
     let env = push_context ~strict:false uctx env in
-    let () =
-      if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints uctx) then
-        QGraph.check_rigid_paths env.env_qualities
-    in
     let (qvars, _), _ = UVars.UContext.to_context_set uctx in
     let env = map_universes (UGraph.Internal.add_template_qvars qvars) env in
     env

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -379,6 +379,10 @@ val check_univ_constraints : Univ.UnivConstraints.t -> env -> bool
 val check_constraints : PConstraints.t -> env -> bool
 (** Check constraints are satifiable in the environment. *)
 
+val check_ucontext : UContext.t -> env -> unit
+(** Check that the sort context of the argument satisfies the well-formedness
+    conditions ensuring the existence of an instance. *)
+
 val push_context : ?strict:bool -> UContext.t -> env -> env
 (** [push_context ?(strict=false) ctx env] pushes the universe context to the environment.
     @raise UGraph.AlreadyDeclared if one of the universes is already declared. *)

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -543,11 +543,8 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
       Environ.Internal.push_template_context uctx env
     | Monomorphic_ind_entry -> env
     | Polymorphic_ind_entry ctx ->
+      let () = check_ucontext ctx env in
       let env = push_context ctx env in
-      let () =
-        if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints ctx) then
-          QGraph.check_rigid_paths (Environ.qualities env)
-      in
       env
   in
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -114,11 +114,8 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
               error (WithSignatureMismatch (IncompatibleUnivConstraints { got = ctx; expect = uctx }))
           in
           (** Terms are compared in a context with De Bruijn universe indices *)
+          let () = check_ucontext (UVars.AbstractContext.repr uctx) env in
           let env' = Environ.push_context ~strict:false (UVars.AbstractContext.repr uctx) env in
-          let () =
-            if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints (UVars.AbstractContext.repr uctx)) then
-              QGraph.check_rigid_paths (Environ.qualities env')
-          in
           let () = match cb.const_body with
             | Undef _ | OpaqueDef _ ->
               let j = Typeops.infer env' wth.w_def in

--- a/kernel/qGraph.ml
+++ b/kernel/qGraph.ml
@@ -328,8 +328,11 @@ let pr_arc prq =
   | u, G.Alias v ->
     prq u  ++ str " = " ++ prq v ++ fnl ()
 
-
 let repr g = G.repr g.graph
+
+let is_declared q g = match G.check_declared g.graph (Quality.Set.singleton q) with
+| Result.Ok _ -> true
+| Result.Error _ -> false
 
 let pr_qualities prq g = pr_pmap Pp.mt (pr_arc prq) (repr g)
 

--- a/kernel/qGraph.mli
+++ b/kernel/qGraph.mli
@@ -82,6 +82,8 @@ val update_rigids : t -> t -> t
 val check_rigid_paths : t -> unit
 val add_rigid_path : Quality.t -> Quality.t -> t -> t
 
+val is_declared : Quality.t -> t -> bool
+
 val eliminates_to : t -> Quality.t -> Quality.t -> bool
 
 val eliminates_to_prop : t -> Quality.t -> bool

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -692,7 +692,11 @@ let push_section_context uctx senv =
   let qctx, ctx = UVars.UContext.to_context_set uctx in
   let () = assert (Sorts.QVar.Set.for_all Sorts.QVar.is_global (fst qctx)) in
   let () = assert Sorts.QVar.Set.(is_empty (inter (fst qctx) (fst senv.qualities))) in
-  (* push_context checks freshness *)
+  let check_fresh u = match UGraph.check_declared_universes (Environ.universes senv.env) (Univ.Level.Set.singleton u) with
+  | Result.Ok _ -> assert false
+  | Result.Error _ -> ()
+  in
+  let () = Univ.Level.Set.iter check_fresh (fst ctx) in
   let env = Environ.push_context_set ~strict:false ctx senv.env in
   (* FIXME: check validity of the sort context *)
   (* FIXME: marking the section-local sorts as rigid makes little sense *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1606,8 +1606,7 @@ let import lib vmtab vodigest senv =
     not (QGraph.is_declared (Sorts.Quality.QVar q) (Environ.qualities senv.env))
   in
   let () = assert (Sorts.QVar.Set.for_all check_quality (fst qualities)) in
-  (* XXX why are these global constraints not rigid??? *)
-  let env = Environ.push_qualities ~rigid:false qualities senv.env in
+  let env = Environ.push_qualities ~rigid:true qualities senv.env in
   let env = Environ.push_context_set ~strict:true univs env in
   let env = Environ.link_vm_library vmtab env in
   let env =

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -102,11 +102,8 @@ let check_universes error env u1 u2 =
     if not (UGraph.check_subtype (Environ.universes env) auctx2 auctx1) then
       error (IncompatibleUnivConstraints { got = auctx1; expect = auctx2; } )
     else
+      let () = Environ.check_ucontext (UVars.AbstractContext.repr auctx2) env in
       let env = Environ.push_context ~strict:false (UVars.AbstractContext.repr auctx2) env in
-      let () =
-        if not (Sorts.ElimConstraints.is_empty @@ UVars.UContext.elim_constraints (UVars.AbstractContext.repr auctx2)) then
-          QGraph.check_rigid_paths (Environ.qualities env)
-      in
       env
   | Monomorphic, Polymorphic _ -> error (PolymorphicStatusExpected true)
   | Polymorphic _, Monomorphic -> error (PolymorphicStatusExpected false)


### PR DESCRIPTION
We now correctly check that section sort and level variables are not already declared, and we also add checks for binder well-formedness in some missing parts.