### PR TITLE
Equi-eliminability of sorts does not imply equality anymore.

### DIFF
--- a/test-suite/success/sort_poly.v
+++ b/test-suite/success/sort_poly.v
@@ -69,6 +69,9 @@ Module Conversion.
   Check fun A:SProp => eq_refl : t1 A = t2 A.
   Check fun A:SProp => eq_refl : box _ (t1' A) = box _ (t2' A).
 
+  Fail Definition equi_eliminable@{s1 s2;|s1 -> s2, s2 -> s1} (A : Type@{s1;Set}) : Type@{s2;Set} := A.
+  Fail Definition equi_eliminable@{s1 s2;|s1 -> s2, s2 -> s1} (A : Type@{s2;Set}) : Type@{s1;Set} := A.
+
   Definition ignore@{s;u|} {A:Type@{s;u}} (x:A) := tt.
   Definition unfold_ignore@{s;u|} (A:Type@{s;u}) : ignore (t1 A) = ignore (t2 A) := eq_refl.
 


### PR DESCRIPTION
This is a minimalistic patch written in a way that makes it easy to backport. We now track quality equality in QGraph separately from eliminability in a not extremely clever variant of union-find. This should not really be a problem for performance though, since the upper layers use basically the same data structure already, and the kernel never gets to see non-trivial equality constraints.

Actually, the proper fix would rather to remove sort unification from the kernel and keep it in UState only, but this is a much deeper redesign that will require touching quite a few APIs.