### PR TITLE
Stop unifying sorts in the kernel.

### DIFF
--- a/checker/coqchk_main.ml
+++ b/checker/coqchk_main.ml
@@ -308,7 +308,6 @@ let explain_exn = function
       | CantApplyNonFunctional _ -> str"CantApplyNonFunctional"
       | IllFormedRecBody _ -> str"IllFormedRecBody"
       | IllTypedRecBody _ -> str"IllTypedRecBody"
-      | UnsatisfiedElimConstraints _ -> str"UnsatisfiedElimConstraints"
       | UnsatisfiedUnivConstraints _ -> str"UnsatisfiedUnivConstraints"
       | UnsatisfiedPConstraints _ -> str"UnsatisfiedPConstraints"
       | NotAllowedSProp -> str"NotAllowedSProp"

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -224,8 +224,8 @@ let rec check_mexpr env opac mse mp_mse res = match mse with
   | MEapply (f,mp) ->
     let sign, delta = check_mexpr env opac f mp_mse res in
     let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
-    let state = ((Environ.qualities env, Environ.universes env), Conversion.checked_universes) in
-    let _ : QGraph.t * UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
+    let state = (Environ.universes env, Conversion.checked_universes) in
+    let _ : UGraph.t = Subtyping.check_subtypes state env mp (MPbound farg_id) farg_b in
     let mp_delta =
       let mb = lookup_module mp env in
       match mod_type mb with
@@ -266,9 +266,9 @@ let rec check_module env opac mp mb opacify =
   | Some (sign,delta) ->
     let mtb1 = mk_mtb sign delta
     and mtb2 = mk_mtb (mod_type mb) delta_mb in
-    let state = ((Environ.qualities env, Environ.universes env), Conversion.checked_universes) in
+    let state = (Environ.universes env, Conversion.checked_universes) in
     let env = Modops.add_module mp (module_body_of_type mtb1) env in
-    let _ : QGraph.t * UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
+    let _ : UGraph.t = Subtyping.check_subtypes state env mp mp mtb2 in
     ()
   in
   opac

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -816,7 +816,8 @@ let eq_constr_univs_test ~evd ~extended_evd t u =
   let eq_universes _ u1 u2 =
     let u1 = EConstr.EInstance.(kind !sigma (make u1)) in
     let u2 = EConstr.EInstance.(kind !sigma (make u2)) in
-    UGraph.check_eq_instances (elim_graph !sigma) (universes !sigma) u1 u2
+    let check_qeq q1 q2 = UState.check_eq_quality (Evd.ustate !sigma) q1 q2 in
+    UGraph.check_eq_instances check_qeq (universes !sigma) u1 u2
   in
   let eq_sorts s1 s2 =
     if Sorts.equal s1 s2 then true

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1205,6 +1205,11 @@ let check_elim_constraints evd csts =
 let check_poly_constraints evd (qcsts,ucsts) =
   check_elim_constraints evd qcsts && check_univ_constraints evd ucsts
 
+let check_quality_constraints evd qcst =
+  let fold (q1, q2) accu = Sorts.ElimConstraints.add (q1, Equal, q2) accu in
+  let qcst = UVars.QPairSet.fold fold qcst Sorts.ElimConstraints.empty in
+  check_elim_constraints evd qcst
+
 let fix_undefined_variables evd =
   { evd with universes = UState.fix_undefined_variables evd.universes }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -607,6 +607,7 @@ val check_leq : evar_map -> esorts -> esorts -> bool
 val check_univ_constraints : evar_map -> Univ.UnivConstraints.t -> bool
 val check_elim_constraints : evar_map -> Sorts.ElimConstraints.t -> bool
 val check_poly_constraints : evar_map -> PConstraints.t -> bool
+val check_quality_constraints : evar_map -> UVars.QPairSet.t -> bool
 
 val ustate : evar_map -> UState.t
 val elim_graph : evar_map -> QGraph.t

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -144,6 +144,8 @@ val check_elim_constraints : t -> ElimConstraints.t -> bool
 
 val check_constraints : t -> UnivProblem.Set.t -> bool
 
+val check_eq_quality : t -> Sorts.Quality.t -> Sorts.Quality.t -> bool
+
 (** {5 Names} *)
 
 val quality_of_name : t -> Id.t -> Sorts.QVar.t

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -128,6 +128,7 @@ type evar_handler = {
   evar_repack : Evar.t * constr list -> constr;
   evar_irrelevant : constr pexistential -> bool;
   qvar_irrelevant : Sorts.QVar.t -> bool;
+  qual_equal : Sorts.Quality.t -> Sorts.Quality.t -> bool;
   abstr_const : Constant.t -> (unit, (unit -> Vmemitcodes.to_patch) Vmemitcodes.pbody_code) Declarations.pconstant_body;
 }
 
@@ -138,6 +139,7 @@ let default_evar_handler env = {
   qvar_irrelevant = (fun q ->
       assert (Sorts.QVar.Set.mem q (Environ.qvars env));
       false);
+  qual_equal = Sorts.Quality.equal;
   abstr_const = fun _ -> assert false;
 }
 
@@ -352,6 +354,9 @@ let is_irrelevant info r = match info.i_cache.i_mode with
   | Sorts.Irrelevant -> true
   | Sorts.RelevanceVar q -> info.i_cache.i_sigma.qvar_irrelevant q
   | Sorts.Relevant -> false
+
+let eq_quality info q1 q2 =
+  info.i_cache.i_sigma.qual_equal q1 q2
 
 (************************************************************************)
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -178,7 +178,6 @@ type clos_infos = {
 let info_flags info = info.i_flags
 let info_env info = info.i_cache.i_env
 let info_univs info = info.i_cache.i_univs
-let info_elims info = Environ.qualities (info_env info)
 
 let push_relevance infos x =
   { infos with i_relevances = Range.cons x.binder_relevance infos.i_relevances }

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -129,6 +129,7 @@ type evar_handler = {
   evar_repack : Evar.t * constr list -> constr;
   evar_irrelevant : constr pexistential -> bool;
   qvar_irrelevant : Sorts.QVar.t -> bool;
+  qual_equal : Sorts.Quality.t -> Sorts.Quality.t -> bool;
   abstr_const : Constant.t -> (unit, (unit -> Vmemitcodes.to_patch) Vmemitcodes.pbody_code) Declarations.pconstant_body;
 }
 
@@ -157,6 +158,7 @@ val set_info_relevances : clos_infos -> Sorts.relevance Range.t -> clos_infos
 val info_relevances : clos_infos -> Sorts.relevance Range.t
 
 val is_irrelevant : clos_infos -> Sorts.relevance -> bool
+val eq_quality : clos_infos -> Sorts.Quality.t -> Sorts.Quality.t -> bool
 
 val infos_with_reds : clos_infos -> reds -> clos_infos
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -148,7 +148,6 @@ val create_tab : unit -> clos_tab
 val info_env : clos_infos -> env
 val info_flags: clos_infos -> reds
 val info_univs : clos_infos -> UGraph.t
-val info_elims : clos_infos -> QGraph.t
 val unfold_projection : clos_infos -> Projection.t -> Sorts.relevance -> stack_member option
 
 val push_relevance : clos_infos -> 'b binder_annot -> clos_infos

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -985,23 +985,23 @@ let rec eq_constr nargs m n =
 
 let equal n m = eq_constr 0 m n (* to avoid tracing a recursive fun *)
 
-let eq_constr_univs quals univs m n =
+let eq_constr_univs _quals univs m n =
   if m == n then true
   else
-    let eq_universes _ = UGraph.check_eq_instances quals univs in
-    let eq_sorts s1 s2 = s1 == s2 || UGraph.check_eq_sort quals univs s1 s2 in
+    let eq_universes _ = UGraph.check_eq_instances Sorts.Quality.equal univs in
+    let eq_sorts s1 s2 = s1 == s2 || UGraph.check_eq_sort Sorts.Quality.equal univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n ||	compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' nargs m n
     in compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' 0 m n
 
-let leq_constr_univs quals univs m n =
+let leq_constr_univs _quals univs m n =
   if m == n then true
   else
-    let eq_universes _ = UGraph.check_eq_instances quals univs in
+    let eq_universes _ = UGraph.check_eq_instances Sorts.Quality.equal univs in
     let eq_sorts s1 s2 = s1 == s2 ||
-      UGraph.check_eq_sort quals univs s1 s2 in
+      UGraph.check_eq_sort Sorts.Quality.equal univs s1 s2 in
     let leq_sorts s1 s2 = s1 == s2 ||
-      UGraph.check_leq_sort quals univs s1 s2 in
+      UGraph.check_leq_sort Sorts.Quality.equal univs s1 s2 in
     let rec eq_constr' nargs m n =
       m == n || compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' nargs m n
     in

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -985,7 +985,7 @@ let rec eq_constr nargs m n =
 
 let equal n m = eq_constr 0 m n (* to avoid tracing a recursive fun *)
 
-let eq_constr_univs _quals univs m n =
+let eq_constr_univs univs m n =
   if m == n then true
   else
     let eq_universes _ = UGraph.check_eq_instances Sorts.Quality.equal univs in
@@ -994,7 +994,7 @@ let eq_constr_univs _quals univs m n =
       m == n ||	compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' nargs m n
     in compare_head_gen eq_universes eq_sorts (eq_existential (eq_constr' 0)) eq_constr' 0 m n
 
-let leq_constr_univs _quals univs m n =
+let leq_constr_univs univs m n =
   if m == n then true
   else
     let eq_universes _ = UGraph.check_eq_instances Sorts.Quality.equal univs in

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -417,11 +417,11 @@ val equal : constr -> constr -> bool
 
 (** [eq_constr_univs u a b] is [true] if [a] equals [b] modulo alpha, casts,
    application grouping and the universe equalities in [u]. *)
-val eq_constr_univs : QGraph.t -> UGraph.t -> constr -> constr -> bool
+val eq_constr_univs : UGraph.t -> constr -> constr -> bool
 
 (** [leq_constr_univs u a b] is [true] if [a] is convertible to [b] modulo
     alpha, casts, application grouping and the universe inequalities in [u]. *)
-val leq_constr_univs : QGraph.t -> UGraph.t -> constr -> constr -> bool
+val leq_constr_univs : UGraph.t -> constr -> constr -> bool
 
 (** [eq_constr_univs a b] [true, c] if [a] equals [b] modulo alpha, casts,
    application grouping and ignoring universe instances. *)

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -951,48 +951,51 @@ let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 
       | NotConvertibleTrace _ -> assert false
   end ()
 
-let check_eq (elims, univs as state) u u' =
-  if UGraph.check_eq_sort elims univs u u'
+let check_eq qeq (_elims, univs as state) u u' =
+  (* TODO: remove useless QGraph argument *)
+  if UGraph.check_eq_sort qeq univs u u'
   then Result.Ok state
   else Result.Error None
 
-let check_leq (elims, univs as state) u u' =
-  if UGraph.check_leq_sort elims univs u u'
+let check_leq qeq (_elims, univs as state) u u' =
+  (* TODO: remove useless QGraph argument *)
+  if UGraph.check_leq_sort qeq univs u u'
   then Result.Ok state
   else Result.Error None
 
-let checked_sort_cmp_universes pb s0 s1 state =
+let checked_sort_cmp_universes qeq = (); fun pb s0 s1 state ->
   match pb with
-  | CUMUL -> check_leq state s0 s1
-  | CONV -> check_eq state s0 s1
+  | CUMUL -> check_leq qeq state s0 s1
+  | CONV -> check_eq qeq state s0 s1
 
-let check_convert_instances ~flex:_ u u' (elims, univs as state) =
-  if UGraph.check_eq_instances elims univs u u' then Result.Ok state
+let check_convert_instances qeq = (); fun ~flex:_ u u' (_elims, univs as state) ->
+  if UGraph.check_eq_instances qeq univs u u' then Result.Ok state
   else Result.Error None
 
 (* general conversion and inference functions *)
-let check_inductive_instances cv_pb variance u1 u2 (elims, univs as state) =
+let check_inductive_instances qeq = (); fun cv_pb variance u1 u2 (_elims, univs as state) ->
+  (* TODO: remove useless QGraph argument *)
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
-  let fold (q1, q2) accu = Sorts.ElimConstraints.add (q1, Equal, q2) accu in
-  let qcsts = UVars.QPairSet.fold fold qcsts Sorts.ElimConstraints.empty in
-  if QGraph.check_constraints qcsts elims && UGraph.check_constraints ucsts univs
+  let check_quality (q1, q2) = qeq q1 q2 in
+  if UVars.QPairSet.for_all check_quality qcsts && UGraph.check_constraints ucsts univs
   then Result.Ok state
   else Result.Error None
 
-let checked_universes =
-  { compare_sorts = checked_sort_cmp_universes;
-    compare_instances = check_convert_instances;
-    compare_cumul_instances = check_inductive_instances; }
+let checked_universes_gen qeq =
+  { compare_sorts = checked_sort_cmp_universes qeq;
+    compare_instances = check_convert_instances qeq;
+    compare_cumul_instances = check_inductive_instances qeq; }
+
+let checked_universes = checked_universes_gen Sorts.Quality.equal
 
 let () =
   let conv infos tab a b =
     try
       let box = Empty.abort in
       let state = info_elims infos, info_univs infos in
+      let qual_equal q1 q2 = CClosure.eq_quality infos q1 q2 in
       let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box } in
-      let state', _ = ccnv CONV false infos el_id el_id a b
-          (state, checked_universes)
-      in
+      let state', _ = ccnv CONV false infos el_id el_id a b (state, checked_universes_gen qual_equal) in
       assert (state==state');
       true
     with

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -175,9 +175,9 @@ let convert_instances_cumul pb var u u' (s, check) =
 let get_cumulativity_constraints cv_pb variance u u' =
   match cv_pb with
   | CONV ->
-    UVars.enforce_eq_variance_instances variance u u' PConstraints.empty
+    UVars.enforce_eq_variance_instances variance u u' (UVars.QPairSet.empty, Univ.UnivConstraints.empty)
   | CUMUL ->
-    UVars.enforce_leq_variance_instances variance u u' PConstraints.empty
+    UVars.enforce_leq_variance_instances variance u u' (UVars.QPairSet.empty, Univ.UnivConstraints.empty)
 
 let inductive_cumulativity_arguments (mind,ind) =
   mind.Declarations.mind_nparams +
@@ -973,6 +973,8 @@ let check_convert_instances ~flex:_ u u' (elims, univs as state) =
 (* general conversion and inference functions *)
 let check_inductive_instances cv_pb variance u1 u2 (elims, univs as state) =
   let qcsts, ucsts = get_cumulativity_constraints cv_pb variance u1 u2 in
+  let fold (q1, q2) accu = Sorts.ElimConstraints.add (q1, Equal, q2) accu in
+  let qcsts = UVars.QPairSet.fold fold qcsts Sorts.ElimConstraints.empty in
   if QGraph.check_constraints qcsts elims && UGraph.check_constraints ucsts univs
   then Result.Ok state
   else Result.Error None

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -34,7 +34,7 @@ type ('a, 'err) universe_state = 'a * ('a, 'err) universe_compare
 type ('a, 'err) generic_conversion_function = ('a, 'err) universe_state -> constr -> constr -> ('a, 'err option) result
 
 val get_cumulativity_constraints : conv_pb -> UVars.Variance.t array ->
-  UVars.Instance.t -> UVars.Instance.t -> PConstraints.t
+  UVars.Instance.t -> UVars.Instance.t -> UVars.QPairSet.t * Univ.UnivConstraints.t
 
 val inductive_cumulativity_arguments : (Declarations.mutual_inductive_body * int) -> int
 val constructor_cumulativity_arguments : (Declarations.mutual_inductive_body * int * int) -> int

--- a/kernel/conversion.mli
+++ b/kernel/conversion.mli
@@ -48,7 +48,7 @@ val convert_instances : flex:bool -> UVars.Instance.t -> UVars.Instance.t ->
   'a * ('a, 'err) universe_compare -> ('a, 'err option) result * ('a, 'err) universe_compare
 
 (** This function never returns an non-empty error. *)
-val checked_universes : (QGraph.t * UGraph.t, 'err) universe_compare
+val checked_universes : (UGraph.t, 'err) universe_compare
 
 (** These two functions can only fail with unit *)
 val conv : constr extended_conversion_function

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -202,19 +202,17 @@ let native_conv_gen pb sigma env univs t1 t2 =
 (* Wrapper for [native_conv] above *)
 let native_conv cv_pb sigma env t1 t2 =
   let univs = Environ.universes env in
-  let elims = Environ.qualities env in
-  let state = elims, univs in
   let b =
-    if cv_pb = CUMUL then Constr.leq_constr_univs elims univs t1 t2
-    else Constr.eq_constr_univs elims univs t1 t2
+    if cv_pb = CUMUL then Constr.leq_constr_univs univs t1 t2
+    else Constr.eq_constr_univs univs t1 t2
   in
   if b then Result.Ok ()
   else
-    let state = (state, checked_universes) in
+    let state = (univs, checked_universes) in
     let t1 = Term.it_mkLambda_or_LetIn t1 (Environ.rel_context env) in
     let t2 = Term.it_mkLambda_or_LetIn t2 (Environ.rel_context env) in
     match native_conv_gen cv_pb sigma env state t1 t2 with
-    | Result.Ok (_ : QGraph.t * UGraph.t) -> Result.Ok ()
+    | Result.Ok (_ : UGraph.t) -> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some _) ->
       (* checked_universes cannot raise this *)

--- a/kernel/pConstraints.ml
+++ b/kernel/pConstraints.ml
@@ -101,10 +101,6 @@ let enforce_leq_univ u v c =
   if Level.equal u v then c
   else add_univ (u, UnivConstraint.Le, v) c
 
-let enforce_eq_quality q1 q2 csts =
-  if Quality.equal q1 q2 then csts
-  else add_quality (q1, ElimConstraint.Equal, q2) csts
-
 let enforce_elim_to q1 q2 csts =
   if QGraph.ElimTable.eliminates_to q1 q2 then csts
   else add_quality (q1, ElimConstraint.ElimTo, q2) csts

--- a/kernel/pConstraints.mli
+++ b/kernel/pConstraints.mli
@@ -62,8 +62,6 @@ val enforce_eq_univ : Level.t constraint_function
 
 val enforce_leq_univ : Level.t constraint_function
 
-val enforce_eq_quality : Quality.t constraint_function
-
 val enforce_elim_to : Quality.t constraint_function
 
 val fold : (ElimConstraint.t -> 'a -> 'a) * (UnivConstraint.t -> 'b -> 'b) -> t

--- a/kernel/qGraph.mli
+++ b/kernel/qGraph.mli
@@ -71,10 +71,6 @@ val enforce_eliminates_to : Quality.t -> Quality.t -> t -> t
     If this constraint creates a cycle that violates the constraints,
     [QualityInconsistency] is raised. *)
 
-val enforce_eq : Quality.t -> Quality.t -> t -> t
-(** Set the first quality equal to the second one in the graph.
-    If it's impossible, raise [QualityInconsistency]. *)
-
 val initial_graph : t
 (** Graph with the constant quality elimination constraints found in
     [Quality.Constants.eliminates_to]. *)
@@ -90,9 +86,6 @@ val eliminates_to : t -> Quality.t -> Quality.t -> bool
 val eliminates_to_prop : t -> Quality.t -> bool
 
 val sort_eliminates_to : t -> Sorts.t -> Sorts.t -> bool
-
-val check_eq : t -> Quality.t -> Quality.t -> bool
-val check_eq_sort : t -> Sorts.t -> Sorts.t -> bool
 
 val domain : t -> Quality.Set.t
 val qvar_domain : t -> QVar.Set.t

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1268,7 +1268,7 @@ let add_mind ?typing_flags l mie senv =
 (** Insertion of module types *)
 
 let check_state senv =
-  ((Environ.qualities senv.env, Environ.universes senv.env), Conversion.checked_universes)
+  (Environ.universes senv.env, Conversion.checked_universes)
 
 let vm_handler env univs c vmtab =
   let env = Environ.set_vm_library vmtab env in
@@ -1495,7 +1495,7 @@ let add_include me is_module inl senv =
       let state = check_state senv in
       (* Module subcomponents are already part of senv.env at this point *)
       let env = Environ.shallow_add_module mp_sup mb senv.env in
-      let (_ : QGraph.t * UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
+      let (_ : UGraph.t) = Subtyping.check_subtypes state env mp_sup (MPbound mbid) mtb in
       let mpsup_delta =
         Modops.inline_delta_resolver senv.env inl mp_sup mbid mtb senv.modresolver
       in

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -263,18 +263,16 @@ module Quality = struct
 end
 
 module ElimConstraint = struct
-  type kind = Equal | ElimTo
+  type kind = ElimTo
 
   let eq_kind : kind -> kind -> bool = (=)
   let compare_kind : kind -> kind -> int = compare
 
   let hash_kind = function
-    | Equal -> 0
-    | ElimTo -> 1
+  | ElimTo -> 0
 
   let pr_kind = function
-    | Equal -> Pp.str "="
-    | ElimTo -> Pp.str "->"
+  | ElimTo -> Pp.str "->"
 
   type t = Quality.t * kind * Quality.t
 

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -337,18 +337,6 @@ struct
     (q, ElimConstraints.filter filter c)
 end
 
-let enforce_eq_quality a b csts =
-  if Quality.equal a b then csts
-  else ElimConstraints.add (a,ElimConstraint.Equal,b) csts
-
-let enforce_elim_to_quality a b csts =
-  if Quality.equal a b then csts
-  else ElimConstraints.add (a,ElimConstraint.ElimTo,b) csts
-
-let enforce_eq_cumul_quality a b csts =
-  if Quality.equal a b then csts
-  else ElimConstraints.add (a, ElimConstraint.Equal, b) csts
-
 type t =
   | SProp
   | Prop

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -127,7 +127,7 @@ module Quality : sig
 end
 
 module ElimConstraint : sig
-  type kind = Equal | ElimTo
+  type kind = ElimTo
 
   val pr_kind : kind -> Pp.t
 

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -156,12 +156,6 @@ sig
   val filter_constant_qualities : t -> t (* XXX: this looks very wrong *)
 end
 
-val enforce_eq_quality : Quality.t -> Quality.t -> ElimConstraints.t -> ElimConstraints.t
-
-val enforce_elim_to_quality : Quality.t -> Quality.t -> ElimConstraints.t -> ElimConstraints.t
-
-val enforce_eq_cumul_quality : Quality.t -> Quality.t -> ElimConstraints.t -> ElimConstraints.t
-
 type t = private
   | SProp
   | Prop

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -71,7 +71,6 @@ type ('constr, 'types, 'r) ptype_error =
   | IllFormedRecBody of 'constr pguard_error * (Name.t, 'r) Context.pbinder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of
       int * (Name.t, 'r) Context.pbinder_annot array * ('constr, 'types) punsafe_judgment array * 'types array
-  | UnsatisfiedElimConstraints of Sorts.ElimConstraints.t
   | UnsatisfiedUnivConstraints of UnivConstraints.t
   | UnsatisfiedPConstraints of PConstraints.t
   | UndeclaredQualities of Sorts.QVar.Set.t
@@ -158,9 +157,6 @@ let error_ill_formed_rec_body env why lna i fixenv vdefj =
 let error_ill_typed_rec_body env i lna vdefj vargs =
   raise (TypeError (env, IllTypedRecBody (i,lna,vdefj,vargs)))
 
-let error_unsatisfied_elim_constraints env c =
-  raise (TypeError (env, UnsatisfiedElimConstraints c))
-
 let error_unsatisfied_univ_constraints env c =
   raise (TypeError (env, UnsatisfiedUnivConstraints c))
 
@@ -223,7 +219,7 @@ let map_pguard_error f = function
 let map_ptype_error fr f = function
 | UnboundRel _ | UnboundVar _ | CaseOnPrivateInd _ | IllFormedCaseParams
 | UndeclaredQualities _ | UndeclaredUniverses _ | NotAllowedSProp
-| UnsatisfiedElimConstraints _ | UnsatisfiedUnivConstraints _
+| UnsatisfiedUnivConstraints _
 | UnsatisfiedPConstraints _
 | ReferenceVariables _ | BadInvert | BadVariance _ | UndeclaredUsedVariables _ | IllFormedConstant _ | IllFormedInductive _ as e -> e
 | NotAType j -> NotAType (on_judgment f j)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -73,7 +73,6 @@ type ('constr, 'types, 'r) ptype_error =
   | IllFormedRecBody of 'constr pguard_error * (Name.t,'r) Context.pbinder_annot array * int * env * ('constr, 'types) punsafe_judgment array
   | IllTypedRecBody of
       int * (Name.t,'r) Context.pbinder_annot array * ('constr, 'types) punsafe_judgment array * 'types array
-  | UnsatisfiedElimConstraints of Sorts.ElimConstraints.t
   | UnsatisfiedUnivConstraints of UnivConstraints.t
   | UnsatisfiedPConstraints of PConstraints.t
   | UndeclaredQualities of Sorts.QVar.Set.t
@@ -152,8 +151,6 @@ val error_ill_formed_rec_body :
 
 val error_ill_typed_rec_body  :
   env -> int -> Name.t binder_annot array -> unsafe_judgment array -> types array -> 'a
-
-val error_unsatisfied_elim_constraints : env -> Sorts.ElimConstraints.t -> 'a
 
 val error_unsatisfied_univ_constraints : env -> Univ.UnivConstraints.t -> 'a
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -234,7 +234,6 @@ let check_subtype univs ctxT ctx =
 (** Instances *)
 
 let check_eq_instances qeq univs t1 t2 =
-  (* TODO: remove QGraph argument *)
   let qt1, ut1 = Instance.to_array t1 in
   let qt2, ut2 = Instance.to_array t2 in
   CArray.equal qeq qt1 qt2

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -137,17 +137,18 @@ let check_type_in_type_qualities q1 q2 =
     | QConstant (QSProp | QProp), _ | _, QConstant (QSProp | QProp) -> true
     | (QConstant _ | QVar _), _ -> false
 
-let check_eq_sort quals univs s1 s2 =
+let check_eq_sort qeq univs s1 s2 =
   if type_in_type univs then
     check_eq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) ||
       check_type_in_type_qualities (Sorts.quality s1) (Sorts.quality s2)
   else
     let u1 = Sorts.univ_of_sort s1 in
     let u2 = Sorts.univ_of_sort s2 in
-    QGraph.check_eq_sort quals s1 s2 &&
-      check_eq univs u1 u2
+    let q1 = Sorts.quality s1 in
+    let q2 = Sorts.quality s2 in
+    qeq q1 q2 && check_eq univs u1 u2
 
-let check_leq_sort quals univs s1 s2 =
+let check_leq_sort qeq univs s1 s2 =
   if type_in_type univs then
     check_leq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2) ||
       check_type_in_type_qualities (Sorts.quality s1) (Sorts.quality s2)
@@ -157,7 +158,7 @@ let check_leq_sort quals univs s1 s2 =
     | (Prop, (Set | Type _)) -> true
     | (Prop, QSort (q, _)) -> is_above_prop univs q
     | (Type _ | Set), (Set | Type _) -> check_leq univs (Sorts.univ_of_sort s1) (Sorts.univ_of_sort s2)
-    | (QSort (_, u1), QSort (_, u2)) -> QGraph.check_eq_sort quals s1 s2 && check_leq univs u1 u2
+    | (QSort (s1, u1), QSort (s2, u2)) -> qeq (Sorts.Quality.QVar s1) (Sorts.Quality.QVar s2) && check_leq univs u1 u2
     | (QSort (q, u1), Type u2) -> is_above_prop univs q && check_leq univs u1 u2
     | ((SProp | Prop | Set | Type _ | QSort _), _) -> false
 
@@ -232,10 +233,11 @@ let check_subtype univs ctxT ctx =
 
 (** Instances *)
 
-let check_eq_instances quals univs t1 t2 =
+let check_eq_instances qeq univs t1 t2 =
+  (* TODO: remove QGraph argument *)
   let qt1, ut1 = Instance.to_array t1 in
   let qt2, ut2 = Instance.to_array t2 in
-  CArray.equal (QGraph.check_eq quals) qt1 qt2
+  CArray.equal qeq qt1 qt2
   && CArray.equal (check_eq_level univs) ut1 ut2
 
 let domain g = G.domain g.graph

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -36,7 +36,7 @@ val initial_universes : t
 val initial_universes_with : t -> t
 
 (** Check equality of instances w.r.t. a universe graph *)
-val check_eq_instances : QGraph.t -> t -> Instance.t -> Instance.t -> bool
+val check_eq_instances : (Sorts.Quality.t -> Sorts.Quality.t -> bool) -> t -> Instance.t -> Instance.t -> bool
 
 (** {6 ... } *)
 (** Merge of constraints in a universes graph.
@@ -62,12 +62,12 @@ val merge_constraints : UnivConstraints.t -> t -> t
 val check_constraint  : t -> UnivConstraint.t -> bool
 val check_constraints : UnivConstraints.t -> t -> bool
 
-val check_eq_sort : QGraph.t -> t -> Sorts.t -> Sorts.t -> bool
+val check_eq_sort : (Sorts.Quality.t -> Sorts.Quality.t -> bool) -> t -> Sorts.t -> Sorts.t -> bool
 (** Checks whether (i) the first quality is equal to the second and (ii)
     that the universe of the first one is equal to the universe of the second one.
     When [type_in_type], only checks relevance. *)
 
-val check_leq_sort : QGraph.t -> t -> Sorts.t -> Sorts.t -> bool
+val check_leq_sort : (Sorts.Quality.t -> Sorts.Quality.t -> bool) -> t -> Sorts.t -> Sorts.t -> bool
 (** Checks whether (i) the second quality eliminates into the first and (ii)
     that the universe of the first one is below the universe of the second one.
     When [type_in_type], only checks relevance. *)

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -193,11 +193,15 @@ end
 
 let eq_sizes (a,b) (a',b') = Int.equal a a' && Int.equal b b'
 
-type 'a pconstraints_function = 'a -> 'a -> PConstraints.t -> PConstraints.t
+module QPair = OrderedType.Pair(Quality)(Quality)
+
+module QPairSet = Set.Make(QPair)
+
+type 'a pconstraints_function = 'a -> 'a -> QPairSet.t * UnivConstraints.t -> QPairSet.t * UnivConstraints.t
 
 let enforce_eq_cumul_quality a b csts =
   if Quality.equal a b then csts
-  else Sorts.ElimConstraints.add (a, Sorts.ElimConstraint.Equal, b) csts
+  else QPairSet.add (a, b) csts
 
 let enforce_eq_instances x y (qcs, ucs as orig) =
   let xq, xu = Instance.to_array x and yq, yu = Instance.to_array y in

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -195,25 +195,29 @@ let eq_sizes (a,b) (a',b') = Int.equal a a' && Int.equal b b'
 
 type 'a pconstraints_function = 'a -> 'a -> PConstraints.t -> PConstraints.t
 
+let enforce_eq_cumul_quality a b csts =
+  if Quality.equal a b then csts
+  else Sorts.ElimConstraints.add (a, Sorts.ElimConstraint.Equal, b) csts
+
 let enforce_eq_instances x y (qcs, ucs as orig) =
   let xq, xu = Instance.to_array x and yq, yu = Instance.to_array y in
   if Array.length xq != Array.length yq || Array.length xu != Array.length yu then
     CErrors.anomaly (Pp.(++) (Pp.str "Invalid argument: enforce_eq_instances called with")
                        (Pp.str " instances of different lengths."));
-  let qcs' = CArray.fold_right2 Sorts.enforce_eq_cumul_quality xq yq qcs in
+  let qcs' = CArray.fold_right2 enforce_eq_cumul_quality xq yq qcs in
   let ucs' = CArray.fold_right2 enforce_eq_level xu yu ucs in
   if qcs' == qcs && ucs' == ucs then orig else qcs', ucs'
 
 let enforce_eq_variance_instances variances x y (qcs,ucs as orig) =
   let xq, xu = Instance.to_array x and yq, yu = Instance.to_array y in
-  let qcs' = CArray.fold_right2 Sorts.enforce_eq_cumul_quality xq yq qcs in
+  let qcs' = CArray.fold_right2 enforce_eq_cumul_quality xq yq qcs in
   let ucs' = Variance.eq_constraints variances xu yu ucs in
   if qcs' == qcs && ucs' == ucs then orig else qcs', ucs'
 
 let enforce_leq_variance_instances variances x y (qcs,ucs as orig) =
   let xq, xu = Instance.to_array x and yq, yu = Instance.to_array y in
   (* no variance for quality variables -> enforce_eq *)
-  let qcs' = CArray.fold_right2 Sorts.enforce_eq_cumul_quality xq yq qcs in
+  let qcs' = CArray.fold_right2 enforce_eq_cumul_quality xq yq qcs in
   let ucs' = Variance.leq_constraints variances xu yu ucs in
   if qcs' == qcs && ucs' == ucs then orig else qcs', ucs'
 

--- a/kernel/uVars.mli
+++ b/kernel/uVars.mli
@@ -85,7 +85,9 @@ end
 val eq_sizes : int * int -> int * int -> bool
 (** Convenient function to compare the result of Instance.length, UContext.size etc *)
 
-type 'a pconstraints_function = 'a -> 'a -> PConstraints.t -> PConstraints.t
+module QPairSet : CSig.SetS with type elt = (Quality.t * Quality.t)
+
+type 'a pconstraints_function = 'a -> 'a -> QPairSet.t * UnivConstraints.t -> QPairSet.t * UnivConstraints.t
 
 val enforce_eq_instances : Instance.t pconstraints_function
 

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -240,21 +240,19 @@ let vm_conv_gen (type err) cv_pb sigma env univs t1 t2 =
 
 let vm_conv cv_pb env t1 t2 =
   let univs = Environ.universes env in
-  let elims = Environ.qualities env in
-  let state = elims, univs in
   let b =
-    if cv_pb = CUMUL then Constr.leq_constr_univs elims univs t1 t2
-    else Constr.eq_constr_univs elims univs t1 t2
+    if cv_pb = CUMUL then Constr.leq_constr_univs univs t1 t2
+    else Constr.eq_constr_univs univs t1 t2
   in
   if b then Result.Ok ()
   else
-    let state = (state, checked_universes) in
-    let ans : (QGraph.t * UGraph.t, 'a option) result =
+    let state = (univs, checked_universes) in
+    let ans : (UGraph.t, 'a option) result =
       NewProfile.profile "vm_conv" (fun () ->
           vm_conv_gen cv_pb (Genlambda.empty_evars env) env state t1 t2)
         ()
     in
     match ans with
-    | Result.Ok (_ : QGraph.t * UGraph.t)-> Result.Ok ()
+    | Result.Ok (_ : UGraph.t)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -193,7 +193,7 @@ let expand_mexpr env mp me =
   (* hack: in order not to overwrite the module binding mp, we first give it a
      name that should not be part of the env and then substitute it away *)
   let mp0 = ModPath.dummy in
-  let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+  let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let mb, (_, cst), _ = Mod_typing.translate_module state vm_state env mp0 inl (MExpr ([], me, None)) in
   let sign = mod_type mb in
   let reso = mod_delta mb in
@@ -201,7 +201,7 @@ let expand_mexpr env mp me =
 
 let expand_modtype env mp me =
   let inl = Declaremods.default_inline_level () in
-  let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+  let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let mtb, _cst, _ = Mod_typing.translate_modtype state vm_state env mp inl ([],me) in
   mtb
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1683,17 +1683,15 @@ let is_impredicative_sort = function
 | _ -> false
 (* Only used for universe level comparisons, so impredicative set is still fine *)
 
-(* XXX Despite their names, we force sort quality equality in the functions
-   below. We should use a different data structure of constraints here *)
 let enforce_eq_sort s1 s2 (qcsts, ucsts as cst) = match s1, s2 with
 | QSort (q1, u1), s2 ->
   let q2 = quality s2 in
-  let qcsts = Sorts.ElimConstraints.add (QVar q1, Sorts.ElimConstraint.Equal, q2) qcsts in
+  let qcsts = UVars.QPairSet.add (QVar q1, q2) qcsts in
   let ucsts = if is_impredicative_sort s2 then ucsts else UnivSubst.enforce_eq u1 (get_algebraic s2) ucsts in
   (qcsts, ucsts)
 | s1, QSort (q2, u2) ->
   let q1 = quality s1 in
-  let qcsts = Sorts.ElimConstraints.add (q1, Sorts.ElimConstraint.Equal, QVar q2) qcsts in
+  let qcsts = UVars.QPairSet.add (q1, QVar q2) qcsts in
   let ucsts = if is_impredicative_sort s2 then ucsts else UnivSubst.enforce_eq (get_algebraic s1) u2 ucsts in
   (qcsts, ucsts)
 | (SProp, SProp) | (Prop, Prop) | (Set, Set) -> cst
@@ -1707,39 +1705,45 @@ let enforce_eq_sort s1 s2 (qcsts, ucsts as cst) = match s1, s2 with
 let enforce_leq_alg_sort s1 s2 g = match s1, s2 with
 | QSort (q1, u1), s2 ->
   let q2 = quality s2 in
-  let qcsts = Sorts.ElimConstraints.singleton (QVar q1, Sorts.ElimConstraint.Equal, q2) in
+  let qcsts = UVars.QPairSet.singleton (QVar q1, q2) in
   let ucsts, g = if is_impredicative_sort s2 then UnivConstraints.empty, g else UGraph.enforce_leq_alg u1 (get_algebraic s2) g in
   (qcsts, ucsts), g
 | s1, QSort (q2, u2) ->
   let q1 = quality s1 in
-  let qcsts = Sorts.ElimConstraints.singleton (q1, Sorts.ElimConstraint.Equal, QVar q2) in
+  let qcsts = UVars.QPairSet.singleton (q1, QVar q2) in
   let ucsts, g = if is_impredicative_sort s2 then UnivConstraints.empty, g else UGraph.enforce_leq_alg (get_algebraic s1) u2 g  in
   (qcsts, ucsts), g
-| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> PConstraints.empty, g
-| (Prop, (Set | Type _)) -> PConstraints.empty, g
+| (SProp, SProp) | (Prop, Prop) | (Set, Set) -> (UVars.QPairSet.empty, Univ.UnivConstraints.empty), g
+| (Prop, (Set | Type _)) -> (UVars.QPairSet.empty, Univ.UnivConstraints.empty), g
 | (((Prop | Set | Type _) as s1), (Prop | SProp as s2))
 | ((SProp as s1), ((Prop | Set | Type _) as s2)) ->
   raise (UGraph.UniverseInconsistency (None, (Le, s1, s2, None)))
 | (Set | Type _), (Set | Type _) ->
   let ucsts, g = UGraph.enforce_leq_alg (get_algebraic s1) (get_algebraic s2) g in
-  (Sorts.ElimConstraints.empty, ucsts), g
+  (UVars.QPairSet.empty, ucsts), g
 
 open Conversion
 
-let infer_eq elims (univs, cstrs as cuniv) s s' =
-  if UGraph.check_eq_sort elims univs s s' then Result.Ok cuniv
+let check_eq_qualities qcst =
+  let check (q1, q2) = Quality.equal q1 q2 in
+  UVars.QPairSet.for_all check qcst
+
+let infer_eq _elims (univs, cstrs as cuniv) s s' =
+  (* TODO: remove the QGraph argument *)
+  if UGraph.check_eq_sort Sorts.Quality.equal univs s s' then Result.Ok cuniv
   else try
-    let qcsts', ucstrs' as cstrs' = enforce_eq_sort s s' PConstraints.empty in
-    if QGraph.check_constraints qcsts' elims then
+    let qcsts', ucstrs' as cstrs' = enforce_eq_sort s s' (UVars.QPairSet.empty, Univ.UnivConstraints.empty) in
+    if check_eq_qualities qcsts' then
       Result.Ok (UGraph.merge_constraints ucstrs' univs, UnivConstraints.union cstrs ucstrs')
     else Result.Error None
   with UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
 
-let infer_leq elims (univs, cstrs as cuniv) s s' =
-  if UGraph.check_leq_sort elims univs s s' then Result.Ok cuniv
+let infer_leq _elims (univs, cstrs as cuniv) s s' =
+  (* TODO: remove the QGraph argument *)
+  if UGraph.check_leq_sort Sorts.Quality.equal univs s s' then Result.Ok cuniv
   else match enforce_leq_alg_sort s s' univs with
   | (qcsts, ucsts), ugraph ->
-    if QGraph.check_constraints qcsts elims then
+    if check_eq_qualities qcsts then
       Result.Ok (univs, UnivConstraints.union cstrs ucsts)
     else Result.Error None
   | exception UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
@@ -1749,17 +1753,13 @@ let infer_cmp_universes elims pb s0 s1 cuniv =
   | CUMUL -> infer_leq elims cuniv s0 s1
   | CONV -> infer_eq elims cuniv s0 s1
 
-let check_qgraph_qualities qgraph qcst =
-  let check (q1, q2) = QGraph.check_eq qgraph q1 q2 in
-  UVars.QPairSet.for_all check qcst
-
-let infer_convert_instances elims ~flex u u' (univs, cstrs as cuniv) =
+let infer_convert_instances _elims ~flex u u' (univs, cstrs as cuniv) =
   if flex then
-    if UGraph.check_eq_instances elims univs u u' then Result.Ok cuniv
+    if UGraph.check_eq_instances Sorts.Quality.equal univs u u' then Result.Ok cuniv
     else Result.Error None
   else try
     let qcstrs, ucstrs as cstrs' = UVars.enforce_eq_instances u u' (UVars.QPairSet.empty, Univ.UnivConstraints.empty) in
-    if check_qgraph_qualities elims qcstrs then
+    if check_eq_qualities qcstrs then
       Result.Ok (UGraph.merge_constraints ucstrs univs, UnivConstraints.union cstrs ucstrs)
     else Result.Error None
   with UGraph.UniverseInconsistency err -> Result.Error (Some (Univ err))
@@ -1767,7 +1767,7 @@ let infer_convert_instances elims ~flex u u' (univs, cstrs as cuniv) =
 
 let infer_inductive_instances elims cv_pb variance u1 u2 (univs,csts) =
   let qcsts, csts' = get_cumulativity_constraints cv_pb variance u1 u2 in
-  if check_qgraph_qualities elims qcsts then
+  if check_eq_qualities qcsts then
     match UGraph.merge_constraints csts' univs with
     | univs -> Result.Ok (univs, Univ.UnivConstraints.union csts csts')
     | exception (UGraph.UniverseInconsistency err) -> Result.Error (Some (Univ err))

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -310,7 +310,7 @@ val is_head_evar : env -> evar_map -> constr -> bool
 exception AnomalyInConversion of exn
 
 (* inferred_universes just gathers the constraints. *)
-val inferred_universes : env -> (UGraph.t * Univ.UnivConstraints.t, Conversion.graph_inconsistency) Conversion.universe_compare
+val inferred_universes : (UGraph.t * Univ.UnivConstraints.t, Conversion.graph_inconsistency) Conversion.universe_compare
 
 val eta_expand : env -> evar_map -> etypes -> etypes -> etypes
 

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -969,7 +969,7 @@ module Interp = struct
 
 let check_sub env mp sub_mtb_l =
   let fold sub_mtb (cst, env) =
-    let state = ((Environ.universes env, cst), Reductionops.inferred_universes env) in
+    let state = ((Environ.universes env, cst), Reductionops.inferred_universes) in
     let ugraph, cst = Subtyping.check_subtypes state env mp mp sub_mtb in
     (cst, Environ.set_universes ugraph env)
   in
@@ -1007,7 +1007,7 @@ let build_subtypes env mp args mtys =
       let mte, ctx' = Modintern.interp_module_ast env Modintern.ModType base mte in
       let env = Environ.push_context_set  ~strict:true ctx' env in
       let ctx = Univ.ContextSet.union ctx ctx' in
-      let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+      let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
       (* functor arguments are already part of the env, we compute the type
          and requantify over them *)
       let mtb, (_, cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
@@ -1036,7 +1036,7 @@ let intern_arg (acc, cst) (mbidl,(mty, base, kind, inl)) =
   let (mty, cst') = Modintern.interp_module_ast env kind base mty in
   let () = Global.push_context_set cst' in
   let () =
-    let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+    let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
     let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state (Global.env ()) base inl ([], mty) in
     Global.add_univ_constraints cst
   in
@@ -1082,7 +1082,7 @@ let start_module_core id args res =
         let (mte, ctx) = Modintern.interp_module_ast env kind base mte in
         let env = Environ.push_context_set ctx env in
         (* We check immediately that mte is well-formed *)
-        let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+        let state = ((Environ.universes env, Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
         let _, (_, cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
         let ctx = Univ.ContextSet.add_constraints cst ctx in
         Some (mte, inl), [], ctx
@@ -1112,7 +1112,7 @@ let end_module_core id m_info objects fs =
 
   let struc = current_struct () in
   let restype' = Option.map (fun (ty,inl) -> (([],ty),inl)) m_info.cur_typ in
-  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes (Global.env ())) in
+  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst), _ =
     Mod_typing.finalize_module state vm_state (Global.env ()) (Global.current_modpath ())
       (struc, current_modresolver ()) restype'
@@ -1192,7 +1192,7 @@ let declare_module id args res mexpr_o =
   | _ -> inl_res
   in
   let () = Global.push_context_set ctx in
-  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let _, (_, cst), _ = Mod_typing.translate_module state vm_state (Global.env ()) mp inl entry in
   let () = Global.add_univ_constraints cst in
   let mp_env,resolver = Global.add_module id entry inl in
@@ -1316,7 +1316,7 @@ let declare_modtype id args mtys (mte,base,kind,inl) =
   let () = Global.push_context_set mte_ctx in
   let env = Global.env () in
   (* We check immediately that mte is well-formed *)
-  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let _, (_, mte_cst), _ = Mod_typing.translate_modtype state vm_state env mp inl ([], mte) in
   let () = Global.push_context_set (Univ.Level.Set.empty, mte_cst) in
   let params = List.map (fun (mbid, _, mte, b) -> (mbid, mte, b)) params in
@@ -1436,7 +1436,7 @@ let declare_one_include_core (me,base,kind,inl) =
   in
   let base_mp = get_module_path me in
 
-  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+  let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
   let sign, (), resolver, (_, cst), _ =
     Mod_typing.translate_mse_include is_mod state vm_state (Global.env ()) (Global.current_modpath ()) inl me
   in
@@ -1447,7 +1447,7 @@ let declare_one_include_core (me,base,kind,inl) =
   let rec compute_sign sign =
     match sign with
     | MoreFunctor(mbid,mtb,str) ->
-      let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes env) in
+      let state = ((Global.universes (), Univ.UnivConstraints.empty), Reductionops.inferred_universes) in
       (* Module subcomponents are already part of env at this point *)
       let env = Environ.shallow_add_module cur_mp mb (Global.env ()) in
       let (_, cst) = Subtyping.check_subtypes state env cur_mp (MPbound mbid) mtb in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -903,11 +903,6 @@ let explain_unsatisfied_univ_constraints env sigma cst =
     Univ.UnivConstraints.pr (Termops.pr_evd_level sigma) cst ++
     spc () ++ str "(maybe a bugged tactic)."
 
-let explain_unsatisfied_elim_constraints env sigma cst =
-  strbrk "Unsatisfied elimination constraints: " ++
-  Sorts.ElimConstraints.pr (Termops.pr_evd_qvar sigma) cst ++
-  spc() ++ str "(maybe a bugged tactic)."
-
 let explain_undeclared_universes env sigma l =
   let l = Univ.Level.Set.elements l in
   strbrk "Undeclared " ++ str (CString.lplural l "universe") ++ strbrk ": " ++
@@ -1046,8 +1041,6 @@ let explain_type_error env sigma err =
     explain_unsatisfied_poly_constraints env sigma cst
   | UnsatisfiedUnivConstraints cst ->
     explain_unsatisfied_univ_constraints env sigma cst
-  | UnsatisfiedElimConstraints cst ->
-    explain_unsatisfied_elim_constraints env sigma cst
   | UndeclaredUniverses l ->
     explain_undeclared_universes env sigma l
   | UndeclaredQualities l ->


### PR DESCRIPTION
We remove the ability to add quantified sort equality constraints in definition binders. This feature was there in the implementation but had no user-facing syntax. This allows pushing all sort equalities outside of the kernel into UState. In particular, QGraph does not contain sort equality information anymore, only eliminability. We have to adapt CClosure evar handlers accordingly to account for the missing quotient.