### PR TITLE
Add Kernel Conversion Dep Heuristic flag for smarter constant unfolding.

### DIFF
--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -21,6 +21,7 @@ let set_local_flags flags env =
     check_eliminations = flags.check_eliminations;
     conv_oracle = flags.conv_oracle;
     share_reduction = flags.share_reduction;
+    unfold_dep_heuristic = flags.unfold_dep_heuristic;
     allow_uip = flags.allow_uip;
     (* These flags may not *)
     enable_VM = envflags.enable_VM;

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -357,7 +357,7 @@ let v_typing_flags =
   v_tuple "typing_flags"
     [|v_bool; v_bool; v_bool; v_bool;
       v_oracle; v_bool; v_bool;
-      v_bool; v_bool; v_bool; v_bool; v_bool|]
+      v_bool; v_bool; v_bool; v_bool; v_bool; v_bool|]
 
 let v_univs = v_sum "universes" 1 [|[|v_abs_context|]|]
 

--- a/doc/changelog/01-kernel/21514-unfold-dep-heuristic-names-Added.rst
+++ b/doc/changelog/01-kernel/21514-unfold-dep-heuristic-names-Added.rst
@@ -1,0 +1,11 @@
+- **Added:**
+  new flag :flag:`Kernel Conversion Dep Heuristic` that enables a heuristic for
+  smarter constant unfolding during conversion. When enabled, if two constants
+  have the same strategy level (see :cmd:`Strategy`) and one constant's
+  definition depends on the other, the dependent constant is unfolded first.
+  This can significantly speed up conversions in cases like checking ``c1 =
+  c2`` vs ``c2 = c1`` where one definition wraps the other. The flag defaults
+  to off, preserving the existing behavior of preferentially unfolding the
+  right-hand side first (`#21514
+  <https://github.com/rocq-prover/rocq/pull/21514>`_, fixes `#21509
+  <https://github.com/rocq-prover/rocq/issues/21509>`_, by Jason Gross).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -559,6 +559,22 @@ which reduction engine to use.  See :ref:`type-cast`.)  For example:
       affects the reduction procedure used by the kernel when
       typechecking. By default sharing is activated.
 
+   .. flag:: Kernel Conversion Dep Heuristic
+
+      This flag controls a heuristic used during conversion when comparing
+      two constants. When enabled, if the two constants have the same
+      strategy level (see :cmd:`Strategy`), the heuristic prefers unfolding
+      the constant that depends on the other.
+
+      For example, if ``c1`` depends on ``c2`` (i.e., ``c1``'s definition mentions ``c2``),
+      then checking ``c1 = c2`` or ``c2 = c1`` will prefer unfolding ``c1`` first.
+      This can significantly speed up conversions in cases where one definition
+      wraps another.
+
+      By default this flag is off, and the conversion algorithm prefers
+      unfolding the right-hand side first when the two constants have the
+      same strategy level.
+
    The call-by-value strategy is the one used in ML languages: the
    arguments of a function call are systematically weakly evaluated
    first. The lazy strategy is similar to how Haskell reduces terms.

--- a/kernel/conv_oracle.mli
+++ b/kernel/conv_oracle.mli
@@ -20,12 +20,21 @@ type oracle
 
 val empty : oracle
 
+(** Result of oracle comparison *)
+type order = Left | Right | Same
+
 (** Order on section paths for unfolding.
    If [oracle_order kn1 kn2] is true, then unfold kn1 first.
    Note: the oracle does not introduce incompleteness, it only
    tries to postpone unfolding of "opaque" constants. *)
 val oracle_order :
   oracle -> bool -> evaluable option -> evaluable option -> bool
+
+(** Like [oracle_order] but returns [Same] when neither constant is preferred
+    based on the oracle alone. This allows the caller to apply additional
+    heuristics. *)
+val oracle_compare :
+  oracle -> evaluable option -> evaluable option -> order
 
 (** Priority for the expansion of constant in the conversion test.
  * Higher levels means that the expansion is less prioritary.

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -465,7 +465,25 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
           in
           let ninfos = infos_with_reds infos.cnv_inf RedFlags.betaiotazeta in
           let () = Control.check_for_interrupt () in
-          if Conv_oracle.oracle_order oracle l2r (to_er fl1) (to_er fl2) then
+          (* Determine which constant to unfold first *)
+          let unfold_left =
+            let order = Conv_oracle.oracle_compare oracle (to_er fl1) (to_er fl2) in
+            match order with
+            | Conv_oracle.Left -> true
+            | Conv_oracle.Right -> false
+            | Conv_oracle.Same ->
+              (* When oracle doesn't prefer either, optionally use dependency heuristic *)
+              let env = CClosure.info_env infos.cnv_inf in
+              if (Environ.typing_flags env).unfold_dep_heuristic then
+                match fl1, fl2 with
+                | ConstKey (cst1, _), ConstKey (cst2, _) ->
+                  if Environ.constant_depends_on env cst1 cst2 then true
+                  else if Environ.constant_depends_on env cst2 cst1 then false
+                  else l2r
+                | _ -> l2r
+              else l2r
+          in
+          if unfold_left then
             let appr1 = whd_stack ninfos infos.lft_tab t1 v1 in
             eqwhnf cv_pb l2r infos (lft1, appr1) appr2 cuniv
           else
@@ -991,7 +1009,7 @@ let () =
       let box = Empty.abort in
       let state = info_univs infos in
       let qual_equal q1 q2 = CClosure.eq_quality infos q1 q2 in
-      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box } in
+      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; } in
       let state', _ = ccnv CONV false infos el_id el_id a b (state, checked_universes_gen qual_equal) in
       assert (state==state');
       true

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -86,6 +86,9 @@ type typing_flags = {
   share_reduction : bool;
   (** Use by-need reduction algorithm *)
 
+  unfold_dep_heuristic : bool;
+  (** If [true], use dependency heuristic when unfolding constants during conversion *)
+
   enable_VM : bool;
   (** If [false], all VM conversions fall back to interpreted ones *)
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -26,6 +26,7 @@ let safe_flags oracle = {
   check_universes = true;
   conv_oracle = oracle;
   share_reduction = true;
+  unfold_dep_heuristic = false;
   enable_VM = true;
   enable_native_compiler = true;
   indices_matter = true;

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -490,6 +490,15 @@ val no_link_info : link_info
 val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
 val retroknowledge : env -> Retroknowledge.retroknowledge
 
+(** {5 Dependency analysis} *)
+
+(** [constant_depends_on c1 c2] is true when [c2] appears in the transitive set of
+    constants reachable from the body of [c1]. Axioms, opaque definitions,
+    and primitives have no body and thus no dependencies. *)
+val constant_depends_on : env -> Constant.t -> Constant.t -> bool
+
+(** {5 Internals} *)
+
 module Internal : sig
   (** Makes the qvars treated as above prop.
       Do not use outside kernel inductive typechecking. *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -335,6 +335,10 @@ let set_share_reduction b senv =
   let flags = Environ.typing_flags senv.env in
   set_typing_flags { flags with share_reduction = b } senv
 
+let set_unfold_dep_heuristic b senv =
+  let flags = Environ.typing_flags senv.env in
+  set_typing_flags { flags with unfold_dep_heuristic = b } senv
+
 let set_VM b senv =
   let flags = Environ.typing_flags senv.env in
   set_typing_flags { flags with enable_VM = b } senv

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -168,6 +168,7 @@ val set_impredicative_set : bool -> safe_transformer0
 val set_indices_matter : bool -> safe_transformer0
 val set_typing_flags : Declarations.typing_flags -> safe_transformer0
 val set_share_reduction : bool -> safe_transformer0
+val set_unfold_dep_heuristic : bool -> safe_transformer0
 val set_check_guarded : bool -> safe_transformer0
 val set_check_positive : bool -> safe_transformer0
 val set_check_universes : bool -> safe_transformer0

--- a/library/global.ml
+++ b/library/global.ml
@@ -249,6 +249,9 @@ let set_strategy k l =
 let set_share_reduction b =
   globalize0 (Safe_typing.set_share_reduction b)
 
+let set_unfold_dep_heuristic b =
+  globalize0 (Safe_typing.set_unfold_dep_heuristic b)
+
 let set_VM b = globalize0 (Safe_typing.set_VM b)
 let set_native_compiler b = globalize0 (Safe_typing.set_native_compiler b)
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -192,6 +192,8 @@ val set_strategy : Conv_oracle.evaluable -> Conv_oracle.level -> unit
 
 val set_share_reduction : bool -> unit
 
+val set_unfold_dep_heuristic : bool -> unit
+
 val set_VM : bool -> unit
 val set_native_compiler : bool -> unit
 

--- a/test-suite/success/UnfoldDepHeuristic.v
+++ b/test-suite/success/UnfoldDepHeuristic.v
@@ -1,0 +1,32 @@
+(* Test for the Kernel Conversion Dep Heuristic flag *)
+
+(* Define a factorial function *)
+Fixpoint fact (n : nat) := match n with O => 1 | S n => (S n) * fact n end.
+
+(* Define constants that depend on each other:
+   fact100' depends on fact100 which depends on fact *)
+Definition fact100 := fact 100.
+Definition fact100' := fact100.
+
+(* Without the heuristic, conversion prefers unfolding right-to-left by default.
+   - fact100 = fact100' is fast because fact100' (on the right) is unfolded first,
+     revealing fact100, and both sides are then syntactically equal
+   - fact100' = fact100 is slow because fact100 (on the right) is unfolded first
+     and fully reduced to normal form before the left side is considered
+
+   With the heuristic enabled, when the oracle doesn't prefer either constant,
+   we prefer unfolding the constant that depends on the other one. Since
+   fact100' depends on fact100, we prefer unfolding fact100' regardless of
+   which side it appears on. *)
+
+(* Test 1: This direction is always fast (unfolds fact100' first) *)
+Timeout 1 Check eq_refl : fact100 = fact100'.
+
+(* Test 2: Without heuristic this times out, with heuristic it's fast *)
+(* First verify the timeout behavior without the heuristic *)
+Unset Kernel Conversion Dep Heuristic.
+Fail Timeout 1 Check eq_refl : fact100' = fact100.
+
+(* Now enable the heuristic and verify it works *)
+Set Kernel Conversion Dep Heuristic.
+Timeout 1 Check eq_refl : fact100' = fact100.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1940,6 +1940,14 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
+      optkey   = ["Kernel"; "Conversion"; "Dep"; "Heuristic"];
+      optread  = (fun () -> (Global.typing_flags ()).Declarations.unfold_dep_heuristic);
+      optwrite = Global.set_unfold_dep_heuristic }
+
+let () =
+  declare_bool_option
+    { optstage = Summary.Stage.Interp;
+      optdepr  = None;
       optkey   = ["Printing";"Compact";"Contexts"];
       optread  = (fun () -> Printer.get_compact_context());
       optwrite = (fun b -> Printer.set_compact_context b) }


### PR DESCRIPTION
This PR adds an optional heuristic to the conversion algorithm that can significantly speed up conversions when two constants have the same oracle level and one depends on the other.

The key insight is that when checking c1 = c2 where c2's definition mentions c1 (c2 depends on c1), it's better to unfold c2 first regardless of which side it appears on.

Example: if fact100' := fact100 and fact100 := fact 100, then:
- Without heuristic: fact100 = fact100' is fast but fact100' = fact100 times out
- With heuristic: both directions are fast

The flag is controlled via "Set Kernel Conversion Dep Heuristic" and defaults to off (preserving current behavior).

Changes:
- kernel/environ.ml: Add constant_dependencies function
- kernel/conv_oracle.ml: Add oracle_compare that returns Same when the oracle doesn't prefer either constant
- kernel/conversion.ml: Use dependency heuristic when flag is enabled and oracle_compare returns Same
- vernac/vernacentries.ml: Add option declaration
- doc/sphinx: Document the new flag
- test-suite: Add test demonstrating the behavior

Code mostly authored by @ppedrot 

Fixes #21509

- [x] Added / updated **test-suite**.

- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.


<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
