### PR TITLE
Control which ocaml warnings are on instead of delegating to dune

### DIFF
--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -49,7 +49,7 @@ let print_usage_common co command =
 \n  -require-export lib, -re lib\
 \n                         load and transitively import Rocq library lib\
 \n                         (equivalent to Require Export lib.)\
-\n  -require-from root lib, -rfrom root lib
+\n  -require-from root lib, -rfrom root lib\
 \n                         load Rocq library lib (From root Require lib.)\
 \n  -require-import-from root lib, -rifrom root lib\
 \n                         load and import Rocq library lib\

--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -12,6 +12,8 @@ open Pp
 open Util
 open Names
 
+[@@@warning "-unused-field"] (* marshalled data *)
+
 let chk_pp = Feedback.msg_notice
 
 let pr_dirpath dp = str (DirPath.to_string dp)

--- a/checker/votour.ml
+++ b/checker/votour.ml
@@ -10,6 +10,9 @@
 
 open Values
 
+(* several records are defined to receive marshalled data *)
+[@@@warning "-unused-field"]
+
 (** {6 Interactive visit of a vo} *)
 
 let max_string_length = 1024

--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -19,7 +19,7 @@ include List
 type 'a cell = {
   head : 'a;
   mutable tail : 'a list;
-}
+} [@@warning "-unused-field"]
 
 external cast : 'a cell -> 'a list = "%identity"
 

--- a/doc/Makefile.docgram
+++ b/doc/Makefile.docgram
@@ -2,13 +2,6 @@
 # doc_grammar tool
 ######################################################################
 
-DOCGRAMWARN ?= 0
-ifeq ($(DOCGRAMWARN),0)
-DOCGRAMWARNFLAG=-no-warn
-else
-DOCGRAMWARNFLAG=
-endif
-
 # List mlg files explicitly to avoid ordering problems (across
 # different installations / make versions).
 DOC_MLGS := \
@@ -51,12 +44,12 @@ endif
 
 doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM'
-	$(HIDE)$(DOC_GRAM) -short -no-warn $(DOC_MLGS)
+	$(HIDE)$(DOC_GRAM) -short $(DOC_MLGS)
 
 #todo: add a dependency of sphinx on updated_rsts when we're ready
 doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
 	$(SHOW)'DOC_GRAM_RSTS'
-	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARNFLAG) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 .PRECIOUS: doc/tools/docgram/orderedGrammar
 
@@ -68,7 +61,7 @@ doc_gram: doc/tools/docgram/fullGrammar
 
 doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM_VERIFY'
-	$(HIDE)$(DOC_GRAM) -no-warn -verify -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) -verify -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 doc_gram_rsts: doc/tools/docgram/updated_rsts
 

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -143,8 +143,6 @@ Other command line arguments:
 
 * `-check-cmds` causes generation of `prodnCommands`
 
-* `-no-warn` suppresses printing of some warning messages
-
 * `-no-update` puts updates to `fullGrammar` and `orderedGrammar` into new files named
   `*.new`, leaving the originals unmodified.  For use in Dune.
 

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -35,7 +35,6 @@ type args = {
   check_tacs : bool;
   check_cmds : bool;
   update: bool;
-  show_warn : bool;
   verbose : bool;
   verify : bool;
 }
@@ -47,7 +46,6 @@ let default_args = {
   check_tacs = false;
   check_cmds = false;
   update = true;
-  show_warn = true;
   verbose = false;
   verify = false;
 }
@@ -1817,7 +1815,6 @@ let parse_args () =
         match arg with
         | "-check-cmds" -> { args with check_cmds = true }
         | "-check-tacs" -> { args with check_tacs = true }
-        | "-no-warn" -> show_warn := false; { args with show_warn = false }
         | "-no-update" -> { args with update = false }
         | "-short" -> { args with fullGrammar = true }
         | "-verbose" -> { args with verbose = true }

--- a/doc/tools/docgram/dune
+++ b/doc/tools/docgram/dune
@@ -44,6 +44,6 @@
   orderedGrammar)
  (action
   (progn
-   (chdir %{project_root} (run doc_grammar -no-warn -check-cmds -no-update %{input}))
+   (chdir %{project_root} (run doc_grammar -check-cmds -no-update %{input}))
    (diff? fullGrammar fullGrammar.new)
    (diff? orderedGrammar orderedGrammar.new))))

--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 ; Default flags for all Rocq libraries.
 (env
- (dev     (flags :standard -w -9-27@60-69@70 \ -short-paths)
+ ; cf explanation for warning settings in configure.ml
+ (dev     (flags :standard -w +a-4-9-27-40..42-44-45-48-58-67-68-70 -warn-error +a \ -short-paths)
           (coq (flags :standard -w +default)))
  (release (flags :standard)
           (ocamlopt_flags :standard -O3 -unbox-closures))

--- a/ide/rocqide/protocol/xml_parser.ml
+++ b/ide/rocqide/protocol/xml_parser.ml
@@ -51,7 +51,6 @@ exception File_not_found of string
 
 type t = {
   mutable check_eof : bool;
-  mutable concat_pcdata : bool;
   source : Lexing.lexbuf;
   stack : Xml_lexer.token Stack.t;
 }
@@ -92,7 +91,6 @@ let make source =
   let () = Xml_lexer.init source in
   {
     check_eof = false;
-    concat_pcdata = true;
     source = source;
     stack = Stack.create ();
   }

--- a/ide/rocqide/rocqDriver.ml
+++ b/ide/rocqide/rocqDriver.ml
@@ -221,9 +221,9 @@ type rocqtop = {
   mutable status : status;
   mutable stopped_in_debugger : bool;
   (* i.e., RocqIDE has received a prompt message *)
-  mutable do_when_ready : (unit -> unit) Queue.t;
+  do_when_ready : (unit -> unit) Queue.t;
   (* for debug msgs only; functions are called when rocqtop is Ready *)
-  mutable basename : string;
+  basename : string;
   mutable set_script_editable : bool -> unit;
   mutable restore_bpts : unit -> unit
 }

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -157,7 +157,6 @@ type process = {
   cout : out_channel;
   oob_resp : in_channel option;
   oob_req  : out_channel option;
-  gchan : ML.async_chan;
   pid : int;
   mutable watch : ML.watch_id option;
   mutable alive : bool;
@@ -192,7 +191,7 @@ let spawn ?(prefer_sock=prefer_sock) ?(env=Unix.environment ())
   Unix.set_nonblock (fst main);
   let gchan = ML.async_chan_of_file_or_socket (fst main) in
   let alive, watch = true, None in
-  let p = { cin; cout; gchan; pid; oob_resp; oob_req; alive; watch } in
+  let p = { cin; cout; pid; oob_resp; oob_req; alive; watch } in
   p.watch <- Some (
     ML.add_watch ~callback:(fun cl ->
       try

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -763,7 +763,6 @@ type static_fix_info =
   { idx : int
   ; name : Id.t
   ; types : types
-  ; offset : int
   ; nb_realargs : int
   ; body_with_param : constr
   ; num_in_block : int }
@@ -1082,7 +1081,6 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
                 { idx = idxs.(i) - fix_offset
                 ; name = Nameops.Name.get_id (fresh_id names.(i).binder_name)
                 ; types
-                ; offset = fix_offset
                 ; nb_realargs =
                     List.length (fst (decompose_lambda sigma bodies.(i)))
                     - fix_offset

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -276,14 +276,10 @@ let check_not_nested env sigma forbidden e =
 
 (* ['a info] contains the local information for traveling *)
 type 'a infos =
-  { nb_arg : int
-  ; (* function number of arguments *)
-    concl_tac : unit Proofview.tactic
+  { concl_tac : unit Proofview.tactic
   ; (* final tactic to finish proofs *)
     rec_arg_id : Id.t
   ; (*name of the declared recursive argument *)
-    is_mes : bool
-  ; (* type of recursion *)
     ih : Id.t
   ; (* induction hypothesis name *)
     f_id : Id.t
@@ -321,7 +317,6 @@ type ('a, 'b) journey_info_tac =
 *)
 type journey_info =
   { letiN : (Name.t * constr * types * constr, constr) journey_info_tac
-  ; lambdA : (Name.t * types * constr, constr) journey_info_tac
   ; casE :
          (   (constr infos -> unit Proofview.tactic)
           -> constr infos
@@ -857,7 +852,6 @@ let terminate_app_rec (f, args) expr_info continuation_tac _ =
 let terminate_info =
   { message = "prove_terminate with term "
   ; letiN = terminate_letin
-  ; lambdA = (fun _ _ _ _ -> assert false)
   ; casE = terminate_case
   ; otherS = terminate_others
   ; apP = terminate_app
@@ -1112,7 +1106,6 @@ let equation_app_rec (f, args) expr_info continuation_tac info =
 let equation_info =
   { message = "prove_equation with term "
   ; letiN = (fun _ -> assert false)
-  ; lambdA = (fun _ _ _ _ -> assert false)
   ; casE = equation_case
   ; otherS = equation_others
   ; apP = equation_app
@@ -1277,10 +1270,8 @@ let whole_start concl_tac nb_args is_mes func input_type relation rec_arg_num :
               is_final = true
             ; (* and on leaf (more or less) *)
               f_terminate = delayed_force rocq_O
-            ; nb_arg = nb_args
             ; concl_tac
             ; rec_arg_id
-            ; is_mes
             ; ih = hrec
             ; f_id
             ; f_constr = mkVar f_id
@@ -1577,8 +1568,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
          (start_equation f_ref terminate_ref (fun x ->
               prove_eq
                 (fun _ -> Proofview.tclUNIT ())
-                { nb_arg
-                ; f_terminate =
+                { f_terminate =
                     EConstr.of_constr
                       (constr_of_monomorphic_global (Global.env ()) terminate_ref)
                 ; f_constr = EConstr.of_constr f_constr
@@ -1600,7 +1590,6 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
                 ; args_assoc = []
                 ; f_id = Id.of_string "______"
                 ; rec_arg_id = Id.of_string "______"
-                ; is_mes = false
                 ; ih = Id.of_string "______" }))
          lemma
   in

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -666,7 +666,6 @@ let pr_let_clauses recflag pr_gen pr l =
     pr_lconstr   : Environ.env -> Evd.evar_map -> 'trm -> Pp.t;
     pr_dconstr   : Environ.env -> Evd.evar_map -> 'dtrm -> Pp.t;
     pr_red_pattern   : Environ.env -> Evd.evar_map -> 'rpat -> Pp.t;
-    pr_pattern   : Environ.env -> Evd.evar_map -> 'pat -> Pp.t;
     pr_lpattern  : Environ.env -> Evd.evar_map -> 'pat -> Pp.t;
     pr_constant  : 'cst -> Pp.t;
     pr_reference : 'ref -> Pp.t;
@@ -1104,7 +1103,6 @@ let pr_let_clauses recflag pr_gen pr l =
       pr_dconstr = pr_constr_expr;
       pr_lconstr = pr_lconstr_expr;
       pr_red_pattern = pr_constr_expr;
-      pr_pattern = pr_constr_pattern_expr;
       pr_lpattern = pr_lconstr_pattern_expr;
       pr_constant = pr_or_by_notation pr_qualid;
       pr_reference = pr_qualid;
@@ -1137,7 +1135,6 @@ let pr_let_clauses recflag pr_gen pr l =
         pr_dconstr = (fun env sigma -> pr_and_constr_expr (pr_glob_constr_env env sigma));
         pr_lconstr = (fun env sigma -> pr_and_constr_expr (pr_lglob_constr_env env sigma));
         pr_red_pattern = (fun env sigma -> pr_and_constr_expr (pr_glob_constr_env env sigma));
-        pr_pattern = (fun env sigma -> pr_pat_and_constr_expr (pr_glob_constr_env env sigma));
         pr_constant = pr_or_var (pr_and_short_name (pr_evaluable_reference_env env));
         pr_lpattern = (fun env sigma -> pr_pat_and_constr_expr (pr_lglob_constr_env env sigma));
         pr_reference = pr_ltac_or_var (pr_located pr_ltac_constant);
@@ -1175,7 +1172,6 @@ let pr_let_clauses recflag pr_gen pr l =
         pr_dconstr = (fun env sigma -> pr_and_constr_expr (pr_glob_constr_env env sigma));
         pr_lconstr = pr_leconstr_env;
         pr_red_pattern = pr_constr_pattern_env;
-        pr_pattern = pr_constr_pattern_env;
         pr_lpattern = pr_lconstr_pattern_env;
         pr_constant = pr_evaluable_reference_env env;
         pr_reference = pr_located pr_ltac_constant;

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -586,7 +586,7 @@ let warn_unqualified_delimiters =
   CWarnings.create_in w
     Pp.(fun (s,delims) ->
         let delims () = prlist_with_sep pr_comma Id.print @@ List.rev delims in
-        fmt "Delimiter arguments to %s must be qualified using \"delimiters\"@
+        fmt "Delimiter arguments to %s must be qualified using \"delimiters\"@\n\
 (e.g. \"%s(delimiters(%t))\")@ unless there is a unique delimiter argument." s s delims)
 
 let delimiters_qid = Libnames.qualid_of_string "delimiters"

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -40,24 +40,21 @@ type zres = (Mc.zArithProof, int * Mc.z list) res
 type qres = (Mc.q Mc.psatz, int * Mc.q list) res
 
 type 'a number_spec =
-  { bigint_to_number : Z.t -> 'a
-  ; number_to_num : 'a -> Q.t
+  { number_to_num : 'a -> Q.t
   ; zero : 'a
   ; unit : 'a
   ; mult : 'a -> 'a -> 'a
   ; eqb : 'a -> 'a -> bool }
 
 let z_spec =
-  { bigint_to_number = Ml2C.bigint
-  ; number_to_num = (fun x -> Q.of_bigint (C2Ml.z_big_int x))
+  { number_to_num = (fun x -> Q.of_bigint (C2Ml.z_big_int x))
   ; zero = Mc.Z0
   ; unit = Mc.Zpos Mc.XH
   ; mult = Mc.Z.mul
   ; eqb = Mc.Z.eqb }
 
 let q_spec =
-  { bigint_to_number = (fun x -> {Mc.qnum = Ml2C.bigint x; Mc.qden = Mc.XH})
-  ; number_to_num = C2Ml.q_to_num
+  { number_to_num = C2Ml.q_to_num
   ; zero = {Mc.qnum = Mc.Z0; Mc.qden = Mc.XH}
   ; unit = {Mc.qnum = Mc.Zpos Mc.XH; Mc.qden = Mc.XH}
   ; mult = Mc.qmult

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1559,21 +1559,18 @@ let micromega_order_change spec cert cert_typ env ff (*: unit Proofview.tactic*)
 
 open Certificate
 
-type ('option, 'a, 'prf, 'model) prover =
-  { name : string
-  ; (* name of the prover *)
-    get_option : unit -> 'option
-  ; (* find the options of the prover *)
-    prover : 'option * 'a list -> ('prf, 'model) Certificate.res
-  ; (* the prover itself *)
-    hyps : 'prf -> ISet.t
-  ; (* extract the indexes of the hypotheses really used in the proof *)
-    compact : 'prf -> (int -> int) -> 'prf
-  ; (* remap the hyp indexes according to function *)
-    pp_prf : out_channel -> 'prf -> unit
-  ; (* pretting printing of proof *)
-    pp_f : out_channel -> 'a -> unit
-        (* pretty printing of the formulas (polynomials)*) }
+type ('option, 'a, 'prf, 'model) prover = {
+  (* find the options of the prover *)
+  get_option : unit -> 'option;
+  (* the prover itself *)
+  prover : 'option * 'a list -> ('prf, 'model) Certificate.res;
+  (* extract the indexes of the hypotheses really used in the proof *)
+  hyps : 'prf -> ISet.t;
+  (* remap the hyp indexes according to function *)
+  compact : 'prf -> (int -> int) -> 'prf;
+  (* pretting printing of proof *)
+  pp_prf : out_channel -> 'prf -> unit;
+}
 
 (**
   * Given a  prover and a disjunction of atoms, find a proof of any of
@@ -2351,80 +2348,72 @@ let memo_nra =
       lift_pexpr_prover (Certificate.nlinear_prover o) s)
 
 let linear_prover_Q =
-  { name = "linear prover"
-  ; get_option = lra_proof_depth
+  { get_option = lra_proof_depth
   ; prover =
       (fun (o, l) ->
         lift_pexpr_prover (Certificate.linear_prover_with_cert o) l)
   ; hyps = hyps_of_cone
   ; compact = compact_cone
   ; pp_prf = pp_psatz pp_q
-  ; pp_f = (fun o x -> pp_pol pp_q o (fst x)) }
+  }
 
 let linear_prover_R =
-  { name = "linear prover"
-  ; get_option = lra_proof_depth
+  { get_option = lra_proof_depth
   ; prover =
       (fun (o, l) ->
         lift_pexpr_prover (Certificate.linear_prover_with_cert o) l)
   ; hyps = hyps_of_cone
   ; compact = compact_cone
   ; pp_prf = pp_psatz pp_q
-  ; pp_f = (fun o x -> pp_pol pp_q o (fst x)) }
+  }
 
 let nlinear_prover_R =
-  { name = "nra"
-  ; get_option = lra_proof_depth
+  { get_option = lra_proof_depth
   ; prover = memo_nra
   ; hyps = hyps_of_cone
   ; compact = compact_cone
   ; pp_prf = pp_psatz pp_q
-  ; pp_f = (fun o x -> pp_pol pp_q o (fst x)) }
+  }
 
 let non_linear_prover_Q str o =
-  { name = "real nonlinear prover"
-  ; get_option = (fun () -> (str, o))
+  { get_option = (fun () -> (str, o))
   ; prover = (fun (o, l) -> call_csdpcert_q o l)
   ; hyps = hyps_of_cone
   ; compact = compact_cone
   ; pp_prf = pp_psatz pp_q
-  ; pp_f = (fun o x -> pp_pol pp_q o (fst x)) }
+  }
 
 let non_linear_prover_R str o =
-  { name = "real nonlinear prover"
-  ; get_option = (fun () -> (str, o))
+  { get_option = (fun () -> (str, o))
   ; prover = (fun (o, l) -> call_csdpcert_q o l)
   ; hyps = hyps_of_cone
   ; compact = compact_cone
   ; pp_prf = pp_psatz pp_q
-  ; pp_f = (fun o x -> pp_pol pp_q o (fst x)) }
+  }
 
 let non_linear_prover_Z str o =
-  { name = "real nonlinear prover"
-  ; get_option = (fun () -> (str, o))
+  { get_option = (fun () -> (str, o))
   ; prover = (fun (o, l) -> lift_ratproof (call_csdpcert_z o) l)
   ; hyps = hyps_of_pt
   ; compact = compact_pt
   ; pp_prf = pp_proof_term
-  ; pp_f = (fun o x -> pp_pol pp_z o (fst x)) }
+  }
 
 let linear_Z =
-  { name = "lia"
-  ; get_option = get_lia_option
+  { get_option = get_lia_option
   ; prover = memo_lia
   ; hyps = hyps_of_pt
   ; compact = compact_pt
   ; pp_prf = pp_proof_term
-  ; pp_f = (fun o x -> pp_pol pp_z o (fst x)) }
+  }
 
 let nlinear_Z =
-  { name = "nlia"
-  ; get_option = get_lia_option
+  { get_option = get_lia_option
   ; prover = memo_nlia
   ; hyps = hyps_of_pt
   ; compact = compact_pt
   ; pp_prf = pp_proof_term
-  ; pp_f = (fun o x -> pp_pol pp_z o (fst x)) }
+  }
 
 (**
   * Functions instantiating micromega_gen with the appropriate theories and

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -16,6 +16,9 @@ module NamedDecl = Context.Named.Declaration
 
 module ERelevance = EConstr.ERelevance
 
+(* many cases, TODO clean them up someday *)
+[@@@warning "-unused-field"]
+
 let debug_zify = CDebug.create ~name:"zify" ()
 
 (* The following [constr] are necessary for constructing the proof terms *)

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -230,7 +230,7 @@ module Make(T : Task) () = struct
     active : Pool.pool;
     queue : (T.task * cancel_switch) TQueue.t;
     cleaner : Thread.t option;
-  }
+  } [@@warning "-unused-field"] (* cleaner unused, not sure if can be removed *)
 
   let create ~spawn_args size priority =
     let cleaner queue =

--- a/stm/workerPool.ml
+++ b/stm/workerPool.ml
@@ -34,7 +34,7 @@ type worker = {
   cancel : bool ref;
   manager : Thread.t;
   process : Model.process;
-}
+} [@@warning "-unused-field"] (* manager & process unused, not sure if can be removed *)
 
 type pre_pool = {
   workers : worker list ref;

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -468,7 +468,6 @@ type solver = { solver :
 module Search = struct
   type autoinfo =
     { search_depth : int list;
-      last_tac : Pp.t Lazy.t;
       search_dep : bool;
       search_only_classes : bool;
       search_cut : hints_path;
@@ -499,7 +498,7 @@ module Search = struct
   let make_autogoal env sigma mst only_classes dep cut best_effort i =
     let hints = make_autogoal_hints env sigma only_classes mst in
     { search_hints = hints;
-      search_depth = [i]; last_tac = lazy (str"none");
+      search_depth = [i];
       search_dep = dep;
       search_only_classes = only_classes;
       search_cut = cut;
@@ -765,7 +764,6 @@ module Search = struct
         let dep' = info.search_dep || Proofview.unifiable sigma' (Goal.goal gl') gls in
         let info' =
           { search_depth = succ j :: i :: info.search_depth;
-            last_tac = pp;
             search_dep = dep';
             search_only_classes = info.search_only_classes;
             search_hints = hints';
@@ -884,7 +882,7 @@ module Search = struct
       make_resolve_hyp env sigma (Hint_db.transparent_state info.search_hints)
                        info.search_only_classes decl info.search_hints in
     let info' =
-      { info with search_hints = ldb; last_tac = lazy (str"intro");
+      { info with search_hints = ldb;
         search_depth = 1 :: 1 :: info.search_depth }
     in
     kont info'

--- a/tools/configure/cmdArgs.ml
+++ b/tools/configure/cmdArgs.ml
@@ -116,9 +116,9 @@ let args_options = Arg.align [
   "-bytecode-compiler", arg_bool (fun p bytecodecompiler -> { p with bytecodecompiler }),
     "(yes|no) Enable Rocq's bytecode reduction machine (VM)";
   "-native-compiler", arg_native (fun p nativecompiler -> { p with nativecompiler }),
-    "(yes|no|ondemand) Compilation to native code for conversion and normalization
-     yes: -native-compiler option of coqc will default to 'yes', stdlib will be precompiled
-     no (default): no native compilation available at all
+    "(yes|no|ondemand) Compilation to native code for conversion and normalization\n\
+     yes: -native-compiler option of coqc will default to 'yes', stdlib will be precompiled\n\
+     no (default): no native compilation available at all\n\
      ondemand: -native-compiler option of coqc will default to 'ondemand', stdlib will not be precompiled";
   "-warn-error", arg_bool (fun p _warn_error -> warn_warn_error (); p),
     " Deprecated option: warnings are now adjusted in the corresponding build tool.";

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -137,8 +137,7 @@ let check_findlib_version prefs { CamlConf.findlib_version; _ } =
     70: ".ml file without .mli file" bogus warning when used generally
 *)
 
-(* Note, we list all warnings to be complete *)
-let coq_warnings = "-w -a+1..3-4+5..8-9+10..26-27+28..39-40-41-42+43-44-45+46..47-48+49..57-58+59..66-67-68+69-70"
+let coq_warnings = "-w +a-4-9-27-40..42-44-45-48-58-67-68-70"
 
 (* Flags used to compile Rocq and plugins (via coq_makefile) *)
 let caml_flags =

--- a/topbin/rocqnative.ml
+++ b/topbin/rocqnative.ml
@@ -78,6 +78,7 @@ end
 
 module Library =
 struct
+[@@@warning "-unused-field"] (* marshalled data *)
 
 type library_objects
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -89,7 +89,6 @@ module Info = struct
 
   type t =
     { poly : PolyFlags.t
-    ; inline : bool
     ; kind : Decls.logical_kind
     ; udecl : UState.universe_decl
     ; scope : Locality.definition_scope
@@ -102,10 +101,10 @@ module Info = struct
 
   (** Note that [opaque] doesn't appear here as it is not known at the
      start of the proof in the interactive case. *)
-  let make ?(poly = PolyFlags.default) ?(inline=false) ?(kind=Decls.(IsDefinition Definition))
+  let make ?(poly = PolyFlags.default) ?(kind=Decls.(IsDefinition Definition))
       ?(udecl=UState.default_univ_decl) ?(scope=Locality.default_scope)
       ?(clearbody=false) ?hook ?typing_flags ?user_warns ?(ntns=[]) () =
-    { poly; inline; kind; udecl; scope; hook; typing_flags; clearbody; user_warns; ntns }
+    { poly; kind; udecl; scope; hook; typing_flags; clearbody; user_warns; ntns }
 end
 
 module SideEff :

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -101,7 +101,6 @@ module Info : sig
      start of the proof in the interactive case. *)
   val make
    : ?poly:PolyFlags.t
-    -> ?inline : bool
     -> ?kind : Decls.logical_kind
     (** Theorem, etc... *)
     -> ?udecl : UState.universe_decl

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1054,16 +1054,12 @@ type notation_modifier = {
   assoc         : Gramlib.Gramext.g_assoc option;
   level         : int option;
   etyps         : (Id.t * CustomName.t simple_constr_prod_entry_key) list;
-
-  (* common to syn_data below *)
-  format        : lstring option;
 }
 
 let default = {
   assoc         = None;
   level         = None;
   etyps         = [];
-  format        = None;
 }
 
 end

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -426,7 +426,8 @@ type ml_module_object =
   ; mnames : (bool * PluginSpec.t) list
   (* bool: if true then implicit dep
      XXX should we init_ml_object even for implicit deps? *)
-  ; mdigests : Digest.t list
+  ; _mdigests : Digest.t list
+  (* never read, it's only used to ensure the vo changes if deps change *)
   }
 
 let cache_ml_objects mnames =
@@ -468,7 +469,7 @@ let declare_ml_modules local mnames =
   then CErrors.user_err Pp.(str "Cannot Declare ML Module while sections are opened.");
   let mnames = PluginSpec.add_deps mnames in
   let mdigests = CList.concat_map (fun (_,plugin) -> PluginSpec.digest plugin) mnames in
-  Lib.add_leaf (inMLModule {mlocal=local; mnames; mdigests});
+  Lib.add_leaf (inMLModule {mlocal=local; mnames; _mdigests = mdigests});
   (* We can't put this in cache_function: it may declare other
      objects, and when the current module is required we want to run
      the ML-MODULE object before them. *)


### PR DESCRIPTION
TBH I'm not sure why we stopped controlling our warning set.

BTW dune 3.21 will change its defaults (to ocaml upstream defaults).