### PR TITLE
Make [rocq-runtime] not depend on its own [META] file.

### DIFF
--- a/dune
+++ b/dune
@@ -21,11 +21,11 @@
 
 (alias
  (name default)
- (deps rocq-runtime.install coq-core.install rocq-core.install coqide-server.install))
+ (deps (alias_rec static_libs_check) rocq-runtime.install coq-core.install rocq-core.install coqide-server.install))
 
 (alias
  (name runtime)
- (deps rocq-runtime.install coq-core.install))
+ (deps (alias_rec static_libs_check) rocq-runtime.install coq-core.install))
 
 (install
  (section lib)

--- a/tools/coqdep/lib/dune
+++ b/tools/coqdep/lib/dune
@@ -6,11 +6,15 @@
 (ocamllex lexer)
 
 (rule
- (targets static_toplevel_libs.ml)
+ (targets static_toplevel_libs.ml.gen)
  (deps %{workspace_root}/_build/install/%{context_name}/lib/rocq-runtime/META)
  (action
   (with-stdout-to %{targets}
    (run ocamlfind query -recursive -predicates native rocq-runtime.toplevel
         -prefix "let static_toplevel_libs = [\n"
-        -format "\"%p\";"
+        -format "  \"%p\";"
         -suffix "\n]\n"))))
+
+(rule
+ (alias static_libs_check)
+ (action (diff static_toplevel_libs.ml static_toplevel_libs.ml.gen)))

--- a/tools/coqdep/lib/static_toplevel_libs.ml
+++ b/tools/coqdep/lib/static_toplevel_libs.ml
@@ -1,0 +1,32 @@
+let static_toplevel_libs = [
+  "str";
+  "unix";
+  "rocq-runtime.coqworkmgrapi";
+  "findlib.internal";
+  "findlib";
+  "threads";
+  "rocq-runtime.clib";
+  "rocq-runtime.config";
+  "rocq-runtime.boot";
+  "rocq-runtime.coqargs";
+  "dynlink";
+  "findlib.dynload";
+  "rocq-runtime.perf";
+  "rocq-runtime.lib";
+  "rocq-runtime.gramlib";
+  "rocq-runtime.vm";
+  "rocq-runtime.kernel";
+  "rocq-runtime.library";
+  "rocq-runtime.engine";
+  "rocq-runtime.pretyping";
+  "zarith";
+  "rocq-runtime.interp";
+  "rocq-runtime.parsing";
+  "rocq-runtime.proofs";
+  "rocq-runtime.printing";
+  "rocq-runtime.tactics";
+  "rocq-runtime.vernac";
+  "rocq-runtime.sysinit";
+  "rocq-runtime.stm";
+  "rocq-runtime.toplevel";
+]


### PR DESCRIPTION
See [#Rocq devs &amp; plugin devs > Dependency cycle with dune's rocq.theory](https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/Dependency.20cycle.20with.20dune's.20rocq.2Etheory/with/568896399) and https://github.com/ocaml/dune/issues/12895.

CC @Janno.