### PR TITLE
Add new `matches` and `tactic` call strategies for generalized rewriting

### DIFF
--- a/dev/ci/user-overlays/21521-mattam82-strat-pattern-ltac.sh
+++ b/dev/ci/user-overlays/21521-mattam82-strat-pattern-ltac.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/mattam82/coq-tactician strat-pattern-ltac 21521

--- a/doc/changelog/04-tactics/21521-strat-pattern-ltac-Added.rst
+++ b/doc/changelog/04-tactics/21521-strat-pattern-ltac-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Add :n:`matches` and :n:`tactic` :ref:`strategies <strategies4rewriting>`
+  to :tacn:`rewrite_strat` for :ref:`Ltac1 <ltac>` and :ref:`Ltac2 <ltac2>` tactics
+  (`#21521 <https://github.com/rocq-prover/rocq/pull/21521>`_,
+  by Matthieu Sozeau and Mathis Bouverot-Dupuis).

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2408,6 +2408,8 @@ rewstrategy1: [
 | "terms" LIST0 constr
 | "eval" red_expr
 | "fold" constr
+| "matches" constr
+| "tactic" tactic
 | rewstrategy0
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -2240,6 +2240,8 @@ rewstrategy1: [
 | "terms" LIST0 one_term
 | "eval" red_expr
 | "fold" one_term
+| "matches" one_term
+| "tactic" ltac_expr
 | rewstrategy0
 | "old_hints" ident
 ]

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -68,17 +68,21 @@ END
 
 let subst_strategy sub = map_strategy
     (Tacsubst.subst_glob_constr_and_expr sub)
+    (fun (x, y, z) -> (x, Tacsubst.subst_glob_constr_and_expr sub y, z))
     (Tacsubst.subst_glob_red_expr sub)
     (fun x -> x)
+    (Tacsubst.subst_tactic sub)
 
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
-let pr_raw_strategy env sigma prc prlc _ (s : Tacexpr.raw_strategy) =
+let pr_raw_strategy env sigma prc prlc prt (s : Tacexpr.raw_strategy) =
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc,Pputils.pr_or_var Pp.int, Redexpr.pr_raw_user_red_expr) in
-  Rewrite.pr_strategy (prc env sigma) prr Pputils.pr_lident s
-let pr_glob_strategy env sigma prc prlc _ (s : Tacexpr.glob_strategy) =
+  Rewrite.pr_strategy (prc env sigma) (prc env sigma) prr Pputils.pr_lident (prt env sigma Constrexpr.LevelSome) s
+let pr_glob_strategy env sigma prc prlc prt (s : Tacexpr.glob_strategy) =
   let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prc, Pputils.pr_or_var Pp.int, Redexpr.pr_glob_user_red_expr) in
-  Rewrite.pr_strategy (prc env sigma) prr Id.print s
+  let prpat (_, c, _) = prc env sigma c in
+  let prt = prt env sigma Constrexpr.LevelSome in
+  Rewrite.pr_strategy (prc env sigma) prpat prr Id.print prt s
 
 }
 
@@ -124,6 +128,8 @@ GRAMMAR EXTEND Gram
       | IDENT "terms"; h = LIST0 constr -> { StratTerms h }
       | IDENT "eval"; r = red_expr -> { StratEval r }
       | IDENT "fold"; c = constr -> { StratFold c }
+      | IDENT "matches"; c = constr -> { StratMatches c }
+      | IDENT "tactic"; c = tactic -> { StratTactic c }
       | h = rewstrategy0 -> { h } ] ]
   ;
   rewstrategy0:

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -378,8 +378,8 @@ type atomic_tactic_expr =
 
 (** Misc *)
 
-type raw_strategy = (constr_expr, Redexpr.raw_red_expr, lident) Rewrite.strategy_ast
-type glob_strategy = (Genintern.glob_constr_and_expr, Redexpr.glob_red_expr, Id.t) Rewrite.strategy_ast
+type raw_strategy = (constr_expr, constr_expr, Redexpr.raw_red_expr, lident, raw_tactic_expr) Rewrite.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, Genintern.glob_constr_pattern_and_expr, Redexpr.glob_red_expr, Id.t, glob_tactic_expr) Rewrite.strategy_ast
 
 (** Traces *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -735,6 +735,12 @@ let intern_strategy ist s =
     | StratHints (b, id) -> StratHints (b, id)
     | StratEval r -> StratEval (intern_red_expr ist r)
     | StratFold c -> StratFold (intern_constr ist c)
+    | StratMatches c ->
+       let _, ip = intern_constr_pattern ist ~as_type:false ~ltacvars:Id.Set.empty c in
+       StratMatches ip
+    | StratTactic t ->
+       let it = intern_tactic_or_tacarg ist t in
+       StratTactic it
   in
   aux Id.Set.empty s
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -750,12 +750,6 @@ let interp_red_expr ist env sigma r =
   in
   Redexpr.Interp.interp_red_expr ist env sigma r
 
-let interp_strategy ist _env _sigma s =
-  let interp_redexpr r = fun env sigma -> interp_red_expr ist env sigma r in
-  let interp_constr c = (fst c, fun env sigma -> interp_open_constr ist env sigma c) in
-  let s = Rewrite.map_strategy interp_constr interp_redexpr (fun x -> x) s in
-  Rewrite.strategy_of_ast s
-
 let interp_may_eval f ist env sigma = function
   | ConstrEval (r,c) ->
       let (sigma,redexp) = interp_red_expr ist env sigma r in
@@ -1979,6 +1973,14 @@ let eval_tactic t =
 let eval_tactic_ist ist t =
   Proofview.tclLIFT (db_initialize false) <*>
   eval_tactic_ist ist t
+
+let interp_strategy ist env sigma s =
+  let interp_redexpr r = fun env sigma -> interp_red_expr ist env sigma r in
+  let interp_constr c = (fst c, fun env sigma -> interp_open_constr ist env sigma c) in
+  let interp_pattern (_, p, up) = Patternops.interp_pattern env sigma Glob_ops.empty_lvar up in
+  let s = Rewrite.map_strategy interp_constr interp_pattern interp_redexpr
+            (fun x -> x) (interp_tactic ist) s in
+  Rewrite.strategy_of_ast s
 
 (** FFI *)
 

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -204,6 +204,23 @@ let fun2 arg1 arg2 res = {
   r_to = to_fun2 arg1.r_of arg2.r_of res.r_to;
 }
 
+type ('a, 'b, 'c, 'd) fun3 = 'a -> 'b -> 'c -> 'd Proofview.tactic
+
+let of_fun3 to_arg1 to_arg2 to_arg3 of_res f =
+  of_closure (mk_closure (arity_suc (arity_suc arity_one)) (fun x y z ->
+      Proofview.Monad.map of_res @@
+      f (to_arg1 x) (to_arg2 y) (to_arg3 z)))
+
+let to_fun3 of_arg1 of_arg2 of_arg3 to_res f x y z =
+  Proofview.Monad.map to_res @@
+  apply (to_closure f) [of_arg1 x; of_arg2 y; of_arg3 z]
+
+let fun3 arg1 arg2 arg3 res = {
+  r_of = of_fun3 arg1.r_to arg2.r_to arg3.r_to res.r_of;
+  r_to = to_fun3 arg1.r_of arg2.r_of arg3.r_of res.r_to;
+}
+
+
 let of_ext tag c =
   ValExt (tag, c)
 

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -113,6 +113,12 @@ val of_fun2 : (valexpr -> 'a) -> (valexpr -> 'b) -> ('c -> valexpr) -> ('a, 'b, 
 val to_fun2 : ('a -> valexpr) -> ('b -> valexpr) -> (valexpr -> 'c) -> valexpr -> ('a, 'b, 'c) fun2
 val fun2 : 'a repr -> 'b repr -> 'c repr -> ('a, 'b, 'c) fun2 repr
 
+type ('a, 'b, 'c, 'd) fun3 = 'a -> 'b -> 'c -> 'd Proofview.tactic
+
+val of_fun3 : (valexpr -> 'a) -> (valexpr -> 'b) -> (valexpr -> 'c) -> ('d -> valexpr) -> ('a, 'b, 'c, 'd) fun3 -> valexpr
+val to_fun3 : ('a -> valexpr) -> ('b -> valexpr) -> ('c -> valexpr) -> (valexpr -> 'd) -> valexpr -> ('a, 'b, 'c, 'd) fun3
+val fun3 : 'a repr -> 'b repr -> 'c repr -> 'd repr -> ('a, 'b, 'c, 'd) fun3 repr
+
 val of_block : (int * valexpr array) -> valexpr
 val to_block : valexpr -> (int * valexpr array)
 val block : (int * valexpr array) repr

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -131,3 +131,5 @@ val congruence : int option -> constr list option -> unit Proofview.tactic
 val simple_congruence : int option -> constr list option -> unit Proofview.tactic
 
 val f_equal : unit Proofview.tactic
+
+val wrap_tactic_call : (constr -> constr -> constr option -> Rewrite.rewrite_result Proofview.tactic) -> Rewrite.strategy

--- a/test-suite/ltac2/rewrite_strat.v
+++ b/test-suite/ltac2/rewrite_strat.v
@@ -156,3 +156,113 @@ Goal (forall x, S x = 0) -> 1 = 0.
 intro H.
 my_rewrite_strat H.
 Abort.
+
+From Ltac2 Require Import Ltac2 Rewrite.
+From Ltac2 Require Import Message.
+Ltac2 msg x := print (of_string x).
+
+Module StratLtac2Matches.
+
+  Import Strategy.
+
+  (* Heavy computation if unfolded at any point during unification *)
+  Definition foo (n : nat) :=
+    Nat.pow 2 n.
+
+  Ltac2 rew_match carrier lhs _rel :=
+   let rhs := Std.eval (Std.Red.vm None) lhs in
+   Success {rel := '(@eq $carrier); rhs; prf := '(@eq_refl $carrier $rhs) }.
+
+  Goal foo (200 + 200) = foo 400.
+  Proof.
+    rewrite_strat (bottomup (seq (matches pat:(Nat.add _ _)) (tactic rew_match))) None.
+    match! goal with
+    | [ |- foo 400 = foo 400 ] => id
+    end.
+    reflexivity.
+  Qed.
+End StratLtac2Matches.
+
+Module StratLtac2Tactic.
+  Import Strategy.
+
+  Ltac2 is_closed_add t :=
+    match! t with
+    | Nat.add _ _ => true
+    | _ => false
+    end.
+
+  Ltac2 reduce_fo_ind_value carrier lhs _rel :=
+    if Constr.equal carrier '(nat) then
+      if is_closed_add lhs then
+        let ty := Constr.type lhs in
+        let rhs := Std.eval (Std.Red.cbv RedFlags.all) lhs in
+        Rewrite.Strategy.Success { rel := '(@eq $ty); rhs := rhs; prf := '(@eq_refl $ty $rhs) }
+      else Fail
+    else Fail.
+
+  (* Heavy computation if unfolded at any point during unification *)
+  Definition foo (n : nat) :=
+    Nat.pow 2 n.
+
+  Ltac2 reduce_fo_ind cl :=
+    rewrite_strat (fix_ (fun s => choice (tactic reduce_fo_ind_value) (subterm s))) cl.
+
+  Lemma heavy : foo (2000 + 2000) = foo 4000.
+  Proof.
+    reduce_fo_ind None.
+    reflexivity.
+  Qed.
+
+  Axiom add_comm : forall (x y : nat), x + y = y + x.
+
+  (* We use a flag to rewrite with a lemma only once *)
+  Ltac2 Type flag := { mutable used : bool }.
+  Import List.
+  Ltac2 message_of_list f l :=
+    List.fold_right (fun x acc => Message.concat (f x) acc) l Message.empty.
+
+  Ltac2 of_hyps h :=
+    message_of_list
+      (fun (na, _, ty) =>
+         Message.concat Message.space
+           (Message.concat (of_ident na) (Message.concat (of_string " : ") (of_constr ty)))) h.
+
+  Import Printf.
+
+  Ltac2 rw_lemma fl lhs :=
+    if fl.(used) then Fail else
+      (let h := Control.hyps () in
+       let concl := Control.goal () in
+       printf "lhs = %t, goal = %m |- %t" lhs (of_hyps h) concl;
+    match! lhs with
+    | Nat.add ?l ?r =>
+        fl.(used) := true;
+        Strategy.Success { rel := '(@eq nat); rhs := '(Nat.add $r $l); prf := '(add_comm $l $r) }
+    | _ => Fail
+    end).
+
+  Ltac2 use_lemma_once () :=
+    let flag := { used := false } in
+    fun _carrier lhs _rel => rw_lemma flag lhs.
+
+  (* This example goes under binders to apply a rewrite only once *)
+  Lemma with_env (b : bool) : forall (v : nat), (v + 2) = S (S v).
+  Proof.
+    rewrite_strat (topdown (tactic (use_lemma_once ()))) None.
+    match! goal with
+    | [ |- forall v, (2 + v) = (S (S v)) ] => id
+    end.
+    now reflexivity.
+  Qed.
+
+  Ltac2 failing () :=
+    fun _carrier lhs _rel => exact tt; Strategy.Identity.
+
+  (* This example goes under binders to apply a rewrite only once *)
+  Lemma failure_test (b : bool) : forall (v : nat), (v + 2) = S (S v).
+  Proof.
+    Fail rewrite_strat (topdown (tactic (failing ()))) None.
+  Abort.
+
+End StratLtac2Tactic.

--- a/test-suite/success/rewrite_strat.v
+++ b/test-suite/success/rewrite_strat.v
@@ -1,5 +1,6 @@
 Require Import Setoid.
 
+
 Parameter X : Set.
 
 Parameter f : X -> X.
@@ -55,8 +56,8 @@ Proof.
   reflexivity.
 Time Qed. (* 0.06 s *)
 
-Set Printing All.
-Set Printing Depth 100000.
+(* Set Printing All. *)
+(* Set Printing Depth 100000. *)
 
 Tactic Notation "my_rewrite_strat" constr(x) := rewrite_strat topdown x.
 Tactic Notation "my_rewrite_strat2" uconstr(x) := rewrite_strat topdown x.
@@ -66,3 +67,125 @@ my_rewrite_strat H.
 Undo.
 my_rewrite_strat2 H.
 Abort.
+
+Module StratMatches.
+  Lemma add_0_r x : x + 0 = x.
+  Admitted.
+
+  Goal forall x : nat, x + (x + 0) = x + x.
+  Proof.
+    Fail rewrite_strat (bottomup (matches (x + 0) ; add_0_r)).
+    rewrite_strat (bottomup (matches (_ + 0) ; add_0_r)).
+    reflexivity.
+  Qed.
+
+  Goal forall x : nat, x + (x + 0) = x + x.
+  Proof.
+    intros x.
+    rewrite_strat (bottomup (matches (x + 0) ; add_0_r)).
+    reflexivity.
+  Qed.
+
+  (* Heavy computation if unfolded at any point during unification *)
+  Definition foo (n : nat) :=
+    Nat.pow 2 n.
+
+  Goal foo (200 + 200) = foo 400.
+  Proof.
+    rewrite_strat (bottomup (matches (_ + _); eval cbn)).
+    reflexivity.
+  Qed.
+
+  Goal foo (200 + 200) = foo (399 + 1).
+  Proof.
+    rewrite_strat (bottomup (matches (_ + _); eval cbn)).
+    reflexivity.
+  Qed.
+
+  Import Decimal.
+
+  Lemma heavy : foo (2000 + 2000) = foo (40 * 100).
+  Proof.
+    (* Fail Timeout 1 cbn. *)
+    (* 1.5sec *)
+    Time rewrite_strat (bottomup (choice (matches (_ + _)) (matches (_ * _)); eval cbn)).
+    Undo.
+    (* ~30x faster: 0.05s *)
+    Time rewrite_strat (bottomup (choice (matches (_ + _)) (matches (_ * _)); eval vm_compute)).
+    reflexivity.
+  Defined.
+
+  (* A more complex situation where FO unification is not tried *)
+  Definition bar n (k : nat) := foo n.
+
+  Lemma heavier : foo (200 + 2000 + 1800) = bar (400 * 10) 10.
+  Proof.
+    (* exact_no_check (@eq_refl nat 40000). *)
+    (* Fail Timeout 1 Qed. *)
+    (* Undo. Undo. *)
+    (* Strategy 200 [Nat.add]. *)
+    (* Strategy -300 [Nat.pow foo]. *)
+    (* (* Fail Timeout 1 reflexivity. *) *)
+    (* (* Fail Timeout 1 cbn. *) *)
+    (* (* Untractable *) *)
+    (* (* Fail Timeout 1 rewrite_strat (bottomup (choice (matches (_ + _)) (matches (_ * _)); eval cbn)). *) *)
+    (* (* 0.5s *) *)
+    Time rewrite_strat (bottomup (choice (matches (_ + _)) (matches (_ * _)); eval vm_compute)).
+    unfold bar; reflexivity.
+    (* Immmediate *)
+  Defined.
+
+End StratMatches.
+Import Decimal Nat.
+
+Module StratTactic.
+
+  Ltac is_closed_add t :=
+    match t with
+    | Nat.add _ _ => idtac
+    end.
+
+  Ltac reduce_fo_ind_value :=
+    match goal with
+    | [ |- ?R ?lhs ?rhs ] =>
+        let ty := type of lhs in
+        match ty with
+        | nat =>
+            is_closed_add lhs;
+            (* idtac "match"; *)
+          let rhs' := eval cbv in lhs in
+            (* instantiate is using right-to-left order! *)
+            instantiate (2 := @eq ty);
+            instantiate (1 := rhs');
+            exact_no_check (@eq_refl ty rhs')
+        end
+    end.
+
+  (* Heavy computation if unfolded at any point during unification *)
+  Definition foo (n : nat) :=
+    Nat.pow 2 n.
+
+  Ltac reduce_fo_ind :=
+    rewrite_strat (fix s := choice (tactic reduce_fo_ind_value) (subterm s)).
+
+  Variant rewrite {A : Type} (lhs : A) : Prop :=
+    | success : forall (R : A -> A -> Prop) (rhs : A) (prf : R lhs rhs), rewrite lhs
+    | fail : rewrite lhs
+    | identity : rewrite lhs.
+
+  Lemma heavy : foo (200 + 200) = foo 400.
+  Proof.
+    Time reduce_fo_ind.
+    reflexivity.
+  Time Qed.
+
+  Lemma binders (b : bool) : forall x, (2 + x) = S (S x).
+  Proof.
+    reduce_fo_ind.
+    match goal with
+    | |- forall x, S (S x) = S (S x) => idtac
+    end.
+    trivial.
+  Qed.
+
+End StratTactic.

--- a/theories/Ltac2/Rewrite.v
+++ b/theories/Ltac2/Rewrite.v
@@ -120,6 +120,36 @@ Module Strategy.
   Ltac2 @external fix_ : (t -> t) -> t :=
     "rocq-runtime.plugins.ltac2" "rewstrat_fix".
 
+  (** The identity if the pattern matching succeeds, fails otherwise *)
+  Ltac2 @external matches : pattern -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_matches".
+
+  (** The rewrite success datatype, where [prf] should be of type [rel lhs rhs] *)
+  Ltac2 Type rewrite_success := { rel : constr; rhs : constr; prf : constr }.
+
+  (** A rewrite result can be any of a success, and identity step (no progress), or a failure *)
+  Ltac2 Type rewrite_result := [ Success (rewrite_success) | Identity | Fail ].
+
+  (** The [tactic f] strategy applies [f] to arguments [ty], [lhs] and [rel],
+      where [lhs] is the subterm being rewritten, of type [ty], and
+      an optional relation constraint [rel] is given.
+
+      The tactic is applied to a single goal of type [unit] whose context
+      corresponds to the context of the term to rewrite (i.e. the context of the
+      goal at the start of the [rewrite_strat] call extended with the binders
+      that were traversed to attain this subterm. The tactic should return a
+      [rewrite_result] indicating success, failure or no progress and should
+      *not* solve the goal. Solving the goal is an error that aborts the
+      [rewrite_strat] call. The success record contains the chosen relation
+      [rel], new right hand-side [rhs] and a proof [prf] of [rel t rhs].
+
+      If the proof [prf] is syntactically [eq_refl _], then the witness
+      of the rewriting is simply a *conversion* requiring no explicit
+      proof and no congruence lemmas for the context of the rewrite.
+   *)
+  Ltac2 @external tactic : (constr -> constr -> constr option -> rewrite_result) -> t :=
+    "rocq-runtime.plugins.ltac2" "rewstrat_tactic".
+
 End Strategy.
 
 (* Tactics *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR adds two new strategies to rewrite_strat:
- a `matches p` strategy that is the identity when the pattern matches the subterm and otherwise a failure
- a `tactic t` strategy that calls a tactic with a goal of the shape `?R lhs ?rhs` and the current environment. 
  If the tactic succeeds, the strategy succeeds with the given proof and rewrites the subterm to `?rhs`  (which can be instantiated), otherwise the tactic fails.
- A new `Ltac2.Rewrite.Strategies` `tactic` strategy that takes a closure `constr -> constr option -> rewrite_result`.
  The tactic is called with lhs term and optional relation constraint, if it returns a `rewrite_result`  (Identity, Fail or Success) we use that as the result of the strategy. This allows a somewhat finer control than the current Ltac1 interface and avoids creating evars at each call. We just raise if we get a TacitcFailure exception (I think we're not doing this the right way ATM)

This PR was co-designed with @MathisBD 
It was prompted by feedback from the Google ISE Formal team (@andres-erbsen) and discussions with @gmalecha and @kyoDralliam, among others.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.