### PR TITLE
Experiment: Local import `let Import` in terms

### DIFF
--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -178,6 +178,7 @@ and constr_expr_r =
   | CPrim of prim_token
   | CDelimiters of delimiter_depth * string * constr_expr
   | CArray of instance_expr option * constr_expr array * constr_expr * constr_expr
+  | CLetImport of qualid * ModPath.t * constr_expr
 and constr_expr = constr_expr_r CAst.t
 
 and case_expr = constr_expr                 (* expression that is being matched *)

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -129,6 +129,7 @@ module Interner : sig
   ; prim : t -> prim_token fn
   ; delimiters : t -> (delimiter_depth * string * constr_expr) fn
   ; array : t -> (instance_expr option * constr_expr array * constr_expr * constr_expr) fn
+  ; letimport : t -> (qualid * ModPath.t * constr_expr) fn
   }
 
   val eval : t -> constr_expr_r fn
@@ -283,3 +284,7 @@ val interp_mutual_univ_decl_opt : Environ.env -> universe_decl_expr option list 
   Evd.evar_map * UState.universe_decl
 (** Check that all defined udecls of a list of udecls associated to a mutual definition
     are the same and interpret this common udecl *)
+
+type with_local_import = { with_local_import : 'a. ModPath.t -> (unit -> 'a) -> 'a }
+
+val set_with_local_import : with_local_import -> unit

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -2002,7 +2002,8 @@ let rec add_args id new_args =
       CErrors.anomaly ~label:"add_args " (Pp.str "CGeneralization.")
     | CDelimiters _ ->
       CErrors.anomaly ~label:"add_args " (Pp.str "CDelimiters.")
-    | CArray _ -> CErrors.anomaly ~label:"add_args " (Pp.str "CArray."))
+    | CArray _ -> CErrors.anomaly ~label:"add_args " (Pp.str "CArray.")
+    | CLetImport _ -> CErrors.anomaly ~label:"add_args " (Pp.str "CLetImport."))
 
 let rec get_args b t :
     Constrexpr.local_binder_expr list

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -710,6 +710,13 @@ let pr ~flags pr sep lev_after inherited a =
                  ++ keyword "in") ++
           pr spc lev_after ltop b))
       lletin
+  | CLetImport (qid,mp,b) ->
+    return (fun lev_after ->
+        hv 0 (
+          hov 2 (keyword "let Import" ++ spc() ++ pr_qualid qid ++ keyword "in") ++
+          (* XXX may be unprintable without importing *)
+          pr spc lev_after ltop b))
+      lletin
   | CProj (true,(f,us),l,c) ->
     let l = List.map (function (c,None) -> c | _ -> assert false) l in
     return (fun lev_after -> pr_proj (pr mt) pr_appexpl c (f,us) l) lproj

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -186,3 +186,8 @@ val debug_print_modtab : unit -> Pp.t
 
 val process_module_binding :
   MBId.t -> (Constr.t * UVars.AbstractContext.t option) Declarations.module_alg_expr -> unit
+
+(* parses AFTER "let Import" *)
+val let_import : Constrexpr.constr_expr Procq.Entry.t
+
+val with_local_import : ModPath.t -> (unit -> 'a) -> 'a

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1059,7 +1059,7 @@ GRAMMAR EXTEND Gram
 END
 
 GRAMMAR EXTEND Gram
-  GLOBAL: command query_command coercion_class gallina_ext search_query search_queries;
+  GLOBAL: command query_command coercion_class gallina_ext search_query search_queries binder_constr;
 
   gallina_ext: TOP
     [ [ IDENT "Export"; "Set"; table = setting_name; v = option_setting ->
@@ -1067,7 +1067,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Export"; IDENT "Unset"; table = setting_name ->
           { VernacSynterp (VernacSetOption (true, table, OptionUnset)) }
     ] ];
-
+  binder_constr: TOP
+    [ [ "let"; IDENT "Import"; c = let_import -> { c } ] ];
   command:
     [ [ IDENT "Comments"; l = LIST0 comment -> { VernacSynPure (VernacComments l) }
 


### PR DESCRIPTION
Handles parsing and internalization. Does not handle pretyping (mostly typeclasses and coercions?).
eg
~~~coq
Module M.
  Notation "x +++ y" := (x + y) (at level 42).
End M.

Check let Import M in 0 +++ 1.
~~~