### PR TITLE
Stop exposing implementation internals in Environ API.

### DIFF
--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -37,10 +37,6 @@ type link_info =
 
 type key = int CEphemeron.key option ref
 
-type constant_key = constant_body * (link_info ref * key) * KerName.t
-
-type mind_key = mutual_inductive_body * link_info ref * KerName.t
-
 type named_context_val = private {
   env_named_ctx : Constr.named_context;
   env_named_map : Constr.named_declaration Id.Map.t;
@@ -173,12 +169,13 @@ val fold_inductives : (MutInd.t -> Declarations.mutual_inductive_body -> 'a -> '
 val add_constant : Constant.t -> constant_body -> env -> env
 val add_constant_key : Constant.t -> constant_body -> link_info ->
   env -> env
-val lookup_constant_key :  Constant.t -> env -> constant_key
 
 (** Looks up in the context of global constant names
    raises an anomaly if the required path is not found *)
 val lookup_constant    : Constant.t -> env -> constant_body
 val lookup_constant_opt : Constant.t -> env -> constant_body option
+val lookup_constant_key :  Constant.t -> env -> link_info ref * key
+val lookup_constant_canonical :  Constant.t -> env -> KerName.t
 val evaluable_constant : Constant.t -> env -> bool
 val constant_relevance : Constant.t -> env -> Sorts.relevance
 
@@ -243,13 +240,16 @@ val get_projection : env -> inductive -> proj_arg:int -> Names.Projection.Repr.t
 val get_projections : env -> inductive -> (Names.Projection.Repr.t * Sorts.relevance) array option
 
 (** {5 Inductive types } *)
-val lookup_mind_key : MutInd.t -> env -> mind_key
+val lookup_mind_key : MutInd.t -> env -> link_info ref
 val add_mind_key : MutInd.t -> mutual_inductive_body -> link_info -> env -> env
 val add_mind : MutInd.t -> mutual_inductive_body -> env -> env
 
 (** Looks up in the context of global inductive names
    raises an anomaly if the required path is not found *)
 val lookup_mind : MutInd.t -> env -> mutual_inductive_body
+
+(** Returns the canonical name of the inductive *)
+val lookup_mind_canonical : MutInd.t -> env -> KerName.t
 
 val mem_mind : MutInd.t -> env -> bool
 
@@ -497,8 +497,8 @@ module Internal : sig
   module View :
   sig
     type t = {
-      env_constants : constant_key Cmap_env.t;
-      env_inductives : mind_key Mindmap_env.t;
+      env_constants : constant_body Cmap_env.t;
+      env_inductives : mutual_inductive_body Mindmap_env.t;
       env_modules : module_body ModPath.Map.t;
       env_modtypes : module_type_body ModPath.Map.t;
       env_named_context : named_context_val;

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -73,13 +73,13 @@ type prefix = string
 
 (* Linked code location utilities *)
 let get_mind_prefix env mind =
-   let _,name,_ = lookup_mind_key mind env in
+   let name = lookup_mind_key mind env in
    match !name with
    | NotLinked -> ""
    | Linked s -> s
 
 let get_const_prefix env c =
-   let _,(nameref,_),_ = lookup_constant_key c env in
+   let nameref, _ = lookup_constant_key c env in
    match !nameref with
    | NotLinked -> ""
    | Linked s -> s
@@ -2283,7 +2283,8 @@ let empty_updates = Mindmap_env.empty, Cmap_env.empty
 
 let compile_mind_deps cenv env prefix
     (comp_stack, (mind_updates, const_updates) as init) mind =
-  let mib,nameref,_ = lookup_mind_key mind env in
+  let mib = lookup_mind mind env in
+  let nameref = lookup_mind_key mind env in
   if is_code_loaded nameref
     || Mindmap_env.mem mind mind_updates
   then init
@@ -2306,7 +2307,8 @@ let compile_deps cenv env sigma prefix init t =
   | Ind ((mind,_),_u) -> compile_mind_deps cenv env prefix init mind
   | Const (c, _u) ->
     let c, _ = get_alias env sigma c in
-    let cb,(nameref,_),_ = lookup_constant_key c env in
+    let cb = lookup_constant c env in
+    let (nameref, _) = lookup_constant_key c env in
     let (_, (_, const_updates)) = init in
     if is_code_loaded nameref
     || (Cmap_env.mem c const_updates)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -125,11 +125,11 @@ let instantiate_context env u subst nas ctx =
   instantiate (Array.length nas - 1) ctx
 
 let check_constant env cst =
-  let _, _, can = Environ.lookup_constant_key cst env in
+  let can = Environ.lookup_constant_canonical cst env in
   if not (KerName.equal can (Constant.canonical cst)) then error_ill_formed_constant env cst can
 
 let check_mind env mind =
-  let _, _, can = Environ.lookup_mind_key mind env in
+  let can = Environ.lookup_mind_canonical mind env in
   if not (KerName.equal can (MutInd.canonical mind)) then error_ill_formed_inductive env mind can
 
 (************************************************)

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -269,7 +269,7 @@ let rec slot_for_getglobal env sigma kn envcache table =
   let cb = CClosure.lookup_constant_handler env sigma.Genlambda.evars_val kn in
   let rk =
     if Environ.mem_constant kn env then
-      let (_, (_, rk),_) = lookup_constant_key kn env in
+      let (_, rk) = lookup_constant_key kn env in
       rk
     else
       ref None


### PR DESCRIPTION
The fact that we store bits of the data together as a tuple should not have been reflected in the API. It is annoying every time we want to add additional data to the tuple. See for instance #21514.