### PR TITLE
Port native_compute to OCaml 5 (using tag 0 and caml_curry2_1)

### DIFF
--- a/doc/changelog/01-kernel/21540-native5-tag0-alt-Changed.rst
+++ b/doc/changelog/01-kernel/21540-native5-tag0-alt-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Reenable support for `native_compute` when compiled with OCaml 5. As it relies on some architecture-specific code, only some x86 setups are supported for now
+  (`#21540 <https://github.com/rocq-prover/rocq/pull/21540>`_,
+  fixes `#13940 <https://github.com/rocq-prover/rocq/issues/13940>`_,
+  by Guillaume Melquiond).

--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -107,13 +107,39 @@ value rocq_tcode_array(value tcodes) {
   CAMLreturn(res);
 }
 
-CAMLprim value rocq_obj_set_tag (value arg, value new_tag)
-{
-#if OCAML_VERSION >= 50000
-// Placeholder used by native_compute
-  abort();
+/* The rocq_curry2_1 function returns a pointer to some code that
+   immediately branches to caml_curry2_1. It can be used as field 0 of
+   an OCaml closure, as long as field 3 contains a closure whose code
+   pointer accepts exactly two arguments (the first argument is stored
+   in field 2).
+
+   Since the word before the branch indicates to the garbage collector
+   that this block should be ignored, the code pointer can be used
+   inside blocks that do not have tag 247. */
+
+#if defined(__GNUC__) && defined(__amd64__)
+
+asm(".align 8\n\t"
+    ".quad 3067\n"
+    "rocq_curry2_1:\n\t"
+    "jmp caml_curry2_1\n");
+
+#elif defined(__GNUC__) && defined(__i386__)
+
+asm(".align 4\n\t"
+    ".long 3067\n"
+    "rocq_curry2_1:\n\t"
+    "jmp caml_curry2_1\n");
+
 #else
-  Tag_val (arg) = Int_val (new_tag);
+
+void rocq_curry2_1() {
+  abort();
+}
+
 #endif
-  return Val_unit;
+
+value rocq_curry2_1_addr(value) {
+  extern void rocq_curry2_1();
+  return (value)&rocq_curry2_1;
 }

--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -121,7 +121,13 @@ value rocq_tcode_array(value tcodes) {
 
    Keep the compile-time checks in sync with rocq_configure.c */
 
-#if defined(NO_NAKED_POINTERS)
+#ifdef NO_NATIVE_COMPUTE
+
+value rocq_curry2_1_addr(value) {
+  return Val_unit;
+}
+
+#elif defined(NO_NAKED_POINTERS)
 
 __attribute__((weak))
 void caml_curry2_1() {
@@ -143,16 +149,12 @@ asm(".align 4\n\t"
     "jmp caml_curry2_1\n");
 
 #else
-#define no_native_compute
+#error "Unsupported architecture for native_compute."
 #endif
 
 value rocq_curry2_1_addr(value) {
-#ifdef no_native_compute
-  return (value)NULL;
-#else
   extern void rocq_curry2_1();
   return (value)&rocq_curry2_1;
-#endif
 }
 
 #else // not NO_NAKED_POINTERS

--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -116,7 +116,8 @@ value rocq_tcode_array(value tcodes) {
 
    Since the word before the branch indicates to the garbage collector
    that this block should be ignored, the code pointer can be used
-   inside blocks that do not have tag 247.
+   inside blocks that do not have tag 247. This 2043 value is the
+   result of Caml_out_of_heap_header(2, Abstract_tag).
 
    Keep the compile-time checks in sync with rocq_configure.c */
 
@@ -130,14 +131,14 @@ void caml_curry2_1() {
 #if defined(__GNUC__) && defined(__amd64__)
 
 asm(".align 8\n\t"
-    ".quad 3067\n"
+    ".quad 2043\n"
     "rocq_curry2_1:\n\t"
     "jmp caml_curry2_1\n");
 
 #elif defined(__GNUC__) && defined(__i386__)
 
 asm(".align 4\n\t"
-    ".long 3067\n"
+    ".long 2043\n"
     "rocq_curry2_1:\n\t"
     "jmp caml_curry2_1\n");
 

--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -115,7 +115,9 @@ value rocq_tcode_array(value tcodes) {
 
    Since the word before the branch indicates to the garbage collector
    that this block should be ignored, the code pointer can be used
-   inside blocks that do not have tag 247. */
+   inside blocks that do not have tag 247.
+
+   Keep the compile-time checks in sync with rocq_configure.c */
 
 #if defined(__GNUC__) && defined(__amd64__)
 

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -103,10 +103,7 @@ let caml_version_nums { CamlConf.caml_version; _ } =
   generic_version_nums ~name:"the OCaml compiler" caml_version
 
 let check_caml_version prefs caml_version caml_version_nums =
-  if caml_version_nums >= [5;0;0] && prefs.nativecompiler <> NativeNo then
-    let () = cprintf prefs "Your version of OCaml is %s." caml_version in
-    die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0"
-  else if caml_version_nums >= [4;14;0] then
+  if caml_version_nums >= [4;14;0] then
     cprintf prefs "You have OCaml %s. Good!" caml_version
   else
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -102,12 +102,15 @@ let resolve_caml () =
 let caml_version_nums { CamlConf.caml_version; _ } =
   generic_version_nums ~name:"the OCaml compiler" caml_version
 
-external native_5x_available : unit -> bool = "rocq_native_5x_available"
+external native_available : unit -> bool = "rocq_native_available"
 
 let check_caml_version prefs caml_version caml_version_nums =
-  if caml_version_nums >= [5;0;0] && not (native_5x_available ()) && prefs.nativecompiler <> NativeNo then
+  if prefs.nativecompiler <> NativeNo && not (native_available ()) then
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in
-    die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0 on this architecture"
+    if caml_version_nums >= [5;0;0] then
+      die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0 on this architecture"
+    else
+      die "You have enabled Rocq's native compiler, however it is not compatible with your OCaml compiler"
   else if caml_version_nums >= [4;14;0] then
     cprintf prefs "You have OCaml %s. Good!" caml_version
   else

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -330,15 +330,24 @@ let cflags_dflt = "-Wall -Wno-unused -g -O2"
 let cflags_sse2 = "-msse2 -mfpmath=sse"
 
 (* cflags, sse2_math = *)
-let compute_cflags () =
-  let _, slurp =
-    (* Test SSE2_MATH support <https://stackoverflow.com/a/45667927> *)
-    tryrun camlexec.find
-      ["ocamlc"; "-ccopt"; cflags_dflt ^ " -march=native -dM -E " ^ cflags_sse2;
-       "-c"; coqsrc/"dev/header.c"] in  (* any file *)
-  if List.exists (fun line -> starts_with line "#define __SSE2_MATH__ 1") slurp
-  then (cflags_dflt ^ " " ^ cflags_sse2, true)
-  else (cflags_dflt, false)
+let compute_cflags prefs =
+  let cflags = Buffer.create 17 in
+  Buffer.add_string cflags cflags_dflt;
+  let sse2_math =
+    let _, slurp =
+      (* Test SSE2_MATH support <https://stackoverflow.com/a/45667927> *)
+      tryrun camlexec.find
+        ["ocamlc"; "-ccopt"; cflags_dflt ^ " -march=native -dM -E " ^ cflags_sse2;
+         "-c"; coqsrc/"dev/header.c"] in  (* any file *)
+    List.exists (fun line -> starts_with line "#define __SSE2_MATH__ 1") slurp in
+  if sse2_math then
+    begin
+      Buffer.add_char cflags ' ';
+      Buffer.add_string cflags cflags_sse2
+    end;
+  if prefs.nativecompiler = NativeNo then
+    Buffer.add_string cflags " -DNO_NATIVE_COMPUTE";
+  (Buffer.contents cflags, sse2_math)
 
 (** Test at configure time that no harmful double rounding seems to
     be performed with an intermediate 80-bit representation (x87).
@@ -521,7 +530,7 @@ let main () =
   let install_dirs = install_dirs prefs arch in
   let install_prefix = select "COQPREFIX" install_dirs |> fst in
   let coqenv = resolve_coqenv install_dirs in
-  let cflags, sse2_math = compute_cflags () in
+  let cflags, sse2_math = compute_cflags prefs in
   check_fmath sse2_math;
   if not prefs.quiet then
     print_summary prefs arch camlenv install_dirs browser;

--- a/tools/configure/configure.ml
+++ b/tools/configure/configure.ml
@@ -102,8 +102,13 @@ let resolve_caml () =
 let caml_version_nums { CamlConf.caml_version; _ } =
   generic_version_nums ~name:"the OCaml compiler" caml_version
 
+external native_5x_available : unit -> bool = "rocq_native_5x_available"
+
 let check_caml_version prefs caml_version caml_version_nums =
-  if caml_version_nums >= [4;14;0] then
+  if caml_version_nums >= [5;0;0] && not (native_5x_available ()) && prefs.nativecompiler <> NativeNo then
+    let () = cprintf prefs "Your version of OCaml is %s." caml_version in
+    die "You have enabled Rocq's native compiler, however it is not compatible with OCaml >= 5.0.0 on this architecture"
+  else if caml_version_nums >= [4;14;0] then
     cprintf prefs "You have OCaml %s. Good!" caml_version
   else
     let () = cprintf prefs "Your version of OCaml is %s." caml_version in

--- a/tools/configure/dune
+++ b/tools/configure/dune
@@ -1,7 +1,11 @@
 (library
  (name conf)
  (modules :standard \ configure)
- (libraries unix str))
+ (libraries unix str)
+ (foreign_stubs
+  (language c)
+  (names rocq_configure)
+  (flags :standard)))
 
 (executable
  (name configure)

--- a/tools/configure/rocq_configure.c
+++ b/tools/configure/rocq_configure.c
@@ -1,24 +1,17 @@
-#include <stdlib.h>
-#include <stdio.h>
 #include <caml/memory.h>
-#include <memory.h>
 
 /* Keep in sync with rocq_values.c */
 
 #if defined(__GNUC__) && defined(__amd64__)
-
-#define rocq_proxy_accu_defined
-
 #elif defined(__GNUC__) && defined(__i386__)
-
-#define rocq_proxy_accu_defined
-
+#elif defined(NO_NAKED_POINTERS)
+#define no_native_compute
 #endif
 
-value rocq_native_5x_available(value dummy) {
-#ifdef rocq_proxy_accu_defined
-  return Val_int(1);
-#else
+value rocq_native_available(value dummy) {
+#ifdef no_native_compute
   return Val_int(0);
+#else
+  return Val_int(1);
 #endif
 }

--- a/tools/configure/rocq_configure.c
+++ b/tools/configure/rocq_configure.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <caml/memory.h>
+#include <memory.h>
+
+/* Keep in sync with rocq_values.c */
+
+#if defined(__GNUC__) && defined(__amd64__)
+
+#define rocq_proxy_accu_defined
+
+#elif defined(__GNUC__) && defined(__i386__)
+
+#define rocq_proxy_accu_defined
+
+#endif
+
+value rocq_native_5x_available(value dummy) {
+#ifdef rocq_proxy_accu_defined
+  return Val_int(1);
+#else
+  return Val_int(0);
+#endif
+}


### PR DESCRIPTION
This is a variant of #20495, but instead of handcoding some assembly trampoline to the `accumulate` function, it reuses `caml_curry2_1`, which plays the same role. This considerably reduces the burden of maintaining the assembly code, as it is now agnostic to the calling convention of the specific architecture (`caml_curry2_1` will take care of it). It is also much closer to the original OCaml code, since we no longer need to pass `accumulate` to the C code during initialization.

Fixes / closes #13940.

- [X] Added **changelog**.