### PR TITLE
Typo in apply_under_binders

### DIFF
--- a/test-suite/bugs/bug_21544.v
+++ b/test-suite/bugs/bug_21544.v
@@ -1,0 +1,5 @@
+Set Primitive Projections.
+Record prod A B := pair { pr1: A; pr2: B }.
+
+Definition f {A B} (p : prod A B) : nat := let '(pair _ _ a b) := p in 0.
+Definition g {A B} '(pair _ _ a b : prod A B) : nat := 0.

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -68,7 +68,7 @@ let protect_pattern_in_binder bl c ctypopt =
           evd, mkLambda (x,t,c)
         | LetIn (x,b,t,c) ->
           let evd,c = aux (push_rel (LocalDef (x,b,t)) env) evd c in
-          evd, mkLetIn (x,t,b,c)
+          evd, mkLetIn (x,b,t,c)
         | Case (ci,u,pms,p,iv,a,bl) ->
           let (ci, p, iv, a, bl) = EConstr.expand_case env evd (ci, u, pms, p, iv, a, bl) in
           let evd,bl = Array.fold_left_map (aux env) evd bl in


### PR DESCRIPTION
I'm surprised this wasn't noticed before.

Fixes / closes #21544

- [x] Added / updated **test-suite**.
