### PR TITLE
Put back -no-warn option of doc_grammar

### DIFF
--- a/doc/Makefile.docgram
+++ b/doc/Makefile.docgram
@@ -2,6 +2,13 @@
 # doc_grammar tool
 ######################################################################
 
+DOCGRAMWARN ?= 0
+ifeq ($(DOCGRAMWARN),0)
+DOCGRAMWARNFLAG=-no-warn
+else
+DOCGRAMWARNFLAG=
+endif
+
 # List mlg files explicitly to avoid ordering problems (across
 # different installations / make versions).
 DOC_MLGS := \
@@ -44,12 +51,12 @@ endif
 
 doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM'
-	$(HIDE)$(DOC_GRAM) -short $(DOC_MLGS)
+	$(HIDE)$(DOC_GRAM) -short -no-warn $(DOC_MLGS)
 
 #todo: add a dependency of sphinx on updated_rsts when we're ready
 doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
 	$(SHOW)'DOC_GRAM_RSTS'
-	$(HIDE)$(DOC_GRAM) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) $(DOCGRAMWARNFLAG) -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 .PRECIOUS: doc/tools/docgram/orderedGrammar
 
@@ -61,7 +68,7 @@ doc_gram: doc/tools/docgram/fullGrammar
 
 doc_gram_verify: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM_VERIFY'
-	$(HIDE)$(DOC_GRAM) -verify -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
+	$(HIDE)$(DOC_GRAM) -no-warn -verify -check-cmds -check-tacs $(DOC_MLGS) $(DOC_RSTS)
 
 doc_gram_rsts: doc/tools/docgram/updated_rsts
 

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -143,6 +143,8 @@ Other command line arguments:
 
 * `-check-cmds` causes generation of `prodnCommands`
 
+* `-no-warn` suppresses printing of some warning messages
+
 * `-no-update` puts updates to `fullGrammar` and `orderedGrammar` into new files named
   `*.new`, leaving the originals unmodified.  For use in Dune.
 

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -1821,6 +1821,7 @@ let parse_args () =
         match arg with
         | "-check-cmds" -> { args with check_cmds = true }
         | "-check-tacs" -> { args with check_tacs = true }
+        | "-no-warn" -> show_warn := false; args
         | "-no-update" -> { args with update = false }
         | "-short" -> { args with fullGrammar = true }
         | "-verbose" -> { args with verbose = true }

--- a/doc/tools/docgram/dune
+++ b/doc/tools/docgram/dune
@@ -44,6 +44,6 @@
   orderedGrammar)
  (action
   (progn
-   (chdir %{project_root} (run doc_grammar -check-cmds -no-update %{input}))
+   (chdir %{project_root} (run doc_grammar -no-warn -check-cmds -no-update %{input}))
    (diff? fullGrammar fullGrammar.new)
    (diff? orderedGrammar orderedGrammar.new))))


### PR DESCRIPTION
I didn't notice that it was both set imperatively and set in the option record (where the field is then unused) when dealing with the unused field warning.