### PR TITLE
setoid rewriting: improve support for forall_relation

### DIFF
--- a/test-suite/success/rewrite_forall_relation.v
+++ b/test-suite/success/rewrite_forall_relation.v
@@ -1,0 +1,15 @@
+(** Test setoid rewriting with forall_relation. *)
+
+From Corelib Require Import Morphisms.
+
+Axiom K : nat -> nat -> nat -> Type.
+Axiom T : nat -> forall n1 n2 n3, K n1 n2 n3 -> Prop.
+
+Instance T_Proper : Proper (le ==> forallR n1 n2 n3, eq ==> Basics.impl)%signature T.
+Admitted.
+
+Lemma test i j (Hle : i <= j) n1 n2 n3 (k : K n1 n2 n3) (H : T i n1 n2 n3 k) : T j n1 n2 n3 k.
+Proof.
+  rewrite <-Hle.
+  exact H.
+Qed.


### PR DESCRIPTION
This PR improves the support for `forall_relation` in setoid rewriting:
1. Added support for `forall_relation` in the normalization wrt flip algorithm of setoid rewriting.
2. Added a notation for `forall_relation` in scope `signature_scope` which allows writing instances like `Proper (R ==> ∀ x y, S)` with `x` and `y` appearing in `S`.