### PR TITLE
 Move rewrite strat asts to ltac1 plugin

### DIFF
--- a/dev/ci/user-overlays/21571-SkySkimmer-rew-strar-ast.sh
+++ b/dev/ci/user-overlays/21571-SkySkimmer-rew-strar-ast.sh
@@ -1,0 +1,1 @@
+overlay tactician https://github.com/SkySkimmer/coq-tactician rew-strar-ast 21571

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -20,6 +20,7 @@ open Genintern
 open Geninterp
 open Extraargs
 open Rewrite
+open RewriteStratAst
 open ComRewrite
 open Stdarg
 open Tactypes
@@ -66,7 +67,8 @@ END
 
 {
 
-let subst_strategy sub = map_strategy
+let subst_strategy sub =
+  RewriteStratAst.map_strategy
     (Tacsubst.subst_glob_constr_and_expr sub)
     (fun (x, y, z) -> (x, Tacsubst.subst_glob_constr_and_expr sub y, z))
     (Tacsubst.subst_glob_red_expr sub)
@@ -76,13 +78,13 @@ let subst_strategy sub = map_strategy
 let pr_strategy _ _ _ (s : strategy) = Pp.str "<strategy>"
 let pr_raw_strategy env sigma prc prlc prt (s : Tacexpr.raw_strategy) =
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, Pputils.pr_or_by_notation Libnames.pr_qualid, prc,Pputils.pr_or_var Pp.int, Redexpr.pr_raw_user_red_expr) in
-  Rewrite.pr_strategy (prc env sigma) (prc env sigma) prr Pputils.pr_lident (prt env sigma Constrexpr.LevelSome) s
+  RewriteStratAst.pr_strategy (prc env sigma) (prc env sigma) prr Pputils.pr_lident (prt env sigma Constrexpr.LevelSome) s
 let pr_glob_strategy env sigma prc prlc prt (s : Tacexpr.glob_strategy) =
   let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prc, Pputils.pr_or_var Pp.int, Redexpr.pr_glob_user_red_expr) in
   let prpat (_, c, _) = prc env sigma c in
   let prt = prt env sigma Constrexpr.LevelSome in
-  Rewrite.pr_strategy (prc env sigma) prpat prr Id.print prt s
+  RewriteStratAst.pr_strategy (prc env sigma) prpat prr Id.print prt s
 
 }
 

--- a/plugins/ltac/rewriteStratAst.ml
+++ b/plugins/ltac/rewriteStratAst.ml
@@ -1,0 +1,148 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+open Names
+open Rewrite
+
+type unary_strategy =
+    Subterms | Subterm | Innermost | Outermost
+  | Bottomup | Topdown | Progress | Try | Any | Repeat
+
+type binary_strategy =
+  | Compose
+
+type nary_strategy = Choice
+
+type ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast =
+  | StratId | StratFail | StratRefl
+  | StratUnary of unary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratBinary of
+      binary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratNAry of nary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast list
+  | StratConstr of 'constr * bool
+  | StratTerms of 'constr list
+  | StratHints of bool * string
+  | StratEval of 'redexpr
+  | StratFold of 'constr
+  | StratVar of 'id
+  | StratFix of 'id * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratMatches of 'constr_pattern
+  | StratTactic of 'tactic
+
+let rec map_strategy f g h i j = function
+  | StratId | StratFail | StratRefl as s -> s
+  | StratUnary (s, str) -> StratUnary (s, map_strategy f g h i j str)
+  | StratBinary (s, str, str') -> StratBinary (s, map_strategy f g h i j str, map_strategy f g h i j str')
+  | StratNAry (s, strs) -> StratNAry (s, List.map (map_strategy f g h i j) strs)
+  | StratConstr (c, b) -> StratConstr (f c, b)
+  | StratTerms l -> StratTerms (List.map f l)
+  | StratHints (b, id) -> StratHints (b, id)
+  | StratEval r -> StratEval (h r)
+  | StratFold c -> StratFold (f c)
+  | StratVar id -> StratVar (i id)
+  | StratFix (id, s) -> StratFix (i id, map_strategy f g h i j s)
+  | StratMatches c -> StratMatches (g c)
+  | StratTactic t -> StratTactic (j t)
+
+let pr_ustrategy = function
+| Subterms -> str "subterms"
+| Subterm -> str "subterm"
+| Innermost -> str "innermost"
+| Outermost -> str "outermost"
+| Bottomup -> str "bottomup"
+| Topdown -> str "topdown"
+| Progress -> str "progress"
+| Try -> str "try"
+| Any -> str "any"
+| Repeat -> str "repeat"
+
+let paren p = str "(" ++ p ++ str ")"
+
+let rec pr_strategy0 prc prcp prr prid prtac = function
+| StratId -> str "id"
+| StratFail -> str "fail"
+| StratRefl -> str "refl"
+| str -> paren (pr_strategy prc prcp prr prid prtac str)
+
+and pr_strategy1 prc prcp prr prid prtac = function
+| StratUnary (s, str) ->
+  pr_ustrategy s ++ spc () ++ pr_strategy1 prc prcp prr prid prtac str
+| StratNAry (Choice, strs) ->
+  str "choice" ++ brk (1,2) ++ prlist_with_sep spc (fun str -> hov 0 (pr_strategy0 prc prcp prr prid prtac str)) strs
+| StratConstr (c, true) -> prc c
+| StratConstr (c, false) -> str "<-" ++ spc () ++ prc c
+| StratVar id -> prid id
+| StratTerms cl -> str "terms" ++ spc () ++ pr_sequence prc cl
+| StratHints (old, id) ->
+  let cmd = if old then "old_hints" else "hints" in
+  str cmd ++ spc () ++ str id
+| StratEval r -> str "eval" ++ spc () ++ prr r
+| StratFold c -> str "fold" ++ spc () ++ prc c
+| StratMatches p -> str "pattern" ++ spc () ++ prcp p
+| StratTactic t -> str"tactic" ++ spc () ++ prtac t
+| str -> pr_strategy0 prc prcp prr prid prtac str
+
+and pr_strategy2 prc prcp prr prid prtac = function
+| StratBinary (Compose, str1, str2) ->
+  pr_strategy2 prc prcp prr prid prtac str1 ++ str ";" ++ spc () ++ hov 0 (pr_strategy1 prc prcp prr prid prtac str2)
+| str -> hov 0 (pr_strategy1 prc prcp prr prid prtac str)
+
+and pr_strategy prc prcp prr prid prtac = function
+| StratFix (id,s) -> str "fix" ++ spc() ++ prid id ++ spc() ++ str ":=" ++ spc() ++ hov 0 (pr_strategy1 prc prcp prr prid prtac s)
+| str -> pr_strategy2 prc prcp prr prid prtac str
+
+let strategy_of_ast bindings strat =
+  let rec aux bindings = function
+  | StratId -> Strategies.id
+  | StratFail -> Strategies.fail
+  | StratRefl -> Strategies.refl
+  | StratUnary (f, s) ->
+    let s' = aux bindings s in
+    let f' = match f with
+      | Subterms -> Strategies.all_subterms
+      | Subterm -> Strategies.one_subterm
+      | Innermost -> Strategies.innermost
+      | Outermost -> Strategies.outermost
+      | Bottomup -> Strategies.bottomup
+      | Topdown -> Strategies.topdown
+      | Progress -> Strategies.progress
+      | Try -> Strategies.try_
+      | Any -> Strategies.any
+      | Repeat -> Strategies.repeat
+    in f' s'
+  | StratBinary (f, s, t) ->
+    let s' = aux bindings s in
+    let t' = aux bindings t in
+    let f' = match f with
+      | Compose -> Strategies.seq
+    in f' s' t'
+  | StratNAry (Choice, strs) ->
+    let strs = List.map (aux bindings) strs in
+    begin match strs with
+      | [] -> assert false
+      | s::strs -> List.fold_left Strategies.choice s strs
+    end
+  | StratConstr ((_, c), b) -> Strategies.one_lemma c b None AllOccurrences
+  | StratHints (old, id) -> if old then Strategies.old_hints id else Strategies.hints id
+  | StratTerms l -> Strategies.lemmas (List.map (fun (_, c) -> (c, true, None)) l)
+  | StratEval r ->
+    Strategies.with_env @@ fun env sigma ->
+    let sigma, r = r env sigma in
+    sigma, Strategies.reduce r
+  | StratFold c -> Strategies.fold_glob (fst c)
+  | StratVar id -> Id.Map.get id bindings
+  | StratFix (id, s) -> Strategies.fix (fun self -> aux (Id.Map.add id self bindings) s)
+  | StratMatches p -> Strategies.matches p
+  | StratTactic t -> Strategies.ltac1_tactic_call t
+  in aux bindings strat
+
+
+let strategy_of_ast s = strategy_of_ast Id.Map.empty s

--- a/plugins/ltac/rewriteStratAst.mli
+++ b/plugins/ltac/rewriteStratAst.mli
@@ -1,0 +1,48 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open Tactypes
+open EConstr
+
+type unary_strategy =
+    Subterms | Subterm | Innermost | Outermost
+  | Bottomup | Topdown | Progress | Try | Any | Repeat
+
+type binary_strategy =
+  | Compose
+
+type nary_strategy = Choice
+
+type ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast =
+  | StratId | StratFail | StratRefl
+  | StratUnary of unary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratBinary of
+      binary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratNAry of nary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast list
+  | StratConstr of 'constr * bool
+  | StratTerms of 'constr list
+  | StratHints of bool * string
+  | StratEval of 'redexpr
+  | StratFold of 'constr
+  | StratVar of 'id
+  | StratFix of 'id * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
+  | StratMatches of 'constr_pattern
+  | StratTactic of 'tactic
+
+val strategy_of_ast :
+  (Glob_term.glob_constr * constr delayed_open, Pattern.constr_pattern, Redexpr.red_expr delayed_open, Id.t, unit Proofview.tactic) strategy_ast ->
+  Rewrite.strategy
+
+val map_strategy : ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) -> ('g -> 'h) -> ('i -> 'j) ->
+  ('a, 'c, 'e, 'g, 'i) strategy_ast -> ('b, 'd, 'f, 'h, 'j) strategy_ast
+
+val pr_strategy : ('a -> Pp.t) -> ('b -> Pp.t) -> ('c -> Pp.t) -> ('d -> Pp.t) -> ('e -> Pp.t) ->
+  ('a, 'b, 'c, 'd, 'e) strategy_ast -> Pp.t

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -378,8 +378,8 @@ type atomic_tactic_expr =
 
 (** Misc *)
 
-type raw_strategy = (constr_expr, constr_expr, Redexpr.raw_red_expr, lident, raw_tactic_expr) Rewrite.strategy_ast
-type glob_strategy = (Genintern.glob_constr_and_expr, Genintern.glob_constr_pattern_and_expr, Redexpr.glob_red_expr, Id.t, glob_tactic_expr) Rewrite.strategy_ast
+type raw_strategy = (constr_expr, constr_expr, Redexpr.raw_red_expr, lident, raw_tactic_expr) RewriteStratAst.strategy_ast
+type glob_strategy = (Genintern.glob_constr_and_expr, Genintern.glob_constr_pattern_and_expr, Redexpr.glob_red_expr, Id.t, glob_tactic_expr) RewriteStratAst.strategy_ast
 
 (** Traces *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -716,15 +716,16 @@ let glob_tactic_env l env x =
   intern_pure_tactic { (Genintern.empty_glob_sign ~strict:true env) with ltacvars } x
 
 let intern_strategy ist s =
+  let open RewriteStratAst in
   let rec aux stratvars = function
-    | Rewrite.StratVar x ->
+    | StratVar x ->
       (* We could make this whole branch assert false, since it's
          unreachable except from plugins. But maybe it's useful if any
          plug-in wants to craft a strategy by hand. *)
-      if Id.Set.mem x.v stratvars then Rewrite.StratVar x.v
+      if Id.Set.mem x.v stratvars then StratVar x.v
       else CErrors.user_err ?loc:x.loc Pp.(str "Unbound strategy" ++ spc() ++ Id.print x.v)
     | StratConstr ({ v = CRef (qid, None) }, true) when idset_mem_qualid qid stratvars ->
-      let (_, x) = repr_qualid qid in Rewrite.StratVar x
+      let (_, x) = repr_qualid qid in StratVar x
     | StratConstr (c, b) -> StratConstr (intern_constr ist c, b)
     | StratFix (x, s) -> StratFix (x.v, aux (Id.Set.add x.v stratvars) s)
     | StratId | StratFail | StratRefl as s -> s

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1978,9 +1978,9 @@ let interp_strategy ist env sigma s =
   let interp_redexpr r = fun env sigma -> interp_red_expr ist env sigma r in
   let interp_constr c = (fst c, fun env sigma -> interp_open_constr ist env sigma c) in
   let interp_pattern (_, p, up) = Patternops.interp_pattern env sigma Glob_ops.empty_lvar up in
-  let s = Rewrite.map_strategy interp_constr interp_pattern interp_redexpr
+  let s = RewriteStratAst.map_strategy interp_constr interp_pattern interp_redexpr
             (fun x -> x) (interp_tactic ist) s in
-  Rewrite.strategy_of_ast s
+  RewriteStratAst.strategy_of_ast s
 
 (** FFI *)
 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1579,6 +1579,11 @@ module Strategies =
             let sigma, c = Pretyping.understand_tcc env (goalevars evars) c in
             state, run_fold_in env (sigma, cstrevars evars) c t ty
       }
+
+    let with_env f =
+      { strategy = fun ({ state = (); env; evars } as input) ->
+            let sigma, s = f env (goalevars evars) in
+            s.strategy { input with evars = (sigma, cstrevars evars) } }
 end
 
 (** The strategy for a single rewrite, dealing with occurrences. *)
@@ -1791,144 +1796,6 @@ let cl_rewrite_clause l left2right occs clause =
 (** Setoid rewriting when called with "rewrite_strat" *)
 let cl_rewrite_clause_strat strat clause =
   cl_rewrite_clause_strat false strat clause
-
-(* Syntax for rewriting with strategies *)
-
-type unary_strategy =
-    Subterms | Subterm | Innermost | Outermost
-  | Bottomup | Topdown | Progress | Try | Any | Repeat
-
-type binary_strategy =
-  | Compose
-
-type nary_strategy = Choice
-
-type ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast =
-  | StratId | StratFail | StratRefl
-  | StratUnary of unary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
-  | StratBinary of
-      binary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
-  | StratNAry of nary_strategy * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast list
-  | StratConstr of 'constr * bool
-  | StratTerms of 'constr list
-  | StratHints of bool * string
-  | StratEval of 'redexpr
-  | StratFold of 'constr
-  | StratVar of 'id
-  | StratFix of 'id * ('constr,'constr_pattern,'redexpr,'id,'tactic) strategy_ast
-  | StratMatches of 'constr_pattern
-  | StratTactic of 'tactic
-
-let rec map_strategy f g h i j = function
-  | StratId | StratFail | StratRefl as s -> s
-  | StratUnary (s, str) -> StratUnary (s, map_strategy f g h i j str)
-  | StratBinary (s, str, str') -> StratBinary (s, map_strategy f g h i j str, map_strategy f g h i j str')
-  | StratNAry (s, strs) -> StratNAry (s, List.map (map_strategy f g h i j) strs)
-  | StratConstr (c, b) -> StratConstr (f c, b)
-  | StratTerms l -> StratTerms (List.map f l)
-  | StratHints (b, id) -> StratHints (b, id)
-  | StratEval r -> StratEval (h r)
-  | StratFold c -> StratFold (f c)
-  | StratVar id -> StratVar (i id)
-  | StratFix (id, s) -> StratFix (i id, map_strategy f g h i j s)
-  | StratMatches c -> StratMatches (g c)
-  | StratTactic t -> StratTactic (j t)
-
-let pr_ustrategy = function
-| Subterms -> str "subterms"
-| Subterm -> str "subterm"
-| Innermost -> str "innermost"
-| Outermost -> str "outermost"
-| Bottomup -> str "bottomup"
-| Topdown -> str "topdown"
-| Progress -> str "progress"
-| Try -> str "try"
-| Any -> str "any"
-| Repeat -> str "repeat"
-
-let paren p = str "(" ++ p ++ str ")"
-
-let rec pr_strategy0 prc prcp prr prid prtac = function
-| StratId -> str "id"
-| StratFail -> str "fail"
-| StratRefl -> str "refl"
-| str -> paren (pr_strategy prc prcp prr prid prtac str)
-
-and pr_strategy1 prc prcp prr prid prtac = function
-| StratUnary (s, str) ->
-  pr_ustrategy s ++ spc () ++ pr_strategy1 prc prcp prr prid prtac str
-| StratNAry (Choice, strs) ->
-  str "choice" ++ brk (1,2) ++ prlist_with_sep spc (fun str -> hov 0 (pr_strategy0 prc prcp prr prid prtac str)) strs
-| StratConstr (c, true) -> prc c
-| StratConstr (c, false) -> str "<-" ++ spc () ++ prc c
-| StratVar id -> prid id
-| StratTerms cl -> str "terms" ++ spc () ++ pr_sequence prc cl
-| StratHints (old, id) ->
-  let cmd = if old then "old_hints" else "hints" in
-  str cmd ++ spc () ++ str id
-| StratEval r -> str "eval" ++ spc () ++ prr r
-| StratFold c -> str "fold" ++ spc () ++ prc c
-| StratMatches p -> str "pattern" ++ spc () ++ prcp p
-| StratTactic t -> str"tactic" ++ spc () ++ prtac t
-| str -> pr_strategy0 prc prcp prr prid prtac str
-
-and pr_strategy2 prc prcp prr prid prtac = function
-| StratBinary (Compose, str1, str2) ->
-  pr_strategy2 prc prcp prr prid prtac str1 ++ str ";" ++ spc () ++ hov 0 (pr_strategy1 prc prcp prr prid prtac str2)
-| str -> hov 0 (pr_strategy1 prc prcp prr prid prtac str)
-
-and pr_strategy prc prcp prr prid prtac = function
-| StratFix (id,s) -> str "fix" ++ spc() ++ prid id ++ spc() ++ str ":=" ++ spc() ++ hov 0 (pr_strategy1 prc prcp prr prid prtac s)
-| str -> pr_strategy2 prc prcp prr prid prtac str
-
-let strategy_of_ast bindings strat =
-  let rec aux bindings = function
-  | StratId -> Strategies.id
-  | StratFail -> Strategies.fail
-  | StratRefl -> Strategies.refl
-  | StratUnary (f, s) ->
-    let s' = aux bindings s in
-    let f' = match f with
-      | Subterms -> Strategies.all_subterms
-      | Subterm -> Strategies.one_subterm
-      | Innermost -> Strategies.innermost
-      | Outermost -> Strategies.outermost
-      | Bottomup -> Strategies.bottomup
-      | Topdown -> Strategies.topdown
-      | Progress -> Strategies.progress
-      | Try -> Strategies.try_
-      | Any -> Strategies.any
-      | Repeat -> Strategies.repeat
-    in f' s'
-  | StratBinary (f, s, t) ->
-    let s' = aux bindings s in
-    let t' = aux bindings t in
-    let f' = match f with
-      | Compose -> Strategies.seq
-    in f' s' t'
-  | StratNAry (Choice, strs) ->
-    let strs = List.map (aux bindings) strs in
-    begin match strs with
-      | [] -> assert false
-      | s::strs -> List.fold_left Strategies.choice s strs
-    end
-  | StratConstr ((_, c), b) -> Strategies.one_lemma c b None AllOccurrences
-  | StratHints (old, id) -> if old then Strategies.old_hints id else Strategies.hints id
-  | StratTerms l -> Strategies.lemmas (List.map (fun (_, c) -> (c, true, None)) l)
-  | StratEval r -> { strategy =
-    (fun ({ state = () ; env ; evars } as input) ->
-     let (sigma, r_interp) = r env (goalevars evars) in
-     (Strategies.reduce r_interp).strategy { input with
-                                             evars = (sigma,cstrevars evars) }) }
-  | StratFold c -> Strategies.fold_glob (fst c)
-  | StratVar id -> Id.Map.get id bindings
-  | StratFix (id, s) -> Strategies.fix (fun self -> aux (Id.Map.add id self bindings) s)
-  | StratMatches p -> Strategies.matches p
-  | StratTactic t -> Strategies.ltac1_tactic_call t
-  in aux bindings strat
-
-
-let strategy_of_ast s = strategy_of_ast Id.Map.empty s
 
 let proper_projection env sigma r ty =
   let rel_vect n m = Array.init m (fun i -> mkRel(n+m-i)) in


### PR DESCRIPTION
Depends:
- https://github.com/rocq-prover/rocq/pull/21521 (to reduce rebase pain)

While talking about #21521, I'm not sure if the `ltac1_tactic_call` could be implemented based on `tactic_call` and moved to ltac1 plugin. The main (only?) issue is `make_tactic_goal` using APIs internal to rewrite.ml `new_cstr_evar` and the sort dependant mk_relation.

Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/127