### PR TITLE
iris-examples: prepare for opam file being renamed

### DIFF
--- a/dev/ci/scripts/ci-iris.sh
+++ b/dev/ci/scripts/ci-iris.sh
@@ -8,7 +8,7 @@ ci_dir="$(dirname "$0")"
 git_download iris_examples
 
 # Extract required version of Iris (avoiding "+" which does not work on MacOS :( *)
-iris_CI_REF=$(grep -F '"rocq-iris-heap-lang"' < "${CI_BUILD_DIR}/iris_examples/coq-iris-examples.opam" | sed 's/.*"dev\.[0-9][0-9.-]*\.\([0-9a-z][0-9a-z]*\)".*/\1/')
+iris_CI_REF=$(grep -F '"rocq-iris-heap-lang"' < "${CI_BUILD_DIR}"/iris_examples/*-iris-examples.opam | sed 's/.*"dev\.[0-9][0-9.-]*\.\([0-9a-z][0-9a-z]*\)".*/\1/')
 [ -n "$iris_CI_REF" ] || { echo "Could not find Iris dependency version" && exit 1; }
 
 # Download Iris


### PR DESCRIPTION
I have not pushed the change to iris-examples yet as that would break Rocq CI (the MR is ready [here](https://gitlab.mpi-sws.org/iris/examples/-/merge_requests/74)). I hope by using a wildcard both the old and new name will work.

Alternatively, I can hard-code the new name here, and the you tell me when is a good time to push the change in iris/examples to minimize Rocq CI breakage.