### PR TITLE
Stop using genarg for constr syntax extension

### DIFF
--- a/dev/ci/user-overlays/21574-SkySkimmer-genconstr.sh
+++ b/dev/ci/user-overlays/21574-SkySkimmer-genconstr.sh
@@ -1,0 +1,5 @@
+overlay tactician https://github.com/SkySkimmer/coq-tactician genconstr 21574
+
+overlay elpi https://github.com/SkySkimmer/coq-elpi genconstr 21574
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations genconstr 21574

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -164,10 +164,10 @@ and constr_expr_r =
   | CIf of constr_expr * (lname option * constr_expr option)
          * constr_expr * constr_expr
   | CHole   of Evar_kinds.glob_evar_kind option
-  | CGenarg of Genarg.raw_generic_argument
+  | CGenarg of GenConstr.raw
 
   (* because print for genargs wants to print directly the glob without an extern phase (??) *)
-  | CGenargGlob of Genarg.glob_generic_argument
+  | CGenargGlob of GenConstr.glb
 
   | CPatVar of Pattern.patvar
   | CEvar   of Glob_term.existential_name CAst.t * (lident * constr_expr) list

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2176,8 +2176,8 @@ module Interner = struct
   ; lettuple : t -> (lname list * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; if_ : t -> (constr_expr * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; hole : t -> Evar_kinds.glob_evar_kind option fn
-  ; genarg : t -> Genarg.raw_generic_argument fn
-  ; genargglob : t -> Genarg.glob_generic_argument fn
+  ; genarg : t -> GenConstr.raw fn
+  ; genargglob : t -> GenConstr.glb fn
   ; patvar : t -> (Pattern.patvar) fn
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn
@@ -2741,10 +2741,10 @@ let genarg self genv env lvar ?loc gen =
     strict_check = match env.strict_check with None -> false | Some b -> b;
   } in
   let intern = if env.pattern_mode
-    then Genintern.generic_intern_pat ?loc
-    else Genintern.generic_intern
+    then Genintern.generic_intern_pat
+    else Genintern.generic_intern_constr
   in
-  let (_, glb) = intern ist gen in
+  let glb = intern ?loc ist gen in
   DAst.make ?loc @@
   GGenarg glb
 

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -118,8 +118,8 @@ module Interner : sig
   ; lettuple : t -> (lname list * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; if_ : t -> (constr_expr * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; hole : t -> Evar_kinds.glob_evar_kind option fn
-  ; genarg : t -> Genarg.raw_generic_argument fn
-  ; genargglob : t -> Genarg.glob_generic_argument fn
+  ; genarg : t -> GenConstr.raw fn
+  ; genargglob : t -> GenConstr.glb fn
   ; patvar : t -> (Pattern.patvar) fn
   ; evar : t -> (Glob_term.existential_name CAst.t * (lident * constr_expr) list) fn
   ; sort : t -> sort_expr fn

--- a/interp/genintern.mli
+++ b/interp/genintern.mli
@@ -48,17 +48,17 @@ type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * Pattern.un
 type ('raw, 'glb) intern_fun = glob_sign -> 'raw -> glob_sign * 'glb
 (** The type of functions used for internalizing generic arguments. *)
 
+type ('raw, 'glb) constr_intern_fun = ?loc:Loc.t -> glob_sign -> 'raw -> 'glb
+
 val intern : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb) intern_fun
 
 val generic_intern : (raw_generic_argument, glob_generic_argument) intern_fun
 
+val generic_intern_constr : (GenConstr.raw, GenConstr.glb) constr_intern_fun
+
 (** {5 Internalization in tactic patterns} *)
 
-type ('raw,'glb) intern_pat_fun = ?loc:Loc.t -> ('raw,'glb) intern_fun
-
-val intern_pat : ('raw, 'glb, 'top) genarg_type -> ('raw, 'glb) intern_pat_fun
-
-val generic_intern_pat : (raw_generic_argument, glob_generic_argument) intern_pat_fun
+val generic_intern_pat : (GenConstr.raw, GenConstr.glb) constr_intern_fun
 
 (** {5 Notation functions} *)
 
@@ -67,20 +67,26 @@ val generic_intern_pat : (raw_generic_argument, glob_generic_argument) intern_pa
    may raise an exception if it fails, None for recursive part variables *)
 type 'glb ntn_subst_fun = ntnvar_status Id.Map.t -> (Id.t -> Glob_term.glob_constr option) -> 'glb -> 'glb
 
-val substitute_notation : ('raw, 'glb, 'top) genarg_type -> 'glb ntn_subst_fun
+val substitute_notation : (_, 'glb) GenConstr.tag -> 'glb ntn_subst_fun
 
-val generic_substitute_notation : glob_generic_argument ntn_subst_fun
+val generic_substitute_notation : GenConstr.glb ntn_subst_fun
 
 (** Registering functions *)
 
 val register_intern0 : ('raw, 'glb, 'top) genarg_type ->
   ('raw, 'glb) intern_fun -> unit
 
-val register_intern_pat : ('raw, 'glb, 'top) genarg_type ->
-  ('raw, 'glb) intern_pat_fun -> unit
+val register_intern_constr : ('raw, 'glb) GenConstr.tag ->
+  ('raw, 'glb) constr_intern_fun -> unit
 
-val register_ntn_subst0 : ('raw, 'glb, 'top) genarg_type ->
-  'glb ntn_subst_fun -> unit
+val register_intern_pat : ('raw, 'glb) GenConstr.tag ->
+  ('raw, 'glb) constr_intern_fun -> unit
+
+val register_ntn_subst0 : (_, 'glb) GenConstr.tag -> 'glb ntn_subst_fun -> unit
 
 (** Used to compute the set of used notation variables during internalization.*)
 val with_used_ntnvars : ntnvar_status Id.Map.t -> (unit -> 'a) -> Id.Set.t * 'a
+
+(** Registers trivial intern and subst functions. Other registers
+    should be done by the caller. *)
+val create_uniform_genconstr : string -> ('a, 'a) GenConstr.tag

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -923,7 +923,7 @@ let rec subst_notation_constr subst bound raw =
     else NHole nknd
 
   | NGenarg arg ->
-    let arg' = Gensubst.generic_substitute subst arg in
+    let arg' = Gensubst.constr_subst subst arg in
     if arg' == arg then raw
     else NGenarg arg'
 

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -26,7 +26,7 @@ type notation_constr =
   | NApp of notation_constr * notation_constr list
   | NProj of (Constant.t * glob_instance option) * notation_constr list * notation_constr
   | NHole of glob_evar_kind
-  | NGenarg of Genarg.glob_generic_argument
+  | NGenarg of GenConstr.glb
   | NList of Id.t * Id.t * notation_constr * notation_constr * (* associativity: *) bool
   (* Part only in [glob_constr] *)
   | NLambda of Name.t * notation_constr option * notation_constr

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -292,8 +292,7 @@ GRAMMAR EXTEND Gram
   ;
   term: LEVEL "0"
     [ [ IDENT "ltac"; ":"; "("; tac = Pltac.ltac_expr; ")" ->
-        { let arg = Genarg.in_gen (Genarg.rawwit Tacarg.wit_ltac_in_term) tac in
-          CAst.make ~loc @@ CGenarg arg } ] ]
+        { CAst.make ~loc @@ CGenarg (Raw (Tacarg.wit_ltac_in_term, tac)) } ] ]
   ;
   END
 

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1420,17 +1420,24 @@ let () =
   ltop (LevelLe 0)
 
 let () =
-  declare_extra_genarg_pprule_with_level wit_ltac_in_term
-    (fun env sigma _ _ prtac l tac -> prtac env sigma l tac)
-    (fun env sigma _ _ prtac l (used_ntnvars,tac) ->
-       let ppids =
-         let ids = Id.Set.elements used_ntnvars in
-         if List.is_empty ids then mt()
-         else hov 0 (pr_sequence Id.print ids ++ str " |-") ++ spc()
-       in
-       hov 2 (ppids ++ prtac env sigma l tac))
-    (fun env sigma _ _ _ _ tac -> Util.Empty.abort tac)
-  ltop (LevelLe 0)
+  let printer f x =
+    Genprint.PrinterNeedsLevel {
+      default_already_surrounded = ltop;
+      default_ensure_surrounded = LevelLe 0;
+      printer = (fun env sigma n -> f env sigma n x);
+    }
+  in
+  let pr_glob_tac_in_term env sigma l (used_ntnvars,tac) =
+    let ppids =
+      let ids = Id.Set.elements used_ntnvars in
+      if List.is_empty ids then mt()
+      else hov 0 (pr_sequence Id.print ids ++ str " |-") ++ spc()
+    in
+    hov 2 (ppids ++ pr_glob_tactic_level env l tac)
+  in
+  Genprint.register_constr_print wit_ltac_in_term
+    (printer pr_raw_tactic_level)
+    (printer pr_glob_tac_in_term)
 
 let () =
   let printer f x =

--- a/plugins/ltac/tacarg.ml
+++ b/plugins/ltac/tacarg.ml
@@ -30,7 +30,7 @@ let wit_quantified_hypothesis = wit_quant_hyp
 let wit_tactic : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
   make0 "tactic"
 
-let wit_ltac_in_term = make0 "ltac_in_term"
+let wit_ltac_in_term = GenConstr.create "ltac_in_term"
 
 let wit_ltac = Gentactic.make "ltac"
 

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -44,7 +44,7 @@ val wit_quantified_hypothesis : quantified_hypothesis uniform_genarg_type
 
 val wit_tactic : (raw_tactic_expr, glob_tactic_expr, Geninterp.Val.t) genarg_type
 
-val wit_ltac_in_term : (raw_tactic_expr, Names.Id.Set.t * glob_tactic_expr, Util.Empty.t) genarg_type
+val wit_ltac_in_term : (raw_tactic_expr, Names.Id.Set.t * glob_tactic_expr) GenConstr.tag
 
 (** [wit_ltac] is subtly different from [wit_tactic]: they only change for their
     toplevel interpretation. The one of [wit_ltac] forces the tactic and

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -701,7 +701,7 @@ let used_all_ntnvars ntnvars =
   in
   Id.Map.domain ntnvars
 
-let intern_ltac_in_term ist tac =
+let intern_ltac_in_term ?loc:_ ist tac =
   let tac = intern_tactic_or_tacarg ist tac in
   used_all_ntnvars ist.intern_sign.notation_variable_status, tac
 
@@ -775,7 +775,7 @@ let () =
   Genintern.register_intern0 wit_ident intern_ident';
   Genintern.register_intern0 wit_hyp (lift intern_hyp);
   Genintern.register_intern0 wit_tactic (lift intern_tactic_or_tacarg);
-  Genintern.register_intern0 wit_ltac_in_term (lift intern_ltac_in_term);
+  Genintern.register_intern_constr wit_ltac_in_term intern_ltac_in_term;
   Gentactic.register_intern wit_ltac (lift intern_ltac);
   Genintern.register_intern0 wit_quant_hyp (lift intern_quantified_hypothesis);
   Genintern.register_intern0 wit_constr (fun ist c -> (ist,intern_constr ist c));

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -287,7 +287,7 @@ let () =
   Gensubst.register_subst0 wit_intropattern subst_intro_pattern [@warning "-3"];
   Gensubst.register_subst0 wit_simple_intropattern subst_intro_pattern;
   Gensubst.register_subst0 wit_tactic subst_tactic;
-  Gensubst.register_subst0 wit_ltac_in_term (fun s (used_ntnvars,tac) -> used_ntnvars, subst_tactic s tac);
+  Gensubst.register_constr_subst wit_ltac_in_term (fun s (used_ntnvars,tac) -> used_ntnvars, subst_tactic s tac);
   Gentactic.register_subst wit_ltac subst_tactic;
   Gensubst.register_subst0 wit_constr subst_glob_constr;
   Gensubst.register_subst0 wit_clause_dft_concl (fun _ v -> v);

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -944,8 +944,7 @@ let rules = [
       (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.ident)
     begin fun id _ _ loc ->
       let id = CAst.make ~loc id in
-      let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_var_quotation) (None, id) in
-      CAst.make ~loc (CGenarg arg)
+      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (None, id))))
     end
   );
 
@@ -955,8 +954,7 @@ let rules = [
        Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.identref ++
        Symbol.token (PKEYWORD ":") ++ Symbol.nterm Prim.identref)
     begin fun id _ kind _ _ loc ->
-      let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_var_quotation) (Some kind, id) in
-      CAst.make ~loc (CGenarg arg)
+      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_var_quotation, (Some kind, id))))
     end
   );
 
@@ -965,8 +963,7 @@ let rules = [
       (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.ident)
     begin fun id _ _ loc ->
       let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
-      let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
-      CAst.make ~loc (CGenarg arg)
+      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac)))
     end
   );
 
@@ -975,8 +972,7 @@ let rules = [
       (Rule.stop ++ Symbol.token (PIDENT (Some "ltac2")) ++ Symbol.token (PKEYWORD ":") ++
        Symbol.token (PKEYWORD "(") ++ Symbol.nterm ltac2_expr ++ Symbol.token (PKEYWORD ")"))
     begin fun _ tac _ _ _ loc ->
-      let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
-      CAst.make ~loc (CGenarg arg)
+      CAst.make ~loc (CGenarg (Raw (Tac2env.wit_ltac2_constr, tac)))
     end
   )
 ] in

--- a/plugins/ltac2/tac2env.ml
+++ b/plugins/ltac2/tac2env.ml
@@ -306,8 +306,8 @@ type var_quotation_kind =
   | PatternVar
   | HypVar
 
-let wit_ltac2_constr = Genarg.make0 "ltac2:in-constr"
-let wit_ltac2_var_quotation = Genarg.make0 "ltac2:quotation"
+let wit_ltac2_constr = GenConstr.create "ltac2:in-constr"
+let wit_ltac2_var_quotation = GenConstr.create "ltac2:quotation"
 let wit_ltac2_tac = Gentactic.make "ltac2:tactic"
 
 let is_constructor_id id =

--- a/plugins/ltac2/tac2env.mli
+++ b/plugins/ltac2/tac2env.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Genarg
 open Names
 open Libnames
 open Nametab
@@ -181,7 +180,7 @@ val ltac1_prefix : ModPath.t
 
 (** {5 Generic arguments} *)
 
-val wit_ltac2_constr : (raw_tacexpr, Id.Set.t * glb_tacexpr, Util.Empty.t) genarg_type
+val wit_ltac2_constr : (raw_tacexpr, Id.Set.t * glb_tacexpr) GenConstr.tag
 (** Ltac2 quotations in Gallina terms *)
 
 val wit_ltac2_tac : (raw_tacexpr, glb_tacexpr) Gentactic.tag
@@ -193,7 +192,7 @@ type var_quotation_kind =
   | PatternVar
   | HypVar
 
-val wit_ltac2_var_quotation : (lident option * lident, var_quotation_kind * Id.t, Util.Empty.t) genarg_type
+val wit_ltac2_var_quotation : (lident option * lident, var_quotation_kind * Id.t) GenConstr.tag
 (** Ltac2 quotations for variables "$x" or "$kind:foo" in Gallina terms.
     NB: "$x" means "$constr:x" *)
 

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -11,7 +11,6 @@
 open Util
 open Pp
 open Names
-open Genarg
 open Tac2ffi
 open Tac2env
 open Tac2expr
@@ -34,8 +33,8 @@ let gtypref kn = GTypRef (Other kn, [])
 
 let of_glob_constr (c:Glob_term.glob_constr) =
   match DAst.get c with
-  | GGenarg (GenArg (Glbwit tag, v)) ->
-    begin match genarg_type_eq tag wit_ltac2_var_quotation with
+  | GGenarg (Glb (tag, v)) ->
+    begin match GenConstr.eq tag wit_ltac2_var_quotation with
     | Some Refl ->
       begin match (fst v) with
       | ConstrVar -> GlbTacexpr (GTacVar (snd v))
@@ -390,7 +389,7 @@ let () =
         | HypVar -> str "hyp:"
       in
       str "$" ++ ppkind ++ Id.print id) in
-  Genprint.register_noval_print0 wit_ltac2_var_quotation pr_raw pr_glb
+  Genprint.register_constr_print wit_ltac2_var_quotation pr_raw pr_glb
 
 let () =
   let subs ntnvars globs (ids, tac as orig) =
@@ -434,7 +433,7 @@ let () =
     *)
     Genprint.PrinterBasic Pp.(fun _env _sigma -> ids ++ Tac2print.pr_glbexpr ~avoid:Id.Set.empty e)
   in
-  Genprint.register_noval_print0 wit_ltac2_constr pr_raw pr_glb
+  Genprint.register_constr_print wit_ltac2_constr pr_raw pr_glb
 
 let () =
   let pr_raw e = Genprint.PrinterBasic (fun _ _ ->

--- a/plugins/ltac2/tac2intern.ml
+++ b/plugins/ltac2/tac2intern.ml
@@ -2107,7 +2107,7 @@ let genintern ?check_unused ist locals expected v =
 
 let () =
   let open Genintern in
-  let intern ist tac =
+  let intern ?loc ist tac =
     let t_preterm = monomorphic (GTypRef (Other t_preterm, [])) in
     let ntn_vars = ist.intern_sign.notation_variable_status in
     let locals =
@@ -2128,9 +2128,9 @@ let () =
           CErrors.user_err ?loc:tac.loc Pp.(str "Cannot use binder notation variable " ++ Id.print id ++ str " as a preterm."))
         ids
     in
-    (ist, (ids, v))
+    (ids, v)
   in
-  Genintern.register_intern0 wit_ltac2_constr intern
+  Genintern.register_intern_constr wit_ltac2_constr intern
 
 let () =
   let open Genintern in
@@ -2142,10 +2142,10 @@ let () =
   in
   Gentactic.register_intern wit_ltac2_tac intern
 
-let () = Gensubst.register_subst0 wit_ltac2_constr (fun s (ids, e) -> ids, subst_expr s e)
+let () = Gensubst.register_constr_subst wit_ltac2_constr (fun s (ids, e) -> ids, subst_expr s e)
 let () = Gentactic.register_subst wit_ltac2_tac subst_expr
 
-let intern_var_quotation_gen ~ispat ist (kind, { CAst.v = id; loc }) =
+let intern_var_quotation_gen ?loc ~ispat ist (kind, { CAst.v = id; loc }) =
   let open Genintern in
   let kind = match kind with
     | None -> ConstrVar
@@ -2196,11 +2196,11 @@ let intern_var_quotation_gen ~ispat ist (kind, { CAst.v = id; loc }) =
   in
   let t = fresh_mix_type_scheme env t in
   let () = unify ?loc env t (GTypRef (Other typ, [])) in
-  (ist, (kind, id))
+  (kind, id)
 
-let intern_var_quotation = intern_var_quotation_gen ~ispat:false
+let intern_var_quotation ?loc = intern_var_quotation_gen ?loc ~ispat:false
 
-let () = Genintern.register_intern0 wit_ltac2_var_quotation intern_var_quotation
+let () = Genintern.register_intern_constr wit_ltac2_var_quotation intern_var_quotation
 
 let intern_var_quotation_pat ?loc ist v =
   intern_var_quotation_gen ~ispat:true ist v
@@ -2208,4 +2208,4 @@ let intern_var_quotation_pat ?loc ist v =
 let () = Genintern.register_intern_pat wit_ltac2_var_quotation
     intern_var_quotation_pat
 
-let () = Gensubst.register_subst0 wit_ltac2_var_quotation (fun _ v -> v)
+let () = Gensubst.register_constr_subst wit_ltac2_var_quotation (fun _ v -> v)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -1207,7 +1207,7 @@ let rec subst_glob_constr env subst = DAst.map (function
     else GHole nknd
 
   | GGenarg arg as raw ->
-    let arg' = Gensubst.generic_substitute subst arg in
+    let arg' = Gensubst.constr_subst subst arg in
     if arg' == arg then raw
     else GGenarg arg'
 

--- a/pretyping/genConstr.ml
+++ b/pretyping/genConstr.ml
@@ -1,0 +1,51 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module D = Dyn.Make()
+
+type ('raw, 'glb) tag = ('raw * 'glb) D.tag
+
+let create name = D.create name
+
+let eq t1 t2 = D.eq t1 t2
+
+let repr tag = D.repr tag
+
+type raw = Raw : ('raw, _) tag * 'raw -> raw
+
+type glb = Glb : (_, 'glb) tag * 'glb -> glb
+
+module Register(M : sig type ('raw, 'glb) t end) = struct
+
+  module V = struct type _ t = V : ('raw, 'glb) M.t -> ('raw * 'glb) t end
+
+  module VMap = D.Map(V)
+
+  let vals = ref VMap.empty
+
+  let mem tag = VMap.mem tag !vals
+
+  let register tag v =
+    assert (not @@ mem tag);
+    vals := VMap.add tag (V v) !vals
+
+  let find_opt tag =
+    try
+      let V v = VMap.find tag !vals in
+      Some v
+    with Not_found -> None
+
+  let get tag =
+    try
+      let V v = VMap.find tag !vals in
+      v
+    with Not_found -> assert false
+
+end

--- a/pretyping/genConstr.mli
+++ b/pretyping/genConstr.mli
@@ -1,0 +1,44 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Tags for extensible terms. The [raw] type is contained in
+    constrexpr, and the [glb] type in glob terms. *)
+type ('raw, 'glb) tag
+
+(** Create a new tag. Tags should be registered with
+    [GlobEnv.register_constr_interp0], [Genintern.register_intern_constr],
+    [Gensubst.register_constr_subst] and [Genprint.register_constr_print].
+
+    Also optionally
+    - [Genintern.register_ntn_subst0] (to be used in notations)
+
+    - [Genintern.register_intern_pat] and [Genintern.register_interp_pat]
+      (to be used in tactic patterns)
+*)
+val create : string -> _ tag
+
+val eq : ('raw1, 'glb1) tag -> ('raw2, 'glb2) tag -> ('raw1 * 'glb1, 'raw2 * 'glb2) Util.eq option
+
+val repr : _ tag -> string
+
+type raw = Raw : ('raw, _) tag * 'raw -> raw
+
+type glb = Glb : (_, 'glb) tag * 'glb -> glb
+
+module Register (M : sig type ('raw, 'glb) t end) : sig
+  val register : ('raw, 'glb) tag -> ('raw, 'glb) M.t -> unit
+
+  val mem : _ tag -> bool
+
+  val find_opt : ('raw, 'glb) tag -> ('raw, 'glb) M.t option
+
+  (** Assert false if not present *)
+  val get : ('raw, 'glb) tag -> ('raw, 'glb) M.t
+end

--- a/pretyping/genarg.mli
+++ b/pretyping/genarg.mli
@@ -15,23 +15,6 @@
     (raw level printers are always useful for clearer [-time] output, for beautify,
     and some other debug prints)
 
-    - extensible constr syntax beyond notations (eg [ltac:()], [ltac2:()] and ltac2 [$x]).
-      Such genargs appear in glob_term GGenarg and constrexpr CGenarg.
-      They must be registered with [Genintern.register_intern0]
-      and [GlobEnv.register_constr_interp0].
-
-      The glob level may be kept through notations and other operations like Ltac definitions
-      (eg [Ltac foo := exact ltac2:(foo)]) in which case [Gensubst.register_subst0]
-      and a glob level printer are useful.
-
-      Other useful registrations are
-      - [Genintern.register_intern_pat] and [Patternops.register_interp_pat]
-        to be used in tactic patterns.
-      - [Genintern.register_ntn_subst0] to be used in notations
-        (eg [Notation "foo" := ltac2:(foo)]).
-
-      NB: only the base [ExtraArg] is allowed here.
-
     - vernac arguments, used by vernac extend. Usually declared in mlg
       using VERNAC ARGUMENT EXTEND then used in VERNAC EXTEND.
 

--- a/pretyping/gensubst.ml
+++ b/pretyping/gensubst.ml
@@ -27,3 +27,17 @@ let register_subst0 = Subst.register0
 
 let generic_substitute subs (GenArg (Glbwit wit, v)) =
   in_gen (glbwit wit) (substitute wit subs v)
+
+module CSubstObj = struct
+  type (_, 'g) t = 'g subst_fun
+end
+
+module CSubst = GenConstr.Register(CSubstObj)
+
+let register_constr_subst = CSubst.register
+
+let constr_subst subst (GenConstr.Glb (tag, v) as o) =
+  let substf = CSubst.get tag in
+  let v' = substf subst v in
+  if v == v' then o else
+  GenConstr.Glb (tag, v')

--- a/pretyping/gensubst.mli
+++ b/pretyping/gensubst.mli
@@ -21,3 +21,7 @@ val generic_substitute : glob_generic_argument subst_fun
 
 val register_subst0 : ('raw, 'glb, 'top) genarg_type ->
   'glb subst_fun -> unit
+
+val constr_subst : GenConstr.glb subst_fun
+
+val register_constr_subst : (_, 'glb) GenConstr.tag -> 'glb subst_fun -> unit

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -191,17 +191,13 @@ type 'a obj_interp_fun =
 
 module ConstrInterpObj =
 struct
-  type ('r, 'g, 't) obj = 'g obj_interp_fun
-  let name = "constr_interp"
-  let default _ = None
+  type ('r, 'g) t = 'g obj_interp_fun
 end
 
-module ConstrInterp = Genarg.Register(ConstrInterpObj)
+module ConstrInterp = GenConstr.Register(ConstrInterpObj)
 
-let register_constr_interp0 = ConstrInterp.register0
+let register_constr_interp0 = ConstrInterp.register
 
-let interp_glob_genarg ?loc ~poly env sigma ty arg =
-  let open Genarg in
-  let GenArg (Glbwit tag, arg) = arg in
-  let interp = ConstrInterp.obj tag in
+let interp_glob_genarg ?loc ~poly env sigma ty (GenConstr.Glb (tag, arg)) =
+  let interp = ConstrInterp.get tag in
   interp ?loc ~poly env sigma ty arg

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -26,7 +26,7 @@ type 'a obj_interp_fun =
   'a -> unsafe_judgment * Evd.evar_map
 
 val register_constr_interp0 :
-  ('r, 'g, 't) Genarg.genarg_type -> 'g obj_interp_fun -> unit
+  (_, 'g) GenConstr.tag -> 'g obj_interp_fun -> unit
 
 (** {6 Pretyping name management} *)
 
@@ -95,4 +95,4 @@ val interp_ltac_id : t -> Id.t -> Id.t
     into account the possible renaming *)
 
 val interp_glob_genarg : ?loc:Loc.t -> poly:PolyFlags.t -> t -> evar_map -> Evardefine.type_constraint ->
-  Genarg.glob_generic_argument -> unsafe_judgment * evar_map
+  GenConstr.glb -> unsafe_judgment * evar_map

--- a/pretyping/glob_term.mli
+++ b/pretyping/glob_term.mli
@@ -113,7 +113,7 @@ type 'a glob_constr_r =
              'a glob_constr_g array * 'a glob_constr_g array
   | GSort of glob_sort
   | GHole of glob_evar_kind
-  | GGenarg of Genarg.glob_generic_argument
+  | GGenarg of GenConstr.glb
   | GCast of 'a glob_constr_g * Constr.cast_kind option * 'a glob_constr_g
   | GProj of (Constant.t * glob_instance option) * 'a glob_constr_g list * 'a glob_constr_g
   | GInt of Uint63.t

--- a/pretyping/pattern.mli
+++ b/pretyping/pattern.mli
@@ -46,7 +46,7 @@ type 'i constr_pattern_r =
 
 type constr_pattern = Util.Empty.t constr_pattern_r
 
-type uninstantiated_pattern = Genarg.glob_generic_argument constr_pattern_r
+type uninstantiated_pattern = GenConstr.glb constr_pattern_r
 
 (** Nota : in a [PCase], the array of branches might be shorter than
     expected, denoting the use of a final "_ => _" branch *)

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -57,4 +57,4 @@ type 'a pat_interp_fun = Environ.env -> Evd.evar_map -> Ltac_pretype.ltac_var_ma
 
 val interp_pattern : uninstantiated_pattern pat_interp_fun
 
-val register_interp_pat : (_, 'g, _) Genarg.genarg_type -> 'g pat_interp_fun -> unit
+val register_interp_pat : (_, 'g) GenConstr.tag -> 'g pat_interp_fun -> unit

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -632,7 +632,7 @@ type pretyper = {
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
   pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
-  pretype_genarg : pretyper -> Genarg.glob_generic_argument -> unsafe_judgment pretype_fun;
+  pretype_genarg : pretyper -> GenConstr.glb -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -202,7 +202,7 @@ type pretyper = {
   pretype_rec : pretyper -> glob_fix_kind * Id.t array * glob_decl list array * glob_constr array * glob_constr array -> unsafe_judgment pretype_fun;
   pretype_sort : pretyper -> glob_sort -> unsafe_judgment pretype_fun;
   pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
-  pretype_genarg : pretyper -> Genarg.glob_generic_argument -> unsafe_judgment pretype_fun;
+  pretype_genarg : pretyper -> GenConstr.glb -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * Constr.cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;

--- a/printing/genprint.mli
+++ b/printing/genprint.mli
@@ -56,3 +56,12 @@ val generic_raw_print : rlevel generic_argument printer
 val generic_glb_print : glevel generic_argument printer
 val generic_top_print : tlevel generic_argument top_printer
 val generic_val_print : Geninterp.Val.t top_printer
+
+(* For terms *)
+(* XXX do we need the full complexity of [printer]? especially since
+   ppconstr currently doesn't pass a level *)
+val register_constr_print : ('raw, 'glb) GenConstr.tag ->
+  'raw printer -> 'glb printer -> unit
+
+val raw_print_constr : GenConstr.raw printer
+val glb_print_constr : GenConstr.glb printer

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -623,28 +623,25 @@ let pr_cast = let open Constr in function
     | None -> str ":>"
 
 type raw_or_glob_genarg =
-  | Rawarg of Genarg.raw_generic_argument
-  | Globarg of Genarg.glob_generic_argument
+  | Rawarg of GenConstr.raw
+  | Globarg of GenConstr.glb
 
 let pr_genarg return arg =
   (* In principle this may use the env/sigma, in practice not sure if it
      does except through pr_constr_expr in beautify mode. *)
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let name, parg = let open Genarg in
+  let name, parg =
     match arg with
-    | Globarg arg ->
-      let GenArg (Glbwit tag, _) = arg in
-      begin match tag with
-      | ExtraArg tag -> ArgT.repr tag, Pputils.pr_glb_generic env sigma arg
-      | _ -> assert false
-      end
-    | Rawarg arg ->
-      let GenArg (Rawwit tag, _) = arg in
-      begin match tag with
-      | ExtraArg tag -> ArgT.repr tag, Pputils.pr_raw_generic env sigma arg
-      | _ -> assert false
-      end
+    | Globarg (Glb (tag, _) as arg) ->
+      GenConstr.repr tag, Genprint.glb_print_constr arg
+    | Rawarg (Raw (tag, _) as arg) ->
+      GenConstr.repr tag, Genprint.raw_print_constr arg
+  in
+  let parg = match parg with
+    | PrinterBasic pp -> pp env sigma
+    | PrinterNeedsLevel { default_already_surrounded = level; printer } ->
+      printer env sigma level
   in
   let name =
     (* cheat the name system


### PR DESCRIPTION
Instead we have a separate Dyn

I kept the registers next to the genarg registers (ie in gensubst.ml genintern.ml etc), but we could probably move genarg up to vernac if we change that.
EDIT except for Val since that's still in pretyping arguments

Overlays:
- https://github.com/coq-tactician/coq-tactician/pull/126
- https://github.com/mattam82/Coq-Equations/pull/694
- https://github.com/LPCIC/coq-elpi/pull/955