### PR TITLE
Assumptions.traverse: return multiset instead of set

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,3 +1,11 @@
+## Changes between Rocq 9.2 and Rocq 9.3
+
+### Vernac
+
+- `Assumptions.traverse` now returns `int GlobRef.Map_env.t` (multisets)
+  instead of `GlobRef.Set_env.t` (sets). This allows callers to see how many
+  times each reference appears, useful for dependency analysis tools.
+
 ## Changes between Coq 8.17 and Coq 8.18
 
 ### XML protocol

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -23,7 +23,7 @@ open Printer
 *)
 val traverse :
   Global.indirect_accessor -> GlobRef.t list ->
-    (GlobRef.Set_env.t * GlobRef.Set_env.t option GlobRef.Map_env.t *
+    (int GlobRef.Map_env.t * int GlobRef.Map_env.t option GlobRef.Map_env.t *
      (GlobRef.t * Constr.rel_context * types) list GlobRef.Map_env.t)
 
 (** Collects all the assumptions (optionally including opaque definitions)


### PR DESCRIPTION
Add GlobRef.Multiset_env module (map from GlobRef to int count) and change Assumptions.traverse to return multisets instead of sets. This allows callers to see how many times each reference appears, which is useful for dependency analysis tools like coq-dpdgraph's SearchDepend.  This will allow coq-dpdgraph to route through `traverse`.

- [x] Added **changelog**.

- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
