### PR TITLE
Add private constructors to GADT indices types

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -12,8 +12,8 @@ exception ParseError of string
 
 (* Functorial interface *)
 
-type norec
-type mayrec
+type norec = private [ `norec ]
+type mayrec = private [ `mayrec ]
 
 module type S = sig
   type keyword_state


### PR DESCRIPTION
Starting from OCaml 5.5, abstract types will stop being considered distinguishable solely based on them having different names in the current namespace. Instead, they must rely on existing discriminating features such as different constructors. Private constructors in an implementation make this apparent as they can serve basically no other purpose.
A regular constructor would incur warning "unused-constructor", which would not happen in OCaml 5.5, but this solution is backwards compatible.

(After this fix, Rocq fully compiles with OCaml 5.5.0+dev2, thank you @kit-ty-kate for noticing the issue)