### PR TITLE
Add support for OCaml 5.5

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -12,8 +12,8 @@ exception ParseError of string
 
 (* Functorial interface *)
 
-type norec
-type mayrec
+type norec = private [`NoRec]
+type mayrec = private [`MayRec]
 
 module type S = sig
   type keyword_state


### PR DESCRIPTION
This adds support for the upcoming OCaml release.
The reason for this change is detailed in https://github.com/ocaml/ocaml/issues/14224