### PR TITLE
Revert "custom parsers do not use continue_parser"

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1617,7 +1617,7 @@ module Entry = struct
   let of_parser_val e { parser_fun = p } = {
     eentry = e;
     estart = (fun gstate _ (strm:_ LStream.t) -> p gstate.kwstate strm);
-    econtinue = (fun _ _ _ _ _ (strm__ : _ LStream.t) -> assert false);
+    econtinue = (fun _ _ _ _ _ (strm__ : _ LStream.t) -> Error ());
     edesc = Dparser p;
   }
   let of_parser n p estate =


### PR DESCRIPTION
It seems to be possible to hit this code through the recovery code in `parser_cont`.

For instance download
https://github.com/impermeable/coq-waterproof/commit/004b4f25701a160bf842a5b225f548f1431013c7 remove the Waterproof Notation for `;` in Waterproof.v and compile with Rocq V9.2+rc1 (needs some more overlays for master).

The assert failure will be triggered eg in test TakeSuchThat line 66 `Take x : nat; such that x > 1 as (i).`.

(proof mode entry is a of_parser entry, it successfully parses `Take x : nat`, rejects `;` then gramlib tries to recover)

This reverts commit c7da07d72e647516e5b416cf9a1ae251a33b9881 (the raise became a functional Error).
