### PR TITLE
Typecheck ignoring errors instead of globalize for Ltac2 Globalize

### DIFF
--- a/plugins/ltac2/tac2entries.ml
+++ b/plugins/ltac2/tac2entries.ml
@@ -1599,8 +1599,9 @@ let typecheck_expr e =
 
 let globalize_expr e =
   let avoid = Id.Set.empty in
-  let e = Tac2intern.debug_globalize_allow_ext avoid e in
-  Feedback.msg_notice (Tac2print.pr_rawexpr_gen E5 ~avoid e)
+  let e, t, errors = Tac2intern.intern_accumulate_errors ~strict:false [] e in
+  (* XXX print type and errors? *)
+  Feedback.msg_notice (Tac2print.pr_glbexpr_gen E5 ~avoid e)
 
 (** Calling tactics *)
 

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -418,7 +418,6 @@ let () =
   let pr_raw e = Genprint.PrinterBasic (fun _env _sigma ->
       let avoid = Id.Set.empty in
       (* FIXME avoid set, same as pr_glb *)
-      let e = Tac2intern.debug_globalize_allow_ext avoid e in
       Tac2print.pr_rawexpr_gen ~avoid E5 e) in
   let pr_glb (ids, e) =
     let ids =
@@ -438,7 +437,6 @@ let () =
 
 let () =
   let pr_raw e = Genprint.PrinterBasic (fun _ _ ->
-      let e = Tac2intern.debug_globalize_allow_ext Id.Set.empty e in
       Tac2print.pr_rawexpr_gen ~avoid:Id.Set.empty E5 e)
   in
   let pr_glb e = Genprint.PrinterBasic (fun _ _ -> Tac2print.pr_glbexpr ~avoid:Id.Set.empty e) in

--- a/plugins/ltac2/tac2intern.mli
+++ b/plugins/ltac2/tac2intern.mli
@@ -19,6 +19,9 @@ val intern_typedef : (KerName.t * int) Id.Map.t -> raw_quant_typedef -> glb_quan
 val intern_open_type : raw_typexpr -> type_scheme
 val intern_notation_data : Id.Set.t -> raw_tacexpr -> Tac2env.notation_data
 
+val intern_accumulate_errors : strict:bool -> context -> raw_tacexpr ->
+  glb_tacexpr * type_scheme * Pp.t Loc.located list
+
 (** [check_unused] is default true *)
 val genintern_warn_not_unit : ?check_unused:bool ->
   Genintern.glob_sign ->
@@ -65,10 +68,6 @@ val subst_rawexpr : substitution -> raw_tacexpr -> raw_tacexpr
 val globalize : Id.Set.t -> raw_tacexpr -> raw_tacexpr
 (** Replaces all qualified identifiers by their corresponding kernel name. The
     set represents bound variables in the context. *)
-
-val debug_globalize_allow_ext : Id.Set.t -> raw_tacexpr -> raw_tacexpr
-(** Variant of globalize which can accept CTacExt using the provided function.
-    Intended for debugging. *)
 
 (** Errors *)
 

--- a/plugins/ltac2/tac2typing_env.mli
+++ b/plugins/ltac2/tac2typing_env.mli
@@ -21,8 +21,14 @@ end
 
 type t
 
-(** default strict:true *)
-val empty_env : ?strict:bool -> unit -> t
+(** default strict:true, accumulate_errors:false *)
+val empty_env : ?strict:bool -> ?accumulate_errors:bool -> unit -> t
+
+(** In accumulate mode, add the error to the list in the env. Otherwise raise UserError. *)
+val add_error : ?loc:Loc.t -> t -> Pp.t -> unit
+
+(** Get accumulated errors. Assertion failure if not in accumulate mode. *)
+val get_errors : t -> Pp.t Loc.located list
 
 val set_rec : (KerName.t * int) Id.Map.t -> t -> t
 

--- a/test-suite/output/ltac2_check_globalize.out
+++ b/test-suite/output/ltac2_check_globalize.out
@@ -16,25 +16,26 @@ let x := fun x => x in
 let _ := x 1 in
 let _ := x "" in
 () : unit
-let accu := { contents := []} in
-(let x := fun x => accu.(contents) := (x :: accu.(contents)) in
- let _ := x 1 in
- let _ := x "" in
- ());
+let accu := { contents := [] } in
+let _ :=
+  let x := fun x => accu.(contents) := (x :: accu.(contents)) in
+  let _ := x 1 in
+  let _ := x "" in
+  ()
+in
 accu.(contents)
 File "./output/ltac2_check_globalize.v", line 38, characters 0-144:
 The command has indeed failed with message:
 This expression has type string but an expression was expected of type 
 int
-let (m : '__α Pattern.goal_matching) :=
-  ([(([(None, (Pattern.MatchPattern, pat:(_)))],
+let m :=
+  [(([(None, (Pattern.MatchPattern, pat:(_)))],
       (Pattern.MatchPattern, pat:(_))),
      (fun h =>
       let h := Array.get h 0 in
       fun _ => fun _ => fun _ => fun _ => Std.clear h));
-     (([], (Pattern.MatchPattern, pat:(_))),
+    (([], (Pattern.MatchPattern, pat:(_))),
       (fun _ => fun _ => fun _ => fun _ => fun _ => ()))]
-    : _ Pattern.goal_matching)
 in
-Pattern.lazy_goal_match0 false m :'__α
+Pattern.lazy_goal_match0 false m
 constr:(ltac2:(()))

--- a/test-suite/output/ltac2_typed_notations.out
+++ b/test-suite/output/ltac2_typed_notations.out
@@ -2,12 +2,10 @@ File "./output/ltac2_typed_notations.v", line 5, characters 9-10:
 The command has indeed failed with message:
 This expression has type bool but an expression was expected of type 
 constr
-fun (b : bool) =>
-(let c := b in
- let (m : '__α Pattern.constr_matching) :=
-   [(Pattern.MatchPattern, pat:(true),
-     (fun _ => fun (_ : constr array) => true));
-     (Pattern.MatchPattern, pat:(false),
-      (fun _ => fun (_ : constr array) => false))]
- with (t : constr) := c in
- Pattern.one_match0 t m :'__α : bool)
+fun b =>
+let c := b in
+let m :=
+  [(Pattern.MatchPattern, pat:(true), (fun _ => fun _ => true));
+    (Pattern.MatchPattern, pat:(false), (fun _ => fun _ => false))]
+with t := c in
+Pattern.one_match0 t m


### PR DESCRIPTION
This adds a mode to ltac2 typechecking which accumulates errors instead of raising an exception at the first error.

Ltac2 Globalize then uses this mode and ignores the accumulated errors (we could print them instead).

The accumulation mode could also be used to provide all errors from an ltac2 expression in regular code in the future (with a flag).

Together with #21617 this gets us closer to removing the globalize code (which doesn't work on quotations so should be avoided).