### PR TITLE
fix bug in Procq.parse_string

### DIFF
--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -274,7 +274,8 @@ let eoi_entry en =
    (use eoi_entry) *)
 
 let parse_string f ?loc x =
-  let strm = Stream.of_string x in
+  let offset = loc |> Option.map (fun loc -> loc.Loc.bp) in
+  let strm = Stream.of_string ?offset x in
   Entry.parse f (Parsable.make ?loc strm)
 
 module GrammarObj =


### PR DESCRIPTION
Fix incorrect handling of locations in `Procq.parse_string` as discussed with Gaëtan on zulip [#Rocq devs &amp; plugin devs > extend constr grammar @ 💬](https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/extend.20constr.20grammar/near/573358918)