### PR TITLE
Only expose 1 state monad API in evd

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1472,7 +1472,7 @@ let set_extra_data extras evd = { evd with extras }
 (*******************************************************************)
 (* The state monad with state an evar map. *)
 
-module MonadR =
+module Monad =
   Monad.Make (struct
 
     type +'a t = evar_map -> evar_map * 'a
@@ -1489,26 +1489,6 @@ module MonadR =
 
     let map f x = fun s ->
       on_snd f (x s)
-
-  end)
-
-module Monad =
-  Monad.Make (struct
-
-    type +'a t = evar_map -> 'a * evar_map
-
-    let return a = fun s -> (a,s)
-
-    let (>>=) x f = fun s ->
-      let (a,s') = x s in
-      f a s'
-
-    let (>>) x y = fun s ->
-      let ((),s') = x s in
-      y s'
-
-    let map f x = fun s ->
-      on_fst f (x s)
 
   end)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -503,8 +503,7 @@ val set_extra_data : Store.t -> evar_map -> evar_map
 
 (** {5 The state monad with state an evar map} *)
 
-module MonadR : Monad.S with type +'a t = evar_map -> evar_map * 'a
-module Monad  : Monad.S with type +'a t = evar_map -> 'a * evar_map
+module Monad : Monad.S with type +'a t = evar_map -> evar_map * 'a
 
 (** Unification constraints *)
 type conv_pb = Conversion.conv_pb

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1740,7 +1740,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           let (sigma,c_interp) = interp_type ist env sigma c in
           sigma , (interp_ident ist env sigma id,n,c_interp) in
         let (sigma,l_interp) =
-          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l sigma
+          Evd.Monad.List.map_right (fun c sigma -> f sigma c) l sigma
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (FixTactics.mutual_fix (interp_ident ist env sigma id) n l_interp)
@@ -1756,7 +1756,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           let (sigma,c_interp) = interp_type ist env sigma c in
           sigma , (interp_ident ist env sigma id,c_interp) in
         let (sigma,l_interp) =
-          Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l sigma
+          Evd.Monad.List.map_right (fun c sigma -> f sigma c) l sigma
         in
         Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (FixTactics.mutual_cofix (interp_ident ist env sigma id) l_interp)

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -645,7 +645,7 @@ module Interp = struct
     | Lazy f -> sigma , Lazy (interp_flag ist env sigma f)
     | Pattern l ->
       let (sigma,l_interp) =
-        Evd.MonadR.List.map_right
+        Evd.Monad.List.map_right
           (fun c sigma -> interp_constr_with_occurrences ist env sigma c) l sigma
       in
       sigma , Pattern l_interp


### PR DESCRIPTION
The convention is to return evar map on the left, there is no reason to expose a state monad where it's returned on the right.
