### PR TITLE
Cleanup beautify handling

### DIFF
--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -461,8 +461,7 @@ and ``rocq repl``, unless stated otherwise:
   removed tokens.  Requires that ``-color`` is enabled.  (see Section
   :ref:`showing_diffs`).
 :-beautify: Pretty-print each command to *file.beautified* when
-  compiling *file.v*, in order to get old-fashioned
-  syntax/definitions/notations.
+  compiling *file.v*. Very buggy.
 :-emacs, -ide-slave: Start a special toplevel to communicate with a
   specific IDE.
 :-impredicative-set: Change the logical theory of Rocq by declaring the

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -50,6 +50,8 @@ module type S = sig
 
     val comments : t -> ((int * int) * string) list
 
+    val drop_comments : t -> unit
+
     val loc : t -> Loc.t
     (** [loc pa] Return parsing position for [pa] *)
 
@@ -1592,6 +1594,8 @@ module Parsable = struct
     {pa_tok_strm = ts; lexer_state}
 
   let comments p = L.State.get_comments !(p.lexer_state)
+
+  let drop_comments p = p.lexer_state := L.State.drop_comments !(p.lexer_state)
 
   let loc t = LStream.current_loc t.pa_tok_strm
   let consume { pa_tok_strm } len kwstate = LStream.njunk kwstate len pa_tok_strm

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -60,6 +60,7 @@ module type S = sig
     type t
     val make : ?loc:Loc.t -> (unit,char) Stream.t -> t
     val comments : t -> ((int * int) * string) list
+    val drop_comments : t -> unit
     val loc : t -> Loc.t
     val consume : t -> int -> unit with_kwstate
   end

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -32,6 +32,7 @@ module type S = sig
     val get : unit -> t
     val drop : unit -> unit
     val get_comments : t -> ((int * int) * string) list
+    val drop_comments : t -> t
   end
 
 end

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -490,7 +490,7 @@ let adjust_implicit_arguments ~flags inctx n args impl =
           (flags.ExternFlags.implicits && flags.ExternFlags.implicits_explicit_args) ||
           (is_needed_for_correct_partial_application tail imp) ||
           (flags.ExternFlags.implicits_defensive &&
-           (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
+           (not (is_inferable_implicit inctx n imp)) &&
            is_significant_implicit (Lazy.force a))
         in
         if visible then

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -45,10 +45,6 @@ let in_ml_toplevel = ref false
 
 let in_synterp_phase = ref None
 
-(* Translate *)
-let beautify = ref false
-let beautify_file = ref false
-
 (* Silent / Verbose *)
 let quiet = ref false
 let silently f x = with_option quiet f x

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -42,10 +42,6 @@ val in_ml_toplevel : bool ref
 (* Used to check stages are used correctly. *)
 val in_synterp_phase : bool option ref
 
-(* Beautify command line flags, should move to printing? *)
-val beautify : bool ref
-val beautify_file : bool ref
-
 (* Rocq quiet mode. Note that normal mode is called "verbose" here,
    whereas [quiet] suppresses normal output such as goals in rocq repl *)
 val quiet : bool ref

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -793,6 +793,7 @@ module MakeLexer (Diff : sig val mode : bool end)
     let get () =
       (!comment_begin, Buffer.contents current_comment, !between_commands, !comments)
     let drop () = set (init ())
+    let drop_comments (o,s,b,_) = (o,s,b,[])
     let get_comments (_,_,_,c) = c
 
   end

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -184,7 +184,7 @@ let pr_generalization bk c =
   str "`" ++ str hd ++ c ++ str tl
 
 let pr_com_at n =
-  if !Flags.beautify && not (Int.equal n 0) then comment (Pputils.extract_comments n)
+  if not (Int.equal n 0) then comment (Pputils.extract_comments n)
   else mt()
 
 let pr_with_comments ?loc pp = pr_located (fun x -> x) (loc, pp)

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -64,7 +64,6 @@ type coqargs_config = {
   native_include_dirs : CUnix.physical_path list;
   output_directory : CUnix.physical_path option;
   exclude_dirs : CUnix.physical_path list;
-  beautify : bool;
   quiet : bool;
   time : time_config option;
   test_mode : bool;
@@ -127,7 +126,6 @@ let default_config = {
   native_include_dirs = [];
   output_directory = None;
   exclude_dirs = [];
-  beautify = false;
   quiet = false;
   time = None;
   test_mode = false;
@@ -376,7 +374,6 @@ let parse_args ~init arglist : t * string list =
 
     (* Options with zero arg *)
     |"-test-mode" -> { oval with config = { oval.config with test_mode = true } }
-    |"-beautify" -> { oval with config = { oval.config with beautify = true } }
     |"-config"|"--config" -> set_query oval PrintConfig
 
     |"-bt" -> add_set_debug oval "backtrace"

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -59,7 +59,6 @@ type coqargs_config = {
   native_include_dirs : CUnix.physical_path list;
   output_directory : CUnix.physical_path option;
   exclude_dirs : CUnix.physical_path list;
-  beautify : bool;
   quiet : bool;
   time : time_config option;
   test_mode : bool;

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -192,12 +192,6 @@ let init_document opts =
   (* Test mode *)
   Flags.test_mode := opts.config.test_mode;
 
-  (* beautify *)
-  if opts.config.beautify then begin
-    Flags.beautify := true;
-    CLexer.record_comments := true;
-  end;
-
   if opts.config.quiet then begin
     Flags.quiet := true;
   end;

--- a/test-suite/misc/comment-lexing/test.v.beautified
+++ b/test-suite/misc/comment-lexing/test.v.beautified
@@ -17,11 +17,13 @@ intro c0.
       et on doit alors prouver [coul_suiv c0 = Vert]
       sous cette hypothèse supplémentaire ;
       lorsque l'on introduit une hypothèse, on lui donne un nom. *)
+
 intro c0rou.
 (* /!\   CRASH ON THIS LINE   /!\ *)
 (** Le raisonnement sous-jacent est :
       soit c0rou une preuve arbitraire (inconnue) de [c0 = Rouge],
       on peut s'en servir pour démontrer coul_suiv [c0 = Vert]. *)
+
 rewrite c0rou.
 cbn[coul_suiv].
 reflexivity.

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -36,6 +36,8 @@ let compile opts stm_options injections copts ~f_in ~f_out =
   in
   let long_f_dot_in, long_f_dot_out =
     ensure_exists_with_prefix ~src:f_in ~tgt:f_out ~src_ext:ext_in ~tgt_ext:ext_out in
+  let beautify = copts.beautify in
+  let () = if beautify then CLexer.record_comments := true in
   match mode with
   | BuildVo | BuildVok ->
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
@@ -59,7 +61,7 @@ let compile opts stm_options injections copts ~f_in ~f_out =
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
       let source = source ldir long_f_dot_in in
-      let state = Vernac.load_vernac ~check ~state ~source long_f_dot_in in
+      let state = Vernac.load_vernac ~beautify ~check ~state ~source long_f_dot_in in
       let fullstate = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs ~filename:long_f_dot_in fullstate;
       let () = Stm.join ~doc:state.doc in
@@ -84,7 +86,7 @@ let compile opts stm_options injections copts ~f_in ~f_out =
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       let source = source ldir long_f_dot_in in
-      let state = Vernac.load_vernac ~check:false ~source ~state long_f_dot_in in
+      let state = Vernac.load_vernac ~beautify ~check:false ~source ~state long_f_dot_in in
       let state = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs state ~filename:long_f_dot_in;
       let () = Stm.snapshot_vos ~doc ~output_native_objects ldir long_f_dot_out in
@@ -98,11 +100,7 @@ let compile opts stm_opts copts injections ~f_in ~f_out =
 
 let compile_file opts stm_opts copts injections f_in =
   let f_out = copts.compilation_output_name in
-  if !Flags.beautify then
-    Flags.with_option Flags.beautify_file
-      (fun f_in -> compile opts stm_opts copts injections ~f_in ~f_out) f_in
-  else
-    compile opts stm_opts copts injections ~f_in ~f_out
+  compile opts stm_opts copts injections ~f_in ~f_out
 
 let compile_file opts stm_opts copts injections =
   Option.iter (compile_file opts stm_opts copts injections) copts.compile_file

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -20,6 +20,8 @@ type t =
   ; compile_file: string option
   ; compilation_output_name : string option
 
+  ; beautify : bool
+
   ; glob_out    : glob_output option
 
   ; output_context : bool
@@ -30,6 +32,8 @@ let default =
 
   ; compile_file = None
   ; compilation_output_name = None
+
+  ; beautify = false
 
   ; glob_out = None
 
@@ -100,6 +104,7 @@ let parse arglist : t =
         (* Non deprecated options *)
         | "-output-context" ->
           { oval with output_context = true }
+        |"-beautify" -> { oval with beautify = true }
         (* Output filename *)
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -32,6 +32,8 @@ type t =
   ; compile_file: string option  (* bool is verbosity  *)
   ; compilation_output_name : string option
 
+  ; beautify : bool
+
   ; glob_out    : glob_output option
 
   ; output_context : bool

--- a/toplevel/load.ml
+++ b/toplevel/load.ml
@@ -28,11 +28,8 @@ let load_vernacular opts ~state =
   List.fold_left
     (fun state f_in ->
       let s = Loadpath.locate_file f_in in
-      (* Should make the beautify logic clearer *)
       let load_vernac f = Vernac.load_vernac ~check:true ~state f in
-      if !Flags.beautify
-      then Flags.with_option Flags.beautify_file load_vernac f_in
-      else load_vernac s
+      load_vernac s
     ) state opts.pre.load_vernacular_list
 
 let load_init_vernaculars opts ~state =

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -32,5 +32,5 @@ val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
 
 (** [load_vernac sid file] Loads [file] on top of [sid].
     Callers are expected to handle and print errors in form of exceptions. *)
-val load_vernac : check:bool ->
+val load_vernac : ?beautify:bool -> check:bool ->
   state:State.t -> ?source:Loc.source -> string -> State.t


### PR DESCRIPTION
- remove Flags.beautify and beautify_file

- `-beautify` is now only supported for compile mode

- beautify printing is done incrementally between parsing and executing commands instead of all at once at the end of the file. This prevents errors from notations disappearing etc (close #8640).

- cleanup comment handling functions (extract_comments and Pp comment printing)

- stop checking the flag in constrextern (anyway extern should not be used in beautify since cf049ec9e1)
