### PR TITLE
Remove -load-vernac-source-verbose and -verbose command line flags

### DIFF
--- a/boot/usage.ml
+++ b/boot/usage.ml
@@ -40,8 +40,6 @@ let print_usage_common co command =
 \n\
 \n  -load-vernac-source f  load Rocq file f.v (Load \"f\".)\
 \n  -l f                   (idem)\
-\n  -load-vernac-source-verbose f  load Rocq file f.v (Load Verbose \"f\".)\
-\n  -lv f	           (idem)\
 \n  -require lib           load Rocq library lib (Require lib)\
 \n  -require-import lib, -ri lib\
 \n                         load and import Rocq library lib\

--- a/doc/changelog/08-vernac-commands-and-options/21626-noverbose-Removed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21626-noverbose-Removed.rst
@@ -1,0 +1,7 @@
+- **Removed:**
+  `-verbose` and `load-vernac-source-verbose` (`-lv`).
+  `-verbose` has been ignored for several versions.
+  `-lv` would print the input file (as-is from source, not pretty printed)
+  which does not seem useful
+  (`#21626 <https://github.com/rocq-prover/rocq/pull/21626>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -326,9 +326,6 @@ and ``rocq repl``, unless stated otherwise:
 :-q: Do not to load the default resource file.
 :-l *file*, -load-vernac-source *file*: Load and execute the Rocq
   script from *file.v*.
-:-lv *file*, -load-vernac-source-verbose *file*: Load and execute the
-  Rocq script from *file.v*. Write its contents to the standard output as
-  it is executed.
 :-require *qualid*: Load Rocq compiled library :n:`@qualid`.
   This is equivalent to running :cmd:`Require` :n:`@qualid`
   (note: the short form `-r *qualid*` is intentionally not provided to
@@ -372,8 +369,6 @@ and ``rocq repl``, unless stated otherwise:
   order of command-line options.
 :-load-vernac-object *qualid*: Obsolete synonym of :n:`-require qualid`.
 :-batch: Exit just after argument parsing. Available for ``rocq repl`` only.
-:-verbose: Output the content of the input file as it is compiled.
-  This option is available for ``rocq compile`` only.
 :-native-compiler (yes|no|ondemand): Enable the :tacn:`native_compute`
   reduction machine and precompilation to ``.cmxs`` files for future use
   by :tacn:`native_compute`.

--- a/sysinit/coqargs.ml
+++ b/sysinit/coqargs.ml
@@ -86,7 +86,7 @@ type coqargs_pre = {
   ml_includes : string list;
   vo_includes : vo_path list;
 
-  load_vernacular_list : (string * bool) list;
+  load_vernacular_list : string list;
   injections  : injection_command list;
 }
 
@@ -173,8 +173,8 @@ let add_vo_include opts unix_path rocq_path implicit =
 let add_vo_require opts d ?(allow_failure=false) p export =
   { opts with pre = { opts.pre with injections = RequireInjection {lib=d; prefix=p; export; allow_failure} :: opts.pre.injections }}
 
-let add_load_vernacular opts verb s =
-    { opts with pre = { opts.pre with load_vernacular_list = (CUnix.make_suffix s ".v",verb) :: opts.pre.load_vernacular_list }}
+let add_load_vernacular opts s =
+    { opts with pre = { opts.pre with load_vernacular_list = (CUnix.make_suffix s ".v") :: opts.pre.load_vernacular_list }}
 
 let add_set_option opts opt_name value =
   { opts with pre = { opts.pre with injections = OptionInjection (opt_name, value) :: opts.pre.injections }}
@@ -301,10 +301,7 @@ let parse_args ~init arglist : t * string list =
       { oval with config = { oval.config with rcfile = Some (next ()); }}
 
     |"-load-vernac-source"|"-l" ->
-      add_load_vernacular oval false (next ())
-
-    |"-load-vernac-source-verbose"|"-lv" ->
-      add_load_vernacular oval true (next ())
+      add_load_vernacular oval (next ())
 
     |"-mangle-names" ->
       let oval = add_set_option oval ["Mangle"; "Names"] (OptionSet None) in

--- a/sysinit/coqargs.mli
+++ b/sysinit/coqargs.mli
@@ -81,7 +81,7 @@ type coqargs_pre = {
   ml_includes : CUnix.physical_path list;
   vo_includes : vo_path list;
 
-  load_vernacular_list : (string * bool) list;
+  load_vernacular_list : string list;
   injections  : injection_command list;
 }
 

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -22,7 +22,7 @@ let source ldir file = Loc.InFile {
   }
 
 (* Compile a vernac file *)
-let compile opts stm_options injections copts ~echo ~f_in ~f_out =
+let compile opts stm_options injections copts ~f_in ~f_out =
   let open Vernac.State in
   let output_native_objects = match opts.config.native_compiler with
     | NativeOff -> false | NativeOn {ondemand} -> not ondemand
@@ -59,7 +59,7 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       let wall_clock1 = Unix.gettimeofday () in
       let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
       let source = source ldir long_f_dot_in in
-      let state = Vernac.load_vernac ~echo ~check ~state ~source long_f_dot_in in
+      let state = Vernac.load_vernac ~check ~state ~source long_f_dot_in in
       let fullstate = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs ~filename:long_f_dot_in fullstate;
       let () = Stm.join ~doc:state.doc in
@@ -84,25 +84,25 @@ let compile opts stm_options injections copts ~echo ~f_in ~f_out =
       let state = Load.load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       let source = source ldir long_f_dot_in in
-      let state = Vernac.load_vernac ~echo ~check:false ~source ~state long_f_dot_in in
+      let state = Vernac.load_vernac ~check:false ~source ~state long_f_dot_in in
       let state = Stm.finish ~doc:state.doc in
       ensure_no_pending_proofs state ~filename:long_f_dot_in;
       let () = Stm.snapshot_vos ~doc ~output_native_objects ldir long_f_dot_out in
       Stm.reset_task_queue ();
       ()
 
-let compile opts stm_opts copts injections ~echo ~f_in ~f_out =
+let compile opts stm_opts copts injections ~f_in ~f_out =
   ignore(CoqworkmgrApi.get 1);
-  compile opts stm_opts injections copts ~echo ~f_in ~f_out;
+  compile opts stm_opts injections copts ~f_in ~f_out;
   CoqworkmgrApi.giveback 1
 
-let compile_file opts stm_opts copts injections (f_in, echo) =
+let compile_file opts stm_opts copts injections f_in =
   let f_out = copts.compilation_output_name in
   if !Flags.beautify then
     Flags.with_option Flags.beautify_file
-      (fun f_in -> compile opts stm_opts copts injections ~echo ~f_in ~f_out) f_in
+      (fun f_in -> compile opts stm_opts copts injections ~f_in ~f_out) f_in
   else
-    compile opts stm_opts copts injections ~echo ~f_in ~f_out
+    compile opts stm_opts copts injections ~f_in ~f_out
 
 let compile_file opts stm_opts copts injections =
   Option.iter (compile_file opts stm_opts copts injections) copts.compile_file

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -29,10 +29,8 @@ type glob_output =
 type t =
   { compilation_mode : compilation_mode
 
-  ; compile_file: (string * bool) option  (* bool is verbosity  *)
+  ; compile_file: string option  (* bool is verbosity  *)
   ; compilation_output_name : string option
-
-  ; echo : bool
 
   ; glob_out    : glob_output option
 

--- a/toplevel/coqrc.ml
+++ b/toplevel/coqrc.ml
@@ -21,7 +21,7 @@ let load_rcfile ~rcfile ~state =
       match rcfile with
       | Some rcfile ->
         if CUnix.file_readable_p rcfile then
-          Vernac.load_vernac ~echo:false ~check:true ~state rcfile
+          Vernac.load_vernac ~check:true ~state rcfile
         else raise (Sys_error ("Cannot read rcfile: "^ rcfile))
       | None ->
         try
@@ -32,7 +32,7 @@ let load_rcfile ~rcfile ~state =
             Envars.home ~warn / "."^rcdefaultname^"."^Coq_config.version;
             Envars.home ~warn / "."^rcdefaultname
           ] in
-          Vernac.load_vernac ~echo:false ~check:true ~state inferedrc
+          Vernac.load_vernac ~check:true ~state inferedrc
         with Not_found -> state
         (*
         Flags.if_verbose

--- a/toplevel/load.ml
+++ b/toplevel/load.ml
@@ -26,10 +26,10 @@ let load_init_file opts ~state =
 
 let load_vernacular opts ~state =
   List.fold_left
-    (fun state (f_in, echo) ->
+    (fun state f_in ->
       let s = Loadpath.locate_file f_in in
       (* Should make the beautify logic clearer *)
-      let load_vernac f = Vernac.load_vernac ~echo ~check:true ~state f in
+      let load_vernac f = Vernac.load_vernac ~check:true ~state f in
       if !Flags.beautify
       then Flags.with_option Flags.beautify_file load_vernac f_in
       else load_vernac s

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -30,8 +30,7 @@ end
     state. *)
 val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
 
-(** [load_vernac echo sid file] Loads [file] on top of [sid], will
-    echo the commands if [echo] is set. Callers are expected to handle
-    and print errors in form of exceptions. *)
-val load_vernac : echo:bool -> check:bool ->
+(** [load_vernac sid file] Loads [file] on top of [sid].
+    Callers are expected to handle and print errors in form of exceptions. *)
+val load_vernac : check:bool ->
   state:State.t -> ?source:Loc.source -> string -> State.t


### PR DESCRIPTION
They would print the input file to stdout as it compiled.

This was probably used by people calling coqtop directly in the terminal and is useless now.

`-verbose` has been a noop for a while BTW.
