### PR TITLE
Align Evd and UState API names

### DIFF
--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -607,7 +607,6 @@ val check_quality_constraints : evar_map -> UVars.QPairSet.t -> bool
 
 val ustate : evar_map -> UState.t
 val elim_graph : evar_map -> QGraph.t
-val evar_universe_context : evar_map -> UState.t [@@deprecated "(9.0) Use [Evd.ustate]"]
 
 val universe_context_set : evar_map -> Univ.ContextSet.t
 val sort_context_set : evar_map -> UnivGen.sort_context_set
@@ -626,8 +625,11 @@ val check_univ_decl : poly:PolyFlags.t -> evar_map -> UState.universe_decl -> US
     starting to build a declaration interactively *)
 val check_univ_decl_early : poly:PolyFlags.t -> with_obls:bool -> evar_map -> UState.universe_decl -> Constr.t list -> unit
 
-val merge_universe_context : evar_map -> UState.t -> evar_map
+val merge_ustate : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map
+
+val merge_universe_context : evar_map -> UState.t -> evar_map
+[@@deprecated "(9.3) Use [Evd.merge_ustate]"]
 
 val merge_universe_context_set : ?loc:Loc.t -> ?sideff:bool -> rigid -> evar_map -> Univ.ContextSet.t -> evar_map
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -1282,7 +1282,7 @@ let univ_flexible_alg = UnivFlexible true
 (** ~sideff indicates that it is ok to redeclare a universe.
     Also merges the universe context in the local constraint structures
     and not only in the graph. *)
-let merge_universe_context ?loc ~sideff rigid uctx (levels, ucst) =
+let merge_universe_context_set ?loc ~sideff rigid uctx (levels, ucst) =
   let declare g =
     Level.Set.fold (fun u g ->
         try UGraph.add_universe ~strict:false u g
@@ -1341,9 +1341,9 @@ let merge_sort_variables ?loc ?(sort_rigid=false) ?src ~sideff uctx (qvars, csts
   let local = (us, (Sorts.ElimConstraints.union qcst csts, ucst)) in
   { uctx with local; sort_variables; names }
 
-let merge_sort_context ?loc ?sort_rigid ?src ~sideff rigid uctx ((qvars, levels), (qcst, ucst)) =
+let merge_sort_context_set ?loc ?sort_rigid ?src ~sideff rigid uctx ((qvars, levels), (qcst, ucst)) =
   let uctx = merge_sort_variables ?loc ?sort_rigid ?src ~sideff uctx (qvars, qcst) in
-  merge_universe_context ?loc ~sideff rigid uctx (levels, ucst)
+  merge_universe_context_set ?loc ~sideff rigid uctx (levels, ucst)
 
 let demote_global_univs (lvl_set, univ_csts) uctx =
   let (local_univs, local_constraints) = uctx.local in
@@ -1429,7 +1429,7 @@ let add_universe ?loc name strict uctx u =
   in
   { uctx with names; local; initial_universes; universes }
 
-let new_sort_variable ?loc ?(sort_rigid = false) ?name uctx =
+let new_quality_variable ?loc ?(sort_rigid = false) ?name uctx =
   let q = UnivGen.fresh_sort_quality () in
   (* don't need to check_fresh as it's guaranteed new *)
   let sort_variables = QState.add ~check_fresh:false ~rigid:(sort_rigid || Option.has_some name)
@@ -1441,7 +1441,7 @@ let new_sort_variable ?loc ?(sort_rigid = false) ?name uctx =
   in
   { uctx with sort_variables; names }, q
 
-let new_univ_variable ?loc rigid name uctx =
+let new_univ_level_variable ?loc rigid name uctx =
   let u = UnivGen.fresh_level () in
   let uctx =
     match rigid with
@@ -1459,7 +1459,7 @@ let make_with_initial_binders ~qualities univs binders =
   let uctx = make ~qualities univs in
   List.fold_left
     (fun uctx { CAst.loc; v = id } ->
-       fst (new_univ_variable ?loc univ_rigid (Some id) uctx))
+       fst (new_univ_level_variable ?loc univ_rigid (Some id) uctx))
     uctx binders
 
 let from_env ?(binders=[]) env =

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -187,9 +187,9 @@ val univ_rigid : rigid
 val univ_flexible : rigid
 val univ_flexible_alg : rigid
 
-val merge_sort_context : ?loc:Loc.t -> ?sort_rigid:bool -> ?src:constraint_source ->
+val merge_sort_context_set : ?loc:Loc.t -> ?sort_rigid:bool -> ?src:constraint_source ->
     sideff:bool -> rigid -> t -> UnivGen.sort_context_set -> t
-val merge_universe_context : ?loc:Loc.t -> sideff:bool -> rigid -> t -> Univ.ContextSet.t -> t
+val merge_universe_context_set : ?loc:Loc.t -> sideff:bool -> rigid -> t -> Univ.ContextSet.t -> t
 
 val demote_global_univs : Univ.ContextSet.t -> t -> t
 (** After declaring global universes, call this if you want to keep using the UState.
@@ -213,10 +213,10 @@ val demote_global_univ_entry : universes_entry -> t -> t
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 (** Calls [demote_global_univs] for the private constant universes. *)
 
-val new_sort_variable : ?loc:Loc.t -> ?sort_rigid:bool -> ?name:Id.t -> t -> t * QVar.t
+val new_quality_variable : ?loc:Loc.t -> ?sort_rigid:bool -> ?name:Id.t -> t -> t * QVar.t
 (** Declare a new local sort. *)
 
-val new_univ_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Level.t
+val new_univ_level_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Level.t
 (** Declare a new local universe; use rigid if a global or bound
     universe; use flexible for a universe existential variable; use
     univ_flexible_alg for a universe existential variable allowed to

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -151,7 +151,7 @@ let inner_ssrapplytac gviews (ggenl, gclr) ist =
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in
     let clr', lemma = interp_agens ist env sigma ~concl agens in
-    let sigma = Evd.merge_universe_context sigma (Evd.ustate (fst lemma)) in
+    let sigma = Evd.merge_ustate sigma (Evd.ustate (fst lemma)) in
     Tacticals.tclTHENLIST [Proofview.Unsafe.tclEVARS sigma; cleartac clr; refine_with ~beta:true lemma; cleartac clr']
   | _, _ ->
     Tacticals.tclTHENLIST [apply_top_tac; cleartac clr]))

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -687,7 +687,7 @@ let abs_ssrterm ?(resolve_typeclasses=false) ist env sigma t =
        sigma, Evarutil.nf_evar sigma ct in
   let c, abstracted_away, ucst = abs_evars env sigma0 t in
   let n = List.length abstracted_away in
-  let sigma = Evd.merge_universe_context sigma0 ucst in
+  let sigma = Evd.merge_ustate sigma0 ucst in
   let t = abs_cterm env sigma n c in
   sigma, t, n
 
@@ -761,7 +761,7 @@ let pf_interp_ty ?(resolve_typeclasses=false) env sigma0 ist ty =
        sigma, Evarutil.nf_evar sigma cty in
    let c, evs, ucst = abs_evars env sigma0 ty in
    let n = List.length evs in
-   let sigma0 = Evd.merge_universe_context sigma0 ucst in
+   let sigma0 = Evd.merge_ustate sigma0 ucst in
    let lam_c = abs_cterm env sigma0 n c in
    let ctx, c = EConstr.decompose_lambda_n_assum sigma n lam_c in
    sigma0, n, EConstr.it_mkProd_or_LetIn c ctx, lam_c
@@ -1049,7 +1049,7 @@ let get_hyp env sigma id =
 (* XXX the k of the redex should percolate out *)
 let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
   let pat = interp_cpattern env sigma t None in (* UGLY API *)
-  let sigma = Evd.merge_universe_context sigma (Evd.ustate @@ pat.pat_sigma) in
+  let sigma = Evd.merge_ustate sigma (Evd.ustate @@ pat.pat_sigma) in
   let sigma, c, cl = fill_rel_occ_pattern env sigma concl pat occ in
   let clr = interp_clr sigma (oclr, (tag_of_cpattern t, c)) in
   if not(occur_existential sigma c) then
@@ -1062,7 +1062,7 @@ let pf_interp_gen_aux env sigma ~concl to_ind ((oclr, occ), t) =
     else let sigma, ccl =  pf_mkprod env sigma c cl in false, pat, ccl, c, clr, sigma
   else if to_ind && occ = None then
     let p, evs, ucst' = abs_evars env sigma (pat.pat_sigma, c) in
-    let sigma = Evd.merge_universe_context sigma ucst' in
+    let sigma = Evd.merge_ustate sigma ucst' in
     if List.is_empty evs then anomaly "occur_existential but no evars" else
     let sigma, pty, rp = pfe_type_relevance_of env sigma p in
     false, pat, EConstr.mkProd (make_annot (constr_name sigma c) rp, pty, concl), p, clr, sigma
@@ -1131,7 +1131,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
   | _, Some ((x, "@"), Some p) ->
      let x = hoi_id x in
      let cp = interp_cpattern env sigma p None in
-     let sigma = Evd.merge_universe_context sigma (Evd.ustate cp.pat_sigma) in
+     let sigma = Evd.merge_ustate sigma (Evd.ustate cp.pat_sigma) in
      let sigma, t, c = fill_rel_occ_pattern env sigma c cp None in
      evar_closed t p;
      let ut = red_product_skip_id env sigma t in
@@ -1140,7 +1140,7 @@ let abs_wgen env sigma keep_let f gen (args,c) =
   | _, Some ((x, _), Some p) ->
      let x = hoi_id x in
      let cp = interp_cpattern env sigma p None in
-     let sigma = Evd.merge_universe_context sigma (Evd.ustate cp.pat_sigma) in
+     let sigma = Evd.merge_ustate sigma (Evd.ustate cp.pat_sigma) in
      let sigma, t, c = fill_rel_occ_pattern env sigma c cp None in
      evar_closed t p;
      let sigma, ty, r = pfe_type_relevance_of env sigma t in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -100,7 +100,7 @@ let congrtac ((n, t), ty) ist =
   debug_ssr (fun () -> (Pp.str"===congr==="));
   debug_ssr (fun () -> Pp.(str"concl=" ++ Printer.pr_econstr_env env sigma concl));
   let nsigma, _ as it = interp_term env sigma ist t in
-  let sigma = Evd.merge_universe_context sigma (Evd.ustate nsigma) in
+  let sigma = Evd.merge_ustate sigma (Evd.ustate nsigma) in
   let f, _, _ucst = abs_evars env sigma it in
   let ist' = {ist with lfun =
     Id.Map.add pattern_id (Tacinterp.Value.of_constr f) Id.Map.empty } in
@@ -458,7 +458,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty c_so
   end
 
 let pf_merge_uc_of s sigma =
-  Evd.merge_universe_context sigma (Evd.ustate s)
+  Evd.merge_ustate sigma (Evd.ustate s)
 
 let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   let open Proofview.Notations in
@@ -676,7 +676,7 @@ let rwrxtac ?under ?map_redex occ rdx_pat dir rule =
   let concl0 = Reductionops.nf_evar sigma0 concl0 in
   let concl = eval_pattern env0 sigma0 concl0 rdx_pat occ find_R in
   let (d, (_, sigma, uc, t)), rdx = conclude concl in
-  let r = Evd.merge_universe_context sigma uc, t in
+  let r = Evd.merge_ustate sigma uc, t in
   rwcltac ?under ?map_redex concl rdx d r
   end
 

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -63,7 +63,7 @@ let ssrsettac id ((_, (pat, pty)), (_, occ)) =
   let (c, ucst), cl =
     try fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
     with NoMatch -> redex_of_pattern_tc env pat, cl in
-  let sigma = Evd.merge_universe_context sigma ucst in
+  let sigma = Evd.merge_ustate sigma ucst in
   if Termops.occur_existential sigma c then errorstrm(str"The pattern"++spc()++
     pr_econstr_pat env sigma c++spc()++str"did not match and has holes."++spc()++
     str"Did you mean pose?") else

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -760,7 +760,7 @@ let tclLAST_GEN ~to_ind ((oclr, occ), t) conclusion = tclINDEPENDENTL begin
   else
     if to_ind && occ = None then
       let p, _, ucst' = Ssrcommon.abs_evars env sigma0 (pat.pat_sigma, c) in
-      let sigma = Evd.merge_universe_context sigma ucst' in
+      let sigma = Evd.merge_ustate sigma ucst' in
       Unsafe.tclEVARS sigma <*>
       Ssrcommon.tacTYPEOF p >>= fun pty ->
       (* TODO: check bug: cl0 no lift? *)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1461,7 +1461,7 @@ let fill_rel_occ_pattern env sigma cl pat occ =
     try fill_occ_pattern ~raise_NoMatch:true env sigma cl pat occ 1
     with NoMatch -> redex_of_pattern_nf env pat, cl
   in
-  let sigma = Evd.merge_universe_context sigma us in
+  let sigma = Evd.merge_ustate sigma us in
   sigma, e, cl
 
 (* clenup interface for external use *)

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -145,7 +145,7 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
      (but due to #13324 we still want to inline them) *)
   let effs = Evd.seff_private @@ Evd.eval_side_effects sigma in
   let body, ctx = Safe_typing.inline_private_constants env ((body, Univ.ContextSet.empty), effs) in
-  let _uctx = UState.merge_universe_context ~sideff:true Evd.univ_rigid uctx ctx in
+  let _uctx = UState.merge_universe_context_set ~sideff:true Evd.univ_rigid uctx ctx in
   body, typ, univs, uctx
 
 let build_by_tactic_opt env ~uctx ~poly ~typ tac =

--- a/stm/partac.ml
+++ b/stm/partac.ml
@@ -158,7 +158,7 @@ let assign_tac ~abstract res : unit Proofview.tactic =
     let open Notations in
     let push_state ctx =
       Proofview.tclEVARMAP >>= fun sigma ->
-      Proofview.Unsafe.tclEVARS (Evd.merge_universe_context sigma ctx)
+      Proofview.Unsafe.tclEVARS (Evd.merge_ustate sigma ctx)
     in
     (if abstract then Abstract.tclABSTRACT None else (fun x -> x))
       (push_state uc <*> Tactics.exact_no_check (EConstr.of_constr pt))

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -82,7 +82,7 @@ let with_context_set ctx (b, ctx') =
   (b, UnivGen.sort_context_union ctx ctx')
 
 let of_context_set env ctx =
-  UState.merge_sort_context ~sideff:false ~src:UState.Internal UnivRigid (UState.from_env env) ctx
+  UState.merge_sort_context_set ~sideff:false ~src:UState.Internal UnivRigid (UState.from_env env) ctx
 
 let build_dependent_inductive ind (mib,mip) =
   let realargs,_ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -670,7 +670,7 @@ let build_beq_scheme env handle kn =
   let auctx = Declareops.universes_context mib.mind_universes in
   let u, ctx = UnivGen.fresh_instance_from auctx None in
   let uctx = UState.from_env env in
-  let uctx = UState.merge_sort_context ~sideff:false UState.univ_rigid ~src:UState.Internal uctx ctx in
+  let uctx = UState.merge_sort_context_set ~sideff:false UState.univ_rigid ~src:UState.Internal uctx ctx in
 
   (* number of inductives in the mutual *)
   let nb_ind = Array.length mib.mind_packets in
@@ -1184,7 +1184,7 @@ let make_bl_scheme env handle mind =
   (* Setting universes *)
   let auctx = Declareops.universes_context mib.mind_universes in
   let u, uctx = UnivGen.fresh_instance_from auctx None in
-  let uctx = UState.merge_sort_context ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
+  let uctx = UState.merge_sort_context_set ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
 
   let ind = (mind,0) in
   let nparrec = mib.mind_nparams_rec in
@@ -1319,7 +1319,7 @@ let make_lb_scheme env handle mind =
   (* Setting universes *)
   let auctx = Declareops.universes_context mib.mind_universes in
   let u, uctx = UnivGen.fresh_instance_from auctx None in
-  let uctx = UState.merge_sort_context ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
+  let uctx = UState.merge_sort_context_set ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
 
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec =
@@ -1515,7 +1515,7 @@ let make_eq_decidability env handle mind =
   (* Setting universes *)
   let auctx = Declareops.universes_context mib.mind_universes in
   let u, uctx = UnivGen.fresh_instance_from auctx None in
-  let uctx = UState.merge_sort_context ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
+  let uctx = UState.merge_sort_context_set ~sideff:false UState.univ_rigid ~src:UState.Internal (UState.from_env env) uctx in
 
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -703,7 +703,7 @@ let declare_private_constant ?role ?ts ~name ~opaque de effs =
 
 let inline_private_constants ~uctx env (body, eff) =
   let body, ctx = Safe_typing.inline_private_constants env (body, SideEff.get eff) in
-  let uctx = UState.merge_universe_context ~sideff:true Evd.univ_rigid uctx ctx in
+  let uctx = UState.merge_universe_context_set ~sideff:true Evd.univ_rigid uctx ctx in
   body, uctx
 
 (** Declaration of section variables and local definitions *)


### PR DESCRIPTION
eg Evd.new_quality_variable was equivalent to
UState.new_sort_variable, and Evd.new_sort_variable combined new_quality and new_univ (fixed by renaming the UState API to match Evd)

also renamed Evd.merge_universe_context -> merge_ustate for clarity
