### PR TITLE
Stop zeta-normalizing the proofs in generalized rewriting

### DIFF
--- a/doc/changelog/04-tactics/21631-stop-zeta-rewrite-Changed.rst
+++ b/doc/changelog/04-tactics/21631-stop-zeta-rewrite-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Stop zeta-normalizing generalized rewriting proofs for better
+  sharing and performance
+  (`#21631 <https://github.com/rocq-prover/rocq/pull/21631>`_,
+  by Matthieu Sozeau).

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1623,9 +1623,6 @@ let solve_constraints env (evars,cstrs) =
   let evars' = TC.resolve_typeclasses env ~filter:TC.all_evars ~fail:true evars' in
   Evd.set_typeclass_evars evars' oldtcs
 
-let nf_zeta =
-  Reductionops.clos_norm_flags (RedFlags.mkflags [RedFlags.fZETA])
-
 exception RewriteFailure of Environ.env * Evd.evar_map * pretype_error
 
 type result = (evar_map * constr option * types) option option
@@ -1667,7 +1664,6 @@ let cl_rewrite_clause_aux ?(abs=None) strat env avoid sigma concl is_hyp : resul
     let res = match res.rew_prf with
       | RewCast c -> None
       | RewPrf (rel, p) ->
-        let p = nf_zeta env evars p in
         let term =
           match abs with
           | None -> p


### PR DESCRIPTION
<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

This just removes a spurious (and incorrectly scoped) `zeta` normalization phase for generalized rewriting proofs that was supposed to remove a few `let foo := do_subrelation` tags but actually also completely destroys sharing in the proof terms (it reduced the let bindings from all the intermediary goals). Should be a net performance improvement at Qed time and memory improvement overall.