### PR TITLE
More clever fast path for commutative cut fixpoint guard condition.

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1021,6 +1021,16 @@ let get_recargs_approx cache ?evars env tree ind args =
   assigned Norec *)
   build_recargs_nested (env,[]) tree (ind, args)
 
+(* Check that the parameter arguments of an inductive type do not mention some
+   variable range. This is used as a fast-path when casting recursive trees
+   against a commutative cut: indices are irrelevant for the tree
+   computation in {!get_recargs_approx}. *)
+let has_constant_parameters env nvars k ((mind, _), _) args =
+  let mib = Environ.lookup_mind mind env in
+  let auxnpar = mib.mind_nparams_rec in
+  let (lpar, _) = List.chop auxnpar args in
+  List.for_all (fun c -> noccur_with_meta (1 + k) (nvars + k) c) lpar
+
 (* [restrict_spec env spec p] restricts the size information in spec to what is
    allowed to flow out of a match with predicate p in environment env. *)
 let restrict_spec cache ?evars env spec p =
@@ -1028,63 +1038,67 @@ let restrict_spec cache ?evars env spec p =
   | Not_subterm | Internally_bound_subterm _ -> spec
   | _ ->
   let absctx, ar = whd_decompose_lambda_decls ?evars env p in
+  let absctxlen = Context.Rel.length absctx in
   (* Optimization: if the predicate is not dependent, no restriction is needed
      and we avoid building the recargs tree. *)
-  if noccur_with_meta 1 (Context.Rel.length absctx) ar then spec
+  if noccur_with_meta 1 absctxlen ar then spec
   else
   let env = push_rel_context absctx env in
-  let arctx, s = whd_decompose_prod_decls ?evars env ar in
+  let arctx, s = whd_decompose_prod ?evars env ar in
   let env = push_rel_context arctx env in
   let i,args = decompose_app_list (whd_all ?evars env s) in
   match kind i with
   | Ind i ->
-     begin match spec with
-           | Dead_code -> spec
-           | Subterm(l,st,tree) ->
-              let recargs = get_recargs_approx cache ?evars env tree i args in
-              let recargs = inter_wf_paths tree recargs in
-              Subterm(l,st,recargs)
-           | _ -> assert false
-     end
+    if has_constant_parameters env absctxlen (List.length arctx) i args then spec
+    else begin match spec with
+    | Dead_code -> spec
+    | Subterm (l, st, tree) ->
+      let recargs = get_recargs_approx cache ?evars env tree i args in
+      let recargs = inter_wf_paths tree recargs in
+      Subterm (l, st, recargs)
+    | _ -> assert false
+    end
   | _ -> Not_subterm
 
 (* [filter_stack_domain env spec p] restricts the size information in stack to
    what is allowed to enter under a match with predicate p in environment env. *)
 let filter_stack_domain cache stack_element_specif set_iota_specif ?evars env p stack =
   let absctx, ar = Term.decompose_lambda_decls p in
+  let absctxlen = Context.Rel.length absctx in
   (* Optimization: if the predicate is not dependent, no restriction is needed
      and we avoid building the recargs tree. *)
-  if noccur_with_meta 1 (Context.Rel.length absctx) ar then stack
-  else let env = push_rel_context absctx env in
-  let rec filter_stack env ar stack =
-    match stack with
+  if noccur_with_meta 1 absctxlen ar then stack
+  else
+    let env = push_rel_context absctx env in
+    let rec filter_stack env k ar stack = match stack with
     | [] -> []
     | elt :: stack' ->
-    let t = whd_all ?evars env ar in
-    match kind t with
-    | Prod (n,a,c0) ->
-      let d = LocalAssum (n,a) in
-      let ctx, a = whd_decompose_prod_decls ?evars env a in
-      let env = push_rel_context ctx env in
-      let ty, args = decompose_app_list (whd_all ?evars env a) in
-      let elt = match kind ty with
-      | Ind ind ->
-        let spec = stack_element_specif cache ?evars elt in
-        let sarg =
-        lazy (match Lazy.force spec with
-        | Not_subterm | Dead_code | Internally_bound_subterm _ as spec -> spec
-        | Subterm(l,s,path) ->
-            let recargs = get_recargs_approx cache ?evars env path ind args in
-            let path = inter_wf_paths path recargs in
-            Subterm(l,s,path))
+      let t = whd_all ?evars env ar in
+      match kind t with
+      | Prod (n, a, c0) ->
+        let d = LocalAssum (n, a) in
+        let ctx, a = whd_decompose_prod ?evars env a in
+        let env = push_rel_context ctx env in
+        let ty, args = decompose_app_list (whd_all ?evars env a) in
+        let elt = match kind ty with
+        | Ind ind ->
+          let spec = stack_element_specif cache ?evars elt in
+          if has_constant_parameters env absctxlen (k + List.length ctx) ind args then SArg spec
+          else
+            let sarg = lazy begin match Lazy.force spec with
+            | Not_subterm | Dead_code | Internally_bound_subterm _ as spec -> spec
+            | Subterm (l, s, path) ->
+              let recargs = get_recargs_approx cache ?evars env path ind args in
+              let path = inter_wf_paths path recargs in
+              Subterm (l, s, path)
+            end in
+            SArg sarg
+        | _ -> SArg (set_iota_specif (lazy Not_subterm))
         in
-        SArg sarg
-      | _ -> SArg (set_iota_specif (lazy Not_subterm))
-      in
-      elt :: filter_stack (push_rel d env) c0 stack'
-    | _ -> List.fold_right (fun _ l -> SArg (set_iota_specif (lazy Not_subterm)) :: l) stack []
+        elt :: filter_stack (push_rel d env) (k + 1) c0 stack'
+      | _ -> List.fold_right (fun _ l -> SArg (set_iota_specif (lazy Not_subterm)) :: l) stack []
   in
-  filter_stack env ar stack
+  filter_stack env 0 ar stack
 
 (* [subterm_specif renv t] computes the recursive structure of [t] and
    compare its size with the size of the initial recursive argument of


### PR DESCRIPTION
Inductive indices (and non-uniform parameters) are irrelevant for the associated recursive tree. Thus, when casting a tree across a commutative cut for subterm computation, they can be safely ignored. One must only check for the presence of variables introduced by the return clause in the parameters of the inductive type being transtyped.

This optimization makes the guardedness check from #21105 go from around ~20 seconds to less than a second on my machine.