### PR TITLE
Add flag to control printing alternate match syntaxes

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21645-print-regular-match-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21645-print-regular-match-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  flag :flag:`Printing Regular Matches` to disable alternate match syntaxes
+  (`#21645 <https://github.com/rocq-prover/rocq/pull/21645>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -348,6 +348,19 @@ This example emphasizes what the printing settings offer.
 
        Print snd.
 
+Printing regular match syntax
++++++++++++++++++++++++++++++
+
+.. flag:: Printing Regular Matches
+
+   When enabled, this flag makes printing avoid the alternate case
+   analysis syntaxes (with :ref:`if <if-then-else>` and :ref:`let
+   <irrefutable-patterns>`), overriding :table:`Printing If` and
+   :table:`Printing Let` and disregarding the syntax used to input the
+   case analysis (so e.g. `let 'tt := tt in tt` will be printed using `match`).
+
+   This flag is off by default.
+
 Conventions about unused pattern-matching variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pretyping/printingFlags.ml
+++ b/pretyping/printingFlags.ml
@@ -94,6 +94,9 @@ let { Goptions.get = print_relevances } =
     ~value:false
     ()
 
+(* detyping *)
+let always_print_regular_match_style = make_flag ["Printing";"Regular";"Matches"] false
+
 (* detyping.ml but extern time *)
 let { Goptions.get = print_factorize_match_patterns } =
   Goptions.declare_bool_option_and_ref
@@ -253,9 +256,9 @@ module Detype = struct
     primproj_params = print_primproj_params();
     unfolded_primproj_as_match = print_unfolded_primproj_asmatch();
     match_paramunivs = print_match_paramunivs();
+    always_regular_match_style = !always_print_regular_match_style;
 
     (* not yet exposed (except through Printing All) *)
-    always_regular_match_style = false;
     nonpropositional_letin_types = false;
   }
 


### PR DESCRIPTION
This was already possible using Printing All but didn't have a separate flag.
