### PR TITLE
Remove "Generate Goal Names" from known RocqIDE options

### DIFF
--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -67,7 +67,6 @@ let rocqide_known_option table = List.mem table [
   ["Printing";"Universes"];
   ["Printing";"Unfocused"];
   ["Printing";"Goal";"Names"];
-  ["Generate";"Goal";"Names"];
   ["Diffs"]]
 
 let is_known_option cmd = match cmd with


### PR DESCRIPTION
This fixes the incorrect "Set this option from the IDE menu instead" warning in RocqIDE, triggered when setting the option through `Set Generate Goal Names.`.

Thanks @yannl35133 for the report :smile: 