### PR TITLE
Prevent line breaking in Print LoadPath

### DIFF
--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -31,7 +31,7 @@ let pp p =
   let installed = Pp.str (if p.path_installed then "i" else " ") in
   let dir = DP.print p.path_logical in
   let path = Pp.str (CUnix.escaped_string_of_physical_path p.path_physical) in
-  Pp.(hov 2 (installed ++ spc () ++ dir ++ spc () ++ path))
+  Pp.(h (installed ++ spc () ++ dir ++ spc () ++ path))
 
 let get_load_paths () = !load_paths
 


### PR DESCRIPTION
Should help those who want to parse this output (https://rocq-prover.zulipchat.com/#narrow/channel/304019-Proof-General-users/topic/.22Go.20to.20definition.22.20in.20Emacs.20not.20working.20for.20Ocaml.205.2E3.2F5.2E4/near/574570432)