### PR TITLE
Stop going through genargs to print values in Pptactic.pr_value

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -144,29 +144,15 @@ let string_of_genarg_arg (ArgumentType arg) =
       let (v1, v2) = unbox v Val.typ_pair in
       str "(" ++ pr_value lev v1 ++ str ", " ++ pr_value lev v2 ++ str ")"
     else
-      let Val.Dyn (tag, x) = v in
-      let name = Val.repr tag in
-      let default = str "<" ++ str name ++ str ">" in
-      match ArgT.name name with
-      | None -> default
-      | Some (ArgT.Any arg) ->
-        let wit = ExtraArg arg in
-        match val_tag (Topwit wit) with
-        | Val.Base t ->
-          begin match Val.eq t tag with
-          | None -> default
-          | Some Refl ->
-             let open Genprint in
-             match generic_top_print (in_gen (Topwit wit) x) with
-             | TopPrinterBasic pr -> pr ()
-             | TopPrinterNeedsContext pr ->
-               let env = Global.env() in
-               pr env (Evd.from_env env)
-             | TopPrinterNeedsContextAndLevel { default_ensure_surrounded; printer } ->
-               let env = Global.env() in
-               printer env (Evd.from_env env) default_ensure_surrounded
-          end
-        | _ -> default
+      let open Genprint in
+      match generic_val_print v with
+      | TopPrinterBasic pr -> pr ()
+      | TopPrinterNeedsContext pr ->
+        let env = Global.env() in
+        pr env (Evd.from_env env)
+      | TopPrinterNeedsContextAndLevel { default_ensure_surrounded; printer } ->
+        let env = Global.env() in
+        printer env (Evd.from_env env) default_ensure_surrounded
 
   let pr_with_occurrences prvar pr c = Ppred.pr_with_occurrences prvar pr keyword c
   let pr_red_expr env sigma pr c = Ppred.pr_red_expr_env env sigma pr keyword c

--- a/printing/genprint.ml
+++ b/printing/genprint.ml
@@ -111,7 +111,6 @@ let _ =
 type ('raw, 'glb, 'top) genprinter = {
   raw : 'raw -> printer_result;
   glb : 'glb -> printer_result;
-  top : 'top -> top_printer_result;
 }
 
 let basic_default name =
@@ -126,7 +125,6 @@ struct
     let printer = {
       raw = (fun _ -> PrinterBasic (fun env sigma -> str "<genarg:" ++ str name ++ str ">"));
       glb = (fun _ -> PrinterBasic (fun env sigma -> str "<genarg:" ++ str name ++ str ">"));
-      top = (fun _ -> TopPrinterBasic (fun () -> str "<genarg:" ++ str name ++ str ">"));
     } in
     Some printer
 end
@@ -134,7 +132,7 @@ end
 module Print = Register (PrintObj)
 
 let register_print0 wit raw glb top =
-  let printer = { raw; glb; top; } in
+  let printer = { raw; glb; } in
   Print.register0 wit printer;
   match val_tag (Topwit wit), wit with
   | Val.Base t, ExtraArg t' when Geninterp.Val.repr t = ArgT.repr t' ->
@@ -144,23 +142,19 @@ let register_print0 wit raw glb top =
      ()
 
 let register_noval_print0 wit raw glb =
-  let top = Util.Empty.abort in
-  let printer = { raw; glb; top; } in
+  let printer = { raw; glb; } in
   Print.register0 wit printer
 
 let register_vernac_print0 wit raw =
   let glb = Util.Empty.abort in
-  let top = Util.Empty.abort in
-  let printer = { raw; glb; top; } in
+  let printer = { raw; glb; } in
   Print.register0 wit printer
 
 let raw_print wit v = (Print.obj wit).raw v
 let glb_print wit v = (Print.obj wit).glb v
-let top_print wit v = (Print.obj wit).top v
 
 let generic_raw_print (GenArg (Rawwit w, v)) = raw_print w v
 let generic_glb_print (GenArg (Glbwit w, v)) = glb_print w v
-let generic_top_print (GenArg (Topwit w, v)) = top_print w v
 
 module CPrintObj = struct
   type ('raw, 'glb) t = ('raw -> printer_result) * ('glb -> printer_result)

--- a/printing/genprint.mli
+++ b/printing/genprint.mli
@@ -38,9 +38,6 @@ val raw_print : ('raw, 'glb, 'top) genarg_type -> 'raw printer
 val glb_print : ('raw, 'glb, 'top) genarg_type -> 'glb printer
 (** Printer for glob level generic arguments. *)
 
-val top_print : ('raw, 'glb, 'top) genarg_type -> 'top top_printer
-(** Printer for top level generic arguments. *)
-
 val register_print0 : ('raw, 'glb, 'top) genarg_type ->
   'raw printer -> 'glb printer -> 'top top_printer -> unit
 (** The genarg must be registered in [Geninterp.register_val0] *)
@@ -54,7 +51,6 @@ val register_vernac_print0 : 'raw vernac_genarg_type ->
 
 val generic_raw_print : rlevel generic_argument printer
 val generic_glb_print : glevel generic_argument printer
-val generic_top_print : tlevel generic_argument top_printer
 val generic_val_print : Geninterp.Val.t top_printer
 
 (* For terms *)


### PR DESCRIPTION
This removes the only user of (generic_)top_print, so we remove top_print.

(top printers are still used by val printers ie generic_val_print)