### PR TITLE
[documentation] Deploy the refman of Stdlib only for master branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -488,16 +488,17 @@ doc:refman:deploy:
     - rm -rf _deploy/$CI_COMMIT_REF_NAME/api
     - rm -rf _deploy/$CI_COMMIT_REF_NAME/refman
     - rm -rf _deploy/$CI_COMMIT_REF_NAME/corelib
-    - rm -rf _deploy/$CI_COMMIT_REF_NAME/refman-stdlib
+    - if [ $CI_COMMIT_REF_NAME = "master" ] ; then rm -rf _deploy/$CI_COMMIT_REF_NAME/refman-stdlib ; fi
     - rm -rf _deploy/$CI_COMMIT_REF_NAME/stdlib
     - mkdir -p _deploy/$CI_COMMIT_REF_NAME
     - cp -rv _build/default/_doc/_html _deploy/$CI_COMMIT_REF_NAME/api
     - cp -rv _build/default/doc/refman-html _deploy/$CI_COMMIT_REF_NAME/refman
     - cp -rv _build/default/doc/corelib/html _deploy/$CI_COMMIT_REF_NAME/corelib
-    - cp -rv saved_build_ci/stdlib/_build/default/doc/refman-html _deploy/$CI_COMMIT_REF_NAME/refman-stdlib
+    - if [ $CI_COMMIT_REF_NAME = "master" ] ; then cp -rv saved_build_ci/stdlib/_build/default/doc/refman-html _deploy/$CI_COMMIT_REF_NAME/refman-stdlib ; fi
     - cp -rv saved_build_ci/stdlib/_build/default/doc/stdlib/html _deploy/$CI_COMMIT_REF_NAME/stdlib
     - cd _deploy/$CI_COMMIT_REF_NAME/
-    - git add api refman corelib refman-stdlib stdlib
+    - git add api refman corelib stdlib
+    - if [ $CI_COMMIT_REF_NAME = "master" ] ; then git add refman-stdlib ; fi
     - git commit -m "Documentation of branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"
     - git push # TODO: rebase and retry on failure
 


### PR DESCRIPTION
Temporary solution until this refman gets automatically deployed by the Stdlib library repo.
C.f., https://github.com/rocq-prover/stdlib/issues/239
