### PR TITLE
Support for matching global sorts

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -92,7 +92,7 @@ let check_quality_mask env qmask lincheck =
   let open Sorts.Quality in
   match qmask with
   | PQConstant QSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_not_allowed_sprop env
-  | PQConstant (QProp | QType) -> lincheck
+  | PQConstant (QProp | QType) | PQGlobal _ -> lincheck
   | PQVar qio -> Partial_subst.maybe_add_quality qio () lincheck
 
 let check_instance_mask env udecl umask lincheck =
@@ -141,6 +141,7 @@ and get_holes_profiles_head env nargs ndecls lincheck = function
       check_instance_mask env mib.mind_universes u lincheck
   | PHInt _  | PHFloat _ | PHString _ -> lincheck
   | PHSort PSSProp -> if Environ.sprop_allowed env then lincheck else Type_errors.error_not_allowed_sprop env
+  | PHSort PSGlobal (_, io)
   | PHSort PSType io -> Partial_subst.maybe_add_univ io () lincheck
   | PHSort PSQSort (qio, uio) ->
       lincheck

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -498,13 +498,18 @@ let v_retroknowledge =
 let v_puniv = v_opt v_int
 
 let v_pqvar = v_opt v_int
-let v_quality_pattern = v_sum "quality_pattern" 0 [|[|v_pqvar|];[|v_constant_quality|]|]
+let v_quality_pattern = v_sum "quality_pattern" 0 [|
+  [|v_pqvar|];
+  [|v_constant_quality|];
+  [|v_qglobal|];
+|]
 
 let v_instance_mask = v_pair (v_array v_quality_pattern) (v_array v_puniv)
 
 let v_sort_pattern = v_sum_c ("sort_pattern", 3,
-  [|[|v_puniv|];         (* PSType *)
-    [|v_pqvar; v_puniv|] (* PSQSort *)
+  [|[|v_puniv|];             (* PSType *)
+    [|v_qglobal; v_puniv|];  (* PSGlobal *)
+    [|v_pqvar; v_puniv|];    (* PSQSort *)
   |])
 
 let [_v_hpattern;v_elimination;_v_head_elim;_v_patarg] : _ Vector.t =

--- a/doc/changelog/01-kernel/21663-rr-match-global-sorts-Added.rst
+++ b/doc/changelog/01-kernel/21663-rr-match-global-sorts-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Added support for matching on specific global sorts in rewrite rules
+  (`#21663 <https://github.com/rocq-prover/rocq/pull/21663>`_,
+  by Yann Leray).

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -303,12 +303,12 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 (** {6 Rewrite rules } *)
 
 type 'q quality_pattern = 'q Sorts.Quality.pattern =
-  | PQVar of 'q | PQConstant of Sorts.Quality.constant
+  | PQVar of 'q | PQConstant of Sorts.Quality.constant | PQGlobal of Sorts.QGlobal.t
 
 type ('q, 'u) instance_mask = ('q, 'u) UVars.Instance.mask
 
 type ('q, 'u) sort_pattern = ('q, 'u) Sorts.pattern =
-  | PSProp | PSSProp | PSSet | PSType of 'u | PSQSort of 'q * 'u
+  | PSProp | PSSProp | PSSet | PSType of 'u | PSGlobal of Sorts.QGlobal.t * 'u | PSQSort of 'q * 'u
 
 (** Patterns are internally represented as pairs of a head-pattern and a list of eliminations
     Eliminations correspond to elements of the stack in a reduction machine,

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -29,6 +29,7 @@ sig
   type t
 
   val var_index : t -> int option
+  val name : t -> QGlobal.t option
 
   val make_var : int -> t
   val make_unif : string -> int -> t
@@ -121,7 +122,7 @@ module Quality : sig
   module Map : CMap.ExtS with type key = t and module Set := Set
 
   type 'q pattern =
-    PQVar of 'q | PQConstant of constant
+    PQVar of 'q | PQConstant of constant | PQGlobal of QGlobal.t
 
   val pattern_match : int option pattern -> t -> ('t, t, 'u) Partial_subst.t -> ('t, t, 'u) Partial_subst.t option
 end
@@ -211,6 +212,6 @@ val pr : (QVar.t -> Pp.t) -> (Univ.Universe.t -> Pp.t) -> t -> Pp.t
 val raw_pr : t -> Pp.t
 
 type ('q, 'u) pattern =
-  | PSProp | PSSProp | PSSet | PSType of 'u | PSQSort of 'q * 'u
+  | PSProp | PSSProp | PSSet | PSType of 'u | PSGlobal of QGlobal.t * 'u | PSQSort of 'q * 'u
 
 val pattern_match : (int option, int option) pattern -> t -> ('t, Quality.t, Univ.Level.t) Partial_subst.t -> ('t, Quality.t, Univ.Level.t) Partial_subst.t option

--- a/test-suite/success/rewrule_quality_match.v
+++ b/test-suite/success/rewrule_quality_match.v
@@ -1,29 +1,35 @@
 (* -*- mode: coq; coq-prog-args: ("-allow-rewrite-rules") -*- *)
 
-#[universes(polymorphic)] Symbol irrel@{q;u} : forall {A : Type@{q;u}}, A -> bool.
+#[universes(polymorphic)] Symbol dispatch@{q;u} : forall {A : Type@{q;u}}, A -> nat.
+
+Sort s.
 
 Rewrite Rule id_rew :=
-| irrel@{SProp|_} _ => true
-| irrel@{Type|_} _ => false.
+| dispatch@{SProp;_} _ => 0
+| dispatch@{Type;_} _ => 1
+| dispatch@{s;_} _ => 2.
 
 Inductive STrue : SProp := SI.
 
+#[universes(template=no)]
+Inductive sTrue : Type@{s;_} := sI.
+
 Goal True.
-  let c := constr:((irrel SI, irrel tt)) in
+  let c := constr:((dispatch SI, dispatch tt, dispatch sI)) in
   let cl := eval lazy in c in
-  constr_eq cl (true, false).
+  constr_eq cl (0, 1, 2).
 
-  let c := constr:((irrel SI, irrel tt)) in
+  let c := constr:((dispatch SI, dispatch tt, dispatch sI)) in
   let cl := eval cbv in c in
-  constr_eq cl (true, false).
+  constr_eq cl (0, 1, 2).
 
-  let c := constr:((irrel SI, irrel tt)) in
+  let c := constr:((dispatch SI, dispatch tt, dispatch sI)) in
   let cl := eval cbn in c in
-  constr_eq cl (true, false).
+  constr_eq cl (0, 1, 2).
 
-  let c := constr:((irrel SI, irrel tt)) in
+  let c := constr:((dispatch SI, dispatch tt, dispatch sI)) in
   let cl := eval simpl in c in
-  constr_eq cl (true, false).
+  constr_eq cl (0, 1, 2).
 
   exact I.
 Qed.

--- a/vernac/comRewriteRule.ml
+++ b/vernac/comRewriteRule.ml
@@ -112,9 +112,11 @@ let safe_quality_pattern_of_quality ~loc evd qsubst stateq q =
   match Sorts.Quality.(subst (subst_fn qsubst) q) with
   | QConstant qc -> stateq, PQConstant qc
   | QVar qv ->
-    let qio = Sorts.QVar.var_index qv in
-    let stateq = Option.fold_right (update_invtblq1 ~loc evd q) qio stateq in
-    stateq, PQVar qio
+    match Sorts.QVar.repr qv with
+    | Global qg -> stateq, PQGlobal qg
+    | Var qi ->
+        update_invtblq1 ~loc evd q qi stateq, PQVar (Some qi)
+    | Unif _ -> stateq, PQVar None
 
 let update_invtblu ~loc evd (qsubst, usubst) (state, stateq, stateu : state) u : state * _ =
   let (q, u) = u |> UVars.Instance.to_array in
@@ -147,8 +149,9 @@ let safe_sort_pattern_of_sort ~loc evd (qsubst, usubst) (st, sq, su as state) s 
   | Prop -> state, PSProp
   | Set -> state, PSSet
   | QSort (qold, u) ->
+      let qv = match Sorts.Quality.subst_fn qsubst qold with QConstant _ -> assert false | QVar qv -> qv in
       let sq, bq =
-        match Sorts.Quality.(var_index @@ subst_fn qsubst qold) with
+        match Sorts.QVar.var_index qv with
         | Some q -> update_invtblq1 ~loc evd (QVar qold) q sq, Some q
         | None -> sq, None
       in
@@ -157,7 +160,9 @@ let safe_sort_pattern_of_sort ~loc evd (qsubst, usubst) (st, sq, su as state) s 
         | Some (lvlold, lvl) -> update_invtblu1 ~loc evd lvlold lvl su, Some lvl
         | None -> su, None
       in
-      (st, sq, su), PSQSort (bq, ba)
+      match Sorts.QVar.name qv with
+      | Some qg -> (st, sq, su), PSGlobal (qg, ba)
+      | None -> (st, sq, su), PSQSort (bq, ba)
 
 
 let warn_irrelevant_pattern =
@@ -510,6 +515,7 @@ let interp_rule (udecl, lhs, rhs: Constrexpr.universe_decl_expr option * _ * _) 
           Pp.(str "Sort variable " ++ Termops.pr_evd_qvar evd q ++ str " appears in the replacement but does not appear in the pattern.")
     | Some n when n < 0 || n > nvarqs' -> CErrors.anomaly Pp.(str "Unknown sort variable in rewrite rule.")
     | Some _ -> ()
+    | None when Option.has_some (Sorts.QVar.name q) -> ()
     | None ->
         if not @@ Sorts.QVar.Set.mem q (evd |> Evd.sort_context_set |> fst |> fst) then
           CErrors.user_err ?loc:rhs_loc


### PR DESCRIPTION
I had already implemented this for a bespoke dev branch, but this can be upstreamed directly.