### PR TITLE
Disallow Type@{s; _} from being a valid template conclusion

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21665-fix-21664-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21665-fix-21664-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Inductives living in a universe with a global sort stop trying to be template polymorphic
+  (`#21665 <https://github.com/rocq-prover/rocq/pull/21665>`_,
+  fixes `#21664 <https://github.com/rocq-prover/rocq/issues/21664>`_,
+  by Yann Leray).

--- a/test-suite/bugs/bug_21664.v
+++ b/test-suite/bugs/bug_21664.v
@@ -1,0 +1,3 @@
+Sort s.
+Inductive I : Type@{s; _} := C.
+(* Universe inconsistency. Cannot enforce Prop <= Type@{s | Set}. *)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -109,6 +109,7 @@ let rec check_type_conclusion ind =
         (* should have been made flexible *)
         assert false
       | (None, UAnonymous {rigid=UnivFlexible _}) -> false
+      | (Some _, _) -> false
       | _ -> true
     end
   | GProd (_, _, _, _, e)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
I don't know if this is right.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21664
