### PR TITLE
Use automata rather than regular trees for guard checking.

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -172,7 +172,7 @@ let check_same_record r1 r2 = match r1, r2 with
 let check_packet mind ind
     { mind_typename; mind_arity_ctxt; mind_user_arity; mind_record; mind_sort; mind_consnames; mind_user_lc;
       mind_nrealargs; mind_nrealdecls; mind_squashed; mind_nf_lc;
-      mind_consnrealargs; mind_consnrealdecls; mind_recargs; mind_relevance;
+      mind_consnrealargs; mind_consnrealdecls; mind_recargs; mind_automaton; mind_relevance;
       mind_nb_constant; mind_nb_args; mind_reloc_tbl } =
   let check = check mind in
 
@@ -195,6 +195,7 @@ let check_packet mind ind
   check "mind_consnrealdecls" (Array.equal Int.equal ind.mind_consnrealdecls mind_consnrealdecls);
 
   check "mind_recargs" (Rtree.equal eq_recarg ind.mind_recargs mind_recargs);
+  check "mind_automaton" (Rtree.Automaton.equal eq_recarg ind.mind_automaton mind_automaton);
 
   check "mind_relevant" (Sorts.relevance_equal ind.mind_relevance mind_relevance);
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -436,6 +436,10 @@ let v_wfp =
       [|v_int;v_array v_wfp|] (* Rtree.Rec *)
     |]))
 
+let v_automaton =
+  v_tuple "automaton"
+    [|v_int; v_array (v_pair v_recarg (v_array (v_array v_int)))|]
+
 let v_squash_info = v_sum "squash_info" 1 [|[|v_set v_quality|]|]
 
 let v_has_eta = v_enum "has_eta" 3
@@ -458,6 +462,7 @@ let v_one_ind = v_tuple "one_inductive_body"
     v_array v_int;
     v_array v_int;
     v_wfp;
+    v_automaton;
     v_relevance;
     v_int;
     v_int;

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -250,6 +250,8 @@ type one_inductive_body = {
 
     mind_recargs : wf_paths; (** Signature of recursive arguments in the constructors *)
 
+    mind_automaton : recarg Rtree.Automaton.t; (** Minimal automaton generated from the above *)
+
     mind_relevance : Sorts.relevance;
     (* XXX this is redundant with mind_sort, is it actually worth keeping? *)
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -159,6 +159,18 @@ let eq_recarg r1 r2 = match r1, r2 with
 | Mrec t1, Mrec t2 -> eq_recarg_type t1 t2
 | Mrec _, _ -> false
 
+let compare_recarg_type t1 t2 = match t1, t2 with
+| RecArgInd ind1, RecArgInd ind2 -> Names.Ind.CanOrd.compare ind1 ind2
+| RecArgInd _, RecArgPrim _ -> -1
+| RecArgPrim c1, RecArgPrim c2 -> Names.Constant.CanOrd.compare c1 c2
+| RecArgPrim _, RecArgInd _ -> 1
+
+let compare_recarg r1 r2 = match r1, r2 with
+| Norec, Norec -> 0
+| Norec, Mrec _ -> -1
+| Mrec t1, Mrec t2 -> compare_recarg_type t1 t2
+| Mrec _, Norec -> 1
+
 let pr_recarg_type = let open Pp in function
   | RecArgInd (mind,i) ->
      str "Mrec[" ++ Names.MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
@@ -209,6 +221,9 @@ let recarg_length p j =
 
 let subst_wf_paths subst p = Rtree.Smart.map (subst_recarg subst) p
 
+let subst_automaton subst a =
+  Rtree.Automaton.map (fun r -> subst_recarg subst r) a
+
 (** {7 Substitution of inductive declarations } *)
 
 let subst_mind_record subst r = match r with
@@ -234,6 +249,7 @@ let subst_mind_packet subst mbp =
     mind_nrealdecls = mbp.mind_nrealdecls;
     mind_squashed = mbp.mind_squashed;
     mind_recargs = subst_wf_paths subst mbp.mind_recargs (*wf_paths*);
+    mind_automaton = subst_automaton subst mbp.mind_automaton;
     mind_relevance = mbp.mind_relevance;
     mind_nb_constant = mbp.mind_nb_constant;
     mind_nb_args = mbp.mind_nb_args;

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -40,6 +40,7 @@ val is_opaque : ('a, 'b) pconstant_body -> bool
 (** {6 Inductive types} *)
 
 val eq_recarg : recarg -> recarg -> bool
+val compare_recarg : recarg -> recarg -> int
 
 val pr_recarg : recarg -> Pp.t
 val pr_wf_paths : wf_paths -> Pp.t

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -156,6 +156,7 @@ let cook_one_ind info cache ~params ~ntypes mip =
     mind_consnrealargs = mip.mind_consnrealargs;
     mind_consnrealdecls = mip.mind_consnrealdecls;
     mind_recargs = mip.mind_recargs;
+    mind_automaton = mip.mind_automaton;
     mind_relevance = lift_relevance info mip.mind_relevance;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -543,6 +543,10 @@ let build_inductive env ~sec_univs names prv univs template variance
            les tag des constructeur non constant a 1 (0 => accumulator) *)
     in
     let rtbl = Array.map transf consnrealargs in
+    let automaton =
+      let automaton = Rtree.Automaton.make recarg in
+      Rtree.Automaton.compact compare_recarg automaton
+    in
       (* Build the inductive packet *)
       { mind_typename = id;
         mind_record;
@@ -558,6 +562,7 @@ let build_inductive env ~sec_univs names prv univs template variance
         mind_user_lc = lc;
         mind_nf_lc = nf_lc;
         mind_recargs = recarg;
+        mind_automaton = automaton;
         mind_relevance;
         mind_nb_constant = !nconst;
         mind_nb_args = !nblock;

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -664,27 +664,55 @@ let size_glb s1 s2 =
        empty type
  *)
 
-type subterm_spec =
-    Subterm of (Int.Set.t * size * wf_paths)
-  | Dead_code
-  | Not_subterm
-  | Internally_bound_subterm of Int.Set.t
+let inter_recarg r1 r2 = if eq_recarg r1 r2 then Some r1 else None
 
-let is_norec_path t = match Rtree.dest_head t with
+module WfPaths :
+sig
+type t
+val make : wf_paths -> t
+val repr : t -> wf_paths
+val inter : t -> t -> t
+val restrict : t -> wf_paths -> t
+val dest_subterms : t -> t list array
+val is_norec : t -> bool
+val is_inductive : env -> inductive -> t -> bool
+val is_primitive : env -> Constant.t -> t -> bool
+end =
+struct
+type t = wf_paths
+let make x = x
+let repr x = x
+let inter t1 t2 = Rtree.inter Declareops.eq_recarg inter_recarg Norec t1 t2
+let restrict = inter
+
+let dest_subterms = dest_subterms
+
+let is_norec t = match Rtree.dest_head t with
 | Norec -> true
 | Mrec _ -> false
 | exception Failure _ ->
   anomaly ~label:"rtree" Pp.(str "Non-closed recursive tree during guard checking.")
 
-let inter_recarg r1 r2 = if eq_recarg r1 r2 then Some r1 else None
+let is_inductive env ind t = match dest_recarg t with
+| Mrec (RecArgInd i) -> QInd.equal env ind i
+| Norec | Mrec (RecArgPrim _) -> false
 
-let inter_wf_paths = Rtree.inter Declareops.eq_recarg inter_recarg Norec
+let is_primitive env cst t = match dest_recarg t with
+| Mrec (RecArgPrim c) -> QConstant.equal env cst c
+| Norec | Mrec _ -> false
+
+end
+
+type subterm_spec =
+    Subterm of (Int.Set.t * size * WfPaths.t)
+  | Dead_code
+  | Not_subterm
+  | Internally_bound_subterm of Int.Set.t
 
 let incl_wf_paths = Rtree.incl Declareops.eq_recarg inter_recarg Norec
 
 let spec_of_tree internal t =
-  if is_norec_path t
-  then Not_subterm
+  if WfPaths.is_norec t then Not_subterm
   else Subterm (internal, Strict, t)
 
 let merge_internal_subterms l1 l2 =
@@ -700,7 +728,7 @@ let inter_spec s1 s2 =
   | Subterm (l1,a1,t1), Internally_bound_subterm l2 -> Subterm (merge_internal_subterms l1 l2,a1,t1)
   | Internally_bound_subterm l1, Subterm (l2,a2,t2) -> Subterm (merge_internal_subterms l1 l2,a2,t2)
   | Subterm (l1,a1,t1), Subterm (l2,a2,t2) ->
-     Subterm (merge_internal_subterms l1 l2, size_glb a1 a2, inter_wf_paths t1 t2)
+     Subterm (merge_internal_subterms l1 l2, size_glb a1 a2, WfPaths.inter t1 t2)
 
 let subterm_spec_glb =
   Array.fold_left inter_spec Dead_code
@@ -800,11 +828,6 @@ let lookup_subterms env ind =
   let (_,mip) = lookup_mind_specif env ind in
   mip.mind_recargs
 
-let match_inductive ind ra =
-  match ra with
-    | Mrec (RecArgInd i) -> Ind.CanOrd.equal ind i
-    | Norec | Mrec (RecArgPrim _) -> false
-
 (* In {match c as z in ci y_s return P with | C_i x_s => t end}
    [branches_specif renv c_spec ci] returns an array of x_s specs knowing
    c_spec. *)
@@ -821,18 +844,14 @@ let branches_specif renv c_spec ci =
     | Rtree.Kind.Node (_, v) -> Array.map Array.length v
     | Rtree.Kind.Var _ -> assert false
   in
-  let subterms = lazy begin match Lazy.force c_spec with
-  | Subterm (_, _, t) -> dest_subterms t
-  | Dead_code | Internally_bound_subterm _ | Not_subterm -> assert false
-  end in
   Array.mapi
       (fun i nca -> (* i+1-th cstructor has arity nca *)
          let lvra = lazy
            (match Lazy.force c_spec with
-                Subterm (internal,_,t) when match_inductive ci.ci_ind (dest_recarg t) ->
-                  let vra = Array.of_list (Lazy.force subterms).(i) in
-                  assert (Int.equal nca (Array.length vra));
-                  Array.map (spec_of_tree internal) vra
+                Subterm (internal,_,t) when WfPaths.is_inductive renv.env ci.ci_ind t ->
+                  let vra = (WfPaths.dest_subterms t).(i) in
+                  let () = assert (Int.equal nca (List.length vra)) in
+                  Array.map_of_list (fun t -> spec_of_tree internal t) vra
               | Dead_code -> Array.make nca Dead_code
               | Internally_bound_subterm _ as x -> Array.make nca x
               | Subterm _ | Not_subterm -> Array.make nca Not_subterm) in
@@ -942,23 +961,19 @@ let get_recargs_approx cache ?evars env tree ind args =
     | Ind ind_kn ->
        (* When the inferred tree allows it, we consider that we have a potential
        nested inductive type *)
-       begin match dest_recarg tree with
-             | Mrec (RecArgInd ind') when QInd.equal env (fst ind_kn) ind' ->
-               build_recargs_nested ienv tree (ind_kn, largs)
-             | Norec | Mrec _ -> mk_norec
-       end
+      if WfPaths.is_inductive env (fst ind_kn) tree then
+        build_recargs_nested ienv tree (ind_kn, largs)
+      else mk_norec
     | Const (c,_) when is_primitive_positive_container env c ->
-       begin match dest_recarg tree with
-             | Mrec (RecArgPrim c') when QConstant.equal env c c' ->
-               build_recargs_nested_primitive ienv tree (c, largs)
-             | Norec | Mrec _ -> mk_norec
-       end
+      if WfPaths.is_primitive env c tree then
+        build_recargs_nested_primitive ienv tree (c, largs)
+      else mk_norec
     | _err ->
        mk_norec
 
   and build_recargs_nested (env,_ra_env as ienv) tree (((mind,i),u), largs) =
     (* If the inferred tree already disallows recursion, no need to go further *)
-    if is_norec_path tree then tree
+    if WfPaths.is_norec tree then mk_norec
     else
     let mib = Environ.lookup_mind mind env in
     let nonrecpar = mib.mind_nparams - mib.mind_nparams_rec in
@@ -973,8 +988,8 @@ let get_recargs_approx cache ?evars env tree ind args =
     computed statically. This is fine because nested inductive types with
     mutually recursive containers are not supported. *)
     let trees =
-      if Int.equal auxntyp 1 then [|dest_subterms tree|]
-      else Cache.get_inductive_subterms mind mib cache
+      if Int.equal auxntyp 1 then [|WfPaths.dest_subterms tree|]
+      else Array.map (fun v -> Array.map (fun l -> List.map WfPaths.make l) v) (Cache.get_inductive_subterms mind mib cache)
     in
     let mk_irecargs j mip =
       (* The nested inductive type with parameters removed *)
@@ -993,12 +1008,12 @@ let get_recargs_approx cache ?evars env tree ind args =
     (Rtree.mk_rec irecargs).(i)
 
   and build_recargs_nested_primitive (env, ra_env) tree (c, largs) =
-    if is_norec_path tree then tree
+    if WfPaths.is_norec tree then mk_norec
     else
     let ntypes = 1 in (* Primitive types are modelled by non-mutual inductive types *)
     let ra_env = List.map (fun (r,t) -> (r,Rtree.lift ntypes t)) ra_env in
     let ienv = (env, ra_env) in
-    let paths = List.map2 (build_recargs ienv) (dest_subterms tree).(0) largs in
+    let paths = List.map2 (build_recargs ienv) (WfPaths.dest_subterms tree).(0) largs in
     let recargs = [| mk_paths (Mrec (RecArgPrim c)) [| paths |] |] in
     (Rtree.mk_rec recargs).(0)
 
@@ -1054,7 +1069,7 @@ let restrict_spec cache ?evars env spec p =
     | Dead_code -> spec
     | Subterm (l, st, tree) ->
       let recargs = get_recargs_approx cache ?evars env tree i args in
-      let tree = inter_wf_paths tree recargs in
+      let tree = WfPaths.restrict tree recargs in
       Subterm (l, st, tree)
     | _ -> assert false
     end
@@ -1089,7 +1104,7 @@ let filter_stack_domain cache stack_element_specif set_iota_specif ?evars env p 
             | Not_subterm | Dead_code | Internally_bound_subterm _ as spec -> spec
             | Subterm (l, s, tree) ->
               let recargs = get_recargs_approx cache ?evars env tree ind args in
-              let tree = inter_wf_paths tree recargs in
+              let tree = WfPaths.restrict tree recargs in
               Subterm (l, s, tree)
             end in
             SArg sarg
@@ -1151,7 +1166,7 @@ let rec subterm_specif cache ?evars renv stack t =
                      (* Why Strict here ? To be general, it could also be
                         Large... *)
           assign_var_spec renv'
-          (nbfix-i, lazy (Subterm(Int.Set.empty,Strict,recargs))) in
+          (nbfix-i, lazy (Subterm(Int.Set.empty,Strict,WfPaths.make recargs))) in
         let decrArg = recindxs.(i) in
         let theBody = bodies.(i)   in
         let nbOfAbst = decrArg+1 in
@@ -1180,7 +1195,7 @@ let rec subterm_specif cache ?evars renv stack t =
       (match subt with
        | Subterm (internal, _s, wf) ->
          (* We take the subterm specs of the constructor of the record *)
-         let wf_args = (dest_subterms wf).(0) in
+         let wf_args = (WfPaths.dest_subterms wf).(0) in
          (* We extract the tree of the projected argument *)
          let n = Projection.arg p in
          spec_of_tree internal (List.nth wf_args n)
@@ -1225,7 +1240,7 @@ and primitive_specif cache ?evars renv op args =
     let subt = subterm_specif cache ?evars renv [] arg in
     begin match subt with
     | Subterm (internal, _s, wf) ->
-      let wf_args = (dest_subterms wf).(0) in
+      let wf_args = (WfPaths.dest_subterms wf).(0) in
       spec_of_tree internal (List.nth wf_args 0) (* first and only parameter of `array` *)
     | Dead_code -> Dead_code
     | Not_subterm -> Not_subterm
@@ -1280,7 +1295,7 @@ type check_subterm_result =
 let check_is_subterm x tree =
   match Lazy.force x with
   | Subterm (need_reduce,Strict,tree') ->
-    if incl_wf_paths tree tree' then NeedReduceSubterm need_reduce
+    if incl_wf_paths tree (WfPaths.repr tree') then NeedReduceSubterm need_reduce
     else InvalidSubterm
   | Dead_code -> NeedReduceSubterm Int.Set.empty
   | Not_subterm | Subterm (_,Large,_) -> InvalidSubterm
@@ -1738,7 +1753,7 @@ let check_fix_pre_sorts ?evars env ((nvect, _), (names, _, bodies as recdef) as 
       let trees = Array.map get_tree inds in
       for i = 0 to Array.length bodies - 1 do
         let (fenv, body) = rdef.(i) in
-        let renv = make_renv fenv nvect.(i) trees.(i) in
+        let renv = make_renv fenv nvect.(i) (WfPaths.make trees.(i)) in
         try check_one_fix cache ?evars renv nvect trees body
         with FixGuardError (err_env, err) -> raise_err err_env i err
       done
@@ -1791,13 +1806,13 @@ let check_one_cofix cache ?evars env nbfix def deftype =
             let realargs = List.skipn mib.mind_nparams args in
             let rec process_args_of_constr = function
               | (t::lr), (rar::lrar) ->
-                  if is_norec_path rar then
+                  if WfPaths.is_norec rar then
                     if noccur_with_meta n nbfix t
                     then process_args_of_constr (lr, lrar)
                     else raise (CoFixGuardError
                                  (env,RecCallInNonRecArgOfConstructor t))
                   else begin
-                      check_rec_call env true n rar (dest_subterms rar) t;
+                      check_rec_call env true n rar (WfPaths.dest_subterms rar) t;
                       process_args_of_constr (lr, lrar)
                     end
               | [],_ -> ()
@@ -1836,7 +1851,7 @@ let check_one_cofix cache ?evars env nbfix def deftype =
                if (noccur_with_meta n nbfix p) then
                  if (noccur_with_meta n nbfix tm) then
                    if (List.for_all (noccur_with_meta n nbfix) args) then
-                     let vlra = dest_subterms tree in
+                     let vlra = WfPaths.dest_subterms tree in
                      Array.iter (check_rec_call env alreadygrd n tree vlra) vrest
                    else
                      raise (CoFixGuardError (env,RecCallInCaseFun c))
@@ -1855,8 +1870,8 @@ let check_one_cofix cache ?evars env nbfix def deftype =
            raise (CoFixGuardError (env,NotGuardedForm t)) in
 
   let ((mind, _),_) = codomain_is_coind ?evars env deftype in
-  let vlra = lookup_subterms env mind in
-  check_rec_call env false 1 vlra (dest_subterms vlra) def
+  let vlra = WfPaths.make (lookup_subterms env mind) in
+  check_rec_call env false 1 vlra (WfPaths.dest_subterms vlra) def
 
 (* The  function which checks that the whole block of definitions
    satisfies the guarded condition *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -664,33 +664,10 @@ let size_glb s1 s2 =
        empty type
  *)
 
-module RecArg =
-struct
-let compare_recarg_type t1 t2 = match t1, t2 with
-| RecArgInd ind1, RecArgInd ind2 -> Names.Ind.CanOrd.compare ind1 ind2
-| RecArgInd _, RecArgPrim _ -> -1
-| RecArgPrim c1, RecArgPrim c2 -> Names.Constant.CanOrd.compare c1 c2
-| RecArgPrim _, RecArgInd _ -> 1
-
-let compare r1 r2 = match r1, r2 with
-| Norec, Norec -> 0
-| Norec, Mrec _ -> -1
-| Mrec t1, Mrec t2 -> compare_recarg_type t1 t2
-| Mrec _, Norec -> 1
-
-let meet r1 r2 = match r1, r2 with
-| Mrec _, Mrec _ ->
-  let () = assert (eq_recarg r1 r2) in
-  r1
-| Norec, Norec -> Norec
-| (Norec, Mrec _) | (Mrec _, Norec) -> Norec
-
-end
-
 module WfPaths :
 sig
 type t
-val make : wf_paths -> t
+val make : recarg Rtree.Automaton.t -> t (* must be minimal! *)
 val inter : t -> t -> t
 val restrict : t -> wf_paths -> t
 val dest_subterms : t -> t list array
@@ -705,17 +682,24 @@ module Atm = Rtree.Automaton
 
 type t = recarg Atm.t
 
-let make path =
-  let automaton = Atm.make path in
-  Atm.compact RecArg.compare automaton
+let make t = t
+
+let meet_recarg r1 r2 = match r1, r2 with
+| Mrec _, Mrec _ ->
+  let () = assert (eq_recarg r1 r2) in
+  r1
+| Norec, Norec -> Norec
+| (Norec, Mrec _) | (Mrec _, Norec) -> Norec
 
 let inter t1 t2 =
-  let automaton = Atm.inter RecArg.meet t1 t2 in
-  if automaton == t1 then t1 else Atm.compact RecArg.compare automaton
+  let automaton = Atm.inter meet_recarg t1 t2 in
+  if automaton == t1 then t1 else Atm.compact compare_recarg automaton
 
 let restrict t p =
-  let automaton = Atm.inter RecArg.meet t (make p) in
-  Atm.compact RecArg.compare automaton
+  let p = Atm.make p in
+  let p = Atm.compact compare_recarg p in
+  let automaton = Atm.inter meet_recarg t p in
+  Atm.compact compare_recarg automaton
 
 let dest_subterms t =
   let trans = Atm.transitions t (Atm.initial t) in
@@ -865,7 +849,7 @@ let lift1_stack = lift_stack 1
 
 let lookup_subterms env ind =
   let (_,mip) = lookup_mind_specif env ind in
-  mip.mind_recargs
+  WfPaths.make mip.mind_automaton
 
 (* In {match c as z in ci y_s return P with | C_i x_s => t end}
    [branches_specif renv c_spec ci] returns an array of x_s specs knowing
@@ -967,15 +951,15 @@ module Cache :
 sig
   type t
   val create : unit -> t
-  val get_inductive_subterms : MutInd.t -> mutual_inductive_body -> t -> wf_paths list array array
+  val get_inductive_subterms : MutInd.t -> mutual_inductive_body -> t -> WfPaths.t list array array
 end =
 struct
-  type ans = wf_paths list array array
+  type ans = WfPaths.t list array array
   type t = ans Mindmap_env.t ref
   let create () = ref Mindmap_env.empty
   let get_inductive_subterms mind mib cache = match Mindmap_env.find_opt mind !cache with
   | None ->
-    let ans = Array.map (fun mip -> dest_subterms mip.mind_recargs) mib.mind_packets in
+    let ans = Array.map (fun mip -> WfPaths.dest_subterms (WfPaths.make mip.mind_automaton)) mib.mind_packets in
     let () = cache := Mindmap_env.add mind ans !cache in
     ans
   | Some ans -> ans
@@ -1028,7 +1012,7 @@ let get_recargs_approx cache ?evars env tree ind args =
     mutually recursive containers are not supported. *)
     let trees =
       if Int.equal auxntyp 1 then [|WfPaths.dest_subterms tree|]
-      else Array.map (fun v -> Array.map (fun l -> List.map WfPaths.make l) v) (Cache.get_inductive_subterms mind mib cache)
+      else Cache.get_inductive_subterms mind mib cache
     in
     let mk_irecargs j mip =
       (* The nested inductive type with parameters removed *)
@@ -1205,7 +1189,7 @@ let rec subterm_specif cache ?evars renv stack t =
                      (* Why Strict here ? To be general, it could also be
                         Large... *)
           assign_var_spec renv'
-          (nbfix-i, lazy (Subterm(Int.Set.empty,Strict,WfPaths.make recargs))) in
+          (nbfix-i, lazy (Subterm(Int.Set.empty,Strict,recargs))) in
         let decrArg = recindxs.(i) in
         let theBody = bodies.(i)   in
         let nbOfAbst = decrArg+1 in
@@ -1785,11 +1769,7 @@ let check_fix_pre_sorts ?evars env ((nvect, _), (names, _, bodies as recdef) as 
   let raise_err = raise_fix_guard_err_fn env recdef names in
   let () =
     if flags.check_guarded then
-      let get_tree (kn,i) =
-        let mib = Environ.lookup_mind kn env in
-        WfPaths.make mib.mind_packets.(i).mind_recargs
-      in
-      let trees = Array.map get_tree inds in
+      let trees = Array.map (fun ind -> lookup_subterms env ind) inds in
       for i = 0 to Array.length bodies - 1 do
         let (fenv, body) = rdef.(i) in
         let renv = make_renv fenv nvect.(i) trees.(i) in
@@ -1909,7 +1889,7 @@ let check_one_cofix cache ?evars env nbfix def deftype =
            raise (CoFixGuardError (env,NotGuardedForm t)) in
 
   let ((mind, _),_) = codomain_is_coind ?evars env deftype in
-  let vlra = WfPaths.make (lookup_subterms env mind) in
+  let vlra = lookup_subterms env mind in
   check_rec_call env false 1 vlra (WfPaths.dest_subterms vlra) def
 
 (* The  function which checks that the whole block of definitions

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -664,30 +664,68 @@ let size_glb s1 s2 =
        empty type
  *)
 
-let inter_recarg r1 r2 = if eq_recarg r1 r2 then Some r1 else None
+module RecArg =
+struct
+let compare_recarg_type t1 t2 = match t1, t2 with
+| RecArgInd ind1, RecArgInd ind2 -> Names.Ind.CanOrd.compare ind1 ind2
+| RecArgInd _, RecArgPrim _ -> -1
+| RecArgPrim c1, RecArgPrim c2 -> Names.Constant.CanOrd.compare c1 c2
+| RecArgPrim _, RecArgInd _ -> 1
+
+let compare r1 r2 = match r1, r2 with
+| Norec, Norec -> 0
+| Norec, Mrec _ -> -1
+| Mrec t1, Mrec t2 -> compare_recarg_type t1 t2
+| Mrec _, Norec -> 1
+
+let meet r1 r2 = match r1, r2 with
+| Mrec _, Mrec _ ->
+  let () = assert (eq_recarg r1 r2) in
+  r1
+| Norec, Norec -> Norec
+| (Norec, Mrec _) | (Mrec _, Norec) -> Norec
+
+end
 
 module WfPaths :
 sig
 type t
 val make : wf_paths -> t
-val repr : t -> wf_paths
 val inter : t -> t -> t
 val restrict : t -> wf_paths -> t
 val dest_subterms : t -> t list array
 val is_norec : t -> bool
 val is_inductive : env -> inductive -> t -> bool
 val is_primitive : env -> Constant.t -> t -> bool
+val equal : t -> t -> bool
 end =
 struct
-type t = wf_paths
-let make x = x
-let repr x = x
-let inter t1 t2 = Rtree.inter Declareops.eq_recarg inter_recarg Norec t1 t2
-let restrict = inter
 
-let dest_subterms = dest_subterms
+module Atm = Rtree.Automaton
 
-let is_norec t = match Rtree.dest_head t with
+type t = recarg Atm.t
+
+let make path =
+  let automaton = Atm.make path in
+  Atm.compact RecArg.compare automaton
+
+let inter t1 t2 =
+  let automaton = Atm.inter RecArg.meet t1 t2 in
+  if automaton == t1 then t1 else Atm.compact RecArg.compare automaton
+
+let restrict t p =
+  let automaton = Atm.inter RecArg.meet t (make p) in
+  Atm.compact RecArg.compare automaton
+
+let dest_subterms t =
+  let trans = Atm.transitions t (Atm.initial t) in
+  let map v = Array.map_to_list (fun tgt -> Atm.move t tgt) v in
+  Array.map map trans
+
+let dest_recarg t =
+  Atm.data t (Atm.initial t)
+
+let is_norec t = match dest_recarg t with
 | Norec -> true
 | Mrec _ -> false
 | exception Failure _ ->
@@ -701,6 +739,9 @@ let is_primitive env cst t = match dest_recarg t with
 | Mrec (RecArgPrim c) -> QConstant.equal env cst c
 | Norec | Mrec _ -> false
 
+let equal t1 t2 =
+  Atm.equal eq_recarg t1 t2
+
 end
 
 type subterm_spec =
@@ -708,8 +749,6 @@ type subterm_spec =
   | Dead_code
   | Not_subterm
   | Internally_bound_subterm of Int.Set.t
-
-let incl_wf_paths = Rtree.incl Declareops.eq_recarg inter_recarg Norec
 
 let spec_of_tree internal t =
   if WfPaths.is_norec t then Not_subterm
@@ -1295,7 +1334,7 @@ type check_subterm_result =
 let check_is_subterm x tree =
   match Lazy.force x with
   | Subterm (need_reduce,Strict,tree') ->
-    if incl_wf_paths tree (WfPaths.repr tree') then NeedReduceSubterm need_reduce
+    if WfPaths.equal tree tree' then NeedReduceSubterm need_reduce
     else InvalidSubterm
   | Dead_code -> NeedReduceSubterm Int.Set.empty
   | Not_subterm | Subterm (_,Large,_) -> InvalidSubterm
@@ -1748,12 +1787,12 @@ let check_fix_pre_sorts ?evars env ((nvect, _), (names, _, bodies as recdef) as 
     if flags.check_guarded then
       let get_tree (kn,i) =
         let mib = Environ.lookup_mind kn env in
-        mib.mind_packets.(i).mind_recargs
+        WfPaths.make mib.mind_packets.(i).mind_recargs
       in
       let trees = Array.map get_tree inds in
       for i = 0 to Array.length bodies - 1 do
         let (fenv, body) = rdef.(i) in
-        let renv = make_renv fenv nvect.(i) (WfPaths.make trees.(i)) in
+        let renv = make_renv fenv nvect.(i) trees.(i) in
         try check_one_fix cache ?evars renv nvect trees body
         with FixGuardError (err_env, err) -> raise_err err_env i err
       done

--- a/kernel/rtree.ml
+++ b/kernel/rtree.ml
@@ -244,9 +244,9 @@ let is_infinite cmp t =
   is_inf [] t
 
 (* Pretty-print a tree (not so pretty) *)
-open Pp
 
 let rec pr_tree prl t =
+  let open Pp in
   match t with
     | Var (i,j) -> str"#"++int i++str":"++int j
     | Node(lab,[||]) -> prl lab
@@ -265,3 +265,192 @@ let rec pr_tree prl t =
         else
           hv 2 (str"Rec{"++int i++str","++brk(1,0)++
                  prvect_with_sep pr_comma (pr_tree prl) v++str"}")
+
+module Automaton =
+struct
+
+type 'a rtree = 'a t
+
+type label = { constructor : int; argpos : int }
+
+module Label =
+struct
+  type t = label
+  let compare p q =
+    let c = Int.compare p.constructor q.constructor in
+    if Int.equal c 0 then Int.compare p.argpos q.argpos else c
+end
+
+module H = Hopcroft.Make(Label)
+
+type state = int
+
+type 'a data = {
+  uid : int;
+  elt : 'a Int.Map.t;
+  trs : state array array Int.Map.t;
+}
+
+type 'a t = {
+  init : int;
+  states : ('a * state array array) array;
+}
+
+let initial a = a.init
+let data a i = fst a.states.(i)
+let transitions a i = snd a.states.(i)
+let move a i = { init = i; states = a.states }
+
+let make r =
+  let rec aux env state = function
+  | Var (i, j) ->
+    let vec = Range.get env i in
+    state, vec.(j)
+  | Node (lbl, args) ->
+    let node = state.uid in
+    let state = { state with elt = Int.Map.add node lbl state.elt; uid = state.uid + 1 } in
+    let fold accu v = Array.fold_left_map (fun accu r -> aux env accu r) accu v in
+    let (state, tr) = Array.fold_left_map fold state args in
+    let state = { state with trs = Int.Map.add node tr state.trs } in
+    state, node
+  | Rec (j, v) ->
+    let map = function
+    | Var _ | Rec _ ->
+      assert false (* does not happen for rtrees generated from an inductive *)
+    | Node (lbl, args) -> (lbl, args)
+    in
+    let uid = state.uid in
+    let v = Array.map map v in
+    let self = Array.mapi (fun i _ -> state.uid + i) v in
+    let nelt = Array.fold_left_i (fun i accu (lbl, _) -> Int.Map.add (state.uid + i) lbl accu) state.elt v in
+    let state = { state with elt = nelt; uid = state.uid + Array.length v } in
+    let env = Range.cons self env in
+    let fold pos accu (_lbl, args) =
+      let fold accu v = Array.fold_left_map (fun accu r -> aux env accu r) accu v in
+      let (accu, tr) = Array.fold_left_map fold accu args in
+      { accu with trs = Int.Map.add (uid + pos) tr accu.trs }
+    in
+    let state = Array.fold_left_i fold state v in
+    state, self.(j)
+  in
+  let state, init = aux Range.empty { uid = 0; trs = Int.Map.empty; elt = Int.Map.empty } r in
+  let states = Array.init state.uid (fun i -> Int.Map.find i state.elt, Int.Map.find i state.trs) in
+  { init; states }
+
+let compact (type data) (cmp : data -> data -> int) { init; states } =
+  let module Data = struct type t = data let compare = cmp end in
+  let module LMap = Map.Make(Data) in
+  let fold i accu (label, _) = match LMap.find_opt label accu with
+  | None -> LMap.add label [i] accu
+  | Some l -> LMap.add label (i :: l) accu
+  in
+  let partitions = Array.fold_left_i fold LMap.empty states in
+  let partitions = List.map snd @@ LMap.bindings partitions in
+  let fold src accu (_, trs) =
+    let fold i accu v =
+      let fold j accu dst = { H.src = src; H.lbl = { constructor = i; argpos = j }; H.dst = dst } :: accu in
+      Array.fold_left_i fold accu v
+    in
+    Array.fold_left_i fold accu trs
+  in
+  let transitions = Array.fold_left_i fold [] states in
+  let classes =
+    if List.is_empty transitions then
+      Array.of_list partitions
+    else
+      let automaton = {
+        H.states = Array.length states;
+        H.partitions = partitions;
+        H.transitions = transitions;
+      } in
+      H.reduce automaton
+  in
+  (* Canonicalize transitions *)
+  let fold i accu l = List.fold_left (fun accu orig -> Int.Map.add orig i accu) accu l in
+  let map = Array.fold_left_i fold Int.Map.empty classes in
+  let canon st =
+    let can = match st with
+    | [] -> assert false
+    | can :: _ -> can
+    in
+    let v, tr = states.(can) in
+    let ntr = Array.map (fun v -> Array.map (fun dst -> Int.Map.get dst map) v) tr in
+    v, ntr
+  in
+  let nstates = Array.map canon classes in
+  let ninit = Int.Map.find init map in
+  { init = ninit; states = nstates }
+
+module IntPair = OrderedType.Pair(Int)(Int)
+module IntPairMap = Map.Make(IntPair)
+
+let merge_array f v1 v2 =
+  let len1 = Array.length v1 in
+  let len2 = Array.length v2 in
+  let len = if len1 < len2 then len1 else len2 in
+  Array.init len (fun i -> f v1.(i) v2.(i))
+
+let inter f a1 a2=
+  let { init = i1; states = st1 } = a1 in
+  let { init = i2; states = st2 } = a2 in
+  if Int.equal i1 i2 && st1 == st2 then a1
+  else
+    let rec search seen i1 i2 =
+      if IntPairMap.mem (i1, i2) seen then seen
+      else
+        let (v1, tr1) = st1.(i1) in
+        let (v2, tr2) = st2.(i2) in
+        let v = f v1 v2 in
+        let merge v1 v2 = merge_array (fun t1 t2 -> t1, t2) v1 v2 in
+        let tr = merge_array merge tr1 tr2 in
+        let seen = IntPairMap.add (i1, i2) (v, tr) seen in
+        let fold seen v =
+          let fold seen (tgt1, tgt2) = search seen tgt1 tgt2 in
+          Array.fold_left fold seen v
+        in
+        Array.fold_left fold seen tr
+    in
+    let seen = search IntPairMap.empty i1 i2 in
+    let fold p _ (i, dir, rev) = (i + 1, IntPairMap.add p i dir, Int.Map.add i p rev) in
+    let (_, dir, rev) = IntPairMap.fold fold seen (0, IntPairMap.empty, Int.Map.empty) in
+    let len = IntPairMap.cardinal dir in
+    let mk i =
+      let p = Int.Map.find i rev in
+      let (v, tr) = IntPairMap.find p seen in
+      let ntr = Array.map (fun v -> Array.map (fun p -> IntPairMap.find p dir) v) tr in
+      (v, ntr)
+    in
+    let nstates = Array.init len mk in
+    let ninit = IntPairMap.get (i1, i2) dir in
+    { init = ninit; states = nstates }
+
+exception Different
+
+let check_len v1 v2 =
+  if not (Int.equal (Array.length v1) (Array.length v2)) then raise Different
+
+(* The function below expects the automata to be minimal *)
+let equal eqf { init = i1; states = st1 } { init = i2; states = st2 } =
+  let rec search seen1 seen2 equiv i1 i2 =
+    if IntPairMap.mem (i1, i2) equiv then (seen1, seen2, equiv)
+    else if Int.Set.mem i1 seen1 || Int.Set.mem i2 seen2 then raise Different
+    else
+      let (v1, tr1) = st1.(i1) in
+      let (v2, tr2) = st2.(i2) in
+      let () = if not (eqf v1 v2) then raise Different in
+      let seen1 = Int.Set.add i1 seen1 in
+      let seen2 = Int.Set.add i2 seen2 in
+      let equiv = IntPairMap.add (i1, i2) () equiv in
+      let () = check_len tr1 tr2 in
+      let fold accu v1 v2 =
+        let () = check_len v1 v2 in
+        Array.fold_left2 (fun (seen1, seen2, equiv) tgt1 tgt2 -> search seen1 seen2 equiv tgt1 tgt2) accu v1 v2
+      in
+      Array.fold_left2 fold (seen1, seen2, equiv) tr1 tr2
+  in
+  (Int.equal i1 i2 && st1 == st2) ||
+  match search Int.Set.empty Int.Set.empty IntPairMap.empty i1 i2 with
+  | _ -> true
+  | exception Different -> false
+
+end

--- a/kernel/rtree.ml
+++ b/kernel/rtree.ml
@@ -453,4 +453,9 @@ let equal eqf { init = i1; states = st1 } { init = i2; states = st2 } =
   | _ -> true
   | exception Different -> false
 
+let map f { init; states } =
+  let map (v, tr) = f v, tr in
+  let states = Array.map map states in
+  { init; states }
+
 end

--- a/kernel/rtree.mli
+++ b/kernel/rtree.mli
@@ -144,4 +144,7 @@ val inter : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
 (** Equality of minimal automata, i.e. only valid after compaction *)
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
+(** Map the data of each node *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+
 end

--- a/kernel/rtree.mli
+++ b/kernel/rtree.mli
@@ -109,3 +109,39 @@ val kind : 'a t -> 'a kind
 val repr : 'a t -> 'a rtree
 
 end
+
+module Automaton :
+sig
+
+type 'a rtree = 'a t
+
+type state
+
+type 'a t
+
+(** Compile a regular tree into an automaton, not necessarily minimal *)
+val make : 'a rtree -> 'a t
+
+(** Get the initial state of the automaton *)
+val initial : 'a t -> state
+
+(** Get the data associated to a given state in the automaton *)
+val data : 'a t -> state -> 'a
+
+(** Get the transitions of the automaton from a given state *)
+val transitions : 'a t -> state -> state array array
+
+(** Move the automaton into the given state *)
+val move : 'a t -> state -> 'a t
+
+(** Given a comparison function on the data, produce a minimal automaton *)
+val compact  : ('a -> 'a -> int) -> 'a t -> 'a t
+
+(** Intersection of two automata given an intersection on data. Does not
+    produce a minimal automaton on general. *)
+val inter : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+
+(** Equality of minimal automata, i.e. only valid after compaction *)
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+end

--- a/lib/hopcroft.ml
+++ b/lib/hopcroft.ml
@@ -1,0 +1,365 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Partition refinement algorithm *)
+
+module type PartitionS =
+sig
+  type t
+  (** Type of partition structure *)
+
+  type set
+  (** Type of partitions *)
+
+  val create : int -> t
+  (** Create a partition structure of the given size *)
+
+  val length : t -> int
+  (** Number of partitions *)
+
+  val size : set -> t -> int
+  (** Number of elements of a partition *)
+
+  val partition : int -> t -> set
+  (** [partition i t] returns the index of the partition which contains [i] *)
+
+  val iter : set -> (int -> unit) -> t -> unit
+  (** Iter on elements of a partition. Don't [mark] and [split] in the loop! *)
+
+  val fold : set -> (int -> 'a -> 'a) -> t -> 'a -> 'a
+  (** Fold left to right on elements of a partition. Don't [mark] and [split] in
+      the loop! *)
+
+  val iter_all : (set -> unit) -> t -> unit
+  (** Iter on partitions. Don't [mark] and [split] in the loop! *)
+
+  val fold_all : (set -> 'a -> 'a) -> t -> 'a -> 'a
+  (** Fold left to right on partitions. Don't [mark] and [split] in the loop! *)
+
+  val mark : int -> t -> unit
+  (** Mark an element for splitting *)
+
+  val split : set -> t -> set
+  (** Performs splitting and return the set of marked elements *)
+
+  val is_marked : set -> t -> bool
+  (** Returns [true] if some element of the set is marked *)
+
+  val is_valid : set -> bool
+  (** Test whether a splitting succeeded *)
+
+  val represent : set -> int
+  (** Associate a unique number to each partition. If the partition is valid, then
+      the returned number is guaranteed to be between [0] and [len - 1] when
+      [len] is the number of partitions of the structure. *)
+end
+
+module Partition =
+struct
+
+type set = int
+
+type t = {
+  mutable partitions : int;
+  (** number of partitions *)
+  mutable first : int array;
+  (** index of the first element of a partition *)
+  mutable last : int array;
+  (** successor index of the last element of a partition *)
+  mutable marked : int array;
+  (** index of the last marked element of a partition *)
+  index : set array;
+  (** associate a partition to an element *)
+  elements : int array;
+  (** contain elements in a contiguous way w.r.t. partitions *)
+  location : int array;
+  (** keep the location of an element in [elements] *)
+}
+
+let initial_size n = max (n / 100) 7
+
+let create n = {
+  partitions = 0;
+  first = Array.make (initial_size n) 0;
+  last = Array.make (initial_size n) n;
+  marked = Array.make (initial_size n) 0;
+  index = Array.make n 0;
+  elements = Array.init n (fun i -> i);
+  location = Array.init n (fun i -> i);
+}
+
+let uget (t : int array) i = Array.get t i
+let uset (t : int array) i x = Array.set t i x
+
+let length t = succ t.partitions
+
+let size s t =
+  uget t.last s - uget t.first s
+
+let partition i t = uget t.index i
+
+let iter s f t =
+  let fst = uget t.first s in
+  let lst = uget t.last s in
+  for i = fst to lst - 1 do
+    f (uget t.elements i);
+  done
+
+let fold s f t accu =
+  let fst = uget t.first s in
+  let lst = uget t.last s in
+  let rec fold accu i =
+    if lst <= i then accu
+    else fold (f (uget t.elements i) accu) (succ i)
+  in
+  fold accu fst
+
+let iter_all f t =
+  for i = 0 to t.partitions do f i; done
+
+let fold_all f t accu =
+  let rec fold accu i =
+    if t.partitions <= i then accu
+    else fold (f i accu) (succ i)
+  in
+  fold accu 0
+
+let resize t =
+  let len = Array.length t.first in
+  if len <= t.partitions then begin
+    let nlen = 2 * len + 1 in
+    let pfirst = t.first in
+    let plast = t.last in
+    let pmarked = t.marked in
+    let nfirst = Array.make nlen 0 in
+    let nlast = Array.make nlen 0 in
+    let nmarked = Array.make nlen 0 in
+    for i = 0 to pred len do
+      uset nfirst i (uget pfirst i);
+      uset nlast i (uget plast i);
+      uset nmarked i (uget pmarked i);
+    done;
+    t.first <- nfirst;
+    t.last <- nlast;
+    t.marked <- nmarked;
+  end
+
+let split s t =
+  if uget t.marked s = uget t.last s then uset t.marked s (uget t.first s);
+  if uget t.marked s = uget t.first s then -1
+  (* Nothing to split *)
+  else begin
+    let len = succ t.partitions in
+    t.partitions <- len;
+    resize t;
+    uset t.first len (uget t.first s);
+    uset t.marked len (uget t.first s);
+    uset t.last len (uget t.marked s);
+    uset t.first s (uget t.marked s);
+    for i = uget t.first len to pred (uget t.last len) do
+      uset t.index (uget t.elements i) len;
+    done;
+    len
+  end
+
+let mark i t =
+  let set = uget t.index i in
+  let loc = uget t.location i in
+  let mark = uget t.marked set in
+  if mark <= loc then begin
+    uset t.elements loc (uget t.elements mark);
+    uset t.location (uget t.elements loc) loc;
+    uset t.elements mark i;
+    uset t.location i mark;
+    uset t.marked set (succ mark);
+  end
+
+let is_marked s t = (uget t.marked s) <> (uget t.first s)
+
+let is_valid s = 0 <= s
+
+let represent s = s
+
+end
+
+(** Hopcroft algorithm *)
+
+module type S =
+sig
+  type label
+  type state
+  type transition = {
+    src : state;
+    lbl : label;
+    dst : state;
+  }
+
+  type automaton = {
+    states : int;
+    partitions : state list list;
+    transitions : transition list;
+  }
+
+  val reduce : automaton -> state list array
+end
+
+module Make (Label : Map.OrderedType) : S
+  with type label = Label.t
+  and type state = int =
+struct
+
+type label = Label.t
+type state = int
+
+type transition = {
+  src : state;
+  lbl : label;
+  dst : state;
+}
+
+module TMap = Map.Make(Label)
+
+type automaton = {
+  states : int;
+  partitions : state list list;
+  transitions : transition list;
+}
+
+(** Partitions of states *)
+module SPartition : PartitionS = Partition
+
+(** Partitions of transitions *)
+module TPartition : PartitionS = Partition
+
+type environment = {
+  state_partition : SPartition.t;
+  splitter_partition : TPartition.t;
+  transition_source : int array;
+}
+
+(** Associate the list of transitions ending in a given state *)
+let reverse automaton =
+  let ans = Array.make automaton.states [] in
+  let add (x : int) l = (* if List.mem x l then l else *) x :: l in
+  let iter i trans =
+    let l = Array.get ans trans.dst in
+    Array.set ans trans.dst (add i l)
+  in
+  let () = List.iteri iter automaton.transitions in
+  ans
+
+let init automaton =
+  let transitions = automaton.transitions in
+  let len = List.length transitions in
+  (* Sort transitions according to their label *)
+  let env = {
+    state_partition = SPartition.create automaton.states;
+    splitter_partition = TPartition.create len;
+    transition_source = Array.make len (-1);
+  } in
+  (* Set the source of the transitions *)
+  let iteri i trans = env.transition_source.(i) <- trans.src in
+  let () = List.iteri iteri transitions in
+  (* Split splitters according to their label *)
+  let fold i accu trans = match TMap.find_opt trans.lbl accu with
+  | None -> TMap.add trans.lbl [i] accu
+  | Some l -> TMap.add trans.lbl (i :: l) accu
+  in
+  let lblmap = CList.fold_left_i fold 0 TMap.empty transitions in
+  let p = env.splitter_partition in
+  let pt = TPartition.partition 0 p in
+  let iter _ trs =
+    let iter idx = TPartition.mark idx p in
+    let () = List.iter iter trs in
+    ignore (TPartition.split pt p : TPartition.set)
+  in
+  let () = TMap.iter iter lblmap in
+  (* Push every splitter in the todo stack *)
+  let fold pt todo = pt :: todo in
+  let splitter_todo = TPartition.fold_all fold env.splitter_partition [] in
+  env, splitter_todo, automaton.partitions
+
+let split_partition s inv env todo =
+  let p = env.state_partition in
+  let r = SPartition.split s p in
+  if SPartition.is_valid r then begin
+    let r = if SPartition.size r p < SPartition.size s p then r else s in
+    let fold state accu =
+      let fold accu trans =
+        let pt = TPartition.partition trans env.splitter_partition in
+        let accu =
+          if TPartition.is_marked pt env.splitter_partition then accu
+          else pt :: accu
+        in
+        let () = TPartition.mark trans env.splitter_partition in
+        accu
+      in
+      List.fold_left fold accu inv.(state)
+    in
+    let splitter_touched = SPartition.fold r fold p [] in
+    let fold_touched todo pt =
+      let npt = TPartition.split pt env.splitter_partition in
+      if TPartition.is_valid npt then npt :: todo
+      else todo
+    in
+    List.fold_left fold_touched todo splitter_touched
+  end else
+    todo
+
+let reduce_aux automaton =
+  let env, splitter_todo, initial = init automaton in
+  let inv = reverse automaton in
+  (* Mark every state in each initial partition and split *)
+  let ps = SPartition.partition 0 env.state_partition in
+  let splitter_todo =
+    let separate todo pt =
+      let iter state () = SPartition.mark state env.state_partition in
+      let () = List.fold_right iter pt () in
+      split_partition ps inv env todo
+    in
+    List.fold_left separate splitter_todo initial
+  in
+  (* Main loop *)
+  let rec loop = function
+  | [] -> ()
+  | pt :: todo ->
+    let fold t state_touched =
+      let previous = env.transition_source.(t) in
+      let equiv = SPartition.partition previous env.state_partition in
+      let state_touched =
+        if SPartition.is_marked equiv env.state_partition then state_touched
+        else equiv :: state_touched
+      in
+      let () = SPartition.mark previous env.state_partition in
+      state_touched
+    in
+    let state_touched = TPartition.fold pt fold env.splitter_partition [] in
+    let fold_touched todo equiv = split_partition equiv inv env todo in
+    let splitter_todo = List.fold_left fold_touched todo state_touched in
+    loop splitter_todo
+  in
+  let () = loop splitter_todo in
+  (env, inv)
+
+let reduce automaton =
+  let (ans, _) = reduce_aux automaton in
+  let mapping = Array.make (SPartition.length ans.state_partition) [] in
+  let iter set =
+    let pi = SPartition.represent set in
+    let iter i =
+      let map = Array.get mapping pi in
+      Array.set mapping pi (i :: map)
+    in
+    SPartition.iter set iter ans.state_partition
+  in
+  let () = SPartition.iter_all iter ans.state_partition in
+  mapping
+
+end

--- a/lib/hopcroft.mli
+++ b/lib/hopcroft.mli
@@ -1,0 +1,38 @@
+(************************************************************************)
+(*         *      The Rocq Prover / The Rocq Development Team           *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Hopcroft algorithm *)
+
+module type S =
+sig
+  type label
+  type state
+  type transition = {
+    src : state;
+    lbl : label;
+    dst : state;
+  }
+
+  type automaton = {
+    states : int;
+    (** The number of states of the automaton. *)
+    partitions : state list list;
+    (** A set of state partitions initially known to be observationally
+        distinct. For instance, if the automaton has the list [l] as accepting
+        states, one can set [partitions = [l]]. *)
+    transitions : transition list;
+    (** The transitions of the automaton without duplicates. *)
+  }
+
+  val reduce : automaton -> state list array
+  (** Associate the array of equivalence classes of the states of an automaton *)
+end
+
+module Make (Label : Map.OrderedType) : S with type label = Label.t and type state = int


### PR DESCRIPTION
This representation prevents an exponential blowup when nesting inductive types. It makes guard checking basically instantaneous on some examples that used to take about 30s.

Fixes #19650: Taking a long time to type check inductive types
Fixes #21526: Slow fixpoint type-checking due to the guard condition.
