### PR TITLE
Remove the not extremely well-named Inv.inv function.

### DIFF
--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -103,7 +103,7 @@ let functional_inversion kn hid fconst f_correct =
               [applist (f_correct, Array.to_list f_args @ [res; mkVar hid])]
           ; clear [hid]
           ; Simple.intro hid
-          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp (CAst.make hid))
+          ; Inv.inv_clause Inv.FullInversion None [] (Tactypes.NamedHyp (CAst.make hid))
           ; Proofview.Goal.enter (fun gl ->
                 let new_ids =
                   List.filter

--- a/tactics/inv.mli
+++ b/tactics/inv.mli
@@ -23,9 +23,6 @@ val inv_clause :
   inversion_kind -> or_and_intro_pattern option -> Id.t list ->
     quantified_hypothesis -> unit Proofview.tactic
 
-val inv : inversion_kind -> or_and_intro_pattern option ->
-  quantified_hypothesis -> unit Proofview.tactic
-
 val dinv : inversion_kind -> constr option ->
   or_and_intro_pattern option -> quantified_hypothesis -> unit Proofview.tactic
 


### PR DESCRIPTION
It was only used once in funind and the function is easily reachable through the Inv.inv_clause wrapper.