### PR TITLE
Disallow Type@{s; _} from being a valid template conclusion

### DIFF
--- a/test-suite/bugs/bug_21664.v
+++ b/test-suite/bugs/bug_21664.v
@@ -1,0 +1,12 @@
+Sort s.
+
+Inductive Ind1 : Type@{s; _} := C.
+(* Universe inconsistency. Cannot enforce Prop <= Type@{s | Set}. *)
+
+Fail #[universes(template)] Inductive ofTy A : Type@{s; _} := OfTy (_:A).
+(* not yet implemented *)
+
+Inductive ofTy A : Type@{s;_} := OfTy (_:A).
+
+(* parameter A was inferred to be in sort s *)
+Check ofTy Ind1.


### PR DESCRIPTION
Fix #21664

Less syntactic, more semantic version of #21665
