### PR TITLE
Stop using infer_conv_ustate in unification

### DIFF
--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -255,6 +255,8 @@ val is_conv : ?reds:TransparentState.t -> env -> evar_map -> constr -> constr ->
 val is_conv_leq : ?reds:TransparentState.t -> env -> evar_map -> constr -> constr -> bool
 val is_fconv : ?reds:TransparentState.t -> conv_pb -> env -> evar_map -> constr -> constr -> bool
 
+val is_conv_nounivs : ?reds:TransparentState.t -> env -> evar_map -> constr -> constr -> bool
+
 (** [infer_conv] Adds necessary universe constraints to the evar map.
     pb defaults to CUMUL and ts to a full transparent state.
     @raise UniverseInconsistency iff catch_incon is set to false,
@@ -262,9 +264,6 @@ val is_fconv : ?reds:TransparentState.t -> conv_pb -> env -> evar_map -> constr 
  *)
 val infer_conv : ?catch_incon:bool -> ?pb:conv_pb -> ?ts:TransparentState.t ->
   env -> evar_map -> constr -> constr -> evar_map option
-
-val infer_conv_ustate : ?catch_incon:bool -> ?pb:conv_pb -> ?ts:TransparentState.t ->
-  env -> evar_map -> constr -> constr -> UnivProblem.Set.t option
 
 (** Conversion with inference of universe constraints *)
 val vm_infer_conv : ?pb:conv_pb -> env -> evar_map -> constr -> constr ->

--- a/test-suite/bugs/bug_21674.v
+++ b/test-suite/bugs/bug_21674.v
@@ -1,0 +1,28 @@
+Polymorphic Axiom foo@{u} : nat -> Prop.
+
+Axiom bar : forall n, foo n.
+
+Goal foo 0.
+  Succeed simple apply bar.
+  apply bar.
+Qed.
+
+
+Require Import Corelib.Array.PrimArray.
+
+
+Axiom P : forall A t i (a:A), get t i = a.
+Axiom Q : forall A a i, @length@{length.u0} A a = i.
+
+Lemma test : forall A a i, @length@{P.u0} A a = i.
+Proof.
+  intros A a i.
+  Succeed refine (Q _ _ _).
+  Succeed simple eapply Q.
+  eapply Q.
+Qed.
+
+(* future work: make this succeed *)
+Fail Definition should_work@{u v|} : length@{u} [| | 0 |] = length@{v} [| | 0 |]
+  := eq_refl.
+(* Universe constraints are not implied by the ones declared: u = v *)


### PR DESCRIPTION
The type compatibility check throws away the univ constraints, so we use a univ-ignoring comparison instead.

The main call is incorrect when alpha equality infers unsatisfiable constraints and reducing is needed.

Fix #21674
