### PR TITLE
Stop inlining abstracted subproofs in tactics in terms.

### DIFF
--- a/doc/changelog/04-tactics/21676-constr-quotation-abstract-no-inline-Changed.rst
+++ b/doc/changelog/04-tactics/21676-constr-quotation-abstract-no-inline-Changed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  :tacn:`abstract`-ed subproofs within tactic quotations are not
+  inlined any more. The previous behavior can be restored through
+  the deprecated :flag:`Inline Abstract Subproof` flag
+  (`#21676 <https://github.com/rocq-prover/rocq/pull/21676>`_,
+  fixes `#7905 <https://github.com/rocq-prover/rocq/issues/7905>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/corelib/index-list.html.template
+++ b/doc/corelib/index-list.html.template
@@ -173,6 +173,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Corelib/Compat/Coq820.v
     theories/Corelib/Compat/Rocq90.v
     theories/Corelib/Compat/Rocq91.v
+    theories/Corelib/Compat/Rocq92.v
     theories/Ltac2/Compat/Coq818.v
     theories/Ltac2/Compat/Coq819.v
   </dd>

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -1000,8 +1000,7 @@ Proving a subgoal as a separate lemma: abstract
       The abstract tactic, while very useful, still has some known
       limitations.  See `#9146 <https://github.com/rocq-prover/rocq/issues/9146>`_ for more
       details. We recommend caution when using it in some
-      "non-standard" contexts. In particular, ``abstract`` doesn't
-      work properly when used inside quotations ``ltac:(...)``.
+      "non-standard" contexts.
       If used as part of typeclass resolution, it may produce incorrect
       terms when in polymorphic universe mode.
 
@@ -1030,6 +1029,12 @@ Proving a subgoal as a separate lemma: abstract
       .. exn:: Proof is not complete.
          :name: Proof is not complete. (abstract)
          :undocumented:
+
+   .. flag:: Inline Abstract Subproof
+
+      Restore the pre-9.3 behavior of :tacn:`abstract` inside quotations.
+
+      .. deprecated:: 9.3
 
 .. _requestinginformation:
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1290,6 +1290,11 @@ let push_side_effects ?role ?ts name de ctx effs =
   } in
   kn, effs
 
+let avoid_side_effect_label id sigma =
+  let eff = sigma.effects in
+  let eff = { eff with seff_labels = Id.Set.add id eff.seff_labels } in
+  { sigma with effects = eff }
+
 let seff_mem_label id effs =
   Id.Set.mem id effs.seff_labels
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -413,6 +413,8 @@ val push_side_effects :
   Id.t -> Safe_typing.side_effect_declaration -> Univ.ContextSet.t ->
   side_effects -> Constant.t * side_effects
 
+val avoid_side_effect_label : Id.t -> evar_map -> evar_map
+
 (** {6 Accessors} *)
 
 val seff_mem_label : Id.t -> side_effects -> bool

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2201,7 +2201,8 @@ let () =
     | Some ty -> sigma, ty
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
-    let (c, sigma) = Subproof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma ty tac in
+    let inline = Abstract.get_inline_abstract_subproof () in
+    let (c, sigma) = Subproof.refine_by_tactic ~inline ~name ~poly (GlobEnv.renamed_env env) sigma ty tac in
     let j = { Environ.uj_val = c; uj_type = ty } in
     (j, sigma)
   in

--- a/plugins/ltac2/tac2extravals.ml
+++ b/plugins/ltac2/tac2extravals.ml
@@ -261,7 +261,8 @@ let () =
     | Some ty -> sigma, ty
     | None -> GlobEnv.new_type_evar env sigma ~src:(loc,Evar_kinds.InternalHole)
     in
-    let c, sigma = Subproof.refine_by_tactic ~name ~poly (GlobEnv.renamed_env env) sigma concl tac in
+    let inline = Abstract.get_inline_abstract_subproof () in
+    let c, sigma = Subproof.refine_by_tactic ~inline ~name ~poly (GlobEnv.renamed_env env) sigma concl tac in
     let j = { Environ.uj_val = c; Environ.uj_type = concl } in
     (j, sigma)
   in

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -16,7 +16,7 @@ module NamedDecl = Context.Named.Declaration
 (**********************************************************************)
 (* Shortcut to build a term using tactics *)
 
-let refine_by_tactic ~name ~poly env sigma ty tac =
+let refine_by_tactic ~name ~poly ?(inline = false) env sigma ty tac =
   (* Save the initial side-effects to restore them afterwards. *)
   let eff = Evd.eval_side_effects sigma in
   let old_len = Safe_typing.length_private @@ Evd.seff_private eff in
@@ -39,25 +39,31 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
   | _ -> assert false
   in
   let ans = EConstr.to_constr ~abort_on_undefined_evars:false sigma ans in
-  (* [neff] contains the freshly generated side-effects *)
-  let neff = Evd.seff_private @@ Evd.eval_side_effects sigma in
-  let new_len = Safe_typing.length_private neff in
-  let neff, _ = Safe_typing.pop_private neff (new_len - old_len) in
-  (* Reset the old side-effects *)
-  let sigma = Evd.set_side_effects eff sigma in
+  let sigma, ans =
+    if inline then
+      (* [neff] contains the freshly generated side-effects *)
+      let neff = Evd.seff_private @@ Evd.eval_side_effects sigma in
+      let new_len = Safe_typing.length_private neff in
+      let neff, _ = Safe_typing.pop_private neff (new_len - old_len) in
+      (* Get rid of the fresh side-effects by internalizing them in the term
+        itself. Note that this is unsound, because the tactic may have solved
+        other goals that were already present during its invocation, so that
+        those goals rely on effects that are not present anymore. Hopefully,
+        this hack will work in most cases. *)
+      let (ans, uctx) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
+      (* Reset the old side-effects *)
+      let sigma = Evd.set_side_effects eff sigma in
+      let sigma = Evd.merge_universe_context_set ~sideff:true UState.UnivRigid sigma uctx in
+      sigma, ans
+    else
+      sigma, ans
+  in
   (* Restore former goals *)
   let _goals, sigma = Evd.pop_future_goals sigma in
   (* Push remaining goals as future_goals which is the only way we
      have to inform the caller that there are goals to collect while
      not being encapsulated in the monad *)
   let sigma = List.fold_right Evd.declare_future_goal goals sigma in
-  (* Get rid of the fresh side-effects by internalizing them in the term
-     itself. Note that this is unsound, because the tactic may have solved
-     other goals that were already present during its invocation, so that
-     those goals rely on effects that are not present anymore. Hopefully,
-     this hack will work in most cases. *)
-  let (ans, uctx) = Safe_typing.inline_private_constants env ((ans, Univ.ContextSet.empty), neff) in
-  let sigma = Evd.merge_universe_context_set ~sideff:true UState.UnivRigid sigma uctx in
   EConstr.of_constr ans, sigma
 
 (* Abstract internals *)

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -165,6 +165,8 @@ let extract_monomorphic = function
 
 let declare_abstract ~name ~poly ~sign ~secsign ~opaque ~solve_tac env sigma concl =
   let (const, safe, sigma') =
+    (* Prevents the nested call to generate the now reserved [name] *)
+    let sigma = Evd.avoid_side_effect_label name sigma in
     try build_constant_by_tactic ~name ~poly ~env ~sigma ~sign:secsign concl solve_tac
     with Logic_monad.TacticFailure e as src ->
     (* if the tactic [tac] fails, it reports a [TacticFailure e],

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -145,7 +145,7 @@ let build_by_tactic env ~uctx ~poly ~typ tac =
      (but due to #13324 we still want to inline them) *)
   let effs = Evd.seff_private @@ Evd.eval_side_effects sigma in
   let body, ctx = Safe_typing.inline_private_constants env ((body, Univ.ContextSet.empty), effs) in
-  let _uctx = UState.merge_universe_context_set ~sideff:true Evd.univ_rigid uctx ctx in
+  let uctx = UState.merge_universe_context_set ~sideff:true Evd.univ_rigid uctx ctx in
   body, typ, univs, uctx
 
 let build_by_tactic_opt env ~uctx ~poly ~typ tac =

--- a/proofs/subproof.mli
+++ b/proofs/subproof.mli
@@ -11,16 +11,18 @@
 val refine_by_tactic
   :  name:Names.Id.t
   -> poly:PolyFlags.t
+  -> ?inline:bool
   -> Environ.env
   -> Evd.evar_map
   -> EConstr.types
   -> unit Proofview.tactic
   -> EConstr.constr * Evd.evar_map
 (** A variant of {!Proof.solve} that handles open terms as well.
-    Caveat: all effects are purged in the returned term at the end, but other
-    evars solved by side-effects are NOT purged, so that unexpected failures may
-    occur. Ideally all code using this function should be rewritten in the
-    monad. *)
+
+    Caveat: when the [inline] flag is set all effects are purged in the returned
+    term at the end, but other evars solved by side-effects are NOT purged, so
+    that unexpected failures may occur. As a result it should not be set in
+    newly written code. *)
 
 val build_by_tactic :
   Environ.env ->

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -106,3 +106,10 @@ let abstract_subproof ~opaque tac =
 
 let tclABSTRACT ?(opaque=true) name_op tac =
   abstract_subproof ~opaque ~name_op tac
+
+let { Goptions.get = get_inline_abstract_subproof } =
+  Goptions.declare_bool_option_and_ref
+    ~depr:(Deprecation.make ~since:"9.3" ())
+    ~key:["Inline"; "Abstract"; "Subproof"]
+    ~value:false
+    ()

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -20,3 +20,5 @@ val cache_term_by_tactic_then
   -> unit Proofview.tactic
 
 val tclABSTRACT : ?opaque:bool -> Id.t option -> unit Proofview.tactic -> unit Proofview.tactic
+
+val get_inline_abstract_subproof : unit -> bool

--- a/test-suite/bugs/bug_21676_1.v
+++ b/test-suite/bugs/bug_21676_1.v
@@ -1,0 +1,1 @@
+Definition bar := ltac:(abstract exact ltac:(abstract exact Type)).

--- a/test-suite/bugs/bug_21676_2.v
+++ b/test-suite/bugs/bug_21676_2.v
@@ -1,0 +1,1 @@
+Check ltac:(abstract exact Type).

--- a/theories/Corelib/Compat/Rocq92.v
+++ b/theories/Corelib/Compat/Rocq92.v
@@ -8,8 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Compatibility file for making Rocq act similar to Coq v9.1 *)
+(** Compatibility file for making Rocq act similar to Coq v9.2 *)
 
-Require Export Corelib.Compat.Rocq92.
+(* When adding Rocq93.v, uncomment the following line *)
+(* Require Export Corelib.Compat.Rocq93. *)
 
-#[export] Set Warnings "-deprecated-since-9.2".
+#[export] Set Warnings "-deprecated-since-9.3".
+
+#[export]
+Set Inline Abstract Subproof.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2114,10 +2114,10 @@ let check_may_eval env sigma redexp rc =
       Evarutil.j_nf_evar sigma (Retyping.get_judgment_of env sigma c)
     else
       let env = Evarutil.nf_env_evar sigma env in
-      let env = Environ.push_qualities ~rigid:false (qs, fst csts) env in (* XXX *)
-      let env = Environ.push_context_set (us, snd csts) env in
-      let c = EConstr.to_constr sigma c in
+      let env = Environ.set_qualities (Evd.elim_graph sigma) env in
+      let env = Environ.set_universes (Evd.universes sigma) env in
       let env = Safe_typing.push_private_constants env (Evd.seff_private @@ Evd.eval_side_effects sigma) in
+      let c = EConstr.to_constr sigma c in
       (* OK to call kernel which does not support evars *)
       Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
   in


### PR DESCRIPTION
This is probably going to break some developments like fiat-crypto and friends, so for now I'm just running the CI and if there is too much breakage I'll provide a (deprecated) compatibility flag.

Fixes #7905: abstract in tactics in terms should not inline.

Depends on:
- #21755 