### PR TITLE
Introduce an efficient typing rule for let-bindings in Typeops.

### DIFF
--- a/checker/checkFlags.ml
+++ b/checker/checkFlags.ml
@@ -23,6 +23,7 @@ let set_local_flags flags env =
     share_reduction = flags.share_reduction;
     unfold_dep_heuristic = flags.unfold_dep_heuristic;
     allow_uip = flags.allow_uip;
+    expand_let = flags.expand_let;
     (* These flags may not *)
     enable_VM = envflags.enable_VM;
     enable_native_compiler = envflags.enable_native_compiler;

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -357,7 +357,7 @@ let v_typing_flags =
   v_tuple "typing_flags"
     [|v_bool; v_bool; v_bool; v_bool;
       v_oracle; v_bool; v_bool;
-      v_bool; v_bool; v_bool; v_bool; v_bool; v_bool|]
+      v_bool; v_bool; v_bool; v_bool; v_bool; v_bool; v_bool|]
 
 let v_univs = v_sum "universes" 1 [|[|v_abs_context|]|]
 

--- a/dev/ci/user-overlays/21678-ppedrot-preserve-let-in-kernel-the-return.sh
+++ b/dev/ci/user-overlays/21678-ppedrot-preserve-let-in-kernel-the-return.sh
@@ -1,0 +1,1 @@
+overlay fiat_crypto https://github.com/ppedrot/fiat-crypto preserve-let-in-kernel-the-return 21678

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -89,6 +89,9 @@ type typing_flags = {
   unfold_dep_heuristic : bool;
   (** If [true], use dependency heuristic when unfolding constants during conversion *)
 
+  expand_let : bool;
+  (** Whether to infer [let x := t in u : T{x := t}] or [let x := t in u : let x := t in T]  *)
+
   enable_VM : bool;
   (** If [false], all VM conversions fall back to interpreted ones *)
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -27,6 +27,7 @@ let safe_flags oracle = {
   conv_oracle = oracle;
   share_reduction = true;
   unfold_dep_heuristic = false;
+  expand_let = true;
   enable_VM = true;
   enable_native_compiler = true;
   indices_matter = true;

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -577,6 +577,7 @@ let same_flags {
      indices_matter;
      share_reduction;
      unfold_dep_heuristic;
+     expand_let;
      enable_VM;
      enable_native_compiler;
      impredicative_set;
@@ -591,6 +592,7 @@ let same_flags {
   indices_matter == alt.indices_matter &&
   share_reduction == alt.share_reduction &&
   unfold_dep_heuristic == alt.unfold_dep_heuristic &&
+  expand_let == alt.expand_let &&
   enable_VM == alt.enable_VM &&
   enable_native_compiler == alt.enable_native_compiler &&
   impredicative_set == alt.impredicative_set &&

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -733,7 +733,7 @@ and execute_aux tbl env cstr =
       let () = check_cast env c1 c1t DEFAULTcast c2 in
       let env1 = push_rel (LocalDef (name,c1,c2)) env in
       let c3t = execute tbl env1 c3 in
-      subst1 c1 c3t
+      if (Environ.typing_flags env).expand_let then subst1 c1 c3t else mkLetIn (name, c1, c2, c3t)
 
     | Cast (c,k,t) ->
       let ct = execute tbl env c in
@@ -919,7 +919,9 @@ let infer_type env constr =
   let () = check_wellformed_universes env constr in
   let hconstr = HConstr.of_constr env constr in
   let constr = HConstr.self hconstr in
-  let t = execute env hconstr in
+  (* Returned j_type is not observable *)
+  let tenv = Environ.set_typing_flags { (Environ.typing_flags env) with expand_let = false } env in
+  let t = execute tenv hconstr in
   let s = check_type env constr t in
   {utj_val = constr; utj_type = s}
 


### PR DESCRIPTION
When the expand_let typing flag is set in the environment, we change the kernel typing rule for let-bindings from
```
let x := t in u : T{x := t}
```
to
```
let x := t in u : let x := t in T.
```
We cannot do this by default since it may change the inferred type for some expressions, which is returned when the expected type is not provided. To work around this, we statically set the flag in expressions for which the precise inferred type is not relevant. For now there is no user-facing flag that would allow setting this option in a more fine-grained way though, but it is easy to fix.

This is a revival of #13606 and a partial fix of #11838. The latter still suffers from superlinear blowups in unrelated parts of the kernel, namely VM and native compilation.