### PR TITLE
Implement extruded uniform parameters in the dumbest possible way.

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1294,8 +1294,8 @@ let find_uniform_parameters recindx nargs (_, types, bodies) =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
-      (* A recursive reference to the i-th body *)
-      if Int.equal n (nbodies + k - i) then
+      (* Check if this is a recursive reference to any body of the mutual fixpoint *)
+      if n > k && n <= k + nbodies then
         List.fold_left_i (fun j nuniformparams a ->
             match kind a with
             | Rel m when Int.equal m (k - j) ->
@@ -1328,8 +1328,8 @@ let drop_uniform_parameters_bodies nuniformparams bodies =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
-      (* A recursive reference to the i-th body *)
-      if Int.equal n (nbodies + k - i) then
+      (* Check if this is a recursive reference to any body of the mutual fixpoint *)
+      if n > k && n <= k + nbodies then
         let new_args = List.skipn_at_best nuniformparams l in
         Term.applist (f, new_args)
       else

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -308,6 +308,21 @@ let decompose_lambda_n_assum n =
   in
   lamdec_rec Context.Rel.empty n
 
+let decompose_prod_n_assum n =
+  if n < 0 then
+    anomaly (str "decompose_prod_n_assum: integer parameter must be positive.");
+  let rec proddec_rec l n c =
+    if Int.equal n 0 then l,c
+    else
+      let open Context.Rel.Declaration in
+      match kind c with
+      | Prod (x,t,c)  -> proddec_rec (Context.Rel.add (LocalAssum (x,t)) l) (n-1) c
+      | LetIn (x,b,t,c) -> proddec_rec (Context.Rel.add (LocalDef (x,b,t)) l) n c
+      | Cast (c,_,_)    -> proddec_rec l n c
+      | _c -> anomaly (str "decompose_lambda_n_assum: not enough abstractions.")
+  in
+  proddec_rec Context.Rel.empty n
+
 (* Given a positive integer n, decompose a lambda or let-in term [fun
    (x1:T1)..(xi:=ci:Ti)..(xn:Tn) => T] into the pair of the abstracted
    context [(xn,None,Tn);...;(xi,Some ci,Ti);...;(x1,None,T1)] and of

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -148,6 +148,9 @@ val decompose_lambda_prod_n_decls : int -> constr -> types -> Constr.rel_context
     as given by the decreasing index + 1 *)
 val decompose_lambda_n_assum : int -> constr -> Constr.rel_context * constr
 
+(** Same as above for Prod rather than Lambda *)
+val decompose_prod_n_assum : int -> constr -> Constr.rel_context * constr
+
 (** Idem, counting let-ins *)
 val decompose_lambda_n_decls : int -> constr -> Constr.rel_context * constr
 

--- a/test-suite/bugs/bug_12417.v
+++ b/test-suite/bugs/bug_12417.v
@@ -12,11 +12,17 @@ Fixpoint max_list (p: nat) (l: list nat) : nat :=
   | cons n l' => max_list (Init.Nat.max n p) l'
   end.
 
-Fixpoint map {A B} (f : A -> B) (l : list A) : list B :=
+Section List.
+
+Context {A B : Type}  (f : A -> B).
+
+Fixpoint map (l : list A) : list B :=
 match l with
 | nil => nil
-| cons x l => cons (f x) (map f l)
+| cons x l => cons (f x) (map l)
 end.
+
+End List.
 
 Fixpoint depth (t: tm) : nat :=
   match t with

--- a/test-suite/bugs/bug_21682.v
+++ b/test-suite/bugs/bug_21682.v
@@ -1,0 +1,10 @@
+Fail Fixpoint F (n : nat) : nat :=
+  match n with
+  | O => O
+  | S k =>
+    (fix f (p : nat) (m : nat) {struct m} :=
+       match m with O => p | S m' => g (S p) m' end
+     with g (q : nat) (m : nat) {struct m} :=
+       match m with O => F q | S m' => f q m' end
+     for f) k k
+  end.

--- a/test-suite/bugs/bug_21683.v
+++ b/test-suite/bugs/bug_21683.v
@@ -1,0 +1,2 @@
+Fail Fixpoint F (n : nat) : False :=
+  (fix G F (n : nat) {struct n} : False := F n) F n.

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -530,7 +530,7 @@ match l with
 | cons x l => cons (f x) (lmap f l)
 end.
 
-Fixpoint map {A B} (f : A -> B) (t : tree A) {struct t} : tree B :=
+Fail Fixpoint map {A B} (f : A -> B) (t : tree A) {struct t} : tree B :=
 match t with
 | Node _ x l => Node _ (f x) (lmap (map f) l)
 end.

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -530,7 +530,7 @@ match l with
 | cons x l => cons (f x) (lmap f l)
 end.
 
-Fail Fixpoint map {A B} (f : A -> B) (t : tree A) {struct t} : tree B :=
+Fixpoint map {A B} (f : A -> B) (t : tree A) {struct t} : tree B :=
 match t with
 | Node _ x l => Node _ (f x) (lmap (map f) l)
 end.


### PR DESCRIPTION
The fist part is a partial revert of #17986. As evidenced by the flurry of LLM-discovered soundness issues with the guard check, this commit was clearly not analyzed enough. We first simply revert the part that introduced the uniform parameter support and leave the cleanups.

The second part is an extremely dumb algorithm for uniform parameter expansion. We simply compute at runtime the extrusion of said parameters and proceed to check the guard on this term instead. As observed in one comment, it is not clear that this is really safe for nested mutual fixpoints where the type of those parameters may change across fixpoint body.

Alternative to #21684.