### PR TITLE
Simplify module substitution API

### DIFF
--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -273,17 +273,15 @@ let functorize_module params mb =
 
 (** Substitutions of modular structures *)
 
-type subst_kind = Codom | Both | Neither | Shallow of Mod_subst.substitution
+type subst_kind = Codom | Both | Neither
 
 let subst_codom = Codom
 let subst_dom_codom = Both
-let subst_shallow_dom_codom s = Shallow s
 
 let apply_subst skind subst delta = match skind with
 | Codom -> subst_codom_delta_resolver subst delta
 | Both -> subst_dom_codom_delta_resolver subst delta
 | Neither -> delta
-| Shallow subst' -> subst_dom_codom_delta_resolver subst' delta (* ignore subst *)
 
 let is_functor = function
   | NoFunctor _ -> false

--- a/kernel/mod_declarations.ml
+++ b/kernel/mod_declarations.ml
@@ -273,15 +273,13 @@ let functorize_module params mb =
 
 (** Substitutions of modular structures *)
 
-type subst_kind = Dom | Codom | Both | Neither | Shallow of Mod_subst.substitution
+type subst_kind = Codom | Both | Neither | Shallow of Mod_subst.substitution
 
-let subst_dom = Dom
 let subst_codom = Codom
 let subst_dom_codom = Both
 let subst_shallow_dom_codom s = Shallow s
 
 let apply_subst skind subst delta = match skind with
-| Dom -> subst_dom_delta_resolver subst delta
 | Codom -> subst_codom_delta_resolver subst delta
 | Both -> subst_dom_codom_delta_resolver subst delta
 | Neither -> delta

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -96,7 +96,6 @@ val set_retroknowledge : module_body -> Retroknowledge.action list -> module_bod
 (** {6 Substitution} *)
 
 type subst_kind
-val subst_dom : subst_kind
 val subst_codom : subst_kind
 val subst_dom_codom : subst_kind
 val subst_shallow_dom_codom : Mod_subst.substitution -> subst_kind

--- a/kernel/mod_declarations.mli
+++ b/kernel/mod_declarations.mli
@@ -98,7 +98,6 @@ val set_retroknowledge : module_body -> Retroknowledge.action list -> module_bod
 type subst_kind
 val subst_codom : subst_kind
 val subst_dom_codom : subst_kind
-val subst_shallow_dom_codom : Mod_subst.substitution -> subst_kind
 
 val subst_signature : subst_kind -> substitution ->
   ModPath.t -> module_signature -> module_signature

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -553,7 +553,9 @@ let subset_prefixed_by mp resolver =
   in
   Deltamap.fold mp_prefix kn_prefix resolver (empty_delta_resolver mp)
 
-let subst_dom_delta_resolver subst resolver =
+let subst_dom_delta_resolver mp_from mp_to resolver =
+  let () = assert (ModPath.equal mp_from resolver.Deltamap.root) in
+  let subst = map_mp mp_from mp_to (empty_delta_resolver mp_to) in
   let mp_apply_subst mkey mequ rslv =
     Deltamap.add_mp (subst_mp subst mkey) mequ rslv
   in
@@ -570,8 +572,7 @@ let subst_mp_delta subst mp mkey =
     (* root(resolve) ⊆ mp' *)
       let mp1 = find_prefix resolve mp' in
       let resolve1 = subset_prefixed_by mp1 resolve in
-      (subst_dom_delta_resolver
-         (map_mp mp1 mkey (empty_delta_resolver mkey)) resolve1), mp1
+      subst_dom_delta_resolver mp1 mkey resolve1, mp1
 
 let gen_subst_delta_resolver dom subst resolver =
   let mp_apply_subst mkey mequ rslv =

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -94,8 +94,9 @@ val map_mp :
 val join : substitution -> substitution -> substitution
 
 
-(** Apply the substitution on the domain of the resolver  *)
-val subst_dom_delta_resolver : substitution -> delta_resolver -> delta_resolver
+(** [subst_dom_delta_resolver mpfrom mpto delta] substitutes the root of the
+    resolver [delta] from [mpfrom] to [mpto], i.e. performs α-equivalence. *)
+val subst_dom_delta_resolver : ModPath.t -> ModPath.t -> delta_resolver -> delta_resolver
 
 (** Apply the substitution on the codomain of the resolver  *)
 val subst_codom_delta_resolver :

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -351,7 +351,7 @@ and strengthen_and_subst_struct struc subst mp_from mp_to alias incl reso =
         let mp_from' = MPdot (mp_from,l) in
         let mp_to' = MPdot(mp_to,l) in
         let subst' = add_mp mp_from' mp_to' (empty_delta_resolver mp_to') subst in
-        let mty' = subst_modtype (subst_shallow_dom_codom subst') subst' mp_from' mty in
+        let mty' = subst_modtype subst_dom_codom subst' mp_from' mty in
         let item' = if mty' == mty then item else (l, SFBmodtype mty') in
         add_mp_delta_resolver mp_to' mp_to' reso', item'
   in

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -278,7 +278,7 @@ let rec strengthen_and_subst_module mb subst mp_from mp_to =
           mp_from mp_to false false delta_mb
       in
       (* Don't forget to add the original resolver up to substitution *)
-      let reso' = add_delta_resolver (subst_dom_delta_resolver subst delta_mb) (add_mp_delta_resolver mp_to mp_from reso') in
+      let reso' = add_delta_resolver (subst_dom_delta_resolver mp_from mp_to delta_mb) (add_mp_delta_resolver mp_to mp_from reso') in
       strengthen_module_body ~src:mp_from (NoFunctor struc') reso' mb
   | MoreFunctor _ ->
     let subst = add_mp mp_from mp_to (empty_delta_resolver mp_to) subst in
@@ -380,10 +380,9 @@ let strengthen_and_subst_module_body mp_from mb mp include_b = match mod_type mb
     (* if mb.mod_mp is an alias then the strengthening is useless
        (i.e. it is already done)*)
     let mp_alias = mp_of_delta delta_mb mp_from in
-    let subst_resolver = map_mp mp_from mp (empty_delta_resolver mp) in
     let new_resolver =
       add_mp_delta_resolver mp mp_alias
-        (subst_dom_delta_resolver subst_resolver delta_mb)
+        (subst_dom_delta_resolver mp_from mp delta_mb)
     in
     let subst = map_mp mp_from mp new_resolver in
     let reso',struc' =


### PR DESCRIPTION
We remove two useless substitution APIs in Mod_declarations (`subst_dom` and `subst_shallow_dom_codom`) and expose the fact that domain substitution of δ-resolvers only requires knowledge of the the resolver root and its substituted image in the substitution.