### PR TITLE
allScheme: Check for arities deeply using Reduction.is_arity.

### DIFF
--- a/tactics/allScheme.ml
+++ b/tactics/allScheme.ml
@@ -44,9 +44,8 @@ let init_value env uparams =
       | Some _ ->
           aux (push_rel decl env) tel
       | None   ->
-          let ty = Reduction.whd_all env (get_type decl) in
           let (env, init_value) = aux (push_rel decl env) tel in
-          (env, Term.isArity ty :: init_value)
+          (env, Reduction.is_arity env (get_type decl) :: init_value)
     in
     aux env (List.rev uparams)
 

--- a/test-suite/output/nested_eliminators.out
+++ b/test-suite/output/nested_eliminators.out
@@ -1635,3 +1635,13 @@ Arguments MRT_ind (P MRTnode)%_function_scope m
 MRT_ind is transparent
 Expands to: Constant nested_eliminators.TestWarning.MRT_ind
 Declared in library nested_eliminators, line 403, characters 2-55
+Nester_all@{α ; u} :
+forall X : unit -> P unit,
+(forall u u0 : unit, X u u0 -> Type@{α ; u}) ->
+Nester X -> Type@{max(P.u1,u)}
+(* α ; *u |=  *)
+
+Nester_all is universe polymorphic
+Arguments Nester_all (X PX)%_function_scope n
+Expands to: Inductive nested_eliminators.DeepArities.Nester_all
+Declared in library nested_eliminators, line 417, characters 2-24

--- a/test-suite/output/nested_eliminators.v
+++ b/test-suite/output/nested_eliminators.v
@@ -406,3 +406,15 @@ Module TestWarning.
   About MRT_ind.
 
 End TestWarning.
+
+
+
+Module DeepArities.
+  Definition P A := A -> Type.
+
+  Inductive Nester (X : unit -> P unit) : Type :=
+  | nester_intro : X tt tt -> Nester X.
+  Scheme All for Nester.
+
+  About Nester_all.
+End DeepArities.


### PR DESCRIPTION
The previous code did not reduce recursively under head products when checking for arities in uniform parameters.