### PR TITLE
Properly compute polymorphic "with Definition" module types.

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -362,6 +362,18 @@ and lack of checking of relevance marks on constants in coqchk
 - exploit: see issue
 - risk: could be exploited by mistake when using heavy module machinery
 
+#### Incorrect subtyping rule for universe polymorphic "with Definition".
+
+- component: modules
+- introduced: 8.5
+- impacted released versions: 8.5-9.1
+- impacted coqchk version: none
+- fixed in: V9.2.0
+- found by: Tristan Stérin
+- GH issue number: rocq-prover/rocq#21702
+- exploit: see issue
+- risk: moderate, requires uncommon features
+
 ### Universes
 
 #### issue with two parameters in the same universe level

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -83,25 +83,25 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
       (* In the spirit of subtyping.check_constant, we accept
          any implementations of parameters and opaque terms,
          as long as they have the right type *)
-      let ctx' =
+      let typ, ctx' =
         match cb.const_universes, wth.w_univs with
         | Monomorphic, Monomorphic ->
           let error_univ_mismatch env t1 t2 = function
             | Conversion.Univ err -> error (WithSignatureMismatch (IncompatibleUniverses { err; env; t1; t2 }))
             | Conversion.Qual err -> error (WithSignatureMismatch (IncompatibleQualities { err; env; t1; t2 }))
           in
+          let j = Typeops.infer env' wth.w_def in
           begin match cb.const_body with
           | Undef _ | OpaqueDef _ ->
-            let j = Typeops.infer env' wth.w_def in
             let typ = cb.const_type in
             begin match infer_gen_conv_leq (cst, ustate) env' j.uj_type typ with
-            | Result.Ok cst -> cst
+            | Result.Ok cst -> j.uj_type, cst
             | Result.Error None -> error (WithSignatureMismatch (NotConvertibleTypeField (env', j.uj_type, typ)))
             | Result.Error (Some e) -> error_univ_mismatch env' j.uj_type typ e
             end
           | Def c' ->
             begin match infer_gen_conv (cst, ustate) env' wth.w_def c' with
-            | Result.Ok cst -> cst
+            | Result.Ok cst -> j.uj_type, cst
             | Result.Error None -> error (WithSignatureMismatch (NotConvertibleBodyField (Some (env', wth.w_def, c'))))
             | Result.Error (Some e) -> error_univ_mismatch env' wth.w_def c' e
             end
@@ -115,10 +115,14 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
           in
           (** Terms are compared in a context with De Bruijn universe indices *)
           let () = check_ucontext (UVars.AbstractContext.repr uctx) env in
-          let env' = Environ.push_context ~strict:false (UVars.AbstractContext.repr uctx) env in
+          let j =
+            (* Use 1. the external environment with 2. the with Definition constraints *)
+            let jenv = Environ.push_context ~strict:false (UVars.AbstractContext.repr ctx) env in
+            Typeops.infer jenv wth.w_def
+          in
+          let env' = Environ.push_context ~strict:false (UVars.AbstractContext.repr uctx) env' in
           let () = match cb.const_body with
             | Undef _ | OpaqueDef _ ->
-              let j = Typeops.infer env' wth.w_def in
               let typ = cb.const_type in
               begin match Conversion.conv_leq env' j.uj_type typ with
               | Result.Ok () -> ()
@@ -132,13 +136,14 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
             | Primitive _ -> error WithCannotConstrainPrimitive
             | Symbol _ -> error WithCannotConstrainSymbol
           in
-          cst
+          j.uj_type, cst
         | Monomorphic, Polymorphic _ -> error (WithSignatureMismatch (PolymorphicStatusExpected true))
         | Polymorphic _, Monomorphic -> error (WithSignatureMismatch (PolymorphicStatusExpected false))
       in
       let cb' =
         { cb with
           const_body = Def wth.w_def;
+          const_type = typ;
           const_universes = wth.w_univs;
           const_body_code = wth.w_bytecode; }
       in

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -83,7 +83,7 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
       (* In the spirit of subtyping.check_constant, we accept
          any implementations of parameters and opaque terms,
          as long as they have the right type *)
-      let typ, ctx' =
+      let (univs, typ), ctx' =
         match cb.const_universes, wth.w_univs with
         | Monomorphic, Monomorphic ->
           let error_univ_mismatch env t1 t2 = function
@@ -95,13 +95,13 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
           | Undef _ | OpaqueDef _ ->
             let typ = cb.const_type in
             begin match infer_gen_conv_leq (cst, ustate) env' j.uj_type typ with
-            | Result.Ok cst -> j.uj_type, cst
+            | Result.Ok cst -> (cb.const_universes, cb.const_type), cst
             | Result.Error None -> error (WithSignatureMismatch (NotConvertibleTypeField (env', j.uj_type, typ)))
             | Result.Error (Some e) -> error_univ_mismatch env' j.uj_type typ e
             end
           | Def c' ->
             begin match infer_gen_conv (cst, ustate) env' wth.w_def c' with
-            | Result.Ok cst -> j.uj_type, cst
+            | Result.Ok cst -> (cb.const_universes, cb.const_type), cst
             | Result.Error None -> error (WithSignatureMismatch (NotConvertibleBodyField (Some (env', wth.w_def, c'))))
             | Result.Error (Some e) -> error_univ_mismatch env' wth.w_def c' e
             end
@@ -136,15 +136,23 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
             | Primitive _ -> error WithCannotConstrainPrimitive
             | Symbol _ -> error WithCannotConstrainSymbol
           in
-          j.uj_type, cst
+          (cb.const_universes, cb.const_type), cst
         | Monomorphic, Polymorphic _ -> error (WithSignatureMismatch (PolymorphicStatusExpected true))
         | Polymorphic _, Monomorphic -> error (WithSignatureMismatch (PolymorphicStatusExpected false))
       in
+      (* Here we have two choices for the type of the constant: either pick the
+         type T from module constant or the type U from the with Definition
+         constant, including their universe constraints. In general, we only
+         have U ≤ T, so the corresponding module types will only satisfy
+         MU ≤ MT. In some sense MU is minimal and MT maximal, so both are
+         canonical. Depending on the context, one may be preferred to the
+         other but there is no "best" choice a priori. Some code out there
+         depends on picking MT, so we enshrine this decision here. *)
       let cb' =
         { cb with
           const_body = Def wth.w_def;
           const_type = typ;
-          const_universes = wth.w_univs;
+          const_universes = univs;
           const_body_code = wth.w_bytecode; }
       in
       before@(lab,SFBconst(cb'))::after, ctx'

--- a/test-suite/bugs/bug_21702.v
+++ b/test-suite/bugs/bug_21702.v
@@ -1,0 +1,31 @@
+(* Regression test for check_with_def universe constraint dropping bug.
+   Bug: mod_typing.ml stored with Definition result using the WITH body's
+   (weaker) universe constraints instead of the spec's (stronger) constraints.
+   This allowed creating a coerce function Type@{u} -> Type@{v} with no
+   constraint between u and v, leading to a proof of False via Girard's paradox. *)
+
+Set Universe Polymorphism.
+
+Module Type SIG.
+  Section S.
+    Universe u v.
+    Constraint u <= v.
+    Parameter coerce@{} : Type@{u} -> Type@{v}.
+  End S.
+End SIG.
+
+(* The identity function satisfies coerce's type only when u <= v.
+   The bug dropped this constraint from the result. *)
+Module Type SIG2 := SIG with Definition coerce@{u v} := fun (x : Type@{u}) => x.
+Declare Module M : SIG2.
+
+(* After the fix, M.coerce should retain the Type@{u} -> Type@{u} type.
+   Therefore, using it to push Type@{u} into a smaller universe should fail. *)
+Section Test.
+  Universe big small.
+  Constraint small < big.
+
+  (* This should fail: M.coerce@{big+1, small} would require big+1 <= small,
+     but we have small < big, contradiction. *)
+  Fail Definition A : Type@{small} := M.coerce Type@{big}.
+End Test.

--- a/test-suite/bugs/bug_21707.v
+++ b/test-suite/bugs/bug_21707.v
@@ -1,0 +1,16 @@
+Module Type T.
+  Parameter t : Type.
+End T.
+
+Module F(X:T with Definition t := nat).
+End F.
+
+Module N.
+  Definition t : Type := nat.
+End N.
+
+(** Check that the type of [X:T with Definition t := nat] is
+    the largest type rather than the smallest type, i.e. it
+    has field [Definition t : Type := nat] rather than
+    [Definition t : Set := nat.] *)
+Module FN := F N.


### PR DESCRIPTION
The most expressive fix is not the one suggested by the LLM. Rather than strenghtening the local universe constraints of the with definition, we pick the most precise type of this definition. By cumulativity, this will preserve typing in all instances while resulting in a more general module type.

This commit also covertly fixes two hidden bugs.
- The first one occurred for with Definition where the constant being replaced has a body: the previous code did not typecheck the new body in this case and called conversion on a potentially ill-typed term.
- The second one was due to a misused environment leading to a potentially cyclic definition.

Fixes #21702: Incorrect with Definition universe constraint handling.