### PR TITLE
Remove Sorts.Quality.all (which contains a dummy `QVar -1`)

### DIFF
--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -71,7 +71,6 @@ module QualityOrSet = struct
   let raw_pr = pr Sorts.QVar.raw_pr
 
   let all_constants = Set :: List.map (fun q -> Qual q) Quality.all_constants
-  let all = Set :: List.map (fun q -> Qual q) Quality.all
 end
 
 type sort_context_set = (QVar.Set.t * Univ.Level.Set.t) * PConstraints.t

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -40,7 +40,6 @@ module QualityOrSet : sig
   val raw_pr : t -> Pp.t
 
   val all_constants : t list
-  val all : t list
 end
 
 type univ_length_mismatch = {

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -202,7 +202,6 @@ module Quality = struct
   let raw_pr q = pr QVar.raw_pr q
 
   let all_constants = List.map (fun q -> QConstant q) Constants.all
-  let all = var (-1) :: all_constants
 
   let hash = let open Hashset.Combine in function
     | QConstant q -> Constants.hash q

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -105,8 +105,6 @@ module Quality : sig
   val raw_pr : t -> Pp.t
 
   val all_constants : t list
-  val all : t list
-  (* Returns a dummy variable *)
 
   val hash : t -> int
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1437,14 +1437,14 @@ let add_subnames_of ?loc len n ns full_n ref =
     let ns = Array.fold_left_i (fun j ns _ -> add1 (ConstructRef ((mind,i),j+1)) ns)
         ns mip.mind_consnames
     in
-    List.fold_left (fun ns q ->
-        let s = Elimschemes.elimination_suffix q in
+    let suffixes = List.map Elimschemes.elimination_suffix UnivGen.QualityOrSet.all_constants in
+    List.fold_left (fun ns s ->
         let n_elim = Id.of_string (Id.to_string mip.mind_typename ^ s) in
         match importable_extended_global_of_path ?loc (Libnames.add_path_suffix path_prefix n_elim) with
         | exception Not_found -> ns
         | None -> ns
         | Some ref -> (len, ref) :: ns)
-      ns UnivGen.QualityOrSet.all
+      ns suffixes
 
 let interp_names m ns =
   let dp_m = Nametab.path_of_module m in


### PR DESCRIPTION
For the change in vernacentries add_subnames_of, note that elimination_suffix produces _rect on both QVar and QType, so the dummy var is not needed.
