### PR TITLE
Fix minimize universes api

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -32,8 +32,8 @@ let create_clos_infos env sigma flags =
 (* Expanding/testing/exposing existential variables *)
 (****************************************************)
 
-let finalize ?abort_on_undefined_evars ?(to_type = true) sigma f =
-  let sigma = minimize_universes ~to_type sigma in
+let finalize ?abort_on_undefined_evars ?poly sigma f =
+  let sigma = minimize_universes ?poly sigma in
   let uvars = ref Univ.Level.Set.empty in
   let nf_constr c =
     let _, varsc = EConstr.universes_of_constr sigma c in

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -150,7 +150,7 @@ val nf_evars_universes : evar_map -> Constr.constr -> Constr.constr
 
     Note that the normalizer passed to [f] holds some imperative state
    in its closure. *)
-val finalize : ?abort_on_undefined_evars:bool -> ?to_type:bool -> evar_map ->
+val finalize : ?abort_on_undefined_evars:bool -> ?poly:PolyFlags.t -> evar_map ->
   ((EConstr.t -> Constr.t) -> 'a) ->
   evar_map * 'a
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1215,14 +1215,17 @@ let collapse_sort_variables ?except ?(to_type = true) evd =
   let universes = UState.collapse_sort_variables ?except ~to_type evd.universes in
   { evd with universes }
 
-let minimize_universes ?(collapse_sort_variables=true) ?(to_type = true) evd =
-  let uctx' = if collapse_sort_variables
-    then UState.collapse_sort_variables ~to_type evd.universes
-    else evd.universes
-  in
-  let uctx' = UState.normalize_variables uctx' in
+let minimize_universes_no_collapse evd =
+  let uctx' = UState.normalize_variables evd.universes in
   let uctx' = UState.minimize uctx' in
   {evd with universes = uctx'}
+
+let minimize_universes ?(poly=PolyFlags.default) evd =
+  let collapse_sort_variables = PolyFlags.collapse_sort_variables poly in
+  let uctx' =
+    UState.collapse_sort_variables ~to_type:collapse_sort_variables evd.universes
+  in
+  minimize_universes_no_collapse {evd with universes = uctx'}
 
 let universe_of_name evd s = UState.universe_of_name evd.universes s
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -644,8 +644,10 @@ val collapse_sort_variables : ?except:Sorts.QVar.Set.t -> ?to_type:bool -> evar_
 
 val fix_undefined_variables : evar_map -> evar_map
 
-(** Universe minimization (collapse_sort_variables is true by default) *)
-val minimize_universes : ?collapse_sort_variables:bool -> ?to_type:bool -> evar_map -> evar_map
+val minimize_universes_no_collapse : evar_map -> evar_map
+
+(** Universe minimization *)
+val minimize_universes : ?poly:PolyFlags.t -> evar_map -> evar_map
 
 (** Lift [UState.update_sigma_univs] *)
 val update_sigma_univs : UGraph.t -> evar_map -> evar_map

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -212,7 +212,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
   end in
   let avoid = ref Id.Set.empty in
   let Proof.{sigma} = Proof.data pf in
-  let sigma = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) sigma in
+  let sigma = Evd.minimize_universes ~poly sigma in
   let rec fill_holes c =
     match EConstr.kind sigma c with
     | Evar (e,args) ->

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -420,7 +420,7 @@ let do_instance_resolve_TC ~poly termtype sigma env =
   let sigma = Typeclasses.resolve_typeclasses ~filter:Typeclasses.all_evars ~fail:false env sigma in
   let sigma = Evarutil.nf_evar_map_undefined sigma in
   (* Beware of this step, it is required as to minimize universes. *)
-  let sigma = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) sigma in
+  let sigma = Evd.minimize_universes ~poly sigma in
   (* Check that the type is free of evars now. *)
   Pretyping.check_evars env sigma termtype;
   termtype, sigma

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -190,7 +190,7 @@ let interp_context_gen ~program_mode ~poly ~kind ~autoimp_enable ~coercions env 
   let sigma, (ienv, ((env, ctx), impls, locs)) = interp_named_context_evars ~program_mode ~poly ~autoimp_enable env sigma l in
   (* Note, we must use the normalized evar from now on! *)
   let sigma = solve_remaining_evars all_and_fail_flags env ~initial sigma in
-  let sigma, ctx = Evarutil.finalize ~to_type:(PolyFlags.collapse_sort_variables poly) sigma @@ fun nf ->
+  let sigma, ctx = Evarutil.finalize ~poly sigma @@ fun nf ->
     List.map (NamedDecl.map_constr_het (fun x -> x) nf) ctx
   in
   (* reorder, evar-normalize and add implicit status *)

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -157,7 +157,7 @@ let do_definition_interactive ?loc ~program_mode ?hook ~name ~scope ?clearbody ~
   let evd =
     let inference_hook = if program_mode then Some Declare.Obls.program_inference_hook else None in
     Pretyping.solve_remaining_evars ?hook:inference_hook flags env evd in
-  let evd = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) evd in
+  let evd = Evd.minimize_universes ~poly evd in
   Pretyping.check_evars_are_solved ~program_mode env evd;
   let typ = EConstr.to_constr evd typ in
   Evd.check_univ_decl_early ~poly ~with_obls:false evd udecl [typ];

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -580,7 +580,7 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
 
   (* Instantiate evars and check all are resolved *)
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
-  let sigma = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) sigma in
+  let sigma = Evd.minimize_universes ~poly sigma in
 
   let sigma, ({fixdefs=bodies;fixrs;fixtypes;fixwfs} as fix), obls, hook =
     match pm with

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -648,7 +648,7 @@ let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~
 
      We also need to restrict to avoid seeing spurious bounds from below
      (ie v <= template_u with v getting restricted away). *)
-  let sigma = Evd.minimize_universes ~collapse_sort_variables:false sigma in
+  let sigma = Evd.minimize_universes_no_collapse sigma in
   let sigma = restrict_inductive_universes sigma ctx_params arities constructors in
 
   let sigma, univ_entry, ubinders, global_univs =

--- a/vernac/comRewriteRule.ml
+++ b/vernac/comRewriteRule.ml
@@ -46,7 +46,7 @@ let do_symbol ~poly ~unfold_fix udecl (id, typ) =
       env evd typ
   in
   Pretyping.check_evars_are_solved ~program_mode:false env evd;
-  let evd = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) evd in
+  let evd = Evd.minimize_universes ~poly evd in
   let _qvars, uvars = EConstr.universes_of_constr evd typ in
   let evd = Evd.restrict_universe_context evd uvars in
   let typ = EConstr.to_constr evd typ in
@@ -432,7 +432,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
     undeclared_evars_rr = true; expand_evars = false;
     solve_unification_constraints = false; poly } in
   let evd, lhs, typ = Pretyping.understand_tcc_ty ~flags env evd lhs in
-  let evd = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) evd in
+  let evd = Evd.minimize_universes ~poly evd in
   let _qvars, uvars = EConstr.universes_of_constr evd lhs in
   let evd = Evd.restrict_universe_context evd uvars in
   let uctx, uctx' = UState.check_univ_decl_rev (Evd.ustate evd) udecl in
@@ -482,7 +482,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
         Pp.(surround (str "the replacement term doesn't have the type of the pattern") ++ str "." ++ fnl () ++ Himsg.explain_pretype_error env' evd' e);
       Pretyping.understand_tcc ~flags env evd rhs
   in
-  let evd' = Evd.minimize_universes ~to_type:collapse_sort_variables evd' in
+  let evd' = Evd.minimize_universes ~poly evd' in
   let _qvars', uvars' = EConstr.universes_of_constr evd' rhs in
   let evd' = Evd.restrict_universe_context evd' (Univ.Level.Set.union uvars uvars') in
   let fail pp = warn_rewrite_rules_break_SR ?loc:rhs_loc Pp.(surround (str "universe inconsistency") ++ str"." ++ spc() ++ str "Missing constraints: " ++ pp) in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1097,7 +1097,7 @@ let declare_definition ~info ~cinfo ~opaque ~obls ~body ?using sigma =
   Option.iter (check_evars_are_solved env sigma) typ;
   check_evars_are_solved env sigma body;
   let poly = info.Info.poly in
-  let sigma = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) sigma in
+  let sigma = Evd.minimize_universes ~poly sigma in
   let body = EConstr.to_constr sigma body in
   let typ = Option.map (EConstr.to_constr sigma) typ in
   let uctx = Evd.ustate sigma in
@@ -1114,8 +1114,7 @@ let prepare_obligations ~name poly ?types ~body env sigma =
     | Some t -> t
     | None -> Retyping.get_type_of env sigma body
   in
-  let to_type = PolyFlags.collapse_sort_variables poly in
-  let sigma, (body, types) = Evarutil.finalize ~abort_on_undefined_evars:false ~to_type
+  let sigma, (body, types) = Evarutil.finalize ~abort_on_undefined_evars:false ~poly
       sigma (fun nf -> nf body, nf types)
   in
   RetrieveObl.check_evars env sigma;
@@ -1127,7 +1126,7 @@ let prepare_obligations ~name poly ?types ~body env sigma =
 let prepare_parameter ~poly ~udecl ~types sigma =
   let env = Global.env () in
   Pretyping.check_evars_are_solved ~program_mode:false env sigma;
-  let sigma, typ = Evarutil.finalize ~abort_on_undefined_evars:true ~to_type:(PolyFlags.collapse_sort_variables poly)
+  let sigma, typ = Evarutil.finalize ~abort_on_undefined_evars:true ~poly
       sigma (fun nf -> nf types)
   in
   let univs = Evd.check_univ_decl ~poly sigma udecl in
@@ -2089,7 +2088,7 @@ let prepare_proof ?(warn_incomplete=true) { proof; pinfo; sideff } =
     Proof.unfocus_all proof
   in
   let eff = SideEff.make @@ Evd.eval_side_effects evd in
-  let evd = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) evd in
+  let evd = Evd.minimize_universes ~poly evd in
   let to_constr c =
     match EConstr.to_constr_opt evd c with
     | Some p -> p
@@ -2253,7 +2252,7 @@ let save_admitted ~pm ~proof =
   let sigma = Evd.from_ctx proof.initial_euctx in
   List.iter (check_type_evars_solved (Global.env()) sigma) typs;
   let sec_vars = compute_proof_using_for_admitted proof.pinfo proof typs iproof in
-  let sigma = Evd.minimize_universes ~to_type:(PolyFlags.collapse_sort_variables poly) sigma in
+  let sigma = Evd.minimize_universes ~poly sigma in
   let uctx = Evd.ustate sigma in
   let typs = List.map (fun typ -> (EConstr.to_constr sigma typ, uctx)) typs in
   finish_admitted ~pm ~pinfo:proof.pinfo ~sec_vars typs

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -264,9 +264,8 @@ let def_class_levels ~def ~env_ar_params sigma aritysorts ctors =
     sigma, s, ctor
 
 let finalize_def_class ~poly env sigma ~params ~sort ~projtyp =
-  let to_type = PolyFlags.collapse_sort_variables poly in
   let sigma, (params, sort, typ, projtyp) =
-    Evarutil.finalize ~abort_on_undefined_evars:false ~to_type sigma (fun nf ->
+    Evarutil.finalize ~abort_on_undefined_evars:false ~poly sigma (fun nf ->
         let typ = EConstr.it_mkProd_or_LetIn (EConstr.mkSort sort) params in
         let typ = nf typ in
         (* we know the context is exactly the params because we built typ from mkSort *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -186,8 +186,7 @@ let show_top_evars ~proof =
 
 let show_universes ~proof =
   let Proof.{ goals; sigma; poly } = Proof.data proof in
-  let to_type = PolyFlags.collapse_sort_variables poly in
-  let ctx = Evd.sort_context_set (Evd.minimize_universes ~to_type sigma) in
+  let ctx = Evd.sort_context_set (Evd.minimize_universes ~poly sigma) in
   UState.pr (Evd.ustate sigma) ++ fnl () ++
   v 1 (str "Normalized constraints:" ++ cut() ++
        UnivGen.pr_sort_context (Termops.pr_evd_qvar sigma) (Termops.pr_evd_level sigma) ctx)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

Fixes the API of `minimize_universes` to take a PolyFlags.t record to drive minimization.
Luckily? All minimize_universes calls in the CI do not pass flags yet.

