### PR TITLE
Use levels instead of separate entries for rewrite strategies

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -975,10 +975,10 @@ Strategies for rewriting
 Usage
 ~~~~~
 
-.. tacn:: rewrite_strat @rewstrategy {? in @ident }
+.. tacn:: rewrite_strat @rewstrategy2 {? in @ident }
    :name: rewrite_strat
 
-   Rewrite using :n:`@rewstrategy` in the conclusion or in the hypothesis :n:`@ident`.
+   Rewrite using :n:`@rewstrategy2` in the conclusion or in the hypothesis :n:`@ident`.
 
    .. exn:: Nothing to rewrite.
 
@@ -1022,11 +1022,12 @@ further allows arbitrary customization of strategies through :ref:`Ltac1 <ltac>`
 The following describes the :ref:`Ltac1 <ltac>` version of the strategies. An :ref:`Ltac2 <ltac2>` version
 with the same primitives is available in the :g:`Ltac2.Rewrite` module.
 
-.. insertprodn rewstrategy rewstrategy0
+.. insertprodn rewstrategy2 rewstrategy0
 
 .. prodn::
-   rewstrategy ::= fix @ident := @rewstrategy1
+   rewstrategy2 ::= fix @ident := @rewstrategy1
    | {+; @rewstrategy1 }
+   | @rewstrategy1
    rewstrategy1 ::= <- @one_term
    | progress @rewstrategy1
    | try @rewstrategy1
@@ -1051,7 +1052,7 @@ with the same primitives is available in the :g:`Ltac2.Rewrite` module.
    | fail
    | id
    | refl
-   | ( @rewstrategy )
+   | ( @rewstrategy2 )
 
 :n:`@one_term`
    lemma, left to right
@@ -1080,7 +1081,7 @@ with the same primitives is available in the :g:`Ltac2.Rewrite` module.
 :n:`try @rewstrategy1`
    try catch
 
-:n:`@rewstrategy ; @rewstrategy1`
+:n:`{+; @rewstrategy1 }`
    composition
 
 :n:`choice {+ @rewstrategy0 }`
@@ -1128,8 +1129,8 @@ with the same primitives is available in the :g:`Ltac2.Rewrite` module.
    fixpoint operator, where :math:`\texttt{fix }f := v` evaluates to
    :math:`\subst{v}{f}{(\texttt{fix }f := v)}`
 
-:n:`( @rewstrategy )`
-   parenthesizes for disambiguation, applies :n:`@rewstrategy`
+:n:`( @rewstrategy2 )`
+   parenthesizes for disambiguation, applies :n:`@rewstrategy2`
 
 :n:`old_hints @ident`
    to be documented

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -2306,7 +2306,7 @@ Tactics
 Ltac language
 ^^^^^^^^^^^^^
 - **Added:**
-  In :tacn:`rewrite_strat`, :n:`@rewstrategy` now supports the fixpoint operator :n:`fix @ident := @rewstrategy1`
+  In :tacn:`rewrite_strat`, :n:`@rewstrategy2` now supports the fixpoint operator :n:`fix @ident := @rewstrategy1`
   (`#18094 <https://github.com/rocq-prover/rocq/pull/18094>`_,
   fixes `#13702 <https://github.com/rocq-prover/rocq/issues/13702>`_,
   by Jason Gross and Gaëtan Gilbert).

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1110,9 +1110,9 @@ simple_tactic: [
 | DELETE "setoid_symmetry"
 | REPLACE "setoid_symmetry" "in" hyp
 | WITH "setoid_symmetry" OPT ( "in" hyp )
-| REPLACE "rewrite_strat" rewstrategy "in" hyp
-| WITH "rewrite_strat" rewstrategy OPT ( "in" hyp )
-| DELETE "rewrite_strat" rewstrategy
+| REPLACE "rewrite_strat" rewstrategy2 "in" hyp
+| WITH "rewrite_strat" rewstrategy2 OPT ( "in" hyp )
+| DELETE "rewrite_strat" rewstrategy2
 | REPLACE "protect_fv" string "in" ident
 | WITH "protect_fv" string OPT ( "in" ident )
 | DELETE "protect_fv" string
@@ -2255,14 +2255,7 @@ as_or_and_ipat: [
 | "as" or_and_intropattern
 ]
 
-ne_rewstrategy1_list_sep_semicolon: [
-| DELETE rewstrategy1
-| REPLACE ne_rewstrategy1_list_sep_semicolon ";" rewstrategy1
-| WITH LIST1 rewstrategy1 SEP ";"
-]
-
 SPLICE: [
-| ne_rewstrategy1_list_sep_semicolon
 | clause
 | noedit_mode
 | match_list

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1875,8 +1875,8 @@ simple_tactic: [
 | "autoapply" constr "with" preident
 | "decide" "equality"
 | "compare" constr constr
-| "rewrite_strat" rewstrategy "in" hyp
-| "rewrite_strat" rewstrategy
+| "rewrite_strat" rewstrategy2 "in" hyp
+| "rewrite_strat" rewstrategy2
 | "rewrite_db" preident "in" hyp
 | "rewrite_db" preident
 | "substitute" orient glob_constr_with_bindings
@@ -2389,12 +2389,11 @@ glob_constr_with_bindings: [
 ]
 
 rewstrategy: [
-| "fix" identref ":=" rewstrategy1
-| ne_rewstrategy1_list_sep_semicolon
 ]
 
-ne_rewstrategy1_list_sep_semicolon: [
-| ne_rewstrategy1_list_sep_semicolon ";" rewstrategy1
+rewstrategy2: [
+| "fix" identref ":=" rewstrategy1
+| LIST1 rewstrategy1 SEP ";"
 | rewstrategy1
 ]
 
@@ -2426,7 +2425,7 @@ rewstrategy0: [
 | "id"
 | "fail"
 | "refl"
-| "(" rewstrategy ")"
+| "(" rewstrategy2 ")"
 ]
 
 id_or_meta: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1537,7 +1537,6 @@ simple_tactic: [
 | "not_evar" one_term
 | "is_ground" one_term
 | "autoapply" one_term "with" ident
-| "rewrite_strat" rewstrategy OPT ( "in" ident )
 | "rewrite_db" ident OPT ( "in" ident )
 | "substitute" OPT [ "->" | "<-" ] one_term_with_bindings
 | "setoid_rewrite" OPT [ "->" | "<-" ] one_term_with_bindings OPT ( "at" rewrite_occs ) OPT ( "in" ident )
@@ -1550,6 +1549,7 @@ simple_tactic: [
 | "eintros" LIST0 intropattern
 | "decide" "equality"
 | "compare" one_term one_term
+| "rewrite_strat" rewstrategy2 OPT ( "in" ident )
 | "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "eapply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
 | "simple" "apply" LIST1 one_term_with_bindings SEP "," OPT in_hyp_as
@@ -2223,8 +2223,12 @@ rewrite_occs: [
 ]
 
 rewstrategy: [
+]
+
+rewstrategy2: [
 | "fix" ident ":=" rewstrategy1
 | LIST1 rewstrategy1 SEP ";"
+| rewstrategy1
 ]
 
 rewstrategy1: [
@@ -2255,7 +2259,7 @@ rewstrategy0: [
 | "fail"
 | "id"
 | "refl"
-| "(" rewstrategy ")"
+| "(" rewstrategy2 ")"
 ]
 
 l3_tactic: [

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -101,17 +101,12 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: rewstrategy;
   rewstrategy:
-    [ NONA
-      [ IDENT "fix"; id = identref; ":="; s = rewstrategy1 -> { StratFix (id, s) }
-      | h = ne_rewstrategy1_list_sep_semicolon -> { h } ] ]
-  ;
-  ne_rewstrategy1_list_sep_semicolon:
-    [ LEFTA
-      [ h = SELF; ";"; h' = rewstrategy1 -> { StratBinary (Compose, h, h') }
-      | h = rewstrategy1 -> { h } ] ]
-  ;
-  rewstrategy1:
-    [ RIGHTA
+    [ "2" NONA
+      [ IDENT "fix"; id = identref; ":="; s = rewstrategy LEVEL "1" -> { StratFix (id, s) }
+      | h = LIST1 rewstrategy LEVEL "1" SEP ";" -> {
+          let x, h = match h with [] -> assert false | x::h -> x, h in
+          List.fold_left (fun a b -> StratBinary (Compose, a, b)) x h } ]
+    | "1" RIGHTA
       [ "<-"; c = constr -> { StratConstr (c, false) }
       | IDENT "subterms"; h = SELF -> { StratUnary (Subterms, h) }
       | IDENT "subterm"; h = SELF -> { StratUnary (Subterm, h) }
@@ -123,18 +118,15 @@ GRAMMAR EXTEND Gram
       | IDENT "try"; h = SELF -> { StratUnary (Try, h) }
       | IDENT "any"; h = SELF -> { StratUnary (Any, h) }
       | IDENT "repeat"; h = SELF -> { StratUnary (Repeat, h) }
-      | IDENT "choice"; h = LIST1 rewstrategy0 -> { StratNAry (Choice, h) }
+      | IDENT "choice"; h = LIST1 rewstrategy LEVEL "0" -> { StratNAry (Choice, h) }
       | IDENT "old_hints"; h = preident -> { StratHints (true, h) }
       | IDENT "hints"; h = preident -> { StratHints (false, h) }
       | IDENT "terms"; h = LIST0 constr -> { StratTerms h }
       | IDENT "eval"; r = red_expr -> { StratEval r }
       | IDENT "fold"; c = constr -> { StratFold c }
       | IDENT "matches"; c = constr -> { StratMatches c }
-      | IDENT "tactic"; c = tactic -> { StratTactic c }
-      | h = rewstrategy0 -> { h } ] ]
-  ;
-  rewstrategy0:
-    [ NONA
+      | IDENT "tactic"; c = tactic -> { StratTactic c } ]
+    | "0" NONA
       [ c = constr -> { StratConstr (c, true) }
       | IDENT "id" -> { StratId }
       | IDENT "fail" -> { StratFail }


### PR DESCRIPTION
We could use NEXT instead of explicit levels in most of these but to minimize changes I used explicit levels.
