### PR TITLE
Use `dune` wrapped modules to decrease namespace pollution

### DIFF
--- a/checker/dune
+++ b/checker/dune
@@ -8,7 +8,8 @@
  (synopsis "Rocq's Standalone Proof Checker")
  (modules :standard \ rocqchk coqchk votour)
  (wrapped true)
- (libraries rocq-runtime.boot rocq-runtime.kernel))
+ (libraries rocq-runtime.boot rocq-runtime.kernel)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.checklib)

--- a/dev/dune
+++ b/dev/dune
@@ -8,7 +8,7 @@
  ; but we still want to load_printer ltac2
  ; so that its genarg printers are present in the debugger's printer process
  (libraries rocq-runtime.vernac rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (library
  (name debugger_support)
@@ -17,7 +17,7 @@
  (wrapped false)
  (modules debugger_support)
  (libraries rocq-runtime.dev)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (rule
   (targets dune-dbg)

--- a/dev/dune
+++ b/dev/dune
@@ -7,7 +7,8 @@
  ; NB currently we have no "install_printer" using ltac2,
  ; but we still want to load_printer ltac2
  ; so that its genarg printers are present in the debugger's printer process
- (libraries rocq-runtime.vernac rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2))
+ (libraries rocq-runtime.vernac rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2)
+ (flags :standard -open Rocqutils))
 
 (library
  (name debugger_support)
@@ -15,7 +16,8 @@
  (synopsis "Rocq Support for ocamldebug")
  (wrapped false)
  (modules debugger_support)
- (libraries rocq-runtime.dev))
+ (libraries rocq-runtime.dev)
+ (flags :standard -open Rocqutils))
 
 (rule
   (targets dune-dbg)

--- a/doc/plugin_tutorial/tuto0/src/dune
+++ b/doc/plugin_tutorial/tuto0/src/dune
@@ -1,7 +1,8 @@
 (library
  (name tuto0_plugin)
  (public_name rocq-runtime.plugins.tutorial.p0)
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (rule
  (targets g_tuto0.ml)

--- a/doc/plugin_tutorial/tuto1/src/dune
+++ b/doc/plugin_tutorial/tuto1/src/dune
@@ -1,7 +1,8 @@
 (library
  (name tuto1_plugin)
  (public_name rocq-runtime.plugins.tutorial.p1)
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (rule
  (targets g_tuto1.ml)

--- a/doc/plugin_tutorial/tuto1/src/dune
+++ b/doc/plugin_tutorial/tuto1/src/dune
@@ -2,7 +2,7 @@
  (name tuto1_plugin)
  (public_name rocq-runtime.plugins.tutorial.p1)
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (rule
  (targets g_tuto1.ml)

--- a/doc/plugin_tutorial/tuto2/src/dune
+++ b/doc/plugin_tutorial/tuto2/src/dune
@@ -1,7 +1,8 @@
 (library
  (name tuto2_plugin)
  (public_name rocq-runtime.plugins.tutorial.p2)
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (rule
  (targets g_tuto2.ml)

--- a/doc/plugin_tutorial/tuto2/src/dune
+++ b/doc/plugin_tutorial/tuto2/src/dune
@@ -2,7 +2,7 @@
  (name tuto2_plugin)
  (public_name rocq-runtime.plugins.tutorial.p2)
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (rule
  (targets g_tuto2.ml)

--- a/doc/plugin_tutorial/tuto3/src/dune
+++ b/doc/plugin_tutorial/tuto3/src/dune
@@ -1,7 +1,7 @@
 (library
  (name tuto3_plugin)
  (public_name rocq-runtime.plugins.tutorial.p3)
- (flags :standard -warn-error -3)
+ (flags :standard -warn-error -3 -open Rocqutils)
  (libraries rocq-runtime.plugins.ltac))
 
 (rule

--- a/doc/plugin_tutorial/tuto3/src/dune
+++ b/doc/plugin_tutorial/tuto3/src/dune
@@ -1,7 +1,7 @@
 (library
  (name tuto3_plugin)
  (public_name rocq-runtime.plugins.tutorial.p3)
- (flags :standard -warn-error -3 -open Rocqutils)
+ (flags :standard -warn-error -3 -open Rocqutils -open Rocqpretyping)
  (libraries rocq-runtime.plugins.ltac))
 
 (rule

--- a/doc/plugin_tutorial/tuto4/src/dune
+++ b/doc/plugin_tutorial/tuto4/src/dune
@@ -1,4 +1,5 @@
 (library
  (name tuto4_plugin)
  (public_name rocq-runtime.plugins.tutorial.p4)
- (libraries rocq-runtime.plugins.ltac2))
+ (libraries rocq-runtime.plugins.ltac2)
+ (flags :standard -open Rocqutils))

--- a/engine/dune
+++ b/engine/dune
@@ -5,7 +5,8 @@
  (wrapped false)
  ; until ocaml/dune#4892 fixed
  ; (private_modules univSubst)
- (libraries library))
+ (libraries library)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.engine)

--- a/gramlib/dune
+++ b/gramlib/dune
@@ -2,7 +2,8 @@
  (name gramlib)
  (public_name rocq-runtime.gramlib)
  (modules_without_implementation plexing)
- (libraries rocq-runtime.lib))
+ (libraries rocq-runtime.lib)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.gramlib)

--- a/ide/rocqide/dune
+++ b/ide/rocqide/dune
@@ -6,7 +6,8 @@
  (public_name coqide-server.core)
  (wrapped false)
  (modules document)
- (libraries rocq-runtime.boot rocq-runtime.lib))
+ (libraries rocq-runtime.boot rocq-runtime.lib)
+ (flags :standard -open Rocqutils))
 
 (executable
  (name idetop)
@@ -14,6 +15,7 @@
  (package coqide-server)
  (modules idetop)
  (libraries rocq-runtime.toplevel coqide-server.protocol platform_specific)
+ (flags :standard -open Rocqutils)
  (link_flags -linkall))
 
 ; IDE Client, we may want to add the macos_prehook.ml conditionally.

--- a/ide/rocqide/dune
+++ b/ide/rocqide/dune
@@ -15,7 +15,7 @@
  (package coqide-server)
  (modules idetop)
  (libraries rocq-runtime.toplevel coqide-server.protocol platform_specific)
- (flags :standard -open Rocqutils)
+ (flags :standard -open Rocqutils -open Rocqpretyping)
  (link_flags -linkall))
 
 ; IDE Client, we may want to add the macos_prehook.ml conditionally.

--- a/ide/rocqide/dune
+++ b/ide/rocqide/dune
@@ -27,7 +27,8 @@
  (foreign_stubs
   (language c)
   (names rocqide_os_stubs))
- (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3 platform_specific))
+ (libraries coqide-server.protocol coqide-server.core lablgtk3-sourceview3 platform_specific)
+ (flags :standard -open Rocqutils))
 
 (library
  (name platform_specific)
@@ -69,7 +70,8 @@
  (package rocqide)
  (modules rocqide_main)
  (modes exe byte)
- (libraries rocqide_gui))
+ (libraries rocqide_gui)
+ (flags :standard -open Rocqutils))
 
 (documentation
  (package rocqide))

--- a/ide/rocqide/protocol/dune
+++ b/ide/rocqide/protocol/dune
@@ -3,6 +3,7 @@
  (public_name coqide-server.protocol)
  (wrapped false)
  (modules_without_implementation interface)
- (libraries rocq-runtime.lib))
+ (libraries rocq-runtime.lib)
+ (flags :standard -open Rocqutils))
 
 (ocamllex xml_lexer)

--- a/interp/dune
+++ b/interp/dune
@@ -4,7 +4,8 @@
  (public_name rocq-runtime.interp)
  (wrapped false)
  (modules_without_implementation constrexpr notation_term)
- (libraries zarith pretyping gramlib))
+ (libraries zarith pretyping gramlib)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.interp)

--- a/interp/dune
+++ b/interp/dune
@@ -4,8 +4,8 @@
  (public_name rocq-runtime.interp)
  (wrapped false)
  (modules_without_implementation constrexpr notation_term)
- (libraries zarith pretyping gramlib)
- (flags :standard -open Rocqutils))
+ (libraries zarith rocqpretyping gramlib)
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.interp)

--- a/kernel/dune
+++ b/kernel/dune
@@ -5,7 +5,8 @@
  (wrapped false)
  (modules_without_implementation values declarations entries)
  (modules (:standard \ genOpcodeFiles uint63_31 uint63_63 float64_31 float64_63))
- (libraries boot lib coqrun dynlink))
+ (libraries boot rocqutils coqrun dynlink)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.kernel)

--- a/lib/dune
+++ b/lib/dune
@@ -1,8 +1,8 @@
 (library
- (name lib)
+ (name rocqutils)
  (synopsis "Rocq's Utility Library [rocq-specific]")
  (public_name rocq-runtime.lib)
- (wrapped false)
+ (wrapped true)
  (modules_without_implementation xml_datatype)
  (libraries
   rocq-runtime.boot rocq-runtime.clib rocq-runtime.config

--- a/library/dune
+++ b/library/dune
@@ -3,7 +3,8 @@
  (synopsis "Rocq's Loadable Libraries (vo) Support")
  (public_name rocq-runtime.library)
  (wrapped false)
- (libraries kernel))
+ (libraries kernel)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.library)

--- a/parsing/dune
+++ b/parsing/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.parsing)
  (wrapped false)
  (modules_without_implementation notation_gram)
- (libraries rocq-runtime.gramlib interp))
+ (libraries rocq-runtime.gramlib interp)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.parsing)

--- a/parsing/dune
+++ b/parsing/dune
@@ -4,7 +4,7 @@
  (wrapped false)
  (modules_without_implementation notation_gram)
  (libraries rocq-runtime.gramlib interp)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.parsing)

--- a/plugins/btauto/dune
+++ b/plugins/btauto/dune
@@ -2,7 +2,8 @@
  (name btauto_plugin)
  (public_name rocq-runtime.plugins.btauto)
  (synopsis "Rocq's btauto plugin")
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.btauto)

--- a/plugins/cc/dune
+++ b/plugins/cc/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.plugins.cc_core)
  (synopsis "Rocq's congruence closure plugin")
  (modules (:standard \ g_congruence))
- (libraries rocq-runtime.tactics))
+ (libraries rocq-runtime.tactics)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.cc_core)

--- a/plugins/cc/dune
+++ b/plugins/cc/dune
@@ -4,7 +4,7 @@
  (synopsis "Rocq's congruence closure plugin")
  (modules (:standard \ g_congruence))
  (libraries rocq-runtime.tactics)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.cc_core)
@@ -15,7 +15,7 @@
  (public_name rocq-runtime.plugins.cc)
  (synopsis "Rocq's congruence closure plugin (Ltac1 syntax)")
  (modules g_congruence)
- (flags :standard -open Cc_core_plugin)
+ (flags :standard -open Cc_core_plugin -open Rocqpretyping)
  (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.cc_core))
 
 (deprecated_library_name

--- a/plugins/derive/dune
+++ b/plugins/derive/dune
@@ -2,7 +2,8 @@
  (name derive_plugin)
  (public_name rocq-runtime.plugins.derive)
  (synopsis "Rocq's derive plugin")
- (libraries rocq-runtime.vernac))
+ (libraries rocq-runtime.vernac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.derive)

--- a/plugins/derive/dune
+++ b/plugins/derive/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.derive)
  (synopsis "Rocq's derive plugin")
  (libraries rocq-runtime.vernac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.derive)

--- a/plugins/extraction/dune
+++ b/plugins/extraction/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.extraction)
  (synopsis "Rocq's extraction plugin")
  (libraries rocq-runtime.vernac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.extraction)

--- a/plugins/extraction/dune
+++ b/plugins/extraction/dune
@@ -2,7 +2,8 @@
  (name extraction_plugin)
  (public_name rocq-runtime.plugins.extraction)
  (synopsis "Rocq's extraction plugin")
- (libraries rocq-runtime.vernac))
+ (libraries rocq-runtime.vernac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.extraction)

--- a/plugins/firstorder/dune
+++ b/plugins/firstorder/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.plugins.firstorder_core)
  (synopsis "Rocq's first order logic solver plugin")
  (modules (:standard \ g_ground))
- (libraries rocq-runtime.tactics))
+ (libraries rocq-runtime.tactics)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.firstorder_core)
@@ -13,7 +14,7 @@
  (name firstorder_plugin)
  (public_name rocq-runtime.plugins.firstorder)
  (synopsis "Rocq's first order logic solver plugin (Ltac1 syntax)")
- (flags :standard -open Firstorder_core_plugin)
+ (flags :standard -open Firstorder_core_plugin -open Rocqutils)
  (modules g_ground)
  (libraries rocq-runtime.plugins.firstorder_core rocq-runtime.plugins.ltac))
 

--- a/plugins/firstorder/dune
+++ b/plugins/firstorder/dune
@@ -4,7 +4,7 @@
  (synopsis "Rocq's first order logic solver plugin")
  (modules (:standard \ g_ground))
  (libraries rocq-runtime.tactics)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.firstorder_core)
@@ -14,7 +14,7 @@
  (name firstorder_plugin)
  (public_name rocq-runtime.plugins.firstorder)
  (synopsis "Rocq's first order logic solver plugin (Ltac1 syntax)")
- (flags :standard -open Firstorder_core_plugin -open Rocqutils)
+ (flags :standard -open Firstorder_core_plugin -open Rocqutils -open Rocqpretyping)
  (modules g_ground)
  (libraries rocq-runtime.plugins.firstorder_core rocq-runtime.plugins.ltac))
 

--- a/plugins/funind/dune
+++ b/plugins/funind/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.funind)
  (synopsis "Rocq's functional induction plugin")
  (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.extraction)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.funind)

--- a/plugins/funind/dune
+++ b/plugins/funind/dune
@@ -2,7 +2,8 @@
  (name funind_plugin)
  (public_name rocq-runtime.plugins.funind)
  (synopsis "Rocq's functional induction plugin")
- (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.extraction))
+ (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.extraction)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.funind)

--- a/plugins/ltac/dune
+++ b/plugins/ltac/dune
@@ -5,7 +5,7 @@
  (modules :standard \ tauto)
  (modules_without_implementation tacexpr)
  (libraries rocq-runtime.vernac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac)
@@ -17,7 +17,7 @@
  (synopsis "Rocq's tauto tactic")
  (modules tauto)
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.tauto)

--- a/plugins/ltac/dune
+++ b/plugins/ltac/dune
@@ -4,7 +4,8 @@
  (synopsis "Rocq's LTAC tactic language")
  (modules :standard \ tauto)
  (modules_without_implementation tacexpr)
- (libraries rocq-runtime.vernac))
+ (libraries rocq-runtime.vernac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac)
@@ -15,7 +16,8 @@
  (public_name rocq-runtime.plugins.tauto)
  (synopsis "Rocq's tauto tactic")
  (modules tauto)
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.tauto)

--- a/plugins/ltac2/dune
+++ b/plugins/ltac2/dune
@@ -4,7 +4,7 @@
  (synopsis "Ltac2 plugin")
  (modules_without_implementation tac2expr tac2qexpr tac2types)
  (libraries vernac rocq-runtime.plugins.cc_core)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac2)

--- a/plugins/ltac2/dune
+++ b/plugins/ltac2/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.plugins.ltac2)
  (synopsis "Ltac2 plugin")
  (modules_without_implementation tac2expr tac2qexpr tac2types)
- (libraries vernac rocq-runtime.plugins.cc_core))
+ (libraries vernac rocq-runtime.plugins.cc_core)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac2)

--- a/plugins/ltac2_ltac1/dune
+++ b/plugins/ltac2_ltac1/dune
@@ -2,7 +2,8 @@
  (name ltac2_ltac1_plugin)
  (public_name rocq-runtime.plugins.ltac2_ltac1)
  (synopsis "Ltac2 and Ltac1 interoperability plugin")
- (libraries ltac_plugin ltac2_plugin))
+ (libraries ltac_plugin ltac2_plugin)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac2_ltac1)

--- a/plugins/ltac2_ltac1/dune
+++ b/plugins/ltac2_ltac1/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.ltac2_ltac1)
  (synopsis "Ltac2 and Ltac1 interoperability plugin")
  (libraries ltac_plugin ltac2_plugin)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ltac2_ltac1)

--- a/plugins/micromega/dune
+++ b/plugins/micromega/dune
@@ -14,7 +14,7 @@
  (public_name rocq-runtime.plugins.micromega)
  ; be careful not to link the executable to the plugin!
  (modules (:standard \ micromega numCompat mutils sos_types sos_lib sos csdpcert g_zify zify))
- (flags :standard -open Micromega_core_plugin)
+ (flags :standard -open Micromega_core_plugin -open Rocqutils)
  (synopsis "Rocq's micromega plugin")
  (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.micromega_core))
 
@@ -35,7 +35,8 @@
  (public_name rocq-runtime.plugins.zify)
  (modules g_zify zify)
  (synopsis "Rocq's zify plugin")
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.zify)

--- a/plugins/micromega/dune
+++ b/plugins/micromega/dune
@@ -14,7 +14,7 @@
  (public_name rocq-runtime.plugins.micromega)
  ; be careful not to link the executable to the plugin!
  (modules (:standard \ micromega numCompat mutils sos_types sos_lib sos csdpcert g_zify zify))
- (flags :standard -open Micromega_core_plugin -open Rocqutils)
+ (flags :standard -open Micromega_core_plugin -open Rocqutils -open Rocqpretyping)
  (synopsis "Rocq's micromega plugin")
  (libraries rocq-runtime.plugins.ltac rocq-runtime.plugins.micromega_core))
 
@@ -36,7 +36,7 @@
  (modules g_zify zify)
  (synopsis "Rocq's zify plugin")
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.zify)

--- a/plugins/nsatz/dune
+++ b/plugins/nsatz/dune
@@ -15,7 +15,7 @@
  (public_name rocq-runtime.plugins.nsatz)
  (synopsis "Rocq's nsatz solver plugin (Ltac1 syntax)")
  (modules g_nsatz)
- (flags :standard -open Nsatz_core_plugin)
+ (flags :standard -open Nsatz_core_plugin -open Rocqpretyping)
  (libraries rocq-runtime.plugins.nsatz_core rocq-runtime.plugins.ltac))
 
 (deprecated_library_name

--- a/plugins/nsatz/dune
+++ b/plugins/nsatz/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.plugins.nsatz_core)
  (synopsis "Rocq's nsatz solver plugin")
  (modules (:standard \ g_nsatz))
- (libraries rocq-runtime.tactics))
+ (libraries rocq-runtime.tactics)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.nsatz_core)

--- a/plugins/ring/dune
+++ b/plugins/ring/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.ring)
  (synopsis "Rocq's ring plugin")
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ring)

--- a/plugins/ring/dune
+++ b/plugins/ring/dune
@@ -2,7 +2,8 @@
  (name ring_plugin)
  (public_name rocq-runtime.plugins.ring)
  (synopsis "Rocq's ring plugin")
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ring)

--- a/plugins/rtauto/dune
+++ b/plugins/rtauto/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.rtauto)
  (synopsis "Rocq's rtauto plugin")
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.rtauto)

--- a/plugins/rtauto/dune
+++ b/plugins/rtauto/dune
@@ -2,7 +2,8 @@
  (name rtauto_plugin)
  (public_name rocq-runtime.plugins.rtauto)
  (synopsis "Rocq's rtauto plugin")
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.rtauto)

--- a/plugins/ssr/dune
+++ b/plugins/ssr/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.ssreflect)
  (synopsis "Rocq's ssreflect plugin")
  (modules_without_implementation ssrast)
- (flags :standard -open Gramlib)
+ (flags :standard -open Gramlib -open Rocqutils)
  (libraries rocq-runtime.plugins.ssrmatching))
 
 (deprecated_library_name

--- a/plugins/ssr/dune
+++ b/plugins/ssr/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.ssreflect)
  (synopsis "Rocq's ssreflect plugin")
  (modules_without_implementation ssrast)
- (flags :standard -open Gramlib -open Rocqutils)
+ (flags :standard -open Gramlib -open Rocqutils -open Rocqpretyping)
  (libraries rocq-runtime.plugins.ssrmatching))
 
 (deprecated_library_name

--- a/plugins/ssrmatching/dune
+++ b/plugins/ssrmatching/dune
@@ -3,7 +3,7 @@
  (public_name rocq-runtime.plugins.ssrmatching)
  (synopsis "Rocq ssrmatching plugin")
  (libraries rocq-runtime.plugins.ltac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ssrmatching)

--- a/plugins/ssrmatching/dune
+++ b/plugins/ssrmatching/dune
@@ -2,7 +2,8 @@
  (name ssrmatching_plugin)
  (public_name rocq-runtime.plugins.ssrmatching)
  (synopsis "Rocq ssrmatching plugin")
- (libraries rocq-runtime.plugins.ltac))
+ (libraries rocq-runtime.plugins.ltac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.ssrmatching)

--- a/plugins/syntax/dune
+++ b/plugins/syntax/dune
@@ -3,7 +3,8 @@
  (public_name rocq-runtime.plugins.number_string_notation)
  (synopsis "Rocq number and string notation plugin")
  (modules g_number_string number_string)
- (libraries rocq-runtime.vernac))
+ (libraries rocq-runtime.vernac)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.number_string_notation)

--- a/plugins/syntax/dune
+++ b/plugins/syntax/dune
@@ -4,7 +4,7 @@
  (synopsis "Rocq number and string notation plugin")
  (modules g_number_string number_string)
  (libraries rocq-runtime.vernac)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.plugins.number_string_notation)

--- a/pretyping/dune
+++ b/pretyping/dune
@@ -1,8 +1,8 @@
 (library
- (name pretyping)
+ (name rocqpretyping)
  (synopsis "Rocq's Type Inference Component (Pretyper)")
  (public_name rocq-runtime.pretyping)
- (wrapped false)
+ (wrapped true)
  (modules_without_implementation locus pattern glob_term ltac_pretype)
  (libraries engine)
  (flags :standard -open Rocqutils))

--- a/pretyping/dune
+++ b/pretyping/dune
@@ -4,7 +4,8 @@
  (public_name rocq-runtime.pretyping)
  (wrapped false)
  (modules_without_implementation locus pattern glob_term ltac_pretype)
- (libraries engine))
+ (libraries engine)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.pretyping)

--- a/printing/dune
+++ b/printing/dune
@@ -3,7 +3,8 @@
  (synopsis "Rocq's Term Pretty Printing Library")
  (public_name rocq-runtime.printing)
  (wrapped false)
- (libraries parsing proofs))
+ (libraries parsing proofs)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.printing)

--- a/printing/dune
+++ b/printing/dune
@@ -4,7 +4,7 @@
  (public_name rocq-runtime.printing)
  (wrapped false)
  (libraries parsing proofs)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.printing)

--- a/proofs/dune
+++ b/proofs/dune
@@ -4,8 +4,8 @@
  (public_name rocq-runtime.proofs)
  (wrapped false)
  (modules_without_implementation tactypes)
- (libraries pretyping)
- (flags :standard -open Rocqutils))
+ (libraries rocqpretyping)
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.proofs)

--- a/proofs/dune
+++ b/proofs/dune
@@ -4,7 +4,8 @@
  (public_name rocq-runtime.proofs)
  (wrapped false)
  (modules_without_implementation tactypes)
- (libraries pretyping))
+ (libraries pretyping)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.proofs)

--- a/stm/dune
+++ b/stm/dune
@@ -5,7 +5,8 @@
  (wrapped false)
  ; until ocaml/dune#4892 fixed
  ; (private_modules dag proofBlockDelimiter tQueue vcs workerPool)
- (libraries sysinit coqworkmgrApi))
+ (libraries sysinit coqworkmgrApi)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.stm)

--- a/sysinit/dune
+++ b/sysinit/dune
@@ -17,7 +17,8 @@
  (synopsis "Rocq's initialization")
  (wrapped false)
  (modules :standard \ coqargs)
- (libraries rocq-runtime.boot rocq-runtime.vernac coqargs findlib))
+ (libraries rocq-runtime.boot rocq-runtime.vernac coqargs findlib)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.sysinit)

--- a/tactics/dune
+++ b/tactics/dune
@@ -6,7 +6,8 @@
  (modules_without_implementation genredexpr)
  ; until ocaml/dune#4892 fixed
  ; (private_modules btermdn dn)
- (libraries printing))
+ (libraries printing)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.tactics)

--- a/tactics/dune
+++ b/tactics/dune
@@ -7,7 +7,7 @@
  ; until ocaml/dune#4892 fixed
  ; (private_modules btermdn dn)
  (libraries printing)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.tactics)

--- a/tools/coqdep/lib/dune
+++ b/tools/coqdep/lib/dune
@@ -1,6 +1,7 @@
 (library
  (name coqdeplib)
  (public_name rocq-runtime.coqdeplib)
- (libraries rocq-runtime.boot rocq-runtime.lib findlib.internal))
+ (libraries rocq-runtime.boot rocq-runtime.lib findlib.internal)
+ (flags :standard -open Rocqutils))
 
 (ocamllex lexer)

--- a/tools/dune
+++ b/tools/dune
@@ -16,7 +16,8 @@
 (library
  (name rocqmakefile)
  (modules rocqmakefile)
- (libraries rocq-runtime.boot rocq-runtime.lib))
+ (libraries rocq-runtime.boot rocq-runtime.lib)
+ (flags :standard -open Rocqutils))
 
 (executable
  (name coq_makefile)

--- a/tools/dune_rule_gen/dune
+++ b/tools/dune_rule_gen/dune
@@ -7,5 +7,5 @@
 (executable
  (name gen_rules)
  (modules gen_rules)
- (flags :standard -w +a-40-42)
+ (flags :standard -w +a-40-42 -open Rocqutils)
  (libraries coq_dune))

--- a/topbin/dune
+++ b/topbin/dune
@@ -12,7 +12,8 @@
  (modules rocq)
  (modes exe byte)
  ; we statically link the "small" subcommands instead of having separate binaries
- (libraries rocqshim coqdeplib coqpp coqdoclib rocqwc rocqworkmgr rocqtex rocqmakefile))
+ (libraries rocqshim coqdeplib coqpp coqdoclib rocqwc rocqworkmgr rocqtex rocqmakefile)
+ (flags :standard -open Rocqutils))
 
 (install
  (section bin)
@@ -45,7 +46,8 @@
  (modules rocqnative)
  (libraries rocq-runtime.kernel)
  (modes exe byte) ; NB byte not installed, just exists for debugger
- (link_flags -linkall))
+ (link_flags -linkall)
+ (flags :standard -open Rocqutils))
 
 (executable
  (name coqnative)
@@ -67,7 +69,8 @@
  (name rocqworker_with_drop)
  (modules rocqworker_with_drop)
  (modes byte)
- (libraries compiler-libs.toplevel rocq-runtime.config.byte rocq-runtime.toplevel rocq-runtime.dev findlib.top))
+ (libraries compiler-libs.toplevel rocq-runtime.config.byte rocq-runtime.toplevel rocq-runtime.dev findlib.top)
+ (flags :standard -open Rocqutils))
 
 (install
  (section libexec)

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -9,7 +9,7 @@
   (select memtrace_init.ml from
    (memtrace -> memtrace_init.memtrace.ml)
    (!memtrace -> memtrace_init.default.ml)))
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.toplevel)

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -8,7 +8,8 @@
  (libraries rocq-runtime.stm
   (select memtrace_init.ml from
    (memtrace -> memtrace_init.memtrace.ml)
-   (!memtrace -> memtrace_init.default.ml))))
+   (!memtrace -> memtrace_init.default.ml)))
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.toplevel)

--- a/vernac/dune
+++ b/vernac/dune
@@ -6,7 +6,8 @@
  (modules_without_implementation vernacexpr)
  ; until ocaml/dune#4892 fixed
  ; (private_modules comProgramFixpoint egramcoq)
- (libraries tactics parsing findlib.dynload))
+ (libraries tactics parsing findlib.dynload)
+ (flags :standard -open Rocqutils))
 
 (deprecated_library_name
  (old_public_name coq-core.vernac)

--- a/vernac/dune
+++ b/vernac/dune
@@ -7,7 +7,7 @@
  ; until ocaml/dune#4892 fixed
  ; (private_modules comProgramFixpoint egramcoq)
  (libraries tactics parsing findlib.dynload)
- (flags :standard -open Rocqutils))
+ (flags :standard -open Rocqutils -open Rocqpretyping))
 
 (deprecated_library_name
  (old_public_name coq-core.vernac)


### PR DESCRIPTION
<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

This PR changes
```dune
(wrapped false)
```
to
```dune
(wrapped true)
```
in `lib/dune` and `pretyping/dune` to decrease namespace pollution from unwrapped modules. The main motivation behind this was that in projects that depend on `rocq-runtime` libraries, Rocq's unwrapped modules would cause name conflicts, mostly with files in `lib` (e.g. `Spawn`, `Flags`).
```
File "_none_", line 1:
Error:  Duplicated implementations:
         Multiple definitions of module Flags in files /home/ky28059/.../_opam/lib/core_kernel/flags/flags.cmxa,
         /home/ky28059/.../_opam/lib/rocq-runtime/lib/lib.cmxa,
         Multiple definitions of module Spawn in files /home/ky28059/.../_opam/lib/spawn/spawn.cmxa,
         /home/ky28059/.../_opam/lib/rocq-runtime/lib/lib.cmxa
```
In general, though, using wrapped modules should allow for better control over module naming.

In terms of naming, this PR wraps lib as `Rocqutil` and pretyping as `Rocqpretyping` (to ensure that unique, non-conflicting names are used) but it should be easy to rename these by simply replacing all occurrences of
```ocaml
open Rocqutil
```
with the new module name (and changing the `(name ...)` field in the corresponding `dune` file). I've tested that the project builds with `dune build` and `opam install`, but am not sure which other things this may break.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
