### PR TITLE
Mark tactician allow_failure due to slow overlay merging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1321,6 +1321,7 @@ plugin:ci-stalmarck:
 
 plugin:ci-tactician:
   extends: .ci-template-flambda
+  allow_failure: true # slow overlay merging
 
 plugin:ci-waterproof:
   extends: .ci-template-flambda


### PR DESCRIPTION
Unless we can get more people with merge rights there I think it should be removed from CI.

cc @LasseBlaauwbroek 