### PR TITLE
Experiment: optimized representation for `nat` constants (a zarith Z.t values)

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -107,6 +107,7 @@ let to_entry mind (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
     mind_entry_universes;
     mind_entry_variance;
     mind_entry_private = mb.mind_private;
+    mind_entry_is_nat = mb.mind_is_nat;
   }
 
 let check_abstract_uctx a b =
@@ -217,7 +218,9 @@ let check_inductive env mind mb retro =
   let { mind_packets; mind_finite; mind_hyps; mind_univ_hyps;
         mind_nparams; mind_nparams_rec; mind_params_ctxt;
         mind_universes; mind_template; mind_variance; mind_sec_variance;
-        mind_private; mind_typing_flags; }
+        mind_private; mind_typing_flags;
+        mind_is_nat;
+      }
     =
     (* Locally set typing flags for further typechecking *)
     let env = CheckFlags.set_local_flags mb.mind_typing_flags env in
@@ -251,6 +254,8 @@ let check_inductive env mind mb retro =
 
   ignore mind_typing_flags;
   (* TODO non oracle flags *)
+
+  check "mind_is_nat" (Bool.equal mb.mind_is_nat mind_is_nat);
 
   add_mind mind mb env
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -245,6 +245,9 @@ let v_proj = v_tuple "projection" [|v_proj_repr; v_bool|]
 let v_uint63 =
   if Sys.word_size == 64 then v_int else v_int64
 
+(* TODO *)
+let v_z = v_any
+
 let v_constr =
   fix (fun v_constr ->
 let v_prec =
@@ -277,7 +280,8 @@ let v_case_return = v_tuple_c ("case_return", [|v_tuple_c ("case_return'", [|v_a
     [|v_uint63|]; (* v_int *)
     [|v_float64|]; (* Float *)
     [|v_string|]; (* v_string *)
-    [|v_instance;v_array v_constr;v_constr;v_constr|] (* v_array *)
+    [|v_instance;v_array v_constr;v_constr;v_constr|]; (* v_array *)
+    [|v_ind;v_z|]; (* nat *)
   |]))
 
 let v_rdecl = v_sum "rel_declaration" 0
@@ -477,7 +481,9 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     v_opt (v_array v_variance);
     v_opt (v_array v_variance);
     v_opt v_bool;
-    v_typing_flags|]
+    v_typing_flags;
+    v_bool;
+  |]
 
 let v_prim_ind = v_enum "prim_ind" 6
 (* Number of "Register ... as kernel.ind_..." in Primv_int63.v and PrimFloat.v *)
@@ -489,6 +495,7 @@ let v_retro_action =
   v_sum "retro_action" 0 [|
     [|v_prim_ind; v_ind|];
     [|v_prim_type; v_cst|];
+    [|v_ind|]
   |]
 
 let v_retroknowledge =

--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -54,7 +54,7 @@ check_variable () {
 
 # example: coq-hott.dev git+https://github.com/some-user/coq-hott#some-branch
 # (make sure to include the version for the opam package, note that just https won't work)
-: "${new_opam_override_urls:=}"
+: "${new_opam_override_urls:=rocq-elpi.dev git+https://github.com/skyskimmer/coq-elpi#bignat rocq-equations.dev git+https://github.com/skyskimmer/coq-equations#bignat rocq-metarocq-template.dev https://github.com/skyskimmer/metarocq#bignat coq-performance-tests-lite git+https://github.com/SkySkimmer/coq-performance-tests#bignat}"
 : "${old_opam_override_urls:=}"
 
 if [ "$CI" ]; then

--- a/dev/ci/user-overlays/21729-SkySkimmer-bignat.sh
+++ b/dev/ci/user-overlays/21729-SkySkimmer-bignat.sh
@@ -1,0 +1,7 @@
+overlay elpi https://github.com/SkySkimmer/coq-elpi bignat 21729
+
+overlay equations https://github.com/SkySkimmer/Coq-Equations bignat 21729
+
+overlay metarocq https://github.com/SkySkimmer/metarocq bignat 21729
+
+overlay coq_performance_tests https://github.com/SkySkimmer/coq-performance-tests bignat 21729

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -1,6 +1,7 @@
 install_printer Top_printers.pP
 install_printer Top_printers.ppexninfo
 install_printer Top_printers.ppfuture
+install_printer Top_printers.ppZ
 install_printer Top_printers.ppid
 install_printer Top_printers.ppmbid
 install_printer Top_printers.ppdir

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -43,6 +43,8 @@ let ppexninfo e =
 
 let ppfuture kx = pp (Future.print (fun _ -> str "_") kx)
 
+let ppZ z = pp (str (Z.to_string z))
+
 (* name printers *)
 let ppid id = pp (Id.print id)
 let ppmbid mbid = pp (str (MBId.debug_to_string mbid))
@@ -408,6 +410,7 @@ let constr_display csr =
       ^(Array.fold_right (fun x i -> (name_display x)^(if not(i="")
         then (";"^i) else "")) lna "")^","
       ^(array_display bl)^")"
+  | Nat (ind,n) -> "Nat("^(MutInd.to_string (fst ind))^Z.to_string n^")"
   | Int i ->
       "Int("^(Uint63.to_string i)^")"
   | Float f ->
@@ -570,6 +573,8 @@ let print_pure_constr csr =
           print_cut();
         done
       in print_string"{"; print_fix (); print_string"}"
+  | Nat (ind,n) ->
+     print_string ("Nat("^MutInd.to_string (fst ind)^(Z.to_string n)^")")
   | Int i ->
      print_string ("Int("^(Uint63.to_string i)^")")
   | Float f ->

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -19,6 +19,8 @@ val pp_as_format : Pp.t -> unit
 
 val ppfuture : 'a Future.computation -> unit
 
+val ppZ : Z.t -> unit
+
 val ppid : Names.Id.t -> unit
 val ppmbid : Names.MBId.t -> unit
 val ppdir : Names.DirPath.t -> unit

--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -77,6 +77,7 @@ and ppwhd whd =
   | Vcofix _ -> print_string "cofix"
   | Vconst i -> print_string "C(";print_int i;print_string")"
   | Vblock b -> ppvblock b
+  | Vnat n -> printf "nat(%s)" (Z.to_string n)
   | Vint64 i -> printf "int64(%LiL)" i
   | Vfloat64 f -> printf "float64(%.17g)" f
   | Vstring s -> printf "string(%S)" (Pstring.to_string s)

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -99,7 +99,7 @@ struct
     (* Despite the type, the sparse list contains no default element *)
     SList.Skip.iter (f h) args
   | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-  | Construct _ | Int _ | Float _ | String _ -> ()
+  | Construct _ | Nat _ | Int _ | Float _ | String _ -> ()
   | Cast (c, _, t) -> f h c; f h t
   | Prod (_, t, c) -> f h t; f (liftn_handle 1 h) c
   | Lambda (_, t, c) -> f h t; f (liftn_handle 1 h) c
@@ -128,7 +128,7 @@ struct
     (* Despite the type, the sparse list contains no default element *)
     SList.Skip.iter (f l h) args
   | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-  | Construct _ | Int _ | Float _ | String _ -> ()
+  | Construct _ | Nat _ | Int _ | Float _ | String _ -> ()
   | Cast (c, _, t) -> f l h c; f l h t
   | Prod (_, t, c) -> f l h t; f (g l) (liftn_handle 1 h) c
   | Lambda (_, t, c) -> f l h t; f (g l) (liftn_handle 1 h) c
@@ -209,6 +209,7 @@ let mkCoFix f = of_kind (CoFix f)
 let mkProj (p, r, c) = of_kind (Proj (p, r, c))
 let mkArrow t1 r t2 = of_kind (Prod (make_annot Anonymous r, t1, t2))
 let mkArrowR t1 t2 = mkArrow t1 ERelevance.relevant t2
+let mkNat ind n = of_kind (Nat (ind,n))
 let mkInt i = of_kind (Int i)
 let mkFloat f = of_kind (Float f)
 let mkString s = of_kind (String s)
@@ -244,6 +245,7 @@ let isFix sigma c = match kind sigma c with Fix _ -> true | _ -> false
 let isCoFix sigma c = match kind sigma c with CoFix _ -> true | _ -> false
 let isCase sigma c = match kind sigma c with Case _ -> true | _ -> false
 let isProj sigma c = match kind sigma c with Proj _ -> true | _ -> false
+let isNat sigma c = match kind sigma c with Nat _ -> true | _ -> false
 
 let rec isType sigma c = match kind sigma c with
   | Sort s -> (match ESorts.kind sigma s with
@@ -349,6 +351,13 @@ let destRef sigma c = let open GlobRef in match kind sigma c with
   | Ind (ind,u) -> IndRef ind, u
   | Construct (c,u) -> ConstructRef c, u
   | _ -> raise DestKO
+
+let kind_nonat sigma c =
+  match kind sigma c with
+  | Nat (ind,n) ->
+    if Z.equal n Z.zero then Construct (in_punivs (ind,1))
+    else App (of_kind (Construct (in_punivs (ind,2))), [|of_kind (Nat (ind,Z.pred n))|])
+  | k -> k
 
 let decompose_app sigma c =
   match kind sigma c with
@@ -659,11 +668,17 @@ let contract_case env _sigma (ci, (p,r), iv, c, bl) =
   let bl = of_branches bl in
   (ci, u, pms, p, iv, c, bl)
 
+let unfold_nat ind n = of_constr @@ unfold_nat ind n
+let unfold_if_nat sigma c =
+  match kind sigma c with
+  | Nat (ind,n) -> unfold_nat ind n
+  | _ -> c
+
 let iter_with_full_binders env sigma g f n c =
   let open Context.Rel.Declaration in
   match kind sigma c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> ()
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> ()
   | Cast (c,_,t) -> f n c; f n t
   | Prod (na,t,c) -> f n t; f (g (LocalAssum (na, t)) n) c
   | Lambda (na,t,c) -> f n t; f (g (LocalAssum (na, t)) n) c
@@ -1249,7 +1264,7 @@ let kind_of_type sigma t = match kind sigma t with
   | (Rel _ | Meta _ | Var _ | Evar _ | Const _
   | Proj _ | Case _ | Fix _ | CoFix _ | Ind _)
     -> AtomicType (t,[||])
-  | (Lambda _ | Construct _ | Int _ | Float _ | String _ | Array _) -> failwith "Not a type"
+  | (Lambda _ | Construct _ | Nat _ | Int _ | Float _ | String _ | Array _) -> failwith "Not a type"
 
 module Unsafe =
 struct

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -117,6 +117,8 @@ val kind : Evd.evar_map -> t -> (t, t, ESorts.t, EInstance.t, ERelevance.t) Cons
 val kind_upto : Evd.evar_map -> Constr.t ->
   (Constr.t, Constr.t, Sorts.t, UVars.Instance.t, Sorts.relevance) Constr.kind_of_term
 
+val kind_nonat : Evd.evar_map -> t -> (t, t, ESorts.t, EInstance.t, ERelevance.t) Constr.kind_of_term
+
 val to_constr : ?abort_on_undefined_evars:bool -> Evd.evar_map -> t -> Constr.t
 (** Returns the evar-normal form of the argument. Note that this
    function is supposed to be called when the original term has not
@@ -179,6 +181,7 @@ val mkFix : (t, t, ERelevance.t) pfixpoint -> t
 val mkCoFix : (t, t, ERelevance.t) pcofixpoint -> t
 val mkArrow : t -> ERelevance.t  -> t -> t
 val mkArrowR : t -> t -> t
+val mkNat : inductive -> Z.t -> t
 val mkInt : Uint63.t -> t
 val mkFloat : Float64.t -> t
 val mkString : Pstring.t -> t
@@ -253,6 +256,7 @@ val isFix : Evd.evar_map -> t -> bool
 val isCoFix : Evd.evar_map -> t -> bool
 val isCase : Evd.evar_map -> t -> bool
 val isProj : Evd.evar_map -> t -> bool
+val isNat : Evd.evar_map -> t -> bool
 
 val isType : Evd.evar_map -> constr -> bool
 
@@ -463,6 +467,9 @@ val expand_branch : Environ.env -> Evd.evar_map ->
 
 val contract_case : Environ.env -> Evd.evar_map ->
   (t,t,ERelevance.t) Inductive.pexpanded_case -> case
+
+val unfold_nat : inductive -> Z.t -> constr
+val unfold_if_nat : Evd.evar_map -> constr -> constr
 
 (** {5 Extra} *)
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1613,7 +1613,7 @@ let rec kind sigma h c = match Constr.kind c with
   end
 | Meta _ | Sort _ | Cast _  | Prod _ | Lambda _ | LetIn _ | App _
 | Const _ | Ind _ | Construct _ | Case _ | Fix _ | CoFix _ | Proj _
-| Int _ | Float _ | String _ | Array _ as c0 ->
+| Nat _ | Int _ | Float _ | String _ | Array _ as c0 ->
   (h, c0)
 
 let expand0 sigma h c =

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -119,6 +119,7 @@ let head_name sigma c = (* Find the head constant of a constr if any *)
     | Prod (_,_,c) | Lambda (_,_,c) | LetIn (_,_,_,c)
     | Cast (c,_,_) | App (c,_) -> hdrec c
     | Proj (kn,_,_) -> Some (Constant.label (Projection.constant kn))
+    | Nat (ind,n) -> Some (Nametab.basename_of_global (ConstructRef (ctor_of_nat ind n)))
     | Const _ | Ind _ | Construct _ | Var _ as c ->
         Some (Nametab.basename_of_global (global_of_constr c))
     | Fix ((_,i),(lna,_,_)) | CoFix (i,(lna,_,_)) ->
@@ -156,6 +157,7 @@ let hdchar env sigma c =
     | Const (kn,_) -> lowercase_first_char (Constant.label kn)
     | Ind (x,_) -> (try lowercase_first_char (Nametab.basename_of_global (GlobRef.IndRef x)) with Not_found when !Flags.in_debugger -> "zz")
     | Construct (x,_) -> (try lowercase_first_char (Nametab.basename_of_global (GlobRef.ConstructRef x)) with Not_found when !Flags.in_debugger -> "zz")
+    | Nat (ind,n) -> (try lowercase_first_char (Nametab.basename_of_global (GlobRef.ConstructRef (ctor_of_nat ind n))) with _ when !Flags.in_debugger -> "zz")
     | Var id  -> lowercase_first_char id
     | Sort s -> sort_hdchar (ESorts.kind sigma s)
     | Rel n ->

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -553,9 +553,9 @@ let map_left2 f a g b =
 let map_constr_with_binders_left_to_right env sigma g f l c =
   let open RelDecl in
   let open EConstr in
-  match EConstr.kind sigma c with
+  match EConstr.kind_nonat sigma c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> c
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> c
   | Cast (b,k,t) ->
     let b' = f l b in
     let t' = f l t in
@@ -631,7 +631,7 @@ let map_constr_with_full_binders env sigma g f l cstr =
   let open EConstr in
   match EConstr.kind sigma cstr with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> cstr
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> cstr
   | Cast (c,k, t) ->
       let c' = f l c in
       let t' = f l t in
@@ -703,7 +703,7 @@ let fold_constr_with_full_binders env sigma g f n acc c =
   let open EConstr.Vars in
   let open Context.Rel.Declaration in
   match EConstr.kind sigma c with
-  | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _  | Int _ | Float _ | String _ -> acc
+  | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _  | Nat _ | Int _ | Float _ | String _ -> acc
   | Cast (c,_, t) -> f n (f n acc c) t
   | Prod (na,t,c) -> f (g (LocalAssum (na,t)) n) (f n acc t) c
   | Lambda (na,t,c) -> f (g (LocalAssum (na,t)) n) (f n acc t) c
@@ -1359,6 +1359,11 @@ let constr_ord_int f t1 t2 =
     | CoFix _, _ -> -1 | _, CoFix _ -> 1
     | Proj (p1,_r1,c1), Proj (p2,_r2,c2) -> compare [(Projection.CanOrd.compare, p1, p2); (f, c1, c2)]
     | Proj _, _ -> -1 | _, Proj _ -> 1
+    | Nat (ind1,n1), Nat (ind2,n2) ->
+      let c = Ind.CanOrd.compare ind1 ind2 in
+      if c <> 0 then c else Z.compare n1 n2
+    | Nat _, _ -> -1
+    | _, Nat _ -> -1
     | Int i1, Int i2 -> Uint63.compare i1 i2
     | Int _, _ -> -1 | _, Int _ -> 1
     | Float f1, Float f2 -> Float64.total_compare f1 f2
@@ -1419,6 +1424,7 @@ let rec hash t =
     | String s -> combinesmall 20 (Pstring.hash s)
     | Array(u,t,def,ty) ->
       combinesmall 21 (combine4 (Instance.hash u) (hash_term_array t) (hash def) (hash ty))
+    | Nat (ind,i) -> combinesmall 22 (combine (Ind.CanOrd.hash ind) (Z.hash i))
 
 and hash_invert = function
   | NoInvert -> 0

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1037,6 +1037,12 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
     let c = extern depth true (fst scopes,(scl, snd (snd scopes))) eenv c in
     CCast (c, k, c')
 
+  | GNat (_,n) ->
+    (* XXX should use the inductive!! *)
+     extern_prim_token_delimiter_if_required
+       (Number NumTok.(Signed.of_bigint CHex n))
+       "nat" "nat_scope" (snd scopes)
+
   | GInt i ->
      extern_prim_token_delimiter_if_required
        (Number NumTok.(Signed.of_bigint CHex (Z.of_int64 (Uint63.to_int64 i))))
@@ -1507,6 +1513,7 @@ let rec glob_of_pat
   | PSort (Qual (QConstant QType | QVar _)) -> GSort Glob_ops.glob_Type_sort
   | PSort (Qual (QGlobal _ as q)) -> GSort (Some (GQuality q), Glob_ops.glob_rigid_univ)
   | PSort Set -> GSort Glob_ops.glob_Set_sort
+  | PNat (ind,n) -> GNat (ind,n)
   | PInt i -> GInt i
   | PFloat f -> GFloat f
   | PString s -> GString s

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -880,7 +880,7 @@ let rec adjust_env env = function
   | NCast (c,_,_) -> adjust_env env c
   | NApp _ -> restart_no_binders env
   | NVar _ | NRef _ | NHole _ | NGenarg _ | NCases _ | NLetTuple _ | NIf _
-  | NRec _ | NSort _ | NProj _ | NInt _ | NFloat _ | NString _ | NArray _
+  | NRec _ | NSort _ | NProj _ | NNat _ | NInt _ | NFloat _ | NString _ | NArray _
   | NList _ | NBinderList _ -> env (* to be safe, but restart should be ok *)
 
 let subst_var loc intern_pat intern ntnvars binders (terms, binderopt, _terminopt) (renaming, env) id =
@@ -1781,6 +1781,15 @@ type global_reference_test = {
   test_kind : ?loc:Loc.t -> GlobRef.t -> unit
 }
 
+let rcp_of_nat ?loc ind n =
+  assert (Z.leq Z.zero n);
+  let ctor_S = GlobRef.ConstructRef (ind,2) in
+  let rec aux acc n =
+    if Z.equal n Z.zero then acc
+    else aux (RCPatCstr (ctor_S, [DAst.make ?loc acc])) (Z.pred n)
+  in
+  aux (RCPatCstr (ConstructRef (ind,1), [])) n
+
 let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
   (* At toplevel, Constructors and Inductives are accepted, in recursive calls
      only constructor are allowed *)
@@ -1812,12 +1821,14 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
           List.iter (check_allowed_ref_in_pat test_kind_inner) l
         | _ -> raise Not_found
         end
+      | GNat _ -> ()
       | _ -> raise Not_found)) in
   (* Interpret a primitive notation (part of Glob_ops.cases_pattern_of_glob_constr) *)
   let rec rcp_of_glob scopes x = DAst.(map_with_loc (fun ?loc -> function
     | GVar id -> RCPatAtom (Some (CAst.make ?loc id,scopes))
     | GHole _ -> RCPatAtom None
     | GRef (g,_) -> RCPatCstr (g, in_patargs ?loc scopes g ~expanded:true ~no_impl:false [] [])
+    | GNat (ind,n) -> rcp_of_nat ?loc ind n
     | GApp (r, l) ->
       begin match DAst.get r with
       | GRef (g,_) ->
@@ -1986,6 +1997,11 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
     | NRef (g,_) ->
       ensure_kind test_kind ?loc g;
       DAst.make ?loc @@ RCPatCstr (g, in_patargs ?loc scopes g ~expanded:true ~no_impl:false [] args)
+    | NNat (ind,n) ->
+      (* test_kind should return the same on all constructors of nat
+         so no need to call multiple times *)
+      ensure_kind test_kind ?loc (ConstructRef (ctor_of_nat ind n));
+      DAst.make ?loc @@ rcp_of_nat ?loc ind n
     | NApp (NRef (g,_),ntnpl) ->
       ensure_kind test_kind ?loc g;
       let ntnpl = List.map (in_not test_kind_inner loc scopes fullsubst []) ntnpl in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -240,7 +240,7 @@ let rec is_rigid_head sigma t = match kind sigma t with
         | Fix ((fi,i),_) -> is_rigid_head sigma (args.(fi.(i)))
         | _ -> is_rigid_head sigma f)
   | Lambda _ | LetIn _ | Construct _ | CoFix _ | Fix _
-  | Prod _ | Meta _ | Cast _ | Int _ | Float _ | String _ | Array _ -> assert false
+  | Prod _ | Meta _ | Cast _ | Nat _ | Int _ | Float _ | String _ | Array _ -> assert false
 
 let is_rigid env sigma t =
   let open Context.Rel.Declaration in

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -341,6 +341,9 @@ let glob_prim_constr_key c = match DAst.get c with
     | _ -> None
     end
   | GProj ((cst,_), _, _) -> Some (canonical_gr (GlobRef.ConstRef cst))
+  | GNat (ind,n) ->
+    let c = Constr.ctor_of_nat ind n in
+    Some (canonical_gr (GlobRef.ConstructRef c))
   | _ -> None
 
 let check_required_module ?loc sc (sp,d) =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -255,6 +255,7 @@ let compare_notation_constr lt var_eq_hole (vars1,vars2) t1 t2 =
     aux vars renaming c1 c2;
     if not (Option.equal cast_kind_eq k1 k2) then raise_notrace Exit;
     aux vars renaming t1 t2
+  | NNat (ind1,n1), NNat (ind2,n2) when Z.equal n1 n2 && Ind.CanOrd.equal ind1 ind2 -> ()
   | NInt i1, NInt i2 when Uint63.equal i1 i2 -> ()
   | NFloat f1, NFloat f2 when Float64.equal f1 f2 -> ()
   | NArray(t1,def1,ty1), NArray(t2,def2,ty2) ->
@@ -263,7 +264,7 @@ let compare_notation_constr lt var_eq_hole (vars1,vars2) t1 t2 =
     aux vars renaming ty1 ty2
   | (NRef _ | NVar _ | NApp _ | NProj _ | NHole _ | NGenarg _ | NList _ | NLambda _ | NProd _
     | NBinderList _ | NLetIn _ | NCases _ | NLetTuple _ | NIf _
-    | NRec _ | NSort _ | NCast _ | NInt _ | NFloat _ | NString _ | NArray _), _ -> raise_notrace Exit in
+    | NRec _ | NSort _ | NCast _ | NNat _ | NInt _ | NFloat _ | NString _ | NArray _), _ -> raise_notrace Exit in
   try
     let _ = aux (vars1,vars2) [] t1 t2 in
     if not lt then
@@ -466,6 +467,7 @@ let glob_constr_of_notation_constr_with_binders ?loc g f ?(h=default_binder_stat
   | NHole x  -> GHole x
   | NGenarg arg -> GGenarg arg
   | NRef (x,u) -> GRef (x,u)
+  | NNat (ind,n) -> GNat (ind,n)
   | NInt i -> GInt i
   | NFloat f -> GFloat f
   | NString s -> GString s
@@ -700,6 +702,7 @@ let notation_constr_and_vars_of_glob_constr recvars a =
     if Option.is_empty k then forgetful := { !forgetful with forget_volatile_cast = true };
     NCast (aux c, k, aux t)
   | GSort s -> NSort s
+  | GNat (ind,n) -> NNat (ind,n)
   | GInt i -> NInt i
   | GFloat f -> NFloat f
   | GString s -> NString s
@@ -908,6 +911,7 @@ let rec subst_notation_constr subst bound raw =
           NRec (fk,idl,dll',tl',bl')
 
   | NSort _ -> raw
+  | NNat _ -> raw
   | NInt _ -> raw
   | NFloat _ -> raw
   | NString _ -> raw
@@ -1479,6 +1483,11 @@ let is_var_term = function
   | GRef (GlobRef.VarRef _,None) -> true
   | _ -> false
 
+let unfold_nat ind n =
+  let ctor = NRef (ConstructRef (Constr.ctor_of_nat ind n), None) in
+  if Z.equal n Z.zero then ctor
+  else NApp (ctor, [NNat (ind, Z.pred n)])
+
 let rec match_ inner u alp metas sigma a1 a2 =
   let open CAst in
   let loc = a1.loc in
@@ -1592,6 +1601,18 @@ let rec match_ inner u alp metas sigma a1 a2 =
      (Behaviour deliberately introduced in a38fbefca61f3392efe0ba98adfbae138022cce4 AFAICT) *)
   | GSort s1, NSort s2 when glob_sort_eq s1 s2 -> sigma
 
+  | GNat (ind1, n1), NNat (ind2, n2) ->
+    if Z.equal n1 n2 && Ind.CanOrd.equal ind1 ind2 then sigma
+    else raise No_match
+
+  | GNat (ind, n), (NApp (NRef _,_) | NRef _) ->
+    let a1 = Glob_ops.unfold_nat ?loc ind n in
+    match_ inner u alp metas sigma a1 a2
+
+  | (GApp _ | GRef _), NNat (ind, n) ->
+    let a2 = unfold_nat ind n in
+    match_ inner u alp metas sigma a1 a2
+
   | GInt i1, NInt i2 when Uint63.equal i1 i2 -> sigma
   | GFloat f1, NFloat f2 when Float64.equal f1 f2 -> sigma
   | GString s1, NString s2 when Pstring.equal s1 s2 -> sigma
@@ -1629,7 +1650,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
 
   | (GRef _ | GVar _ | GEvar _ | GPatVar _ | GApp _ | GProj _ | GLambda _ | GProd _
      | GLetIn _ | GCases _ | GLetTuple _ | GIf _ | GRec _ | GSort _ | GHole _ | GGenarg _
-     | GCast _ | GInt _ | GFloat _ | GString _ | GArray _), _ -> raise No_match
+     | GCast _ | GNat _ | GInt _ | GFloat _ | GString _ | GArray _), _ -> raise No_match
 
 and match_in_type u alp metas sigma t = function
   | None -> sigma
@@ -1787,6 +1808,11 @@ let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
         (* Convention: notations to @f don't keep implicit arguments *)
         let no_implicit = le2 = 0 in
         (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(no_implicit,le2,more_args)
+  | PatCstr ((ind,_),_,_), NNat (ind',n) ->
+    if Ind.CanOrd.equal ind ind' then
+      let a2 = unfold_nat ind' n in
+      match_cases_pattern metas sigma a1 a2
+    else raise No_match
   | r1, NList (x,y,iter,termin,revert) ->
       (match_cases_pattern_list (match_cases_pattern_no_more_args)
         metas (terms,termlists,(),()) a1 x y iter termin revert),(false,0,[])

--- a/interp/notation_term.mli
+++ b/interp/notation_term.mli
@@ -44,6 +44,7 @@ type notation_constr =
       notation_constr array * notation_constr array
   | NSort of glob_sort
   | NCast of notation_constr * Constr.cast_kind option * notation_constr
+  | NNat of inductive * Z.t
   | NInt of Uint63.t
   | NFloat of Float64.t
   | NString of Pstring.t

--- a/interp/primNotations.ml
+++ b/interp/primNotations.ml
@@ -187,6 +187,7 @@ type 'a token_kind =
 | TConst of Constant.t * 'a list
 | TInd of inductive * 'a list
 | TConstruct of constructor * 'a list
+| TNat of inductive * Z.t
 | TInt of Uint63.t
 | TFloat of Float64.t
 | TString of Pstring.t
@@ -216,6 +217,7 @@ let kind c =
   | Float f -> TFloat f
   | String s -> TString s
   | Array (_, t, u, v) -> TArray (t, u, v)
+  | Nat (ind,n) -> TNat (ind,n)
   | Rel _ | Meta _ | Evar _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
   | Proj _ | Case _ | Fix _ | CoFix _ -> TOther
 
@@ -299,6 +301,15 @@ let rec check_glob env sigma g c =
        try List.fold_left2_map (check_glob env) sigma gcl (Array.to_list gc'a)
        with Invalid_argument _ -> raise NotAValidPrimToken in
      sigma, mkApp (c, Array.of_list cl)
+  | Glob_term.GNat (ind,n), Constr.Nat (ind',n')
+    when Z.equal n n' && Environ.QInd.equal env ind ind' ->
+    sigma, mkNat ind n
+  | GNat (ind, n), (Construct _ | App _) ->
+    let g = Glob_ops.unfold_nat ?loc:g.loc ind n in
+    check_glob env sigma g c
+  | (GRef (ConstructRef _, None) | GApp _), Nat (ind, n) ->
+    let c = Constr.unfold_nat ind n in
+    check_glob env sigma g c
   | Glob_term.GInt i, Constr.Int i' when Uint63.equal i i' -> sigma, mkInt i
   | Glob_term.GFloat f, Constr.Float f' when Float64.equal f f' -> sigma, mkFloat f
   | Glob_term.GString s, Constr.String s' when Pstring.equal s s' -> sigma, mkString s
@@ -331,9 +342,24 @@ let rec constr_of_glob to_post post env sigma g =
          if List.exists (function ToPostHole _ -> false | _ -> true) a then raise NotAValidPrimToken;
          constr_of_globref env sigma r
       end
+  | GNat (ind,n) ->
+    let ctor = GlobRef.ConstructRef (ctor_of_nat ind n) in
+    let o = List.find_opt (fun (_,r',_) -> Environ.QGlobRef.equal env ctor r') post in
+    begin match o with
+    | None -> sigma, mkNat ind n
+    | Some _ ->
+      let ctor = DAst.make ?loc:g.loc @@ GRef (ctor, None) in
+      let g = if Z.equal n Z.zero then ctor
+        else DAst.make ?loc:g.loc @@ GApp (ctor, [DAst.make ?loc:g.loc @@ GNat (ind, Z.pred n)])
+      in
+      constr_of_glob to_post post env sigma g
+    end
   | Glob_term.GApp (gc, gcl) ->
       let o = match DAst.get gc with
         | Glob_term.GRef (r, _) -> List.find_opt (fun (_,r',_) -> Environ.QGlobRef.equal env r r') post
+        | GNat (ind,n) ->
+          let r = GlobRef.ConstructRef (ctor_of_nat ind n) in
+          List.find_opt (fun (r',_,_) -> Environ.QGlobRef.equal env r r') post
         | _ -> None in
       begin match o with
       | None ->
@@ -390,6 +416,7 @@ let rec glob_of_constr token_kind ?loc env sigma c = match Constr.kind c with
   | Const (c, _) -> DAst.make ?loc (Glob_term.GRef (GlobRef.ConstRef c, None))
   | Ind (ind, _) -> DAst.make ?loc (Glob_term.GRef (GlobRef.IndRef ind, None))
   | Var id -> DAst.make ?loc (Glob_term.GRef (GlobRef.VarRef id, None))
+  | Nat (ind,n) -> DAst.make ?loc (Glob_term.GNat (ind,n))
   | Int i -> DAst.make ?loc (Glob_term.GInt i)
   | Float f -> DAst.make ?loc (Glob_term.GFloat f)
   | String s -> DAst.make ?loc (Glob_term.GString s)
@@ -425,6 +452,7 @@ let rec glob_of_token token_kind ?loc env sigma c = match TokenValue.kind c with
     let ce = DAst.make ?loc (Glob_term.GRef (GlobRef.VarRef id, None)) in
     let cel = List.map (glob_of_token token_kind ?loc env sigma) l in
     mkGApp ?loc ce cel
+  | TNat (ind,n) -> DAst.make ?loc (GNat (ind,n))
   | TInt i -> DAst.make ?loc (Glob_term.GInt i)
   | TFloat f -> DAst.make ?loc (Glob_term.GFloat f)
   | TString s -> DAst.make ?loc (Glob_term.GString s)
@@ -451,11 +479,21 @@ let no_such_prim_token uninterpreted_token_kind ?loc ?errmsg ty =
     pr_opt (fun errmsg -> surround errmsg) errmsg)
 
 let rec postprocess env token_kind ?loc ty to_post post g =
-  let g', gl = match DAst.get g with Glob_term.GApp (g, gl) -> g, gl | _ -> g, [] in
+  let g', gl = match DAst.get g with
+    | Glob_term.GApp (g, gl) -> g, gl
+    | GNat (ind,n) ->
+      let r = DAst.make @@ GRef (GlobRef.ConstructRef (ctor_of_nat ind n), None) in
+      if Z.equal n Z.zero then r, []
+      else r, [DAst.make @@ GNat (ind, Z.pred n)]
+    | _ -> g, []
+  in
   let o =
     match DAst.get g' with
     | Glob_term.GRef (r, None) ->
-       List.find_opt (fun (r',_,_) -> Environ.QGlobRef.equal env r r') post
+      List.find_opt (fun (r',_,_) -> Environ.QGlobRef.equal env r r') post
+    | GNat (ind,n) ->
+      let r = GlobRef.ConstructRef (ctor_of_nat ind n) in
+      List.find_opt (fun (r',_,_) -> Environ.QGlobRef.equal env r r') post
     | _ -> None in
   match o with None -> g | Some (_, r, a) ->
   let rec f n a gl = match a, gl with

--- a/kernel/byterun/rocq_interp.c
+++ b/kernel/byterun/rocq_interp.c
@@ -29,6 +29,17 @@
 #include "rocq_memory.h"
 #include "rocq_values.h"
 
+value ml_z_succ(value);
+value ml_z_pred(value);
+
+#ifdef ARCH_SIXTYFOUR
+#define Z_MAX_INT       0x3fffffffffffffff
+#define Z_MIN_INT     (-0x4000000000000000)
+#else
+#define Z_MAX_INT       0x3fffffff
+#define Z_MIN_INT     (-0x40000000)
+#endif
+
 #if OCAML_VERSION < 41000
 extern void caml_minor_collection(void);
 
@@ -1041,6 +1052,20 @@ value rocq_interprete
         Next;
       }
 
+      Instruct(MAKESUCC) {
+        print_instr("MAKESUCC");
+        if (Is_block(accu) && Tag_val(accu) != Custom_tag) {
+          value block;
+          Rocq_alloc_small(block, 1, 1);
+          Field(block, 0) = accu;
+          accu = block;
+        } else if (Is_long(accu) && accu < Val_long(Z_MAX_INT)) {
+          accu = accu + 2;
+        } else {
+          accu = ml_z_succ(accu);
+        }
+        Next;
+      }
 
 /* Access to components of blocks */
 
@@ -1060,6 +1085,30 @@ value rocq_interprete
           pc += pc[index];
         }
           Next;
+      }
+
+      Instruct(SWITCHNAT) {
+        print_instr("SWITCHNAT");
+        if (Is_long(accu) && Long_val(accu) == 0) {
+          print_instr("0");
+          pc += pc[0];
+        } else if (Is_accu(accu)) {
+          print_instr("accu");
+          pc += pc[1];
+        } else if (Is_block(accu) && Tag_val(accu) == 1) {
+          print_instr("S of unclosed");
+          pc += pc[2];
+        } else if (Is_long(accu)) {
+          print_instr("small nat");
+          /* nonzero nat: cannot underflow */
+          *--sp = accu - 2;
+          pc += pc[3];
+        } else {
+          print_instr("big nat");
+          *--sp = ml_z_pred(accu);
+          pc += pc[3];
+        }
+        Next;
       }
 
       Instruct(PUSHFIELDS){

--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -17,6 +17,10 @@
 #include "rocq_memory.h"
 #include "rocq_values.h"
 #include <memory.h>
+
+#define CAML_INTERNALS
+#include <caml/custom.h>
+
 /* KIND OF VALUES */
 
 #define Setup_for_gc
@@ -165,3 +169,18 @@ value rocq_curry2_1_addr(value v) {
 }
 
 #endif
+
+/* although we could try to hack some ocaml code based on [compare] of
+   different custom kinds always producing the same thing, it risks
+   the ocaml compiler making incorrect assumptions that we are calling
+   [compare] is at sensible types.
+
+   For instance [compare Int64.max_int (Obj.magic v)] gets optimized
+   assuming that [v] is a int64.
+*/
+value rocq_is_int64(value v) {
+  if (Is_block(v) && Tag_val(v) == Custom_tag) {
+    return Val_bool(Custom_ops_val(v) == &caml_int64_ops);
+  }
+  return Val_bool(0);
+}

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -96,6 +96,7 @@ and fterm =
   | FProd of Name.t binder_annot * fconstr * constr * usubs
   | FLetIn of Name.t binder_annot * fconstr * fconstr * constr * usubs
   | FEvar of Evar.t * constr list * usubs * evar_repack
+  | FNat of inductive * Z.t
   | FInt of Uint63.t
   | FFloat of Float64.t
   | FString of Pstring.t
@@ -235,7 +236,7 @@ let usubs_shft (n,(e,u)) = subs_shft (n, e), u
    when the lift is 0. *)
 let rec lft_fconstr n ft =
   match ft.term with
-    | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FString _|FIrrelevant) -> ft
+    | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FNat _|FInt _|FFloat _|FString _|FIrrelevant) -> ft
     | FRel i -> {mark=ft.mark;term=FRel(i+n)}
     | FLambda(k,tys,f,e) -> {mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
     | FFix(fx,e) ->
@@ -321,6 +322,8 @@ let destFLambda clos_fun t =
     (usubst_binder e na,clos_fun e ty,{mark=t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
   | _ -> assert false
 
+let mkFNat ind n = {mark = Cstr; term = FNat (ind, n)}
+
 (* Optimization: do not enclose variables in a closure.
    Makes variable access much faster *)
 let mk_clos (e:usubs) t =
@@ -334,6 +337,7 @@ let mk_clos (e:usubs) t =
     | Meta _ -> {mark = Ntrl; term = FAtom t }
     | Ind kn -> {mark = Ntrl; term = FInd (usubst_punivs e kn) }
     | Construct kn -> {mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
+    | Nat (ind,n) -> mkFNat ind n
     | Int i -> {mark = Cstr; term = FInt i}
     | Float f -> {mark = Cstr; term = FFloat f}
     | String s -> {mark = Cstr; term = FString s}
@@ -593,6 +597,8 @@ let rec to_constr lfts v =
       repack (ev, List.map (fun a -> subst_constr subs a) args)
     | FLIFT (k,a) -> to_constr (el_shft k lfts) a
 
+    | FNat (ind,n) ->
+       Constr.mkNat ind n
     | FInt i ->
        Constr.mkInt i
     | FFloat f ->
@@ -937,6 +943,15 @@ let get_branch infos ci pms cterm br e =
     in
     let ext = push (Array.length args - 1) [] ctx in
     (br, usubs_consv (Array.rev_of_list ext) e)
+
+let get_nat_branch ind n br e =
+  if Z.equal n Z.zero then
+    let _nas, br = br.(0) in
+    br, e
+  else
+    let _nas, br = br.(1) in
+    let n = Z.pred n in
+    br, usubs_cons (mkFNat ind n) e
 
 (** [eta_expand_ind_stack env ind c s t] computes stacks corresponding
     to the conversion of the eta expansion of t, considered as an inhabitant
@@ -1387,6 +1402,7 @@ let rec knh info m stk =
        | None -> (m, stk)
        | Some s -> knh info c (s :: zupdate info m stk))
     | FConstruct _ -> strip_update_shift_absorb_app m stk
+    | FNat _ -> strip_update_shift_absorb_app m stk
 
 (* cases where knh stops *)
     | (FFlex _|FLetIn _|FEvar _|FCaseInvert _|FIrrelevant|
@@ -1425,8 +1441,8 @@ and knht info e t stk =
       | None -> ({ mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
       | Some s -> knht info e c (s :: stk)
       end
-    | Construct _ -> knh info (mk_clos e t) stk
-    | (Ind _|Const _|Var _|Meta _ | Sort _ | Int _|Float _|String _) -> (mk_clos e t, stk)
+    | Construct _ | Nat _ -> knh info (mk_clos e t) stk
+    | (Ind _|Const _|Var _|Meta _ | Sort _|Int _|Float _|String _) -> (mk_clos e t, stk)
     | CoFix cfx ->
       { mark = Cstr; term = FCoFix (cfx,e) }, stk
     | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
@@ -1896,22 +1912,22 @@ let rec knr info tab ~pat_state m stk =
      let use_match = red_set info.i_flags fMATCH in
      let use_fix = red_set info.i_flags fFIX in
      if use_match || use_fix then
-      (match [@ocaml.warning "-4"] m,  stk with
-        | (_, Zapp _ :: _) -> assert false (* knh *)
-        | (c, ZcaseT(ci,_,pms,_,br,e)::s) when use_match ->
+      (match [@ocaml.warning "-4"] stk with
+        | (Zapp _ :: _) -> assert false (* knh *)
+        | (ZcaseT(ci,_,pms,_,br,e)::s) when use_match ->
             assert (ci.ci_npar>=0);
             (* instance on the case and instance on the constructor are compatible by typing *)
-            let (br, e) = get_branch info ci pms c br e in
+            let (br, e) = get_branch info ci pms m br e in
             knit info tab ~pat_state e br s
-        | (rarg, Zfix(fx,par)::s) when use_fix ->
-            let stk' = par @ append_stack [|rarg|] s in
+        | (Zfix(fx,par)::s) when use_fix ->
+            let stk' = par @ append_stack [|m|] s in
             let (fxe,fxbd) = contract_fix_vect fx.term in
             knit info tab ~pat_state fxe fxbd stk'
-        | (m, Zproj (p,_)::s) when use_match ->
+        | (Zproj (p,_)::s) when use_match ->
             let rargs = drop_parameters (Projection.Repr.npars p) m in
             let rarg = rargs.(Projection.Repr.arg p) in
             kni info tab ~pat_state rarg s
-        | (m, s) ->
+        | s ->
           if is_irrelevant_constructor info c then
             knr_ret info tab ~pat_state (mk_irrelevant, skip_irrelevant_stack info stk)
           else
@@ -1919,6 +1935,26 @@ let rec knr info tab ~pat_state m stk =
      else if is_irrelevant_constructor info c then
       knr_ret info tab ~pat_state (mk_irrelevant, skip_irrelevant_stack info stk)
      else
+       knr_ret info tab ~pat_state (m, stk)
+  | FNat (ind,n) ->
+    let use_match = red_set info.i_flags fMATCH in
+    let use_fix = red_set info.i_flags fFIX in
+    if use_match || use_fix then
+      (match [@ocaml.warning "-4"] stk with
+       | (Zapp _ :: _) -> assert false (* knh *)
+       | (ZcaseT(ci,_,_,_,br,e)::s) when use_match ->
+         assert (ci.ci_npar>=0);
+         (* instance on the case and instance on the constructor are compatible by typing *)
+         let (br, e) = get_nat_branch ind n br e in
+         knit info tab ~pat_state e br s
+       | (Zfix(fx,par)::s) when use_fix ->
+         let stk' = par @ append_stack [|m|] s in
+         let (fxe,fxbd) = contract_fix_vect fx.term in
+         knit info tab ~pat_state fxe fxbd stk'
+       | (Zproj _::_) ->
+         assert false
+       | s -> knr_ret info tab ~pat_state (m,s))
+    else
       knr_ret info tab ~pat_state (m, stk)
   | FCoFix ((i, (lna, _, _)), e) ->
     if is_irrelevant info (usubst_relevance e (lna.(i)).binder_relevance) then
@@ -2036,7 +2072,7 @@ let kh info tab v stk = fapp_stack(kni info tab v stk)
       calls itself recursively. *)
 
 let is_val v = match v.term with
-| FAtom _ | FRel _   | FInd _ | FConstruct (_,[||]) | FInt _ | FFloat _ | FString _ -> true
+| FAtom _ | FRel _   | FInd _ | FConstruct (_,[||]) | FNat _ | FInt _ | FFloat _ | FString _ -> true
 | FFlex _ -> v.mark == Ntrl
 | FConstruct _ | FApp _ | FProj _ | FFix _ | FCoFix _ | FCaseT _ | FCaseInvert _ | FLambda _
 | FProd _ | FLetIn _ | FEvar _ | FArray _ | FLIFT _ | FCLOS _ -> false
@@ -2065,7 +2101,7 @@ and klt info tab e t = match kind t with
     if hd' == hd && args' == args then t
     else mkApp (hd', args')
   | Var _ | Const _ | CoFix _ | Lambda _ | Fix _ | Prod _ | Evar _ | Case _
-  | Cast _ | LetIn _ | Proj _ | Array _ | Rel _ | Meta _ | Sort _ | Int _
+  | Cast _ | LetIn _ | Proj _ | Array _ | Rel _ | Meta _ | Sort _ | Nat _ | Int _
   | Float _ | String _ ->
     let share = info.i_cache.i_share in
     let (nm,s) = knit info tab e t [] in
@@ -2091,7 +2127,7 @@ and klt info tab e t = match kind t with
   let (nm,s) = knit info tab e t [] in
   let () = if share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)
   zip_term info tab (norm_head info tab nm) s
-| Meta _ | Sort _ | Ind _ | Construct _ | Int _ | Float _ | String _ ->
+| Meta _ | Sort _ | Ind _ | Construct _ | Nat _ | Int _ | Float _ | String _ ->
   subst_instance_constr (snd e) t
 
 (* no redex: go up for atoms and already normalized terms, go down
@@ -2141,7 +2177,7 @@ and norm_head info tab m =
         mkArray (u, a, def, ty)
       | FConstruct (c,args) -> mkApp (mkConstructU c, Array.map (kl info tab) args)
       | FLOCKED | FRel _ | FAtom _ | FFlex _ | FInd _
-      | FApp _ | FCaseT _ | FCaseInvert _ | FLIFT _ | FCLOS _ | FInt _
+      | FApp _ | FCaseT _ | FCaseInvert _ | FLIFT _ | FCLOS _ | FNat _ | FInt _
       | FFloat _ | FString _ -> term_of_fconstr m
       | FIrrelevant -> assert false (* only introduced when converting *)
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -48,6 +48,7 @@ type fterm =
   | FProd of Name.t binder_annot * fconstr * constr * usubs
   | FLetIn of Name.t binder_annot * fconstr * fconstr * constr * usubs
   | FEvar of Evar.t * constr list * usubs * evar_repack
+  | FNat of inductive * Z.t
   | FInt of Uint63.t
   | FFloat of Float64.t
   | FString of Pstring.t
@@ -107,6 +108,8 @@ val inject : constr -> fconstr
 
 val mk_clos      : usubs -> constr -> fconstr
 val mk_clos_vect : usubs -> constr array -> fconstr array
+
+val mkFNat : inductive -> Z.t -> fconstr
 
 val zip : fconstr -> stack -> fconstr
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -112,6 +112,7 @@ type ('constr, 'types, 'sort, 'univs, 'r) kind_of_term =
   | Float     of Float64.t
   | String    of Pstring.t
   | Array     of 'univs * 'constr array * 'constr * 'types
+  | Nat of inductive * Z.t
 
 (* constr is the fixpoint of the previous type. *)
 type t = T of (t, t, Sorts.t, Instance.t, Sorts.relevance) kind_of_term [@@unboxed]
@@ -149,6 +150,13 @@ let rec kind_nocast_gen kind c =
   | k -> k
 
 let kind_nocast c = kind_nocast_gen kind c
+
+let kind_nonat c =
+  match kind c with
+  | Nat (ind,n) ->
+    if Z.equal n Z.zero then Construct (in_punivs (ind,1))
+    else App (T (Construct (in_punivs (ind,2))), [|T (Nat (ind,Z.pred n))|])
+  | k -> k
 
 (**********************************************************************)
 (*          Non primitive term destructors                            *)
@@ -360,6 +368,7 @@ let of_kind = function
 | Sort Sorts.SProp -> mkSProp
 | Sort Sorts.Prop -> mkProp
 | Sort Sorts.Set -> mkSet
+| Nat (_,i) as k -> assert (Z.leq Z.zero i); T k
 | k -> T k
 
 (* Construct a type *)
@@ -455,6 +464,16 @@ let mkRef (gr,u) = let open GlobRef in match gr with
   | ConstructRef c -> mkConstructU (c,u)
   | VarRef x -> mkVar x
 
+let mkNat ind i = of_kind @@ Nat (ind,i)
+
+let ctor_of_nat natind i =
+  let ctor = if Z.equal i Z.zero then 1 else 2 in
+  natind, ctor
+
+let unfold_nat natind n =
+    if Z.equal n Z.zero then mkConstruct (natind, 1)
+  else mkApp (mkConstruct (natind, 2), [|mkNat natind (Z.sub n Z.one)|])
+
 (* Constructs a primitive integer *)
 let mkInt i = of_kind @@ Int i
 
@@ -488,7 +507,7 @@ let fold_invert f acc = function
 
 let fold f acc c = match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> acc
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> acc
   | Cast (c,_,t) -> f (f acc c) t
   | Prod (_,t,c) -> f (f acc t) c
   | Lambda (_,t,c) -> f (f acc t) c
@@ -516,7 +535,7 @@ let iter_invert f = function
 
 let iter f c = match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> ()
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> ()
   | Cast (c,_,t) -> f c; f t
   | Prod (_,t,c) -> f t; f c
   | Lambda (_,t,c) -> f t; f c
@@ -538,7 +557,7 @@ let iter f c = match kind c with
 
 let iter_with_binders g f n c = match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> ()
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> ()
   | Cast (c,_,t) -> f n c; f n t
   | Prod (_,t,c) -> f n t; f (g n) c
   | Lambda (_,t,c) -> f n t; f (g n) c
@@ -571,7 +590,7 @@ let iter_with_binders g f n c = match kind c with
 let fold_constr_with_binders g f n acc c =
   match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> acc
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> acc
   | Cast (c,_, t) -> f n (f n acc c) t
   | Prod (_na,t,c) -> f (g  n) (f n acc t) c
   | Lambda (_na,t,c) -> f (g  n) (f n acc t) c
@@ -635,7 +654,7 @@ let map_invert f = function
 
 let map f c = match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> c
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> c
   | Cast (b,k,t) ->
       let b' = f b in
       let t' = f t in
@@ -720,7 +739,7 @@ let fold_map_return_predicate f accu (p,r as v) =
 
 let fold_map f accu c = match kind c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> accu, c
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> accu, c
   | Cast (b,k,t) ->
       let accu, b' = f accu b in
       let accu, t' = f accu t in
@@ -788,7 +807,7 @@ let fold_map f accu c = match kind c with
 
 let map_with_binders g f l c0 = match kind c0 with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
-    | Construct _ | Int _ | Float _ | String _) -> c0
+    | Construct _ | Nat _ | Int _ | Float _ | String _) -> c0
   | Cast (c, k, t) ->
     let c' = f l c in
     let t' = f l t in
@@ -898,12 +917,32 @@ let eq_invert eq iv1 iv2 =
 let eq_under_context eq (_nas1, p1) (_nas2, p2) =
   eq p1 p2
 
+let eq_nat_gen ind n kind c =
+  let rec aux n c =
+    match kind_nocast_gen kind c with
+    | Nat (ind',n') -> Z.equal n n' && Ind.CanOrd.equal ind ind'
+    | Construct ((ind',1),_) -> Z.equal n Z.zero && Ind.CanOrd.equal ind ind'
+    | App (hd, [|a|]) ->
+      begin match kind_nocast_gen kind hd with
+      | Construct ((ind',2),_) ->
+        Ind.CanOrd.equal ind ind' &&
+        aux (Z.pred n) a
+      | _ -> false
+      end
+    | _ -> false
+  in
+  aux n c
+
 let compare_head_gen_leq_with kind1 kind2 leq_universes leq_sorts eq_evars eq leq nargs t1 t2 =
   match kind_nocast_gen kind1 t1, kind_nocast_gen kind2 t2 with
   | Cast _, _ | _, Cast _ -> assert false (* kind_nocast *)
   | Rel n1, Rel n2 -> Int.equal n1 n2
   | Meta m1, Meta m2 -> Int.equal m1 m2
   | Var id1, Var id2 -> Id.equal id1 id2
+  | Nat (ind1,n1), Nat (ind2,n2) ->
+    Z.equal n1 n2 && Ind.CanOrd.equal ind1 ind2
+  | Nat (ind1,n1), _ -> eq_nat_gen ind1 n1 kind2 t2
+  | _, Nat (ind2,n2) -> eq_nat_gen ind2 n2 kind1 t1
   | Int i1, Int i2 -> Uint63.equal i1 i2
   | Float f1, Float f2 -> Float64.equal f1 f2
   | String s1, String s2 -> Pstring.equal s1 s2
@@ -1104,6 +1143,7 @@ let hasheq_kind t1 t2 =
       && array_eqeq lna1 lna2
       && array_eqeq tl1 tl2
       && array_eqeq bl1 bl2
+    | Nat (ind1,i1), Nat (ind2,i2) -> ind1 == ind2 && Z.equal i1 i2
     | Int i1, Int i2 -> i1 == i2
     | Float f1, Float f2 -> Float64.equal f1 f2
     | String s1, String s2 -> Pstring.equal s1 s2
@@ -1111,7 +1151,7 @@ let hasheq_kind t1 t2 =
       u1 == u2 && def1 == def2 && ty1 == ty2 && array_eqeq t1 t2
     | (Rel _ | Meta _ | Var _ | Sort _ | Cast _ | Prod _ | Lambda _ | LetIn _
       | App _ | Proj _ | Evar _ | Const _ | Ind _ | Construct _ | Case _
-      | Fix _ | CoFix _ | Int _ | Float _ | String _ | Array _), _ -> false
+      | Fix _ | CoFix _ | Nat _ | Int _ | Float _ | String _ | Array _), _ -> false
 
 let hasheq t1 t2 = hasheq_kind (kind t1) (kind t2)
 
@@ -1311,6 +1351,9 @@ let rec hash_term (t : t) : int * (constr,constr,_,_,_) kind_of_term =
     let hty, ty = sh_rec ty in
     let h = combine4 hu ht hdef hty in
     (combinesmall 21 h, Array(u,t,def,ty))
+  | Nat (ind,i) ->
+    let hind, ind = hcons_ind ind in
+    combinesmall 22 (combine hind (Z.hash i)), Nat (ind, i)
 
 and sh_invert civ iv = match civ, iv with
   | NoInvert, NoInvert -> 0, NoInvert
@@ -1460,6 +1503,9 @@ let rec debug_print c =
            Name.print na.binder_name ++ str":" ++ debug_print ty ++
            cut() ++ str":=" ++ debug_print bd) (Array.to_list fixl)) ++
          str"}")
+  | Nat (ind,i) ->
+    str "Nat(" ++ MutInd.print (fst ind) ++ pr_comma () ++ int (snd ind) ++ pr_comma() ++
+    str (Z.to_string i) ++ str ")"
   | Int i -> str"Int("++str (Uint63.to_string i) ++ str")"
   | Float i -> str"Float("++str (Float64.to_string i) ++ str")"
   | String s -> str"String("++str (Printf.sprintf "%S" (Pstring.to_string s)) ++ str")"

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -73,6 +73,12 @@ val mkVar : Id.t -> constr
 (** Constructs a machine integer *)
 val mkInt : Uint63.t -> constr
 
+(** Construct an optimized nat. Must be >= 0. *)
+val mkNat : inductive -> Z.t -> constr
+
+val ctor_of_nat : inductive -> Z.t -> constructor
+val unfold_nat : inductive -> Z.t -> constr
+
 (** Constructs an array *)
 val mkArray : UVars.Instance.t * constr array * constr * types -> constr
 
@@ -291,6 +297,7 @@ type ('constr, 'types, 'sort, 'univs, 'r) kind_of_term =
   | Array     of 'univs * 'constr array * 'constr * 'types
   (** [Array (u,vals,def,t)] is an array of [vals] in type [t] with default value [def].
       [u] is a universe containing [t]. *)
+  | Nat of inductive * Z.t
 
 (** User view of [constr]. For [App], it is ensured there is at
    least one argument and the function is not itself an applicative
@@ -303,6 +310,8 @@ val kind_nocast_gen : ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term) ->
   ('v -> ('v, 'v, 'sort, 'univs, 'r) kind_of_term)
 
 val kind_nocast : constr -> (constr, types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
+
+val kind_nonat : constr -> (constr, types, Sorts.t, UVars.Instance.t, Sorts.relevance) kind_of_term
 
 (** {6 Simple case analysis} *)
 val isRel  : constr -> bool

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -317,6 +317,7 @@ let rec compare_under e1 c1 e2 c2 =
     end
   | Meta m1, Meta m2 -> Int.equal m1 m2
   | Var id1, Var id2 -> Id.equal id1 id2
+  | Nat (ind1,i1), Nat (ind2,i2) -> Z.equal i1 i2 && Ind.CanOrd.equal ind1 ind2 (* XXX also try to fast check nat vs constructor? *)
   | Int i1, Int i2 -> Uint63.equal i1 i2
   | Float f1, Float f2 -> Float64.equal f1 f2
   | String s1, String s2 -> Pstring.equal s1 s2
@@ -358,7 +359,7 @@ let rec compare_under e1 c1 e2 c2 =
     && compare_under e1 ty1 e2 ty2
   | (Rel _ | Meta _ | Var _ | Sort _ | Prod _ | Lambda _ | LetIn _ | App _
     | Proj _ | Evar _ | Const _ | Ind _ | Construct _ | Case _ | Fix _
-    | CoFix _ | Int _ | Float _ | String _ | Array _), _ -> false
+    | CoFix _ | Nat _ | Int _ | Float _ | String _ | Array _), _ -> false
 
 
 let rec fast_test lft1 term1 lft2 term2 = match fterm_of term1, fterm_of term2 with
@@ -678,6 +679,35 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
             eqappr cv_pb l2r infos (lft1,(hd1,v1)) (lft2,(hd2,v2)) cuniv
       else raise NotConvertible
 
+    | FNat (ind1,n1), FNat (ind2,n2) ->
+      let () = assert_reduced_constructor v1 in
+      let () = assert_reduced_constructor v2 in
+      if Z.equal n1 n2 && Ind.CanOrd.equal ind1 ind2 then cuniv
+      else raise NotConvertible
+
+    (* XXX should we expect reduction to turn fconstruct into fnat when possible? *)
+    | FNat (ind1,n1), FConstruct (((ind2,j2),_),args2) ->
+      let () = assert_reduced_constructor v1 in
+      let () = assert_reduced_constructor v2 in
+      if not (Ind.CanOrd.equal ind1 ind2) then raise NotConvertible
+      else if Z.equal n1 Z.zero then
+        if Int.equal j2 1 && Array.is_empty args2 then cuniv
+        else raise NotConvertible
+      else if Int.equal j2 2 && Int.equal (Array.length args2) 1 then
+        ccnv CONV l2r infos lft1 lft2 (mkFNat ind1 (Z.sub n1 Z.one)) args2.(0) cuniv
+      else raise NotConvertible
+
+    | FConstruct (((ind1,j1),_),args1), FNat (ind2,n2) ->
+      let () = assert_reduced_constructor v1 in
+      let () = assert_reduced_constructor v2 in
+      if not (Ind.CanOrd.equal ind1 ind2) then raise NotConvertible
+      else if Z.equal n2 Z.zero then
+        if Int.equal j1 1 && Array.is_empty args1 then cuniv
+        else raise NotConvertible
+      else if Int.equal j1 2 && Int.equal (Array.length args1) 1 then
+        ccnv CONV l2r infos lft1 lft2 args1.(0) (mkFNat ind2 (Z.sub n2 Z.one)) cuniv
+      else raise NotConvertible
+
     (* Eta expansion of records *)
     | (FConstruct (((ind1,j1),u1), _),_) ->
       let () = assert_reduced_constructor v1 in
@@ -812,7 +842,7 @@ and eqwhnf cv_pb l2r infos (lft1, (hd1, v1) as appr1) (lft2, (hd2, v2) as appr2)
        | (FLOCKED,_) | (_,FLOCKED) ) -> assert false
 
      | (FRel _ | FAtom _ | FInd _ | FFix _ | FCoFix _ | FCaseInvert _
-       | FProd _ | FEvar _ | FInt _ | FFloat _ | FString _
+       | FProd _ | FEvar _ | FNat _ | FInt _ | FFloat _ | FString _
        | FArray _ | FIrrelevant), _ -> raise NotConvertible
 
 and convert_stacks ?(mask = [||]) l2r infos lft1 lft2 stk1 stk2 cuniv =

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -303,6 +303,8 @@ type mutual_inductive_body = {
     mind_private : bool option; (** allow pattern-matching: Some true ok, Some false blocked *)
 
     mind_typing_flags : typing_flags; (** typing flags at the time of the inductive creation *)
+
+    mind_is_nat : bool;
 }
 
 type mind_specif = mutual_inductive_body * one_inductive_body

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -269,6 +269,7 @@ let subst_mind_body subst mib =
     mind_sec_variance = mib.mind_sec_variance;
     mind_private = mib.mind_private;
     mind_typing_flags = mib.mind_typing_flags;
+    mind_is_nat = (assert (not mib.mind_is_nat); false);
   }
 
 let mind_ntypes mib = Array.length mib.mind_packets

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -208,6 +208,7 @@ let cook_inductive info mib =
     mind_sec_variance;
     mind_private = mib.mind_private;
     mind_typing_flags = mib.mind_typing_flags;
+    mind_is_nat = (assert (not mib.mind_is_nat); false);
   }
 
 let cook_rel_context info ctx =

--- a/kernel/dune
+++ b/kernel/dune
@@ -5,7 +5,7 @@
  (wrapped false)
  (modules_without_implementation values declarations entries)
  (modules (:standard \ genOpcodeFiles uint63_31 uint63_63 float64_31 float64_63))
- (libraries boot lib coqrun dynlink))
+ (libraries boot lib coqrun dynlink zarith))
 
 (deprecated_library_name
  (old_public_name coq-core.kernel)

--- a/kernel/entries.mli
+++ b/kernel/entries.mli
@@ -66,6 +66,7 @@ type mutual_inductive_entry = {
      the entry to [None] if to be inferred or [Some v] if to be
      checked. *)
   mind_entry_private : bool option;
+  mind_entry_is_nat : bool;
 }
 
 (** {6 Constants (Definition/Axiom) } *)

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -1178,6 +1178,10 @@ end
 
 module QGlobRef = HackQ(GlobRef)(GlobRef.Map_env)
 
+let is_nat env ind =
+  let mib = lookup_mind (fst ind) env in
+  mib.mind_is_nat
+
 let rec constant_dependencies_with_cache env cache kn =
   match DepCache.get kn cache with
   | Inl deps -> deps

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -504,6 +504,8 @@ val constant_depends_on : env -> Constant.t -> Constant.t -> bool
 
 (** {5 Internals} *)
 
+val is_nat : env -> inductive -> bool
+
 module Internal : sig
   (** Makes the qvars treated as above prop.
       Do not use outside kernel inductive typechecking. *)

--- a/kernel/genOpcodeFiles.ml
+++ b/kernel/genOpcodeFiles.ml
@@ -80,7 +80,9 @@ let opcodes =
     "MAKEBLOCK2", 1;
     "MAKEBLOCK3", 1;
     "MAKEBLOCK4", 1;
+    "MAKESUCC", 0;
     "SWITCH", -1;
+    "SWITCHNAT", 4;
     "PUSHFIELDS", 1;
     "GETFIELD0", 0;
     "GETFIELD1", 0;

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -18,7 +18,12 @@ open Constr
 
 type reloc_table = (int * int) array
 
-type case_annot = case_info * reloc_table * Declarations.recursivity_kind
+type case_annot = {
+  ci : case_info;
+  reloc : reloc_table;
+  finite : Declarations.recursivity_kind;
+  is_nat : bool;
+}
 
 type 'v node =
 | Lrel          of Name.t * int
@@ -38,7 +43,9 @@ type 'v node =
 | Lint          of int
 | Lparray       of 'v lambda array * 'v lambda
 | Lmakeblock    of inductive * int * 'v lambda array
-  (* inductive name, constructor tag, arguments *)
+(* inductive name, constructor tag, arguments *)
+| Lmakesucc     of 'v lambda
+| Lnat of Z.t
 | Luint         of Uint63.t
 | Lfloat        of Float64.t
 | Lstring       of Pstring.t
@@ -155,6 +162,8 @@ let rec pp_lam lam =
       (str "(makeblock " ++ int tag ++ spc() ++
        prlist_with_sep spc pp_lam (Array.to_list args) ++
        str")")
+  | Lmakesucc arg -> hov 1 (str "(makesucc" ++ spc() ++ pp_lam arg ++ str ")")
+  | Lnat i -> str (Z.to_string i)
   | Luint i -> str (Uint63.to_string i)
   | Lfloat f -> str (Float64.to_string f)
   | Lstring s -> str (Printf.sprintf "%S" (Pstring.to_string s))
@@ -232,7 +241,7 @@ let decompose_Llam_Llet lam =
 
 let map_lam_with_binders g f n lam =
   match lam.node with
-  | Lrel _ | Lvar _  | Lconst _ | Lval _ | Lsort _ | Lind _ | Lint _ | Luint _
+  | Lrel _ | Lvar _  | Lconst _ | Lval _ | Lsort _ | Lind _ | Lnat _ | Lint _ | Luint _
   | Lfloat _ | Lstring _ -> lam
   | Levar (evk, args) ->
     let args' = Array.Smart.map (f n) args in
@@ -289,6 +298,9 @@ let map_lam_with_binders g f n lam =
   | Lmakeblock (inds, tag, args) ->
     let args' = Array.Smart.map (f n) args in
     if args == args' then lam else mknode @@ Lmakeblock (inds, tag,args')
+  | Lmakesucc arg ->
+    let arg' = f n arg in
+    if arg == arg' then lam else mknode @@ Lmakesucc arg'
   | Lprim(kn,op,args) ->
     let args' = Array.Smart.map (f n) args in
     if args == args' then lam else mknode @@ Lprim(kn,op,args')
@@ -301,7 +313,7 @@ let map_lam_with_binders g f n lam =
 let free_rels lam =
   let rec aux k accu lam = match node lam with
   | Lrel (_, n) -> if n >= k then Int.Set.add (n - k + 1) accu else accu
-  | Lvar _  | Lconst _ | Lval _ | Lsort _ | Lind _ | Lint _ | Luint _
+  | Lvar _  | Lconst _ | Lval _ | Lsort _ | Lind _ | Lnat _ | Lint _ | Luint _
   | Lfloat _ | Lstring _ -> accu
   | Levar (_, args) ->
     Array.fold_left (fun accu lam -> aux k accu lam) accu args
@@ -331,6 +343,7 @@ let free_rels lam =
     aux k accu def
   | Lmakeblock (_, _, args) ->
     Array.fold_left (fun accu lam -> aux k accu lam) accu args
+  | Lmakesucc arg -> aux k accu arg
   | Lprim (_, _, args) ->
     Array.fold_left (fun accu lam -> aux k accu lam) accu args
   | Lproj (_, arg) ->
@@ -380,10 +393,10 @@ let lam_subst_args subst args =
 (* Invariant: Terms in [subst] are already simplified and can be substituted *)
 
 let can_subst lam = match node lam with
-| Lrel _ | Lvar _ | Lconst _ | Luint _
+| Lrel _ | Lvar _ | Lconst _ | Lnat _ | Luint _
 | Lval _ | Lsort _ | Lind _ -> true
 | Levar _ | Lprod _ | Llam _ | Llet _ | Lapp _ | Lcase _ | Lfix _ | Lcofix _
-| Lparray _ | Lmakeblock _ | Lfloat _ | Lstring _ | Lprim _ | Lproj _ -> false
+| Lparray _ | Lmakesucc _ | Lmakeblock _ | Lfloat _ | Lstring _ | Lprim _ | Lproj _ -> false
 | Lint _ -> false (* TODO: allow substitution of integers *)
 
 let simplify lam =
@@ -463,7 +476,7 @@ let rec occurrence k kind lam =
     if n = k then
       if kind then false else raise Not_found
     else kind
-  | Lvar _  | Lconst _  | Lval _ | Lsort _ | Lind _ | Lint _ | Luint _
+  | Lvar _  | Lconst _  | Lval _ | Lsort _ | Lind _ | Lnat _ | Lint _ | Luint _
   | Lfloat _ | Lstring _ -> kind
   | Levar (_, args) ->
     occurrence_args k kind args
@@ -479,6 +492,7 @@ let rec occurrence k kind lam =
     occurrence_args k (occurrence k kind def) args
   | Lprim(_,_,args) | Lmakeblock(_, _,args) ->
     occurrence_args k kind args
+  | Lmakesucc arg -> occurrence k kind arg
   | Lcase(_, t, a, branches) ->
     let kind = occurrence k (occurrence k kind t) a in
     let r = ref kind in
@@ -509,9 +523,9 @@ let occur_once lam =
 
 let is_value lam = match node lam with
 | Lrel _ | Lvar _ | Lconst _ | Luint _
-| Lval _ | Lsort _ | Lind _ | Lint _ | Llam _ | Lfix _ | Lcofix _ | Lfloat _ | Lstring _ -> true
+| Lval _ | Lsort _ | Lind _ | Lnat _ | Lint _ | Llam _ | Lfix _ | Lcofix _ | Lfloat _ | Lstring _ -> true
 | Levar _ | Lprod _ | Llet _ | Lapp _ | Lcase _
-| Lparray _ | Lmakeblock _ | Lprim _ | Lproj _ -> false
+| Lparray _ | Lmakesucc _ | Lmakeblock _ | Lprim _ | Lproj _ -> false
 
 let rec remove_let subst lam =
   match lam.node with
@@ -541,27 +555,43 @@ let rec get_alias env sigma kn =
 
 (* Translation of constructors *)
 
-let make_args start _end =
-  Array.init (start - _end + 1) (fun i -> mknode @@ Lrel (Anonymous, start - i))
+let make_args start end_ =
+  Array.init (start - end_ + 1) (fun i -> mknode @@ Lrel (Anonymous, start - i))
 
-let expand_constructor ind tag nparams arity =
+let expand_constructor ~is_nat ind tag nparams arity =
   let anon = Context.make_annot Anonymous Sorts.Relevant in (* TODO relevance *)
   let ids = Array.make (nparams + arity) anon in
   if Int.equal arity 0 then mkLlam ids (mknode @@ (Lint tag))
   else
-  let args = make_args arity 1 in
-  mknode @@ Llam(ids, mknode @@ Lmakeblock (ind, tag, args))
+    let body = if is_nat then
+        (* NB treating O as a normal 0-arity ctor ie Lint 0 is fine,
+           so this is only the S case *)
+        let () = assert (Int.equal arity 1) in
+        mknode @@ Lmakesucc (mknode @@ Lrel (Anonymous, 1))
+      else
+        let args = make_args arity 1 in
+        mknode @@ Lmakeblock (ind, tag, args)
+    in
+    mknode @@ Llam(ids, body)
 
-let makeblock as_val ind tag nparams arity args =
+let makeblock ~is_nat as_val ind tag nparams arity args =
   let nargs = Array.length args in
   if nparams > 0 || nargs < arity then
-    mkLapp (expand_constructor ind tag nparams arity) args
+    mkLapp (expand_constructor ~is_nat ind tag nparams arity) args
   else
     (* The constructor is fully applied *)
   if arity = 0 then mknode @@ Lint tag
+  else if is_nat then
+    let () = assert (Int.equal nargs 1) in
+    begin match args.(0).node with
+    | Lnat n -> mknode @@ Lnat (Z.succ n)
+    | Lint n -> mknode @@ Lnat (Z.succ @@ Z.of_int n)
+    | _ -> mknode @@ Lmakesucc args.(0)
+    end
   else match as_val tag args with
   | Some v -> mknode @@ Lval v
-  | None -> mknode @@ Lmakeblock (ind, tag, args)
+  | None ->
+    mknode @@ Lmakeblock (ind, tag, args)
 
 (* Compilation of primitive *)
 
@@ -599,8 +629,8 @@ module Make (Val : S) =
 struct
 
 (* [nparams] is the number of parameters still expected *)
-let makeblock _env ind tag nparams arity args =
-  makeblock Val.as_value ind tag nparams arity args
+let makeblock ~is_nat ind tag nparams arity args =
+  makeblock ~is_nat Val.as_value ind tag nparams arity args
 
 (*i Global environment *)
 
@@ -615,7 +645,12 @@ module Cache =
 
     module ConstrTable = Hashtbl.Make(Construct.UserOrd)
 
-    type constructor_info = tag * int * int (* nparam nrealargs *)
+    type constructor_info = {
+      tag : tag;
+      nparams : int;
+      arity :  int;
+      is_nat : bool;
+    }
 
     let get_construct_info cache env c : constructor_info =
       try ConstrTable.find cache c
@@ -626,7 +661,8 @@ module Cache =
         let () = Val.check_inductive (mind, j) oib in
         let tag,arity = oip.mind_reloc_tbl.(i-1) in
         let nparams = oib.mind_nparams in
-        let r = (tag, nparams, arity) in
+        let is_nat = oib.mind_is_nat in
+        let r = { tag; nparams; arity; is_nat } in
         ConstrTable.add cache c r;
         r
   end
@@ -706,7 +742,7 @@ let rec lambda_of_constr cache env sigma c =
     let oib = mib.mind_packets.(i) in
     let tbl = oib.mind_reloc_tbl in
     (* Building info *)
-    let annot_sw = (ci, tbl, mib.mind_finite) in
+    let annot_sw = { ci; reloc = tbl; finite = mib.mind_finite; is_nat = mib.mind_is_nat } in
     (* translation of the argument *)
     let la = lambda_of_constr cache env sigma a in
     (* translation of the type *)
@@ -757,6 +793,8 @@ let rec lambda_of_constr cache env sigma c =
       let lbodies = lambda_of_args cache env sigma 0 rec_bodies in
       mknode @@ Lcofix(init, (names, ltypes, lbodies))
 
+  | Nat (_,i) -> mknode @@ Lnat i
+
   | Int i -> mknode @@ Luint i
 
   | Float f -> mknode @@ Lfloat f
@@ -791,12 +829,12 @@ and lambda_of_app cache env sigma f args =
           mkLapp (mknode @@ Lconst (kn, u)) (lambda_of_args cache env sigma 0 args)
       end
   | Construct ((ind,_ as c),_) ->
-    let tag, nparams, arity = Cache.get_construct_info cache env c in
+    let { Cache.tag; nparams; arity; is_nat } = Cache.get_construct_info cache env c in
     let nargs = Array.length args in
     if nparams < nargs then (* got all parameters *)
       let args = lambda_of_args cache env sigma nparams args in
-      makeblock env ind tag 0 arity args
-    else makeblock env ind tag (nparams - nargs) arity empty_args
+      makeblock ~is_nat ind tag 0 arity args
+    else makeblock ~is_nat ind tag (nparams - nargs) arity empty_args
   | _ ->
       let f = lambda_of_constr cache env sigma f in
       let args = lambda_of_args cache env sigma 0 args in

--- a/kernel/genlambda.mli
+++ b/kernel/genlambda.mli
@@ -15,7 +15,12 @@ open Constr
 
 type reloc_table = (int * int) array
 
-type case_annot = case_info * reloc_table * Declarations.recursivity_kind
+type case_annot = {
+  ci : case_info;
+  reloc : reloc_table;
+  finite : Declarations.recursivity_kind;
+  is_nat : bool;
+}
 
 type 'v lambda
 
@@ -38,6 +43,8 @@ type 'v node =
 | Lparray       of 'v lambda array * 'v lambda
 | Lmakeblock    of inductive * int * 'v lambda array
   (* inductive name, constructor tag, arguments *)
+| Lmakesucc     of 'v lambda
+| Lnat of Z.t
 | Luint         of Uint63.t
 | Lfloat        of Float64.t
 | Lstring       of Pstring.t

--- a/kernel/hConstr.ml
+++ b/kernel/hConstr.ml
@@ -285,6 +285,7 @@ let hash_kind = let open Hashset.Combine in function
   | Float f -> combinesmall 19 (Float64.hash f)
   | String s -> combinesmall 20 (Pstring.hash s)
   | Array (u,t,def,ty) -> combinesmall 21 (combine4 (UVars.Instance.hash u) (hash_array hash t) def.hash ty.hash)
+  | Nat (ind,i) -> combinesmall 22 (combine (Ind.UserOrd.hash ind) (Z.hash i))
 
 let kind_to_constr = function
   | Rel n -> mkRel n
@@ -315,6 +316,7 @@ let kind_to_constr = function
   | Float f -> mkFloat f
   | String s -> mkString s
   | Array (u,t,def,ty) -> mkArray (u,Array.map self t,def.self,ty.self)
+  | Nat (ind,i) -> mkNat ind i
 
 let of_kind_nohashcons = function
   | App (c, [||]) -> c
@@ -452,6 +454,7 @@ and of_constr_aux henv c =
     let _, p = Projection.hcons p in
     let c = of_constr henv c in
     Proj (p,r,c)
+  | Nat _ as t -> t
   | Int _ as t -> t
   | Float _ as t -> t
   | String _ as t -> t

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -494,7 +494,7 @@ let compute_projections ind ~nparamargs ~nf_lc ~consnrealdecls =
   Array.of_list (List.rev rs),
   Array.of_list (List.rev pbs)
 
-let build_inductive env ~sec_univs names prv univs template variance
+let build_inductive env ~is_nat ~sec_univs names prv univs template variance
     paramsctxt kn isrecord isfinite inds nmr recargs not_prim_or_has_eta =
   let ntypes = Array.length inds in
   (* Compute the set of used section variables *)
@@ -597,10 +597,51 @@ let build_inductive env ~sec_univs names prv univs template variance
     mind_sec_variance = sec_variance;
     mind_private = prv;
     mind_typing_flags = Environ.typing_flags env;
+    mind_is_nat = is_nat;
   }
 
 (************************************************************************)
 (************************************************************************)
+
+let check_primitive_nat univs template params finite inds =
+  let () = match univs with Monomorphic -> () | Polymorphic _ ->
+    CErrors.user_err Pp.(str "Primitive nat may not be universe polymorphic.")
+  in
+  let () = if Option.has_some template then CErrors.user_err Pp.(str "Primitive nat may not be template polymorphic.") in
+  let () = if not @@ List.is_empty params then CErrors.user_err Pp.(str "Primitive nat may not have parameters.") in
+  let () = match finite with
+    | Finite -> ()
+    | CoFinite | BiFinite -> CErrors.user_err Pp.(str "Primitive nat must be inductive.")
+  in
+  let (arity,_),(indices,splayed_lc),squashed,_ = match inds with
+    | [|i|] -> i
+    | _ -> CErrors.user_err Pp.(str "Primitive nat may not be mutual.")
+  in
+  let () = if not @@ CList.is_empty indices then
+      CErrors.user_err Pp.(str "Primitive nat must not have indices.")
+  in
+  let () = if not @@ Sorts.is_set arity.IndTyping.sort then
+      (* arguably not needed to check this? *)
+      CErrors.user_err Pp.(str "Primitive nat must be in Set.")
+  in
+  let () = if Option.has_some squashed then
+      CErrors.user_err Pp.(str "Primitive nat may not be squashed.")
+  in
+  let c_0, c_S = match splayed_lc with
+    | [|a;b|] -> a, b
+    | _ -> CErrors.user_err Pp.(str "Primitive nat must have 2 constructors.")
+  in
+  (* no need to check second projection of splayed constructors: no
+     params, no indices and no mutual means guaranteed to be the
+     inductive itself. *)
+  let () = if not @@ CList.is_empty @@ fst c_0 then
+      CErrors.user_err Pp.(str "Primitive nat first constructor (for 0) may not have arguments.")
+  in
+  let () = match fst c_S with
+    | [LocalAssum (_,t)] when isRelN 1 t -> ()
+    | _ -> CErrors.user_err Pp.(str "Invalid second constructor of primitive nat.")
+  in
+  ()
 
 let check_inductive env ~sec_univs kn mie =
   (* First type-check the inductive definition *)
@@ -616,11 +657,13 @@ let check_inductive env ~sec_univs kn mie =
       env_ar_par paramsctxt mie.mind_entry_finite
       (Array.map (fun ((_,lc),(indices,_),_,_) -> Context.Rel.nhyps indices,lc) inds)
   in
+  let () = if mie.mind_entry_is_nat then check_primitive_nat univs template paramsctxt mie.mind_entry_finite inds in
   (* Build the inductive packets *)
   let mib =
     build_inductive env ~sec_univs names mie.mind_entry_private univs template variance
       paramsctxt kn record mie.mind_entry_finite
       inds nmr recargs not_prim_reason_or_has_eta
+      ~is_nat:mie.mind_entry_is_nat
   in
   (* From this point onward, we only care if there is a reason why
      the primitive projection was not possible *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1318,7 +1318,7 @@ let rec subterm_specif ?evars renv stack t =
     | Meta _ -> assert false
 
     | Var _ | Sort _ | Cast _ | Prod _ | LetIn _ | App _ | Ind _
-      | Construct _ | CoFix _ | Int _ | Float _ | String _
+      | Construct _ | CoFix _ | Nat _ | Int _ | Float _ | String _
       | Array _ -> Subterm.not_subterm
 
 
@@ -1550,9 +1550,10 @@ let check_one_fix ?evars renv recpos trees def =
                  constructor in c_0 (we unfold definitions too) *)
               let hd, args = reduce_and_contract_cofix ?evars renv.env c_0 in
               match kind hd with
+              (* XXX Nat? *)
               | Construct cstr -> Some (apply_branch cstr (Array.to_list args) ci brs, [])
               | CoFix _ | Ind _ | Lambda _ | Prod _ | LetIn _
-              | Sort _ | Int _ | Float _ | String _ | Array _ -> assert false
+              | Sort _ | Nat _ | Int _ | Float _ | String _ | Array _ -> assert false
               | Rel _ | Var _ | Const _ | App _ | Case _ | Fix _
               | Proj _ | Cast _ | Meta _ | Evar _ -> None)
 
@@ -1599,7 +1600,7 @@ let check_one_fix ?evars renv recpos trees def =
               let c = whd_all ?evars renv.env (lift n recArg) in
               let hd, _ = decompose_app_list c in
               match kind hd with
-              | Construct _ -> Some (contract_fix fix, absorbed_stack)
+              | Construct _ | Nat _ -> Some (contract_fix fix, absorbed_stack)
               | CoFix _ | Ind _ | Lambda _ | Prod _ | LetIn _
               | Sort _ | Int _ | Float _ | String _
               | Array _ -> assert false
@@ -1651,7 +1652,7 @@ let check_one_fix ?evars renv recpos trees def =
               match kind hd with
               | Construct _ -> Some (args.(Projection.npars p + Projection.arg p), [])
               | CoFix _ | Ind _ | Lambda _ | Prod _ | LetIn _
-              | Sort _ | Int _ | Float _ | String _ | Array _ -> assert false
+              | Sort _ | Nat _ | Int _ | Float _ | String _ | Array _ -> assert false
               | Rel _ | Var _ | Const _ | App _ | Case _ | Fix _
               | Proj _ | Cast _ | Meta _ | Evar _ -> None)
             end
@@ -1681,7 +1682,7 @@ let check_one_fix ?evars renv recpos trees def =
             let rs = check_rec_call_stack renv stack rs c in
             rs
 
-        | Sort _ | Int _ | Float _ | String _ ->
+        | Sort _ | Nat _ | Int _ | Float _ | String _ ->
             (* See [Prod]: we cannot ensure that the stack is empty *)
             rs
 
@@ -1942,7 +1943,7 @@ let check_one_cofix ?evars env nbfix def deftype =
         | Evar _ ->
             List.iter (check_rec_call env alreadygrd n tree) args
         | Rel _ | Var _ | Sort _ | Cast _ | Prod _ | LetIn _ | App _ | Const _
-          | Ind _ | Fix _ | Proj _ | Int _ | Float _ | String _
+          | Ind _ | Fix _ | Proj _ | Nat _ | Int _ | Float _ | String _
           | Array _ ->
            raise (CoFixGuardError (env,NotGuardedForm t)) in
 

--- a/kernel/inferCumulativity.ml
+++ b/kernel/inferCumulativity.ml
@@ -186,6 +186,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
     end
   | FEvar _ -> assert false
   | FRel _ -> infer_stack infos variances stk
+  | FNat _ -> infer_stack infos variances stk
   | FInt _ -> infer_stack infos variances stk
   | FFloat _ -> infer_stack infos variances stk
   | FString _ -> infer_stack infos variances stk

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -52,7 +52,7 @@ let rec is_lazy env t =
   | Array (_, t, d, _) -> Array.exists (fun t -> is_lazy env t) t || is_lazy env d
   | Cast (c, _, _) | Prod (_, c, _) -> is_lazy env c
   | Const (c, _) -> get_const_lazy env c
-  | Rel _ | Meta _ | Var _ | Sort _ | Ind _ | Construct _ | Int _
+  | Rel _ | Meta _ | Var _ | Sort _ | Ind _ | Construct _ | Nat _ | Int _
   | Float _ | String _ | Lambda _ | Evar _ | Fix _ | CoFix _ ->
     false
 
@@ -292,6 +292,9 @@ type primitive =
   | Lazy
   | Coq_primitive of CPrimitives.t * bool (* check for accu *)
   | Mk_empty_instance
+  | Mk_nat
+  | Mk_succ
+  | Force_nat
 
 let eq_primitive p1 p2 =
   match p1, p2 with
@@ -333,6 +336,9 @@ let eq_primitive p1 p2 =
   | Get_symbols, Get_symbols
   | Lazy, Lazy
   | Mk_empty_instance, Mk_empty_instance
+  | Mk_nat, Mk_nat
+  | Mk_succ, Mk_succ
+  | Force_nat, Force_nat
     -> true
 
   | Mk_fix (rp1, i1), Mk_fix (rp2, i2) -> Int.equal i1 i2 && eq_rec_pos rp1 rp2
@@ -384,7 +390,10 @@ let eq_primitive p1 p2 =
     | Get_symbols
     | Lazy
     | Coq_primitive _
-    | Mk_empty_instance), _
+    | Mk_empty_instance
+    | Mk_nat
+    | Mk_succ
+    | Force_nat), _
     -> false
 
 let primitive_hash = function
@@ -436,6 +445,9 @@ let primitive_hash = function
   | Lazy -> 42
   | Mk_empty_instance -> 43
   | Mk_string -> 44
+  | Mk_nat -> 45
+  | Mk_succ -> 46
+  | Force_nat -> 47
 
 type mllambda =
   | MLlocal        of lname
@@ -450,6 +462,7 @@ type mllambda =
                               (* argument, prefix, accu branch, branches *)
   | MLconstruct    of string * inductive * int * mllambda array
                    (* prefix, inductive name, tag, arguments *)
+  | MLnat          of Z.t
   | MLint          of int
   | MLuint         of Uint63.t
   | MLfloat        of Float64.t
@@ -523,6 +536,7 @@ let rec eq_mllambda gn1 gn2 n env1 env2 t1 t2 =
       Ind.UserOrd.equal ind1 ind2 &&
       Int.equal tag1 tag2 &&
       Array.equal (eq_mllambda gn1 gn2 n env1 env2) args1 args2
+  | MLnat n1, MLnat n2 -> Z.equal n1 n2
   | MLint i1, MLint i2 ->
       Int.equal i1 i2
   | MLuint i1, MLuint i2 ->
@@ -544,7 +558,7 @@ let rec eq_mllambda gn1 gn2 n env1 env2 t1 t2 =
     String.equal s1 s2 && Ind.UserOrd.equal ind1 ind2 &&
     eq_mllambda gn1 gn2 n env1 env2 ml1 ml2
   | (MLlocal _ | MLglobal _ | MLprimitive _ | MLlam _ | MLletrec _ | MLlet _ |
-    MLapp _ | MLif _ | MLmatch _ | MLconstruct _ | MLint _ | MLuint _ |
+    MLapp _ | MLif _ | MLmatch _ | MLconstruct _ | MLnat _ | MLint _ | MLuint _ |
     MLfloat _ | MLstring _ | MLsetref _ | MLsequence _ |
     MLarray _ | MLisaccu _), _ -> false
 
@@ -637,6 +651,7 @@ let rec hash_mllambda gn n env t =
       combinesmall 17 (Float64.hash f)
   | MLstring s ->
       combinesmall 18 (Pstring.hash s)
+  | MLnat n -> combinesmall 19 (Z.hash n)
 
 and hash_mllambda_letrec gn n env init defs =
   let hash_def (_,args,ml) =
@@ -670,7 +685,7 @@ let fv_lam l =
     match l with
     | MLlocal l ->
         if LNset.mem l bind then fv else LNset.add l fv
-    | MLglobal _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> fv
+    | MLglobal _ | MLnat _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> fv
     | MLprimitive (_, args) ->
         let fv_arg arg fv = aux arg bind fv in
         Array.fold_right fv_arg args fv
@@ -1352,12 +1367,12 @@ let compile_prim env decl cond paux =
          (* Remark: if we do not want to compile the predicate we
             should a least compute the fv, then store the lambda representation
             of the predicate (not the mllambda) *)
-      let annot, finite =
-        let (ci, tbl, finite) = annot in {
+      let annot, finite, is_nat =
+        let { ci; reloc = tbl; finite; is_nat } = annot in {
           asw_ind = ci.ci_ind;
           asw_reloc = tbl;
           asw_prefix = env.env_mind_prefix (fst ci.ci_ind);
-      }, finite in
+      }, finite, is_nat in
       let env_p = restart_env env in
       let pn = fresh_gpred env.env_cenv l in
       let mlp = ml_of_lam env_p l p in
@@ -1398,10 +1413,13 @@ let compile_prim env decl cond paux =
       in
       (* Final result *)
       let arg = ml_of_lam env l a in
-      let force =
+      let arg = if is_nat then MLprimitive (Force_nat, [|arg|])
+        else arg
+      in
+      let arg =
         if finite <> CoFinite then arg
         else mkForceCofix env.env_cenv annot.asw_prefix annot.asw_ind arg in
-      mkMLapp (MLapp (MLglobal cn, fv_args env fvn fvr)) [|force|]
+      mkMLapp (MLapp (MLglobal cn, fv_args env fvn fvr)) [|arg|]
   | Lfix ((rec_pos, inds, start), (ids, tt, tb)) ->
       (* let type_f fvt = [| type fix |]
          let norm_f1 fv f1 .. fn params1 = body1
@@ -1538,6 +1556,13 @@ let compile_prim env decl cond paux =
       let knot = push_global_cofix env.env_cenv knot fv_params (Array.mapi map t_norm_f) in
       MLprimitive (Array_get, [|MLapp (MLglobal knot, fv_args); MLint start|])
 
+  | Lnat n ->
+    if Obj.is_int (Obj.repr n) then
+      MLprimitive (Mk_int, [|MLint (Obj.magic n)|])
+    else MLprimitive (Mk_nat, [|MLnat n|])
+
+  | Lmakesucc v -> MLprimitive (Mk_succ, [|ml_of_lam env l v|])
+
   | Lint tag -> MLprimitive (Mk_int, [|MLint tag|])
 
   | Lmakeblock (cn,tag,args) ->
@@ -1584,7 +1609,7 @@ let mllambda_of_lambda cenv univ constpref constlazy mindpref auxdefs l t =
 
 let can_subst l =
   match l with
-  | MLlocal _ | MLint _ | MLuint _ | MLglobal _ -> true
+  | MLlocal _ | MLnat _ | MLint _ | MLuint _ | MLglobal _ -> true
   | _ -> false
 
 let subst s l =
@@ -1593,7 +1618,7 @@ let subst s l =
     let rec aux l =
       match l with
       | MLlocal id -> (try LNmap.find id s with Not_found -> l)
-      | MLglobal _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> l
+      | MLglobal _ | MLnat _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> l
       | MLprimitive (p, args) -> MLprimitive (p, Array.map aux args)
       | MLlam(params,body) -> MLlam(params, aux body)
       | MLletrec(defs,body) ->
@@ -1664,7 +1689,7 @@ let optimize gdef l =
   let rec optimize s l =
     match l with
     | MLlocal id -> (try LNmap.find id s with Not_found -> l)
-    | MLglobal _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> l
+    | MLglobal _ | MLnat _ | MLint _ | MLuint _ | MLfloat _ | MLstring _ -> l
     | MLprimitive (p, args) ->
         MLprimitive (p, Array.map (optimize s) args)
     | MLlam(params,body) ->
@@ -1870,6 +1895,7 @@ let pp_mllam fmt l =
     | MLconstruct(prefix,ind,tag,args) ->
         Format.fprintf fmt "@[<2>(Obj.magic@ @[<2>(%s%a)@] : Nativevalues.t)@]"
           (string_of_construct prefix ~constant:false ind tag) pp_cargs args
+    | MLnat n -> Format.fprintf fmt "%S" (Z.to_bits n)
     | MLint i -> pp_int fmt i
     | MLuint i -> Format.fprintf fmt "(%s)" (Uint63.compile i)
     | MLfloat f -> Format.fprintf fmt "(%s)" (Float64.compile f)
@@ -2007,6 +2033,9 @@ let pp_mllam fmt l =
     | Mk_float -> Format.fprintf fmt "mk_float"
     | Mk_string -> Format.fprintf fmt "mk_string"
     | Mk_int -> Format.fprintf fmt "mk_int"
+    | Mk_nat -> Format.fprintf fmt "mk_nat"
+    | Mk_succ -> Format.fprintf fmt "mk_succ"
+    | Force_nat -> Format.fprintf fmt "force_nat"
     | Val_to_int -> Format.fprintf fmt "val_to_int"
     | Mk_evar -> Format.fprintf fmt "mk_evar_accu"
     | MLand -> Format.fprintf fmt "(&&)"

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -63,6 +63,8 @@ let rec conv_val env pb lvl v1 v2 cu =
         if Int.equal i1 i2 then cu else raise NotConvertible
     | Vint64 i1, Vint64 i2 ->
       if Int64.equal i1 i2 then cu else raise NotConvertible
+    | Vnat n1, Vnat n2 ->
+      if Z.equal n1 n2 then cu else raise NotConvertible
     | Vfloat64 f1, Vfloat64 f2 ->
         if Float64.(equal (of_float f1) (of_float f2)) then cu
         else raise NotConvertible
@@ -87,7 +89,7 @@ let rec conv_val env pb lvl v1 v2 cu =
         in
         aux lvl (n1-1) b1 b2 0 cu
     | (Vfix e | Vcofix e), _ | _, (Vfix e | Vcofix e) -> Empty.abort e
-    | (Vaccu _ | Vprod _ | Vconst _ | Vint64 _ | Vfloat64 _ | Vstring _ | Varray _ | Vblock _), _ -> raise NotConvertible
+    | (Vaccu _ | Vprod _ | Vconst _ | Vnat _ | Vint64 _ | Vfloat64 _ | Vstring _ | Varray _ | Vblock _), _ -> raise NotConvertible
 
 and conv_accu env pb lvl k1 k2 cu =
   let n1 = accu_nargs k1 in

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -229,6 +229,30 @@ let cast_accu v = (Obj.magic v:accumulator)
 let mk_int (x : int) = (Obj.magic x : t)
 [@@ocaml.inline always]
 
+let mk_nat (x:string) = (Obj.magic (Z.of_bits x) : t)
+
+type native_nat =
+  | NatAccu of t
+  | NatZero
+  | NatSucc of t
+[@@warning "-a"]
+
+let mk_succ (x:t) =
+  let x = Obj.repr x in
+  if Obj.is_int x || Obj.tag x = Obj.custom_tag then
+    Obj.magic (Z.succ (Obj.magic x))
+  else Obj.magic (NatSucc (Obj.magic x))
+
+let force_nat (x:t) : t =
+  if Obj.is_int @@ Obj.repr x then
+    let x : int = Obj.magic x in
+    if Int.equal x 0 then Obj.magic NatZero
+    else Obj.magic @@ NatSucc (Obj.magic (pred x))
+  else if Obj.tag (Obj.repr x) = Obj.custom_tag then
+    let x : Z.t = Obj.magic x in
+    Obj.magic @@ NatSucc (Obj.magic @@ Z.pred x)
+  else x
+
 (* Rocq's booleans are reversed... *)
 let mk_bool (b : bool) = (Obj.magic (not b) : t)
 [@@ocaml.inline always]
@@ -252,6 +276,12 @@ let block_tag (b:block) =
 
 type kind = (t, accumulator, t -> t, Name.t * t * t, Empty.t, Empty.t, block) Values.kind
 
+external is_int64 : t -> bool = "rocq_is_int64"
+
+let nat_or_int64 v =
+  if is_int64 v then Vint64 (Obj.magic v)
+  else Vnat (Obj.magic v)
+
 let kind_of_value (v:t) =
   let o = Obj.repr v in
   if Obj.is_int o then Vconst (Obj.magic v)
@@ -264,7 +294,7 @@ let kind_of_value (v:t) =
         if Int.equal tag prod_tag then Obj.magic w
         else Varray (Obj.magic v)
       else Vaccu (Obj.magic v)
-    else if Int.equal tag Obj.custom_tag then Vint64 (Obj.magic v)
+    else if Int.equal tag Obj.custom_tag then nat_or_int64 v
     else if Int.equal tag Obj.double_tag then Vfloat64 (Obj.magic v)
     else if Int.equal tag Obj.string_tag then Vstring (Obj.magic v)
     else if (tag < Obj.lazy_tag) then Vblock (Obj.magic v)

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -97,6 +97,12 @@ val mk_bool : bool -> t
 
 val mk_int : int -> t
 
+val mk_nat : string -> t
+
+val mk_succ : t -> t
+
+val force_nat : t -> t
+
 val mk_uint : Uint63.t -> t
 
 val mk_float : Float64.t -> t

--- a/kernel/primred.ml
+++ b/kernel/primred.ml
@@ -5,11 +5,12 @@ open Retroknowledge
 open Environ
 open CErrors
 
-type _ action_kind =
-  | IncompatTypes : _ prim_type -> Constant.t action_kind
-  | IncompatInd : _ prim_ind -> inductive action_kind
+type _ action_error =
+  | IncompatTypes : _ prim_type -> Constant.t action_error
+  | IncompatInd : _ prim_ind -> inductive action_error
+  | IncompatNat : inductive action_error
 
-type exn += IncompatibleDeclarations : 'a action_kind * 'a * 'a -> exn
+type exn += IncompatibleDeclarations : 'a action_error * 'a * 'a -> exn
 
 let check_same_types typ c1 c2 =
   if not (Constant.UserOrd.equal c1 c2)

--- a/kernel/primred.mli
+++ b/kernel/primred.mli
@@ -2,11 +2,12 @@ open Names
 open Environ
 
 (** {5 Reduction of primitives} *)
-type _ action_kind =
-  | IncompatTypes : _ CPrimitives.prim_type -> Constant.t action_kind
-  | IncompatInd : _ CPrimitives.prim_ind -> inductive action_kind
+type _ action_error =
+  | IncompatTypes : _ CPrimitives.prim_type -> Constant.t action_error
+  | IncompatInd : _ CPrimitives.prim_ind -> inductive action_error
+  | IncompatNat : inductive action_error
 
-type exn += IncompatibleDeclarations : 'a action_kind * 'a * 'a -> exn
+type exn += IncompatibleDeclarations : 'a action_error * 'a * 'a -> exn
 
 (** May raise [IncomtibleDeclarations] *)
 val add_retroknowledge : env -> Retroknowledge.action -> env

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -23,10 +23,10 @@ open Context.Rel.Declaration
 let whd_all ?evars env t =
   match kind t with
     | (Sort _|Meta _|Ind _|Construct _|
-       Prod _|Lambda _|Fix _|CoFix _|Int _|Float _|String _|Array _) -> t
+       Prod _|Lambda _|Fix _|CoFix _|Nat _ | Int _|Float _|String _|Array _) -> t
     | App (c, _) ->
       begin match kind c with
-      | Ind _ | Construct _ | Meta _ | Int _ | Float _ | String _ | Array _ -> t
+      | Ind _ | Construct _ | Meta _ | Nat _ | Int _ | Float _ | String _ | Array _ -> t
       | Sort _ | Rel _ | Var _ | Evar _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
         | Const _ |Case _ | Fix _ | CoFix _ | Proj _ ->
          whd_val (create_clos_infos ?evars RedFlags.all env) (create_tab ()) (inject t)
@@ -37,10 +37,10 @@ let whd_all ?evars env t =
 let whd_allnolet ?evars env t =
   match kind t with
     | (Sort _|Meta _|Ind _|Construct _|
-       Prod _|Lambda _|Fix _|CoFix _|LetIn _|Int _|Float _|String _|Array _) -> t
+       Prod _|Lambda _|Fix _|CoFix _|LetIn _|Nat _ | Int _|Float _|String _|Array _) -> t
     | App (c, _) ->
       begin match kind c with
-      | Ind _ | Construct _ | Meta _ | LetIn _ | Int _ | Float _ | String _ | Array _ -> t
+      | Ind _ | Construct _ | Meta _ | LetIn _ | Nat _ | Int _ | Float _ | String _ | Array _ -> t
       | Sort _ | Rel _ | Var _ | Evar _ | Cast _ | Prod _ | Lambda _ | App _
         | Const _ | Case _ | Fix _ | CoFix _ | Proj _ ->
          whd_val (create_clos_infos ?evars RedFlags.allnolet env) (create_tab ()) (inject t)

--- a/kernel/relevanceops.ml
+++ b/kernel/relevanceops.ml
@@ -62,7 +62,7 @@ let rec relevance_of_term_extra env extra lft c =
   | Fix ((_,i),(lna,_,_)) -> (lna.(i)).binder_relevance
   | CoFix (i,(lna,_,_)) -> (lna.(i)).binder_relevance
   | Proj (_, r, _) -> r
-  | Int _ | Float _ | String _ -> Sorts.Relevant
+  | Nat _ | Int _ | Float _ | String _ -> Sorts.Relevant
   | Array _ -> Sorts.Relevant
 
   | Meta _ | Evar _ -> Sorts.Relevant (* let's assume metas and evars are relevant for now *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1326,7 +1326,8 @@ let add_mind l mie senv =
     let senv = push_context_set ~strict:true (levels, uctx) senv in
     senv
   in
-  (kn, why_not_prim_record), add_checked_mind kn mib senv
+  let senv = add_checked_mind kn mib senv in
+  (kn, why_not_prim_record), senv
 
 let add_mind ?typing_flags l mie senv =
   with_typing_flags ?typing_flags senv ~f:(add_mind l mie)

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -316,6 +316,12 @@ let type_of_prim_type _env u (type a) (prim : a CPrimitives.prim_type) = match p
     | _ -> anomaly Pp.(str"universe instance for array type should have length 1")
     end
 
+let type_of_nat env ind n =
+  assert (Z.leq Z.zero n);
+  let mib = Environ.lookup_mind (fst ind) env in
+  assert mib.mind_is_nat;
+  UnsafeMonomorphic.mkInd ind
+
 let type_of_int env =
   match (Environ.retroknowledge env).Retroknowledge.retro_int63 with
   | Some c -> UnsafeMonomorphic.mkConst c
@@ -817,6 +823,8 @@ and execute_aux tbl env cstr =
       fix_ty
 
     (* Primitive types *)
+    | Nat (ind,n) ->
+      type_of_nat env ind n
     | Int _ -> type_of_int env
     | Float _ -> type_of_float env
     | String _ -> type_of_string env

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -77,6 +77,7 @@ val check_hyps_inclusion : env -> ?evars:CClosure.evar_handler ->
 
 (** Types for primitives *)
 
+val type_of_nat : env -> inductive -> Z.t -> types
 val type_of_int : env -> types
 val type_of_float : env -> types
 val type_of_string : env -> types

--- a/kernel/values.mli
+++ b/kernel/values.mli
@@ -16,6 +16,7 @@ type ('value, 'vaccu, 'vfun, 'vprod, 'vfix, 'vcofix, 'vblock) kind =
   | Vcofix of 'vcofix
   | Vconst of int
   | Vblock of 'vblock
+  | Vnat of Z.t
   | Vint64 of int64
   | Vfloat64 of float
   | Vstring of Pstring.t

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -293,7 +293,7 @@ let map_constr_relevance f c =
   | Rel _ | Var _ | Meta _ | Evar _
   |  Sort _ | Cast _ | App _
   | Const _ | Ind _ | Construct _
-  | Int _ | Float _ | String _ | Array _ -> c
+  | Nat _ | Int _ | Float _ | String _ | Array _ -> c
 
   | Prod (na,x,y) ->
     let na' = map_annot_relevance f na in
@@ -340,7 +340,7 @@ let fold_kind_relevance f acc c =
   | Rel _ | Var _ | Meta _ | Evar _
   |  Sort _ | Cast _ | App _
   | Const _ | Ind _ | Construct _
-  | Int _ | Float _ | String _ | Array _ -> acc
+  | Nat _ | Int _ | Float _ | String _ | Array _ -> acc
 
   | Prod (na,_,_) | Lambda (na,_,_) | LetIn (na,_,_,_) ->
     fold_annot_relevance f acc na

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -100,6 +100,8 @@ and conv_whd env pb k whd1 whd2 cu =
         done;
         !rcu
       else raise NotConvertible
+  | Vnat n1, Vnat n2 ->
+    if Z.equal n1 n2 then cu else raise NotConvertible
   | Vint64 i1, Vint64 i2 ->
     if Int64.equal i1 i2 then cu else raise NotConvertible
   | Vfloat64 f1, Vfloat64 f2 ->
@@ -119,7 +121,7 @@ and conv_whd env pb k whd1 whd2 cu =
      (* on the fly eta expansion *)
       conv_val env CONV (k+1) (apply_whd k whd1) (apply_whd k whd2) cu
 
-  | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconst _, _ | Vint64 _, _
+  | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconst _, _ | Vnat _, _ | Vint64 _, _
   | Vfloat64 _, _ | Vstring _, _ | Varray _, _ | Vblock _, _ | Vaccu _, _ -> raise NotConvertible
 
 

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -163,7 +163,7 @@ let rec apply_stack a stk v =
 let apply_whd k whd =
   let v = val_of_rel k in
   match whd with
-  | Vprod _ | Vconst _ | Vblock _ | Vint64 _ | Vfloat64 _ | Vstring _ | Varray _ ->
+  | Vprod _ | Vconst _ | Vblock _ | Vnat _ | Vint64 _ | Vfloat64 _ | Vstring _ | Varray _ ->
      assert false
   | Vfun f -> reduce_fun k f
   | Vfix(f, None) ->

--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -65,8 +65,10 @@ type instruction =
   | Ksubstinstance of UVars.Instance.t
   | Kconst of structured_constant
   | Kmakeblock of int * tag
+  | Kmakesucc
   | Kmakeswitchblock of Label.t * Label.t * annot_switch * int
   | Kswitch of Label.t array * Label.t array
+  | Kswitchnat of Label.t * Label.t * Label.t * Label.t (* 0, accu, S, nonzero Z.t *)
   | Kpushfields of int
   | Kfield of int
   | Ksetfield of int
@@ -152,6 +154,7 @@ let rec pp_instr i =
       str "const " ++ pp_struct_const sc
   | Kmakeblock(n, m) ->
       str "makeblock " ++ int n ++ str ", " ++ int m
+  | Kmakesucc -> str "makesucc"
   | Kmakeswitchblock(lblt,lbls,_,sz) ->
       str "makeswitchblock " ++ pp_lbl lblt ++ str ", " ++
         pp_lbl lbls ++ str ", " ++ int sz
@@ -159,7 +162,9 @@ let rec pp_instr i =
       hv 1 (str "switch " ++
              prlist_with_sep spc pp_lbl (Array.to_list lblc) ++
              str " | " ++
-             prlist_with_sep spc pp_lbl (Array.to_list lblb))
+            prlist_with_sep spc pp_lbl (Array.to_list lblb))
+  | Kswitchnat (l0,lAcc,lS,lZ) ->
+    hv 1 (str "switchnat " ++ prlist_with_sep spc pp_lbl [l0;lAcc;lS;lZ])
   | Kpushfields n -> str "pushfields " ++ int n
   | Kfield n -> str "field " ++ int n
   | Ksetfield n -> str "setfield " ++ int n

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -63,8 +63,10 @@ type instruction =
   | Kmakeblock of (* size: *) int * tag (** allocate an ocaml block. Index 0
                                          ** is accu, all others are popped from
                                          ** the top of the stack  *)
+  | Kmakesucc
   | Kmakeswitchblock of Label.t * Label.t * annot_switch * int
   | Kswitch of Label.t array * Label.t array (** consts,blocks *)
+  | Kswitchnat of Label.t * Label.t * Label.t * Label.t (* 0, accu, S, nonzero Z.t *)
   | Kpushfields of int
   | Kfield of int                       (** accu = accu[n] *)
   | Ksetfield of int                    (** accu[n] = sp[0] ; sp = pop sp *)

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -566,6 +566,14 @@ let rec compile_lam env cenv lam sz cont =
   match node lam with
   | Lrel(_, i) -> pos_rel i cenv sz :: cont
 
+  | Lnat n ->
+    if Obj.is_int (Obj.repr n) then
+      compile_structured_constant cenv (Const_b0 (Obj.magic n : int)) sz cont
+    else compile_structured_constant cenv (Const_val (Obj.magic n)) sz cont
+
+  | Lmakesucc v ->
+    compile_lam env cenv v sz (Kmakesucc :: cont)
+
   | Lint i -> compile_structured_constant cenv (Const_b0 i) sz cont
 
   | Lval v -> compile_structured_constant cenv (Const_val (get_lval v)) sz cont
@@ -701,10 +709,11 @@ let rec compile_lam env cenv lam sz cont =
       compile_fv cenv fv.fv_rev sz
         (Kclosurecofix(fv.size, init, lbl_types, lbl_bodies) :: cont)
 
-  | Lcase ((ci, rtbl, _), t, a, branches) ->
+  | Lcase ({ci; reloc = rtbl; finite=_; is_nat}, t, a, branches) ->
       let ind = ci.ci_ind in
       let mib = lookup_mind (fst ind) env.env in
       let oib = mib.mind_packets.(snd ind) in
+      let lbl_nat_s = if is_nat then Some (ref None) else None in
       let lbl_consts = Array.make oib.mind_nb_constant Label.no in
       let nallblock = oib.mind_nb_args + 1 in (* +1 : accumulate *)
       let nconst = Array.length branches.constant_branches in
@@ -715,7 +724,8 @@ let rec compile_lam env cenv lam sz cont =
       let branch1, cont = make_branch cont in
       (* Compilation of the return type *)
       let ret_env = { cenv with max_stack_size = ref 0 } in
-      let fcode = compile_lam env ret_env t sz [Kpop sz; Kstop] in
+      let fcode = Kpop sz :: Kstop :: [] in
+      let fcode = compile_lam env ret_env t sz fcode in
       let fcode = ensure_stack_capacity ret_env fcode in
       let lbl_typ,fcode = label_code fcode in
       let () = push_fun env fcode in
@@ -761,6 +771,13 @@ let rec compile_lam env cenv lam sz cont =
         let code_b =
             if tag < Obj.last_non_constant_constructor_tag then begin
                 set_max_stack_size cenv (sz_b + arity);
+                let code_b = match lbl_nat_s with
+                  | None -> code_b
+                  | Some l ->
+                    let lbl, c = label_code code_b in
+                    l := Some lbl;
+                    c
+                in
                 Kpushfields arity :: code_b
               end
             else begin
@@ -786,7 +803,16 @@ let rec compile_lam env cenv lam sz cont =
       in
       lbl_blocks.(0) <- lbl_accu;
 
-      c := Klabel lbl_sw :: Kswitch(lbl_consts,lbl_blocks) :: code_accu;
+      let kswitch = match lbl_nat_s with
+        | None -> Kswitch(lbl_consts,lbl_blocks)
+        | Some { contents = None } -> assert false
+        | Some { contents = Some l } ->
+          match lbl_consts, lbl_blocks with
+          | [|l0|], [|lAcc;lS|] ->
+            Kswitchnat(l0,lAcc,lS,l)
+          | _ -> assert false
+      in
+      c := Klabel lbl_sw :: kswitch :: code_accu;
       let code_sw =
         match branch1 with
         (* spiwack : branch1 can't be a lbl anymore it's a Branch instead

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -516,6 +516,7 @@ let emit_instr env = function
   | Kmakeblock(n, t) ->
       if 0 < n && n < 4 then (out env(opMAKEBLOCK1 + n - 1); out_int env t)
       else (out env opMAKEBLOCK; out_int env n; out_int env t)
+  | Kmakesucc -> out env opMAKESUCC
   | Kmakeswitchblock(typlbl,swlbl,annot,sz) ->
       out env opMAKESWITCHBLOCK;
       out_label env typlbl; out_label env swlbl;
@@ -530,6 +531,10 @@ let emit_instr env = function
       let org = env.out_position in
       Array.iter (out_label_with_orig env org) tbl_const;
       Array.iter (out_label_with_orig env org) tbl_block
+  | Kswitchnat (l0, lAcc, lS, lZ) ->
+    out env opSWITCHNAT;
+    let org = env.out_position in
+    Array.iter (out_label_with_orig env org) [|l0;lAcc;lS;lZ|]
   | Kpushfields n ->
       out env opPUSHFIELDS;out_int env n
   | Kfield n ->

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -358,6 +358,12 @@ external accumulate : unit -> tcode = "rocq_accumulate"
 external set_bytecode_field : Obj.t -> int -> tcode -> unit = "rocq_set_bytecode_field"
 let accumulate = accumulate ()
 
+external is_int64 : values -> bool = "rocq_is_int64"
+
+let nat_or_int64 v =
+  if is_int64 v then Vint64 (Obj.magic v)
+  else Vnat (Obj.magic v)
+
 let whd_val (v: values) =
   let o = Obj.repr v in
   if Obj.is_int o then Vconst (Obj.obj o)
@@ -375,7 +381,7 @@ let whd_val (v: values) =
       | VCfix -> Vfix (Obj.obj o, None)
       | VCfix_partial -> Vfix (Obj.obj (Obj.field o 2), Some (Obj.obj o))
       | VCaccu -> Vaccu (Aid (RelKey (int_tcode (fun_code o) 1)), [])
-    else if Int.equal tag Obj.custom_tag then Vint64 (Obj.magic v)
+    else if Int.equal tag Obj.custom_tag then nat_or_int64 v
     else if Int.equal tag Obj.double_tag then Vfloat64 (Obj.magic v)
     else if Int.equal tag Obj.string_tag then Vstring (Obj.magic v)
     else
@@ -651,6 +657,7 @@ and pr_kind w =
   | Vcofix _ -> str "Vcofix"
   | Vconst i -> str "Vconst(" ++ int i ++ str ")"
   | Vblock _b -> str "Vblock"
+  | Vnat n -> Format.sprintf "Vnat(%s)" (Z.to_string n) |> str
   | Vint64 i -> i |> Format.sprintf "Vint64(%LiL)" |> str
   | Vfloat64 f -> str "Vfloat64(" ++ str (Float64.(to_string (of_float f))) ++ str ")"
   | Vstring s -> Pstring.to_string s |> Format.sprintf "Vstring(%S)" |> str

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -54,7 +54,8 @@ let whd_in_concl =
 let sf_of env sigma c = ESorts.kind sigma (snd (sort_of env sigma c))
 
 let rec decompose_term env sigma t =
-    match EConstr.kind sigma (whd env sigma t) with
+    (* XXX more efficient Nat handling? *)
+    match EConstr.kind_nonat sigma (whd env sigma t) with
       App (f,args)->
         let tf=decompose_term env sigma f in
         let targs=Array.map (decompose_term env sigma) args in

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -411,7 +411,7 @@ let rec extract_type (table : Common.State.t) env sg db j c args =
             | (Info, TypeScheme) ->
               extract_type_app table env sg db (r, type_sign env sg ty) args
             | (Info, Default) -> Tunknown))
-    | Cast _ | LetIn _ | Construct _ | Int _ | Float _ | String _ | Array _ -> assert false
+    | Cast _ | LetIn _ | Construct _ | Nat _ | Int _ | Float _ | String _ | Array _ -> assert false
 
 (*s Auxiliary function dealing with type application.
   Precondition: [r] is a type scheme represented by the signature [s],
@@ -757,6 +757,10 @@ let rec extract_term table env sg mle mlt c args =
        let r = { glob = GlobRef.VarRef v; inst = InfvInst.empty } in
        let extract_var mlt = put_magic (mlt,vty) (MLglob r) in
        extract_app table env sg mle mlt extract_var args
+    | Nat (ind,n) ->
+      (* XXX extraction option to use zarith *)
+      assert (args = []);
+      extract_term table env sg mle mlt (EConstr.unfold_nat ind n) []
     | Int i -> assert (args = []); MLuint i
     | Float f -> assert (args = []); MLfloat f
     | String s -> assert (args = []); MLstring s

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -664,11 +664,12 @@ let build_proof (interactive_proof : bool) (fnames : Constant.t list) ptes_infos
           | _ -> do_finalize dyn_infos )
         | Cast (t, _, _) -> build_proof do_finalize {dyn_infos with info = t}
         | Const _ | Var _ | Meta _ | Evar _ | Sort _ | Construct _ | Ind _
-         |Int _ | Float _ | String _ ->
+        | Nat _ | Int _ | Float _ | String _ ->
           do_finalize dyn_infos
         | App (_, _) -> (
           let f, args = decompose_app_list sigma dyn_infos.info in
           match EConstr.kind sigma f with
+          | Nat _ -> user_err Pp.(str "nat cannot be applied")
           | Int _ -> user_err Pp.(str "integer cannot be applied")
           | Float _ -> user_err Pp.(str "float cannot be applied")
           | String _ -> user_err Pp.(str "string cannot be applied")

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -85,7 +85,7 @@ let is_rec names =
     match DAst.get gt with
     | GVar id -> check_id id names
     | GRef _ | GEvar _ | GPatVar _ | GSort _ | GHole _ | GGenarg _
-    | GInt _ | GFloat _ | GString _ ->
+    | GNat _ | GInt _ | GFloat _ | GString _ ->
       false
     | GCast (b, _, _) -> lookup names b
     | GRec _ -> CErrors.user_err (Pp.str "GRec not handled")

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -468,7 +468,7 @@ let rec build_entry_lc env sigma funnames avoid rt :
   observe (str " Entering : " ++ pr_glob_constr_env env rt);
   let open CAst in
   match DAst.get rt with
-  | GRef _ | GVar _ | GEvar _ | GPatVar _ | GSort _ | GHole _ | GGenarg _ | GInt _
+  | GRef _ | GVar _ | GEvar _ | GPatVar _ | GSort _ | GHole _ | GGenarg _ | GNat _ | GInt _
    |GFloat _ | GString _ ->
     (* do nothing (except changing type of course) *)
     mk_result [] rt avoid
@@ -574,6 +574,7 @@ let rec build_entry_lc env sigma funnames avoid rt :
       build_entry_lc env sigma funnames avoid (mkGApp (b, args))
     | GRec _ -> user_err Pp.(str "Not handled GRec")
     | GProd _ -> user_err Pp.(str "Cannot apply a type")
+    | GNat _ -> user_err Pp.(str "Cannot apply a nat")
     | GInt _ -> user_err Pp.(str "Cannot apply an integer")
     | GFloat _ -> user_err Pp.(str "Cannot apply a float")
     | GString _ -> user_err Pp.(str "Cannot apply a string")
@@ -1208,7 +1209,7 @@ let rec compute_cst_params relnames params gt =
   DAst.with_val
     (function
       | GRef _ | GVar _ | GEvar _ | GPatVar _
-      | GInt _ | GFloat _ | GString _ -> params
+      | GNat _ | GInt _ | GFloat _ | GString _ -> params
       | GApp (f, args) -> (
         match DAst.get f with
         | GVar relname' when Id.Set.mem relname' relnames ->

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -116,7 +116,7 @@ let change_vars =
             , Array.map (change_vars mapping) t
             , change_vars mapping def
             , change_vars mapping ty )
-        | GSort _ | GHole _ | GGenarg _ | GInt _ | GString _ as x -> x)
+        | GSort _ | GHole _ | GGenarg _ | GNat _ | GInt _ | GString _ as x -> x)
       rt
   and change_vars_br mapping ({CAst.loc; v = idl, patl, res} as br) =
     let new_mapping = List.fold_right Id.Map.remove idl mapping in
@@ -284,7 +284,7 @@ let rec alpha_rt excluded rt =
         , alpha_rt excluded lhs
         , alpha_rt excluded rhs )
     | GRec _ -> user_err Pp.(str "Not handled GRec")
-    | (GSort _ | GInt _ | GFloat _ | GString _ | GHole _ | GGenarg _) as rt -> rt
+    | (GSort _ | GNat _ | GInt _ | GFloat _ | GString _ | GHole _ | GGenarg _) as rt -> rt
     | GCast (b, k, c) ->
       GCast (alpha_rt excluded b, k, alpha_rt excluded c)
     | GApp (f, args) ->
@@ -347,7 +347,7 @@ let is_free_in id =
         | GGenarg _ -> false (* XXX isn't this incorrect? *)
         | GCast (b, _, t) ->
           is_free_in b || is_free_in t
-        | GInt _ | GFloat _ | GString _ -> false
+        | GNat _ | GInt _ | GFloat _ | GString _ -> false
         | GArray (_u, t, def, ty) ->
           Array.exists is_free_in t || is_free_in def || is_free_in ty)
       x
@@ -423,6 +423,7 @@ let replace_var_by_term x_id term =
             , replace_var_by_pattern rhs )
         | GRec _ -> CErrors.user_err (Pp.str "Not handled GRec")
         | (GSort _ | GHole _ | GGenarg _) as rt -> rt (* is this correct for GGenarg? *)
+        | GNat _ as rt -> rt
         | GInt _ as rt -> rt
         | GFloat _ as rt -> rt
         | GString _ as rt -> rt
@@ -506,7 +507,7 @@ let expand_as =
   in
   let rec expand_as map =
     DAst.map (function
-      | (GRef _ | GEvar _ | GPatVar _ | GSort _ | GHole _ | GGenarg _ | GInt _
+      | (GRef _ | GEvar _ | GPatVar _ | GSort _ | GHole _ | GGenarg _ | GNat _ | GInt _
          | GFloat _ | GString _ ) as rt -> rt
       | GVar id as rt -> (
         try DAst.get (Id.Map.find id map) with Not_found -> rt )

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -241,7 +241,7 @@ let check_not_nested env sigma forbidden e =
   let rec check_not_nested e =
     match EConstr.kind sigma e with
     | Rel _ -> ()
-    | Int _ | Float _ | String _ -> ()
+    | Nat _ | Int _ | Float _ | String _ -> ()
     | Var x ->
       if Id.List.mem x forbidden then
         user_err
@@ -460,14 +460,14 @@ let rec travel_aux jinfo continuation_tac (expr_info : constr infos) =
           | Fix _ -> user_err Pp.(str "Function cannot treat local fixpoint or cofixpoint")
           | Proj _ -> user_err Pp.(str "Function cannot treat projections")
           | Lambda _ | Cast _ | LetIn _
-          | CoFix _ | Array _ | Int _ | Float _ | String _ ->
+          | CoFix _ | Array _ | Nat _ | Int _ | Float _ | String _ ->
             anomaly
               ( Pp.str "travel_aux : unexpected "
               ++ Printer.pr_leconstr_env env sigma expr_info.info
               ++ Pp.str "." ) )
       | Cast (t, _, _) -> travel jinfo continuation_tac {expr_info with info = t}
       | Const _ | Var _ | Meta _ | Evar _ | Sort _ | Construct _ | Ind _
-       |Int _ | Float _ | String _ ->
+       | Nat _ | Int _ | Float _ | String _ ->
         let new_continuation_tac = jinfo.otherS () expr_info continuation_tac in
         new_continuation_tac expr_info)
 

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -146,7 +146,7 @@ let is_ind x =
 
 let is_constructor x =
   Proofview.tclEVARMAP >>= fun sigma ->
-  match EConstr.kind sigma x with
+  match EConstr.kind_nonat sigma x with
     | Construct _ -> Proofview.tclUNIT ()
     | _ -> Tacticals.tclFAIL (Pp.str "not a constructor")
 

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -484,7 +484,8 @@ let () =
 let () =
   define "constr_kind" (constr @-> eret valexpr) @@ fun c env sigma ->
   let open Constr in
-  match EConstr.kind sigma c with
+  match EConstr.kind_nonat sigma c with
+  | Nat _ -> assert false (* kind_nonat, XXX change ltac2 type kind or add is_nat API *)
   | Rel n ->
     v_blk 0 [|Tac2ffi.of_int n|]
   | Var id ->

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -329,7 +329,7 @@ exception ParseError
 (* A simple but useful getter function *)
 
 let get_left_construct sigma term =
-  match EConstr.kind sigma term with
+  match EConstr.kind_nonat sigma term with
   | Construct ((_, i), _) -> (i, [||])
   | App (l, rst) -> (
     match EConstr.kind sigma l with
@@ -387,7 +387,7 @@ let dump_n x =
    *)
 
 let is_declared_term env evd t =
-  match EConstr.kind evd t with
+  match EConstr.kind_nonat evd t with
   | Const _ | Construct _ -> (
     (* Restrict typeclass resolution to trivial cases *)
     let typ = Retyping.get_type_of env evd t in
@@ -400,7 +400,7 @@ let is_declared_term env evd t =
   | _ -> false
 
 let rec is_ground_term env evd term =
-  match EConstr.kind evd term with
+  match EConstr.kind_nonat evd term with
   | App (c, args) ->
     is_declared_term env evd c && Array.for_all (is_ground_term env evd) args
   | Const _ | Construct _ -> is_declared_term env evd term

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -93,6 +93,10 @@ let rec find_option pred l =
   | [] -> raise Not_found
   | e :: l -> ( match pred e with Some r -> r | None -> find_option pred l )
 
+(* Nat handling is quite adhoc, could probably be improved *)
+let destRef_nonat evd h =
+  EConstr.(destRef evd (of_kind @@ kind_nonat evd h))
+
 module ConstrMap = struct
   open Names.GlobRef
 
@@ -104,11 +108,11 @@ module ConstrMap = struct
   let empty = Map.empty
 
   let find evd h m =
-    match Map.find (fst (EConstr.destRef evd h)) m with
+    match Map.find (fst (destRef_nonat evd h)) m with
     | e :: _ -> e
     | [] -> assert false
 
-  let find_all evd h m = Map.find (fst (EConstr.destRef evd h)) m
+  let find_all evd h m = Map.find (fst (destRef_nonat evd h)) m
 
   let fold f m acc =
     Map.fold
@@ -512,6 +516,7 @@ module ECstOp = struct
   let isConstruct evd c =
     match EConstr.kind evd c with
     | Construct _ | Int _ | Float _ -> true
+    | Nat (_,n) -> Z.equal n Z.zero
     | _ -> false
 
   let mk_elt evd i a =
@@ -641,7 +646,7 @@ module MakeTable (E : Elt) : S = struct
 
   let safe_ref evd c =
     try
-      fst (EConstr.destRef evd c)
+      fst (destRef_nonat evd c)
     with DestKO -> CErrors.user_err Pp.(str "Add Zify "++str E.name ++ str ": the term "++
                                           gl_pr_constr c ++ str " should be a global reference")
 
@@ -1056,7 +1061,7 @@ let is_arrow env evd a p1 p2 =
      The function also transforms (x -> y) as (arrow x y) *)
 let get_operator barrow env evd e =
   let e' = EConstr.whd_evar evd e in
-  match EConstr.kind evd e' with
+  match EConstr.kind_nonat evd e' with
   | Prod (a, p1, p2) ->
     if barrow && is_arrow env evd a p1 p2 then (arrow, [|p1; p2|], false)
     else raise Not_found

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -160,7 +160,10 @@ exception NoProgress
 
 let unif_EQ env sigma p c =
   let env = Environ.set_universes (Evd.universes sigma) env in
-  Reductionops.is_conv env sigma p c
+  try Reductionops.is_conv env sigma p c
+  with Reductionops.AnomalyInConversion _ ->
+    (* terms are in general not at the same type *)
+    false
 
 let unif_EQ_args env sigma pa a =
   let n = Array.length pa in

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -359,7 +359,8 @@ let unify_HO env sigma0 t1 t2 =
   Evd.set_ustate sigma uc
 
 (* This is what the definition of iter_constr should be... *)
-let iter_constr_LR sigma f c = match EConstr.kind sigma c with
+let iter_constr_LR sigma f c = match EConstr.kind_nonat sigma c with
+  | Nat _ -> assert false  (* nonat *)
   | Evar (k, a) -> SList.Skip.iter f a
   | Cast (cc, _, t) -> f cc; f t
   | Prod (_, t, b) | Lambda (_, t, b)  -> f t; f b
@@ -372,7 +373,7 @@ let iter_constr_LR sigma f c = match EConstr.kind sigma c with
   | Proj(_,_,a) -> f a
   | Array(_u,t,def,ty) -> Array.iter f t; f def; f ty
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _
-     | Int _ | Float _ | String _) -> ()
+    | Int _ | Float _ | String _) -> ()
 
 (* The comparison used to determine which subterms matches is KEYED        *)
 (* CONVERSION. This looks for convertible terms that either have the same  *)
@@ -426,7 +427,7 @@ let proj_nparams env c =
   with Not_found -> 0
 
 let isRigid sigma c = match EConstr.kind sigma c with
-  | (Prod _ | Sort _ | Lambda _ | Case _ | Fix _ | CoFix _| Int _
+  | (Prod _ | Sort _ | Lambda _ | Case _ | Fix _ | CoFix _| Nat _ | Int _
     | Float _ | String _ | Array _) -> true
   | (Rel _ | Var _ | Meta _ | Evar (_, _) | Cast (_, _, _) | LetIn (_, _, _, _)
     | App (_, _) | Const (_, _) | Ind ((_, _), _) | Construct (((_, _), _), _)

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1855,6 +1855,7 @@ let build_inversion_problem ~program_mode loc env sigma tms t =
         let l = List.lastn n (Array.to_list v) in
         let l,acc = List.fold_right_map reveal_pattern l acc in
         DAst.make (PatCstr (cstr,l,Anonymous)), acc
+    | Nat (ind,n) -> reveal_pattern (EConstr.unfold_nat ind n) acc
     | _ -> make_patvar t acc in
   let rec aux n env acc_sign tms acc =
     match tms with

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -16,6 +16,8 @@ open Esubst
 
 (**** Call by value reduction ****)
 
+type optimized_def = Add | Mul | Sub | Div2r
+
 (* The type of terms with closure. The meaning of the constructors and
  * the invariants of this datatype are the following:
  *  VAL(k,c) represents the constr c with a delayed shift of k. c must be
@@ -45,6 +47,7 @@ open Esubst
 type cbv_value =
   | VAL of int * constr
   | STACK of int * cbv_value * cbv_stack
+  | OPTIMIZED of optimized_def * cbv_value
   | LAMBDA of int * (Name.t Constr.binder_annot * types) list * constr * cbv_value subs
   | PROD of Name.t Constr.binder_annot * types * types * cbv_value subs
   | LETIN of Name.t Constr.binder_annot * cbv_value * types * constr * cbv_value subs
@@ -52,6 +55,7 @@ type cbv_value =
   | COFIX of cofixpoint * cbv_value subs * cbv_value list
   | CONSTRUCT of constructor UVars.puniverses * cbv_value list
   | PRIMITIVE of CPrimitives.t * pconstant * cbv_value list
+  | NAT of inductive * Z.t
   | ARRAY of UVars.Instance.t * cbv_value Parray.t * cbv_value
   | SYMBOL of { cst: Constant.t UVars.puniverses; unfoldfix: bool; rules: Declarations.machine_rewrite_rule list; stk: cbv_stack }
 
@@ -88,6 +92,7 @@ and cbv_stack =
 let rec shift_value n = function
   | VAL (k,t) -> VAL (k+n,t)
   | STACK(k,v,stk) -> STACK(k+n,v,stk)
+  | OPTIMIZED (o, v) -> OPTIMIZED (o, shift_value n v) (* XXX could rely on optimized values always being closed *)
   | PROD (na,t,u,s) -> PROD(na,t,u,subs_shft(n,s))
   | LETIN (na,b,t,c,s) -> LETIN(na,shift_value n b,t,c,subs_shft(n,s))
   | LAMBDA (nlams,ctxt,b,s) -> LAMBDA (nlams,ctxt,b,subs_shft (n,s))
@@ -99,6 +104,7 @@ let rec shift_value n = function
       CONSTRUCT (c, List.map (shift_value n) args)
   | PRIMITIVE(op,c,args) ->
       PRIMITIVE(op,c,List.map (shift_value n) args)
+  | NAT _ as v -> v
   | ARRAY (u,t,ty) ->
       ARRAY(u, Parray.map (shift_value n) t, shift_value n ty)
   | SYMBOL s -> SYMBOL { s with stk = shift_stack n s.stk }
@@ -192,7 +198,8 @@ let strip_appl head stack =
     | COFIX (cofix,env,app) -> (COFIX(cofix,env,[]), stack_app app stack)
     | CONSTRUCT (c,app) -> (CONSTRUCT(c,[]), stack_app app stack)
     | PRIMITIVE(op,c,app) -> (PRIMITIVE(op,c,[]), stack_app app stack)
-    | LETIN _ | VAL _ | STACK _ | PROD _ | LAMBDA _ | ARRAY _ | SYMBOL _ -> (head, stack)
+    | OPTIMIZED _ | LETIN _ | VAL _ | STACK _ | PROD _ | LAMBDA _
+    | NAT _ | ARRAY _ | SYMBOL _ -> (head, stack)
 
 let destack head stack =
   match head with
@@ -202,7 +209,7 @@ let destack head stack =
   | PRIMITIVE(op,c,app) -> (PRIMITIVE(op,c,[]), stack_app app stack)
   | STACK (k, v, stk) -> (shift_value k v, stack_concat (shift_stack k stk) stack)
   | SYMBOL ({ stk } as s) -> (SYMBOL { s with stk=TOP }, stack_concat stk stack)
-  | LETIN _ | VAL _ | PROD _ | LAMBDA _ | ARRAY _ -> (head, stack)
+  | OPTIMIZED _ | LETIN _ | VAL _ | PROD _ | LAMBDA _ | NAT _ | ARRAY _ -> (head, stack)
 
 let rec fixp_reducible_symb_stk = function
   | TOP -> true
@@ -218,7 +225,7 @@ let fixp_reducible flgs ((reci,i),_) stk =
         | [] -> false
         | v :: appl ->
           if Int.equal n 0 then match v with
-          | CONSTRUCT _ -> true
+          | CONSTRUCT _ | NAT _ -> true
           | SYMBOL { unfoldfix=true; stk; _ } ->
               fixp_reducible_symb_stk stk
           | _ -> false
@@ -412,6 +419,7 @@ and reify_value = function (* reduction under binders *)
       reify_stack (reify_value v) stk
   | STACK (n,v,stk) ->
       lift n (reify_stack (reify_value v) stk)
+  | OPTIMIZED (_, v) -> reify_value v
   | PROD(na,t,u,env) ->
     apply_env env (mkProd (na,t,u))
   | LETIN(na,b,t,c,env) ->
@@ -430,6 +438,7 @@ and reify_value = function (* reduction under binders *)
       mkApp(mkConstructU c, Array.map_of_list reify_value args)
   | PRIMITIVE(op,c,args) ->
       mkApp(mkConstU c, Array.map_of_list reify_value args)
+  | NAT (ind,n) -> mkNat ind n
   | ARRAY (u,t,ty) ->
     let t, def = Parray.to_array t in
       mkArray(u, Array.map reify_value t, reify_value def, reify_value ty)
@@ -489,6 +498,36 @@ let cbv_subst_of_rel_context_instance_list mkclos sign args env =
     | [], [] -> subst
     | _ -> CErrors.anomaly (Pp.str "Instance and signature do not match.")
   in aux env (List.rev sign) args
+
+let is_optimized_constant env cst =
+  List.find_map (fun (s,o) ->
+      if Option.equal (Environ.QGlobRef.equal env)
+          (Some (GlobRef.ConstRef cst))
+          (Rocqlib.lib_ref_opt s)
+      then Some o
+      else None)
+    [
+      "cbv.add", Add;
+      "cbv.mul", Mul;
+      (* tail_mul and mul behave the same on canonical inputs *)
+      "cbv.tail_mul", Mul;
+      "cbv.sub", Sub;
+      "cbv.div2r", Div2r;
+    ]
+
+let sub n m =
+  if Z.leq n m then Z.zero
+  else Z.sub n m
+
+let div2r n = Z.sub n (Z.div n (Z.of_int 2))
+
+let run_optimized_def opt stk =
+  match opt, stk with
+  | Add, APP ([NAT (ind,n); NAT (_,m)], stk) -> Some (NAT (ind,Z.add n m), stk)
+  | Mul, APP ([NAT (ind,n); NAT (_,m)], stk) -> Some (NAT (ind,Z.mul n m), stk)
+  | Sub, APP ([NAT (ind,n); NAT (_,m)], stk) -> Some (NAT (ind,sub n m), stk)
+  | Div2r, APP ([NAT (ind,n)], stk) -> Some (NAT (ind, div2r n), stk)
+  | (Add | Mul | Sub | Div2r), _ -> None
 
 (* The main recursive functions
  *
@@ -572,7 +611,13 @@ let rec norm_head info env t stack =
       (LAMBDA(List.length ctxt, List.rev ctxt,b,env), stack)
   | Fix fix -> (FIX(fix,env,[]), stack)
   | CoFix cofix -> (COFIX(cofix,env,[]), stack)
-  | Construct c -> (CONSTRUCT(c, []), stack)
+  | Construct ((ind,j),_ as c) ->
+    if Environ.is_nat info.env ind then match j, stack with
+      | 1, _ -> NAT (ind,Z.zero), stack
+      | 2, APP ([NAT (ind,n)], stack) -> NAT (ind,Z.succ n), stack
+      | 2, _ -> (CONSTRUCT(c, []), stack)
+      | _ -> assert false
+    else (CONSTRUCT(c, []), stack)
 
   | Array(u,t,def,ty) ->
     let ty = cbv_stack_term info TOP env ty in
@@ -582,6 +627,8 @@ let rec norm_head info env t stack =
       (fun i -> cbv_stack_term info TOP env t.(i))
       (cbv_stack_term info TOP env def) in
     (ARRAY (u,t,ty), stack)
+
+  | Nat (ind,n) -> (NAT (ind,n), stack)
 
   (* neutral cases *)
   | (Sort _ | Meta _ | Ind _ | Int _ | Float _ | String _) -> (VAL(0, t), stack)
@@ -654,6 +701,26 @@ and cbv_stack_value info env = function
     let (envf,redfix) = contract_cofixp env cofix in
     cbv_stack_term info stk envf redfix
 
+  | OPTIMIZED (opt, v), stk ->
+    begin match run_optimized_def opt stk with
+    | None -> cbv_stack_value info env (v, stk)
+    | Some v -> cbv_stack_value info env v
+    end
+
+  (* constructor in a Case -> IOTA *)
+  | (CONSTRUCT(((sp,n),_),[]), APP(args,CASE(u,pms,_p,br,iv,ci,env,stk)))
+    when red_set info.reds fMATCH ->
+    let cargs = List.skipn ci.ci_npar args in
+    let env =
+      if (Int.equal ci.ci_cstr_ndecls.(n - 1) ci.ci_cstr_nargs.(n - 1)) then (* no lets *)
+        List.fold_left (fun accu v -> subs_cons v accu) env cargs
+      else
+        let mkclos env c = cbv_stack_term info TOP env c in
+        let ctx = expand_branch info.env u pms (sp, n) br in
+        cbv_subst_of_rel_context_instance_list mkclos ctx cargs env
+    in
+    cbv_stack_term info stk env (snd br.(n-1))
+
   (* constructor in a Case -> IOTA *)
   | (CONSTRUCT(((sp,n),_),[]), APP(args,CASE(u,pms,_p,br,iv,ci,env,stk)))
     when red_set info.reds fMATCH ->
@@ -681,6 +748,16 @@ and cbv_stack_value info env = function
     in
     cbv_stack_term info stk env (snd br.(n-1))
 
+  (* unlike CONSTRUCT this is the only NAT case (no APP/PROJ at the head of the stack by typing) *)
+  | NAT (ind,n), CASE (_,_,_,br,_,_,env,stk) when red_set info.reds fMATCH ->
+    if Z.equal n Z.zero then
+      let _, br = br.(0) in
+      cbv_stack_term info stk env br
+    else
+      let env = subs_cons (NAT (ind,Z.pred n)) env in
+      let _, br = br.(1) in
+      cbv_stack_term info stk env br
+
   (* constructor in a Projection -> IOTA *)
   | (CONSTRUCT(((sp,n),u),[]), APP(args,PROJ(p,_,stk)))
     when red_set info.reds fMATCH && Projection.unfolded p ->
@@ -690,6 +767,8 @@ and cbv_stack_value info env = function
   (* may be reduced later by application *)
   | (FIX(fix,env,[]), APP(appl,TOP)) -> FIX(fix,env, appl)
   | (COFIX(cofix,env,[]), APP(appl,TOP)) -> COFIX(cofix,env, appl)
+  | CONSTRUCT (((ind,2),_),[]), APP([NAT (ind',n)], TOP) when Environ.QInd.equal info.env ind ind' ->
+    NAT (ind,Z.succ n)
   | (CONSTRUCT(c,[]), APP(appl,TOP)) -> CONSTRUCT(c, appl)
 
   (* primitive apply to arguments *)
@@ -728,23 +807,34 @@ and cbv_value_cache info ref =
     Not_found ->
     let v =
       try
-        let body = match ref with
+        let body, opt = match ref with
           | RelKey n ->
             let open Context.Rel.Declaration in
-            begin match Environ.lookup_rel n info.env with
+            let body =
+              begin match Environ.lookup_rel n info.env with
               | LocalDef (_, c, _) -> lift n c
               | LocalAssum _ -> raise Not_found
-            end
+              end
+            in
+            body, None
           | VarKey id ->
             let open Context.Named.Declaration in
-            begin match Environ.lookup_named id info.env with
+            let body =
+              begin match Environ.lookup_named id info.env with
               | LocalDef (_, c, _) -> c
               | LocalAssum _ -> raise Not_found
-            end
+              end
+            in
+            body, None
           | ConstKey (cst, u) ->
-            EConstr.Unsafe.to_constr @@ EConstr.constant_value_in info.env info.sigma (cst, EConstr.EInstance.make u)
+            let body = EConstr.Unsafe.to_constr @@
+              EConstr.constant_value_in info.env info.sigma (cst, EConstr.EInstance.make u)
+            in
+            let opt = is_optimized_constant info.env cst in
+            body, opt
         in
         let v = cbv_stack_term info TOP (subs_id 0) body in
+        let v = match opt with None -> v | Some opt -> OPTIMIZED (opt, v) in
         Declarations.Def v
       with
       | Environ.NotEvaluableConst (Environ.IsPrimitive (_u,op)) -> Declarations.Primitive op
@@ -951,6 +1041,7 @@ and cbv_norm_value info = function
       apply_stack info (cbv_norm_value info v) stk
   | STACK (n,v,stk) ->
       lift n (apply_stack info (cbv_norm_value info v) stk)
+  | OPTIMIZED (_, v) -> cbv_norm_value info v
   | PROD(na,t,u,env) ->
       mkProd (na,cbv_norm_term info env t,cbv_norm_term info (subs_lift env) u)
   | LETIN (na,b,t,c,env) ->
@@ -981,6 +1072,7 @@ and cbv_norm_value info = function
       mkApp(mkConstructU c, Array.map_of_list (cbv_norm_value info) args)
   | PRIMITIVE(op,c,args) ->
       mkApp(mkConstU c,Array.map_of_list (cbv_norm_value info) args)
+  | NAT (ind,n) -> mkNat ind n
   | ARRAY (u,t,ty) ->
     let ty = cbv_norm_value info ty in
     let t, def = Parray.to_array t in

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -312,23 +312,6 @@ let matches_core env sigma allow_bound_rels (binding_vars, pat) c =
     | _ -> raise PatternMatchingFailure
     end
 
-  | PApp (c1, arg1), App (c2, arg2) ->
-    begin match c1, EConstr.kind sigma c2 with
-    | PRef (GlobRef.ConstRef r), Proj (pr,_,c) when not (Environ.QConstant.equal env r (Projection.constant pr)) ->
-      raise PatternMatchingFailure
-    | PProj (pr1,c1), Proj (pr,_,c) ->
-      let () = if not (Int.equal (Array.length arg1) (Array.length arg2) && Environ.QProjection.equal env pr1 pr) then raise PatternMatchingFailure in
-      Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c) arg1 arg2
-    | _, Proj (pr,_,c) ->
-      begin match Retyping.expand_projection env sigma pr c (Array.to_list arg2) with
-      | term -> sorec ctx env subst p term
-      | exception Retyping.RetypeError _ -> raise PatternMatchingFailure
-      end
-    | _ ->
-      let () = if not (Int.equal (Array.length arg1) (Array.length arg2)) then raise PatternMatchingFailure in
-      Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c2) arg1 arg2
-    end
-
   | PApp (c, args), Proj (pr, _, c2) ->
     begin match c with
     | PRef (GlobRef.ConstRef c1) when not (Environ.QConstant.equal env c1 (Projection.constant pr)) ->
@@ -343,6 +326,50 @@ let matches_core env sigma allow_bound_rels (binding_vars, pat) c =
   | PProj (p1, c1), Proj (p2, _, c2) ->
     if Environ.QProjection.equal env p1 p2 then sorec ctx env subst c1 c2
     else raise PatternMatchingFailure
+
+  | PApp (c1, arg1), App (c2, arg2) when isProj sigma c2 ->
+    let (pr, _, c) = destProj sigma c2 in
+    begin match c1 with
+    | PRef (GlobRef.ConstRef r) when not (Environ.QConstant.equal env r (Projection.constant pr)) ->
+      raise PatternMatchingFailure
+    | PProj (pr1,c1) ->
+      let () = if not (Int.equal (Array.length arg1) (Array.length arg2) && Environ.QProjection.equal env pr1 pr) then raise PatternMatchingFailure in
+      Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c) arg1 arg2
+    | _ ->
+      begin match Retyping.expand_projection env sigma pr c (Array.to_list arg2) with
+      | term -> sorec ctx env subst p term
+      | exception Retyping.RetypeError _ -> raise PatternMatchingFailure
+      end
+    end
+
+  | PNat (ind1,n1), Nat (ind2,n2) ->
+    if Z.equal n1 n2 && Environ.QInd.equal env ind1 ind2 then subst
+    else raise PatternMatchingFailure
+
+  | PNat (ind,n), Construct ((ind',1),_) ->
+    if Z.equal n Z.zero && Environ.QInd.equal env ind ind' then subst
+    else raise PatternMatchingFailure
+
+  | PNat (ind,n), App (c2, arg2) ->
+    if Array.length arg2 <> 1 then raise PatternMatchingFailure
+    else begin match kind sigma c2 with
+      | Construct ((ind',2),_) when Environ.QInd.equal env ind ind' ->
+        sorec ctx env subst (PNat (ind,Z.pred n)) arg2.(0)
+      | _ -> raise PatternMatchingFailure
+    end
+
+  | PRef (ConstructRef (ind,1)), Nat (ind',n) ->
+    if Z.equal n Z.zero && Environ.QInd.equal env ind ind' then subst
+    else raise PatternMatchingFailure
+
+  | PApp (_, arg1), Nat (ind',n) ->
+    if Z.equal n Z.zero || Array.length arg1 <> 1 then
+      raise PatternMatchingFailure
+    else sorec ctx env subst p (EConstr.unfold_nat ind' n)
+
+  | PApp (c1, arg1), App (c2, arg2) ->
+    let () = if not (Int.equal (Array.length arg1) (Array.length arg2)) then raise PatternMatchingFailure in
+    Array.fold_left2 (sorec ctx env) (sorec ctx env subst c1 c2) arg1 arg2
 
   | PProd (na1, c1, d1), Prod (na2, c2, d2) ->
     sorec (push_binder na1 na2 c2 ctx) (EConstr.push_rel (LocalAssum (na2,c2)) env)
@@ -460,7 +487,7 @@ let matches_core env sigma allow_bound_rels (binding_vars, pat) c =
 
   | (PRef _ | PVar _ | PRel _ | PApp _ | PProj _ | PLambda _
       | PProd _ | PLetIn _ | PSort _ | PIf _ | PCase _
-      | PFix _ | PCoFix _| PEvar _ | PInt _ | PFloat _
+      | PFix _ | PCoFix _| PEvar _ | PNat _ | PInt _ | PFloat _
       | PString _ | PArray _), _ -> raise PatternMatchingFailure
 
   | PExtra e, _ -> Util.Empty.abort e
@@ -526,7 +553,8 @@ let sub_match ?(closed=true) env sigma pat c =
   let open EConstr in
   let rec aux env c mk_ctx next =
   let here = authorized_occ env sigma closed pat c mk_ctx in
-  let next () = match EConstr.kind sigma c with
+  let next () = match EConstr.kind_nonat sigma c with
+  | Nat _ -> assert false (* nonat *)
   | Cast (c1,k,c2) ->
       let next_mk_ctx = function
       | [c1] -> mk_ctx (mkCast (c1, k, c2))

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -342,6 +342,7 @@ let computable sigma (nas, ccl) =
        sinon on perd la réciprocité de la synthèse (qui, lui,
        engendrera un prédicat non dépendant) *)
 
+  not !Flags.in_debugger &&
   noccur_between sigma 1 (Array.length nas) ccl
 
 let lookup_name_as_displayed env sigma t s =
@@ -918,6 +919,7 @@ and detype_r d flags avoid env sigma t =
           avoid env sigma case
     | Fix (nvn,recdef) -> detype_fix (detype d) flags avoid env sigma nvn recdef
     | CoFix (n,recdef) -> detype_cofix (detype d) flags avoid env sigma n recdef
+    | Nat (ind,n) -> GNat (ind,n)
     | Int i -> GInt i
     | Float f -> GFloat f
     | String s -> GString s
@@ -1112,6 +1114,7 @@ let rec subst_glob_constr env subst = DAst.map (function
   | GSort _
   | GVar _
   | GEvar _
+  | GNat _
   | GInt _
   | GFloat _
   | GString _

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -180,7 +180,7 @@ let flex_kind_of_term flags env evd c sk =
        else Rigid
     | Evar ev ->
        if is_evar_allowed flags (fst ev) then Flexible ev else Rigid
-    | Lambda _ | Prod _ | Sort _ | Ind _ | Int _ | Float _ | String _ | Array _ -> Rigid
+    | Lambda _ | Prod _ | Sort _ | Ind _ | Nat _ | Int _ | Float _ | String _ | Array _ -> Rigid
     | Construct _ | CoFix _ (* Incorrect: should check only app in sk *) -> Rigid
     | Meta _ -> Rigid
     | Fix _ -> Rigid (* happens when the fixpoint is partially applied (should check it?) *)
@@ -265,7 +265,7 @@ let occur_rigidly flags env evd (evk,_) t =
       (match aux c with
       | Rigid b -> Rigid b
       | _ -> Reducible)
-    | Meta _ | Fix _ | CoFix _ | Int _ | Float _ | String _ | Array _ -> Reducible
+    | Meta _ | Fix _ | CoFix _ | Nat _ | Int _ | Float _ | String _ | Array _ -> Reducible
   in
     match aux t with
     | Rigid b -> b
@@ -1194,7 +1194,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
              only if necessary) or the second argument is potentially
              usable as a canonical projection or canonical value *)
           let rec is_unnamed (hd, args) = match EConstr.kind i hd with
-            | (Var _|Construct _|Ind _|Const _|Prod _|Sort _|Int _ |Float _|String _|Array _) ->
+            | (Var _|Construct _|Ind _|Const _|Prod _|Sort _|Nat _|Int _ |Float _|String _|Array _) ->
               Stack.not_purely_applicative args
             | (CoFix _|Meta _|Rel _)-> true
             | Evar _ -> Stack.not_purely_applicative args
@@ -1339,6 +1339,23 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
         | Array _, Array _ ->
           rigids env evd sk1 term1 sk2 term2
 
+        | Nat (ind1,n1), Nat (ind2,n2) ->
+          if Z.equal n1 n2 && QInd.equal env ind1 ind2 then
+            exact_ise_stack2 env evd (evar_conv_x flags) sk1 sk2
+          else UnifFailure (evd, NotSameHead)
+
+        | Nat (ind1,n1), Construct _ ->
+          let term1 = EConstr.unfold_nat ind1 n1 in
+          let term1, pred1 = decompose_app evd term1 in
+          let sk1 = Stack.append_app pred1 sk1 in
+          rigids env evd sk1 term1 sk2 term2
+
+        | Construct _, Nat (ind2,n2) ->
+          let term2 = EConstr.unfold_nat ind2 n2 in
+          let term2, pred2 = decompose_app evd term2 in
+          let sk2 = Stack.append_app pred2 sk2 in
+          rigids env evd sk1 term1 sk2 term2
+
         | Evar (sp1,al1), Evar (sp2,al2) -> (* Frozen evars *)
           if Evar.equal sp1 sp2 then
             match ise_stack2 false env evd (evar_conv_x flags) sk1 sk2 with
@@ -1413,9 +1430,9 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
           | None -> UnifFailure (evd,NotSameHead)
           end
 
-        | (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Int _ | Float _ | String _ | Array _ | Evar _ | Lambda _), _ ->
+        | (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Nat _ | Int _ | Float _ | String _ | Array _ | Evar _ | Lambda _), _ ->
           UnifFailure (evd,NotSameHead)
-        | _, (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Int _ | Array _ | Evar _ | Lambda _) ->
+        | _, (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Nat _ | Int _ | Array _ | Evar _ | Lambda _) ->
           UnifFailure (evd,NotSameHead)
         | Case _, _ -> UnifFailure (evd,NotSameHead)
         | Proj _, _ -> UnifFailure (evd,NotSameHead)

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -724,12 +724,16 @@ type esubst = {
   (** Reverse map of indices in [ealias] containing the corresponding alias *)
 }
 
-let make_constructor_subst sigma sign args =
+let make_constructor_subst env sigma sign args =
   let rec fold decls args accu = match decls, SList.view args with
   | _ :: _, None | [], Some _ -> assert false
   | [], None -> accu
   | LocalAssum ({ binder_name = id }, _) :: decls, Some (Some a, args) ->
     let accu = fold decls args accu in
+    let a = match EConstr.kind sigma a with
+      | Nat (ind,n) -> EConstr.unfold_nat ind n
+      | _ -> a
+    in
     let a', args = decompose_app sigma a in
     begin match EConstr.kind sigma a' with
     | Construct (cstr, _) ->
@@ -1641,7 +1645,7 @@ let rec invert_definition unify flags choose imitate_defs
   let progress = ref false in
   let aliases = make_alias_map env evd in
   let subst = make_projectable_subst aliases evd sign argsv in
-  let cstr_subst = make_constructor_subst evd sign argsv in
+  let cstr_subst = make_constructor_subst env evd sign argsv in
 
   (* Projection *)
   let project_variable t =
@@ -1759,6 +1763,10 @@ let rec invert_definition unify flags choose imitate_defs
     | _ ->
         progress := true;
         match
+          let t = match EConstr.kind !evdref t with
+            | Nat (ind,n) -> EConstr.unfold_nat ind n
+            | _ -> t
+          in
           let c,args = decompose_app !evdref t in
           match EConstr.kind !evdref c with
           | Construct (cstr,u) when noccur_between !evdref 1 k t ->

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -34,6 +34,12 @@ let cases_predicate_names tml =
     | (tm,(na,None)) -> [na]
     | (tm,(na,Some {v=(_,nal)})) -> na::nal) tml)
 
+let unfold_nat ?loc ind n =
+  let mk c = DAst.make ?loc c in
+  let ctor = mk @@ GRef (ConstructRef (Constr.ctor_of_nat ind n), None) in
+  if Z.equal n Z.zero then ctor
+  else mk @@ GApp (ctor, [mk @@ GNat (ind, Z.pred n)])
+
 let mkGApp ?loc p l = DAst.make ?loc @@
   match DAst.get p with
   | GApp (f,l') -> GApp (f,l'@l)
@@ -213,6 +219,7 @@ let mk_glob_constr_eq f g c1 c2 = match DAst.get c1, DAst.get c2 with
     GlobRef.(CanOrd.equal (ConstRef cst1) (ConstRef cst2)) &&
     Option.equal instance_eq u1 u2 &&
     List.equal f args1 args2 && f c1 c2
+  | GNat (ind1,i1), GNat (ind2,i2) -> Z.equal i1 i2 && Ind.CanOrd.equal ind1 ind2
   | GInt i1, GInt i2 -> Uint63.equal i1 i2
   | GFloat f1, GFloat f2 -> Float64.equal f1 f2
   | GString s1, GString s2 -> Pstring.equal s1 s2
@@ -221,7 +228,7 @@ let mk_glob_constr_eq f g c1 c2 = match DAst.get c1, DAst.get c2 with
     Option.equal instance_eq u1 u2
   | (GRef _ | GVar _ | GEvar _ | GPatVar _ | GApp _ | GLambda _ | GProd _ | GLetIn _ |
      GCases _ | GLetTuple _ | GIf _ | GRec _ | GSort _ | GHole _ | GGenarg _ | GCast _ | GProj _ |
-     GInt _ | GFloat _ | GString _ | GArray _), _ -> false
+     GNat _ | GInt _ | GFloat _ | GString _ | GArray _), _ -> false
 
 let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq (fun na1 na2 _ _ -> Name.equal na1 na2) c
 
@@ -293,7 +300,7 @@ let map_glob_constr_left_to_right_with_names f g = DAst.map (function
       let comp2 = f def in
       let comp3 = f ty in
       GArray (u,comp1,comp2,comp3)
-  | (GVar _ | GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _ | GString _) as x -> x
+  | (GVar _ | GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GNat _ | GInt _ | GFloat _ | GString _) as x -> x
   )
 
 let map_glob_constr_left_to_right f = map_glob_constr_left_to_right_with_names f (fun na -> na)
@@ -329,7 +336,7 @@ let fold_glob_constr f acc = DAst.with_val (function
   | GProj (p,args,c) ->
     f (List.fold_left f acc args) c
   | GArray (_u,t,def,ty) -> f (f (Array.fold_left f acc t) def) ty
-  | (GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _ | GString _) -> acc
+  | (GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GNat _ | GInt _ | GFloat _ | GString _) -> acc
   )
 let fold_return_type_with_binders f g v acc (na,tyopt) =
   (* eta expansion is important if g has effects, eg bound_glob_vars below, see #11959 *)
@@ -374,7 +381,7 @@ let fold_glob_constr_with_binders g f v acc = DAst.(with_val (function
   | GProj (p,args,c) ->
     f v (List.fold_left (f v) acc args) c
   | GArray (_u, t, def, ty) -> f v (f v (Array.fold_left (f v) acc t) def) ty
-  | (GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GInt _ | GFloat _ | GString _) -> acc))
+  | (GSort _ | GHole _ | GGenarg _ | GRef _ | GEvar _ | GPatVar _ | GNat _ | GInt _ | GFloat _ | GString _) -> acc))
 
 let iter_glob_constr f = fold_glob_constr (fun () -> f) ()
 

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -53,6 +53,8 @@ val cases_pattern_loc : 'a cases_pattern_g -> Loc.t option
 
 val cases_predicate_names : 'a tomatch_tuples_g -> Name.t list
 
+val unfold_nat : ?loc:Loc.t -> inductive -> Z.t -> _ glob_constr_g
+
 (** Apply a list of arguments to a glob_constr *)
 val mkGApp : ?loc:Loc.t -> 'a glob_constr_g -> 'a glob_constr_g list -> 'a glob_constr_g
 

--- a/pretyping/glob_term.mli
+++ b/pretyping/glob_term.mli
@@ -112,6 +112,7 @@ type 'a glob_constr_r =
   | GGenarg of GenConstr.glb
   | GCast of 'a glob_constr_g * Constr.cast_kind option * 'a glob_constr_g
   | GProj of (Constant.t * glob_instance option) * 'a glob_constr_g list * 'a glob_constr_g
+  | GNat of inductive * Z.t
   | GInt of Uint63.t
   | GFloat of Float64.t
   | GString of Pstring.t

--- a/pretyping/heads.ml
+++ b/pretyping/heads.ml
@@ -76,7 +76,7 @@ and kind_of_head env sigma t =
   | Proj (p,_,c) -> RigidHead RigidOther
 
   | Case (_,_,_,_,_,c,_) -> aux k [] c true
-  | Int _ | Float _ | String _ | Array _ -> ConstructorHead
+  | Nat _ | Int _ | Float _ | String _ | Array _ -> ConstructorHead
   | Fix ((i,j),_) ->
       let n = i.(j) in
       try aux k [] (List.nth l n) true

--- a/pretyping/keys.ml
+++ b/pretyping/keys.ml
@@ -85,6 +85,10 @@ let equiv_keys k k' =
 
 let mkKGlob env gr = KGlob (Environ.QGlobRef.canonize env gr)
 
+let mkKNat env natind i =
+  let ctor = if Z.equal i Z.zero then 1 else 2 in
+  mkKGlob env (ConstructRef (natind, ctor))
+
 (** Registration of keys as an object *)
 
 let load_keys _ (ref,ref') =
@@ -128,6 +132,7 @@ let constr_key env kind c =
       | Const (c, _) -> mkKGlob env (GlobRef.ConstRef c)
       | Ind (i, u) -> mkKGlob env (GlobRef.IndRef i)
       | Construct (c,u) -> mkKGlob env (GlobRef.ConstructRef c)
+      | Nat (ind,i) -> mkKNat env ind i
       | Var id -> mkKGlob env (GlobRef.VarRef id)
       | App (f, _) -> aux f
       | Proj (p, _, _) -> mkKGlob env (GlobRef.ConstRef (Projection.constant p))

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -110,6 +110,9 @@ let find_rectype_a env sigma c =
 
 let construct_of_constr_notnative const env tag (ind,u) allargs =
   let mib,mip = lookup_mind_specif env ind in
+  if mib.mind_is_nat && const then
+    mkNat ind (Z.of_int tag), mkIndU (ind,EConstr.Unsafe.to_instance u)
+  else
   let nparams = mib.mind_nparams in
   let params = Array.sub allargs 0 nparams in
   let i = invert_tag const tag mip.mind_reloc_tbl in
@@ -211,6 +214,9 @@ let rec nf_val env sigma v typ =
       let body = nf_val env sigma (f (mk_rel_accu lvl)) codom in
       mkLambda(name,dom,body)
   | Vconst n -> construct_of_constr_const env sigma n typ
+  | Vnat n ->
+    let (ind,_),_ = find_rectype_a env sigma (EConstr.of_constr typ) in
+    mkNat ind n
   | Vint64 i -> i |> Uint63.of_int64 |> mkInt
   | Vfloat64 f -> f |> Float64.of_float |> mkFloat
   | Vstring s -> s |> mkString

--- a/pretyping/pattern.mli
+++ b/pretyping/pattern.mli
@@ -38,6 +38,7 @@ type 'i constr_pattern_r =
       (int * Name.t array * 'i constr_pattern_r) list (** index of constructor, nb of args *)
   | PFix of (int array * int) * (Name.t array * 'i constr_pattern_r array * 'i constr_pattern_r array)
   | PCoFix of int * (Name.t array * 'i constr_pattern_r array * 'i constr_pattern_r array)
+  | PNat of inductive * Z.t
   | PInt of Uint63.t
   | PFloat of Float64.t
   | PString of Pstring.t

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -21,68 +21,6 @@ open Mod_subst
 open Pattern
 open Environ
 
-let case_info_pattern_eq env i1 i2 =
-  i1.cip_style == i2.cip_style &&
-  Option.equal (fun i1 i2 -> QInd.equal env i1 i2) i1.cip_ind i2.cip_ind &&
-  i1.cip_extensible == i2.cip_extensible
-
-let rec constr_pattern_eq env (p1:constr_pattern) p2 = match p1, p2 with
-| PRef r1, PRef r2 -> QGlobRef.equal env r1 r2
-| PVar v1, PVar v2 -> Id.equal v1 v2
-| PEvar (ev1, ctx1), PEvar (ev2, ctx2) ->
-  Evar.equal ev1 ev2 && List.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) ctx1 ctx2
-| PRel i1, PRel i2 ->
-  Int.equal i1 i2
-| PApp (t1, arg1), PApp (t2, arg2) ->
-  constr_pattern_eq env t1 t2 && Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) arg1 arg2
-| PSoApp (id1, arg1), PSoApp (id2, arg2) ->
-  Id.equal id1 id2 && List.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) arg1 arg2
-| PLambda (v1, t1, b1), PLambda (v2, t2, b2) ->
-  Name.equal v1 v2 && constr_pattern_eq env t1 t2 && constr_pattern_eq env b1 b2
-| PProd (v1, t1, b1), PProd (v2, t2, b2) ->
-  Name.equal v1 v2 && constr_pattern_eq env t1 t2 && constr_pattern_eq env b1 b2
-| PLetIn (v1, b1, t1, c1), PLetIn (v2, b2, t2, c2) ->
-  Name.equal v1 v2 && constr_pattern_eq env b1 b2 &&
-  Option.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) t1 t2 && constr_pattern_eq env c1 c2
-| PSort s1, PSort s2 -> UnivGen.QualityOrSet.equal s1 s2
-| PMeta m1, PMeta m2 -> Option.equal Id.equal m1 m2
-| PIf (t1, l1, r1), PIf (t2, l2, r2) ->
-  constr_pattern_eq env t1 t2 && constr_pattern_eq env l1 l2 && constr_pattern_eq env r1 r2
-| PCase (info1, p1, r1, l1), PCase (info2, p2, r2, l2) ->
-  case_info_pattern_eq env info1 info2 &&
-  Option.equal (fun (nas1, p1) (nas2, p2) -> Array.equal Name.equal nas1 nas2 && constr_pattern_eq env p1 p2) p1 p2 &&
-  constr_pattern_eq env r1 r2 &&
-  List.equal (fun p1 p2 -> pattern_eq env p1 p2) l1 l2
-| PFix ((ln1,i1),f1), PFix ((ln2,i2),f2) ->
-  Array.equal Int.equal ln1 ln2 && Int.equal i1 i2 && rec_declaration_eq env f1 f2
-| PCoFix (i1,f1), PCoFix (i2,f2) ->
-  Int.equal i1 i2 && rec_declaration_eq env f1 f2
-| PProj (p1, t1), PProj (p2, t2) ->
-   QProjection.equal env p1 p2 && constr_pattern_eq env t1 t2
-| PInt i1, PInt i2 ->
-   Uint63.equal i1 i2
-| PFloat f1, PFloat f2 ->
-   Float64.equal f1 f2
-| PString s1, PString s2 ->
-   Pstring.equal s1 s2
-| PArray (t1, def1, ty1), PArray (t2, def2, ty2) ->
-  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) t1 t2 && constr_pattern_eq env def1 def2
-  && constr_pattern_eq env ty1 ty2
-| PExtra e, _ -> Util.Empty.abort e
-| (PRef _ | PVar _ | PEvar _ | PRel _ | PApp _ | PSoApp _
-   | PLambda _ | PProd _ | PLetIn _ | PSort _ | PMeta _
-   | PIf _ | PCase _ | PFix _ | PCoFix _ | PProj _ | PInt _
-   | PFloat _ | PString _ | PArray _), _ -> false
-(** FIXME: fixpoint and cofixpoint should be relativized to pattern *)
-
-and pattern_eq env (i1, j1, p1) (i2, j2, p2) =
-  Int.equal i1 i2 && Array.equal Name.equal j1 j2 && constr_pattern_eq env p1 p2
-
-and rec_declaration_eq env (n1, c1, r1) (n2, c2, r2) =
-  Array.equal Name.equal n1 n2 &&
-  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) c1 c2 &&
-  Array.equal (fun c1 c2 -> constr_pattern_eq env c1 c2) r1 r2
-
 let rec occurn_pattern : 'a. _ -> 'a constr_pattern_r -> _
   = fun (type a) n (p:a constr_pattern_r) -> match p with
   | PRel p -> Int.equal n p
@@ -103,7 +41,7 @@ let rec occurn_pattern : 'a. _ -> 'a constr_pattern_r -> _
       (List.exists (fun (_, nas, p) -> occurn_pattern (Array.length nas + n) p) br)
   | PMeta _ | PSoApp _ -> true
   | PEvar (_,args) -> List.exists (occurn_pattern n) args
-  | PVar _ | PRef _ | PSort _ | PInt _ | PFloat _ | PString _ -> false
+  | PVar _ | PRef _ | PSort _ | PNat _ | PInt _ | PFloat _ | PString _ -> false
   | PFix (_,(_,tl,bl)) ->
      Array.exists (occurn_pattern n) tl || Array.exists (occurn_pattern (n+Array.length tl)) bl
   | PCoFix (_,(_,tl,bl)) ->
@@ -129,7 +67,7 @@ let rec head_pattern_bound (t:constr_pattern) =
         -> raise BoundPattern
     (* Perhaps they were arguments, but we don't beta-reduce *)
     | PLambda _ -> raise BoundPattern
-    | PCoFix _ | PInt _ | PFloat _ | PString _ | PArray _ ->
+    | PCoFix _ | PNat _ | PInt _ | PFloat _ | PString _ | PArray _ ->
       anomaly ~label:"head_pattern_bound" (Pp.str "not a type.")
     | PExtra e -> Util.Empty.abort e
 
@@ -219,7 +157,8 @@ let pattern_of_constr ~broken env sigma t =
        let push env na2 c2 = push_rel (LocalAssum (na2,c2)) env in
        let env' = Array.fold_left2 push env lna tl in
        PCoFix (ln,(Array.map binder_name lna,Array.map (pattern_of_constr env) tl,
-                  Array.map (pattern_of_constr env') bl))
+                   Array.map (pattern_of_constr env') bl))
+    | Nat (ind,n) -> pattern_of_constr env (unfold_nat ind n) (* XXX optimized Nat pattern *)
     | Int i -> PInt i
     | Float f -> PFloat f
     | String s -> PString s
@@ -256,7 +195,7 @@ let map_pattern_with_binders_gen (type a b) g f fgen l : a constr_pattern_r -> b
   | PEvar (ev,ps) -> PEvar (ev, List.map (f l) ps)
   | PExtra x -> fgen l x
   (* Non recursive *)
-  | (PVar _ | PRel _ | PRef _  | PSort _  | PMeta _ | PInt _
+  | (PVar _ | PRel _ | PRef _  | PSort _  | PMeta _ | PNat _ | PInt _
     | PFloat _ | PString _ as x) -> x
 
 let map_pattern_with_binders (type a) g f l (p:a constr_pattern_r) : a constr_pattern_r =
@@ -284,6 +223,7 @@ let rec subst_pattern_gen
   | PVar _
   | PEvar _
   | PRel _
+  | PNat _
   | PInt _
   | PFloat _
   | PString _ -> pat
@@ -586,6 +526,8 @@ let rec pat_of_raw metas vars : _ -> _ constr_pattern_r = DAst.with_loc_val (fun
       let cl = Array.map (fun (ctx,cl) -> it_mkPLambda_or_LetIn cl ctx) ctxtl in
       let names = Array.map (fun id -> Name id) ids in
       PCoFix (n, (names, tl, cl))
+
+  | GNat (ind,n) -> PNat (ind,n)
 
   | GInt i -> PInt i
   | GFloat f -> PFloat f

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -15,8 +15,6 @@ open Pattern
 
 (** {5 Functions on patterns} *)
 
-val constr_pattern_eq : Environ.env -> constr_pattern -> constr_pattern -> bool
-
 val subst_pattern : Environ.env -> Evd.evar_map -> substitution -> constr_pattern -> constr_pattern
 val subst_uninstantiated_pattern : Environ.env -> Evd.evar_map -> substitution -> uninstantiated_pattern -> uninstantiated_pattern
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -618,6 +618,7 @@ type pretyper = {
   pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
   pretype_genarg : pretyper -> GenConstr.glb -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
+  pretype_nat : pretyper -> inductive -> Z.t -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;
   pretype_string : pretyper -> Pstring.t -> unsafe_judgment pretype_fun;
@@ -663,6 +664,8 @@ let eval_pretyper self ~flags tycon env sigma t =
     self.pretype_genarg self arg ?loc ~flags tycon env sigma
   | GCast (c, k, t) ->
     self.pretype_cast self (c, k, t) ?loc ~flags tycon env sigma
+  | GNat (ind,n) ->
+    self.pretype_nat self ind n ?loc ~flags tycon env sigma
   | GInt n ->
     self.pretype_int self n ?loc ~flags tycon env sigma
   | GFloat f ->
@@ -1563,6 +1566,10 @@ let pretype_type self c ?loc ~flags valcon (env : GlobEnv.t) sigma = match DAst.
             ?loc:(loc_of_glob_constr c) !!env sigma tj.utj_val v e
         end
 
+  let pretype_nat self ind n ?loc ~flags tycon env sigma =
+    let resj = Typing.judge_of_nat !!env ind n in
+    discard_trace @@ inh_conv_coerce_to_tycon ?loc ~flags env sigma resj tycon
+
   let pretype_int self i =
     fun ?loc ~flags tycon env sigma ->
         let resj =
@@ -1658,6 +1665,7 @@ let default_pretyper =
     pretype_hole = pretype_hole;
     pretype_genarg = pretype_genarg;
     pretype_cast = pretype_cast;
+    pretype_nat = pretype_nat;
     pretype_int = pretype_int;
     pretype_float = pretype_float;
     pretype_string = pretype_string;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -201,6 +201,7 @@ type pretyper = {
   pretype_hole : pretyper -> Evar_kinds.glob_evar_kind -> unsafe_judgment pretype_fun;
   pretype_genarg : pretyper -> GenConstr.glb -> unsafe_judgment pretype_fun;
   pretype_cast : pretyper -> glob_constr * Constr.cast_kind option * glob_constr -> unsafe_judgment pretype_fun;
+  pretype_nat : pretyper -> inductive -> Z.t -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;
   pretype_string : pretyper -> Pstring.t -> unsafe_judgment pretype_fun;

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -707,6 +707,14 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
     let ctx = expand_branch env sigma u pms (ind, i) br in
     applist (it_mkLambda_or_LetIn (snd br) ctx, args)
 
+let get_nat_branch ind n br =
+  if Z.equal n Z.zero then
+    let _nas, br = br.(0) in
+    br
+  else
+    let _nas, br = br.(1) in
+    let n = Z.pred n in
+    Vars.subst1 (mkNat ind n) br
 
 exception PatternFailure
 
@@ -927,6 +935,21 @@ let rec whd_state_gen flags ?metas env sigma =
         |_, _ -> fold ()
       else fold ()
 
+    | Nat (ind,n) ->
+      let use_match = RedFlags.red_set flags RedFlags.fMATCH in
+      let use_fix = RedFlags.red_set flags RedFlags.fFIX in
+      if use_match || use_fix then
+        match stack with
+        |(Stack.Case (_,_,_,_,_,br)::s') when use_match ->
+          let r = get_nat_branch ind n br in
+          whrec (r, s')
+        |(Stack.Fix (f,s')::s'') when use_fix ->
+          let out_sk = s' @ (Stack.append_app [|x|] s'') in
+          whrec (reduce_and_refold_fix env sigma f out_sk)
+        |(Stack.App _| Proj _ | Primitive _)::_ -> assert false
+        | _ -> fold ()
+      else fold ()
+
     | CoFix cofix ->
       if RedFlags.red_set flags RedFlags.fCOFIX then
         match Stack.strip_app stack with
@@ -1014,6 +1037,23 @@ let local_whd_state_gen flags ?metas env sigma =
         |_, (Stack.App _)::_ -> assert false
         |_, _ -> s
       else s
+
+    | Nat (ind,n) ->
+      let use_match = RedFlags.red_set flags RedFlags.fMATCH in
+      let use_fix = RedFlags.red_set flags RedFlags.fFIX in
+      begin match stack with
+      |(Stack.Case (_,_,_,_,_,br) :: s') ->
+        if use_match then
+          let r = get_nat_branch ind n br in
+          whrec (r, s')
+        else s
+      |(Stack.Fix (f,s')::s'') ->
+        if use_fix then
+          whrec (contract_fix sigma f, s' @ (Stack.append_app [|x|] s''))
+        else s
+      |(Stack.App _ | Proj _ | Primitive _)::_ -> assert false
+      | [] -> s
+      end
 
     | CoFix cofix ->
       if RedFlags.red_set flags RedFlags.fCOFIX then
@@ -1118,7 +1158,7 @@ let shrink_eta sigma c =
         | _ -> x
       else x
     | Meta _ | App _ | Case _ | Fix _ | Construct _ | CoFix _ | Evar _ | Rel _ | Var _ | Sort _ | Prod _
-    | LetIn _ | Const _  | Ind _ | Proj _ | Int _ | Float _ | String _ | Array _ -> x
+    | LetIn _ | Const _  | Ind _ | Proj _ | Nat _ | Int _ | Float _ | String _ | Array _ -> x
   in
   whrec c
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1237,11 +1237,8 @@ let _ = CErrors.register_handler (function
     | _ -> None)
 
 let report_anomaly (e, info) =
-  let e =
-    if is_sync_anomaly e then AnomalyInConversion e
-    else e
-  in
-  Exninfo.iraise (e, info)
+  if is_sync_anomaly e then ()
+  else Exninfo.iraise (e, info)
 
 module CheckUnivs =
 struct
@@ -1301,7 +1298,8 @@ let is_fconv ?(reds=TransparentState.full) pb env sigma t1 t2 =
     with
     | e ->
       let e = Exninfo.capture e in
-      report_anomaly e
+      report_anomaly e;
+      false
 
 let is_conv ?(reds=TransparentState.full) env sigma x y =
   is_fconv ~reds Conversion.CONV env sigma x y
@@ -1330,7 +1328,8 @@ let is_conv_nounivs ?(reds=TransparentState.full) env sigma t1 t2 =
     with
     | e ->
       let e = Exninfo.capture e in
-      report_anomaly e
+      report_anomaly e;
+      false
 
 let sigma_compare_sorts pb s0 s1 sigma =
   match pb with
@@ -1433,7 +1432,8 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Conversion.CUMUL)
   | QGraph.EliminationError _ when catch_incon -> None
   | e ->
     let e = Exninfo.capture e in
-    report_anomaly e
+    report_anomaly e;
+    None
 
 let infer_conv = infer_conv_gen { genconv = fun pb ~l2r sigma ->
       Conversion.generic_conv pb ~l2r ~evars:(Evd.evar_handler sigma) }

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -273,6 +273,7 @@ let retype ?metas ?(polyprop=true) sigma =
         with Invalid_argument _ -> retype_error BadRecursiveType)
     | Cast (c,_, t) -> t
     | Sort _ | Prod _ -> mkSort (sort_of env cstr)
+    | Nat (ind,n) -> EConstr.of_constr (Typeops.type_of_nat env ind n)
     | Int _ -> EConstr.of_constr (Typeops.type_of_int env)
     | Float _ -> EConstr.of_constr (Typeops.type_of_float env)
     | String _ -> EConstr.of_constr (Typeops.type_of_string env)
@@ -455,7 +456,7 @@ let relevance_of_term env sigma c =
       | Evar (evk, _) ->
           let evi = Evd.find_undefined sigma evk in
           Evd.evar_relevance evi
-      | Int _ | Float _ | String _ | Array _ -> ERelevance.relevant
+      | Nat _ | Int _ | Float _ | String _ | Array _ -> ERelevance.relevant
       | Meta _ -> ERelevance.relevant
     in
     aux Range.empty c

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -190,6 +190,7 @@ let rec of_constr sigma t =
   | Prod (_,_,_) -> Prod_cs, None, [t]
   | Proj (p, _, c) -> Proj_cs (Names.Projection.repr p), None, [c]
   | Sort s -> Sort_cs (EConstr.ESorts.quality_or_set sigma s), None, []
+  | Nat (ind,n) -> of_constr sigma (EConstr.unfold_nat ind n)
   | _ -> Const_cs (fst @@ EConstr.destRef sigma t) , None, []
 
 let print = function

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -428,7 +428,7 @@ let compute_constant_coelimination infos env sigma ref u =
           assert (List.is_empty args);
           let open Context.Rel.Declaration in
           srec (push_rel (LocalAssum (id,t)) env) ((id,t)::all_abs) lastref lastu g
-      | Construct _ ->
+      | Construct _ | Nat _ ->
           let c = it_mkLambda (applist (c', args)) all_abs in
           CoEliminationConstruct c
       | Int _ | Float _ | String _ | Array _ (* reduced by primitives *) ->
@@ -589,7 +589,7 @@ let contract_cofix env sigma f (bodynum,(_names,_types,bodies as typedbodies) as
     bodies.(bodynum)
 
 let reducible_construct sigma c = match EConstr.kind sigma c with
-| Construct _ | CoFix _ (* reduced by case *)
+| Nat _ | Construct _ | CoFix _ (* reduced by case *)
 | Int _ | Float _ | String _ | Array _ (* reduced by primitives *) -> true
 | _ -> false
 
@@ -815,7 +815,7 @@ and reduce_params infos env sigma stack l =
       let arg = List.nth stack i in
       let* rarg = whd_construct_stack infos env sigma arg in
       match EConstr.kind sigma (fst rarg) with
-      | Construct _ | Int _ | Float _ | String _ | Array _ ->
+      | Nat _ | Construct _ | Int _ | Float _ | String _ | Array _ ->
         redp (List.assign stack i (applist rarg)) l
       | _ -> NotReducible
   in
@@ -913,7 +913,7 @@ and reduce_fix infos env sigma f fix stack =
   | Some (recargnum,recarg) ->
     let* (recarg'hd,_ as recarg') = whd_construct_stack infos env sigma recarg in
     match EConstr.kind sigma recarg'hd with
-    | Construct _ ->
+    | Construct _ | Nat _ ->
       let stack' = List.assign stack recargnum (applist recarg') in
       Reduced (contract_fix env sigma f fix, stack')
     | _ -> NotReducible
@@ -948,6 +948,16 @@ and reduce_case infos env sigma (ci, u, pms, p, iv, c, lf) =
     let ctx = EConstr.expand_branch env sigma u pms cstr br in
     let br = it_mkLambda_or_LetIn (snd br) ctx in
     Reduced (applist (br, real_cargs))
+  | Nat (ind,n) ->
+    if Z.equal n Z.zero then
+      let _, br = lf.(0) in
+      Reduced br
+    else
+      let br = lf.(1) in
+      let cstr = ctor_of_nat ind n in
+      let ctx = EConstr.expand_branch env sigma u pms cstr br in
+      let br = it_mkLambda_or_LetIn (snd br) ctx in
+      Reduced (applist (br, [mkNat ind (Z.pred n)]))
   | CoFix (bodynum,(names,_,_) as cofix) ->
     let cofix_def = contract_cofix env sigma f cofix in
     (* If the cofix_def does not reduce to a constructor, do we

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -439,7 +439,14 @@ let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let sigma = Evd.add_poly_constraints ~src:UState.Internal sigma csts in
   sigma, (EConstr.of_constr (rename_type env ty (GR.ConstructRef ctor)))
 
+let type_of_nat env ind n = EConstr.of_constr (Typeops.type_of_nat env ind n)
+
 let type_of_int env = EConstr.of_constr (Typeops.type_of_int env)
+
+let judge_of_nat env ind n =
+  if not @@ Z.leq Z.zero n then CErrors.user_err Pp.(str "Optimized nat should be >= 0.");
+  if not (Environ.is_nat env ind) then CErrors.user_err Pp.(str "Optimized nat at non-nat type.");
+  { uj_val = mkNat ind n; uj_type = type_of_nat env ind n }
 
 let judge_of_int env v =
   { uj_val = mkInt v; uj_type = type_of_int env }
@@ -640,6 +647,8 @@ let rec execute env sigma cstr =
         let sigma, tj = type_judgment env sigma tj in
         judge_of_cast env sigma cj k tj
 
+    | Nat (ind,n) -> sigma, judge_of_nat env ind n
+
     | Int i ->
         sigma, judge_of_int env i
 
@@ -773,7 +782,7 @@ let rec recheck_against env sigma good c =
     match kind sigma good, kind sigma c with
     (* No subterms *)
     | _, (Meta _ | Rel _ | Var _ | Const _ | Ind _ | Construct _
-         | Sort _ | Int _ | Float _ | String _) ->
+         | Sort _ | Nat _ | Int _ | Float _ | String _) ->
       default ()
 
     (* Evar (todo deal with Evar differently??? execute recurses on its type)

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -60,6 +60,7 @@ val judge_of_abstraction : Environ.env -> evar_map -> Name.t ->
 val judge_of_product : Environ.env -> evar_map -> Name.t ->
   unsafe_type_judgment -> unsafe_type_judgment -> unsafe_judgment
 val judge_of_projection : env -> evar_map -> Projection.t -> unsafe_judgment -> unsafe_judgment
+val judge_of_nat : Environ.env -> inductive -> Z.t -> unsafe_judgment
 val judge_of_int : Environ.env -> Uint63.t -> unsafe_judgment
 val judge_of_float : Environ.env -> Float64.t -> unsafe_judgment
 val judge_of_string : Environ.env -> Pstring.t -> unsafe_judgment

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -934,7 +934,7 @@ let is_rigid_head sigma flags t =
   match EConstr.kind sigma t with
   | Const (cst,u) -> not (Structures.PrimitiveProjections.is_transparent_constant flags.modulo_delta cst)
   | Ind (i,u) -> true
-  | Construct _ | Int _ | Float _ | String _ | Array _ -> true
+  | Construct _ | Nat _ | Int _ | Float _ | String _ | Array _ -> true
   | Fix _ | CoFix _ -> true
   | Rel _ | Var _ | Meta _ | Evar _ | Sort _ | Cast (_, _, _) | Prod _
     | Lambda _ | LetIn _ | App (_, _) | Case _
@@ -1037,7 +1037,7 @@ let rec is_neutral env sigma ts t =
     | Evar _ | Meta _ -> true
     | Case (_, _, _, _, _, c, _) -> is_neutral env sigma ts c
     | Proj (p, _, c) -> is_neutral env sigma ts c
-    | Lambda _ | LetIn _ | Construct _ | CoFix _ | Int _ | Float _ | String _ | Array _ -> false
+    | Lambda _ | LetIn _ | Construct _ | CoFix _ | Nat _ | Int _ | Float _ | String _ | Array _ -> false
     | Sort _ | Cast (_, _, _) | Prod (_, _, _) | Ind _ -> false (* Really? *)
     | Fix _ -> false (* This is an approximation *)
     | App _ -> assert false
@@ -1312,6 +1312,15 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
             (isMeta sigma f2 && use_metas_pattern_unification sigma flags nb l2
             || use_evars_pattern_unification flags && isAllowedEvar sigma flags f2) ->
           unify_app_pattern false curenvnb pb opt substn cM cM [||] cN f2 l2
+
+        | Nat (ind1,n1), Nat (ind2,n2) when Z.equal n1 n2 && Environ.QInd.equal env ind1 ind2 -> substn
+
+        | Nat (ind1,n1), (Construct _ | App _) ->
+          let curm = EConstr.unfold_nat ind1 n1 in
+          unirec_rec curenvnb pb opt substn ~nargs curm curn
+        | (Construct _ | App _), Nat (ind2,n2) ->
+          let curn = EConstr.unfold_nat ind2 n2 in
+          unirec_rec curenvnb pb opt substn ~nargs curm curn
 
         | App (f1,l1), App (f2,l2) ->
           unify_app curenvnb pb opt substn cM f1 l1 cN f2 l2
@@ -2319,8 +2328,8 @@ let get_max_rel_array sigma v = Array.fold_left (fun accu c -> max accu (get_max
 
 let anorec = AOther [||]
 
-let rec make sigma c0 = match EConstr.kind sigma c0 with
-| (Meta _ | Var _ | Sort _ | Const _ | Ind _ | Construct _ | Int _ | Float _ | String _) ->
+let rec make sigma c0 = match EConstr.kind_nonat sigma c0 with
+| (Meta _ | Var _ | Sort _ | Const _ | Ind _ | Construct _ | Nat _ | Int _ | Float _ | String _) ->
   { proj = c0; self = anorec; data = 0 }
 | Rel n ->
   { proj = c0; self = anorec; data = n }
@@ -2537,6 +2546,8 @@ let w_unify_to_subterm_all ~metas env evd ?(flags=default_unify_flags ()) (op,cl
                 let c1 = mkApp (f,Array.sub args 0 (n-1)) in
                 let c2 = args.(n-1) in
                 bind (matchrec c1) (matchrec c2)
+
+            | Nat (ind,n) -> matchrec (EConstr.unfold_nat ind n) (* XXX seems very bad performance wise *)
 
             | Case(_,_,_,_,_,c,lf) -> (* does not search in the predicate *)
                 bind (matchrec c) (bind_iter matchrec (Array.map snd lf))

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -86,6 +86,8 @@ let construct_of_constr const env sigma tag typ =
   match Constr.kind t with
   | Ind ((mind,_ as ind), u as indu) ->
     let mib,mip = lookup_mind_specif env ind in
+    if mib.mind_is_nat && const then mkNat ind (Z.of_int tag), mkIndU indu
+    else
     let nparams = mib.mind_nparams in
     let i = invert_tag const tag mip.mind_reloc_tbl in
     let params = Array.sub allargs 0 nparams in
@@ -183,6 +185,9 @@ and nf_whd env sigma whd typ =
       let capp,ctyp = construct_of_constr_block env sigma tag typ in
       let args = nf_bargs env sigma b ofs ctyp in
       mkApp(capp,args)
+  | Vnat n ->
+    let ((ind,_),_) = find_rectype_a env sigma (EConstr.of_constr typ) in
+    mkNat ind n
   | Vint64 i -> i |> Uint63.of_int64 |> mkInt
   | Vfloat64 f -> f |> Float64.of_float |> mkFloat
   | Vstring s -> s |> mkString

--- a/tactics/allScheme.ml
+++ b/tactics/allScheme.ml
@@ -967,6 +967,7 @@ let generate_all_aux suffix kn u sub_temp mib uparams strpos nuparams =
       mind_entry_universes = Polymorphic_ind_entry uctx;
       mind_entry_variance = Some (Array.make ulen None);
       mind_entry_private = mib.mind_private;
+      mind_entry_is_nat = false;
       }
   in
   (* DEBUG FUNCTIONS *)

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -212,6 +212,7 @@ struct
       (* UnsafeMonomorphic is fine because the term will only be used
          by pat_of_constr which ignores universes *)
       pat_of_constr (mkApp (UnsafeMonomorphic.mkConst (Projection.constant p), [|c|]))
+    | Nat (ind,n) -> pat_of_constr (unfold_nat ind n) (* optimized Nat? *)
     | Int i -> Some (DInt i, [])
     | Float f -> Some (DFloat f, [])
     | String s -> Some (DString s, [])

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -226,6 +226,7 @@ let constr_val_discr env sigma ts t : constr_res =
         | (Label _ | Nothing) as res -> Label(CaseLabel, PartialConstr res :: stack)
         | Everything -> Everything
       end
+    | Nat (ind,n) -> decomp stack (EConstr.unfold_nat ind n) (* XXX optimized Nat? *)
     | Rel _ | Meta _ | LetIn _ | Fix _ | CoFix _
     | Int _ | Float _ | String _ | Array _ -> Nothing
     in

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -562,6 +562,14 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
   in
   Vars.substl subst (snd br)
 
+let get_nat_branch ind n br =
+  if Z.equal n Z.zero then
+    let _nas, br = br.(0) in
+    br
+  else
+    let _nas, br = br.(1) in
+    let n = Z.pred n in
+    Vars.subst1 (mkNat ind n) br
 
 exception PatternFailure
 
@@ -915,6 +923,53 @@ let rec whd_state_gen ?csts flags env sigma =
           end
         |_, (Stack.App _)::_ -> assert false
         |_, _ -> fold ()
+      else fold ()
+
+    | Nat (ind,n) ->
+      let use_match = RedFlags.red_set flags RedFlags.fMATCH in
+      let use_fix = RedFlags.red_set flags RedFlags.fFIX in
+      if use_match || use_fix then
+        match stack with
+        | (Stack.Case((_,_,_,_,_,br),_)::s') when use_match ->
+          let r = get_nat_branch ind n br in
+          whrec Cst_stack.empty (r, s')
+        | (Stack.Fix (f,s',cst_l)::s'') when use_fix ->
+          let out_sk = s' @ (Stack.append_app [|x|] s'') in
+          reduce_and_refold_fix whrec env sigma cst_l f out_sk
+        | (Stack.Cst {const;curr;remains;volatile;params=s';cst_l} :: s'') ->
+          begin match remains with
+          | [] ->
+            (match const with
+             | Stack.Cst_const const ->
+               (match constant_opt_value_in env const with
+                | None -> fold ()
+                | Some body ->
+                  let const = (fst const, EInstance.make (snd const)) in
+                  let body = EConstr.of_constr body in
+                  let cst_l = Cst_stack.add_cst ~volatile (mkConstU const) cst_l in
+                  whrec cst_l (body, s' @ (Stack.append_app [|x|] s'')))
+             | Stack.Cst_proj (p,r) ->
+               let stack = s' @ (Stack.append_app [|x|] s'') in
+               match Stack.strip_n_app 0 stack with
+               | None -> assert false
+               | Some (_,arg,s'') ->
+                 whrec Cst_stack.empty (arg, Stack.Proj (p,r,cst_l) :: s''))
+          | next :: remains' -> match Stack.strip_n_app (next-curr-1) s'' with
+            | None -> fold ()
+            | Some (bef,arg,s''') ->
+              let cst_l = Stack.Cst
+                  { const;
+                    curr=next;
+                    volatile;
+                    remains=remains';
+                    params=s' @ (Stack.append_app [|x|] bef);
+                    cst_l;
+                  }
+              in
+              whrec Cst_stack.empty (arg, cst_l :: s''')
+          end
+        | (Stack.App _ | Proj _ | Primitive _)::_ -> assert false
+        | _ -> fold ()
       else fold ()
 
     | CoFix cofix ->

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -945,6 +945,11 @@ let find_positions env sigma ~keep_proofs ~no_discr ~eqsort ~goalsort t1 t2 =
           (* if we cannot eliminate to Type, we cannot discriminate but we
              may still try to project *)
           project env posn allowed_elim_on_sort (applist (hd1,args1)) (applist (hd2,args2))
+      | Nat (ind1,n1), Nat (ind2,n2) ->
+        if Z.equal n1 n2 && Environ.QInd.equal env ind1 ind2 then []
+        else findrec posn s (EConstr.unfold_nat ind1 n1) (EConstr.unfold_nat ind2 n2)
+      | Nat (ind1,n1), _ -> findrec posn s (EConstr.unfold_nat ind1 n1) (applist (hd2,args2))
+      | _, Nat (ind2,n2) -> findrec posn s (applist (hd1,args1)) (EConstr.unfold_nat ind2 n2)
       | Int i1, Int i2 ->
         if Uint63.equal i1 i2 then []
         else raise (DiscrFound (List.rev posn, DInt (i1, i2)))

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -48,6 +48,7 @@ let rec head_bound sigma t = match EConstr.kind sigma t with
 | Var id -> GlobRef.VarRef id
 | Proj (p, _, _) -> GlobRef.ConstRef (Projection.constant p)
 | Cast (c, _, _) -> head_bound sigma c
+| Nat (ind,n) -> ConstructRef (ctor_of_nat ind n)
 | Evar _ | Rel _ | Meta _ | Sort _ | Fix _ | Lambda _
 | CoFix _ | Int _ | Float _ | String _ | Array _ -> raise Bound
 

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -148,9 +148,9 @@ fun x : comparison => match x with
      : comparison -> nat
 fun x : comparison =>
 match x return nat with
-| Eq => S O
-| Lt => O
-| Gt => O
+| Eq => 0x1
+| Lt => 0x0
+| Gt => 0x0
 end
      : forall _ : comparison, nat
 fun x : K => match x with

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -5,4 +5,4 @@ Expected an instance of a record or structure.
 File "./output/ErrorInCanonicalStructures.v", line 7, characters 0-29:
 The command has indeed failed with message:
 Could not declare a canonical structure bar.
-Expected an instance of a record or structure.
+Expected a record or structure constructor applied to arguments.

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -17,13 +17,13 @@ option : Type -> Type
 option is template universe polymorphic
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 211, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 212, characters 10-16
 option : Type@{option.u0} -> Type@{max(Set,option.u0)}
 
 option is template universe polymorphic on option.u0 (cannot be instantiated to Prop)
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 211, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 212, characters 10-16
 File "./output/Inductive.v", line 27, characters 4-13:
 The command has indeed failed with message:
 Parameters should be syntactically the same for each inductive type.

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -167,9 +167,9 @@ forall_non_null x y z t : nat , x = y /\ z = t
      : nat * (nat * nat)
 {{RR 1, 2}}
      : nat * nat * nat
-@pair nat (prod nat nat) (S (S O)) (@pair nat nat (S O) O)
+@pair nat (prod nat nat) 0x2 (@pair nat nat 0x1 0x0)
      : prod nat (prod nat nat)
-@pair (prod nat nat) nat (@pair nat nat O (S (S O))) (S O)
+@pair (prod nat nat) nat (@pair nat nat 0x0 0x2) 0x1
      : prod (prod nat nat) nat
 {{RLRR 1, 2}}
      : nat * (nat * nat) * (nat * nat * nat) * (nat * (nat * nat)) *

--- a/test-suite/output/NumberNotations.out
+++ b/test-suite/output/NumberNotations.out
@@ -362,18 +362,18 @@ where
      : Fin.t (S (S (S (S ?n))))
 where
 ?n : [ |- nat]
-@Fin.F1 (S (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.F1 (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
+@Fin.F1 0x2 : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S 0x1) (@Fin.F1 0x1) : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S (S 0x0)) (@Fin.FS (S 0x0) (@Fin.F1 0x0)) : Fin.t 0x3
+     : Fin.t 0x3
 File "./output/NumberNotations.v", line 705, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
 has type "Fin.t (S (S (S (S ?n))))" while it is expected to have type
- "Fin.t (S (S (S O)))".
+ "Fin.t 0x3".
 0
      : list unit
 1
@@ -408,13 +408,13 @@ Ip1 nat nat 1
      : Ip nat nat
 Ip3 1 nat nat
      : Ip nat nat
-Ip0 nat bool O
+Ip0 nat bool 0x0
      : Ip nat bool
-Ip1 bool nat (S O)
+Ip1 bool nat 0x1
      : Ip nat bool
-Ip2 nat (S (S O)) bool
+Ip2 nat 0x2 bool
      : Ip nat bool
-Ip3 (S (S (S O))) nat bool
+Ip3 0x3 nat bool
      : Ip nat bool
 0
      : 0 = 0
@@ -432,7 +432,7 @@ eq_refl
      : id 0 = id 0
 2
      : extra_list_unit
-cons O unit tt (cons O unit tt (nil O unit))
+cons 0x0 unit tt (cons 0x0 unit tt (nil 0x0 unit))
      : extra_list unit
 0
      : Set
@@ -492,18 +492,18 @@ where
      : Fin.t (S (S (S (S ?n))))
 where
 ?n : [ |- nat]
-@Fin.F1 (S (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.F1 (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
+@Fin.F1 0x2 : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S 0x1) (@Fin.F1 0x1) : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S (S 0x0)) (@Fin.FS (S 0x0) (@Fin.F1 0x0)) : Fin.t 0x3
+     : Fin.t 0x3
 File "./output/NumberNotations.v", line 942, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
 has type "Fin.t (S (S (S (S ?n))))" while it is expected to have type
- "Fin.t (S (S (S O)))".
+ "Fin.t 0x3".
 0
      : Fin.t (S ?n)
 where
@@ -546,18 +546,18 @@ where
      : Fin.t (S (S (S (S ?n))))
 where
 ?n : [ |- nat : Set]
-@Fin.F1 (S (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.F1 (S O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
-@Fin.FS (S (S O)) (@Fin.FS (S O) (@Fin.F1 O)) : Fin.t (S (S (S O)))
-     : Fin.t (S (S (S O)))
+@Fin.F1 0x2 : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S 0x1) (@Fin.F1 0x1) : Fin.t 0x3
+     : Fin.t 0x3
+@Fin.FS (S (S 0x0)) (@Fin.FS (S 0x0) (@Fin.F1 0x0)) : Fin.t 0x3
+     : Fin.t 0x3
 File "./output/NumberNotations.v", line 996, characters 11-12:
 The command has indeed failed with message:
 The term
  "@Fin.FS (S (S (S ?n))) (@Fin.FS (S (S ?n)) (@Fin.FS (S ?n) (@Fin.F1 ?n)))"
 has type "Fin.t (S (S (S (S ?n))))" while it is expected to have type
- "Fin.t (S (S (S O)))".
+ "Fin.t 0x3".
 0%float
      : float
 1%float

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -63,7 +63,7 @@ comparison : Set
 
 comparison is not universe polymorphic
 Expands to: Inductive Corelib.Init.Datatypes.comparison
-Declared in library Corelib.Init.Datatypes, line 369, characters 10-20
+Declared in library Corelib.Init.Datatypes, line 370, characters 10-20
 Inductive comparison : Set :=
     Eq : comparison | Lt : comparison | Gt : comparison.
 bar : foo

--- a/test-suite/output/bug_20754.out
+++ b/test-suite/output/bug_20754.out
@@ -5,4 +5,4 @@ prod : Type -> Type -> Type
 prod is template universe polymorphic
 Arguments prod (A B)%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.prod
-Declared in library Corelib.Init.Datatypes, line 257, characters 10-14
+Declared in library Corelib.Init.Datatypes, line 258, characters 10-14

--- a/test-suite/output/primitive_tokens.out
+++ b/test-suite/output/primitive_tokens.out
@@ -9,32 +9,14 @@ end
      : bool
 {| field := 7 |}
      : test
-S
-  (S
-     (S
-        (S
-           (S
-              (S
-                 (S
-                    (S
-                       (S
-                          (S
-                             (S
-                                (S
-                                   (S
-                                      (S
-                                         (S
-                                            (S
-                                               (S
-                                                 (S
-                                                 (S (S (S (S (S (S ...)))))))))))))))))))))))
+0x4d2
      : nat
-Nat.add (S O) (S (S O))
+Nat.add 0x1 0x2
      : nat
-match S O with
+match 0x1 with
 | S O => true
 | _ => false
 end
      : bool
-{| field := S (S (S (S (S (S (S O)))))) |}
+{| field := 0x7 |}
      : test

--- a/test-suite/success/bignat.v
+++ b/test-suite/success/bignat.v
@@ -271,3 +271,10 @@ Qed.
 Definition ignore (x y:N) := x.
 
 Check eq_refl : ignore 1 _ = 1.
+
+Require Import ssreflect.
+
+Lemma test (P:N -> bool) : is_true (P 0).
+Proof.
+  elim: 0.
+Abort.

--- a/test-suite/success/bignat.v
+++ b/test-suite/success/bignat.v
@@ -1,0 +1,273 @@
+Require BinNums.
+
+(* TODO tests that declaring a type that doesn't look like nat with
+   primitive_nat is rejected
+
+   and that multiple primitive_nat types are rejected
+   (or make it supported then test that) *)
+
+#[primitive_nat]
+Inductive N : Set := O | S (_:N).
+
+Fixpoint add n m {struct n} :=
+  match n with
+  | O => m
+  | S k => S (add k m)
+  end where "a + b" := (add a b) : nat_scope.
+
+Fixpoint mul n m {struct n} :=
+  match n with
+  | O => O
+  | S p => m + p * m
+  end where "a * b" := (mul a b) : nat_scope.
+
+Fixpoint tail_add n m :=
+  match n with
+    | O => m
+    | S n => tail_add n (S m)
+  end.
+
+Fixpoint tail_addmul r n m :=
+  match n with
+    | O => r
+    | S n => tail_addmul (tail_add m r) n m
+  end.
+
+Definition tail_mul n m := tail_addmul O n m.
+
+Local Abbreviation ten_raw := (S (S (S (S (S (S (S (S (S (S O)))))))))).
+Local Abbreviation ten := ltac:(let c := constr:(ten_raw) in let c := eval cbv in c in exact c) (only parsing).
+
+Fixpoint of_uint_acc (d:Decimal.uint)(acc:N) :=
+  match d with
+  | Decimal.Nil => acc
+  | Decimal.D0 d => of_uint_acc d (tail_mul ten acc)
+  | Decimal.D1 d => of_uint_acc d (S (tail_mul ten acc))
+  | Decimal.D2 d => of_uint_acc d (S (S (tail_mul ten acc)))
+  | Decimal.D3 d => of_uint_acc d (S (S (S (tail_mul ten acc))))
+  | Decimal.D4 d => of_uint_acc d (S (S (S (S (tail_mul ten acc)))))
+  | Decimal.D5 d => of_uint_acc d (S (S (S (S (S (tail_mul ten acc))))))
+  | Decimal.D6 d => of_uint_acc d (S (S (S (S (S (S (tail_mul ten acc)))))))
+  | Decimal.D7 d => of_uint_acc d (S (S (S (S (S (S (S (tail_mul ten acc))))))))
+  | Decimal.D8 d => of_uint_acc d (S (S (S (S (S (S (S (S (tail_mul ten acc)))))))))
+  | Decimal.D9 d => of_uint_acc d (S (S (S (S (S (S (S (S (S (tail_mul ten acc))))))))))
+  end.
+
+Definition of_uint (d:Decimal.uint) := of_uint_acc d O.
+
+Definition of_num_uint (d:Number.uint) :=
+  match d with
+  | Number.UIntDecimal d => Some (of_uint d)
+  | Number.UIntHexadecimal d => None
+  end.
+
+Fixpoint to_little_uint n acc :=
+  match n with
+  | O => acc
+  | S n => to_little_uint n (Decimal.Little.succ acc)
+  end.
+
+Definition to_uint n :=
+  Decimal.rev (to_little_uint n Decimal.zero).
+
+Fixpoint sub (n m:N) {struct n} : N :=
+  match n, m with
+  | O, _ => n
+  | S k, O => n
+  | S k, S l => k - l
+  end
+where "a - b" := (sub a b).
+
+Register sub as cbv.sub.
+
+Fixpoint div2r (n:N) :=
+  match n with
+  | O | S O => n
+  | S (S k) => S (div2r k)
+  end.
+
+Register div2r as cbv.div2r.
+
+Definition div2 n := n - div2r n.
+
+Definition rem2 n := n - (let x := div2 n in x + x).
+
+Section S.
+  (* NB: p0 is not part of the recursion ([div2 (S (S n))] is never 0).
+     It's only used when the fixpoint is directly called on 0. *)
+  Variables (P:N -> Type) (p0 : P O) (p1 : P (S O)) (p2 : forall n, P (div2 (S (S n))) -> P (S (S n))).
+
+  Fixpoint rec2 n :=
+    match n return P n with
+    | O => p0
+    | S k =>
+        match k as k' return k = k' -> P (S k') with
+        | O => fun _ => p1
+        | S l =>
+            fun e : k = S l =>
+              p2 l
+                (match e in _ = x return P (x - div2r l) with
+                 | eq_refl => rec2 (k - div2r l)
+                 end)
+        end eq_refl
+    end.
+End S.
+
+Section to_bin.
+  (* section for the import for convenience *)
+  Abbreviation myN := N.
+  Import BinNums.
+
+  (* returns xH for 0 *)
+  Definition to_positive (n:myN) : BinNums.positive :=
+    rec2 (fun _ => positive) xH xH
+      (fun n x => (* x = div2 (2+n), we need to produce 2+n = 2*x + rem2 (2+n) *)
+         match rem2 (S (S n)) with
+         | O => xO x
+         | S _ => xI x
+         end)
+      n.
+
+  Definition to_Z n :=
+    match n with
+    | O => Z0
+    | S _ => Zpos (to_positive n)
+    end.
+End to_bin.
+
+Number Notation N of_num_uint to_Z (abstract after 5000) : nat_scope.
+
+(* printing needs add to be registered to be fast (used in rem2) *)
+Set Printing All.
+
+Time Eval cbv in 5000000.
+(* without bignat, stack overflows
+   with bignat, 0.8s
+   (time seems about linear in n, ie exponential in the size of the decimal representation)
+*)
+
+Time Eval cbv in 1000 * 1000.
+(* without bignat, stack overflows
+   with bignat, 0.1s *)
+
+Register add as cbv.add.
+
+Unset Printing All.
+
+Time Eval cbv in 5000000.
+(* still 0.8s *)
+
+Time Eval cbv in 1000 * 1000.
+(* instant (add used in mul) *)
+
+Register mul as cbv.mul.
+
+Time Eval cbv in 200 * 200 * 200 * 200 * 200 * 200 * 200 * 200.
+(* instant (stack overflow without registered mul) *)
+
+Register tail_mul as cbv.tail_mul.
+(* makes parsing fast *)
+
+Time Eval cbv in 5000000.
+(* instant *)
+Time Eval cbv in 50000000.
+(* also instant *)
+Time Eval cbv in 500000000000000000000000000.
+(* still instant *)
+
+Definition pred n := match n with S k => k | 0 => 0 end.
+
+Check eq_refl 0 : pred (pred 1) = 0.
+
+Time Eval lazy in pred ltac:(let c := eval cbv in 500000000 in exact c).
+(* instant (but big + 1 would stack overflow) *)
+
+(* for testing non registered mul with registered add *)
+Fixpoint mymul n m :=
+  match n with
+  | O => O
+  | S p => m + mymul p m
+  end.
+
+Notation "x ** y" := (mymul x y) (at level 41, right associativity).
+
+Time Eval cbv in 200 ** 200000000.
+(* instant *)
+
+Time Eval cbv in 200 ** 200 ** 200 ** 200 ** 200 ** 200 ** 200 ** 200.
+(* right associativity very important here: it means we have 200 * 7 recursions in mymul
+   instead of 200 ^ 7 *)
+
+Definition vmtwo := Eval vm_compute in 1 + 1.
+Check eq_refl : vmtwo = 2.
+Check eq_refl 4 <: vmtwo + 2 = 4.
+
+Definition vmSS x := Eval vm_compute in S (S x).
+Check eq_refl : vmSS = fun x => S (S x).
+
+(* 4611686018427387903 = int63 max_int *)
+Definition vmbig := Eval vm_compute in 2 + 4611686018427387903.
+Check eq_refl : vmbig = 4611686018427387905.
+Check eq_refl vmbig <: vmbig = 4611686018427387905.
+Check eq_refl (S vmbig) <: S vmbig = 4611686018427387906.
+
+Definition nativetwo := Eval native_compute in 1 + 1.
+Check eq_refl : nativetwo = 2.
+Check eq_refl 4 <<: nativetwo + 2 = 4.
+
+Definition nativeSS x := Eval native_compute in S (S x).
+Check eq_refl : nativeSS = fun x => S (S x).
+
+(* 4611686018427387903 = int63 max_int *)
+Definition nativebig := Eval native_compute in 2 + 4611686018427387903.
+Check eq_refl : nativebig = 4611686018427387905.
+Check eq_refl nativebig <<: nativebig = 4611686018427387905.
+Check eq_refl (S nativebig) <<: S nativebig = 4611686018427387906.
+
+Check eq_refl 0 <: pred (pred 1) = 0.
+Check eq_refl 0 <<: pred (pred 1) = 0.
+
+Check eq_refl 4611686018427387900 : 4611686018427387900 = pred (pred (pred 4611686018427387903)).
+Check eq_refl 4611686018427387900 <: 4611686018427387900 = pred (pred (pred 4611686018427387903)).
+Check eq_refl 4611686018427387900 <<: 4611686018427387900 = pred (pred (pred 4611686018427387903)).
+
+Check eq_refl 4611686018427387900 : 4611686018427387900 = pred (pred (pred (pred (pred (pred (3 + 4611686018427387903)))))).
+Check eq_refl 4611686018427387900 <: 4611686018427387900 = pred (pred (pred (pred (pred (pred (3 + 4611686018427387903)))))).
+Check eq_refl 4611686018427387900 <<: 4611686018427387900 = pred (pred (pred (pred (pred (pred (3 + 4611686018427387903)))))).
+
+(* some large number from keyboard mashing (all commands instant including printing) *)
+(* results checked in python 3.13.12 (compute "n * m",
+   "len(bin(n * m)) - 2" (-2 because starts with "0b")
+   and "(n * m).bit_count()" *)
+Definition large := Eval cbv in 534653679184394009346 * 4576931832291539343426.
+Check eq_refl : large = 2447073443510841321595526374542420547659396.
+
+Definition nbits := rec2 (fun _ => N) 0 1 (fun _ x => S x).
+Definition largebits := Eval cbv in nbits large.
+Check eq_refl : largebits = 141.
+
+(* NB [rem2 (S (S n)) = rem2 n] *)
+Definition popcount := rec2 (fun _ => N) 0 1 (fun n x => x + rem2 n).
+Definition largecnt := Eval cbv in popcount large.
+Check eq_refl : largecnt = 69.
+
+Goal forall n:N, 0 = n -> 1 = S n.
+Proof.
+  intros n H.
+  rewrite H.
+  reflexivity.
+Qed.
+
+Goal 1 = 2 -> False.
+  congruence.
+Qed.
+
+Goal forall x, S x = 1 -> x = 0.
+  intros.
+  match goal with h : ?f _ = ?f _ |- _ => injection h as h end.
+  exact H.
+Qed.
+
+Definition ignore (x y:N) := x.
+
+Check eq_refl : ignore 1 _ = 1.

--- a/theories/Corelib/Init/Datatypes.v
+++ b/theories/Corelib/Init/Datatypes.v
@@ -184,6 +184,7 @@ Register BoolSpecF as core.BoolSpec.BoolSpecF.
     Numbers in [nat] can be denoted using a decimal notation;
     e.g. [3%nat] abbreviates [S (S (S O))] *)
 
+#[primitive_nat]
 Inductive nat : Set :=
   | O : nat
   | S : nat -> nat.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -177,7 +177,7 @@ let fold_with_full_binders g f n acc c =
   let open Context.Rel.Declaration in
   let open Constr in
   match kind c with
-  | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _  | Int _ | Float _ | String _ -> acc
+  | Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _ | Construct _  | Nat _ | Int _ | Float _ | String _ -> acc
   | Cast (c,_, t) -> f n (f n acc c) t
   | Prod (na,t,c) -> f (g (LocalAssum (na,t)) n) (f n acc t) c
   | Lambda (na,t,c) -> f (g (LocalAssum (na,t)) n) (f n acc t) c

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -153,7 +153,7 @@ let get_inductive_deps ~noprop env kn =
         | Some c -> aux env accu (EConstr.applist (EConstr.of_constr c,a))
         | None -> accu)
       | Rel _ | Var _ | Sort _ | Prod _ | Lambda _ | LetIn _ | Proj _
-      | Construct _ | Case _ | CoFix _ | Fix _ | Meta _ | Evar _ | Int _
+      | Construct _ | Case _ | CoFix _ | Fix _ | Meta _ | Evar _ | Nat _ | Int _
       | Float _ | String _ | Array _ -> Termops.fold_constr_with_full_binders env sigma EConstr.push_rel aux env (List.fold_left (aux env) accu a) c
     in
     let fold i accu (constr_ctx,_) =
@@ -470,7 +470,7 @@ let build_beq_scheme env handle kn =
     | Fix _ -> None
 
     (* Not building a type *)
-    | Proj _ | CoFix _ | Int _ | Float _ | String _ -> None
+    | Proj _ | CoFix _ | Nat _ | Int _ | Float _ | String _ -> None
 
     | Meta _ | Evar _ -> assert false (* kernel terms *)
     in
@@ -603,7 +603,7 @@ let build_beq_scheme env handle kn =
     | Prod _ -> raise InductiveWithProduct (* loss of decidable if uncountable domain *)
 
     | Meta _ | Evar _ -> None (* assert false! *)
-    | Int _ | Float _ | String _ | Array _ -> None
+    | Nat _ | Int _ | Float _ | String _ | Array _ -> None
     in
     Option.map (fun c -> Term.it_mkLambda_or_LetIn c ctx) c
 

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -627,7 +627,7 @@ let variance_of_entry ~cumulative ~variances uctx =
       assert (lvs <= lus);
       Some (Array.append variances (Array.make (lus - lvs) None))
 
-let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind =
+let interp_mutual_inductive_constr_internal ~sigma ~flags ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind ~is_nat =
   let {
     poly;
     template;
@@ -682,9 +682,14 @@ let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~
       mind_entry_private = if private_ind then Some false else None;
       mind_entry_universes = univ_entry;
       mind_entry_variance = variance;
+      mind_entry_is_nat = is_nat;
     }
   in
   default_dep_elim, mind_ent, ubinders, global_univs
+
+(* wrapper that just sets is_nat:false *)
+let interp_mutual_inductive_constr ~sigma ~flags ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind =
+  interp_mutual_inductive_constr_internal ~sigma ~flags ~udecl ~variances ~ctx_params ~indnames ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind ~is_nat:false
 
 let interp_params ~unconstrained_sorts ~poly env udecl uparamsl paramsl =
   let sigma, udecl, variances = interp_cumul_univ_decl_opt env udecl in
@@ -725,7 +730,7 @@ let maybe_unify_params_in env_ar_par sigma ~ninds ~nparams ~binders:k c =
   in
   aux (env_ar_par,k) sigma c
 
-let interp_mutual_inductive_gen env0 ~flags udecl (uparamsl,paramsl,indl) notations ~private_ind =
+let interp_mutual_inductive_gen env0 ~flags ?(is_nat=false) udecl (uparamsl,paramsl,indl) notations ~private_ind =
   check_all_names_different env0 indl;
   List.iter check_param paramsl;
   if not (List.is_empty uparamsl) && not (List.is_empty notations)
@@ -815,7 +820,7 @@ let interp_mutual_inductive_gen env0 ~flags udecl (uparamsl,paramsl,indl) notati
       indimpls cimpls
   in
   let arities_explicit = List.map (fun ar -> ar.ind_arity_explicit) indl in
-  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr ~flags ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind ~indnames in
+  let default_dep_elim, mie, binders, ctx = interp_mutual_inductive_constr_internal ~flags ~sigma ~ctx_params ~udecl ~variances ~arities_explicit ~arities ~template_syntax ~constructors ~env_ar ~private_ind ~indnames ~is_nat in
   (default_dep_elim, mie, binders, impls, ctx)
 
 
@@ -911,7 +916,7 @@ let rec count_binder_expr = function
   | CLocalPattern {CAst.loc} :: _ ->
     Loc.raise ?loc (Gramlib.Grammar.ParseError "pattern with quote not allowed here")
 
-let interp_mutual_inductive ~env ~flags ?typing_flags udecl indl ~private_ind ~uniform =
+let interp_mutual_inductive ~env ~flags ?typing_flags ?is_nat udecl indl ~private_ind ~uniform =
   let indlocs = List.map (fun ((n,_,_,constructors),_) ->
       let conslocs = List.map (fun (_,(c,_)) -> c.CAst.loc) constructors in
       n.CAst.loc, conslocs)
@@ -927,15 +932,15 @@ let interp_mutual_inductive ~env ~flags ?typing_flags udecl indl ~private_ind ~u
       | NonUniformParameters -> ([], params, indl), None
   in
   let env = Environ.update_typing_flags ?typing_flags env in
-  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen ~flags env udecl indl where_notations ~private_ind in
+  let default_dep_elim, mie, univ_binders, implicits, uctx = interp_mutual_inductive_gen ~flags ?is_nat env udecl indl where_notations ~private_ind in
   let open Mind_decl in
   { mie; default_dep_elim; nuparams; univ_binders; implicits; uctx; where_notations; coercions; indlocs }
 
-let do_mutual_inductive ~flags ?typing_flags udecl indl ~private_ind ~uniform =
+let do_mutual_inductive ~flags ?typing_flags ?is_nat udecl indl ~private_ind ~uniform =
   let open Mind_decl in
   let env = Global.env () in
   let { mie; default_dep_elim; univ_binders; implicits; uctx; where_notations; coercions; indlocs} =
-    interp_mutual_inductive ~flags ~env udecl indl ?typing_flags ~private_ind ~uniform in
+    interp_mutual_inductive ~flags ~env ?is_nat udecl indl ?typing_flags ~private_ind ~uniform in
   (* Declare the global universes *)
   let () = Global.push_context_set uctx in
   (* Declare the mutual inductive block with its associated schemes *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -30,6 +30,7 @@ type uniform_inductive_flag =
 val do_mutual_inductive
   : flags:flags
   -> ?typing_flags:Declarations.typing_flags
+  -> ?is_nat:bool
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
   -> private_ind:bool
@@ -68,6 +69,7 @@ val interp_mutual_inductive
   :  env:Environ.env
   -> flags:flags
   -> ?typing_flags:Declarations.typing_flags
+  -> ?is_nat:bool
   -> cumul_univ_decl_expr option
   -> (one_inductive_expr * notation_declaration list) list
   -> private_ind:bool

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1591,7 +1591,7 @@ let explain_inductive_error env = function
 
 (* Primitive errors *)
 
-let explain_incompatible_prim_declarations (type a) (act:a Primred.action_kind) (x:a) (y:a) =
+let explain_incompatible_prim_declarations (type a) (act:a Primred.action_error) (x:a) (y:a) =
   let open Primred in
   let env = Global.env() in
   (* The newer constant/inductive (either coming from Primitive or a
@@ -1610,6 +1610,10 @@ let explain_incompatible_prim_declarations (type a) (act:a Primred.action_kind) 
   | IncompatInd ind ->
     let px = try pr_inductive env x with Not_found -> MutInd.print (fst x) in
     str "Cannot declare " ++ px ++ str " as primitive " ++ str (CPrimitives.prim_ind_to_string ind) ++
+    str ": " ++ pr_inductive env y ++ str " is already declared."
+  | IncompatNat ->
+    let px = try pr_inductive env x with Not_found -> MutInd.print (fst x) in
+    str "Cannot declare " ++ px ++ str " as primitive nat" ++
     str ": " ++ pr_inductive env y ++ str " is already declared."
 
 (* Recursion schemes errors *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1309,17 +1309,22 @@ let dump_inductive indl_for_glob decl =
     | Inductive _ -> ()
   end
 
+let is_nat_attr = Attributes.key_value_attribute ~key:"primitive_nat" ~empty:() ~values:[]
+
 let vernac_inductive ~atts kind indl =
   let open Preprocessed_Mind_decl in
+  let atts, is_nat = Attributes.parse_with_extra is_nat_attr atts in
+  let is_nat = match is_nat with None -> false | Some () -> true in
   let indl_for_glob, decl = preprocess_inductive_decl ~atts kind indl in
   dump_inductive indl_for_glob decl;
   match decl with
   | Record { flags; kind; udecl; primitive_proj; records } ->
+    let () = if is_nat then CErrors.user_err Pp.(str "\"primitive_nat\" not supported for records.") in
     let _ : _ list =
       Record.definition_structure ~flags udecl kind ~primitive_proj records in
     ()
   | Inductive { flags; udecl; typing_flags; private_ind; uniform; inductives } ->
-    ComInductive.do_mutual_inductive ~flags udecl inductives ?typing_flags ~private_ind ~uniform
+    ComInductive.do_mutual_inductive ~flags udecl inductives ?typing_flags ~private_ind ~uniform ~is_nat
 
 let preprocess_inductive_decl ~atts kind indl =
   snd @@ preprocess_inductive_decl ~atts kind indl


### PR DESCRIPTION
The current state has some random TODOs and term matching (notation printing, ltac matching) is probably janky but is enough to have a look.

Prelude `nat` does not use the optimization (so CI should say nothing interesting), see new test file `bignat` for actual use of the optimization.

The optimization is similar to what agda https://agda.readthedocs.io/en/latest/language/built-ins.html#natural-numbers and lean https://lean-lang.org/doc/reference/latest/Basic-Types/Natural-Numbers/ have: closed nat values ("nat constants") can be represented by `Nat of Z.t`.

The cbv machine has optimized implementations for `+`/`*` on nat constants (the one for tail_mul is necessary to get large literals to work).

The VM produces values using the optimized representation but has no special handling for operators.

cclosure/`lazy`/cclosure-based conversion can handle inputs which contain the optimized representation but do not build larger values using it, ie `1 + 1` where `1` is optimized reduces to `S 1` (which converts correctly to `2`).
TBH I'm not sure how to do otherwise in a lazy/call by name setting, if we see `1 + e` for some arbitrary expression `e` we should not reduce `e` (at least in weak head mode).

~native_compute, cbn and reductionops do `failwith "TODO"` on optimized constants.~
I think tacred treats optimized constants as opaque values but who knows what this code even is.

