### PR TITLE
Add regression test for Scheme universe anomaly (fixes #21730)

### DIFF
--- a/test-suite/bugs/bug_21730.v
+++ b/test-suite/bugs/bug_21730.v
@@ -1,0 +1,17 @@
+(* Regression test for bug #21730 *)
+(* Scheme Elimination for an included inductive should not cause a universe anomaly *)
+
+Definition binary (A : Type) := A -> A -> Prop.
+
+Module Export SLF_DOT_LibContainer_WRAPPED.
+Module Export LibContainer.
+Class BagDisjoint T := { disjoint : binary T }.
+End LibContainer.
+
+Module Export SLF.
+Module Export LibContainer.
+Include SLF_DOT_LibContainer_WRAPPED.LibContainer.
+Scheme SLF_LibContainer_BagDisjoint_caset := Elimination for SLF.LibContainer.BagDisjoint Sort Type.
+End LibContainer.
+End SLF.
+End SLF_DOT_LibContainer_WRAPPED.


### PR DESCRIPTION
The bug was that `Scheme Elimination` for an inductive included from another module could trigger an anomaly about undefined universe levels. This was fixed by commit d142e673b6 which replaced `UState.of_context_set` (which did not include the global universe graph) with `Evd.from_env` followed by `fresh_inductive_instance` in `do_mutual_induction_scheme`.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21730


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.
<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
