### PR TITLE
Renamings, cleanup and UState.from_uctx which respects invariants

### DIFF
--- a/dev/ci/user-overlays/21737-Yann-Leray-ustate-of-names.sh
+++ b/dev/ci/user-overlays/21737-Yann-Leray-ustate-of-names.sh
@@ -1,0 +1,1 @@
+overlay vsrocq https://github.com/Yann-Leray/vsrocq ustate-of-names 21737

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -42,7 +42,7 @@ let finalize ?abort_on_undefined_evars ?poly sigma f =
     c
   in
   let v = f nf_constr in
-  let sigma = restrict_universe_context sigma !uvars in
+  let sigma = restrict_ustate sigma !uvars in
   sigma, v
 
 (** Term exploration up to instantiation. *)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -896,7 +896,9 @@ let empty = {
 
 let from_env ?binders e = { empty with universes = UState.from_env ?binders e }
 
-let from_ctx uctx = { empty with universes = uctx }
+let from_ustate uctx = { empty with universes = uctx }
+
+let from_ctx = from_ustate
 
 let has_undefined evd = not (EvMap.is_empty evd.undf_evars)
 
@@ -909,8 +911,10 @@ let merge_ustate evd uctx' =
 
 let merge_universe_context = merge_ustate
 
-let set_universe_context evd uctx' =
+let set_ustate evd uctx' =
   { evd with universes = uctx' }
+
+let set_universe_context = set_ustate
 
 (* TODO: make unique *)
 let add_conv_pb ?(tail=false) pb d =
@@ -1035,8 +1039,10 @@ let check_univ_decl_early ~poly ~with_obls sigma udecl terms =
   let uctx = UState.restrict uctx vars in
   ignore (UState.check_univ_decl ~poly uctx udecl)
 
-let restrict_universe_context evd vars =
+let restrict_ustate evd vars =
   { evd with universes = UState.restrict evd.universes vars }
+
+let restrict_universe_context = restrict_ustate
 
 let universe_subst evd =
   UState.subst evd.universes

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -900,6 +900,8 @@ let from_ustate uctx = { empty with universes = uctx }
 
 let from_ctx = from_ustate
 
+let from_auctx e names = { empty with universes = UState.from_auctx e names }
+
 let has_undefined evd = not (EvMap.is_empty evd.undf_evars)
 
 let has_given_up evd = not (Evar.Set.is_empty evd.given_up)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -894,7 +894,7 @@ let empty = {
   extras = Store.empty;
 }
 
-let from_env ?binders e = { empty with universes = UState.from_env ?binders e }
+let from_env e = { empty with universes = UState.from_env e }
 
 let from_ustate uctx = { empty with universes = uctx }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -176,6 +176,12 @@ val from_ustate : UState.t -> evar_map
     (e.g. after having interpreted a Theorem statement and preparing
     to open a goal). *)
 
+val from_auctx : Environ.env -> UVars.AbstractContext.t -> evar_map
+(** The empty evar map with given universe context, taking its initial universes
+    from both the env and the variables in the universe context.
+    This is the entry point when restarting from an already finalized declaration
+    (e.g. for printing). *)
+
 val from_ctx : UState.t -> evar_map
 [@@deprecated "(9.3) Use [Evd.from_ustate]"]
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -163,10 +163,10 @@ type evar_map
 val empty : evar_map
 (** The empty evar map. *)
 
-val from_env : ?binders:lident list -> env -> evar_map
-(** The empty evar map with given universe context, taking its initial
-    universes from env, possibly with initial universe binders. This
-    is the main entry point at the beginning of the process of
+val from_env : env -> evar_map
+(** The empty evar map with given universe context,
+    taking its initial universes from env.
+    This is the main entry point at the beginning of the process of
     interpreting a declaration (e.g. before entering the
     interpretation of a Theorem statement). *)
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -170,11 +170,14 @@ val from_env : ?binders:lident list -> env -> evar_map
     interpreting a declaration (e.g. before entering the
     interpretation of a Theorem statement). *)
 
-val from_ctx : UState.t -> evar_map
-(** The empty evar map with given universe context. This is the main
-    entry point when resuming from a already interpreted declaration
-    (e.g.  after having interpreted a Theorem statement and preparing
+val from_ustate : UState.t -> evar_map
+(** The empty evar map with given universe unification state. This is
+    the main entry point when resuming from an already interpreted declaration
+    (e.g. after having interpreted a Theorem statement and preparing
     to open a goal). *)
+
+val from_ctx : UState.t -> evar_map
+[@@deprecated "(9.3) Use [Evd.from_ustate]"]
 
 val is_empty : evar_map -> bool
 (** Whether an evarmap is empty. *)
@@ -559,8 +562,6 @@ val univ_flexible_alg : rigid
 
 type 'a in_ustate = 'a * UState.t
 
-val restrict_universe_context : evar_map -> Univ.Level.Set.t -> evar_map
-
 (** Raises Not_found if not a name for a universe in this map. *)
 val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 val quality_of_name : evar_map -> Id.t -> Sorts.QVar.t
@@ -626,11 +627,18 @@ val check_univ_decl : poly:PolyFlags.t -> evar_map -> UState.universe_decl -> US
     starting to build a declaration interactively *)
 val check_univ_decl_early : poly:PolyFlags.t -> with_obls:bool -> evar_map -> UState.universe_decl -> Constr.t list -> unit
 
+val restrict_ustate : evar_map -> Univ.Level.Set.t -> evar_map
 val merge_ustate : evar_map -> UState.t -> evar_map
-val set_universe_context : evar_map -> UState.t -> evar_map
+val set_ustate : evar_map -> UState.t -> evar_map
+
+val restrict_universe_context : evar_map -> Univ.Level.Set.t -> evar_map
+[@@deprecated "(9.3) Use [Evd.restrict_ustate]"]
 
 val merge_universe_context : evar_map -> UState.t -> evar_map
 [@@deprecated "(9.3) Use [Evd.merge_ustate]"]
+
+val set_universe_context : evar_map -> UState.t -> evar_map
+[@@deprecated "(9.3) Use [Evd.set_ustate]"]
 
 val merge_universe_context_set : ?loc:Loc.t -> ?sideff:bool -> rigid -> evar_map -> Univ.ContextSet.t -> evar_map
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1103,7 +1103,7 @@ module Unsafe = struct
     Pv.modify (fun ps -> { solution = evd; comb = undefined evd ps.comb })
 
   let tclEVARUNIVCONTEXT ctx =
-    Pv.modify (fun ps -> { ps with solution = Evd.set_universe_context ps.solution ctx })
+    Pv.modify (fun ps -> { ps with solution = Evd.set_ustate ps.solution ctx })
 
   let push_future_goals p =
     { p with solution = Evd.push_future_goals p.solution }

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -421,7 +421,7 @@ let empty =
     initial_universes = UGraph.initial_universes;
     minim_extra = UnivMinim.empty_extra; }
 
-let make ~qualities univs =
+let make qualities univs =
   { empty with
     universes = univs;
     initial_universes = univs ;
@@ -1488,18 +1488,7 @@ let new_univ_level_variable ?loc rigid name uctx =
 
 let add_forgotten_univ uctx u = add_universe None true uctx u
 
-let make_with_initial_binders ~qualities univs binders =
-  let uctx = make ~qualities univs in
-  List.fold_left
-    (fun uctx { CAst.loc; v = id } ->
-       fst (new_univ_level_variable ?loc univ_rigid (Some id) uctx))
-    uctx binders
-
-let from_env ?(binders=[]) env =
-  make_with_initial_binders
-    ~qualities:(Environ.qualities env)
-    (Environ.universes env)
-    binders
+let from_env env = make (Environ.qualities env) (Environ.universes env)
 
 let make_nonalgebraic_variable uctx u =
   { uctx with univ_variables = UnivFlex.make_nonalgebraic_variable uctx.univ_variables u }

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -421,13 +421,6 @@ let empty =
     initial_universes = UGraph.initial_universes;
     minim_extra = UnivMinim.empty_extra; }
 
-let make qualities univs =
-  { empty with
-    universes = univs;
-    initial_universes = univs ;
-    sort_variables = QState.of_elims qualities
-  }
-
 let is_empty uctx =
   PContextSet.is_empty uctx.local &&
   UnivFlex.is_empty uctx.univ_variables
@@ -609,6 +602,7 @@ let is_above_prop uctx qv = QState.is_above_prop uctx.sort_variables qv
 
 let is_algebraic l uctx = UnivFlex.is_algebraic l uctx.univ_variables
 
+(** Deprecated *)
 let of_names (ubind,(revqbind,revubind)) =
   let revqbind = QVar.Map.map (fun id -> { uname = Some id; uloc = None }) revqbind in
   let revubind = Level.Map.map (fun id -> { uname = Some id; uloc = None }) revubind in
@@ -1451,6 +1445,14 @@ let add_loc l loc (names, (qnames_rev,unames_rev) as orig) =
   | None -> orig
   | Some _ -> (names, (qnames_rev, Level.Map.add l { uname = None; uloc = loc } unames_rev))
 
+let add_quality_variable ?loc ?(check_fresh=true) ~name ~rigid uctx q =
+  let sort_variables = QState.add ~check_fresh ~rigid q uctx.sort_variables in
+  let names = match name with
+    | Some n -> add_qnames ?loc n q uctx.names
+    | None -> add_qloc q loc uctx.names
+  in
+  { uctx with sort_variables; names }
+
 let add_universe ?loc name strict uctx u =
   let initial_universes = UGraph.add_universe ~strict u uctx.initial_universes in
   let universes = UGraph.add_universe ~strict u uctx.universes in
@@ -1465,14 +1467,7 @@ let add_universe ?loc name strict uctx u =
 let new_quality_variable ?loc ?(sort_rigid = false) ?name uctx =
   let q = UnivGen.fresh_sort_quality () in
   (* don't need to check_fresh as it's guaranteed new *)
-  let sort_variables = QState.add ~check_fresh:false ~rigid:(sort_rigid || Option.has_some name)
-      q uctx.sort_variables
-  in
-  let names = match name with
-    | Some n -> add_qnames ?loc n q uctx.names
-    | None -> add_qloc q loc uctx.names
-  in
-  { uctx with sort_variables; names }, q
+  add_quality_variable ?loc ~name ~rigid:(sort_rigid || Option.has_some name) uctx q, q
 
 let new_univ_level_variable ?loc rigid name uctx =
   let u = UnivGen.fresh_level () in
@@ -1488,7 +1483,22 @@ let new_univ_level_variable ?loc rigid name uctx =
 
 let add_forgotten_univ uctx u = add_universe None true uctx u
 
-let from_env env = make (Environ.qualities env) (Environ.universes env)
+let from_env env =
+  { empty with
+    universes = Environ.universes env;
+    initial_universes = Environ.universes env;
+    sort_variables = QState.of_elims (Environ.qualities env);
+  }
+
+let from_auctx env auctx =
+  let ustate = from_env env in
+  let names = AbstractContext.names auctx in
+  let name_to_option = function Name id -> Some id | Anonymous -> None in
+  (* Inlined call to [AbstractContext.repr] to know what qvars, levels and constraints to add *)
+  let ustate = Array.fold_left_i (fun i ustate name -> add_quality_variable ~rigid:true ~name:(name_to_option name) ustate (QVar.make_var i)) ustate names.quals in
+  let ustate = Array.fold_left_i (fun i ustate name -> add_universe (name_to_option name) false ustate (Level.var i)) ustate names.univs in
+  let ustate = add_poly_constraints ustate (AbstractContext.constraints auctx) in
+  ustate
 
 let make_nonalgebraic_variable uctx u =
   { uctx with univ_variables = UnivFlex.make_nonalgebraic_variable uctx.univ_variables u }

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -32,15 +32,8 @@ type t
 
 val empty : t
 
-val make : qualities:QGraph.t -> UGraph.t -> t
-[@@ocaml.deprecated "(8.13) Use from_env"]
-
-val make_with_initial_binders : qualities:QGraph.t -> UGraph.t -> lident list -> t
-[@@ocaml.deprecated "(8.13) Use from_env"]
-
-val from_env : ?binders:lident list -> Environ.env -> t
-(** Main entry point at the beginning of a declaration declaring the
-    binding names as rigid universes. *)
+val from_env : Environ.env -> t
+(** Main entry point at the beginning of a declaration. *)
 
 val of_names : (UnivNames.universe_binders * UnivNames.rev_binders) -> t
 (** Main entry point when only names matter, e.g. for printing. *)

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -35,9 +35,13 @@ val empty : t
 val from_env : Environ.env -> t
 (** Main entry point at the beginning of a declaration. *)
 
-val of_names : (UnivNames.universe_binders * UnivNames.rev_binders) -> t
-(** Main entry point when only names matter, e.g. for printing. *)
+val from_auctx : Environ.env -> UVars.AbstractContext.t -> t
+(** Main entry point when the universe declaration has already been computed,
+    e.g. for printing. *)
 
+val of_names : (UnivNames.universe_binders * UnivNames.rev_binders) -> t
+[@@deprecated "(9.3) Use [UState.from_uctx]"]
+(** Main entry point when only names matter, e.g. for printing. *)
 
 (** Misc *)
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -111,7 +111,7 @@ let rec check_with_def (cst, ustate) env struc (idl, wth) mp reso =
         | Polymorphic uctx, Polymorphic ctx ->
           let () =
             if not (Subtyping.check_polymorphic_universes env uctx ctx) then
-              error (WithSignatureMismatch (IncompatibleUnivConstraints { got = ctx; expect = uctx }))
+              error (WithSignatureMismatch (IncompatibleUnivConstraints { env; got = ctx; expect = uctx }))
           in
           (** Terms are compared in a context with De Bruijn universe indices *)
           let () = check_ucontext (UVars.AbstractContext.repr uctx) env in

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -50,7 +50,7 @@ type signature_mismatch_error =
   | IncompatibleUniverses of { err : UGraph.univ_inconsistency; env : env; t1 : types; t2 : types }
   | IncompatibleQualities of { err : QGraph.elimination_error; env : env; t1 : types; t2 : types }
   | IncompatiblePolymorphism of env * types * types
-  | IncompatibleUnivConstraints of { got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
+  | IncompatibleUnivConstraints of { env : env; got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
   | IncompatibleVariance
   | NoRewriteRulesSubtyping
 

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -104,7 +104,7 @@ type signature_mismatch_error =
   | IncompatibleUniverses of { err : UGraph.univ_inconsistency; env : env; t1 : types; t2 : types }
   | IncompatibleQualities of { err : QGraph.elimination_error; env : env; t1 : types; t2 : types }
   | IncompatiblePolymorphism of env * types * types
-  | IncompatibleUnivConstraints of { got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
+  | IncompatibleUnivConstraints of { env : env; got : UVars.AbstractContext.t; expect : UVars.AbstractContext.t }
   | IncompatibleVariance
   | NoRewriteRulesSubtyping
 

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -112,7 +112,7 @@ let check_universes error env u1 u2 =
   | Monomorphic, Monomorphic -> env
   | Polymorphic auctx1, Polymorphic auctx2 ->
     if not (check_polymorphic_universes env auctx2 auctx1) then
-      error (IncompatibleUnivConstraints { got = auctx1; expect = auctx2; } )
+      error (IncompatibleUnivConstraints { env; got = auctx1; expect = auctx2; } )
     else
       let () = Environ.check_ucontext (UVars.AbstractContext.repr auctx2) env in
       let env = Environ.push_context ~strict:false (UVars.AbstractContext.repr auctx2) env in

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -384,6 +384,8 @@ struct
 
   let names (nas, _) = nas
 
+  let constraints (_, csts) = csts
+
   let hcons ({quals = qnames; univs = unames}, cst) =
     let hqnames, qnames = Hashcons.hashcons_array Names.Name.hcons qnames in
     let hunames, unames = Hashcons.hashcons_array Names.Name.hcons unames in
@@ -406,6 +408,10 @@ struct
   let repr (names, cst as self) : UContext.t =
     let inst = Instance.abstract_instance (size self) in
     (names, (inst, cst))
+
+  let refine_names names' (names, x) =
+    let merge_names = Array.map2 Names.(fun old refined -> match refined with Anonymous -> old | Name _ -> refined) in
+    ({quals = merge_names names.quals names'.quals; univs = merge_names names.univs names'.univs}, x)
 
   let pr prq pru ?variance ctx = UContext.pr prq pru ?variance (repr ctx)
 

--- a/kernel/uVars.mli
+++ b/kernel/uVars.mli
@@ -195,6 +195,12 @@ sig
   val names : t -> bound_names
   (** Return the names of the bound universe variables *)
 
+  val constraints : t -> PConstraints.t
+  (** Return the constraints on the universe variables *)
+
+  val refine_names : bound_names -> t -> t
+  (** Use names to name the possibly yet unnamed universes *)
+
   val pr : (QVar.t -> Pp.t) -> (Level.t -> Pp.t) -> ?variance:Variance.t array -> t -> Pp.t
 end
 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1151,7 +1151,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
     let not_free_in_t id = not (is_free_in id t) in
     let evd = Evd.from_env env in
     let t', ctx = Pretyping.understand env evd t in
-    let evd = Evd.from_ctx ctx in
+    let evd = Evd.from_ustate ctx in
     let type_t' = Retyping.get_type_of env evd t' in
     let new_env =
       EConstr.push_rel (LocalDef (make_annot n ERelevance.relevant, t', type_t')) env

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1512,7 +1512,7 @@ let com_terminate interactive_proof tcc_lemma_name tcc_lemma_ref is_mes
   in
   try
     let sigma, new_goal_type = build_new_goal_type lemma in
-    let sigma = Evd.from_ctx (Evd.ustate sigma) in
+    let sigma = Evd.from_ustate (Evd.ustate sigma) in
     open_new_goal ~lemma start_proof sigma using_lemmas tcc_lemma_ref
       (Some tcc_lemma_name) new_goal_type
   with EmptySubgoals ->
@@ -1552,7 +1552,7 @@ let com_eqn uctx nb_arg eq_name functional_ref f_ref terminate_ref
     | GlobRef.ConstRef c -> is_opaque_constant c
     | _ -> anomaly ~label:"terminate_lemma" (Pp.str "not a constant.")
   in
-  let evd = Evd.from_ctx uctx in
+  let evd = Evd.from_ustate uctx in
   let f_constr = constr_of_monomorphic_global (Global.env ()) f_ref in
   let equation_lemma_type = subst1 f_constr equation_lemma_type in
   let info = Declare.Info.make () in
@@ -1689,7 +1689,7 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls
   in
   let relation, evuctx = interp_constr env_with_pre_rec_args evd r in
   let () = check_relation_type env_with_pre_rec_args evd relation in
-  let evd = Evd.from_ctx evuctx in
+  let evd = Evd.from_ustate evuctx in
   let tcc_lemma_name = add_suffix function_name "_tcc" in
   let tcc_lemma_constr = ref Undefined in
   (* let _ = Pp.msgnl (fun _ _ -> str "relation := " ++ Printer.pr_lconstr_env env_with_pre_rec_args relation) in *)

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -198,7 +198,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
     user_err
     (str"Computed inversion goal was not closed in initial signature.");
   *)
-  let pf = Proof.start ~name ~poly (Evd.from_ctx (ustate sigma)) [invEnv,invGoal] in
+  let pf = Proof.start ~name ~poly (Evd.from_ustate (ustate sigma)) [invEnv,invGoal] in
   let pf, _, () = Proof.run_tactic env (tclTHEN intro (onLastHypId inv_op)) pf in
   let pfterm = List.hd (Proof.partial_proof pf) in
   let global_named_context = Global.named_context_val () in
@@ -244,7 +244,7 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let c, uctx = Constrintern.interp_type env sigma com in
-  let sigma = Evd.from_ctx uctx in
+  let sigma = Evd.from_ustate uctx in
   let sigma, sort = Evd.fresh_sort_in_quality ~rigid:univ_rigid sigma comsort in
   add_inversion_lemma ~poly na env sigma c sort bool tac
 

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -171,7 +171,7 @@ let _ = add_tacdef false ((Loc.ghost,Id.of_string"ring_closed_term"
 
 let ic env sigma c =
   let c, uctx = Constrintern.interp_constr env sigma c in
-  (Evd.from_ctx uctx, c)
+  (Evd.from_ustate uctx, c)
 
 let ic_unsafe env sigma c = (*FIXME remove *)
   fst (Constrintern.interp_constr env sigma c)

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -926,7 +926,7 @@ let refine_with ?(first_goes_last=false) ?beta ?(with_evars=true) oc =
   let sigma = Proofview.Goal.sigma gl in
   let uct = Evd.ustate (fst oc) in
   let n, oc = abs_evars_pirrel env sigma oc in
-  Proofview.Unsafe.tclEVARS (Evd.set_universe_context sigma uct) <*>
+  Proofview.Unsafe.tclEVARS (Evd.set_ustate sigma uct) <*>
   Proofview.tclORELSE (applyn ~with_evars ~first_goes_last ?beta n oc)
     (fun _ -> Proofview.tclZERO dependent_apply_error)
   end

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -468,7 +468,7 @@ let rwcltac ?under ?map_redex cl rdx dir (sigma, r) =
   let concl = Proofview.Goal.concl gl in
   let sigma = resolve_typeclasses ~where:r ~fail:false env sigma in
   let r_n, evs, ucst = abs_evars env sigma0 (sigma, r) in
-  let sigma0 = Evd.set_universe_context sigma0 ucst in
+  let sigma0 = Evd.set_ustate sigma0 ucst in
   let n = List.length evs in
   let r_n' = abs_cterm env sigma0 n r_n in
   let r' = EConstr.Vars.subst_var sigma pattern_id r_n' in
@@ -731,10 +731,10 @@ let rwargtac ?under ?map_redex ist ((dir, mult), (((oclr, occ), grx), (kind, gt)
     (* Evarmaps below are extensions of sigma, so setting the universe context is correct *)
     let sigma = match rx with
     | None -> sigma
-    | Some { pat_sigma = s } -> Evd.set_universe_context sigma (Evd.ustate s)
+    | Some { pat_sigma = s } -> Evd.set_ustate sigma (Evd.ustate s)
     in
     let t = interp env sigma gt in
-    let sigma = Evd.set_universe_context sigma  (Evd.ustate (fst t)) in
+    let sigma = Evd.set_ustate sigma  (Evd.ustate (fst t)) in
     Proofview.Unsafe.tclEVARS sigma <*>
     (match kind with
     | RWred sim -> simplintac occ rx sim

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -343,7 +343,7 @@ let unif_end ?(solve_TC=true) env sigma0 ise0 pt ok =
   let c, s, uc, t = nf_open_term sigma0 ise pt in
   let ise1 = create_evar_defs s in
   let ise1 = Evd.set_typeclass_evars ise1 (Evar.Set.filter (fun ev -> Evd.is_undefined ise1 ev) tcs) in
-  let ise1 = Evd.set_universe_context ise1 uc in
+  let ise1 = Evd.set_ustate ise1 uc in
   let ise2 =
     if solve_TC then Typeclasses.resolve_typeclasses ~fail:true env ise1
     else ise1 in
@@ -356,7 +356,7 @@ let unif_end ?(solve_TC=true) env sigma0 ise0 pt ok =
 let unify_HO env sigma0 t1 t2 =
   let sigma = unif_HO env sigma0 t1 t2 in
   let _, sigma, uc, _ = unif_end ~solve_TC:false env sigma0 sigma t2 (fun _ -> true) in
-  Evd.set_universe_context sigma uc
+  Evd.set_ustate sigma uc
 
 (* This is what the definition of iter_constr should be... *)
 let iter_constr_LR sigma f c = match EConstr.kind sigma c with
@@ -1521,7 +1521,7 @@ let ssrpatterntac arg =
   let pat = interp_rpattern env sigma0 arg in
   let (t, uc), concl_x =
     fill_occ_pattern env sigma0 concl0 pat noindex 1 in
-  let sigma = Evd.set_universe_context sigma0 uc in
+  let sigma = Evd.set_ustate sigma0 uc in
   let sigma, tty = Typing.type_of env sigma t in
   let concl = EConstr.mkLetIn (make_annot (Name (Id.of_string "selected")) EConstr.ERelevance.relevant, t, tty, concl_x) in
   Proofview.Unsafe.tclEVARS sigma <*>

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -399,7 +399,7 @@ let reinterpret_get_type_of ~src env sigma c =
 let get_judgment_of env evc c = { uj_val = c; uj_type = get_type_of env evc c }
 
 let get_type_of_constr ?polyprop ?lax env ?(uctx=UState.from_env env) c =
-  EConstr.Unsafe.to_constr (get_type_of ?polyprop ?lax env (Evd.from_ctx uctx) (EConstr.of_constr c))
+  EConstr.Unsafe.to_constr (get_type_of ?polyprop ?lax env (Evd.from_ustate uctx) (EConstr.of_constr c))
 
 (* Returns sorts of a context *)
 let sorts_of_context env evc ctxt =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -227,64 +227,49 @@ let q_ident = Id.of_string "α"
 
 let u_ident = Id.of_string "u"
 
-let universe_binders_with_opt_names orig names =
-  let open Univ in
-  let {UVars.quals = qorig; UVars.univs = uorig} = UVars.AbstractContext.names orig in
-  let qorig, uorig as orig = Array.to_list qorig, Array.to_list uorig in
-  let qdecl, udecl = match names with
-  | None -> orig
+(** Replace the names in [uctx] with either:
+    - the exact names in [user_names];
+    - the existing names in [uctx], eventually freshened; or
+    - fresh names generated from the default id *)
+let fill_names ?user_names uctx =
+  let open UVars in
+  let { quals; univs } = AbstractContext.names uctx in
+  let user_qnames, user_unames = match user_names with
+  | None -> Array.map (fun _ -> Anonymous) quals, Array.map (fun _ -> Anonymous) univs
   | Some (gref, (qdecl, udecl)) ->
-    try
-      let qs =
-        List.map2 (fun orig {CAst.v = na} ->
-            match na with
-            | Anonymous -> orig
-            | Name id -> Name id) qorig qdecl
-      in
-      let us =
-        List.map2 (fun orig {CAst.v = na} ->
-            match na with
-            | Anonymous -> orig
-            | Name id -> Name id) uorig udecl
-      in
-      qs, us
-    with Invalid_argument _ ->
+    let quals = Array.map_of_list (fun lname -> lname.CAst.v) qdecl in
+    let univs = Array.map_of_list (fun lname -> lname.CAst.v) udecl in
+    let user_size = Array.length quals, Array.length univs in
+    if not (eq_sizes (AbstractContext.size uctx) user_size) then
       let open UnivGen in
       raise (UniverseLengthMismatch {
           gref;
-          actual = List.length qorig, List.length uorig;
-          expect = List.length qdecl, List.length udecl;
+          actual = AbstractContext.size uctx;
+          expect = Array.length quals, Array.length univs;
         })
+    else quals, univs
   in
-  let fold_qnamed i ((qbind,ubind),(revqbind,revubind) as o) = function
-    | Name id -> let ui = Sorts.QVar.make_var i in
-      (Id.Map.add id ui qbind, ubind), (Sorts.QVar.Map.add ui id revqbind, revubind)
-    | Anonymous -> o
+  let add_id bounds = function Anonymous -> bounds | Name id -> Id.Set.add id bounds in
+  let boundqs = Array.fold_left add_id Id.Set.empty user_qnames in
+  let boundus = Array.fold_left add_id Id.Set.empty user_unames in
+  let freshen_name bounds user_name name = match user_name, name with
+  | Name id, _ -> bounds, Name id
+  | Anonymous, Anonymous -> bounds, Anonymous
+  | Anonymous, Name id ->
+    let id = Namegen.next_ident_away_from id (fun id -> Id.Set.mem id bounds) in
+    Id.Set.add id bounds, Name id
   in
-  let fold_unamed i ((qbind,ubind),(revqbind,revubind) as o) = function
-    | Name id -> let ui = Level.var i in
-      (qbind, Id.Map.add id ui ubind), (revqbind, Level.Map.add ui id revubind)
-    | Anonymous -> o
+  let boundqs, quals = Array.fold_left2_map freshen_name boundqs user_qnames quals in
+  let boundus, univs = Array.fold_left2_map freshen_name boundus user_unames univs in
+  let gen_name (uid, bounds as acc) = function
+  | Name id -> acc, Name id
+  | Anonymous ->
+    let uid = Namegen.next_ident_away_from uid (fun id -> Id.Set.mem id bounds) in
+    (uid, Id.Set.add uid bounds), Name uid
   in
-  let names = List.fold_left_i fold_qnamed 0 UnivNames.(empty_binders,empty_rev_binders) qdecl in
-  let names = List.fold_left_i fold_unamed 0 names udecl in
-  let fold_qanons i (u_ident, ((qbind,ubind), (revqbind,revubind)) as o) = function
-    | Name _ -> o
-    | Anonymous ->
-      let ui = Sorts.QVar.make_var i in
-      let id = Namegen.next_ident_away_from u_ident (fun id -> Id.Map.mem id qbind) in
-      (id, ((Id.Map.add id ui qbind, ubind), (Sorts.QVar.Map.add ui id revqbind, revubind)))
-  in
-  let fold_uanons i (u_ident, ((qbind,ubind), (revqbind,revubind)) as o) = function
-    | Name _ -> o
-    | Anonymous ->
-      let ui = Level.var i in
-      let id = Namegen.next_ident_away_from u_ident (fun id -> Id.Map.mem id ubind) in
-      (id, ((qbind,Id.Map.add id ui ubind), (revqbind,Level.Map.add ui id revubind)))
-  in
-  let (_, names) = List.fold_left_i fold_qanons 0 (q_ident, names) qdecl in
-  let (_, names) = List.fold_left_i fold_uanons 0 (u_ident, names) udecl in
-  names
+  let _, quals = Array.fold_left_map gen_name (q_ident, boundqs) quals in
+  let _, univs = Array.fold_left_map gen_name (u_ident, boundus) univs in
+  AbstractContext.refine_names { quals; univs } uctx
 
 let pr_sort_context_set sigma c =
   if !PrintingFlags.print_universes && not (UnivGen.is_empty_sort_context c) then

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -153,17 +153,15 @@ val pr_universes  : evar_map ->
   ?variance:UVars.Variance.t array -> ?priv:Univ.ContextSet.t ->
   Declarations.universes -> Pp.t
 
-(** [universe_binders_with_opt_names ref l]
+(** [fill_names ref l]
 
-    If [l] is [Some univs] return the universe binders naming the
-   bound levels of [ref] by [univs] (generating names for Anonymous).
-   May error if the lengths mismatch.
-
-    Otherwise return the bound universe names registered for [ref].
-
+    Generates names for Anonymous entries in [ref].
+    If [l] is [Some univs], use first the names in [univs],
+    then those in [ref] and finally generated names.
+    Can raise [UniverseLengthMismatch].
     Inefficient on large contexts due to name generation. *)
-val universe_binders_with_opt_names : UVars.AbstractContext.t ->
-  (GlobRef.t * UnivNames.univ_name_list) option -> UnivNames.universe_binders * UnivNames.rev_binders
+val fill_names : ?user_names:(GlobRef.t * UnivNames.univ_name_list) ->
+  UVars.AbstractContext.t -> UVars.AbstractContext.t
 
 (** Printing global references using names as short as possible *)
 

--- a/proofs/subproof.ml
+++ b/proofs/subproof.ml
@@ -134,13 +134,13 @@ let build_constant_by_tactic ~name ~sigma ~env ~sign ~poly typ tac =
   in
   (* FIXME: return the locally introduced effects *)
   let { Proof.sigma } = Proof.data proof in
-  let sigma = Evd.set_universe_context sigma output_ustate in
+  let sigma = Evd.set_ustate sigma output_ustate in
   (univs, body, typ), status, sigma
 
 let build_by_tactic env ~uctx ~poly ~typ tac =
   let name = Id.of_string "temporary_proof" in
   let sign = Environ.(val_of_named_context (named_context env)) in
-  let sigma = Evd.from_ctx uctx in
+  let sigma = Evd.from_ustate uctx in
   (* status doesn't matter: any given up evars can't be in the body/typ
      (we would get OpenProof exception) and we drop the evar part of the evar map *)
   let (univs, body, typ), _status, sigma = build_constant_by_tactic ~name ~env ~sigma ~sign ~poly typ tac in

--- a/tactics/allScheme.ml
+++ b/tactics/allScheme.ml
@@ -955,7 +955,7 @@ let generate_all_aux suffix kn u sub_temp mib uparams strpos nuparams =
   in
   (* DEBUG FUNCTIONS *)
   let* env = get_env in
-  let sigma = Evd.set_universe_context sigma uctx in
+  let sigma = Evd.set_ustate sigma uctx in
   let () = dbg Pp.(fun () ->
     let params = EConstr.of_rel_context mie.mind_entry_params in
     let ind = List.hd @@ mie.mind_entry_inds in

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -1805,7 +1805,7 @@ let proper_projection env sigma r ty =
 
 let build_morphism_signature env sigma m =
   let m,ctx = Constrintern.interp_constr env sigma m in
-  let sigma = Evd.from_ctx ctx in
+  let sigma = Evd.from_ustate ctx in
   let t = Retyping.get_type_of env sigma m in
   let cstrs =
     let rec aux t =

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -88,10 +88,10 @@ foo@{uu u v} =
 Type@{u} -> Type@{v} -> Type@{uu}
      : Type@{max(uu+1,u+1,v+1)}
 (* uu u v |=  *)
-foo@{u u IMPORTANT} =
-Type@{u} -> Type@{IMPORTANT} -> Type@{u}
-     : Type@{max(u+1,u+1,IMPORTANT+1)}
-(* u u IMPORTANT |=  *)
+foo@{uu u IMPORTANT} =
+Type@{u} -> Type@{IMPORTANT} -> Type@{uu}
+     : Type@{max(uu+1,u+1,IMPORTANT+1)}
+(* uu u IMPORTANT |=  *)
 Inductive Empty@{E} : Type@{E} :=  .
 (* E |=  *)
 Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
@@ -120,7 +120,15 @@ Universe instance length for mono is 0 but should be 1.
 File "./output/UnivBinders.v", line 108, characters 0-33:
 The command has indeed failed with message:
 This object does not support universe names.
-File "./output/UnivBinders.v", line 112, characters 0-50:
+insec0@{i i0} : Type@{i} -> Type@{i} -> Type@{i0} -> Type@{i}
+(* i i0 |=  *)
+
+insec0 is universe polymorphic
+Arguments insec0 (foo bar baz)%_type_scope
+insec0 is transparent
+Expands to: Constant UnivBinders.insec0
+Declared in library UnivBinders, line 114, characters 13-19
+File "./output/UnivBinders.v", line 120, characters 0-50:
 The command has indeed failed with message:
 Cannot enforce v < u because u < gU < gV < v
 insec@{v} = Type@{uu} -> Type@{v}
@@ -161,26 +169,26 @@ axfoo@{i u u0} : Type@{u} -> Type@{i}
 axfoo is universe polymorphic
 Arguments axfoo _%_type_scope
 Expands to: Constant UnivBinders.axfoo
-Declared in library UnivBinders, line 151, characters 6-11
+Declared in library UnivBinders, line 159, characters 6-11
 axbar@{i u u0} : Type@{u0} -> Type@{i}
 (* i u u0 |=  *)
 
 axbar is universe polymorphic
 Arguments axbar _%_type_scope
 Expands to: Constant UnivBinders.axbar
-Declared in library UnivBinders, line 151, characters 17-22
+Declared in library UnivBinders, line 159, characters 17-22
 axfoo' : Type@{axfoo'.u0} -> Type@{axfoo'.i}
 
 axfoo' is not universe polymorphic
 Arguments axfoo' _%_type_scope
 Expands to: Constant UnivBinders.axfoo'
-Declared in library UnivBinders, line 152, characters 18-24
+Declared in library UnivBinders, line 160, characters 18-24
 axbar' : Type@{axfoo'.u1} -> Type@{axfoo'.i}
 
 axbar' is not universe polymorphic
 Arguments axbar' _%_type_scope
 Expands to: Constant UnivBinders.axbar'
-Declared in library UnivBinders, line 152, characters 30-36
+Declared in library UnivBinders, line 160, characters 30-36
 *** [ axfoo@{i u u0} : Type@{u} -> Type@{i} ]
 (* i u u0 |=  *)
 
@@ -195,7 +203,7 @@ Arguments axfoo' _%_type_scope
 *** [ axbar' : Type@{axfoo'.u1} -> Type@{axfoo'.i} ]
 
 Arguments axbar' _%_type_scope
-File "./output/UnivBinders.v", line 158, characters 19-26:
+File "./output/UnivBinders.v", line 166, characters 19-26:
 The command has indeed failed with message:
 When declaring multiple assumptions in one command, only the first name is
 allowed to mention a universe binder (which will be shared by the whole
@@ -203,9 +211,9 @@ block).
 foo@{i} = Type@{M.i} -> Type@{i}
      : Type@{max(M.i+1,i+1)}
 (* i |=  *)
-Type@{u0} -> Type@{UnivBinders.83}
-     : Type@{max(u0+1,UnivBinders.83+1)}
-(* {UnivBinders.83} |=  *)
+Type@{u0} -> Type@{UnivBinders.85}
+     : Type@{max(u0+1,UnivBinders.85+1)}
+(* {UnivBinders.85} |=  *)
 bind_univs.mono = Type@{bind_univs.mono.u}
      : Type@{bind_univs.mono.u+1}
 bind_univs.poly@{u} = Type@{u}
@@ -255,7 +263,7 @@ Arguments MutualI1' A%_type_scope
 Arguments C1' A%_type_scope p1
 Arguments MutualI2' A%_type_scope
 Arguments C2' A%_type_scope p2
-File "./output/UnivBinders.v", line 209, characters 0-33:
+File "./output/UnivBinders.v", line 217, characters 0-33:
 The command has indeed failed with message:
 Universe inconsistency. Cannot enforce a < a because a = a.
 JMeq :
@@ -264,25 +272,25 @@ forall [A : Type@{JMeq.u0}], A -> forall [B : Type@{JMeq.u1}], B -> Prop
 JMeq is template universe polymorphic on JMeq.u0 (cannot be instantiated to Prop)
 Arguments JMeq [A]%_type_scope x [B]%_type_scope _
 Expands to: Inductive UnivBinders.PartialTemplate.JMeq
-Declared in library UnivBinders, line 219, characters 10-14
-File "./output/UnivBinders.v", line 234, characters 2-38:
+Declared in library UnivBinders, line 227, characters 10-14
+File "./output/UnivBinders.v", line 242, characters 2-38:
 The command has indeed failed with message:
 Universe u0 already exists.
-File "./output/UnivBinders.v", line 241, characters 6-26:
+File "./output/UnivBinders.v", line 249, characters 6-26:
 The command has indeed failed with message:
 Tactic failure: Not equal (due to universes).
 eq_rect
      : forall (A : Type@{eq_rect.u1}) (x : A) (P : A -> Type@{eq_rect.u0}),
        P x -> forall y : A, x = y -> P y
-File "./output/UnivBinders.v", line 259, characters 18-19:
+File "./output/UnivBinders.v", line 267, characters 18-19:
 Warning: Separating sorts from universes with "|" is deprecated.
 Use ";" instead.
 [deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]
-File "./output/UnivBinders.v", line 259, characters 33-34:
+File "./output/UnivBinders.v", line 267, characters 33-34:
 Warning: Separating sorts from universes with "|" is deprecated.
 Use ";" instead.
 [deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]
-File "./output/UnivBinders.v", line 265, characters 16-17:
+File "./output/UnivBinders.v", line 273, characters 16-17:
 Warning: Separating sorts from universes with "|" is deprecated.
 Use ";" instead.
 [deprecated-sort-poly-syntax,deprecated-since-9.1,deprecated,default]

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -90,8 +90,8 @@ Fail Definition fo@{uu uu} := Type@{uu}.
 Print foo@{E M N}.
 (* Underscores discard the name if there's one. *)
 Print foo@{_ _ _}.
-(* Can use a name for multiple universes *)
-Print foo@{u u IMPORTANT}.
+(* Can highlight a single universe *)
+Print foo@{_ _ IMPORTANT}.
 
 (* Also works for inductives and records. *)
 Print Empty@{E}.
@@ -106,6 +106,14 @@ Fail Print mono@{E}.
 
 (* Not everything can be printed with custom universe names. *)
 Fail Print Stdlib.Init.Logic@{E}.
+
+(* Case where a universe name appears more than one *)
+Section SomeSec0.
+  Universe i.
+  Context (foo : Type@{i}) (bar : Type@{i}).
+  Definition insec0@{i} (baz : Type@{i}) := foo -> bar.
+End SomeSec0.
+About insec0.
 
 (* Nice error when constraints are impossible. *)
 Monomorphic Universes gU gV. Monomorphic Constraint gU < gV.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -869,7 +869,7 @@ let build_beq_scheme env handle kn =
        For instance template poly inductive produces a univ monomorphic scheme
        which when applied needs to constrain the universe of its argument
     *)
-    let sigma = Evd.from_ctx uctx in
+    let sigma = Evd.from_ustate uctx in
     let sigma = Array.fold_left (fun sigma c ->
         fst @@ Typing.type_of env sigma (EConstr.of_constr c))
         sigma
@@ -1202,7 +1202,7 @@ let make_bl_scheme env handle mind =
   let bl_goal = EConstr.of_constr bl_goal in
   let univ_poly = Declareops.inductive_is_polymorphic mib in
   let poly = PolyFlags.of_univ_poly univ_poly in (* FIXME cumulativity not handled *)
-  let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) bl_goal)) else uctx in
+  let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ustate uctx) bl_goal)) else uctx in
   let (ans, _, _, uctx) = Subproof.build_by_tactic ~poly env ~uctx ~typ:bl_goal
     (compute_bl_tact handle (ind, EConstr.EInstance.make u) lnamesparrec nparrec)
   in
@@ -1335,7 +1335,7 @@ let make_lb_scheme env handle mind =
   let lb_goal = compute_lb_goal env handle (ind,u) lnamesparrec nparrec in
   let lb_goal = EConstr.of_constr lb_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
-  let uctx = if poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) lb_goal)) else uctx in
+  let uctx = if poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ustate uctx) lb_goal)) else uctx in
   let poly = PolyFlags.of_univ_poly poly (* FIXME cumulativity not handled *) in
   let (ans, _, _, ctx) = Subproof.build_by_tactic ~poly env ~uctx ~typ:lb_goal
     (compute_lb_tact handle ind lnamesparrec nparrec)
@@ -1531,7 +1531,7 @@ let make_eq_decidability env handle mind =
   let univ_poly = Declareops.inductive_is_polymorphic mib in
   (* FIXME: cumulativity not handled *)
   let poly = PolyFlags.of_univ_poly univ_poly in
-  let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ctx uctx) dec_goal)) else uctx in
+  let uctx = if univ_poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ustate uctx) dec_goal)) else uctx in
   let (ans, _, _, ctx) = Subproof.build_by_tactic ~poly env ~uctx
       ~typ:dec_goal (compute_dec_tact handle (ind,u) lnamesparrec nparrec)
   in

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -143,7 +143,7 @@ let do_definition_program ?loc ?hook ~pm ~name ~scope ?clearbody ~poly ?typing_f
     interp_definition ~program_mode:true ~poly env evd empty_internalization_env bl red_option c ctypopt
   in
   let body, typ, uctx, _, obls = Declare.Obls.prepare_obligations ~name poly ~body ?types env evd in
-  Evd.check_univ_decl_early ~poly ~with_obls:true (Evd.from_ctx uctx) udecl [body; typ];
+  Evd.check_univ_decl_early ~poly ~with_obls:true (Evd.from_ustate uctx) udecl [body; typ];
   let cinfo = Declare.CInfo.make ?loc ~name ~typ ~impargs () in
   let info = Declare.Info.make ~udecl ~scope ?clearbody ~poly ~kind ?hook ?typing_flags ?user_warns () in
   Declare.Obls.add_definition ~pm ~info ~cinfo ~opaque:false ~body ~uctx ?using obls

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -255,7 +255,7 @@ let build_wellfounded env sigma poly udecl {CAst.v=recname; loc} ctx body ccl im
   let hook, impls =
     if len > 1 then
       let hook { Declare.Hook.S.dref; uctx; obls; _ } =
-        let update c = CVars.replace_vars obls (evmap mkVar (Evarutil.nf_evar (Evd.from_ctx uctx) c)) in
+        let update c = CVars.replace_vars obls (evmap mkVar (Evarutil.nf_evar (Evd.from_ustate uctx) c)) in
         let tuple_value = update tuple_value in
         let ccl = update ccl in
         let ctx = Context.Rel.map_het (ERelevance.kind sigma) update ctx in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -604,7 +604,7 @@ let restrict_inductive_universes sigma ctx_params arities constructors =
   let uvars = List.fold_left (fun acc d -> Context.Rel.Declaration.fold_constr merge_universes_of_constr d acc) uvars ctx_params in
   let uvars = List.fold_right merge_universes_of_constr arities uvars in
   let uvars = List.fold_right (fun (_,ctypes) -> List.fold_right merge_universes_of_constr ctypes) constructors uvars in
-  Evd.restrict_universe_context sigma uvars
+  Evd.restrict_ustate sigma uvars
 
 let check_trivial_variances variances =
   Array.iter (function

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -46,7 +46,7 @@ let do_primitive id udecl prim typopt =
     Pretyping.check_evars_are_solved ~program_mode:false env evd;
     let evd = Evd.minimize_universes evd in
     let _qvars, uvars = EConstr.universes_of_constr evd typ in
-    let evd = Evd.restrict_universe_context evd uvars in
+    let evd = Evd.restrict_ustate evd uvars in
     let typ = EConstr.to_constr evd typ in
     let univ_poly = not (UVars.AbstractContext.is_empty auctx) in
     let poly = PolyFlags.of_univ_poly univ_poly in

--- a/vernac/comRewriteRule.ml
+++ b/vernac/comRewriteRule.ml
@@ -48,7 +48,7 @@ let do_symbol ~poly ~unfold_fix udecl (id, typ) =
   Pretyping.check_evars_are_solved ~program_mode:false env evd;
   let evd = Evd.minimize_universes ~poly evd in
   let _qvars, uvars = EConstr.universes_of_constr evd typ in
-  let evd = Evd.restrict_universe_context evd uvars in
+  let evd = Evd.restrict_ustate evd uvars in
   let typ = EConstr.to_constr evd typ in
   let univs = Evd.check_univ_decl ~poly evd udecl in
   let entry = Declare.symbol_entry ~univs ~unfold_fix typ in
@@ -434,7 +434,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
   let evd, lhs, typ = Pretyping.understand_tcc_ty ~flags env evd lhs in
   let evd = Evd.minimize_universes ~poly evd in
   let _qvars, uvars = EConstr.universes_of_constr evd lhs in
-  let evd = Evd.restrict_universe_context evd uvars in
+  let evd = Evd.restrict_ustate evd uvars in
   let uctx, uctx' = UState.check_univ_decl_rev (Evd.ustate evd) udecl in
 
   let usubst =
@@ -472,7 +472,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
 
   (* 3. Read right hand side *)
   (* The udecl constraints (or, if none, the lhs constraints) must imply those of the rhs *)
-  let evd = Evd.set_universe_context evd uctx in
+  let evd = Evd.set_ustate evd uctx in
   let rhs = Constrintern.(intern_gen WithoutTypeConstraint env evd rhs) in
   let flags = { Pretyping.no_classes_no_fail_inference_flags with poly } in
   let evd', rhs =
@@ -484,7 +484,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
   in
   let evd' = Evd.minimize_universes ~poly evd' in
   let _qvars', uvars' = EConstr.universes_of_constr evd' rhs in
-  let evd' = Evd.restrict_universe_context evd' (Univ.Level.Set.union uvars uvars') in
+  let evd' = Evd.restrict_ustate evd' (Univ.Level.Set.union uvars uvars') in
   let fail pp = warn_rewrite_rules_break_SR ?loc:rhs_loc Pp.(surround (str "universe inconsistency") ++ str"." ++ spc() ++ str "Missing constraints: " ++ pp) in
   let () = UState.check_uctx_impl ~fail (Evd.ustate evd) (Evd.ustate evd') in
   let evd = evd' in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1018,7 +1018,7 @@ let declare_possibly_mutual_parameters ~info ~cinfo ?(mono_uctx_extra=UState.emp
       let typ = Vars.replace_vars subst typ in
       let pe = {
           parameter_entry_secctx = sec_vars;
-          parameter_entry_type = Evarutil.nf_evars_universes (Evd.from_ctx uctx) typ;
+          parameter_entry_type = Evarutil.nf_evars_universes (Evd.from_ustate uctx) typ;
           parameter_entry_universes = univs;
           parameter_entry_inline_code = None;
         } in
@@ -1061,7 +1061,7 @@ let declare_mutual_definitions ~info ~cinfo ~opaque ~eff ~uctx ~bodies ~possible
   let possible_guard, fixrelevances = possible_guard in
   let fixtypes = List.map (fun CInfo.{typ} -> typ) cinfo in
   let rec_declaration = prepare_recursive_declaration cinfo fixtypes fixrelevances bodies in
-  let bodies_types, sigma, indexes = make_recursive_bodies ~sigma:(Evd.from_ctx uctx) env ~typing_flags ~rec_declaration ~possible_guard in
+  let bodies_types, sigma, indexes = make_recursive_bodies ~sigma:(Evd.from_ustate uctx) env ~typing_flags ~rec_declaration ~possible_guard in
   let uctx = Evd.ustate sigma in
   let entries = List.map (fun (body, typ) -> (body, Some typ)) bodies_types in
   let entries_for_using = List.map (fun (body, typ) -> (body, Some typ)) bodies_types in
@@ -1537,7 +1537,7 @@ let subst_prog subst prg =
 
 let declare_definition ~pm prg =
   let varsubst = obligation_substitution true prg in
-  let sigma = Evd.from_ctx prg.prg_uctx in
+  let sigma = Evd.from_ustate prg.prg_uctx in
   let body, types = subst_prog varsubst prg in
   let body, types = EConstr.(of_constr body, of_constr types) in
   let cinfo = { prg.prg_cinfo with CInfo.typ = Some types } in
@@ -1557,7 +1557,7 @@ let declare_mutual_definitions ~pm l =
   let defobl x =
     let oblsubst = obligation_substitution true x in
     let subs, typ = subst_prog oblsubst x in
-    let sigma = Evd.from_ctx x.prg_uctx in
+    let sigma = Evd.from_ustate x.prg_uctx in
     let term = EConstr.of_constr subs in
     let typ = EConstr.of_constr typ in
     let term = EConstr.to_constr sigma term in
@@ -1682,7 +1682,7 @@ let obligation_terminator ~pm ~entry ~eff ~uctx ~oinfo:{name; num; auto; check_f
   in
   (* TODO: we always inline effects here, maybe we could export them when transparent? *)
   let body, uctx = inline_private_constants ~uctx env (body, eff) in
-  let sigma = Evd.from_ctx uctx in
+  let sigma = Evd.from_ustate uctx in
   Inductiveops.control_only_guard (Global.env ()) sigma
     (EConstr.of_constr body);
   (* Declare the obligation ourselves and drop the hook *)
@@ -2249,7 +2249,7 @@ let save_admitted ~pm ~proof =
   let iproof = get proof in
   let Proof.{ entry; poly } = Proof.data iproof in
   let typs = List.map pi3 (Proofview.initial_goals entry) in
-  let sigma = Evd.from_ctx proof.initial_euctx in
+  let sigma = Evd.from_ustate proof.initial_euctx in
   List.iter (check_type_evars_solved (Global.env()) sigma) typs;
   let sec_vars = compute_proof_using_for_admitted proof.pinfo proof typs iproof in
   let sigma = Evd.minimize_universes ~poly sigma in
@@ -2484,7 +2484,7 @@ let solve_by_tac prg obls i tac =
     match Subproof.build_by_tactic_opt env ~uctx ~poly ~typ tac with
     | None -> None
     | Some (body, types, _univs, uctx) ->
-      let () = Inductiveops.control_only_guard env (Evd.from_ctx uctx) (EConstr.of_constr body) in
+      let () = Inductiveops.control_only_guard env (Evd.from_ustate uctx) (EConstr.of_constr body) in
       Some (body, types, uctx)
   with
   | Tacticals.FailError (_, s) as exn ->
@@ -2568,7 +2568,7 @@ let solve_obligation ?check_final prg num tac =
   in
   let obl = subst_deps_obl obls obl in
   let kind = kind_of_obligation (snd obl.obl_status) in
-  let evd = Evd.from_ctx (Internal.get_uctx prg) in
+  let evd = Evd.from_ustate (Internal.get_uctx prg) in
   let evd = Evd.update_sigma_univs (Global.universes ()) evd in
   let auto ~pm n oblset tac = fst (auto_solve_obligations ~pm n ~oblset tac) in
   let proof_ending =

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1305,14 +1305,11 @@ let explain_not_match_error = function
       quote t1 ++ spc () ++
       str "compared to " ++ spc () ++
       quote t2
-  | IncompatibleUnivConstraints { got; expect } ->
+  | IncompatibleUnivConstraints { env; got; expect } ->
     let open UVars in
     let pr_auctx auctx =
-      let sigma = Evd.from_ustate
-          (UState.of_names
-             (Printer.universe_binders_with_opt_names auctx None))
-      in
-      let uctx = AbstractContext.repr auctx in
+      let uctx = UVars.AbstractContext.repr auctx in
+      let sigma = Evd.from_auctx env (Printer.fill_names auctx) in
       Printer.pr_universe_instance_binder sigma
         (UContext.instance uctx)
         (UContext.univ_constraints uctx)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1308,7 +1308,7 @@ let explain_not_match_error = function
   | IncompatibleUnivConstraints { got; expect } ->
     let open UVars in
     let pr_auctx auctx =
-      let sigma = Evd.from_ctx
+      let sigma = Evd.from_ustate
           (UState.of_names
              (Printer.universe_binders_with_opt_names auctx None))
       in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -570,10 +570,10 @@ let do_scheme_all_theorem kn mib kn_nested focus strpos sAllThm keyAllThm =
   let uctx = UState.collapse_above_prop_sort_variables ~to_prop:true uctx in
   let uctx = UState.normalize_variables uctx in
   let uctx = UState.minimize uctx in
-  let sigma = Evd.set_universe_context sigma uctx in
+  let sigma = Evd.set_ustate sigma uctx in
   let thm = UState.nf_universes uctx (EConstr.to_constr sigma thm) in
   let uctx = UState.restrict uctx (Vars.universes_of_constr thm) in
-  let sigma = Evd.set_universe_context sigma uctx in
+  let sigma = Evd.set_ustate sigma uctx in
   (* declare it *)
   let poly_flag = PolyFlags.make ~univ_poly:true ~collapse_sort_variables:true ~cumulative:true in
   let info = Declare.Info.make ~poly:poly_flag () in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -57,8 +57,7 @@ let print_ref env reduce ref udecl =
   let typ, univs = Typeops.type_of_global_in_context env ref in
   let inst = UVars.make_abstract_instance univs in
   let udecl = Option.map (fun x -> ref, x) udecl in
-  let bl = Printer.universe_binders_with_opt_names (Environ.universes_of_global env ref) udecl in
-  let sigma = Evd.from_ustate (UState.of_names bl) in
+  let sigma = Evd.from_auctx env (Printer.fill_names ?user_names:udecl univs) in
   let typ =
     if reduce then
       let ctx,ccl = Reductionops.whd_decompose_prod_decls env sigma (EConstr.of_constr typ)
@@ -237,8 +236,7 @@ let print_squash env ref udecl = match ref with
     | Some squash ->
       let univs = Environ.universes_of_global env ref in
       let udecl = Option.map (fun x -> ref, x) udecl in
-      let bl = Printer.universe_binders_with_opt_names univs udecl in
-      let sigma = Evd.from_ustate (UState.of_names bl) in
+      let sigma = Evd.from_auctx env (Printer.fill_names ?user_names:udecl univs) in
       let inst = if fst @@ UVars.AbstractContext.size univs = 0 then mt()
         else Printer.pr_universe_instance sigma (UVars.make_abstract_instance univs)
       in
@@ -576,11 +574,7 @@ let print_constant env ~with_values with_implicit cst udecl =
   let typ = cb.const_type in
   let univs = cb.const_universes in
   let udecl = Option.map (fun x -> GlobRef.ConstRef cst, x) udecl in
-  let uctx =
-    UState.of_names
-      (Printer.universe_binders_with_opt_names (Declareops.constant_polymorphic_context cb) udecl)
-  in
-  let sigma = Evd.from_ustate uctx in
+  let sigma = Evd.from_auctx env (Printer.fill_names ?user_names:udecl (Declareops.constant_polymorphic_context cb)) in
   let impargs = if with_implicit then select_stronger_impargs (implicits_of_global (ConstRef cst)) else [] in
   let impargs = List.map binding_kind_of_status impargs in
   let pptyp = pr_ltype_env env sigma ~impargs typ in

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -58,7 +58,7 @@ let print_ref env reduce ref udecl =
   let inst = UVars.make_abstract_instance univs in
   let udecl = Option.map (fun x -> ref, x) udecl in
   let bl = Printer.universe_binders_with_opt_names (Environ.universes_of_global env ref) udecl in
-  let sigma = Evd.from_ctx (UState.of_names bl) in
+  let sigma = Evd.from_ustate (UState.of_names bl) in
   let typ =
     if reduce then
       let ctx,ccl = Reductionops.whd_decompose_prod_decls env sigma (EConstr.of_constr typ)
@@ -238,7 +238,7 @@ let print_squash env ref udecl = match ref with
       let univs = Environ.universes_of_global env ref in
       let udecl = Option.map (fun x -> ref, x) udecl in
       let bl = Printer.universe_binders_with_opt_names univs udecl in
-      let sigma = Evd.from_ctx (UState.of_names bl) in
+      let sigma = Evd.from_ustate (UState.of_names bl) in
       let inst = if fst @@ UVars.AbstractContext.size univs = 0 then mt()
         else Printer.pr_universe_instance sigma (UVars.make_abstract_instance univs)
       in
@@ -580,7 +580,7 @@ let print_constant env ~with_values with_implicit cst udecl =
     UState.of_names
       (Printer.universe_binders_with_opt_names (Declareops.constant_polymorphic_context cb) udecl)
   in
-  let sigma = Evd.from_ctx uctx in
+  let sigma = Evd.from_ustate uctx in
   let impargs = if with_implicit then select_stronger_impargs (implicits_of_global (ConstRef cst)) else [] in
   let impargs = List.map binding_kind_of_status impargs in
   let pptyp = pr_ltype_env env sigma ~impargs typ in

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -163,7 +163,7 @@ let pr_mutual_inductive_body env mind mib udecl =
   let bl = Printer.universe_binders_with_opt_names
       (Declareops.inductive_polymorphic_context mib) udecl
   in
-  let sigma = Evd.from_ctx (UState.of_names bl) in
+  let sigma = Evd.from_ustate (UState.of_names bl) in
 
   hov 0 (def keyword ++ spc () ++
          prlist_with_sep (fun () -> fnl () ++ str"  with ")
@@ -278,7 +278,7 @@ let print_body is_impl extent env mp (l,body) =
          | OnlyNames -> mt ()
          | WithContents ->
             let bl = Printer.universe_binders_with_opt_names ctx None in
-            let sigma = Evd.from_ctx (UState.of_names bl) in
+            let sigma = Evd.from_ustate (UState.of_names bl) in
             str " :" ++ spc () ++
             hov 0 (Printer.pr_ltype_env env sigma cb.const_type) ++
             (match cb.const_body with

--- a/vernac/printmod.ml
+++ b/vernac/printmod.ml
@@ -160,10 +160,8 @@ let pr_mutual_inductive_body env mind mib udecl =
        | PrimRecord l -> "Record"
   in
   let udecl = Option.map (fun x -> GlobRef.IndRef (mind,0), x) udecl in
-  let bl = Printer.universe_binders_with_opt_names
-      (Declareops.inductive_polymorphic_context mib) udecl
-  in
-  let sigma = Evd.from_ustate (UState.of_names bl) in
+  let auctx = Printer.fill_names ?user_names:udecl (Declareops.inductive_polymorphic_context mib) in
+  let sigma = Evd.from_auctx env auctx in
 
   hov 0 (def keyword ++ spc () ++
          prlist_with_sep (fun () -> fnl () ++ str"  with ")
@@ -269,25 +267,27 @@ let print_body is_impl extent env mp (l,body) =
     | SFBmodtype _ -> keyword "Module Type" ++ spc () ++ name
     | SFBrules _ -> keyword "Rewrite Rule" ++ spc () ++ name (* TODO: correct? *)
     | SFBconst cb ->
-       let ctx = Declareops.constant_polymorphic_context cb in
-      (match cb.const_body with
-        | Def _ -> def "Definition" ++ spc ()
-        | OpaqueDef _ when is_impl -> def "Theorem" ++ spc ()
-        | _ -> def "Parameter" ++ spc ()) ++ name ++
-      (match extent with
-         | OnlyNames -> mt ()
-         | WithContents ->
-            let bl = Printer.universe_binders_with_opt_names ctx None in
-            let sigma = Evd.from_ustate (UState.of_names bl) in
-            str " :" ++ spc () ++
-            hov 0 (Printer.pr_ltype_env env sigma cb.const_type) ++
-            (match cb.const_body with
-              | Def l when is_impl ->
-                spc () ++
-                hov 2 (str ":= " ++
-                       Printer.pr_lconstr_env env sigma l)
-              | _ -> mt ()) ++ str "." ++
-            Printer.pr_abstract_universe_ctx sigma ctx)
+      let auctx = Declareops.constant_polymorphic_context cb in
+      begin match cb.const_body with
+      | Def _ -> def "Definition" ++ spc ()
+      | OpaqueDef _ when is_impl -> def "Theorem" ++ spc ()
+      | _ -> def "Parameter" ++ spc ()
+      end ++ name ++
+      begin match extent with
+      | OnlyNames -> mt ()
+      | WithContents ->
+        let auctx = Printer.fill_names auctx in
+        let sigma = Evd.from_auctx env auctx in
+        str " :" ++ spc () ++
+        hov 0 (Printer.pr_ltype_env env sigma cb.const_type) ++
+        (match cb.const_body with
+          | Def l when is_impl ->
+            spc () ++
+            hov 2 (str ":= " ++
+                    Printer.pr_lconstr_env env sigma l)
+          | _ -> mt ()) ++ str "." ++
+        Printer.pr_abstract_universe_ctx sigma auctx
+      end
     | SFBmind mib ->
       match extent with
       | WithContents ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1853,7 +1853,7 @@ let vernac_reserve bl =
     let t,ctx = Constrintern.interp_type env sigma c in
     let t =
       let flags = { (PrintingFlags.Detype.current()) with universes = false } in
-      Detyping.detype Detyping.Now ~flags env (Evd.from_ctx ctx) t
+      Detyping.detype Detyping.Now ~flags env (Evd.from_ustate ctx) t
     in
     let t,_ = Notation_ops.notation_constr_of_glob_constr (default_env ()) t in
     Reserve.declare_reserved_type idl t)


### PR DESCRIPTION
The change for universe binder printing will make it slower, but I don't know how often it happens and if I shoud worry about it.

Overlays: https://github.com/rocq-prover/vsrocq/pull/1218