### PR TITLE
Fix instance argument to Print and About with sort variables

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -16,7 +16,7 @@ Displaying
    .. insertprodn univ_name_list univ_name_list
 
    .. prodn::
-      univ_name_list ::= @%{ {* @name } %}
+      univ_name_list ::= @%{ {* @name } {? ; {* @name } } %}
 
    Displays definitions of terms, including opaque terms, for the object :n:`@reference`.
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1566,7 +1566,7 @@ search_queries: [
 ]
 
 univ_name_list: [
-| "@{" LIST0 name "}"
+| "@{" LIST0 name OPT [ ";" LIST0 name ] "}"
 ]
 
 syntax: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1096,7 +1096,7 @@ logical_kind: [
 ]
 
 univ_name_list: [
-| "@{" LIST0 name "}"
+| "@{" LIST0 name OPT [ ";" LIST0 name ] "}"
 ]
 
 enable_notation_flag: [

--- a/engine/univNames.ml
+++ b/engine/univNames.ml
@@ -20,9 +20,7 @@ let empty_binders = Id.Map.empty, Id.Map.empty
 
 let empty_rev_binders = QVar.Map.empty, Level.Map.empty
 
-type univ_name_list = Names.lname list
-
-type full_name_list = lname list * lname list
+type univ_name_list = lname list * lname list
 
 let qualid_of_level (_,ctx) l =
   match Level.name l with

--- a/engine/univNames.mli
+++ b/engine/univNames.mli
@@ -22,9 +22,7 @@ val empty_binders : universe_binders
 
 val empty_rev_binders : rev_binders
 
-type univ_name_list = Names.lname list
-
-type full_name_list = lname list * lname list
+type univ_name_list = lname list * lname list
 
 val pr_level_with_global_universes : ?binders:universe_binders -> Level.t -> Pp.t
 val qualid_of_level : universe_binders -> Level.t -> Libnames.qualid option

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -163,7 +163,7 @@ val pr_universes  : evar_map ->
 
     Inefficient on large contexts due to name generation. *)
 val universe_binders_with_opt_names : UVars.AbstractContext.t ->
-  (GlobRef.t * UnivNames.full_name_list) option -> UnivNames.universe_binders * UnivNames.rev_binders
+  (GlobRef.t * UnivNames.univ_name_list) option -> UnivNames.universe_binders * UnivNames.rev_binders
 
 (** Printing global references using names as short as possible *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1327,7 +1327,7 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   univ_name_list:
-    [ [  "@{" ; l = LIST0 name; "}" -> { [],l } ] ]
+    [ [  "@{" ; l = LIST0 name; l' = OPT [ ";" ; l = LIST0 name -> { l } ] ; "}" -> { match l' with None -> [], l | Some l' -> l, l' } ] ]
   ;
 END
 

--- a/vernac/prettyp.mli
+++ b/vernac/prettyp.mli
@@ -41,7 +41,7 @@ val print_safe_judgment : Safe_typing.judgment -> Pp.t
 
 val print_name : Global.indirect_accessor -> env -> Evd.evar_map
   -> qualid Constrexpr.or_by_notation
-  -> UnivNames.full_name_list option
+  -> UnivNames.univ_name_list option
   -> Pp.t
 val print_notation : env -> Evd.evar_map
   -> qualid Constrexpr.notation_entry_gen
@@ -51,7 +51,7 @@ val print_notation : env -> Evd.evar_map
 val print_abbreviation : Global.indirect_accessor -> env -> Evd.evar_map -> KerName.t -> Pp.t
 
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
-  UnivNames.full_name_list option -> Pp.t
+  UnivNames.univ_name_list option -> Pp.t
 val print_impargs : env -> GlobRef.t -> Pp.t
 
 (** Pretty-printing functions for classes and coercions *)

--- a/vernac/printmod.mli
+++ b/vernac/printmod.mli
@@ -12,6 +12,6 @@ open Names
 
 val pr_mutual_inductive_body : Environ.env ->
   MutInd.t -> Declarations.mutual_inductive_body ->
-  UnivNames.full_name_list option -> Pp.t
+  UnivNames.univ_name_list option -> Pp.t
 val print_module : with_body:bool -> ModPath.t -> Pp.t
 val print_modtype : ModPath.t -> Pp.t

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -53,7 +53,7 @@ type printable =
   | PrintMLLoadPath
   | PrintMLModules
   | PrintDebugGC
-  | PrintName of qualid or_by_notation * UnivNames.full_name_list option
+  | PrintName of qualid or_by_notation * UnivNames.univ_name_list option
   | PrintGraph
   | PrintClasses
   | PrintTypeclasses
@@ -70,7 +70,7 @@ type printable =
   | PrintScopes
   | PrintScope of string
   | PrintVisibility of string option
-  | PrintAbout of qualid or_by_notation * UnivNames.full_name_list option * Goal_select.t option
+  | PrintAbout of qualid or_by_notation * UnivNames.univ_name_list option * Goal_select.t option
   | PrintImplicit of qualid or_by_notation
   | PrintAssumptions of bool * bool * qualid or_by_notation list
   | PrintStrategy of qualid or_by_notation option


### PR DESCRIPTION
I'm honestly not sure this feature is useful to anyone. I first made a branch to completely remove it, before noticing that fixing it was more simple.


- [ ] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.