### PR TITLE
Fix forgotten univ subst when inlining in VM/native

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -72,6 +72,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [conversion would compare the mutated version of primitive arrays instead of undoing mutation where needed](#conversion-would-compare-the-mutated-version-of-primitive-arrays-instead-of-undoing-mutation-where-needed)
       - [tactic code could mutate a global cache of values for section variables](#tactic-code-could-mutate-a-global-cache-of-values-for-section-variables)
       - [incorrect handling of universe polymorphism](#incorrect-handling-of-universe-polymorphism)
+      - [Forgotten universe substitution with Register Inline on universe polymorphic definition](#Forgotten-universe-substitution-with-Register-Inline-on-universe-polymorphic-definition)
     - [Side-effects](#side-effects)
       - [polymorphic side-effects inside monomorphic definitions incorrectly handled as not inlined](#polymorphic-side-effects-inside-monomorphic-definitions-incorrectly-handled-as-not-inlined)
     - [Forgetting unsafe flags](#forgetting-unsafe-flags)
@@ -848,6 +849,21 @@ For instance `α` and `__U03b1_` were the same in the native compiler.
 - GH issue number: rocq-prover/rocq#7723
 - exploit: see issue
 - risk: ??
+
+#### Forgotten universe substitution with Register Inline on universe polymorphic definition
+
+- component: VM and native
+- introduced: V8.5
+- impacted released versions: V8.5-V9.1 (all patch versions)
+- impacted coqchk versions: same (only when using -bytecode-compiler yes)
+- fixed in: V9.2.0
+- found by: Gaëtan Gilbert
+- GH issue number: rocq-prover/rocq#21736
+- exploit: see issue
+- risk: requires Register Inline on universe polymorphic constant
+- additional note: does not seem to be exploitable before 8.8 (until 8.6 Register
+  Inline fails with anomaly on universe polymorphic constants, and before
+  8.8 Register Inline only affects native which fails in ocamlopt)
 
 ### Side-effects
 

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -782,7 +782,9 @@ and lambda_of_app cache env sigma f args =
       begin match cb.const_body with
       | Primitive op -> lambda_of_prim env c op (lambda_of_args cache env sigma 0 args)
       | Def csubst -> (* TODO optimize if f is a proj and argument is known *)
-        if cb.const_inline_code then lambda_of_app cache env sigma csubst args
+        if cb.const_inline_code then
+          let csubst = Vars.subst_instance_constr u csubst in
+          lambda_of_app cache env sigma csubst args
         else
           (* Erase unused arguments *)
           let mapi i arg =

--- a/test-suite/bugs/bug_21736.v
+++ b/test-suite/bugs/bug_21736.v
@@ -1,0 +1,21 @@
+Set Universe Polymorphism.
+
+Definition foo@{u v} : Type@{v} := Type@{u}.
+Register Inline foo.
+
+(* if [typ] is inlined (in the source) the checker rejects bar, I guess because it
+   doesn't use the Register Inline hint when doing its own compilation
+   but does reuse the compilation of [typ] which did the incorrect inlining. *)
+Definition typ@{v u k} := Type@{v} = foo@{u v} :> Type@{k}.
+
+Lemma bar@{v u k|u < v, v < k} : typ@{v u k}.
+Proof.
+  vm_cast_no_check (@eq_refl Type@{k} Type@{v}).
+  Fail Qed.
+Abort.
+
+Lemma bar@{v u k|u < v, v < k} : typ@{v u k}.
+Proof.
+  native_cast_no_check (@eq_refl Type@{k} Type@{v}).
+  Fail Qed.
+Abort.


### PR DESCRIPTION
Fix #21736
