### PR TITLE
Pass modes to class observer

### DIFF
--- a/dev/ci/user-overlays/21742-FissoreD-mode-class.sh
+++ b/dev/ci/user-overlays/21742-FissoreD-mode-class.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/FissoreD/coq-elpi coq-21742 21742

--- a/test-suite/misc/tc_declaration_observer/main.out.reference
+++ b/test-suite/misc/tc_declaration_observer/main.out.reference
@@ -1,4 +1,5 @@
 NewClass Def
+Mode : -
 NewInstance def_nat  
 NewInstance def_bool  33 
 NewInstance def_bool2  21 local

--- a/test-suite/misc/tc_declaration_observer/main.v
+++ b/test-suite/misc/tc_declaration_observer/main.v
@@ -1,6 +1,6 @@
 Declare ML Module "observer.plugin".
 
-Class Def (A : Type) := { default : A }.
+#[mode="-"] Class Def (A : Type) := { default : A }.
 
 Instance def_nat : Def nat := {| default := 0 |}.
 

--- a/test-suite/misc/tc_declaration_observer/observer.ml
+++ b/test-suite/misc/tc_declaration_observer/observer.ml
@@ -8,8 +8,10 @@ let observe x =
   let open Hints in
   let p = Pp.string_of_ppcmds in
   match x with
-  | NewClass { cl_impl } ->
-      Printf.fprintf o "NewClass %s\n" (p (Printer.pr_global cl_impl))
+  | NewClass (ml, { cl_impl }) ->
+      Printf.fprintf o "NewClass %s\n" (p (Printer.pr_global cl_impl));
+      let cnt = Pp.(pr_opt (prlist pp_hint_mode)) ml in
+      Printf.fprintf o "Mode :%s\n" (p cnt)
   | NewInstance { instance ; info = { hint_priority }; locality } ->
       Printf.fprintf o "NewInstance %s %s %s\n"
         (p (Printer.pr_global instance))

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -130,7 +130,7 @@ let instance_input : instance -> obj =
 
 module Event = struct
   type t =
-    | NewClass of typeclass
+    | NewClass of (Hints.hint_mode list option * typeclass)
     | NewInstance of instance
 end
 
@@ -254,9 +254,9 @@ let class_input : typeclass -> obj =
       subst_function = subst_class;
     }
 
-let add_class cl =
+let add_class ?mode cl =
   Lib.add_leaf (class_input cl);
-  observe (Event.NewClass cl)
+  observe (Event.NewClass (mode, cl))
 
 let intern_info {hint_priority;hint_pattern} =
   let env = Global.env() in

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -69,7 +69,7 @@ val declare_new_instance
   -> Vernacexpr.hint_info_expr
   -> unit
 
-val add_class : typeclass -> unit
+val add_class : ?mode:Hints.hint_mode list ->  typeclass -> unit
 
 type instance = {
   class_name : GlobRef.t;
@@ -80,7 +80,7 @@ type instance = {
 
 module Event : sig
   type t =
-    | NewClass of typeclass
+    | NewClass of (Hints.hint_mode list option * typeclass)
     | NewInstance of instance
 end
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -994,8 +994,8 @@ let declare_class_constant entry (data:Data.t) =
 let set_class_mode ref mode ctx =
   let modes =
     match mode with
-    | Some (Some m) -> Some m
-    | _ ->
+    | Some m -> Some m
+    | None ->
       let ctxl = Context.Rel.nhyps ctx in
       let def = typeclasses_default_mode () in
       let mode = match def with
@@ -1061,7 +1061,7 @@ let declare_class ?mode declared =
     cl_projs = projs;
   }
   in
-  Classes.add_class k;
+  Classes.add_class ?mode k;
   set_class_mode impl mode params
 
 let add_constant_class cst =
@@ -1150,7 +1150,7 @@ let definition_structure ~flags udecl kind ~primitive_proj (records : Ast.t list
                         data in
       declare_structure structure ~schemes:flags.schemes
   in
-  if kind_class kind <> NotClass then declare_class ~mode:flags.mode declared;
+  if kind_class kind <> NotClass then declare_class ?mode:flags.mode declared;
   inds
 
 module Internal = struct


### PR DESCRIPTION
Declaring mode before class allows the class observers to know the mode of the class when they are triggered

- [x] TODO: make the test work
- overlay: https://github.com/LPCIC/coq-elpi/pull/973