### PR TITLE
[CI] Reenable jasmin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1060,7 +1060,7 @@ library:ci-mathcomp_word:
   - library:ci-mathcomp
   stage: build-2
 
-.library:ci-jasmin:  # disabled until repaired
+library:ci-jasmin:
   extends: .ci-template-flambda
   needs:
   - build:edge+flambda


### PR DESCRIPTION
Jasmin was removed from CI in https://github.com/rocq-prover/rocq/pull/20589 following changes in mathcomp (https://github.com/math-comp/math-comp/pull/1256) that made the extraction to OCaml fail (see https://github.com/jasmin-lang/jasmin/pull/1093 for the discussion).

We spent some time to make Jasmin (https://github.com/jasmin-lang/jasmin/pull/1372) and its dependency coqword (https://github.com/jasmin-lang/coqword/pull/37) avoid referencing the ring structures of mathcomp in the parts of Jasmin that are extracted (which were the reason of the failed extraction). Now that the changes are merged, extraction works again (we tested it with mathcomp 2.5, hopefully it works also with master), and I hope Jasmin can be enabled back in the CI.