### PR TITLE
Correctly check retroknowledge in the checker.

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -16,6 +16,8 @@ open Util
 
 [@@@ocaml.warning "+9+27"]
 
+type ind_retroknowledge = (int * CPrimitives.prim_ind_ex) option
+
 exception InductiveMismatch of MutInd.t * string
 
 let check mind field b = if not b then raise (InductiveMismatch (mind,field))
@@ -205,7 +207,7 @@ let check_packet mind ind
 
   ()
 
-let check_inductive env mind mb =
+let check_inductive env mind mb retro =
   let entry = to_entry mind mb in
   let { mind_packets; mind_finite; mind_hyps; mind_univ_hyps;
         mind_nparams; mind_nparams_rec; mind_params_ctxt;
@@ -215,6 +217,10 @@ let check_inductive env mind mb =
     (* Locally set typing flags for further typechecking *)
     let env = CheckFlags.set_local_flags mb.mind_typing_flags env in
     let mib, not_prim_record = Indtypes.check_inductive env ~sec_univs:None mind entry in
+    let () = match retro with
+    | None -> ()
+    | Some (i, CPrimitives.PIE retro) -> Safe_typing.check_register_ind (mind, i) retro (mib, mib.mind_packets.(i))
+    in
     assert (Option.is_empty not_prim_record);
     mib
   in
@@ -243,8 +249,8 @@ let check_inductive env mind mb =
 
   add_mind mind mb env
 
-let check_inductive env mind mb : Environ.env =
+let check_inductive env mind mb retro : Environ.env =
   NewProfile.profile "check_inductive"
     ~args:(fun () -> [("name", `String (MutInd.to_string mind))])
-    (fun () -> check_inductive env mind mb)
+    (fun () -> check_inductive env mind mb retro)
     ()

--- a/checker/checkInductive.mli
+++ b/checker/checkInductive.mli
@@ -11,9 +11,11 @@
 open Names
 open Environ
 
+type ind_retroknowledge = (int * CPrimitives.prim_ind_ex) option
+
 exception InductiveMismatch of MutInd.t * string
 (** Some field of the inductive is different from what the kernel infers. *)
 
 (*s The following function does checks on inductive declarations. *)
 
-val check_inductive : env -> MutInd.t -> Declarations.mutual_inductive_body -> env
+val check_inductive : env -> MutInd.t -> Declarations.mutual_inductive_body -> ind_retroknowledge -> env

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -8,12 +8,25 @@ open Environ
 
 (** {6 Checking constants } *)
 
+type opaques = Names.Cset.t Names.Cmap.t
+
+type check_state = {
+  st_opaques : opaques;
+  st_retro : (int * CPrimitives.prim_ind_ex) Mindmap_env.t * CPrimitives.prim_type_ex Cmap_env.t;
+}
+
+let empty_state = {
+  st_opaques = Cmap.empty;
+  st_retro = (Mindmap_env.empty, Cmap_env.empty);
+}
+
 let indirect_accessor : (Opaqueproof.opaque -> Opaqueproof.opaque_proofterm) ref =
   ref (fun _ -> assert false)
 
 let set_indirect_accessor f = indirect_accessor := f
 
-let register_opacified_constant env opac kn cb =
+let register_opacified_constant env chkst kn cb =
+  let opac = chkst.st_opaques in
   let rec gather_consts s c =
     match Constr.kind c with
     | Constr.Const (c, _) -> Cset.add c s
@@ -29,7 +42,7 @@ let register_opacified_constant env opac kn cb =
       (gather_consts Cset.empty cb)
       Cset.empty
   in
-  Cmap.add kn wo_body opac
+  { chkst with st_opaques = Cmap.add kn wo_body opac }
 
 exception BadConstant of Constant.t * Pp.t
 
@@ -76,17 +89,31 @@ let check_constant_declaration env opac kn cb opacify =
       end
     | None -> ()
   in
+  let retro, opac = match Cmap_env.find_opt kn (snd opac.st_retro) with
+  | None -> None, opac
+  | Some retro ->
+    let (ind_retro, cst_retro) = opac.st_retro in
+    let opac = { opac with st_retro = (ind_retro, Cmap_env.remove kn cst_retro) } in
+    Some retro, opac
+  in
   match body with
-  | Some body when opacify -> register_opacified_constant env opac kn body
-  | Some _ | None -> opac
+  | Some body when opacify -> retro, register_opacified_constant env opac kn body
+  | Some _ | None -> retro, opac
 
 let check_constant_declaration env opac kn cb opacify =
-  let opac = NewProfile.profile "check_constant" ~args:(fun () ->
+  let retro, opac = NewProfile.profile "check_constant" ~args:(fun () ->
       [("name", `String (Constant.to_string kn))])
       (fun () -> check_constant_declaration env opac kn cb opacify)
       ()
   in
-  Environ.add_constant kn cb env, opac
+  let env = Environ.add_constant kn cb env in
+  let env = match retro with
+  | None -> env
+  | Some (CPrimitives.PTE prm) ->
+    (* TODO: Some checking is performed by this function, but it looks too lightweight *)
+    Primred.add_retroknowledge env (Retroknowledge.Register_type (prm, kn))
+  in
+  env, opac
 
 let check_quality_mask env qmask lincheck =
   let open Sorts.Quality in
@@ -275,8 +302,8 @@ let rec check_module env opac mp mb opacify =
 
 and check_module_type env mp mty =
   Flags.if_verbose Feedback.msg_notice (str "  checking module type: " ++ str (ModPath.to_string @@ mp));
-  let _ : _ Cmap.t =
-    check_signature env Cmap.empty (mod_type mty) mp (mod_delta mty) Cset.empty in
+  let _ : check_state =
+    check_signature env empty_state (mod_type mty) mp (mod_delta mty) Cset.empty in
   ()
 
 and check_structure_field env opac mp lab res opacify = function
@@ -287,7 +314,15 @@ and check_structure_field env opac mp lab res opacify = function
   | SFBmind mib ->
       let kn = KerName.make mp lab in
       let kn = Mod_subst.mind_of_delta_kn res kn in
-      CheckInductive.check_inductive env kn mib, opac
+      let retro = Mindmap_env.find_opt kn (fst opac.st_retro) in
+      let opac = match retro with
+      | None -> opac
+      | Some _ ->
+        let (ind_retro, cst_retro) = opac.st_retro in
+        let opac = { opac with st_retro = (Mindmap_env.remove kn ind_retro, cst_retro) } in
+        opac
+      in
+      CheckInductive.check_inductive env kn mib retro, opac
   | SFBmodule msb ->
       let mp = MPdot(mp, lab) in
       let opac = check_module env opac mp msb opacify in
@@ -312,8 +347,52 @@ and check_signature env opac sign mp_mse res opacify = match sign with
       in
       opac
 
-let check_module env opac mp mb =
+let eq_prim_ind (type a b) (p : a CPrimitives.prim_ind) (q : b CPrimitives.prim_ind) =
+  String.equal (CPrimitives.prim_ind_to_string p) (CPrimitives.prim_ind_to_string q)
+
+let get_retroknowlege env retro =
+  let fold (imap, cmap, extind) = function
+  | Retroknowledge.Register_ind (prm, (ind, i)) ->
+    (* Tolerate redeclarations because the kernel allows it somehow *)
+    let check_prm map = match Mindmap_env.find_opt ind map with
+    | None -> ()
+    | Some (_, CPrimitives.PIE prm') ->
+      if not (eq_prim_ind prm prm') then
+        CErrors.user_err Pp.(str "Inconsistent primitive registration for inductive " ++ MutInd.print ind ++ str ".")
+    in
+    let () = check_prm imap in
+    let () = check_prm extind in
+    (* It is allowed to register inductives coming from another library, so we have
+       to account for that. *)
+    if Environ.mem_mind ind env then
+      let spec = Inductive.lookup_mind_specif env (ind, i) in
+      let () = Safe_typing.check_register_ind (ind, i) prm spec in
+      (imap, cmap, Mindmap_env.add ind (i, CPrimitives.PIE prm) extind)
+    else
+      (Mindmap_env.add ind (i, CPrimitives.PIE prm) imap, cmap, extind)
+  | Retroknowledge.Register_type (prm, cst) ->
+    let () = assert (not (Cmap_env.mem cst cmap)) in
+    let () = assert (not (Environ.mem_constant cst env)) in
+    (imap, Cmap_env.add cst (CPrimitives.PTE prm) cmap, extind)
+  in
+  let (imap, cmap, _) = List.fold_left fold (Mindmap_env.empty, Cmap_env.empty, Mindmap_env.empty) retro in
+  (imap, cmap)
+
+let check_module env opac retro mp mb =
+  let retro = get_retroknowlege env retro in
+  let st = { st_opaques = opac; st_retro = retro } in
+  let { st_opaques = opac; st_retro = (imap, cmap) } = check_module env st mp mb Cset.empty in
+  let () = match Mindmap_env.choose_opt imap, Cmap_env.choose_opt cmap with
+  | None, None -> ()
+  | Some (ind, _), (None | Some _) ->
+    CErrors.user_err Pp.(str "Retroknowledge registration for unknown inductive " ++ MutInd.print ind ++ str ".")
+  | None, Some (cst, _) ->
+    CErrors.user_err Pp.(str "Retroknowledge registration for unknown constant " ++ Constant.print cst ++ str ".")
+  in
+  opac
+
+let check_module env opac retro mp mb =
   NewProfile.profile "check_module"
     ~args:(fun () -> [("name", `String (ModPath.to_string mp))])
-    (fun () -> check_module env opac mp mb Cset.empty)
+    (fun () -> check_module env opac retro mp mb)
     ()

--- a/checker/mod_checking.mli
+++ b/checker/mod_checking.mli
@@ -8,8 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+type opaques = Names.Cset.t Names.Cmap.t
+
 val set_indirect_accessor : (Opaqueproof.opaque -> Opaqueproof.opaque_proofterm) -> unit
 
-val check_module : Environ.env -> Names.Cset.t Names.Cmap.t -> Names.ModPath.t -> Mod_declarations.module_body -> Names.Cset.t Names.Cmap.t
+val check_module : Environ.env -> opaques -> Retroknowledge.action list -> Names.ModPath.t -> Mod_declarations.module_body -> opaques
 
 exception BadConstant of Names.Constant.t * Pp.t

--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -24,9 +24,8 @@ let import senv opac clib vmtab digest =
   let () = assert (Sorts.QVar.Set.for_all check_quality (fst qualities)) in
   let env = push_qualities ~rigid:true qualities env in
   let env = push_context_set ~strict:true univs env in
-  let env = Modops.add_retroknowledge retro env in
   let env = Environ.link_vm_library vmtab env in
-  let opac = Mod_checking.check_module env opac (Names.ModPath.MPfile dp) mb in
+  let opac = Mod_checking.check_module env opac retro (Names.ModPath.MPfile dp) mb in
   let (_,senv) = Safe_typing.import clib vmtab digest senv in senv, opac
 
 let import senv opac clib vmtab digest : _ * _ =

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1746,8 +1746,7 @@ let register_inline kn senv =
   let cb = {cb with const_inline_code = true} in
   let env = add_constant kn cb env in { senv with env}
 
-let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
-  let (mb,ob as spec) = Inductive.lookup_mind_specif env ind in
+let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) (mb, ob as spec) =
   let ind = match mb.mind_universes with
     | Polymorphic _ -> CErrors.user_err Pp.(str "A universe monomorphic inductive type is expected.")
     | Monomorphic -> Constr.UnsafeMonomorphic.mkInd ind
@@ -1856,7 +1855,8 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) env =
     check_type_cte 8
 
 let register_inductive ind prim senv =
-  check_register_ind ind prim senv.env;
+  let spec = Inductive.lookup_mind_specif senv.env ind in
+  let () = check_register_ind ind prim spec in
   let action = Retroknowledge.Register_ind(prim,ind) in
   add_retroknowledge action senv
 

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -277,6 +277,7 @@ val mind_of_delta_kn_senv : safe_environment -> KerName.t -> MutInd.t
 
 val register_inline : Constant.t -> safe_transformer0
 val register_inductive : inductive -> 'a CPrimitives.prim_ind -> safe_transformer0
+val check_register_ind : inductive -> 'a CPrimitives.prim_ind -> Declarations.mind_specif -> unit
 
 val set_oracle : Conv_oracle.oracle -> safe_transformer0
 val set_strategy : Conv_oracle.evaluable -> Conv_oracle.level -> safe_transformer0


### PR DESCRIPTION
The previous code was not checking anything, probably allowing handcrafted proofs of False passing the checker. Since the kernel does check retroknowledge, this would have required creating malicious vo files. This is not easy but still a potential attack vector.

While writing the patch, I discovered that it is legal to register inductive types coming from a different, previous library. This probably means that we can have weird diamond situations. I do not even known if that makes sense and what we could do with that.