### PR TITLE
Fix #21751: Engine gladly accepts to unify global and thus rigid sorts.

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -163,7 +163,11 @@ let set q qv m =
   let q = repr_node q m in
   let q, rigid = match q with ReprVar (q, rigid) -> q, rigid | ReprConstant _ -> assert false in
   let qv = match qv with QVar qv -> repr_node qv m | QConstant qc -> ReprConstant qc in
-  let enforce_eq q1 q2 g = QGraph.enforce_eliminates_to q1 q2 (QGraph.enforce_eliminates_to q2 q1 g) in
+  let enforce_eq q1 q2 g =
+    let ans = QGraph.enforce_eliminates_to q1 q2 (QGraph.enforce_eliminates_to q2 q1 g) in
+    let () = QGraph.check_rigid_paths ans in
+    ans
+  in
   match qv with
   | ReprVar (qv, _qvrigd) ->
     if QVar.equal q qv then Some m

--- a/test-suite/bugs/bug_21751.v
+++ b/test-suite/bugs/bug_21751.v
@@ -1,0 +1,8 @@
+Set Universe Polymorphism.
+
+Inductive T@{α;} : Type@{α; Set} := C.
+
+#[universes(polymorphic=no)]
+Sort Test.
+
+Fail Goal match C@{Test;} return _ with C => tt end = tt.

--- a/test-suite/output/sort_poly_elab.out
+++ b/test-suite/output/sort_poly_elab.out
@@ -724,14 +724,10 @@ Arguments bool_to_Prop' b
 bool_to_Prop' is transparent
 Expands to: Constant sort_poly_elab.Inductives.bool_to_Prop'
 Declared in library sort_poly_elab, line 490, characters 21-34
-File "./output/sort_poly_elab.v", line 502, characters 2-80:
+File "./output/sort_poly_elab.v", line 502, characters 58-60:
 The command has indeed failed with message:
-Incorrect elimination of "true@{Test ; }" in the inductive type
-"bool@{Test ; }":
-the return type has sort "Set"
-while it should be in a sort Test eliminates to.
-Elimination of a sort polymorphic inductive object instantiated to a variable sort quality
-is only allowed on itself or with an explicit elimination constraint to the target sort.
+This expression would enforce a non-declared elimination constraint between
+Test and Prop
 unit@{α ; u} : Type@{α ; u}
 (* α ; u |=  *)
 


### PR DESCRIPTION
Sort unification in UState was never enforcing that we did not unify rigid sorts, basically.