### PR TITLE
Simplify and fix Indtyping.compute_elim_squash

### DIFF
--- a/dev/ci/user-overlays/21760-SkySkimmer-simpl-indtypig.sh
+++ b/dev/ci/user-overlays/21760-SkySkimmer-simpl-indtypig.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/SkySkimmer/Coq-Equations simpl-indtypig 21760

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -29,10 +29,13 @@ module QualityOrSet = struct
     | Set, Qual _ -> -1
 
   let eliminates_to a b =
-    let to_qual = function
-      | Set -> Quality.qtype
-      | Qual q -> q
-    in Inductive.raw_eliminates_to (to_qual a) (to_qual b)
+    match a, b with
+    | Set, Qual (QConstant QType) -> false
+    | _ ->
+      let to_qual = function
+        | Set -> Quality.qtype
+        | Qual q -> q
+      in Inductive.raw_eliminates_to (to_qual a) (to_qual b)
 
   let of_quality q = Qual q
   let of_sort s = match s with

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -24,6 +24,7 @@ module QualityOrSet : sig
   val quality : t -> Sorts.Quality.t
 
   val eliminates_to : t -> t -> bool
+  (** Set is not considered to eliminate to Type by this function *)
 
   val set : t
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -82,12 +82,18 @@ type univ_info =
   }
 
 let add_squash q info =
-  match info.ind_squashed with
-  | None -> { info with ind_squashed = Some (SometimesSquashed (Sorts.Quality.Set.singleton q)) }
-  | Some AlwaysSquashed -> info
-  | Some (SometimesSquashed qs) ->
-    (* XXX dedup insertion *)
-    { info with ind_squashed = Some (SometimesSquashed (Sorts.Quality.Set.add q qs)) }
+  match q, Sorts.quality info.ind_univ with
+  | Sorts.Quality.QVar _, _ | _, QVar _ ->
+    begin match info.ind_squashed with
+    | None -> { info with ind_squashed = Some (SometimesSquashed (Sorts.Quality.Set.singleton q)) }
+    | Some AlwaysSquashed -> info
+    | Some (SometimesSquashed qs) ->
+      (* XXX dedup insertion *)
+      { info with ind_squashed = Some (SometimesSquashed (Sorts.Quality.Set.add q qs)) }
+    end
+  | _ ->
+    (* no qvar involved: no instantiation can resolve this constraint *)
+    { info with ind_squashed = Some AlwaysSquashed }
 
 let compute_elim_squash ?(is_real_arg=false) env u info =
   let open Sorts.Quality in
@@ -104,38 +110,18 @@ let compute_elim_squash ?(is_real_arg=false) env u info =
         | Prop | Set | Type _ -> { info with record_arg_info = HasRelevantArg }
   in
   if Environ.ignore_elim_constraints env then info else
-  let indu = info.ind_univ
-  and check_univ_consistency f induu uu =
-    if UGraph.check_leq (universes env) uu induu
-    then f info
-    else { info with missing = u :: info.missing } in
-  if Inductive.eliminates_to (Environ.qualities env) (Sorts.quality indu) (Sorts.quality u) then
-        if Sorts.Quality.is_impredicative (Sorts.quality indu)
-        then
-          match u with
-          | Type _ | Set -> { info with ind_squashed = Some AlwaysSquashed }
-          | QSort (q, _) -> add_squash (Sorts.Quality.QVar q) info
-          | SProp | Prop -> info
-        else check_univ_consistency (fun x -> x)
-                (Sorts.univ_of_sort indu)
-                (Sorts.univ_of_sort u)
-  else
-    let check_univ_consistency_squash quality =
-      check_univ_consistency (add_squash quality) in
-    match indu, u with
-    | QSort (_, indu), Type uu ->
-        check_univ_consistency_squash qtype indu uu
-    | QSort (_, indu), QSort (cq, uu) ->
-        check_univ_consistency_squash (QVar cq) indu uu
-    | QSort (q, indu), Set ->
-        if Environ.Internal.is_above_prop env q then info
-        else check_univ_consistency_squash qtype indu Universe.type0
-    | (SProp | Prop), QSort (q, _) ->
-        add_squash (QVar q) info
-    | QSort (q, _), (SProp | Prop) ->
-        if Environ.Internal.is_above_prop env q then info
-        else add_squash (Sorts.quality u) info
-    | _, _ -> { info with ind_squashed = Some AlwaysSquashed }
+  let indu = info.ind_univ in
+
+  if not @@ UGraph.check_leq (universes env) (Sorts.univ_of_sort u) (Sorts.univ_of_sort indu) then
+    if Sorts.Quality.is_impredicative (Sorts.quality indu) then add_squash (Sorts.quality u) info
+    else { info with missing = u :: info.missing }
+  else if Inductive.eliminates_to (Environ.qualities env) (Sorts.quality indu) (Sorts.quality u) then
+    info
+  else match indu, u with
+    (* XXX add a constraint q -> Prop in push_template_context,
+       then we don't need this above_prop test *)
+    | QSort (q, _), (SProp | Prop) when Environ.Internal.is_above_prop env q -> info
+    | _ -> add_squash (Sorts.quality u) info
 
 let check_context_univs ~ctor env info ctx =
   let check_one d (info,env) =

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -113,7 +113,7 @@ let compute_elim_squash ?(is_real_arg=false) env u info =
   let indu = info.ind_univ in
 
   if not @@ UGraph.check_leq (universes env) (Sorts.univ_of_sort u) (Sorts.univ_of_sort indu) then
-    if Sorts.Quality.is_impredicative (Sorts.quality indu) then add_squash (Sorts.quality u) info
+    if Environ.is_impredicative_sort env indu then add_squash (Sorts.quality u) info
     else { info with missing = u :: info.missing }
   else if Inductive.eliminates_to (Environ.qualities env) (Sorts.quality indu) (Sorts.quality u) then
     info

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -342,15 +342,15 @@ let elim_sort (mib,mip) =
      future. *)
   if Option.is_empty mip.mind_squashed &&
        not (is_record && has_args mip && Sorts.is_sprop mip.mind_sort)
-  then Sorts.Quality.qtype
-  else Sorts.quality mip.mind_sort
+  then UnivGen.QualityOrSet.qtype
+  else if Sorts.is_set mip.mind_sort then Set
+  else UnivGen.QualityOrSet.of_quality @@ Sorts.quality mip.mind_sort
 
 let top_allowed_sort env (kn,i as ind) =
   let specif = Inductive.lookup_mind_specif env ind in
   elim_sort specif
 
 let constant_sorts_below top =
-  let top = UnivGen.QualityOrSet.of_quality top in
   List.filter
     (UnivGen.QualityOrSet.eliminates_to top)
     (UnivGen.QualityOrSet.all_constants)

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -126,7 +126,7 @@ val constructor_alltags : env -> constructor -> bool list
 val constructor_has_local_defs : env -> constructor -> bool
 val inductive_has_local_defs : env -> inductive -> bool
 
-val constant_sorts_below : Sorts.Quality.t -> UnivGen.QualityOrSet.t list
+val constant_sorts_below : UnivGen.QualityOrSet.t -> UnivGen.QualityOrSet.t list
 
 val sorts_for_schemes : mind_specif -> UnivGen.QualityOrSet.t list
 
@@ -143,9 +143,9 @@ val is_allowed_elimination : evar_map -> (mind_specif * EInstance.t) -> EConstr.
 val make_allowed_elimination : evar_map -> (mind_specif * EInstance.t) -> EConstr.ESorts.t -> evar_map option
 (** Returns [Some sigma'] if the elimination can be allowed, possibly adding constraints in [sigma'] *)
 
-val elim_sort : mind_specif -> Sorts.Quality.t
+val elim_sort : mind_specif -> UnivGen.QualityOrSet.t
 
-val top_allowed_sort : env -> inductive -> Sorts.Quality.t
+val top_allowed_sort : env -> inductive -> UnivGen.QualityOrSet.t
 
 (** (Co)Inductive records with primitive projections do not have eta-conversion,
     hence no dependent elimination. *)

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -207,9 +207,7 @@ let is_correct_arity env sigma c pj ind specif params =
         sigma, s
       end
     | Evar (ev,_), [] ->
-       let sigma, s = Evd.fresh_sort_in_quality sigma
-           (UnivGen.QualityOrSet.of_quality @@ elim_sort specif)
-       in
+       let sigma, s = Evd.fresh_sort_in_quality sigma (elim_sort specif) in
        let sigma = Evd.define ev (mkSort s) sigma in
        sigma, s
     | _, (LocalDef _ as d)::ar' ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1498,8 +1498,7 @@ let make_projection env sigma params cstr sign elim i n c (ind, u) =
         let (_, mip) as specif = Inductive.lookup_mind_specif env ind in
         let t = lift (i + 1 - n) t in
         let ksort = Retyping.get_sort_quality_of (push_rel_context sign env) sigma t in
-        if UnivGen.QualityOrSet.eliminates_to
-             (UnivGen.QualityOrSet.of_quality @@ Inductiveops.elim_sort specif) ksort then
+        if UnivGen.QualityOrSet.eliminates_to (Inductiveops.elim_sort specif) ksort then
           let arity = List.firstn mip.mind_nrealdecls mip.mind_arity_ctxt in
           let mknas ctx = Array.of_list (List.rev_map get_annot ctx) in
           let ci = Inductiveops.make_case_info env ind MatchStyle in

--- a/test-suite/success/impredicative_set.v
+++ b/test-suite/success/impredicative_set.v
@@ -1,0 +1,8 @@
+(* -*- coq-prog-args: ("-impredicative-set"); -*- *)
+
+Definition foo : Set := forall A : Set, A -> A.
+
+Inductive bar : Set := Bar (_:Type).
+
+Check bar_rec.
+Fail Check bar_rect.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -841,8 +841,12 @@ let build_beq_scheme env handle kn =
          let cores = Array.init nb_ind make_one_eq in
          Array.init nb_ind (fun i ->
             let kelim = Inductiveops.elim_sort (mib,mib.mind_packets.(i)) in
-            if not (Inductive.eliminates_to (Environ.qualities env) kelim Sorts.Quality.qtype) then
-              raise (NonSingletonProp (kn,i));
+            let () =
+              if not (Inductive.eliminates_to (Environ.qualities env)
+                        (UnivGen.QualityOrSet.quality kelim)
+                        Sorts.Quality.qtype)
+              then raise (NonSingletonProp (kn,i))
+            in
             let decrArg = Context.Rel.length nonrecparams_ctx_with_eqs in
             let fix = mkFix (((Array.make nb_ind decrArg),i),(names,types,cores)) in
             Term.it_mkLambda_or_LetIn fix recparams_ctx_with_eqs)
@@ -851,8 +855,12 @@ let build_beq_scheme env handle kn =
          (* If the inductive type is not recursive, the fixpoint is
              not used, so let's replace it with garbage *)
          let kelim = Inductiveops.elim_sort (mib,mib.mind_packets.(0)) in
-         if not (Inductive.eliminates_to (Environ.qualities env) kelim Sorts.Quality.qtype)
-         then raise (NonSingletonProp (kn,0));
+         let () =
+           if not (Inductive.eliminates_to (Environ.qualities env)
+                     (UnivGen.QualityOrSet.quality kelim)
+                     Sorts.Quality.qtype)
+           then raise (NonSingletonProp (kn,0))
+         in
          [|Term.it_mkLambda_or_LetIn (make_one_eq 0) recparams_ctx_with_eqs|]
   in
 

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -213,7 +213,7 @@ let declare_one_case_analysis_scheme ?loc ind =
       Some Names.(Id.of_string (Id.to_string mip.mind_typename ^ "_" ^ suff))
   in
   let kelim = Inductiveops.elim_sort (mib,mip) in
-  if Inductive.raw_eliminates_to kelim Sorts.Quality.qtype then
+  if Inductive.raw_eliminates_to (UnivGen.QualityOrSet.quality kelim) Sorts.Quality.qtype then
     define_individual_scheme ?loc dep id ind
 
 (* Induction/recursion schemes *)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -482,7 +482,7 @@ let warning_or_error ?loc ~info flags indsp err =
       let err = match te with
         | ElimArity (_, _, Some s) ->
           error_elim_explain (Sorts.quality s)
-            (Inductiveops.elim_sort (Global.lookup_inductive indsp))
+            (UnivGen.QualityOrSet.quality @@ Inductiveops.elim_sort (Global.lookup_inductive indsp))
         | _ -> None
       in
         match err with


### PR DESCRIPTION
(It was bugged when declaring inductive in impredicative Set with large arguments, producing a universe error instead of squashing)

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/703