### PR TITLE
Add with_strategy tactic to Ltac2

### DIFF
--- a/doc/changelog/06-Ltac2-language/21762-ltac2-strategy-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21762-ltac2-strategy-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :tacn:`with_strategy` to Ltac2, to allow temporarily changing the strategy
+  level of constants during tactic execution, with automatic restoration
+  afterward
+  (`#21762 <https://github.com/rocq-prover/rocq/pull/21762>`_,
+  by Jason Gross).

--- a/plugins/ltac2/tac2ffi.ml
+++ b/plugins/ltac2/tac2ffi.ml
@@ -500,6 +500,22 @@ let reference = {
   r_to = to_reference;
 }
 
+let of_strategy_level = let open Conv_oracle in function
+| Expand -> ValInt 0
+| Opaque -> ValInt 1
+| Level n -> ValBlk (0, [| of_int n |])
+
+let to_strategy_level = let open Conv_oracle in function
+| ValInt 0 -> Expand
+| ValInt 1 -> Opaque
+| ValBlk (0, [| n |]) -> Level (to_int n)
+| _ -> assert false
+
+let strategy_level = {
+  r_of = of_strategy_level;
+  r_to = to_strategy_level;
+}
+
 let err_notfocussed =
   LtacError (rocq_core "Not_focussed", [||])
 

--- a/plugins/ltac2/tac2ffi.mli
+++ b/plugins/ltac2/tac2ffi.mli
@@ -222,6 +222,10 @@ val of_reference : GlobRef.t -> valexpr
 val to_reference : valexpr -> GlobRef.t
 val reference : GlobRef.t repr
 
+val of_strategy_level : Conv_oracle.level -> valexpr
+val to_strategy_level : valexpr -> Conv_oracle.level
+val strategy_level : Conv_oracle.level repr
+
 val of_modpath : ModPath.t -> valexpr
 val to_modpath : valexpr -> ModPath.t
 val modpath : ModPath.t repr

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -824,6 +824,11 @@ let () =
     (ident @-> transparent_state @-> ret bool) @@ fun v ts ->
     Id.Pred.mem v ts.tr_var
 
+let () =
+  define "with_strategy"
+    (strategy_level @-> list reference @-> thunk valexpr @-> tac valexpr)
+    Tac2tactics.with_strategy
+
 (** Tactics around Evarconv unification (in [Ltac2/Unification.v]). *)
 
 let to_conv_pb v = match Tac2ffi.to_int v with

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -396,6 +396,9 @@ let current_transparent_state () =
 
 let evarconv_unify state x y = Tactics.evarconv_unify ~state x y
 
+let with_strategy lvl ql tac =
+  Tactics.with_set_strategy [(lvl, ql)] (thaw tac)
+
 (** Inversion *)
 
 let inversion knd arg pat ids =

--- a/plugins/ltac2/tac2tactics.mli
+++ b/plugins/ltac2/tac2tactics.mli
@@ -122,6 +122,8 @@ val current_transparent_state : unit -> TransparentState.t tactic
 
 val evarconv_unify : TransparentState.t -> constr -> constr -> unit tactic
 
+val with_strategy : Conv_oracle.level -> GlobRef.t list -> unit thunk -> unit tactic
+
 (** Internal *)
 
 val mk_intro_pattern : intro_pattern -> Tactypes.intro_pattern

--- a/test-suite/ltac2/with_strategy.v
+++ b/test-suite/ltac2/with_strategy.v
@@ -1,0 +1,47 @@
+Require Import Ltac2.Ltac2.
+
+Definition myid {A} (x : A) := x.
+
+Ltac2 myid_ref () :=
+  match Env.expand [@myid] with
+  | r :: _ => r
+  | [] => Control.throw (Invalid_argument (Some (Message.of_string "myid not found")))
+  end.
+
+Ltac2 unfold_myid () :=
+  Std.unfold [(myid_ref (), Std.AllOccurrences)]
+    {Std.on_hyps := None; Std.on_concl := Std.AllOccurrences}.
+
+(* Test with_strategy Expand allows unfolding an opaque constant *)
+Opaque myid.
+Goal myid 0 = 0.
+  TransparentState.with_strategy TransparentState.Expand [myid_ref ()]
+    (fun () => unfold_myid ()).
+  reflexivity.
+Qed.
+
+(* Test that strategy is restored after the tactic *)
+Goal myid 0 = 0.
+  TransparentState.with_strategy TransparentState.Expand [myid_ref ()]
+    (fun () => ()).
+  (* unfold should fail since myid is opaque again *)
+  Fail unfold myid.
+  reflexivity.
+Qed.
+
+(* Test with Level 0 = transparent *)
+Goal myid 0 = 0.
+  TransparentState.with_strategy (TransparentState.Level 0) [myid_ref ()]
+    (fun () => unfold_myid ()).
+  reflexivity.
+Qed.
+
+(* Test Opaque: making a transparent constant temporarily opaque *)
+Transparent myid.
+Goal myid 0 = 0.
+  TransparentState.with_strategy TransparentState.Opaque [myid_ref ()]
+    (fun () => ()).
+  (* myid should be transparent again after with_strategy *)
+  unfold_myid ().
+  reflexivity.
+Qed.

--- a/theories/Ltac2/TransparentState.v
+++ b/theories/Ltac2/TransparentState.v
@@ -9,10 +9,22 @@
 (************************************************************************)
 
 Require Import Ltac2.Init.
+Require Import Ltac2.Std.
 
 (** Abstract type representing a transparency state. A transparency state
     is a set of variables, constants, and primitive projections.  *)
 Ltac2 Type t.
+
+(** Strategy levels used by [with_strategy].
+    [Expand] corresponds to the [-oo] level (always unfold),
+    [Opaque] corresponds to the [+oo] level (never unfold),
+    and [Level n] corresponds to integer level [n]
+    (where [Level 0] is [transparent]). *)
+Ltac2 Type strategy_level := [
+| Expand
+| Opaque
+| Level (int)
+].
 
 (** [empty] is the empty transparency state (all constants are opaque). *)
 Ltac2 @ external empty : t :=
@@ -86,3 +98,11 @@ Ltac2 @ external mem_proj : projection -> t -> bool :=
     transparency state [t]. *)
 Ltac2 @ external mem_var : ident -> t -> bool :=
   "rocq-runtime.plugins.ltac2" "mem_var_transparent_state".
+
+(** [with_strategy lvl refs tac] temporarily sets the strategy level of
+    all references in [refs] to [lvl], executes [tac], and then restores
+    the original strategy levels. This is the Ltac2 analogue of the
+    [with_strategy] Ltac tactic and the [Strategy] vernacular command. *)
+Ltac2 @ external with_strategy :
+  strategy_level -> Std.reference list -> (unit -> 'a) -> 'a :=
+  "rocq-runtime.plugins.ltac2" "with_strategy".


### PR DESCRIPTION
Expose the with_strategy tactic (analogous to the Ltac1 version in extratactics.mlg) in Ltac2 as TransparentState.with_strategy. This allows temporarily changing the strategy level of constants during tactic execution, with automatic restoration afterward.

Adds a strategy_level algebraic type (Expand | Opaque | Level of int) to TransparentState and the corresponding FFI conversion for Conv_oracle.level.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
