### PR TITLE
Add coq.opam file

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -1,0 +1,16 @@
+
+opam-version: "2.0"
+synopsis: "Compatibility metapackage for Coq after the Rocq renaming"
+maintainer: "The Rocq development team <coqdev@inria.fr>"
+authors: "The Rocq development team, INRIA, CNRS, and contributors"
+license: "LGPL-2.1-only"
+homepage: "https://rocq-prover.org/"
+doc: "https://rocq-prover.org/docs/"
+bug-reports: "https://github.com/rocq-prover/rocq/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "coq-core" {= version}
+  "coq-stdlib"
+  "coqide-server" {= version}
+]
+dev-repo: "git+https://github.com/rocq-prover/rocq.git"

--- a/dune-project
+++ b/dune-project
@@ -94,6 +94,14 @@ This package includes compatibility binaries to call Rocq
 through previous Coq commands like coqc coqtop,..."))
 
 (package
+ (name coq)
+ (depends
+  (coq-core (= :version))
+  coq-stdlib
+  (coqide-server (= :version)))
+ (synopsis "Compatibility metapackage for Coq after the Rocq renaming"))
+
+(package
  (name rocq-core)
  (depends
   (rocq-runtime (= :version)))


### PR DESCRIPTION
This allows users to opam pin to the dev repo and still install packages that depend on particular versions of "coq".  Without this, opam install coq attempts to install 8.16.1.  This should be backported to all previous branches that have coq-core.opam but not coq.opam.
