### PR TITLE
Track inductives that depend on indices not mattering

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -173,7 +173,7 @@ let check_packet mind ind
     { mind_typename; mind_arity_ctxt; mind_user_arity; mind_record; mind_sort; mind_consnames; mind_user_lc;
       mind_nrealargs; mind_nrealdecls; mind_squashed; mind_nf_lc;
       mind_consnrealargs; mind_consnrealdecls; mind_recargs; mind_automaton; mind_relevance;
-      mind_nb_constant; mind_nb_args; mind_reloc_tbl } =
+      mind_relies_on_indices_not_mattering; mind_nb_constant; mind_nb_args; mind_reloc_tbl } =
   let check = check mind in
 
   ignore mind_typename; (* passed through *)
@@ -199,6 +199,12 @@ let check_packet mind ind
 
   check "mind_relevant" (Sorts.relevance_equal ind.mind_relevance mind_relevance);
 
+  (* mind_relies_on_indices_not_mattering is computed using the universe graph at type-checking time.
+     During original compilation, the graph may be incomplete (constructor constraints
+     not yet added), making the check conservative (true). During re-checking, the
+     graph has all final constraints, so the check may compute false.
+     Accept when the original is conservatively true but re-check computes false. *)
+  check "mind_relies_on_indices_not_mattering" (ind.mind_relies_on_indices_not_mattering || not mind_relies_on_indices_not_mattering);
   check "mind_nb_args" Int.(equal ind.mind_nb_args mind_nb_args);
   check "mind_nb_constant" Int.(equal ind.mind_nb_constant mind_nb_constant);
   check "mind_reloc_tbl" (eq_reloc_tbl ind.mind_reloc_tbl mind_reloc_tbl);

--- a/checker/check_stat.ml
+++ b/checker/check_stat.ml
@@ -62,6 +62,14 @@ let pr_nonpositive env =
   let inds = fold_inductives (fun c cb acc -> if not cb.mind_typing_flags.check_positive then MutInd.to_string c :: acc else acc) env [] in
   pr_assumptions "Inductives whose positivity is assumed" inds
 
+let pr_indices_matter env =
+  let inds = fold_inductives (fun c cb acc ->
+    if cb.mind_typing_flags.indices_matter then acc
+    else if Array.exists (fun mip -> mip.mind_relies_on_indices_not_mattering) cb.mind_packets
+    then MutInd.to_string c :: acc
+    else acc) env [] in
+  pr_assumptions "Inductives relying on indices not mattering" inds
+
 let print_context env opac =
   if !output_context then begin
     Feedback.msg_notice
@@ -73,7 +81,8 @@ let print_context env opac =
       str "* " ++ hov 0 (pr_axioms env opac ++ fnl()) ++ fnl() ++
       str "* " ++ hov 0 (pr_type_in_type env ++ fnl()) ++ fnl() ++
       str "* " ++ hov 0 (pr_unguarded env ++ fnl()) ++ fnl() ++
-      str "* " ++ hov 0 (pr_nonpositive env ++ fnl()))
+      str "* " ++ hov 0 (pr_nonpositive env ++ fnl()) ++ fnl() ++
+      str "* " ++ hov 0 (pr_indices_matter env ++ fnl()))
       )
   end
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -464,6 +464,7 @@ let v_one_ind = v_tuple "one_inductive_body"
     v_wfp;
     v_automaton;
     v_relevance;
+    v_bool;
     v_int;
     v_int;
     v_vm_reloc_table|]

--- a/doc/changelog/01-kernel/21774-track-indices-matter-Added.rst
+++ b/doc/changelog/01-kernel/21774-track-indices-matter-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  kernel now tracks reliance on ``-indices-matter`` not being passed, and
+  prints this information in the checker, and in :cmd:`Print Assumptions`
+  when ``-indices-matter`` is passed
+  (`#21774 <https://github.com/rocq-prover/rocq/pull/21774>`_,
+  by Jason Gross).

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -914,7 +914,9 @@ or :math:`s_j` must be an impredicative sort (`SProp`, `Prop`, or if `-impredica
 and the `j`\th inductive may not be eliminated to larger sorts:
 
 - for each (non parameter) constructor argument, the universe of its type must be smaller than :math:`s_j`
-- if `-indices-matter` was used, for each index the universe of its type must be smaller than :math:`s_j`
+- if `-indices-matter` was used, for each index the universe of its type must be smaller than :math:`s_j`.
+  When `-indices-matter` is not used, inductives whose indices would contribute
+  universe constraints are printed by :cmd:`Print Assumptions`.
 - if there are 2 or more constructors, `Set` must be smaller than :math:`s_j`
 - unless the inductive is a primitive record, and unless :flag:`Definitional UIP` was used,
   if there is 1 constructor, `Prop` must be smaller than :math:`s_j` (essentially this means :math:`s_j` must not be `SProp`)

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -433,6 +433,11 @@ Requests to the environment
 
    Displays all the assumptions (axioms, parameters and
    variables) one or more theorems or definitions depends on.
+   It also reports inductives that rely on indices not mattering
+   (i.e., whose behavior would change under `-indices-matter`),
+   as well as uses of disabled typing flags such as
+   :flag:`Guard Checking`, :flag:`Positivity Checking`,
+   :flag:`Universe Checking`, and :flag:`Definitional UIP`.
 
    The message "Closed under the global context" indicates that all the theorems and
    definitions have no dependencies.

--- a/kernel/declarations.mli
+++ b/kernel/declarations.mli
@@ -255,6 +255,10 @@ type one_inductive_body = {
     mind_relevance : Sorts.relevance;
     (* XXX this is redundant with mind_sort, is it actually worth keeping? *)
 
+    mind_relies_on_indices_not_mattering : bool;
+    (** true if this inductive relies on indices not mattering,
+        i.e. its behavior would change under -indices-matter. *)
+
 (** {8 Datas for bytecode compilation } *)
 
     mind_nb_constant : int; (** number of constant constructor *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -251,6 +251,7 @@ let subst_mind_packet subst mbp =
     mind_recargs = subst_wf_paths subst mbp.mind_recargs (*wf_paths*);
     mind_automaton = subst_automaton subst mbp.mind_automaton;
     mind_relevance = mbp.mind_relevance;
+    mind_relies_on_indices_not_mattering = mbp.mind_relies_on_indices_not_mattering;
     mind_nb_constant = mbp.mind_nb_constant;
     mind_nb_args = mbp.mind_nb_args;
     mind_reloc_tbl = mbp.mind_reloc_tbl }

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -158,6 +158,7 @@ let cook_one_ind info cache ~params ~ntypes mip =
     mind_recargs = mip.mind_recargs;
     mind_automaton = mip.mind_automaton;
     mind_relevance = lift_relevance info mip.mind_relevance;
+    mind_relies_on_indices_not_mattering = mip.mind_relies_on_indices_not_mattering;
     mind_nb_constant = mip.mind_nb_constant;
     mind_nb_args = mip.mind_nb_args;
     mind_reloc_tbl = mip.mind_reloc_tbl;

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -150,9 +150,24 @@ let check_context_univs ~ctor env info ctx =
   in
   fst (Context.Rel.fold_outside ~init:(info,env) check_one ctx)
 
+let eq_squashed a b =
+  match a, b with
+  | SometimesSquashed a, SometimesSquashed b -> Sorts.Quality.Set.equal a b
+  | AlwaysSquashed, AlwaysSquashed -> true
+  | (SometimesSquashed _ | AlwaysSquashed), _ -> false
+
 let check_indices_matter env_params info indices =
-  if not (indices_matter env_params) then info
-  else check_context_univs ~ctor:false env_params info indices
+  let with_indices = check_context_univs ~ctor:false env_params info indices in
+  let relies_on_indices_not_mattering =
+    not (Option.equal eq_squashed info.ind_squashed with_indices.ind_squashed)
+    || not (List.equal Sorts.equal info.missing with_indices.missing)
+  in
+  if indices_matter env_params then
+    (* indices constraints are enforced, so this inductive does not
+       rely on indices not mattering *)
+    (with_indices, false)
+  else
+    (info, relies_on_indices_not_mattering)
 
 (* env_ar contains the inductives before the current ones in the block, and no parameters *)
 let check_arity ~template env_params env_ar ind =
@@ -166,7 +181,6 @@ let check_arity ~template env_params env_ar ind =
     missing=[];
   }
   in
-  let univ_info = check_indices_matter env_params univ_info indices in
   (* We do not need to generate the universe of the arity with params;
      if later, after the validation of the inductive definition,
      full_arity is used as argument or subject to cast, an upper
@@ -180,7 +194,7 @@ let check_constructor_univs env_ar_par info (args,_) =
   (* We ignore the output, positivity will check that it's the expected inductive type *)
   check_context_univs ~ctor:true env_ar_par info args
 
-let check_constructors env_ar_par isrecord params lc (arity,indices,univ_info) =
+let check_constructors ~env_params ~env_ar_par isrecord params lc (arity,indices,univ_info) =
   let lc = Array.map_of_list (fun c -> (Typeops.infer_type env_ar_par c).utj_val) lc in
   let splayed_lc = Array.map (Reduction.whd_decompose_prod_decls env_ar_par) lc in
   let univ_info =
@@ -214,7 +228,8 @@ let check_constructors env_ar_par isrecord params lc (arity,indices,univ_info) =
   in
   (* generalize the constructors over the parameters *)
   let lc = Array.map (fun c -> Term.it_mkProd_or_LetIn c params) lc in
-  (arity, lc), (indices, splayed_lc), univ_info
+  let univ_info, relies_on_indices_not_mattering = check_indices_matter env_params univ_info indices in
+  (arity, lc), (indices, splayed_lc), univ_info, relies_on_indices_not_mattering
 
 module NotPrimRecordReason = struct
 
@@ -229,7 +244,7 @@ end
 (* Checks whether the record can have primitive projections, and if so, whether it has eta *)
 let check_record data =
   let open NotPrimRecordReason in
-  List.fold_left (fun res (_, (_, splayed_lc), info) ->
+  List.fold_left (fun res (_, (_, splayed_lc), info, _) ->
       if Result.is_error res then res
       else if Option.has_some info.ind_squashed
       (* records must have all projections definable -> equivalent to not being squashed *)
@@ -494,7 +509,7 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
     template_defaults = default_univs;
   }
 
-let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info) =
+let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info,relies_on_indices_not_mattering) =
   if not (List.is_empty univ_info.missing)
   then raise (InductiveError (env, MissingUnivConstraints (univ_info.missing,univ_info.ind_univ)));
   let arity = Vars.subst_univs_level_constr usubst arity in
@@ -522,7 +537,7 @@ let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info) =
       univ_info.ind_squashed
   in
 
-  (arity,lc), (indices,splayed_lc), squashed
+  (arity,lc), (indices,splayed_lc), squashed, relies_on_indices_not_mattering
 
 let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   let () = match mie.mind_entry_inds with
@@ -565,7 +580,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
     | Some None | None -> false
   in
   let data = List.map2 (fun ind data ->
-      check_constructors env_ar_par isrecord params ind.mind_entry_lc data)
+      check_constructors ~env_params ~env_ar_par isrecord params ind.mind_entry_lc data)
       mie.mind_entry_inds data
   in
 
@@ -579,8 +594,8 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
       | Result.Error _ as reason ->
         (* if someone tried to declare a record as SProp but it can't
            be primitive we must squash. *)
-        let data = List.map (fun (a, b, univs) ->
-            a, b, compute_elim_squash env_ar_par Sorts.prop univs)
+        let data = List.map (fun (a, b, univs, im) ->
+            a, b, compute_elim_squash env_ar_par Sorts.prop univs, im)
             data
         in
         data, Some None, Some reason (* back to FakeRecord with a reason why *)

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -50,5 +50,6 @@ val typecheck_inductive : env -> sec_univs:UVars.Instance.t option
   * Constr.rel_context
   * ((inductive_arity * Constr.types array) *
      (Constr.rel_context * (Constr.rel_context * Constr.types) array) *
-     squash_info option)
+     squash_info option *
+     bool (** true if the inductive relies on indices not mattering *))
     array

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -426,7 +426,7 @@ let check_positivity ~chkpos kn names env_ar_par paramsctxt finite inds =
 (* Build the inductive packet *)
 
 let fold_inductive_blocks f acc inds =
-  Array.fold_left (fun acc ((arity,lc),_,_) ->
+  Array.fold_left (fun acc ((arity,lc),_,_,_) ->
       f (Array.fold_left f acc lc) arity.IndTyping.user_arity)
     acc inds
 
@@ -503,7 +503,7 @@ let build_inductive env ~sec_univs names prv univs template variance
   let u = UVars.make_abstract_instance (universes_context univs) in
   let subst = List.init ntypes (fun i -> mkIndU ((kn, ntypes - i - 1), u)) in
   (* Check one inductive *)
-  let build_one_packet i (id,cnames) ((arity,lc),(indices,splayed_lc),squashed) recarg =
+  let build_one_packet i (id,cnames) ((arity,lc),(indices,splayed_lc),squashed,relies_on_indices_not_mattering) recarg =
     let lc = Array.map (substl subst) lc in
     (* Type of constructors in normal form *)
     let nf_lc =
@@ -564,6 +564,7 @@ let build_inductive env ~sec_univs names prv univs template variance
         mind_recargs = recarg;
         mind_automaton = automaton;
         mind_relevance;
+        mind_relies_on_indices_not_mattering = relies_on_indices_not_mattering;
         mind_nb_constant = !nconst;
         mind_nb_args = !nblock;
         mind_reloc_tbl = rtbl;
@@ -614,7 +615,7 @@ let check_inductive env ~sec_univs kn mie =
   in
   let (nmr,recargs) = check_positivity ~chkpos kn names
       env_ar_par paramsctxt mie.mind_entry_finite
-      (Array.map (fun ((_,lc),(indices,_),_) -> Context.Rel.nhyps indices,lc) inds)
+      (Array.map (fun ((_,lc),(indices,_),_,_) -> Context.Rel.nhyps indices,lc) inds)
   in
   (* Build the inductive packets *)
   let mib =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -1098,6 +1098,7 @@ type axiom =
   | Guarded of GlobRef.t
   | TypeInType of GlobRef.t
   | UIP of MutInd.t
+  | IndicesNotMattering of MutInd.t
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)
@@ -1115,7 +1116,8 @@ struct
     | Constant k1 , Constant k2 ->
       Constant.UserOrd.compare k1 k2
     | Positive m1 , Positive m2
-    | UIP m1, UIP m2 ->
+    | UIP m1, UIP m2
+    | IndicesNotMattering m1, IndicesNotMattering m2 ->
       MutInd.UserOrd.compare m1 m2
     | Guarded k1 , Guarded k2
     | TypeInType k1, TypeInType k2 ->
@@ -1128,6 +1130,8 @@ struct
     | _, Guarded _ -> 1
     | TypeInType _, _ -> -1
     | _, TypeInType _ -> 1
+    | UIP _, _ -> -1
+    | _, UIP _ -> 1
 
   let compare x y =
     match x , y with
@@ -1192,6 +1196,8 @@ let pr_assumptionset ?(flags=current_combined()) env sigma s =
           hov 2 (safe_pr_global env gr ++ spc () ++ strbrk"relies on an unsafe hierarchy.")
       | UIP mind ->
           hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on definitional UIP.")
+      | IndicesNotMattering mind ->
+          hov 2 (safe_pr_inductive env mind ++ spc () ++ strbrk"relies on indices not mattering.")
     in
     let fold t typ accu =
       let (v, a, o, tr) = accu in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -251,6 +251,7 @@ type axiom =
   | Guarded of GlobRef.t (* a constant whose (co)fixpoints have been assumed to be guarded *)
   | TypeInType of GlobRef.t (* a constant which relies on type in type *)
   | UIP of MutInd.t (* An inductive using the special reduction rule. *)
+  | IndicesNotMattering of MutInd.t (* An inductive relying on indices not mattering. *)
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)

--- a/test-suite/output-coqchk/bug_13324.out
+++ b/test-suite/output-coqchk/bug_13324.out
@@ -14,3 +14,7 @@ CONTEXT SUMMARY
   
 * Inductives whose positivity is assumed: <none>
   
+* Inductives relying on indices not mattering:
+    Corelib.Init.Datatypes.eq_true
+    Corelib.Init.Logic.eq
+  

--- a/test-suite/output-coqchk/bug_5030.out
+++ b/test-suite/output-coqchk/bug_5030.out
@@ -14,3 +14,7 @@ CONTEXT SUMMARY
   
 * Inductives whose positivity is assumed: <none>
   
+* Inductives relying on indices not mattering:
+    Corelib.Init.Datatypes.eq_true
+    Corelib.Init.Logic.eq
+  

--- a/test-suite/output-coqchk/indices_matter.out
+++ b/test-suite/output-coqchk/indices_matter.out
@@ -16,5 +16,6 @@ CONTEXT SUMMARY
   
 * Inductives relying on indices not mattering:
     Corelib.Init.Datatypes.eq_true
+    indices_matter.M.X
     Corelib.Init.Logic.eq
   

--- a/test-suite/output-coqchk/indices_matter.v
+++ b/test-suite/output-coqchk/indices_matter.v
@@ -1,0 +1,13 @@
+Module Type T.
+  Parameter T : Type.
+End T.
+
+Module F(A:T).
+  Inductive X : A.T -> Prop := .
+End F.
+
+Module A.
+  Definition T := True.
+End A.
+
+Module M := F A.

--- a/test-suite/output/indices_matter.out
+++ b/test-suite/output/indices_matter.out
@@ -1,0 +1,2 @@
+Axioms:
+M.X relies on indices not mattering.

--- a/test-suite/output/indices_matter.v
+++ b/test-suite/output/indices_matter.v
@@ -1,0 +1,4 @@
+(* -*- coq-prog-args: ("-indices-matter"); -*- *)
+Require Import TestSuite.indices_matter_prereq.
+
+Print Assumptions M.X.

--- a/test-suite/prerequisite/indices_matter_prereq.v
+++ b/test-suite/prerequisite/indices_matter_prereq.v
@@ -1,0 +1,13 @@
+Module Type T.
+  Parameter T : Type.
+End T.
+
+Module F(A:T).
+  Inductive X : A.T -> Prop := .
+End F.
+
+Module A.
+  Definition T := True.
+End A.
+
+Module M := F A.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -423,5 +423,12 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (UIP m, l)) Constr.mkProp accu
       in
+      let accu =
+        if not (Environ.indices_matter (Global.env ())) then accu
+        else if not (Array.exists (fun mip -> mip.mind_relies_on_indices_not_mattering) mind.mind_packets) then accu
+        else
+          let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+          ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.mkProp accu
+      in
       accu
   in GlobRef.Map_env.fold fold graph ContextObjectMap.empty


### PR DESCRIPTION
Add mind_indices_matter field to one_inductive_body that records whether an inductive's indices contribute to universe constraints (i.e., would change behavior under -indices-matter). This is detected by always running check_context_univs on indices and checking if the result differs from the input univ_info via physical equality on ind_squashed and missing.

Print Assumptions now reports "relies on indices not mattering" for inductives where indices_matter is false but indices would contribute. coqchk similarly reports these in its context summary.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
