### PR TITLE
Add Set Indices Matter vernacular option 

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21779-set-indices-matter-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21779-set-indices-matter-Added.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  flag :flag:`Indices Matter` to set ``-indices-matter`` locally,
+  controlling whether the types of indices of inductive types
+  contribute universe constraints
+  (`#21779 <https://github.com/rocq-prover/rocq/pull/21779>`_,
+  by Jason Gross).

--- a/doc/sphinx/language/core/inductive.rst
+++ b/doc/sphinx/language/core/inductive.rst
@@ -914,8 +914,8 @@ or :math:`s_j` must be an impredicative sort (`SProp`, `Prop`, or if `-impredica
 and the `j`\th inductive may not be eliminated to larger sorts:
 
 - for each (non parameter) constructor argument, the universe of its type must be smaller than :math:`s_j`
-- if `-indices-matter` was used, for each index the universe of its type must be smaller than :math:`s_j`.
-  When `-indices-matter` is not used, inductives whose indices would contribute
+- if ``-indices-matter`` or :flag:`Indices Matter` was used, for each index the universe of its type must be smaller than :math:`s_j`.
+  When neither ``-indices-matter`` nor :flag:`Indices Matter` is used, inductives whose indices would contribute
   universe constraints are printed by :cmd:`Print Assumptions`.
 - if there are 2 or more constructors, `Set` must be smaller than :math:`s_j`
 - unless the inductive is a primitive record, and unless :flag:`Definitional UIP` was used,

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -434,7 +434,7 @@ Requests to the environment
    Displays all the assumptions (axioms, parameters and
    variables) one or more theorems or definitions depends on.
    It also reports inductives that rely on indices not mattering
-   (i.e., whose behavior would change under `-indices-matter`),
+   (i.e., whose behavior would change under ``-indices-matter`` or :flag:`Indices Matter`),
    as well as uses of disabled typing flags such as
    :flag:`Guard Checking`, :flag:`Positivity Checking`,
    :flag:`Universe Checking`, and :flag:`Definitional UIP`.
@@ -1148,6 +1148,15 @@ Controlling Typing Flags
 
    This :term:`boolean attribute` is similar to the :flag:`Positivity Checking` flag, but on a per-declaration basis.
    Disable positivity checking locally with ``bypass_check(positivity)``.
+
+.. flag:: Indices Matter
+
+   When this :term:`flag` is set (it is off by default), the types of indices
+   of inductive types contribute universe constraints, just as the types of
+   constructor arguments do.  This has the same effect as the ``-indices-matter``
+   command line argument (see :ref:`command-line-options`).
+   Inductives that rely on indices not mattering are printed by
+   :cmd:`Print Assumptions`.
 
 .. flag:: Universe Checking
 

--- a/test-suite/output/indices_matter.out
+++ b/test-suite/output/indices_matter.out
@@ -1,2 +1,5 @@
 Axioms:
 M.X relies on indices not mattering.
+Axioms:
+M.X relies on indices not mattering.
+Closed under the global context

--- a/test-suite/output/indices_matter.v
+++ b/test-suite/output/indices_matter.v
@@ -2,3 +2,11 @@
 Require Import TestSuite.indices_matter_prereq.
 
 Print Assumptions M.X.
+
+(* Test Set Indices Matter *)
+Module SetIndicesMatter.
+  Set Indices Matter.
+  Print Assumptions M.X.
+  Unset Indices Matter.
+  Print Assumptions M.X.
+End SetIndicesMatter.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2043,6 +2043,14 @@ let () =
   declare_bool_option
     { optstage = Summary.Stage.Interp;
       optdepr  = None;
+      optkey   = ["Indices"; "Matter"];
+      optread  = (fun () -> (Global.typing_flags ()).Declarations.indices_matter);
+      optwrite = (fun b -> Global.set_indices_matter b) }
+
+let () =
+  declare_bool_option
+    { optstage = Summary.Stage.Interp;
+      optdepr  = None;
       optkey   = ["Definitional"; "UIP"];
       optread  = (fun () -> (Global.typing_flags ()).Declarations.allow_uip);
       optwrite = (fun b -> Global.set_typing_flags


### PR DESCRIPTION
Expose the indices_matter typing flag as a Set/Unset option,
mirroring other typing flags like Guard Checking and Positivity Checking.

On top of #21774

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
