### PR TITLE
Correctly analyze rec call arguments for uniformity check in the guard.

### DIFF
--- a/dev/doc/critical-bugs.md
+++ b/dev/doc/critical-bugs.md
@@ -28,6 +28,7 @@ This file recollects knowledge about critical bugs found in Coq since version 8.
       - [guard checker does not account for cross calls to compute uniform arguments of a nested mutual fixpoint](#guard-checker-does-not-account-for-cross-calls-to-compute-uniform-arguments-of-a-nested-mutual-fixpoint)
       - [guard checker does not check for correct recursive calls when passed as uniform argument in a nested fixpoint](#guard-checker-does-not-check-for-correct-recursive-calls-when-passed-as-uniform-argument-in-a-nested-fixpoint)
       - [guard checker does not count argument-less recursive calls to compute uniform arguments of a nested mutual fixpoint](#guard-checker-does-not-count-argument-less-recursive-calls-to-compute-uniform-arguments-of-a-nested-mutual-fixpoint)
+      - [guard checker does not check arguments of recursive calls in uniformity analysis](#guard-checker-does-not-check-arguments-of-recursive-calls-in-uniformity-analysis)
     - [Module system](#module-system)
       - [missing universe constraints in typing "with" clause of a module type](#missing-universe-constraints-in-typing-with-clause-of-a-module-type)
       - [universe constraints for module subtyping not stored in vo files](#universe-constraints-for-module-subtyping-not-stored-in-vo-files)
@@ -310,6 +311,16 @@ and lack of checking of relevance marks on constants in coqchk
 - fixed in: V9.2.0 ([#21684](https://github.com/rocq-prover/rocq/pull/21684))
 - found by: Tristan Stérin
 - exploit / GH issue: [#21701](https://github.com/rocq-prover/rocq/issues/21701)
+- risk: unknown (no development in CI was affected)
+
+#### guard checker does not check arguments of recursive calls in uniformity analysis
+- component: guard checking
+- introduced: V8.20 ([#17986](https://github.com/rocq-prover/rocq/pull/17986))
+- impacted released versions: V8.20, V9.0, V9.1
+- impacted coqchk versions: Same
+- fixed in: V9.2.0 ([#21798](https://github.com/rocq-prover/rocq/pull/21798))
+- found by: Pierre-Marie Pédrot
+- exploit / GH issue: [#21797](https://github.com/rocq-prover/rocq/issues/21797)
 - risk: unknown (no development in CI was affected)
 
 ### Module system

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1408,7 +1408,7 @@ let drop_uniform_parameters nuniformparams bodies =
       let l = List.map (fun c -> aux i k c) l in
       (* A recursive reference to the i-th body *)
       if Int.equal n (nbodies + k - i) then
-        let new_args = List.skipn_at_best nuniformparams l in
+        let new_args = List.skipn nuniformparams l in
         Term.applist (f, new_args)
       else Term.applist (f, l)
     | _ -> map_with_binders succ (aux i) k c

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1373,6 +1373,8 @@ let find_uniform_parameters recindx nargs bodies =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
+      let fold accu c = fold_constr_with_binders succ (aux i) k accu c in
+      let nuniformparams = List.fold_left fold nuniformparams l in
       (* A recursive reference to any one of the mutual fixpoints *)
       if n > k && n <= k + nbodies then
         List.fold_left_until (fun j arg ->
@@ -1403,12 +1405,12 @@ let drop_uniform_parameters nuniformparams bodies =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
+      let l = List.map (fun c -> aux i k c) l in
       (* A recursive reference to the i-th body *)
       if Int.equal n (nbodies + k - i) then
         let new_args = List.skipn_at_best nuniformparams l in
         Term.applist (f, new_args)
-      else
-        c
+      else Term.applist (f, l)
     | _ -> map_with_binders succ (aux i) k c
   in
   Array.mapi (fun i -> aux i 0) bodies

--- a/test-suite/bugs/bug_21797.v
+++ b/test-suite/bugs/bug_21797.v
@@ -1,0 +1,62 @@
+(* The function Inductive.find_uniform_parameters did not recurse
+   into arguments of Rel applications.
+   A self-call hidden inside a regular function application was invisible
+   to the uniform parameter analysis, causing over-counting. *)
+Fail Fixpoint naughty (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S n' =>
+    (fix G (a : nat) (f : nat -> nat -> nat) (m : nat) {struct m} : nat :=
+      match m with
+      | 0 => S (naughty a)
+      | S m' => f (G n f m') m'
+      end) n' (fun x _ => x) n'
+  end.
+
+(*
+Lemma naughty_loop : naughty 2 = S (naughty 2).
+Proof.
+remember 0 as n.
+set (v := naughty (S (S n))) at 2.
+remember v as ans; unfold v in *; clearbody v.
+cbn.
+set (n₀ := n) at 3.
+replace n₀ with 0.
+f_equal.
+now symmetry.
+Qed.
+
+Theorem inconsistency : False.
+Proof.
+  assert (Hn : forall n, n <> S n).
+  { induction n; discriminate + (intro H; apply IHn; now injection H). }
+  exact (Hn _ naughty_loop).
+Qed.
+
+Print Assumptions inconsistency.
+*)
+
+(** Another variant of the same issue *)
+
+Fixpoint iter_fg {A} f g (a : A) n :=
+  match n with
+  | 0 => a | S n' => f (iter_fg f g (g a) n')
+  end.
+
+Fail Fixpoint F (n : nat) :=
+  iter_fg S F n 1.
+
+(*
+Theorem wrong : F 0 = S (F 0).
+Proof.
+  unfold F at 1. change (fix F (n : nat) := _) with F.
+  cbn -[F]. reflexivity.
+Qed.
+
+Corollary false : False.
+Proof.
+  assert (H : forall n, n <> S n).
+  { induction n; eauto. }
+  eapply H, wrong.
+Qed.
+*)


### PR DESCRIPTION
Hopefully this is the last of the soundness issues introduced by the handling of uniform fixpoint parameters.

Fixes #21797: Inconsistency due to uniform parameters in the guard.