### PR TITLE
[fix] Avoid C23 extension warning (from Apple clang 17.0.0)

### DIFF
--- a/kernel/byterun/rocq_values.c
+++ b/kernel/byterun/rocq_values.c
@@ -123,7 +123,7 @@ value rocq_tcode_array(value tcodes) {
 
 #ifdef NO_NATIVE_COMPUTE
 
-value rocq_curry2_1_addr(value) {
+value rocq_curry2_1_addr(value v) {
   return Val_unit;
 }
 
@@ -152,14 +152,14 @@ asm(".align 4\n\t"
 #error "Unsupported architecture for native_compute."
 #endif
 
-value rocq_curry2_1_addr(value) {
+value rocq_curry2_1_addr(value v) {
   extern void rocq_curry2_1();
   return (value)&rocq_curry2_1;
 }
 
 #else // not NO_NAKED_POINTERS
 
-value rocq_curry2_1_addr(value) {
+value rocq_curry2_1_addr(value v) {
   extern void caml_curry2_1() __attribute__((weak));
   return (value)&caml_curry2_1;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Minor fix to `rocq_values.c` to avoid a warning from clang:
```
rocq_values.c:126:31: warning: omitting the parameter name in a function definition is a C23 extension [-Wc23-extensions]
  126 | value rocq_curry2_1_addr(value) {
      |                               ^
1 warning generated.
```
