### PR TITLE
Ltac2: Add `@@` and `|>` notation

### DIFF
--- a/doc/changelog/06-Ltac2-language/21819-janno-ltac2-syntax-Added.rst
+++ b/doc/changelog/06-Ltac2-language/21819-janno-ltac2-syntax-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Add OCaml-inspired `@@` and `|>` notations
+  (`#21819 <https://github.com/rocq-prover/rocq/pull/21819>`_,
+  by Jan-Oliver Kaiser).

--- a/test-suite/ltac2/operator_notations.v
+++ b/test-suite/ltac2/operator_notations.v
@@ -1,0 +1,85 @@
+Require Import Ltac2.Ltac2.
+
+(* Associativity *)
+Ltac2 Type a.
+Ltac2 Type b.
+Ltac2 Type rec c := { p : c }.
+Ltac2 Type ('x,'y) h := { h : 'y -> 'x }.
+
+(** Associativity *)
+
+(* Sanity check: the term does not typecheck when wrongly associated. *)
+Fail Ltac2 test_app_assoc_fail (f : b -> a) (g : c -> b) (c : c) :=
+  (f @@ g) c.
+Succeed Ltac2 test_app_assoc_1 (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ g c.
+Succeed Ltac2 test_app_assoc_2 (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ (g c).
+Succeed Ltac2 test_app_assoc_3 (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ g @@ c.
+Succeed Ltac2 test_app_assoc_4 (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ (g @@ c).
+
+(* Sanity check: the term does not typecheck when wrongly associated. *)
+Fail Ltac2 test_pipe_assoc_fail (f : b -> a) (g : c -> b) (c : c) :=
+  c |> (g |> f).
+Succeed Ltac2 test_pipe_assoc_1 (f : b -> a) (g : c -> b) (c : c) :=
+  c |> g |> f.
+Succeed Ltac2 test_pipe_assoc_2 (f : b -> a) (g : c -> b) (c : c) :=
+  (c |> g) |> f.
+
+(** Precedence *)
+(* Sanity check: the term does not typecheck when the notation level is wrong
+   w.r.t. the level of projections. *)
+Fail Ltac2 test_app_prec_fail (f : b -> a) (g : c -> b) (c : c) :=
+  (f @@ g @@ c).(p).
+Ltac2 test_app_prec_1 (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ g @@ c.(p).
+Ltac2 test_app_prec_2 (f : (a,b) h) (g : c -> b) (c : c) :=
+  f.(h) @@ g @@ c.
+Ltac2 test_app_prec_3 (f : b -> a) (g : (b,c) h) (c : c) :=
+  f @@ g.(h) @@ c.
+
+Ltac2 test_app_prec_if (g : c -> b) (c : c) :=
+  if true then g @@ c else g @@ c.
+
+(* Sanity check: the term does not typecheck when the notation level is wrong
+   w.r.t. the level of projections. *)
+Fail Ltac2 test_pip_prec_fail (f : (a,b) h) (g : c -> b) (c : c) :=
+  (c |> g |> f).(h).
+Ltac2 test_pip_prec_1 (f : (a,b) h) (g : c -> b) (c : c) :=
+  c |> g |> f.(h).
+Ltac2 test_pipe_prec_2 (f : b -> a) (g : (b,c) h) (c : c) :=
+  c |> g.(h) |> f.
+Ltac2 test_pipe_prec_3 (f : (a,b) h) (g : (b,c) h) (c : c) :=
+  c |> g.(h) |> f.(h).
+Ltac2 test_pipe_prec_4 (f : (a,b) h) (g : (b,c) h) (c : c) :=
+  c.(p) |> g.(h) |> f.(h).
+
+Ltac2 test_pipe_prec_if (g : c -> b) (c : c) :=
+  if true then c |> g else c |> g.
+
+Ltac2 test_app_pipe_2 (f : b -> a) (g : c -> b) (c : c) :=
+  g @@ c |> f.
+
+Fail Ltac2 test_app_pipe_fail (f : b -> a) (g : c -> b) (c : c) :=
+  f @@ c |> g.
+
+Ltac2 test_pipe_app_1 (t : b -> c -> a) (b : b) (c : c) :=
+  c |> t @@ b.
+
+(** Relation to other operators at levels 2 and 3 *)
+
+Ltac2 test_app_comma_left (g : c -> b) (c : c) (a : a) : b * a := g @@ c, a.
+Ltac2 test_app_comma_right (g : c -> b) (c : c) (a : a) : a * b := a, g @@ c.
+
+Ltac2 test_pipe_comma_left (g : c -> b) (c : c) (a : a) : b * a := c |> g, a.
+(* [test_pipe_comma_right] is accepted by OCaml. *)
+Fail Ltac2 test_pipe_comma_right (g : c -> b) (c : c) (a : a) : a * b := a, c |> g.
+
+Ltac2 test_app_cons_left (g : c list -> b) (c : c) : b := g @@ c :: [].
+(* [test_app_cons_right] is not accepted by OCaml without parentheses around [g @@ c]. *)
+Ltac2 test_app_cons_right (g : c -> b list) (b : b) (c : c) : b list := b :: g @@ c.
+
+Fail Ltac2 test_pipe_cons_left (g : c list -> b) (c : c) : b := c |> g :: [].
+Ltac2 test_pipe_cons_right (g : c list -> b) (cs : c list) (c : c) : b := c :: cs |> g.

--- a/theories/Ltac2/Notations.v
+++ b/theories/Ltac2/Notations.v
@@ -640,3 +640,11 @@ Ltac2 Notation "now" t(thunk(tactic(6))) := now0 t.
 Ltac2 start_profiling () := ltac1:(start ltac profiling).
 Ltac2 stop_profiling () := ltac1:(stop ltac profiling).
 Ltac2 show_profile () := ltac1:(show ltac profile).
+
+(** General programming notations *)
+
+(* [f @@ g @@ h @@ x] is equivalent to [f (g (h x))] up to evaluation order of subterms. *)
+Ltac2 Notation f(self) "@@" x(self) : 2 := f x. (* right associative *)
+
+(* [x |> h |> g |> f] is equivalent to [f (g (h x))] up to evaluation order of subterms. *)
+Ltac2 Notation x(self) "|>" f(self) : 3 := f x. (* left associative *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
