### PR TITLE
Print Assumptions: also traverse types of definitions

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/21825-print-assumptions-globals-types-Fixed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/21825-print-assumptions-globals-types-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  :cmd:`Print Assumptions` now also traverses the types of global
+  definitions, not just their bodies, to detect dependencies on axioms
+  that appear only in the type
+  (`#21825 <https://github.com/rocq-prover/rocq/pull/21825>`_,
+  by Jason Gross).

--- a/test-suite/output/PrintAssumptions.out
+++ b/test-suite/output/PrintAssumptions.out
@@ -9,6 +9,8 @@ bli : Type
 Axioms:
 seq relies on definitional UIP.
 Axioms:
+ax : nat
+Axioms:
 M.foo : False
 Closed under the global context
 Closed under the global context

--- a/test-suite/output/PrintAssumptions.v
+++ b/test-suite/output/PrintAssumptions.v
@@ -72,6 +72,19 @@ Module UIP.
   Print Assumptions UIP.
 End UIP.
 
+(** Print Assumptions should also check the type of globals even when
+    they have a body, since they may mention unrelated references. *)
+
+Module TYPES.
+
+Axiom ax : nat.
+Definition ty := (fun _ : nat => nat) ax.
+(* [foo]'s body is [0] which does not mention [ax], but its type [ty] does. *)
+Definition foo : ty := 0.
+Print Assumptions foo.
+
+End TYPES.
+
 (** Print Assumption and Include *)
 
 Module INCLUDE.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -268,6 +268,16 @@ and traverse_object access (curr, data, ax2ty) body obj =
       let contents,data,ax2ty =
         traverse access obj Context.Rel.empty
                  (GlobRef.Set_env.empty,data,ax2ty) body in
+      (* Also traverse the type of globals, which may mention unrelated
+         references depending on axioms even if they convert to something else. *)
+      let contents,data,ax2ty = match obj with
+        | GlobRef.ConstRef kn ->
+          let cb = lookup_constant kn in
+          let typ = cb.Declarations.const_type in
+          traverse access obj Context.Rel.empty
+                   (contents,data,ax2ty) typ
+        | _ -> (contents,data,ax2ty)
+      in
       GlobRef.Map_env.add obj (Some contents) data, ax2ty
   in
   (GlobRef.Set_env.add obj curr, data, ax2ty)


### PR DESCRIPTION
Print Assumptions previously only traversed the body of global definitions, not their types. However, the type of a definition may mention references depending on axioms that are unrelated to the body, even if the type converts to something else.

cf @ppedrot 's comment at https://github.com/rocq-prover/rocq/pull/21437#issuecomment-4133371206

- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
