### PR TITLE
git_download ls-remote use --branches

### DIFF
--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -144,7 +144,7 @@ git_download()
     mkdir -p "$dest"
     pushd "$dest"
     local commit
-    commit=$(git ls-remote "$giturl" "refs/heads/$ref" | cut -f 1)
+    commit=$(git ls-remote --branches "$giturl" "refs/heads/$ref" | cut -f 1)
     if [[ "$commit" == "" ]]; then
       # $ref must have been a tag or hash, not a branch
       commit="$ref"


### PR DESCRIPTION
git ls-remote https://github.com/CertiRocq/certirocq refs/heads/master gives 2 results:
~~~
a8267f799d826bd411ad3382574f17253704716e        refs/heads/master
59920824db8ba2f0cfdff7e934473873136f1f39        refs/original/refs/heads/master
~~~
filtering to only branches seems to work enough to prevent over matching.
