### PR TITLE
Stop accepting non-globref hints from Hints.

### DIFF
--- a/dev/ci/user-overlays/21833-ppedrot-rm-non-global-hint.sh
+++ b/dev/ci/user-overlays/21833-ppedrot-rm-non-global-hint.sh
@@ -1,0 +1,1 @@
+overlay waterproof https://github.com/ppedrot/coq-waterproof rm-non-global-hint 21833

--- a/doc/changelog/04-tactics/21833-rm-non-global-hint-Removed.rst
+++ b/doc/changelog/04-tactics/21833-rm-non-global-hint-Removed.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  the ability to use non-reference hints in `using` clauses
+  of :tacn:`auto`-like tactics
+  (`#21833 <https://github.com/rocq-prover/rocq/pull/21833>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -85,6 +85,14 @@ Tactics
       variant is very useful for getting a better understanding of automation, or
       to know what lemmas/assumptions were used.
 
+   .. warn:: Use of the non-reference term @term in “using” clauses is ignored
+
+      Any non-reference term passed in a `using` clause is ignored. We
+      recommend adding such hints to the context via the :tacn:`pose proof`
+      tactic instead. For backwards compatibility, we still parse any term
+      in `using` clause for the time being, but you should consider
+      removing them.
+
 .. _info_auto_not_exact:
 
       The tactics shown in the info or debug output currently don't

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -337,7 +337,7 @@ and tac_of_hint dbg db_list local_db concl =
 
 let warn_non_reference_hint_using =
   CWarnings.create ~name:"non-reference-hint-using" ~category:CWarnings.CoreCategories.automation
-    Pp.(fun (env, sigma, c) -> str "Use of the non-reference term " ++ Printer.pr_leconstr_env env sigma c ++ str " in \"using\" clauses is ignored")
+    Pp.(fun (env, sigma, c) -> str "Use of the non-reference term " ++ Printer.pr_leconstr_env env sigma c ++ str " in \"using\" clauses is ignored.")
 
 let get_reference_hints env sigma lems =
   let map lem =

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -335,6 +335,22 @@ and tac_of_hint dbg db_list local_db concl =
   in
   fun h -> tclLOG dbg (pr_hint h) (FullHint.run h tactic)
 
+let warn_non_reference_hint_using =
+  CWarnings.create ~name:"non-reference-hint-using" ~category:CWarnings.CoreCategories.automation
+    Pp.(fun (env, sigma, c) -> str "Use of the non-reference term " ++ Printer.pr_leconstr_env env sigma c ++ str " in \"using\" clauses is ignored")
+
+let get_reference_hints env sigma lems =
+  let map lem =
+    let evd, lem = lem env sigma in
+    let lem0 = drop_extra_implicit_args evd lem in
+    match EConstr.destRef evd lem0 with
+    | (gr, _) -> Some gr
+    | exception Constr.DestKO ->
+      let () = warn_non_reference_hint_using (env, evd, lem) in
+      None
+  in
+  List.map_filter map lems
+
 (** The use of the "core" database can be de-activated by passing
     "nocore" amongst the databases. *)
 
@@ -342,6 +358,7 @@ let gen_trivial ?(debug=Off) lems dbnames =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
+    let lems = get_reference_hints env sigma lems in
     let db_list =
       match dbnames with
       | Some dbnames -> make_db_list dbnames
@@ -408,6 +425,9 @@ let default_search_depth = 5
 
 let gen_auto ?(debug=Off) n lems dbnames =
   Proofview.Goal.enter begin fun gl ->
+    let env = Proofview.Goal.env gl in
+    let sigma = Proofview.Goal.sigma gl in
+    let lems = get_reference_hints env sigma lems in
     let n = match n with None -> default_search_depth | Some n -> n in
     let db_list =
       match dbnames with

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -18,6 +18,8 @@ open Tactypes
 
 val compute_secvars : Proofview.Goal.t -> Id.Pred.t
 
+val get_reference_hints : Environ.env -> Evd.evar_map -> delayed_open_constr list -> GlobRef.t list
+
 (** Default maximum search depth used by [auto] and [trivial]. *)
 val default_search_depth : int
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -355,7 +355,10 @@ let make_initial_state evk dbg n localdb =
 
 let e_search_auto ?(debug = Off) ?depth lems db_list =
   Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
   let p = Option.default default_search_depth depth in
+  let lems = Auto.get_reference_hints env sigma lems in
   let local_db env sigma = make_local_hint_db env sigma ~ts:TransparentState.full true lems in
   let d = mk_eauto_dbg debug in
   let debug = match d with Debug -> true | Info | Off -> false in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -16,12 +16,10 @@ open Constr
 open Context
 open Evd
 open EConstr
-open Vars
 open Environ
 open Mod_subst
 open Globnames
 open Libobject
-open Namegen
 open Libnames
 open Termops
 open Inductiveops
@@ -128,7 +126,6 @@ type hints_path = GlobRef.t hints_path_gen
 
 type hint_term =
   | IsGlobRef of GlobRef.t
-  | IsConstr of constr * UnivGen.sort_context_set option (* None if monomorphic *)
 
 type 'a with_uid = {
   obj : 'a;
@@ -899,7 +896,6 @@ let make_exact_entry env sigma info ?name (c, cty, ctx) =
 
 let name_of_hint = function
 | IsGlobRef gr -> Some gr
-| IsConstr _ -> None
 
 let make_apply_entry env sigma hnf info ?name (c, cty, ctx) =
   let cty = if hnf then hnf_constr0 env sigma cty else cty in
@@ -943,7 +939,6 @@ let fresh_global_or_constr env sigma cr = match cr with
   let (c, ctx) = UnivGen.fresh_global_instance env gr in
   let ctx = if Environ.is_polymorphic env gr then Some ctx else None in
   (EConstr.of_constr c, ctx)
-| IsConstr (c, ctx) -> (c, ctx)
 
 let make_resolves env sigma (eapply, hnf) info ~check cr =
   let name = name_of_hint cr in
@@ -1470,42 +1465,6 @@ type hints_entry =
   | HintsModeEntry of GlobRef.t * hint_mode list
   | HintsExternEntry of hint_info * Gentactic.glob_generic_tactic
 
-let default_prepare_hint_ident = Id.of_string "H"
-
-exception Found of constr * types
-
-let prepare_hint env init (sigma,c) =
-  let sigma = Typeclasses.resolve_typeclasses ~fail:false env sigma in
-  (* We re-abstract over uninstantiated evars and universes.
-     It is actually a bit stupid to generalize over evars since the first
-     thing make_resolves will do is to re-instantiate the products *)
-  let c = Evarutil.nf_evar sigma c in
-  let c = drop_extra_implicit_args sigma c in
-  let vars = ref (collect_vars sigma c) in
-  let subst = ref [] in
-  let rec find_next_evar c = match EConstr.kind sigma c with
-    | Evar (evk,args as ev) ->
-      (* We skip the test whether args is the identity or not *)
-      let t = Evarutil.nf_evar sigma (existential_type sigma ev) in
-      let t = List.fold_right (fun (e,id) c -> replace_term sigma e id c) !subst t in
-      if not (closed0 sigma c) then
-        user_err Pp.(str "Hints with holes dependent on a bound variable not supported.");
-      if occur_existential sigma t then
-        (* Not clever enough to construct dependency graph of evars *)
-        user_err Pp.(str "Not clever enough to deal with evars dependent in other evars.");
-      raise (Found (c,t))
-    | _ -> EConstr.iter sigma find_next_evar c in
-  let rec iter c =
-    try find_next_evar c; c
-    with Found (evar,t) ->
-      let id = next_ident_away_from default_prepare_hint_ident (fun id -> Id.Set.mem id !vars) in
-      vars := Id.Set.add id !vars;
-      subst := (evar,mkVar id)::!subst;
-      mkNamedLambda sigma (make_annot id ERelevance.relevant) t (iter (replace_term sigma evar (mkVar id) c)) in
-  let c' = iter c in
-    let diff = UnivGen.diff_sort_context (Evd.sort_context_set sigma) (Evd.sort_context_set init) in
-    (c', diff)
-
 let warn_non_local_section_hint =
   CWarnings.create ~name:"non-local-section-hint" ~category:CWarnings.CoreCategories.automation
     (fun () -> strbrk "This hint is not local but depends on a section variable. It will disappear when the section is closed.")
@@ -1546,26 +1505,15 @@ let add_hints ~locality dbnames h =
   | HintsExternEntry (info, tacexp) ->
       add_externs info tacexp ~locality dbnames
 
-let warn_non_reference_hint_using =
-  CWarnings.create ~name:"non-reference-hint-using" ~category:CWarnings.CoreCategories.deprecated
-    Pp.(fun (env, sigma, c) -> str "Use of the non-reference term " ++ pr_leconstr_env env sigma c ++ str " in \"using\" clauses is deprecated")
-
 let expand_constructor_hints env sigma lems =
   List.map_append (fun lem ->
-    let evd, lem = lem env sigma in
-    let lem0 = drop_extra_implicit_args evd lem in
-    match EConstr.kind evd lem0 with
-    | Ind (ind,u) ->
+    match lem with
+    | GlobRef.IndRef ind ->
         List.init (nconstructors env ind)
                   (fun i -> IsGlobRef (GlobRef.ConstructRef ((ind,i+1))))
-    | Const (cst, _) -> [IsGlobRef (GlobRef.ConstRef cst)]
-    | Var id -> [IsGlobRef (GlobRef.VarRef id)]
-    | Construct (cstr, _) -> [IsGlobRef (GlobRef.ConstructRef cstr)]
-    | _ ->
-      let () = warn_non_reference_hint_using (env, evd, lem) in
-      let (c, ctx) = prepare_hint env sigma (evd,lem) in
-      let ctx = if UnivGen.is_empty_sort_context ctx then None else Some ctx in
-      [IsConstr (c, ctx)]) lems
+    | GlobRef.ConstRef cst -> [IsGlobRef (GlobRef.ConstRef cst)]
+    | GlobRef.VarRef id -> [IsGlobRef (GlobRef.VarRef id)]
+    | GlobRef.ConstructRef cstr -> [IsGlobRef (GlobRef.ConstructRef cstr)]) lems
 (* builds a hint database from a constr signature *)
 (* typically used with (lid, ltyp) = pf_hyps_types <some goal> *)
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -13,7 +13,6 @@ open Names
 open EConstr
 open Environ
 open Evd
-open Tactypes
 open Typeclasses
 
 (** {6 General functions. } *)
@@ -218,7 +217,7 @@ val push_resolve_hyp :
    Useful to take the current goal hypotheses as hints;
    Boolean tells if lemmas with evars are allowed *)
 
-val make_local_hint_db : env -> evar_map -> ?ts:TransparentState.t -> bool -> delayed_open_constr list -> hint_db
+val make_local_hint_db : env -> evar_map -> ?ts:TransparentState.t -> bool -> GlobRef.t list -> hint_db
 
 val make_db_list : hint_db_name list -> hint_db list
 


### PR DESCRIPTION
We now perform this check at the level of the tactics that call the underlying Hints API and simply ignore the hints when they are not globals. For backwards compatibility syntax-wise, we still allow expressions that evaluate to globrefs up to implicits.

Overlays:
- https://github.com/impermeable/coq-waterproof/pull/232