### PR TITLE
Make argument-scope-delimiter error by default

### DIFF
--- a/test-suite/bugs/bug_4955.v
+++ b/test-suite/bugs/bug_4955.v
@@ -32,7 +32,7 @@ Record Functor (C D : PreCategory) :=
 Arguments object_of {C%_category D%_category} f%_functor c%_object : rename, simpl
 nomatch.
 Arguments morphism_of [C%_category] [D%_category] f%_functor [s%_object d%_object]
-m%morphism : rename, simpl nomatch.
+m%_morphism : rename, simpl nomatch.
 Section path_functor.
   Variable C : PreCategory.
   Variable D : PreCategory.

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -59,6 +59,7 @@ let warn_arguments_assert =
 
 let warn_scope_delimiter_depth =
   CWarnings.create ~name:"argument-scope-delimiter" ~category:Deprecation.Version.v8_19
+    ~default:AsError
     Pp.(fun () ->
         strbrk "The '%' scope delimiter in 'Arguments' commands is deprecated, " ++
         strbrk "use '%_' instead (available since 8.19). The '%' syntax will be " ++


### PR DESCRIPTION
In order to actually handle this 8.19 deprecation in 9.4.

#### Overlays (to be merged before the current PR)

* [x] https://github.com/mit-plv/fiat/pull/130
* [x] https://github.com/Mtac2/Mtac2/pull/429
* [x] https://github.com/math-comp/finmap/pull/155
* [x] https://github.com/rocq-community/fourcolor/pull/77
* [x] https://github.com/math-comp/odd-order/pull/80
* [x] https://github.com/mit-plv/rewriter/pull/199
* [x] https://github.com/rocq-community/corn/pull/221
* [x] https://github.com/mit-plv/bedrock2/pull/522
* [x] https://github.com/jwiegley/category-theory/pull/171
* [x] https://github.com/mit-plv/cross-crypto/pull/44
* [x] https://github.com/mit-plv/fiat-crypto/pull/2297
* [x] https://github.com/JasonGross/neural-net-coq-interp/pull/95
* [x] https://github.com/JasonGross/neural-net-coq-interp/pull/96
* [x] https://github.com/mit-plv/fiat-crypto/pull/2296
