### PR TITLE
Turn require Coq depr warnings as error by default

### DIFF
--- a/dev/ci/user-overlays/21851-proux01-warnerror-require-coq.sh
+++ b/dev/ci/user-overlays/21851-proux01-warnerror-require-coq.sh
@@ -1,0 +1,1 @@
+overlay rewriter https://github.com/proux01/rewriter rocq21851 21851

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -104,7 +104,7 @@ let corelib_id = Id.of_string "Corelib"
 
 let warn_deprecated_dirpath_Coq =
   CWarnings.create ~name:"deprecated-dirpath-Coq"
-    ~category:Deprecation.Version.v9_0
+    ~category:Deprecation.Version.v9_0 ~default:AsError
     ~quickfix:(fun ~loc (old_id, new_id) -> [Quickfix.make ~loc new_id])
     (fun (old_id, new_id) ->
       Pp.(old_id ++ spc () ++ str "has been replaced by" ++ spc () ++ new_id ++ str "."))

--- a/test-suite/bugs/bug_4976.v
+++ b/test-suite/bugs/bug_4976.v
@@ -1,4 +1,4 @@
-Require Import Coq.Setoids.Setoid.
+From Corelib Require Import Setoid.
 Definition silly (n : nat) := True.
 Ltac silly :=
   lazymatch goal with

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -1,8 +1,8 @@
-File "./output/Qf_stdlib.v", line 16, characters 6-22:
+File "./output/Qf_stdlib.v", line 16, characters 42-58:
 Warning: Coq.Init.Nat.add has been replaced by Corelib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 16, characters 6-22 with Corelib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 16, characters 42-58 with Corelib.Init.Nat.add
 Nat.add : nat -> nat -> nat
 
 Nat.add is not universe polymorphic
@@ -10,10 +10,10 @@ Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
 Declared in library Corelib.Init.Nat, line 47, characters 9-12
-File "./output/Qf_stdlib.v", line 17, characters 6-22:
+File "./output/Qf_stdlib.v", line 17, characters 42-58:
 Warning: Coq.Init.Nat.add has been replaced by Corelib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 17, characters 6-22 with Corelib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 17, characters 42-58 with Corelib.Init.Nat.add
 Nat.add
      : nat -> nat -> nat

--- a/test-suite/output/Qf_stdlib.v
+++ b/test-suite/output/Qf_stdlib.v
@@ -13,5 +13,5 @@ Require Import Corelib.ssr.ssrbool.
 From Corelib Require Import ssreflect ssrbool.
 
 (* Note: this tests the two different lookup modes *)
-About Coq.Init.Nat.add.
-Check Coq.Init.Nat.add.
+#[warning="deprecated-dirpath-Coq"] About Coq.Init.Nat.add.
+#[warning="deprecated-dirpath-Coq"] Check Coq.Init.Nat.add.

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -265,7 +265,7 @@ let locate_qualified_library ?root qid :
 
 let warn_deprecated_missing_stdlib =
   CWarnings.create ~name:"deprecated-missing-stdlib"
-    ~category:Deprecation.Version.v9_0
+    ~category:Deprecation.Version.v9_0 ~default:AsError
     (fun qid ->
       Pp.(str "Loading Stdlib without prefix is deprecated." ++ spc ()
           ++ str "Use \"From Stdlib Require " ++ Libnames.pr_qualid qid

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -254,7 +254,7 @@ end
 
 let warn_deprecated_from_Coq =
   CWarnings.create ~name:"deprecated-from-Coq"
-    ~category:Deprecation.Version.v9_0
+    ~category:Deprecation.Version.v9_0 ~default:AsError
     ~quickfix:(fun ~loc qid -> [Quickfix.make ~loc (Libnames.pr_qualid qid)])
     (fun (_qid : qualid) -> strbrk
         "\"From Coq\" has been replaced by \"From Stdlib\".")


### PR DESCRIPTION
#### Overlays (to be merged before the current PR)

* [x] https://github.com/rocq-community/atbr/pull/48
* [x] https://github.com/rocq-community/bignums/pull/110
* [x] https://github.com/mit-plv/fiat/pull/129
* [x] https://github.com/Mtac2/Mtac2/pull/428
* [x] https://github.com/rocq-community/paramcoq/pull/155
* [x] https://github.com/smtcoq/smtcoq/pull/162
* [x] https://github.com/rocq-community/stalmarck/pull/34
* [x] https://github.com/UniMath/UniMath/pull/2075
* [x] https://github.com/rocq-prover/stdlib/pull/253
* [ ] https://github.com/mit-plv/rewriter/pull/200
* [x] https://github.com/LPCIC/coq-elpi/pull/991
* [x] https://github.com/math-comp/hierarchy-builder/pull/588
* [x] https://github.com/math-comp/algebra-tactics/pull/130
* [x] https://github.com/math-comp/analysis/pull/1929