### PR TITLE
VM/native Fix substitution of qualities in relevances of match branch binders

### DIFF
--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -271,11 +271,13 @@ val template_polymorphic_pind : pinductive -> env -> bool
 (** {6 Changes of representation of Case nodes} *)
 
 (** Given an inductive type and its parameters, builds the context of the return
-    clause, including the inductive being eliminated. The additional binder
-    array is only used to set the names of the context variables, we use the
-    less general type to make it easy to use this function on Case nodes. *)
+    clause, including the inductive being eliminated.
+
+    The additional binder array is only used to set the names of the
+    context variables, we use the less general type to make it easy to
+    use this function on Case nodes. *)
 val expand_arity : Declarations.mind_specif -> pinductive -> constr array ->
-  Name.t binder_annot array -> rel_context
+  (Name.t, _) Context.pbinder_annot array -> rel_context
 
 (** Given an inductive type and its parameters, builds the context of the return
     clause, including the inductive being eliminated. The additional binder

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -161,6 +161,10 @@ let build_branches_type env sigma mib mip (ind,u) params (pctx, p) =
     in
     let decl_with_letin = List.firstn mip.mind_consnrealdecls.(i) ctx in
     let nas = get_case_annot decl_with_letin in
+    let nas =
+      let u = EConstr.Unsafe.to_instance u in
+      Array.map (Context.map_annot_relevance (UVars.subst_instance_relevance u)) nas
+    in
     let rec get_lift decls = match decls with
     | [] -> Esubst.el_id
     | LocalDef _ :: decls -> Esubst.el_shft 1 (get_lift decls)

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -329,6 +329,7 @@ and nf_atom_type env sigma atom =
       let params,realargs = Array.chop nparams allargs in
       let pctx =
         let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
+        (* NB expand_arity doesn't look at the relevances in nas *)
         let nas = List.rev_map get_annot realdecls @ [nameR (Id.of_string "c")] in
         expand_arity (mib, mip) (ind, u) params (Array.of_list nas)
       in

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -130,6 +130,7 @@ let build_branches_type env sigma (mind,_ as _ind) mib mip u params (pctx, p) =
     in
     let decl_with_letin = List.firstn mip.mind_consnrealdecls.(i) (fst cty) in
     let nas = get_case_annot decl_with_letin in
+    let nas = Array.map (Context.map_annot_relevance (UVars.subst_instance_relevance u)) nas in
     let rec get_lift decls = match decls with
     | [] -> Esubst.el_id
     | LocalDef _ :: decls -> Esubst.el_shft 1 (get_lift decls)

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -288,6 +288,7 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let params,realargs = Util.Array.chop nparams allargs in
       let pctx =
         let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
+        (* NB expand_arity doesn't look at the relevances in nas *)
         let nas = List.rev_map RelDecl.get_annot realdecls @ [nameR (Id.of_string "c")] in
         expand_arity (mib, mip) (ind, u) params (Array.of_list nas)
       in

--- a/test-suite/bugs/bug_21871.v
+++ b/test-suite/bugs/bug_21871.v
@@ -1,0 +1,40 @@
+Module Br.
+  Set Universe Polymorphism.
+  Inductive Box@{s;u} (A : Type@{s;u}) : Type@{s;u} := box : A -> Box A.
+  Axiom wrap : forall (x : nat), Box nat.
+  Section Bug.
+    Variable x : nat.
+    Lemma vmbug : (match wrap x with box _ v => v end) = (match wrap x with box _ v => v end).
+    Proof.
+      vm_compute.
+      reflexivity.
+    Defined.
+    (* Error: Undeclared quality: β0 (maybe a bugged tactic). *)
+
+    Lemma nativebug : (match wrap x with box _ v => v end) = (match wrap x with box _ v => v end).
+    Proof.
+      native_compute.
+      reflexivity.
+    Defined.
+    (* Error: Undeclared quality: β0 (maybe a bugged tactic). *)
+  End Bug.
+End Br.
+
+Module Index.
+  (* checks that relevances in indices and "as" for the return predicate are correctly substituted
+     (was not broken in the past AFAIK) *)
+  Polymorphic Inductive sTrue@{s;} : Type@{s;Set} := sI.
+  Polymorphic Inductive sFalse@{s;} : sTrue@{s;} -> Type@{s;Set} := .
+  Inductive seq {A:SProp} (a:A) : A -> Prop := srefl : seq a a.
+
+  Lemma vmfoo (x:sFalse sI) : match x return seq x x with  end = srefl _.
+  Proof.
+    vm_compute.
+    destruct x.
+  Defined.
+  Lemma nativefoo (x:sFalse sI) : match x return seq x x with  end = srefl _.
+  Proof.
+    native_compute.
+    destruct x.
+  Defined.
+End Index.


### PR DESCRIPTION
(non kernel bug, only in reification)

Fix #21871
