### PR TITLE
Trigger the ssr rewrite warning at globalization time.

### DIFF
--- a/plugins/ssrrewrite/ssrrewrite.mlg
+++ b/plugins/ssrrewrite/ssrrewrite.mlg
@@ -18,11 +18,8 @@ open Ssreflect_plugin.Ssrequality
 open Ssreflect_plugin.Ssrparser
 open Ssreflect_plugin.Ssrtacs
 
-let warn_deprecated_rewrite =
-  CWarnings.create ~name:"rewrite-rw" ~category:Deprecation.Version.v9_3
-    ~quickfix:(fun ~loc () -> [Quickfix.make ~loc (Pp.str "rw")])
-    (fun () -> Pp.str "The 'rewrite' tactic has been renamed 'rw'.")
-
+let deprecated_rewrite =
+  Deprecation.make ~since:"9.3" ~note:"The 'rewrite' tactic has been renamed 'rw'." ()
 }
 
 DECLARE PLUGIN "rocq-runtime.plugins.ssreflect_rewrite"
@@ -70,12 +67,9 @@ END
 
 (** The "rewrite" tactic *)
 
-TACTIC EXTEND ssrrewrite
+TACTIC EXTEND ssrrewrite DEPRECATED { deprecated_rewrite }
   | [ "rewrite" ssrrewriteargs(args) ssrclauses(clauses) ] ->
-    { let loc = Tacinterp.extract_loc ist
-        |> Option.map (fun l -> Loc.sub l 0 7) in
-      warn_deprecated_rewrite ?loc ();
-      tclCLAUSES (ssrrewritetac ist args) clauses }
+    { tclCLAUSES (ssrrewritetac ist args) clauses }
 END
 
 {


### PR DESCRIPTION
Instead of doing that at runtime, which clutters the output with irrelevant data, we do this at globalization time using an already available mechanism in TACTIC EXTEND.

Note that we lose the quickfix info as there is no way to make a Deprecation.t with a quickfix in the API, should that be fixed first? cc @proux01 and @gares 