### PR TITLE
Add test that the kernel checks relevances in Case binders

### DIFF
--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -90,9 +90,10 @@ let check_assumption env x t ty =
   else
     error_bad_binder_relevance env r' (RelDecl.LocalAssum (x, t))
 
-let check_binding_relevance env na1 na2 =
-  (* Since we know statically the relevance here, we are stricter *)
-  assert (check_relevance env (binder_relevance na1) (binder_relevance na2))
+let check_binding_relevance env na1 na2 t =
+  let r1 = binder_relevance na1 in
+  if not (check_relevance env r1 (binder_relevance na2)) then
+    error_bad_binder_relevance env r1 (LocalAssum (na2, t))
 
 let esubst u s c =
   Vars.esubst Vars.lift_substituend s (subst_instance_constr u c)
@@ -111,7 +112,7 @@ let instantiate_context env u subst nas ctx =
     let subst = Esubst.subs_liftn i subst in
     let na = instantiate_relevance na in
     let ty = esubst u subst ty in
-    let () = check_binding_relevance env na nas.(i) in
+    let () = check_binding_relevance env na nas.(i) ty in
     LocalAssum (nas.(i), ty) :: ctx
   | LocalDef (na, ty, bdy) :: ctx ->
     let ctx = instantiate (pred i) ctx in
@@ -119,7 +120,7 @@ let instantiate_context env u subst nas ctx =
     let na = instantiate_relevance na in
     let ty = esubst u subst ty in
     let bdy = esubst u subst bdy in
-    let () = check_binding_relevance env na nas.(i) in
+    let () = check_binding_relevance env na nas.(i) ty in
     LocalDef (nas.(i), ty, bdy) :: ctx
   in
   instantiate (Array.length nas - 1) ctx

--- a/test-suite/output/check_case_relevance.out
+++ b/test-suite/output/check_case_relevance.out
@@ -1,0 +1,4 @@
+File "./output/check_case_relevance.v", line 10, characters 0-92:
+The command has indeed failed with message:
+Binder (_ : "nat") has relevance mark set to irrelevant but was expected to
+be relevant (maybe a bugged tactic).

--- a/test-suite/output/check_case_relevance.v
+++ b/test-suite/output/check_case_relevance.v
@@ -1,0 +1,10 @@
+From Ltac2 Require Import Ltac2 Constr.
+Import Constr.Unsafe.
+
+Ltac2 bad p i :=
+  let badx := Binder.unsafe_make None Relevance.irrelevant 'nat in
+  let br := make (Lambda badx (make (Lambda badx i))) in
+  let ind := match reference:(prod) with Std.IndRef ind => ind | _ => Control.throw Assertion_failure end in
+  make (Case (case ind) ('(fun (_:nat * nat) => nat), Relevance.relevant) NoInvert p [|br|]).
+
+Fail Definition badfst (p:nat * nat) := ltac2:(let x := bad '&p (make (Rel 2)) in exact $x).


### PR DESCRIPTION
Before 6fae78cd19aeb1f83beb0fd30865d26e9b8a84f0 (8.17) relevance of Case binders was checked by checking the lambdas produced by expand_case.

Before 0cfe16a47599ac49ee059b521b206cfcb6473f59 (8.18) expand_case would use the relevance from the Case instead of from the inductive data (after it used the relevance from the inductive unsubstituted by the univ instance until 269daf2bbe091842ec5a13139d87a7c11a8e0d56 (9.0)).

If we had skipped 6fae78cd19aeb1f83beb0fd30865d26e9b8a84f0 the later patches would have introduced an inconsstency as typechecking would have trusted the Case relevances, but they would be used in conversion.

I think it's worth a test to ensure we don't introduce this possible bug by mistake.

To make testing practical the check is turned into a regular error instead of assert failure.
The test is an output test as otherwise we risk producing some other error if something changes.
