### PR TITLE
Experiment: do not retain hyp types of defined evars

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -59,7 +59,7 @@ check_variable () {
 
 if [ "$CI" ]; then
   : "${new_coq_commit:=$(git rev-parse HEAD^2)}"
-  : "${old_coq_commit:=$(git merge-base HEAD^1 $new_coq_commit)}"
+  old_coq_commit=d6a4a113c2d80dd24b42d370ca9eed38d04cafd3
 else
   echo New coq commit:
   read -r new_coq_commit

--- a/dev/bench/benchUtil.ml
+++ b/dev/bench/benchUtil.ml
@@ -32,9 +32,14 @@ type memory = {
   minor_words : string;
   major_collect : int;
   minor_collect : int;
+  heap_words : string option;
 }
 
-type data = { time : measure; memory : memory option; instructions : int option }
+type data = {
+  time : measure;
+  memory : memory option;
+  instructions : int option;
+}
 
 let dummy_data = { time = dummy_measure; memory = None; instructions = None }
 

--- a/dev/bench/benchUtil.mli
+++ b/dev/bench/benchUtil.mli
@@ -29,9 +29,14 @@ type memory = {
   minor_words : string;
   major_collect : int;
   minor_collect : int;
+  heap_words : string option;
 }
 
-type data = { time : measure; memory : memory option; instructions : int option }
+type data = {
+  time : measure;
+  memory : memory option;
+  instructions : int option;
+}
 
 val dummy_data : data
 

--- a/dev/bench/htmloutput.ml
+++ b/dev/bench/htmloutput.ml
@@ -42,16 +42,22 @@ let pp_collect ~need_comma which c =
       (if need_comma then ", " else "") c which
       (if c = 1 then "collection" else "collections")
 
+let pp_heap ~need_comma = function
+  | None -> need_comma, ""
+  | Some heap ->
+    true, Printf.sprintf "%s%s heap size change" (if need_comma then ", " else "") heap
+
 let pp_memory ch = function
   | None -> ()
-  | Some {major_words; minor_words; major_collect; minor_collect} ->
+  | Some {major_words; minor_words; major_collect; minor_collect; heap_words} ->
     (* need_comma <-> prefix is nontrivial *)
     let need_comma, minor_words = pp_words ~need_comma:false "minor" minor_words in
     let need_comma, major_words = pp_words ~need_comma "major" major_words in
     let need_comma, minor_collect = pp_collect ~need_comma "minor" minor_collect in
     let need_comma, major_collect = pp_collect ~need_comma "major" major_collect in
+    let need_comma, heap = pp_heap ~need_comma heap_words in
     if need_comma then
-      Printf.fprintf ch " (%s%s%s%s)" minor_words major_words minor_collect major_collect
+      Printf.fprintf ch " (%s%s%s%s%s)" minor_words major_words minor_collect major_collect heap
 
 let pp_instr ch = function
   | None -> ()

--- a/dev/bench/profparser.ml
+++ b/dev/bench/profparser.ml
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+let () = Exninfo.record_backtrace true
+
 let die fmt = Printf.kfprintf (fun _ -> exit 1) stderr (fmt^^"\n%!")
 
 module YB = Yojson.Basic
@@ -116,6 +118,9 @@ let mk_memory (lnum, l) =
       minor_words = YBU.(to_string @@ member "minor_words" args);
       major_collect = YBU.(to_int @@ member "major_collect" args);
       minor_collect = YBU.(to_int @@ member "minor_collect" args);
+      heap_words =
+        (try Some YBU.(to_string @@ member "heap_words" args)
+         with YBU.Type_error _ -> None);
     }
   with YBU.Type_error (msg,_) -> die "line %d: %s" lnum msg
 
@@ -139,7 +144,8 @@ let mk_time start stop =
 
 let get_instr (lnum, l) =
   let args = assoc "args" l in
-  YBU.(to_int @@ member "instr" args)
+  try Some YBU.(to_int @@ member "instr" args)
+  with YBU.Type_error _ -> None
 
 let rec process_cmds acc = function
   | [] -> acc
@@ -150,7 +156,7 @@ let rec process_cmds acc = function
     let src_chars = get_src_chars ~lnum:(fst start_event) hdr in
     let time = mk_time start_ts end_ts in
     let memory = mk_memory end_event in
-    let instructions = Some (get_instr end_event) in
+    let instructions = get_instr end_event in
     process_cmds ((src_chars, { time; memory; instructions; }) :: acc) rest
   | [_] -> die "ill parenthesized events"
 

--- a/dev/bench/timelog2html.ml
+++ b/dev/bench/timelog2html.ml
@@ -74,7 +74,7 @@ let file_data data_file =
     data_file, CArray.of_list data
   else
     let data = Timelogparser.parse ~file:data_file in
-    data_file, data |> CArray.map_of_list (fun (loc, time) -> loc, { BenchUtil.time; memory = None; instructions = None })
+    data_file, data |> CArray.map_of_list (fun (loc, time) -> loc, { BenchUtil.dummy_data with time; })
 
 let main args =
   let opts, (vfile, data_files) = parse_args defaults args in

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -16,8 +16,6 @@ open Names
 open Constr
 open Context
 
-module NamedDecl = Context.Named.Declaration
-
 module ERelevance = struct
   include Evd.MiniEConstr.ERelevance
 
@@ -538,24 +536,24 @@ let map_return_predicate f p =
   of_return (Constr.map_return_predicate f (unsafe_to_return p))
 
 let map_instance sigma f evk args =
-  let rec map ctx args = match ctx, SList.view args with
+  let rec map ids args = match ids, SList.view args with
   | [], None -> SList.empty
-  | decl :: ctx, Some (Some c, rem) ->
+  | id :: ids, Some (Some c, rem) ->
     let c' = f c in
-    let rem' = map ctx rem in
+    let rem' = map ids rem in
     if c' == c && rem' == rem then args
-    else if Constr.isVarId (NamedDecl.get_id decl) c' then SList.default rem'
+    else if Constr.isVarId id c' then SList.default rem'
     else SList.cons c' rem'
-  | decl :: ctx, Some (None, rem) ->
-    let c = Constr.mkVar (NamedDecl.get_id decl) in
+  | id :: ids, Some (None, rem) ->
+    let c = Constr.mkVar id in
     let c' = f c in
-    let rem' = map ctx rem in
+    let rem' = map ids rem in
     if c' == c && rem' == rem then args
     else SList.cons c' rem'
   | [], Some _ | _ :: _, None -> assert false
   in
   let EvarInfo evi = Evd.find sigma evk in
-  let ctx = Evd.evar_filtered_context evi in
+  let ctx = Evd.evar_filtered_hyp_names evi in
   map ctx args
 
 let map sigma f c =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -229,20 +229,20 @@ let csubst_subst sigma { csubst_len = k; csubst_var = v; csubst_rel = s } c =
     begin try Id.Map.find id v with Not_found -> c end
   | Evar (evk, args) ->
     let EvarInfo evi = Evd.find sigma evk in
-    let args' = subst_instance n (evar_filtered_context evi) args in
+    let args' = subst_instance n (evar_filtered_hyp_names evi) args in
     if args' == args then c else Constr.mkEvar (evk, args') (* FIXME: preserve sharing *)
   | _ -> Constr.map_with_binders succ subst n c
 
-  and subst_instance n ctx args = match ctx, SList.view args with
+  and subst_instance n ids args = match ids, SList.view args with
   | [], None -> SList.empty
-  | decl :: ctx, Some (c, args) ->
+  | id :: ids, Some (c, args) ->
     let c' = match c with
-    | None -> begin try Some (Id.Map.find (NamedDecl.get_id decl) v) with Not_found -> c end
+    | None -> begin try Some (Id.Map.find id v) with Not_found -> c end
     | Some c ->
       let c' = subst n c in
-      if isVarId (NamedDecl.get_id decl) c' then None else Some c'
+      if isVarId id c' then None else Some c'
     in
-    SList.cons_opt c' (subst_instance n ctx args)
+    SList.cons_opt c' (subst_instance n ids args)
   | _ :: _, None | [], Some _ -> assert false
   in
   let c = if k = 0 && Id.Map.is_empty v then c else subst 0 c in
@@ -730,12 +730,12 @@ let filtered_undefined_evars_of_evar_info (type a) ?cache sigma (evi : a evar_in
     let fold decl accu = cached_evar_of_hyp cache sigma (EConstr.of_named_decl decl) accu in
     Context.Named.fold_outside fold nc ~init:accu
   in
-  let accu = match Evd.evar_body evi with
-  | Evar_empty -> undefined_evars_of_term sigma (Evd.evar_concl evi)
+  match Evd.evar_body evi with
+  | Evar_empty ->
+    let accu = undefined_evars_of_term sigma (Evd.evar_concl evi) in
+    let ctxt = EConstr.Unsafe.to_named_context (evar_filtered_context evi) in
+    evars_of_named_context cache accu ctxt
   | Evar_defined b -> evars_of_term sigma b
-  in
-  let ctxt = EConstr.Unsafe.to_named_context (evar_filtered_context evi) in
-  evars_of_named_context cache accu ctxt
 
 (* spiwack: this is a more complete version of
    {!Termops.occur_evar}. The latter does not look recursively into an

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -218,7 +218,8 @@ type (_, 'a) when_undefined =
 
 type 'a evar_info = {
   evar_concl : ('a, constr) when_undefined;
-  evar_hyps : named_context_val;
+  evar_hyp_names : Id.t list;
+  evar_hyps : ('a, named_context_val) when_undefined;
   evar_body : 'a evar_body;
   evar_filter : Filter.t;
   evar_abstract_arguments : ('a, Abstraction.t) when_undefined;
@@ -239,10 +240,14 @@ let evar_filter evi = evi.evar_filter
 
 let evar_body evi = evi.evar_body
 
-let evar_context evi = named_context_of_val evi.evar_hyps
+let evar_context evi = match evi.evar_hyps with
+  | Undefined v -> named_context_of_val v
 
 let evar_filtered_context evi =
   Filter.filter_list (evar_filter evi) (evar_context evi)
+
+let evar_filtered_hyp_names evi =
+  Filter.filter_list (evar_filter evi) evi.evar_hyp_names
 
 let evar_candidates evi = match evi.evar_candidates with
 | Undefined c -> c
@@ -252,7 +257,9 @@ let evar_abstract_arguments evi = match evi.evar_abstract_arguments with
 
 let evar_relevance evi = evi.evar_relevance
 
-let evar_hyps evi = evi.evar_hyps
+let evar_hyps evi = match evi.evar_hyps with Undefined v -> v
+
+let evar_hyp_names evi = evi.evar_hyp_names
 
 let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
 | None -> evar_hyps evi
@@ -268,13 +275,13 @@ let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
   make_hyps filter (evar_context evi)
 
 let evar_env env evi =
-  Environ.reset_with_named_context evi.evar_hyps env
+  Environ.reset_with_named_context (evar_hyps evi) env
 
 let evar_filtered_env env evi = Environ.reset_with_named_context (evar_filtered_hyps evi) env
 
 let evar_identity_subst evi =
   let len = match Filter.repr evi.evar_filter with
-  | None -> List.length @@ Environ.named_context_of_val evi.evar_hyps
+  | None -> List.length @@ evi.evar_hyp_names
   | Some f -> List.count (fun b -> b) f
   in
   SList.defaultn len SList.empty
@@ -290,7 +297,7 @@ let map_when_undefined (type a b) f : (a, b) when_undefined -> (a, b) when_undef
 let map_evar_info f evi =
   {evi with
     evar_body = map_evar_body f evi.evar_body;
-    evar_hyps = map_named_val (fun d -> NamedDecl.map_constr f d) evi.evar_hyps;
+    evar_hyps = map_when_undefined (map_named_val (fun d -> NamedDecl.map_constr f d)) evi.evar_hyps;
     evar_concl = map_when_undefined f evi.evar_concl;
     evar_candidates = map_when_undefined (fun c -> Option.map (List.map f) c) evi.evar_candidates }
 
@@ -299,35 +306,32 @@ exception NotInstantiatedEvar
 
 (* Note: let-in contributes to the instance *)
 let evar_instance_array empty push info args =
-  let rec instrec pos filter args = match filter with
+  let rec instrec ids filter args = match filter with
   | Filter.Empty -> if SList.is_empty args then empty else instance_mismatch ()
-  | Filter.TCons (n, filter) -> instpush pos n filter args
-  | Filter.FCons (n, filter) -> instrec (pos + n) filter args
-  and instpush pos n filter args =
-    if n <= 0 then instrec pos filter args
-    else match args with
-    | SList.Nil -> assert false
-    | SList.Cons (c, args) ->
-      let d = Range.get info.evar_hyps.env_named_idx pos in
-      let id = NamedDecl.get_id d in
-      push id c (instpush (pos + 1) (n - 1) filter args)
-    | SList.Default (m, args) ->
-      if m <= n then instpush (pos + m) (n - m) filter args
-      else instrec (pos + n) filter (SList.defaultn (m - n) args)
+  | Filter.TCons (n, filter) -> instpush ids n filter args
+  | Filter.FCons (n, filter) -> instrec (List.skipn n ids) filter args
+  and instpush ids n filter args =
+    if n <= 0 then instrec ids filter args
+    else match args, ids with
+    | SList.Nil, _ | _, [] -> assert false
+    | SList.Cons (c, args), id :: ids ->
+      push id c (instpush ids (n - 1) filter args)
+    | SList.Default (m, args), _ ->
+      if m <= n then instpush (List.skipn m ids) (n - m) filter args
+      else instrec (List.skipn n ids) filter (SList.defaultn (m - n) args)
   in
   match Filter.unfold (evar_filter info) with
   | None ->
-    let rec instance pos args = match args with
-    | SList.Nil -> empty
-    | SList.Cons (c, args) ->
-      let d = Range.get info.evar_hyps.env_named_idx pos in
-      let id = NamedDecl.get_id d in
-      push id c (instance (pos + 1) args)
-    | SList.Default (n, args) -> instance (pos + n) args
+    let rec instance ids args = match args, ids with
+    | SList.Nil, _ -> empty
+    | SList.Cons (c, args), id :: ids ->
+      push id c (instance ids args)
+    | SList.Default (n, args), _ -> instance (List.skipn n ids) args
+    | _, [] -> assert false
     in
-    instance 0 args
+    instance info.evar_hyp_names args
   | Some filter ->
-    instrec 0 filter args
+    instrec info.evar_hyp_names filter args
 
 let make_evar_instance_array info args =
   if SList.is_default args then []
@@ -506,6 +510,10 @@ let find d e =
   try EvarInfo (EvMap.find e d.undf_evars)
   with Not_found -> EvarInfo (EvMap.find e d.defn_evars)
 
+let find_defined d e = EvMap.find_opt e d.defn_evars
+
+let find_undefined d e = EvMap.find e d.undf_evars
+
 let rec thin_val = function
   | [] -> []
   | (id, c) :: tl ->
@@ -534,23 +542,23 @@ let replace_vars sigma var_alist x =
       end
     | Constr.Evar (evk, args) ->
       let EvarInfo evi = find sigma evk in
-      let args' = substrec_instance n (evar_filtered_context evi) args in
+      let args' = substrec_instance n (evar_filtered_hyp_names evi) args in
       if args' == args then c
       else Constr.mkEvar (evk, args')
     | _ -> Constr.map_with_binders succ substrec n c
 
     and substrec_instance n ctx args = match ctx, SList.view args with
     | [], None -> SList.empty
-    | decl :: ctx, Some (c, args) ->
+    | id :: ctx, Some (c, args) ->
       let c' = match c with
       | None ->
-        begin match find_var (NamedDecl.get_id decl) var_alist with
+        begin match find_var id var_alist with
         | var -> Some (lift_substituend n var)
         | exception Not_found -> None
         end
       | Some c ->
         let c' = substrec n c in
-        if isVarId (NamedDecl.get_id decl) c' then None
+        if isVarId id c' then None
         else Some c'
       in
       SList.cons_opt c' (substrec_instance n ctx args)
@@ -565,7 +573,7 @@ let instantiate_evar_array sigma info c args =
   | _ -> replace_vars sigma inst c
 
 let expand_existential sigma (evk, args) =
-  let EvarInfo evi = find sigma evk in
+  let evi = find_undefined sigma evk in
   let rec expand ctx args = match ctx, SList.view args with
   | [], None -> []
   | _ :: ctx, Some (Some c, args) -> c :: expand ctx args
@@ -720,10 +728,6 @@ let remove d e =
   { d with undf_evars; defn_evars; future_goals;
            evar_flags; candidate_evars }
 
-let find_defined d e = EvMap.find_opt e d.defn_evars
-
-let find_undefined d e = EvMap.find e d.undf_evars
-
 let mem d e = EvMap.mem e d.undf_evars || EvMap.mem e d.defn_evars
 
 let undefined_map d = d.undf_evars
@@ -777,11 +781,11 @@ let existential_expand_value0 sigma (evk, args) = match existential_opt_value si
 
 let mkLEvar sigma (evk, args) =
   let EvarInfo evi = find sigma evk in
-  let fold decl arg accu =
-    if isVarId (NamedDecl.get_id decl) arg then SList.default accu
+  let fold id arg accu =
+    if isVarId id arg then SList.default accu
     else SList.cons arg accu
   in
-  let args = List.fold_right2 fold (evar_filtered_context evi) args SList.empty in
+  let args = List.fold_right2 fold (evar_filtered_hyp_names evi) args SList.empty in
   mkEvar (evk, args)
 
 let is_relevance_irrelevant sigma r =
@@ -1372,7 +1376,8 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ~relevance
   ?(abstract_arguments = Abstraction.identity) ?candidates
   ?name ?parent ?(typeclass_candidate = false) ?(rrpat = false) sign evd typ =
   let evi = {
-    evar_hyps = sign;
+    evar_hyp_names = List.map NamedDecl.get_id sign.env_named_ctx;
+    evar_hyps = Undefined sign;
     evar_concl = Undefined typ;
     evar_body = Evar_empty;
     evar_filter = filter;
@@ -1400,6 +1405,7 @@ let define_aux def undef evk body =
   let newinfo = { oldinfo with
     evar_body = Evar_defined body;
     evar_concl = Defined;
+    evar_hyps = Defined;
     evar_candidates = Defined;
     evar_abstract_arguments = Defined;
   } in
@@ -1436,7 +1442,7 @@ let define_with_evar evk body evd =
 let restrict evk filter ?candidates ?src evd =
   let evk' = new_untyped_evar () in
   let evar_info = EvMap.find evk evd.undf_evars in
-  let len = Range.length evar_info.evar_hyps.env_named_idx in
+  let len = Range.length (evar_hyps evar_info).env_named_idx in
   let id_inst = Filter.filter_slist filter (SList.defaultn len SList.empty) in
   let evar_info' =
     { evar_info with evar_filter = filter;
@@ -1632,21 +1638,21 @@ let expand0 sigma h c =
   | Evar (evk, args) ->
     (* for efficiency do not expand evars, just their instance *)
     let EvarInfo evi = find sigma evk in
-    let push decl c args =
-      if isVarId (NamedDecl.get_id decl) c then SList.default args
+    let push id c args =
+      if isVarId id c then SList.default args
       else SList.cons c args
     in
-    let rec expand ctx args = match ctx, SList.view args with
+    let rec expand ids args = match ids, SList.view args with
     | [], None -> SList.empty
-    | decl :: ctx, Some (Some c, args) ->
+    | id :: ids, Some (Some c, args) ->
       let c = aux h c in
-      push decl c (expand ctx args)
-    | decl :: ctx, Some (None, args) ->
-      let c = aux h (mkVar (NamedDecl.get_id decl)) in
-      push decl c (expand ctx args)
+      push id c (expand ids args)
+    | id :: ids, Some (None, args) ->
+      let c = aux h (mkVar id) in
+      push id c (expand ids args)
     | [], Some _ | _ :: _, None -> instance_mismatch ()
     in
-    let args = expand (evar_filtered_context evi) args in
+    let args = expand (evar_filtered_hyp_names evi) args in
     mkEvar (evk, args)
   | _ -> Constr.map_with_binders lift aux h c
   in
@@ -1907,11 +1913,9 @@ let evars_of_filtered_evar_info (type a) evd (evi : a evar_info) =
   | Defined -> Evar.Set.empty
   in
   Evar.Set.union concl
-    (Evar.Set.union
-       (match evi.evar_body with
-       | Evar_empty -> Evar.Set.empty
-       | Evar_defined b -> evars_of_term evd b)
-       (evars_of_named_context evd (evar_filtered_context evi)))
+    (match evi.evar_body with
+     | Evar_empty -> evars_of_named_context evd (evar_filtered_context evi)
+     | Evar_defined b -> evars_of_term evd b)
 
 let drop_new_defined ~original sigma =
   NewProfile.profile "drop_new_defined" (fun () ->

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1376,7 +1376,7 @@ let new_pure_evar ?(src=default_source) ?(filter = Filter.identity) ~relevance
   ?(abstract_arguments = Abstraction.identity) ?candidates
   ?name ?parent ?(typeclass_candidate = false) ?(rrpat = false) sign evd typ =
   let evi = {
-    evar_hyp_names = List.map NamedDecl.get_id sign.env_named_ctx;
+    evar_hyp_names = sign.env_named_names;
     evar_hyps = Undefined sign;
     evar_concl = Undefined typ;
     evar_body = Evar_empty;

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -116,11 +116,13 @@ type any_evar_info = EvarInfo : 'a evar_info -> any_evar_info
 val evar_concl : undefined evar_info -> econstr
 (** Type of the evar. *)
 
-val evar_context : 'a evar_info -> (econstr, etypes, erelevance) Context.Named.pt
+val evar_context : undefined evar_info -> (econstr, etypes, erelevance) Context.Named.pt
 (** Context of the evar. *)
 
-val evar_hyps : 'a evar_info -> named_context_val
+val evar_hyps : undefined evar_info -> named_context_val
 (** Context of the evar. *)
+
+val evar_hyp_names : _ evar_info -> Id.t list
 
 val evar_body : 'a evar_info -> 'a evar_body
 (** Optional content of the evar. *)
@@ -145,10 +147,11 @@ val evar_relevance : 'a evar_info -> erelevance
 
 (** {6 Derived projections} *)
 
-val evar_filtered_context : 'a evar_info -> (econstr, etypes, erelevance) Context.Named.pt
-val evar_filtered_hyps : 'a evar_info -> named_context_val
-val evar_env : env -> 'a evar_info -> env
-val evar_filtered_env : env -> 'a evar_info -> env
+val evar_filtered_context : undefined evar_info -> (econstr, etypes, erelevance) Context.Named.pt
+val evar_filtered_hyps : undefined evar_info -> named_context_val
+val evar_filtered_hyp_names : _ evar_info -> Id.t list
+val evar_env : env -> undefined evar_info -> env
+val evar_filtered_env : env -> undefined evar_info -> env
 val evar_identity_subst : 'a evar_info -> econstr SList.t
 
 val map_evar_body : (econstr -> econstr) -> 'a evar_body -> 'a evar_body

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -955,25 +955,17 @@ module Progress = struct
     | Evar_defined _, Evar_defined _ -> true
     | _ -> false
 
-  let fast_eq_named_context_val ctx1 ctx2 =
-    let r_eq _ _ = true (* ignore relevances *) in
-    let c1 = EConstr.named_context_of_val ctx1 in
-    let c2 = EConstr.named_context_of_val ctx2 in
-    let eq_named_declaration d1 d2 = match d1, d2 with
-    | LocalAssum (i1, _), LocalAssum (i2, _) -> Context.eq_annot Names.Id.equal r_eq i1 i2
-    | LocalDef (i1, _, _), LocalDef (i2, _, _) -> Context.eq_annot Names.Id.equal r_eq i1 i2
-    | _ -> false
-    in
-    List.for_all2eq eq_named_declaration c1 c2
+  let fast_eq_hyp_names ctx1 ctx2 =
+    List.for_all2eq Names.Id.equal ctx1 ctx2
 
   let fast_eq_evar_info ei1 ei2 =
     fast_eq_evar_body ei1 ei2 &&
-    fast_eq_named_context_val (Evd.evar_hyps ei1) (Evd.evar_hyps ei2)
+    fast_eq_hyp_names (Evd.evar_hyp_names ei1) (Evd.evar_hyp_names ei2)
 
   (** Equality function on goals *)
   let goal_equal ~evd ~extended_evd evar extended_evar =
-    let EvarInfo evi = Evd.find evd evar in
-    let EvarInfo extended_evi = Evd.find extended_evd extended_evar in
+    let evi = Evd.find_undefined evd evar in
+    let extended_evi = Evd.find_undefined extended_evd extended_evar in
     if fast_eq_evar_info evi extended_evi then
       eq_evar_info evd extended_evd evi extended_evi
     else false
@@ -1213,9 +1205,8 @@ module Goal = struct
           tclEVARMAP >>= fun sigma ->
           let state = get_state goal in
           let goal = drop_state goal in
-          let EvarInfo info = Evd.find sigma goal in
           let goal = {
-            env = Environ.reset_with_named_context (Evd.evar_filtered_hyps info) env ;
+            env = Environ.reset_with_named_context (Evd.evar_filtered_hyps oinfo) env ;
             sigma = sigma ;
             concl = Evd.evar_concl oinfo;
             state = state;

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -140,11 +140,14 @@ match evar_ident evk sigma with
 | Some id ->
   str "?" ++ Libnames.pr_path id
 
+let pr_filtered_id (id,ok) =
+  if ok then Id.print id else str "{" ++ Id.print id ++ str "}"
+
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in
   let print_constr = Internal.print_kconstr in
   match decl with
-  | LocalAssum ({binder_name=id},_) -> if ok then Id.print id else (str "{" ++ Id.print id ++ str "}")
+  | LocalAssum ({binder_name=id},_) -> pr_filtered_id (id,ok)
   | LocalDef ({binder_name=id},c,_) -> str (if ok then "(" else "{") ++ Id.print id ++ str ":=" ++
                            print_constr env sigma c ++ str (if ok then ")" else "}")
 
@@ -186,13 +189,27 @@ let pr_evar_info (type a) env sigma (evi : a Evd.evar_info) =
   let open Evd in
   let print_constr = Internal.print_kconstr in
   let phyps =
-    try
-      let decls = match Filter.repr (evar_filter evi) with
-      | None -> List.map (fun c -> (c, true)) (evar_context evi)
-      | Some filter -> List.combine (evar_context evi) filter
-      in
-      prlist_with_sep spc (pr_decl env sigma) (List.rev decls)
-    with Invalid_argument _ -> str "Ill-formed filtered context" in
+    match Evd.evar_body evi with
+    | Evar_empty -> begin
+        try
+          let decls = match Filter.repr (evar_filter evi) with
+            | None -> List.map (fun c -> (c, true)) (evar_context evi)
+            | Some filter -> List.combine (evar_context evi) filter
+          in
+          prlist_with_sep spc (pr_decl env sigma) (List.rev decls)
+        with Invalid_argument _ -> str "Ill-formed filtered context"
+      end
+    | _ -> begin
+        try
+          let decls = match Filter.repr (evar_filter evi) with
+            | None -> List.map (fun c -> (c, true)) (evar_hyp_names evi)
+            | Some filter -> List.combine (evar_hyp_names evi) filter
+          in
+          prlist_with_sep spc pr_filtered_id (List.rev decls)
+        with Invalid_argument _ -> str "Ill-formed filtered context"
+      end
+
+  in
   let pb =
     match Evd.evar_body evi with
       | Evar_empty -> print_constr env sigma (Evd.evar_concl evi)

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -145,11 +145,14 @@ match evar_ident evk sigma with
 | Some id ->
   str "?" ++ Libnames.pr_path id
 
+let pr_filtered_id (id,ok) =
+  if ok then Id.print id else str "{" ++ Id.print id ++ str "}"
+
 let pr_decl env sigma (decl,ok) =
   let open NamedDecl in
   let print_constr = Internal.print_kconstr in
   match decl with
-  | LocalAssum ({binder_name=id},_) -> if ok then Id.print id else (str "{" ++ Id.print id ++ str "}")
+  | LocalAssum ({binder_name=id},_) -> pr_filtered_id (id,ok)
   | LocalDef ({binder_name=id},c,_) -> str (if ok then "(" else "{") ++ Id.print id ++ str ":=" ++
                            print_constr env sigma c ++ str (if ok then ")" else "}")
 
@@ -191,13 +194,27 @@ let pr_evar_info (type a) env sigma (evi : a Evd.evar_info) =
   let open Evd in
   let print_constr = Internal.print_kconstr in
   let phyps =
-    try
-      let decls = match Filter.repr (evar_filter evi) with
-      | None -> List.map (fun c -> (c, true)) (evar_context evi)
-      | Some filter -> List.combine (evar_context evi) filter
-      in
-      prlist_with_sep spc (pr_decl env sigma) (List.rev decls)
-    with Invalid_argument _ -> str "Ill-formed filtered context" in
+    match Evd.evar_body evi with
+    | Evar_empty -> begin
+        try
+          let decls = match Filter.repr (evar_filter evi) with
+            | None -> List.map (fun c -> (c, true)) (evar_context evi)
+            | Some filter -> List.combine (evar_context evi) filter
+          in
+          prlist_with_sep spc (pr_decl env sigma) (List.rev decls)
+        with Invalid_argument _ -> str "Ill-formed filtered context"
+      end
+    | _ -> begin
+        try
+          let decls = match Filter.repr (evar_filter evi) with
+            | None -> List.map (fun c -> (c, true)) (evar_hyp_names evi)
+            | Some filter -> List.combine (evar_hyp_names evi) filter
+          in
+          prlist_with_sep spc pr_filtered_id (List.rev decls)
+        with Invalid_argument _ -> str "Ill-formed filtered context"
+      end
+
+  in
   let pb =
     match Evd.evar_body evi with
       | Evar_empty -> print_constr env sigma (Evd.evar_concl evi)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -29,7 +29,6 @@ open Structures
 open Notationextern
 
 module ExternFlags = PrintingFlags.Extern
-module NamedDecl = Context.Named.Declaration
 (*i*)
 
 (* Translation from glob_constr to front constr *)
@@ -1400,9 +1399,8 @@ let rec glob_of_pat
   | PEvar (evk,l) ->
       let filter (id, pat) = match pat with PVar id' -> Id.equal id id' | _ -> true in
       let EvarInfo evi = Evd.find sigma evk in
-      let hyps = Evd.evar_filtered_context evi in
-      let map decl pat = NamedDecl.get_id decl, pat in
-      let l = List.filter filter @@ List.map2 map hyps l in
+      let ids = Evd.evar_filtered_hyp_names evi in
+      let l = List.filter filter @@ List.combine ids l in
       let id = match Evd.evar_ident evk sigma with
       | None -> "__"
       | Some id -> Libnames.string_of_path id

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -77,6 +77,7 @@ end
 type mind_key = mutual_inductive_body * link_info ref * KerName.t
 
 type named_context_val = {
+  env_named_names : Id.t list;
   env_named_ctx : Constr.named_context;
   env_named_map : Constr.named_declaration Id.Map.t;
   env_named_idx : Constr.named_declaration Range.t;
@@ -115,6 +116,7 @@ type rewrule_not_allowed = Symb | Rule
 exception RewriteRulesNotAllowed of rewrule_not_allowed
 
 let empty_named_context_val = {
+  env_named_names = [];
   env_named_ctx = [];
   env_named_map = Id.Map.empty;
   env_named_idx = Range.empty;
@@ -191,6 +193,7 @@ let set_rel_context_val v env =
 let push_named_context_val d ctxt =
 (*   assert (not (Id.Map.mem (NamedDecl.get_id d) ctxt.env_named_map)); *)
   {
+    env_named_names = NamedDecl.get_id d :: ctxt.env_named_names;
     env_named_ctx = Context.Named.add d ctxt.env_named_ctx;
     env_named_map = Id.Map.add (NamedDecl.get_id d) d ctxt.env_named_map;
     env_named_idx = Range.cons d ctxt.env_named_idx;
@@ -200,7 +203,13 @@ let match_named_context_val c = match c.env_named_ctx with
 | [] -> None
 | decl :: ctx ->
   let map = Id.Map.remove (NamedDecl.get_id decl) c.env_named_map in
-  let cval = { env_named_ctx = ctx; env_named_map = map; env_named_idx = Range.tl c.env_named_idx } in
+  let cval = {
+    env_named_names = List.tl c.env_named_names;
+    env_named_ctx = ctx;
+    env_named_map = map;
+    env_named_idx = Range.tl c.env_named_idx;
+  }
+  in
   Some (decl, cval)
 
 let map_named_val f ctxt =
@@ -217,7 +226,8 @@ let map_named_val f ctxt =
   if map == ctxt.env_named_map then ctxt
   else
     let idx = List.fold_right Range.cons ctx Range.empty in
-    { env_named_ctx = ctx; env_named_map = map; env_named_idx = idx }
+    let names = List.map NamedDecl.get_id ctx in
+    { env_named_names = names; env_named_ctx = ctx; env_named_map = map; env_named_idx = idx }
 
 let push_named d env =
   {env with env_named_context = push_named_context_val d env.env_named_context}

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -38,6 +38,7 @@ type link_info =
 type key = int CEphemeron.key option ref
 
 type named_context_val = private {
+  env_named_names : Id.t list;
   env_named_ctx : Constr.named_context;
   env_named_map : Constr.named_declaration Id.Map.t;
   (** Identifier-indexed version of [env_named_ctx] *)

--- a/lib/newProfile.ml
+++ b/lib/newProfile.ml
@@ -106,6 +106,7 @@ module Counters = struct
     minor_words : float;
     major_collections : int;
     minor_collections : int;
+    heap_words : int;
     instr : System.instruction_count;
   }
 
@@ -114,6 +115,7 @@ module Counters = struct
     minor_words = 0.;
     major_collections = 0;
     minor_collections = 0;
+    heap_words = 0;
     instr = Ok 0L;
   }
 
@@ -124,6 +126,7 @@ module Counters = struct
       minor_words = gc.minor_words;
       major_collections = gc.major_collections;
       minor_collections = gc.minor_collections;
+      heap_words = gc.heap_words;
       instr = Instr.read_counter();
     }
 
@@ -134,6 +137,7 @@ module Counters = struct
     minor_words = a.minor_words +. b.minor_words;
     major_collections = a.major_collections + b.major_collections;
     minor_collections = a.minor_collections + b.minor_collections;
+    heap_words = a.heap_words + b.heap_words;
     instr = System.instruction_count_add a.instr b.instr;
   }
 
@@ -142,6 +146,7 @@ module Counters = struct
     minor_words = b.minor_words -. a.minor_words;
     major_collections = b.major_collections - a.major_collections;
     minor_collections = b.minor_collections - a.minor_collections;
+    heap_words = b.heap_words - a.heap_words;
     instr = System.instructions_between ~c_start:a.instr ~c_end:b.instr;
   }
 
@@ -154,6 +159,7 @@ module Counters = struct
        (str "minor words:" ++ spc() ++ ppw x.minor_words) ::
        (str "major collections:" ++ spc() ++ int x.major_collections) ::
        (str "minor collections:" ++ spc() ++ int x.minor_collections) ::
+       (str "heap size change:" ++ spc() ++ ppw (float_of_int x.heap_words)) ::
        match x.instr with
        | Ok count -> [str "instructions:" ++ spc() ++ str (Int64.to_string count)]
        | Error _ -> [])
@@ -169,6 +175,7 @@ module Counters = struct
     ("minor_words", ppw x.minor_words) ::
     ("major_collect", ppi x.major_collections) ::
     ("minor_collect", ppi x.minor_collections) ::
+    ("heap_words", ppw (float_of_int x.heap_words)) ::
     instr
 
   let make_diffs ~start ~stop = format (stop - start)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -1268,10 +1268,10 @@ let cleanup_XinE env sigma0 (h_k, _) x rp sigma =
     try ignore(Context.Named.lookup x ctx); (name, fun k ->
         if !name = None then
           let EvarInfo evi = Evd.find sigma k in
-          let nctx = Evd.evar_context evi in
-          let nlen = Context.Named.length nctx in
+          let nctx = Evd.evar_hyp_names evi in
+          let nlen = List.length nctx in
           if nlen > len then begin
-            name := Some (Context.Named.Declaration.get_id (List.nth nctx (nlen - len - 1)))
+            name := Some (List.nth nctx (nlen - len - 1))
           end)
     with Not_found -> ref (Some x), fun _ -> () in
   let new_evars =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1880,13 +1880,9 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
               user_err (Pp.str "Cannot find an instance.")
          else
            ((debug_ho_unification (fun () ->
-               let EvarInfo evi = Evd.find evd evk in
-               let env = Evd.evar_env env_rhs evi in
                Pp.(str"evar is defined: " ++
-                 int (Evar.repr evk) ++ spc () ++
-                 prc env evd (match evar_body evi with Evar_defined c -> c
-                   | Evar_empty -> assert false)));
-            evd))
+                 int (Evar.repr evk))));
+            evd)
        in force_instantiation evd evs
      | [] -> abstract_free_holes evd l
      in force_instantiation evd !evsref
@@ -1896,10 +1892,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
            instantiate evk itself. *)
        (debug_ho_unification (fun () ->
           begin
-            let EvarInfo evi = Evd.find evd evk in
-            let evenv = evar_env env_rhs evi in
-            let body = match evar_body evi with Evar_empty -> assert false | Evar_defined c -> c in
-            Pp.(str"evar was defined already as: " ++ prc evenv evd body)
+            Pp.(str"evar was defined already")
           end);
         evd)
      else

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -618,7 +618,7 @@ let distinct_actual_deps env evd aliases l t =
 
 open Context.Named.Declaration
 let remove_instance_local_defs evd evk args =
-  let EvarInfo evi = Evd.find evd evk in
+  let evi = Evd.find_undefined evd evk in
   let rec aux sign args = match sign, args with
   | [], [] -> []
   | LocalAssum _ :: sign, c :: args -> c :: aux sign args
@@ -1615,7 +1615,7 @@ exception MetaOccurInBodyInternal
 
 let rec invert_definition unify flags choose imitate_defs
                           env evd pbty (evk,argsv as ev) rhs =
-  let EvarInfo evi = Evd.find evd evk in
+  let evi = Evd.find_undefined evd evk in
   let sign = evar_filtered_context evi in
   let rhs = whd_beta env evd rhs (* heuristic *) in
   let fast =

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -769,7 +769,7 @@ struct
             else
               error_evar_not_found ?loc:locid !!env sigma id
       in
-      let EvarInfo evi = Evd.find sigma evk in
+      let evi = Evd.find_undefined sigma evk in
       let hyps = evar_filtered_context evi in
       let sigma, args = pretype_instance self ~flags env sigma loc hyps evk inst in
       let c = mkLEvar sigma (evk, args) in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -552,11 +552,10 @@ let pr_transparent_state ts =
         str"PROJECTIONS: " ++ pr_prpred ts.TransparentState.tr_prj ++ fnl ())
 
 let goal_repr sigma g =
-  let EvarInfo evi = Evd.find sigma g in
+  let evi = Evd.find_undefined sigma g in
   let env = Evd.evar_filtered_env (Global.env ()) evi in
   let concl = match Evd.evar_body evi with
   | Evd.Evar_empty -> Evd.evar_concl evi
-  | Evd.Evar_defined b -> Retyping.get_type_of env sigma b
   in
   env, concl
 
@@ -798,15 +797,12 @@ let queue_term q is_dependent c =
   queue_set q is_dependent (evar_nodes_of_term c)
 
 let process_dependent_evar q acc evm is_dependent e =
-  let EvarInfo evi = Evd.find evm e in
+  let evi = Evd.find_undefined evm e in
   (* Queues evars appearing in the types of the goal (conclusion, then
      hypotheses), they are all dependent. *)
   let () = match Evd.evar_body evi with
   | Evar_empty ->
     queue_term q true (Evd.evar_concl evi)
-  | Evar_defined b ->
-    let env = Evd.evar_filtered_env (Global.env ()) evi in
-    queue_term q true (Retyping.get_type_of env evm b)
   in
   List.iter begin fun decl ->
     let open NamedDecl in
@@ -818,14 +814,6 @@ let process_dependent_evar q acc evm is_dependent e =
   match Evd.evar_body evi with
   | Evar_empty ->
       if is_dependent then Evar.Map.add e None acc else acc
-  | Evar_defined b ->
-      let subevars = evar_nodes_of_term b in
-      (* evars appearing in the definition of an evar [e] are marked
-         as dependent when [e] is dependent itself: if [e] is a
-         non-dependent goal, then, unless they are reach from another
-         path, these evars are just other non-dependent goals. *)
-      queue_set q is_dependent subevars;
-      if is_dependent then Evar.Map.add e (Some subevars) acc else acc
 
 (** [gather_dependent_evars evm seeds] classifies the evars in [evm]
     as dependent_evars and goals (these may overlap). A goal is an evar

--- a/vernac/comRewriteRule.ml
+++ b/vernac/comRewriteRule.ml
@@ -306,7 +306,7 @@ and safe_head_pattern_of_constr ~loc env evd usubst depth state t = Constr.kind 
 
 and safe_arg_pattern_of_constr ~loc env evd usubst depth (st, stateq, stateu as state) t = Constr.kind t |> function
   | Evar (evk, inst) ->
-    let EvarInfo evi = Evd.find evd evk in
+    let evi = Evd.find_undefined evd evk in
     if Evd.is_rewrite_rule_evar evd evk then
       let holei, st = update_invtbl ~loc env evd evk st in
       if not @@ is_rel_inst 1 inst then
@@ -471,7 +471,7 @@ let interp_rule ~collapse_sort_variables (udecl, lhs, rhs: Constrexpr.universe_d
   end;
 
   let update_invtbl evd evk n =
-    let Evd.EvarInfo evi = Evd.find evd evk in
+    let evi = Evd.find_undefined evd evk in
     let vars = Evd.evar_hyps evi |> Environ.named_context_of_val |> Context.Named.instance EConstr.mkVar in
     (n, vars)
   in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2547,7 +2547,7 @@ let vernac_validate_proof ~pstate =
           Some
             Pp.(str "Evar " ++ Printer.pr_evar sigma (e, evi)
                 ++ spc() ++ str "was inferred by unification to be" ++ spc()
-                ++ pr_econstr_env (Evd.evar_env env evi') sigma' body)
+                ++ pr_econstr_env (Evd.evar_env env evi) sigma' body)
         | None, Some _ -> (* ignore new evar *)
           assert (not (Evd.is_defined sigma e));
           None


### PR DESCRIPTION

In the test suite this breaks rewrite rules (probably need to use and
older evar map or something?), "dependent evars line", and "Show Goal at"
(PG prooftree).

Also various debug printers are less informative because it's now
impossible to get a correct env to print the evar body in.
