### PR TITLE
make equality sort poly

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -644,7 +644,7 @@ let mkEtaApp c n imin =
 
 let mkRefl env sigma t c =
   let (sigma, refl) = EConstr.fresh_global env sigma Rocqlib.(lib_ref "core.eq.refl") in
-  sigma, EConstr.mkApp (refl, [|t; c|])
+  Typing.checked_appvect env sigma refl [|t; c|]
 
 let discharge_hyp (id', (id, mode)) =
   let open EConstr in

--- a/theories/Corelib/Init/Logic.v
+++ b/theories/Corelib/Init/Logic.v
@@ -376,7 +376,8 @@ End universal_quantification.
     as it expresses that [x] and [y] are equal iff every property on
     [A] which is true of [x] is also true of [y] *)
 
-Inductive eq (A:Type) (x:A) : A -> Prop :=
+#[universes(polymorphic,cumulative)]
+Inductive eq@{s;i} (A:Type@{s;i}) (x:A) : A -> Prop :=
     eq_refl : x = x :>A
 
 where "x = y :> A" := (@eq A x y) : type_scope.
@@ -407,6 +408,23 @@ Register eq_rect as core.eq.rect.
 Register eq_rec as core.eq.rec.
 
 Scheme Rewriting for eq.
+
+Definition eq_sym_involutive : forall [A : Type] [x y : A] (H : x = y), eq_sym (eq_sym H) = H :=
+fun (A : Type) (x y : A) (H : x = y) =>
+match H as H0 in _ = y0 return eq_sym (eq_sym H0) = H0 with
+| eq_refl => eq_refl
+end.
+
+Definition eq_rew_r_dep : forall [A : Type] [x y : A] (P : forall y0 : A, y0 = y -> Type),
+       P y eq_refl -> forall H : x = y, P x H :=
+fun (A : Type) (x y : A) (P : forall y0 : A, y0 = y -> Type)
+  (HC : P y eq_refl) (H : x = y) =>
+match eq_sym_involutive H in _ = H0 return P x H0 with
+| eq_refl =>
+        match eq_sym H as H0 in _ = y0 return P y0 (eq_sym H0) with
+    | eq_refl => HC
+    end
+end.
 
 Register eq_rew_dep as core.eq.rect_dep.
 Register eq_rew_dep as core.eq.ind_dep.

--- a/theories/Corelib/ssr/ssreflect_rw.v
+++ b/theories/Corelib/ssr/ssreflect_rw.v
@@ -355,7 +355,7 @@ Ltac ssrdone0 :=
    | match goal with H : ~ _ |- _ => solve [case H; trivial] end ].
 
 (**  To unlock opaque constants.  **)
-#[universes(template)]
+#[universes(polymorphic,cumulative)]
 Structure unlockable T v := Unlockable {unlocked : T; _ : unlocked = v}.
 Lemma unlock T x C : @unlocked T x C = x. Proof. by case: C. Qed.
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -46,23 +46,29 @@ let name_context env ctxt =
           let d' = name_assumption env d in (Environ.push_rel d' env, d' :: hyps))
        (env,[]) (List.rev ctxt))
 
+
+let instance_of_qualities ?(us=[]) qs =
+  UVars.Instance.of_array (Array.of_list qs, Array.of_list us)
+
+let polymorphic_instance ?loc env gr ?us qs =
+  let names = instance_of_qualities ?us qs in
+  let c, ctx = UnivGen.fresh_global_instance ?loc ~names env gr in
+  assert (UnivGen.is_empty_sort_context ctx);
+  c
+
 (* Some pre declaration of constant we are going to use *)
-let andb_prop = fun _ -> UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.bool.andb_prop")
-
-let andb_true_intro = fun _ ->
-  UnivGen.constr_of_monomorphic_global (Global.env ())
-    (Rocqlib.lib_ref "core.bool.andb_true_intro")
-
 (* We avoid to use lazy as the binding of constants can change *)
-let bb () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.bool.type")
-let tt () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.bool.true")
-let ff () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.bool.false")
-let eq () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.eq.type")
-let int63_eqb () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "num.int63.eqb")
-let float64_eqb () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "num.float.leibniz.eqb")
+let bb () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.type") []
+let tt () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.true") []
+let ff () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.false") []
+let eq s u = polymorphic_instance (Global.env ()) ~us:[u] (Rocqlib.lib_ref "core.eq.type") [s]
+let int63_eqb () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "num.int63.eqb") []
+let float64_eqb () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "num.float.leibniz.eqb") []
 
-let sumbool () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.sumbool.type")
-let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.env ()) (Rocqlib.lib_ref "core.bool.andb")
+let sumbool () = polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.sum.type") []
+let andb = fun _ -> polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.andb") []
+let andb_prop = fun _ -> polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.andb_prop") []
+let andb_true_intro = fun _ -> polymorphic_instance (Global.env ()) (Rocqlib.lib_ref "core.bool.andb_true_intro") []
 
 let induct_on  c = Induction.induction false None c None None
 let destruct_on c = Induction.destruct false None c None None
@@ -1077,21 +1083,34 @@ let eqI handle (ind,u) list_id =
 
 open Namegen
 
-let compute_bl_goal env handle (ind,u) lnamesparrec nparrec =
+let sort_and_univ env sigma (ind, u) =
+  let ty = Inductiveops.type_of_inductive env (ind,EConstr.EInstance.make u) in
+  let ctx, sort = EConstr.destArity sigma ty in
+  let sort = EConstr.ESorts.kind sigma sort in
+  Sorts.quality sort, Sorts.univ_of_sort sort
+
+let compute_bl_goal env uctx handle (ind,u) lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let eqI = eqI handle (ind,u) list_id in
   let avoid = avoid_of_list_id list_id in
   let x = next_ident_away (Id.of_string "x") avoid in
   let y = next_ident_away (Id.of_string "y") (Id.Set.add x avoid) in
+  let sigma = Evd.from_ustate uctx in
+  let qind, uind = sort_and_univ env sigma (ind, u) in
+  let uctx , fresh_level = UState.new_univ_level_variable UState.univ_flexible None uctx in
+  let uctx = UState.add_constraints uctx @@
+             UnivProblem.Set.singleton (UnivProblem.ULe (Sorts.sort_of_univ uind, (Sorts.sort_of_univ (Univ.Universe.make fresh_level)))) in
+  let indeq = eq qind fresh_level in
+  let booleq = eq Sorts.Quality.qtype Univ.Level.set in
   let open Term in
   let create_input c =
       let bl_typ = List.map (fun (s,seq,_,_) ->
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkVar s) (
             mkNamedProd (Context.make_annot y Sorts.Relevant) (mkVar s) (
               mkArrow
-               ( mkApp(eq (),[|bb (); mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt () |]))
+               ( mkApp(booleq,[|bb (); mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt () |]))
                Sorts.Relevant
-               ( mkApp(eq (),[|mkVar s;mkVar x;mkVar y|]))
+               ( mkApp(indeq,[|mkVar s;mkVar x;mkVar y|]))
           ))
         ) list_id in
       let bl_input = List.fold_left2 ( fun a (s,_,sbl,_) b ->
@@ -1110,13 +1129,13 @@ let compute_bl_goal env handle (ind,u) lnamesparrec nparrec =
         in
         mkNamedProd x (RelDecl.get_type decl) a) eq_input lnamesparrec
     in
-     create_input (
+     uctx, create_input (
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkFullInd env (ind,u) (2*nparrec)) (
           mkNamedProd (Context.make_annot y Sorts.Relevant) (mkFullInd env (ind,u) (2*nparrec+1)) (
             mkArrow
-              (mkApp(eq (),[|bb ();mkApp(eqI,[|mkVar x;mkVar y|]);tt ()|]))
+              (mkApp(booleq,[|bb ();mkApp(eqI,[|mkVar x;mkVar y|]);tt ()|]))
               Sorts.Relevant
-              (mkApp(eq (),[|mkFullInd env (ind,u) (2*nparrec+3);mkVar x;mkVar y|]))
+              (mkApp(indeq,[|mkFullInd env (ind,u) (2*nparrec+3);mkVar x;mkVar y|]))
         )))
 
 let compute_bl_tact handle ind lnamesparrec nparrec =
@@ -1198,7 +1217,7 @@ let make_bl_scheme env handle mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
-  let bl_goal = compute_bl_goal env handle (ind,u) lnamesparrec nparrec in
+  let uctx , bl_goal = compute_bl_goal env uctx handle (ind,u) lnamesparrec nparrec in
   let bl_goal = EConstr.of_constr bl_goal in
   let univ_poly = Declareops.inductive_is_polymorphic mib in
   let poly = PolyFlags.of_univ_poly univ_poly in (* FIXME cumulativity not handled *)
@@ -1223,22 +1242,29 @@ let _ = bl_scheme_kind_aux := fun () -> bl_scheme_kind
 (**********************************************************************)
 (* Leibniz->Boolean *)
 
-let compute_lb_goal env handle (ind,u) lnamesparrec nparrec =
+let compute_lb_goal env uctx handle (ind,u) lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
-  let eq = eq () and tt = tt () and bb = bb () in
+  let tt = tt () and bb = bb () in
   let avoid = avoid_of_list_id list_id in
   let eqI = eqI handle (ind,u) list_id in
   let x = next_ident_away (Id.of_string "x") avoid in
   let y = next_ident_away (Id.of_string "y") (Id.Set.add x avoid) in
+  let sigma = Evd.from_ustate uctx in
+  let qind, uind = sort_and_univ env sigma (ind, u) in
+  let uctx , fresh_level = UState.new_univ_level_variable UState.univ_flexible None uctx in
+  let uctx = UState.add_constraints uctx @@
+             UnivProblem.Set.singleton (UnivProblem.ULe (Sorts.sort_of_univ uind, (Sorts.sort_of_univ (Univ.Universe.make fresh_level)))) in
+  let indeq = eq qind fresh_level in
+  let booleq = eq Sorts.Quality.qtype Univ.Level.set in
   let open Term in
     let create_input c =
       let lb_typ = List.map (fun (s,seq,_,_) ->
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkVar s) (
             mkNamedProd (Context.make_annot y Sorts.Relevant) (mkVar s) (
               mkArrow
-                ( mkApp(eq,[|mkVar s;mkVar x;mkVar y|]))
+                ( mkApp(indeq,[|mkVar s;mkVar x;mkVar y|]))
                 Sorts.Relevant
-                ( mkApp(eq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
+                ( mkApp(booleq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
           ))
         ) list_id in
       let lb_input = List.fold_left2 ( fun a (s,_,_,slb) b ->
@@ -1258,13 +1284,13 @@ let compute_lb_goal env handle (ind,u) lnamesparrec nparrec =
           in
           mkNamedProd x (RelDecl.get_type decl)  a) eq_input lnamesparrec
     in
-      create_input (
+      uctx, create_input (
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkFullInd env (ind,u) (2*nparrec)) (
           mkNamedProd (Context.make_annot y Sorts.Relevant) (mkFullInd env (ind,u) (2*nparrec+1)) (
             mkArrow
-              (mkApp(eq,[|mkFullInd env (ind,u) (2*nparrec+2);mkVar x;mkVar y|]))
+              (mkApp(indeq,[|mkFullInd env (ind,u) (2*nparrec+2);mkVar x;mkVar y|]))
               Sorts.Relevant
-              (mkApp(eq,[|bb;mkApp(eqI,[|mkVar x;mkVar y|]);tt|]))
+              (mkApp(booleq,[|bb;mkApp(eqI,[|mkVar x;mkVar y|]);tt|]))
         )))
 
 let compute_lb_tact handle ind lnamesparrec nparrec =
@@ -1332,7 +1358,7 @@ let make_lb_scheme env handle mind =
   let nparrec = mib.mind_nparams_rec in
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
-  let lb_goal = compute_lb_goal env handle (ind,u) lnamesparrec nparrec in
+  let uctx, lb_goal = compute_lb_goal env uctx handle (ind,u) lnamesparrec nparrec in
   let lb_goal = EConstr.of_constr lb_goal in
   let poly = Declareops.inductive_is_polymorphic mib in
   let uctx = if poly then Evd.ustate (fst (Typing.sort_of env (Evd.from_ustate uctx) lb_goal)) else uctx in
@@ -1362,31 +1388,38 @@ let check_not_is_defined () =
   then raise (UndefinedCst "not")
 
 (* {n=m}+{n<>m}  part  *)
-let compute_dec_goal env ind lnamesparrec nparrec =
+let compute_dec_goal env uctx (ind,u) lnamesparrec nparrec =
   check_not_is_defined ();
-  let eq = eq () and tt = tt () and bb = bb () in
+  let tt = tt () and bb = bb () in
   let list_id = list_id lnamesparrec in
   let avoid = avoid_of_list_id list_id in
   let x = next_ident_away (Id.of_string "x") avoid in
   let y = next_ident_away (Id.of_string "y") (Id.Set.add x avoid) in
+  let sigma = Evd.from_ustate uctx in
+  let qind, uind = sort_and_univ env sigma (ind, u) in
+  let uctx , fresh_level = UState.new_univ_level_variable UState.univ_flexible None uctx in
+  let uctx = UState.add_constraints uctx @@
+             UnivProblem.Set.singleton (UnivProblem.ULe (Sorts.sort_of_univ uind, (Sorts.sort_of_univ (Univ.Universe.make fresh_level)))) in
+  let indeq = eq qind fresh_level in
+  let booleq = eq Sorts.Quality.qtype Univ.Level.set in
   let open Term in
     let create_input c =
       let lb_typ = List.map (fun (s,seq,_,_) ->
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkVar s) (
             mkNamedProd (Context.make_annot y Sorts.Relevant) (mkVar s) (
               mkArrow
-                ( mkApp(eq,[|mkVar s;mkVar x;mkVar y|]))
+                ( mkApp(indeq,[|mkVar s;mkVar x;mkVar y|]))
                 Sorts.Relevant
-                ( mkApp(eq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
+                ( mkApp(booleq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
           ))
         ) list_id in
       let bl_typ = List.map (fun (s,seq,_,_) ->
         mkNamedProd (Context.make_annot x Sorts.Relevant) (mkVar s) (
             mkNamedProd (Context.make_annot y Sorts.Relevant) (mkVar s) (
               mkArrow
-                ( mkApp(eq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
+                ( mkApp(booleq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
                 Sorts.Relevant
-                ( mkApp(eq,[|mkVar s;mkVar x;mkVar y|]))
+                ( mkApp(indeq,[|mkVar s;mkVar x;mkVar y|]))
           ))
         ) list_id in
 
@@ -1411,23 +1444,23 @@ let compute_dec_goal env ind lnamesparrec nparrec =
           in
           mkNamedProd x (RelDecl.get_type decl) a) eq_input lnamesparrec
     in
-        let eqnm = mkApp(eq,[|mkFullInd env ind (3*nparrec+2);mkVar x;mkVar y|]) in
-        create_input (
-          mkNamedProd (Context.make_annot x Sorts.Relevant) (mkFullInd env ind (3*nparrec)) (
-            mkNamedProd (Context.make_annot y Sorts.Relevant) (mkFullInd env ind (3*nparrec+1)) (
+        let eqnm = mkApp(indeq,[|mkFullInd env (ind,u) (3*nparrec+2);mkVar x;mkVar y|]) in
+        uctx, create_input (
+          mkNamedProd (Context.make_annot x Sorts.Relevant) (mkFullInd env (ind,u) (3*nparrec)) (
+            mkNamedProd (Context.make_annot y Sorts.Relevant) (mkFullInd env (ind,u) (3*nparrec+1)) (
               mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global (Global.env ()) @@ Rocqlib.lib_ref "core.not.type",[|eqnm|])|])
           )
         )
       )
 
 let compute_dec_tact handle (ind,u) lnamesparrec nparrec =
-  let eq = eq () and tt = tt ()
-      and ff = ff () and bb = bb () in
+  let tt = tt () and ff = ff () and bb = bb () in
+  let booleq = eq Sorts.Quality.qtype Univ.Level.set in
   let list_id = list_id lnamesparrec in
   let _ = get_scheme handle beq_scheme_kind ind in (* This is just an assertion? *)
   let _non_fresh_eqI = eqI handle (ind,u) list_id in
-  let eqtrue x = mkApp(eq,[|bb;x;tt|]) in
-  let eqfalse x = mkApp(eq,[|bb;x;ff|]) in
+  let eqtrue x = mkApp(booleq,[|bb;x;tt|]) in
+  let eqfalse x = mkApp(booleq,[|bb;x;ff|]) in
   let first_intros =
     ( List.map (fun (s,_,_,_) -> s ) list_id )
     @ ( List.map (fun (_,seq,_,_) -> seq) list_id )
@@ -1491,7 +1524,7 @@ let compute_dec_tact handle (ind,u) lnamesparrec nparrec =
                           intro;
                           Equality.subst_all ();
                           assert_by (Name freshH3)
-                            (EConstr.of_constr (mkApp(eq,[|bb;mkApp(eqI,[|mkVar freshm;mkVar freshm|]);tt|])))
+                            (EConstr.of_constr (mkApp(booleq,[|bb;mkApp(eqI,[|mkVar freshm;mkVar freshm|]);tt|])))
                             (Tacticals.tclTHENLIST [
                                  apply (EConstr.mkApp(lbI,Array.map EConstr.mkVar xargs));
                                  Auto.default_auto
@@ -1527,7 +1560,8 @@ let make_eq_decidability env handle mind =
 
   let lnonparrec,lnamesparrec =
     Inductive.inductive_nonrec_rec_paramdecls (mib,u) in
-  let dec_goal = EConstr.of_constr (compute_dec_goal env (ind,u) lnamesparrec nparrec) in
+  let uctx, dec_goal = compute_dec_goal env uctx (ind,u) lnamesparrec nparrec in
+  let dec_goal = EConstr.of_constr dec_goal in
   let univ_poly = Declareops.inductive_is_polymorphic mib in
   (* FIXME: cumulativity not handled *)
   let poly = PolyFlags.of_univ_poly univ_poly in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This pr is to define a sort poly version of equality in Logic.v

```rocq
#[universes(polymorphic,cumulative)]
Inductive eq@{s;i} (A:Type@{s;i}) (x:A) : A -> Prop :=
    eq_refl : x = x :>A

where "x = y :> A" := (@eq A x y) : type_scope.
```

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
