### PR TITLE
make Set Default Proof Using available at synterp time

### DIFF
--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -223,7 +223,7 @@ let using_from_string us = Procq.Entry.parse entry
 let proof_using_opt_name = ["Default";"Proof";"Using"]
 let () =
   Goptions.(declare_stringopt_option
-    { optstage = Summary.Stage.Interp;
+    { optstage = Summary.Stage.Synterp;
       optdepr  = None;
       optkey   = proof_using_opt_name;
       optread  = (fun () -> Option.map using_to_string !value);


### PR DESCRIPTION
It seems to have no reason to be at interp time.
The option (especially if it is set) is relevant to a document manager when deciding if proofs can be delegated or not.