### PR TITLE
TC search: log hint before hint is applied

### DIFF
--- a/doc/changelog/02-specification-language/21899-janno-typeclasses-debug-Changed.rst
+++ b/doc/changelog/02-specification-language/21899-janno-typeclasses-debug-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  External hints now emit a new log entry starting with "running HINT on GOAL" before the tactic code is executed; all hints had their log entry for a successful application changed from just "HINT on GOAL" to "applied HINT on GOAL"
+  (`#21899 <https://github.com/rocq-prover/rocq/pull/21899>`_,
+  fixes `#21898 <https://github.com/rocq-prover/rocq/issues/21898>`_,
+  by Jan-Oliver Kaiser).

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -837,9 +837,8 @@ module Search = struct
       if path_matches_epsilon derivs then aux e tl
       else
         let i = !idx in
-        let () = ppdebug 0 (fun () ->
-            let i = i + 1 in
-            pr_depth (i :: info.search_depth) ++ str": applying " ++ Lazy.force pp
+        let () = if hint_extern then ppdebug 0 (fun () ->
+            pr_depth (i :: info.search_depth) ++ str": running " ++ Lazy.force pp
             ++ str" on" ++ spc () ++ pr_ev sigma (Proofview.Goal.goal gl))
         in
         ortac

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -777,7 +777,7 @@ module Search = struct
         let gls = CList.map Proofview.drop_state gls in
         let j = List.length gls in
         let () = ppdebug 0 (fun () ->
-            pr_depth (i :: info.search_depth) ++ str": " ++ Lazy.force pp
+            pr_depth (i :: info.search_depth) ++ str": applied " ++ Lazy.force pp
             ++ str" on" ++ spc () ++ pr_ev sigma (Proofview.Goal.goal gl)
             ++ str", " ++ int j ++ str" subgoal(s)" ++
             (Option.cata (fun k -> str " in addition to the first " ++ int k)
@@ -836,9 +836,15 @@ module Search = struct
       in
       if path_matches_epsilon derivs then aux e tl
       else
+        let i = !idx in
+        let () = ppdebug 0 (fun () ->
+            let i = i + 1 in
+            pr_depth (i :: info.search_depth) ++ str": applying " ++ Lazy.force pp
+            ++ str" on" ++ spc () ++ pr_ev sigma (Proofview.Goal.goal gl))
+        in
         ortac
              (with_shelf tac >>= fun s ->
-              let i = !idx in incr idx; result s i None)
+              incr idx; result s i None)
              (fun e' ->
                 (pr_error e'; aux (merge_exceptions e e') tl))
     and aux e = function

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -836,9 +836,14 @@ module Search = struct
       in
       if path_matches_epsilon derivs then aux e tl
       else
+        let i = !idx in
+        let () = if hint_extern then ppdebug 0 (fun () ->
+            pr_depth (i :: info.search_depth) ++ str": running " ++ Lazy.force pp
+            ++ str" on" ++ spc () ++ pr_ev sigma (Proofview.Goal.goal gl))
+        in
         ortac
              (with_shelf tac >>= fun s ->
-              let i = !idx in incr idx; result s i None)
+              incr idx; result s i None)
              (fun e' ->
                 (pr_error e'; aux (merge_exceptions e e') tl))
     and aux e = function

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -1,18 +1,48 @@
 Debug: 1: looking for foo without backtracking
-Debug: 1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1: applied simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1 : foo
 Debug: 1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-1.1: applied simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1 : foo
 Debug: 1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-1.1-1.1: applied simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1 : foo
 Debug: 1.1-1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-1.1-1.1-1.1: applied simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1.1-1 : foo
 Debug: 1.1-1.1-1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-1.1-1.1-1.1-1.1: applied simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
 File "./output/TypeclassDebug.v", line 13, characters 5-33:
 The command has indeed failed with message:
 Tactic failure: Proof search reached its limit.
+Debug: 1: looking for bar without backtracking
+Debug: 1.1: applied simple apply hint on bar, 1 subgoal(s)
+Debug: 1.1-1 : cls
+Debug: 1.1-1: looking for cls without backtracking
+Debug: 1.1-1.1: applied exact c on cls, 0 subgoal(s)
+Debug: 1: looking for bar without backtracking
+Debug: 1.1: running (*external*) (apply hint) on bar
+Debug: 1.1: applied (*external*) (apply hint) on bar, 1 subgoal(s)
+Debug: 1.1-1 : cls
+Debug: 1.1-1: looking for cls without backtracking
+Debug: 1.1-1.1: applied exact c on cls, 0 subgoal(s)
+Debug: 1: looking for bar without backtracking
+Debug:
+1.1: running (*external*) (let c :=
+                                 constr:((ltac:(typeclasses eauto with foo)
+                                          :>
+                                          cls))
+                             in
+                           exact (hint c)) on
+  bar
+Debug: 1: looking for cls without backtracking
+Debug: 1.1: applied exact c on cls, 0 subgoal(s)
+Debug:
+1.1: applied (*external*) (let c :=
+                                 constr:((ltac:(typeclasses eauto with foo)
+                                          :>
+                                          cls))
+                             in
+                           exact (hint c)) on
+  bar, 0 subgoal(s)

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -16,3 +16,31 @@ Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
 File "./output/TypeclassDebug.v", line 13, characters 5-33:
 The command has indeed failed with message:
 Tactic failure: Proof search reached its limit.
+Debug: 1: looking for bar without backtracking
+Debug: 1.1: simple apply hint on bar, 1 subgoal(s)
+Debug: 1.1-1 : cls
+Debug: 1.1-1: looking for cls without backtracking
+Debug: 1.1-1.1: exact c on cls, 0 subgoal(s)
+Debug: 1: looking for bar without backtracking
+Debug: 1.1: running (*external*) (apply hint) on bar
+Debug: 1.1: (*external*) (apply hint) on bar, 1 subgoal(s)
+Debug: 1.1-1 : cls
+Debug: 1.1-1: looking for cls without backtracking
+Debug: 1.1-1.1: exact c on cls, 0 subgoal(s)
+Debug: 1: looking for bar without backtracking
+Debug:
+1.1: running (*external*) (let c :=
+                                 constr:((ltac:(typeclasses eauto with foo)
+                                          :>
+                                          cls))
+                             in
+                           exact (hint c)) on
+  bar
+Debug: 1: looking for cls without backtracking
+Debug: 1.1: exact c on cls, 0 subgoal(s)
+Debug:
+1.1: (*external*) (let c :=
+                         constr:((ltac:(typeclasses eauto with foo) :> cls))
+                     in
+                   exact (hint c)) on
+  bar, 0 subgoal(s)

--- a/test-suite/output/TypeclassDebug.v
+++ b/test-suite/output/TypeclassDebug.v
@@ -12,3 +12,36 @@ Goal foo.
 Typeclasses eauto := debug.
 Fail typeclasses eauto 5 with foo.
 Abort.
+
+(* Ensure that actions triggered by hints are always preceded by debug output for the hint iself. *)
+Parameter bar cls : Prop.
+Axiom c : cls.
+Axiom hint : cls -> bar.
+Hint Resolve c : foo.
+
+Section Resolve.
+  Hint Resolve hint : foo.
+
+  Goal bar.
+  Proof.
+    typeclasses eauto with foo.
+  Qed.
+End Resolve.
+
+Section ExternApply.
+  Hint Extern 0 bar => apply hint : foo.
+
+  Goal bar.
+  Proof.
+    typeclasses eauto with foo.
+  Qed.
+End ExternApply.
+
+Section ExternTC.
+  Hint Extern 0 bar => let c := constr:(ltac:(typeclasses eauto with foo) :> cls) in exact (hint c) : foo.
+
+  Goal bar.
+  Proof.
+    typeclasses eauto with foo.
+  Qed.
+End ExternTC.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This adds a new line of the form `1.2.3: applying <hint> on <goal>`. Without this, it is sometimes impossible to match debug output that results from running the hint to the hint, especially when a `Hint Extern` calls `typeclasses eauto`.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #21898


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
