### PR TITLE
ide: ignore SIGUSR1 by default in idetop

### DIFF
--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -40,7 +40,12 @@ let valid_interrupt () =
 let init_signal_handler () =
   let f _ = if valid_interrupt () then
               if !catch_break then raise Sys.Break else Control.interrupt := true in
-  Sys.set_signal Sys.sigint (Sys.Signal_handle f)
+  Sys.set_signal Sys.sigint (Sys.Signal_handle f);
+  (* Ignore SIGUSR1 by default: it is used by the IDE's Break button to enter
+     the Ltac debugger, and its Unix default action would terminate the process.
+     The Ltac debugger installs its own handler in db_initialize. *)
+  if Sys.os_type = "Unix" then
+    Sys.set_signal Sys.sigusr1 Sys.Signal_ignore
 
 let pr_with_pid s = Printf.eprintf "[pid %d] %s\n%!" (Unix.getpid ()) s
 


### PR DESCRIPTION
The IDE's Break button sends SIGUSR1 to the idetop worker to enter the Ltac debugger. A handler for this signal is installed only by db_initialize in tactic_debug.ml, so pressing Break before the debugger has ever been initialized caused the worker to be killed by the Unix default action for SIGUSR1.