### PR TITLE
QLeq has nothing to do with elimination

### DIFF
--- a/engine/univProblem.ml
+++ b/engine/univProblem.ml
@@ -21,9 +21,9 @@ type t =
   | UWeak of Level.t * Level.t
 
 let is_trivial = function
-  | QLeq (a,b) -> Inductive.raw_eliminates_to a b
+  | QLeq (QConstant QProp, QConstant QType) -> true
+  | QLeq (a, b) | QEq (a, b) -> Quality.equal a b
   | QElimTo (a, b) -> Inductive.raw_eliminates_to a b
-  | QEq (a, b) -> Quality.equal a b
   | ULe (u, v) | UEq (u, v) -> Sorts.equal u v
   | ULub (u, v) | UWeak (u, v) -> Level.equal u v
 


### PR DESCRIPTION
This probably causes some bugs somewhere, since `Type{i} ≤ Type@{α, j}` doesn't resolve `α := Type` until minimisation or kernel check AFAICT.