### PR TITLE
Create `rocq doc` backend for Alectryon

### DIFF
--- a/doc/changelog/09-cli-tools/21950-coqdoc-alectryon-Added.rst
+++ b/doc/changelog/09-cli-tools/21950-coqdoc-alectryon-Added.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  New Alectryon Markdown backend for `rocq doc`
+  (`#21950 <https://github.com/rocq-prover/rocq/pull/21950>`_,
+  by Dario Halilovic).

--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -302,6 +302,9 @@ suffixes ``.v`` and ``.g`` and |Latex| files by the suffix ``.tex``.
   files given on the command line are copied ‘as is’ in the final
   document . DVI and PostScript can be produced directly with the
   options ``-dvi`` and ``-ps`` respectively.
+:Alectryon output: This option creates a single Markdown file on standard output
+                   that can be understood by Alectryon. Use the option ``-o`` to
+                   redirect the output to a file.
 :TEXmacs output: To translate the input files to TEXmacs format,
   to be used by the TEXmacs Rocq interface.
 
@@ -318,6 +321,7 @@ Command line options
   :--|Latex|: Select a |Latex| output.
   :--dvi: Select a DVI output.
   :--ps: Select a PostScript output.
+  :--alectryon: Select a Markdown output for Alectryon.
   :--texmacs: Select a TEXmacs output.
   :--stdout: Write output to stdout.
   :-o file, --output file: Redirect the output into the file ‘file’

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -767,7 +767,9 @@ $(addsuffix .log,$(wildcard coqdoc/*.v)): %.v.log: %.v %.html.out %.tex.out $(PR
 	  f=`basename $*`; \
 	  $(coqdoc) -utf8 -R . Coqdoc -coqlib_url http://coq.inria.fr/stdlib --html $$f.v 2>&1; \
 	  $(coqdoc) -utf8 -R . Coqdoc -coqlib_url http://coq.inria.fr/stdlib --latex $$f.v 2>&1; \
+	  $(coqdoc) -utf8 -R . Coqdoc -coqlib_url http://coq.inria.fr/stdlib --alectryon $$f.v 2>&1; \
 	  diff -u --strip-trailing-cr $$f.html.out Coqdoc.$$f.html 2>&1; R=$$?; times; \
+	  diff -u --strip-trailing-cr $$f.myst.out Coqdoc.$$f.myst 2>&1; R=$$?; times; \
 	  grep -v "^%%" Coqdoc.$$f.tex | diff -u --strip-trailing-cr $$f.tex.out - 2>&1; S=$$?; times; \
 	  if [ $$R = 0 -a $$S = 0 ]; then \
 	    echo $(log_success); \

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -527,6 +527,10 @@ approve-coqdoc: coqdoc
 	  cp "Coqdoc.$${f%.out}" "$$f"; \
 	  echo "Updated $$f!"; \
 	fi; done; \
+	for f in *.myst.out; do if [ -f "$$f" ]; then \
+	  cp "Coqdoc.$${f%.out}" "$$f"; \
+	  echo "Updated $$f!"; \
+	fi; done; \
 	for f in *.tex.out; do if [ -f "$$f" ]; then \
 	  cat "Coqdoc.$${f%.out}" | grep -v "^%%" > "$$f"; \
 	  echo "Updated $$f!"; \

--- a/test-suite/coqdoc/Context.myst.out
+++ b/test-suite/coqdoc/Context.myst.out
@@ -1,0 +1,6 @@
+```{coq}
+Section Sec.
+Context (foo : nat).
+Check foo.
+End Sec.
+```

--- a/test-suite/coqdoc/Record.myst.out
+++ b/test-suite/coqdoc/Record.myst.out
@@ -1,0 +1,4 @@
+```{coq}
+Record a := { b : nat ; c : bool }.
+Definition d := {| b := 0 ; c := true |}.
+```

--- a/test-suite/coqdoc/binder.myst.out
+++ b/test-suite/coqdoc/binder.myst.out
@@ -1,0 +1,7 @@
+```{coq}
+```
+Link binders 
+```{coq}
+
+Definition foo alpha beta := alpha + beta.
+```

--- a/test-suite/coqdoc/bug11194.myst.out
+++ b/test-suite/coqdoc/bug11194.myst.out
@@ -1,0 +1,7 @@
+```{coq}
+Record a_struct := { anum : nat }.
+Canonical Structure a_struct_0 := {| anum := 0|}.
+Definition rename_a_s_0 := a_struct_0.
+Coercion some_nat := (@Some nat).
+Definition rename_some_nat := some_nat.
+```

--- a/test-suite/coqdoc/bug11353.myst.out
+++ b/test-suite/coqdoc/bug11353.myst.out
@@ -1,0 +1,8 @@
+```{coq}
+Definition a := 0. #[   universes( template) ]
+Inductive mysum (A B:Type) : Type :=
+  | myinl : A -> mysum A B
+  | myinr : B -> mysum A B.
+
+#[local]Definition b := 1.
+```

--- a/test-suite/coqdoc/bug12742.myst.out
+++ b/test-suite/coqdoc/bug12742.myst.out
@@ -1,0 +1,26 @@
+```{coq}
+```
+Xxx xxxx xx xxxxx xxxxxxx xxxxx xxx xxxxxxxx xxxxxxx xxx xxx xxxx
+     xxxxxxxxxxxxxx: XX xxx xxxx xxxx xxxxxxxxx xxxxxxxxxxxxx xx xxxxx.
+     Xxx xx xxxxx xxx xxxx xxx xxxxxxxxxxx xx xxxxxxxx xxxxx xxx
+     xxxxxxx xxxxxxxxx xxxxxx xx xxxxxxx xxxxxxxxxxxx.  Xxxxx xxxxx
+     xxxx xxxx xxx xxxxx xxxxxxxxxx:
+
+
+- _Xxxxxxxxx xxxxxxx xxxxxxx_ xxxxxxx "xxxx-xxxxxx" xxxxxxxxx:
+          xxx xxxx xxxx x xxxxxxxxxxx xxx xxxx xxxxxx xxxxxx _xxxx_ xx
+          _xxxxx_ (xx, xxxxxxxxx, _xxx'x xxxx: xxx xxx xx xxxx_).
+          Xxxxxxxx xxxxx xxxxxxxxxxxx xxx xxxxx xxxxxxx xx xxxxxxxx
+          xxxxxxx, xxxx xxxx xxxxxxx xxxxxxxxxxxx xx xxxxxx xxxxx xxx
+          xxx xxxx xxx xx x xxxxxxxxx xx xxxxxxxx.  Xxxxxxxx xx xxxx
+          xxxxx xxxxxxx XXX xxxxxxx, XXX xxxxxxx, xxx xxxxx xxxxxxxx.
+
+
+- _Xxxxx xxxxxxxxxx_ xxx xxxxxx xxxxx xxxx xxxxxxxx xxx xxxx
+          xxxxxxx xxxxxxx xx xxxxxxxx xxxxxx xxxxx xxxxxxxxx xx xxxxx
+          xxxxxxxx xxx xxxx xxxxxxxxx xxxxxxx.  Xxxxxx xxxx xxxxx
+          xxxxxxxxxx xxxxxxx Xxxxxxxx, Xxxx, Xxxxx, XXXx, XXX, xxx Xxx,
+          xxxxx xxxx xxxxxx.
+
+```{coq}
+```

--- a/test-suite/coqdoc/bug5648.myst.out
+++ b/test-suite/coqdoc/bug5648.myst.out
@@ -1,0 +1,21 @@
+```{coq}
+Lemma a : True.
+Proof.
+auto.
+Qed.
+
+Variant t :=
+| A | Add | G | Goal | L | Lemma | P | Proof .
+
+Definition d x :=
+  match x with
+  | A => 0
+  | Add => 1
+  | G => 2
+  | Goal => 3
+  | L => 4
+  | Lemma => 5
+  | P => 6
+  | Proof => 7
+  end.
+```

--- a/test-suite/coqdoc/bug5700.myst.out
+++ b/test-suite/coqdoc/bug5700.myst.out
@@ -1,0 +1,11 @@
+```{coq}
+```
+` foo (* {bar_bar} *) ` 
+```{coq}
+Definition const1 := 1.
+
+```
+` more (* nested (* comments *) within verbatim *) ` 
+```{coq}
+Definition const2 := 2.
+```

--- a/test-suite/coqdoc/details.myst.out
+++ b/test-suite/coqdoc/details.myst.out
@@ -1,0 +1,23 @@
+```{coq}
+```
+:::{dropdown}
+```{coq}
+Definition foo : nat := 3.
+```
+
+:::
+```{coq}
+
+```
+:::{dropdown} Foo bar 
+```{coq}
+Fixpoint idnat (x : nat) : nat :=
+  match x with
+  | S x => S (idnat x)
+  | 0 => 0
+  end.
+```
+
+:::
+```{coq}
+```

--- a/test-suite/coqdoc/links.myst.out
+++ b/test-suite/coqdoc/links.myst.out
@@ -1,0 +1,106 @@
+```{coq}
+```
+Various checks for coqdoc
+
+
+- symbols should not be inlined in string g
+- links to both kinds of notations in a' should work to the right notation
+- with utf8 option, forall must be unicode
+- splitting between symbols and ident should be correct in a' and c
+- ".." should be rendered correctly
+
+```{coq}
+
+Definition a (b: nat) := b.
+
+Definition f := forall C:Prop, C.
+
+Notation "n ++ m" := (plus n m).
+
+Notation "n ++ m" := (mult n m). 
+Notation "n ** m" := (plus n m) (at level 60).
+
+Notation "n ▵ m" := (plus n m) (at level 60).
+
+Notation "n '_' ++ 'x' m" := (plus n m) (at level 3).
+
+Inductive eq (A:Type) (x:A) : A -> Prop := eq_refl : x = x :>A
+
+where "x = y :> A" := (@eq A x y) : type_scope.
+
+Definition eq0 := 0 = 0 :> nat.
+
+Notation "( x # y ; .. ; z )" := (pair .. (pair x y) .. z).
+
+Definition b_α := ((0#0;0) , (0 ** 0)).
+
+Notation h := a.
+
+  Section test.
+
+    Variables b' b2: nat.
+
+    Notation "n + m" := (n ▵ m) : my_scope.
+
+    Delimit Scope my_scope with my.
+
+    Notation l := 0.
+
+    Definition α := (0 + l)%my.
+
+    Definition a' b := b'++0++b2 _ ++x b.
+
+    Definition c := {True}+{True}.
+
+    Definition d := (1+2)%nat.
+
+    Lemma e : nat + nat.
+    Admitted.
+
+  End test.
+
+  Section test2.
+
+    Variables b': nat.
+
+    Section test.
+
+      Variables b2: nat.
+
+      Definition a'' b := b' ++ O ++ b2 _ ++ x b + h 0.
+
+    End test.
+
+  End test2.
+
+```
+skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+
+ skip 
+```{coq}
+
+```

--- a/test-suite/coqdoc/multiple_links.myst.out
+++ b/test-suite/coqdoc/multiple_links.myst.out
@@ -1,0 +1,5 @@
+```{coq}
+Inductive t := X | T : t -> t.
+Check X.
+Check t.
+Check t_ind. ```

--- a/test-suite/coqdoc/reference.html.out
+++ b/test-suite/coqdoc/reference.html.out
@@ -1,0 +1,140 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link href="coqdoc.css" rel="stylesheet" type="text/css" />
+<title>Coqdoc.reference</title>
+</head>
+
+<body>
+
+<div id="page">
+
+<div id="header">
+</div>
+
+<div id="main">
+
+<h1 class="libtitle">Library Coqdoc.reference</h1>
+
+<div class="code">
+</div>
+
+<div class="doc">
+This is a reference file that tests most of rocq doc's features. 
+<div class="paragraph"> </div>
+
+<a id="lab1"></a><h1 class="section">Here's a heading</h1>
+
+
+<div class="paragraph"> </div>
+
+    The number of asterisks in front of the heading determine the level of the
+    heading. For example: 
+<div class="paragraph"> </div>
+
+<a id="lab2"></a><h2 class="section">Here's a subheading</h2>
+<a id="lab3"></a><h3 class="section">Here's a subsubheading</h3>
+<a id="lab4"></a><h4 class="section">Here's the lowest possible heading</h4>
+
+<div class="paragraph"> </div>
+
+ Rocq doc comments are placed between <code>(** </code> and <code>*) </code>. Contrary to regular
+    comments, the comment starts with two asterisks instead of one.
+
+<div class="paragraph"> </div>
+
+    Above, we have used angle brackets to present verbatim material. Verbatim material
+    can also take multiple lines:
+<pre>
+    let rec fact n =
+      if n &lt;= 1 then 1 else n * fact (n - 1)
+</pre>
+
+<div class="paragraph"> </div>
+
+ Rocq material can be quoted inline using square brackets, as follows: <span class="inlinecode"><span class="id" title="keyword">∀</span></span> <span class="inlinecode"><span class="id" title="var">n</span></span> <span class="inlinecode">:</span> <span class="inlinecode"><span class="id" title="var">nat</span>,</span> <span class="inlinecode"><span class="id" title="var">fact</span></span> <span class="inlinecode"><span class="id" title="var">n</span></span> <span class="inlinecode">≥</span> <span class="inlinecode"><span class="id" title="var">n</span></span>.
+    For vernacular material, we double the square brackets, and place them on separate lines, like so:
+    <br/>
+<span class="inlinecode">&nbsp;&nbsp;&nbsp;&nbsp;<span class="id" title="keyword">From</span> <span class="id" title="var">Stdlib</span> <span class="id" title="keyword">Require</span> <span class="id" title="keyword">Import</span> <span class="id" title="var">Lia</span>.<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;
+<div class="paragraph"> </div>
+
+</span>
+<div class="paragraph"> </div>
+
+ Let's implement the <span class="inlinecode"><span class="id" title="var">fact</span></span> OCaml function in Rocq! 
+</div>
+<div class="code">
+
+<br/>
+<span class="id" title="keyword">Fixpoint</span> <a id="fact" class="idref" href="#fact"><span class="id" title="definition">fact</span></a> (<a id="n:1" class="idref" href="#n:1"><span class="id" title="binder">n</span></a> : <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#nat"><span class="id" title="inductive">nat</span></a>) : <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#nat"><span class="id" title="inductive">nat</span></a> :=<br/>
+&nbsp;&nbsp;<span class="id" title="keyword">match</span> <a class="idref" href="Coqdoc.reference.html#n:1"><span class="id" title="variable">n</span></a> <span class="id" title="keyword">with</span><br/>
+&nbsp;&nbsp;| 0 ⇒ 1<br/>
+&nbsp;&nbsp;| <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#S"><span class="id" title="constructor">S</span></a> <span class="id" title="var">n'</span> ⇒<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a class="idref" href="Coqdoc.reference.html#n:1"><span class="id" title="variable">n</span></a> <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Peano.html#ea2ff3d561159081cea6fb2e8113cc54"><span class="id" title="notation">×</span></a> <a class="idref" href="Coqdoc.reference.html#fact:2"><span class="id" title="definition">fact</span></a> <span class="id" title="var">n'</span><br/>
+&nbsp;&nbsp;<span class="id" title="keyword">end</span>.<br/>
+
+<br/>
+</div>
+
+<div class="doc">
+Here's the rest of the formatting rules:
+<ul class="doclist">
+<li> To emphasize text, place it between underscores, <i>like so</i>.
+
+</li>
+<li> To insert LaTeX math:
+<ul class="doclist">
+<li> Use dollar signs for LaTeX in math mode: 
+
+</li>
+<li> Use percent signs for other LaTeX materials: 
+
+</li>
+</ul>
+
+</li>
+</ul>
+
+<div class="paragraph"> </div>
+
+    To create (nested) lists, use bullets, as we have done above! 
+<div class="paragraph"> </div>
+
+<hr/>
+ 
+<div class="paragraph"> </div>
+
+ Finally, some parts of the code can be hidden from the output, or placed in a dropdown. 
+</div>
+<div class="code">
+
+<br/>
+
+<br/>
+</div>
+<details><div class="code">
+<span class="id" title="keyword">Definition</span> <a id="this_definition_is_in_a_dropdown" class="idref" href="#this_definition_is_in_a_dropdown"><span class="id" title="definition">this_definition_is_in_a_dropdown</span></a> : <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#unit"><span class="id" title="inductive">unit</span></a> := <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#tt"><span class="id" title="constructor">tt</span></a>.<br/>
+</div>
+</details><div class="code">
+
+<br/>
+</div>
+<details><summary>Some summary </summary><div class="code">
+<span class="id" title="keyword">Definition</span> <a id="this_definition_is_in_a_dropdown_with_a_summary" class="idref" href="#this_definition_is_in_a_dropdown_with_a_summary"><span class="id" title="definition">this_definition_is_in_a_dropdown_with_a_summary</span></a> : <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#unit"><span class="id" title="inductive">unit</span></a> := <a class="idref" href="http://coq.inria.fr/stdlib/Corelib.Init.Datatypes.html#tt"><span class="id" title="constructor">tt</span></a>.<br/>
+</div>
+</details><div class="code">
+</div>
+</div>
+
+<div id="footer">
+<hr/><a href="index.html">Index</a><hr/>This page has been generated by <a href="http://rocq-prover.org/">coqdoc</a>
+</div>
+
+</div>
+
+</body>
+</html>

--- a/test-suite/coqdoc/reference.myst.out
+++ b/test-suite/coqdoc/reference.myst.out
@@ -1,0 +1,84 @@
+```{coq}
+```
+This is a reference file that tests most of rocq doc's features. 
+
+# Here's a heading
+
+
+
+    The number of asterisks in front of the heading determine the level of the
+    heading. For example: 
+
+## Here's a subheading
+### Here's a subsubheading
+#### Here's the lowest possible heading
+
+
+ Rocq doc comments are placed between `(** ` and `*) `. Contrary to regular
+    comments, the comment starts with two asterisks instead of one.
+
+
+    Above, we have used angle brackets to present verbatim material. Verbatim material
+    can also take multiple lines:
+```
+    let rec fact n =
+      if n <= 1 then 1 else n * fact (n - 1)
+```
+
+
+ Rocq material can be quoted inline using square brackets, as follows: `forall` `n` `:` `nat,` `fact` `n` `>=` `n`.
+    For vernacular material, we double the square brackets, and place them on separate lines, like so:
+    
+```coq
+    From Stdlib Require Import Lia.
+    
+
+```
+
+ Let's implement the `fact` OCaml function in Rocq! 
+```{coq}
+
+Fixpoint fact (n : nat) : nat :=
+  match n with
+  | 0 => 1
+  | S n' =>
+      
+      n * fact n'
+  end.
+
+```
+Here's the rest of the formatting rules:
+- To emphasize text, place it between underscores, _like so_.
+- To insert LaTeX math:
+  * Use dollar signs for LaTeX in math mode: {math}`e = mc^2`
+  * Use percent signs for other LaTeX materials: \usepackage{coqdoc}
+
+
+    To create (nested) lists, use bullets, as we have done above! 
+
+
+---
+ 
+
+ Finally, some parts of the code can be hidden from the output, or placed in a dropdown. 
+```{coq}
+
+
+```
+:::{dropdown}
+```{coq}
+Definition this_definition_is_in_a_dropdown : unit := tt.
+```
+
+:::
+```{coq}
+
+```
+:::{dropdown} Some summary 
+```{coq}
+Definition this_definition_is_in_a_dropdown_with_a_summary : unit := tt.
+```
+
+:::
+```{coq}
+```

--- a/test-suite/coqdoc/reference.tex.out
+++ b/test-suite/coqdoc/reference.tex.out
@@ -1,0 +1,125 @@
+\documentclass[12pt]{report}
+\usepackage[utf8x]{inputenc}
+
+%Warning: tipa declares many non-standard macros used by utf8x to
+%interpret utf8 characters but extra packages might have to be added
+%such as "textgreek" for Greek letters not already in tipa
+%or "stmaryrd" for mathematical symbols.
+%Utf8 codes missing a LaTeX interpretation can be defined by using
+%\DeclareUnicodeCharacter{code}{interpretation}.
+%Use coqdoc's option -p to add new packages or declarations.
+\usepackage{tipa}
+
+\usepackage[T1]{fontenc}
+\usepackage{fullpage}
+\usepackage{coqdoc}
+\usepackage{amsmath,amssymb}
+\usepackage{url}
+\begin{document}
+\coqlibrary{Coqdoc.reference}{Library }{Coqdoc.reference}
+
+\begin{coqdoccode}
+\end{coqdoccode}
+This is a reference file that tests most of rocq doc's features. 
+
+\section{Here's a heading}
+
+
+
+
+    The number of asterisks in front of the heading determine the level of the
+    heading. For example: 
+
+\subsection{Here's a subheading}
+
+\subsubsection{Here's a subsubheading}
+
+\paragraph{Here's the lowest possible heading}
+
+
+
+ Rocq doc comments are placed between \texttt{(** } and \texttt{*) }. Contrary to regular
+    comments, the comment starts with two asterisks instead of one.
+
+
+    Above, we have used angle brackets to present verbatim material. Verbatim material
+    can also take multiple lines:
+\begin{verbatim}
+    let rec fact n =
+      if n <= 1 then 1 else n * fact (n - 1)
+\end{verbatim}
+
+
+ Rocq material can be quoted inline using square brackets, as follows: \coqdockw{\ensuremath{\forall}} \coqdocvar{n} : \coqdocvar{nat}, \coqdocvar{fact} \coqdocvar{n} \ensuremath{\ge} \coqdocvar{n}.
+    For vernacular material, we double the square brackets, and place them on separate lines, like so:
+    \coqdoceol
+\coqdocemptyline
+\coqdocindent{2.00em}
+\coqdockw{From} \coqdocvar{Stdlib} \coqdockw{Require} \coqdockw{Import} \coqdocvar{Lia}.\coqdoceol
+\coqdocindent{2.00em}
+
+
+\coqdocemptyline
+
+
+ Let's implement the \coqdocvar{fact} OCaml function in Rocq! 
+\begin{coqdoccode}
+\coqdocemptyline
+\coqdocnoindent
+\coqdockw{Fixpoint} \coqdef{Coqdoc.reference.fact}{fact}{\coqdocdefinition{fact}} (\coqdef{Coqdoc.reference.n:1}{n}{\coqdocbinder{n}} : \coqexternalref{nat}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocinductive{nat}}) : \coqexternalref{nat}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocinductive{nat}} :=\coqdoceol
+\coqdocindent{1.00em}
+\coqdockw{match} \coqref{Coqdoc.reference.n:1}{\coqdocvariable{n}} \coqdockw{with}\coqdoceol
+\coqdocindent{1.00em}
+\ensuremath{|} 0 \ensuremath{\Rightarrow} 1\coqdoceol
+\coqdocindent{1.00em}
+\ensuremath{|} \coqexternalref{S}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocconstructor{S}} \coqdocvar{n'} \ensuremath{\Rightarrow}\coqdoceol
+\coqdocindent{3.00em}
+\coqdoceol
+\coqdocindent{3.00em}
+\coqref{Coqdoc.reference.n:1}{\coqdocvariable{n}} \coqexternalref{::nat scope:x '*' x}{http://coq.inria.fr/stdlib/Corelib.Init.Peano}{\coqdocnotation{\ensuremath{\times}}} \coqref{Coqdoc.reference.fact:2}{\coqdocdefinition{fact}} \coqdocvar{n'}\coqdoceol
+\coqdocindent{1.00em}
+\coqdockw{end}.\coqdoceol
+\coqdocemptyline
+\end{coqdoccode}
+Here's the rest of the formatting rules:
+
+\begin{itemize}
+\item  To emphasize text, place it between underscores, \textit{like so}.
+
+\item  To insert LaTeX math:
+
+\begin{itemize}
+\item  Use dollar signs for LaTeX in math mode: $e = mc^2$
+
+\item  Use percent signs for other LaTeX materials: \usepackage{coqdoc}
+
+\end{itemize}
+
+\end{itemize}
+
+
+    To create (nested) lists, use bullets, as we have done above! 
+
+\par
+\noindent\hrulefill\par
+\noindent{} 
+
+ Finally, some parts of the code can be hidden from the output, or placed in a dropdown. 
+\begin{coqdoccode}
+\coqdocemptyline
+\coqdocemptyline
+\end{coqdoccode}
+\begin{coqdoccode}
+\coqdocnoindent
+\coqdockw{Definition} \coqdef{Coqdoc.reference.this definition is in a dropdown}{this\_definition\_is\_in\_a\_dropdown}{\coqdocdefinition{this\_definition\_is\_in\_a\_dropdown}} : \coqexternalref{unit}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocinductive{unit}} := \coqexternalref{tt}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocconstructor{tt}}.\coqdoceol
+\end{coqdoccode}
+\begin{coqdoccode}
+\coqdocemptyline
+\end{coqdoccode}
+\begin{coqdoccode}
+\coqdocnoindent
+\coqdockw{Definition} \coqdef{Coqdoc.reference.this definition is in a dropdown with a summary}{this\_definition\_is\_in\_a\_dropdown\_with\_a\_summary}{\coqdocdefinition{this\_definition\_is\_in\_a\_dropdown\_with\_a\_summary}} : \coqexternalref{unit}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocinductive{unit}} := \coqexternalref{tt}{http://coq.inria.fr/stdlib/Corelib.Init.Datatypes}{\coqdocconstructor{tt}}.\coqdoceol
+\end{coqdoccode}
+\begin{coqdoccode}
+\end{coqdoccode}
+\end{document}

--- a/test-suite/coqdoc/reference.v
+++ b/test-suite/coqdoc/reference.v
@@ -1,0 +1,62 @@
+(** This is a reference file that tests most of rocq doc's features. *)
+
+(** * Here's a heading
+
+    The number of asterisks in front of the heading determine the level of the
+    heading. For example: *)
+
+(** ** Here's a subheading *)
+(** *** Here's a subsubheading *)
+(** **** Here's the lowest possible heading *)
+
+(** Rocq doc comments are placed between << (** >> and << *) >>. Contrary to regular
+    comments, the comment starts with two asterisks instead of one.
+
+    Above, we have used angle brackets to present verbatim material. Verbatim material
+    can also take multiple lines:
+<<
+    let rec fact n =
+      if n <= 1 then 1 else n * fact (n - 1)
+>>
+*)
+
+(** Rocq material can be quoted inline using square brackets, as follows: [forall n : nat, fact n >= n].
+    For vernacular material, we double the square brackets, and place them on separate lines, like so:
+    [[
+    From Stdlib Require Import Lia.
+    ]]
+*)
+
+(** Let's implement the [fact] OCaml function in Rocq! *)
+
+Fixpoint fact (n : nat) : nat :=
+  match n with
+  | 0 => 1
+  | S n' =>
+      (* This is a regular comment. *)
+      n * fact n'
+  end.
+
+(** Here's the rest of the formatting rules:
+    - To emphasize text, place it between underscores, _like so_.
+    - To insert LaTeX math:
+      - Use dollar signs for LaTeX in math mode: $e = mc^2$
+      - Use percent signs for other LaTeX materials: %\usepackage{coqdoc}%
+
+    To create (nested) lists, use bullets, as we have done above! *)
+
+(** ---- *)
+
+(** Finally, some parts of the code can be hidden from the output, or placed in a dropdown. *)
+
+(* begin hide *)
+Definition this_definition_will_not_appear : unit := tt.
+(* end hide *)
+
+(* begin details *)
+Definition this_definition_is_in_a_dropdown : unit := tt.
+(* end details *)
+
+(* begin details : Some summary *)
+Definition this_definition_is_in_a_dropdown_with_a_summary : unit := tt.
+(* end details *)

--- a/test-suite/coqdoc/typeclasses.myst.out
+++ b/test-suite/coqdoc/typeclasses.myst.out
@@ -1,0 +1,13 @@
+```{coq}
+Class EqDec T := { eqb : T -> T -> bool }.
+
+Section TC.
+
+#[local] Instance unit_EqDec : EqDec unit := { eqb := fun _ _ => true }.
+
+End TC.
+
+#[local] Existing Instance unit_EqDec.
+
+Existing Class EqDec.
+```

--- a/test-suite/coqdoc/verbatim.myst.out
+++ b/test-suite/coqdoc/verbatim.myst.out
@@ -1,0 +1,52 @@
+```{coq}
+```
+
+
+```
+uint32_t shift_right( uint32_t a, uint32_t shift )
+{
+    return a >> shift;
+}
+```
+
+
+This line and the following shows `verbatim ` text:
+
+
+` A stand-alone inline verbatim `
+
+
+` A non-ended inline verbatim to test line location
+`
+
+
+- item 1
+- item 2 is `verbatim`
+- item 3 is `verbatim` too
+
+```coq
+A coq block : forall n, n = 0
+
+```- `verbatim` again, and a formula `` `True` `->` `False` ``
+-
+```
+multiline
+verbatim
+```
+- last item
+
+
+```
+Γ ⊢ A
+----
+Γ ⊢ A ∨ B
+```
+
+
+```
+A non-ended block verbatim to test line location
+
+*)
+```
+```{coq}
+```

--- a/tools/coqdoc/cmdArgs.ml
+++ b/tools/coqdoc/cmdArgs.ml
@@ -97,6 +97,8 @@ let args_options = Arg.align [
   " Produce a LaTeX document";
   "--texmacs",arg_set (fun p -> { p with targetlang = TeXmacs }),
   " Produce a TeXmacs document";
+  "--alectryon", arg_set (fun p -> { p with targetlang = AlectryonMarkdown }),
+  " Produce a Markdown document for Alectryon";
   "--raw", arg_set (fun p -> { p with targetlang = Raw }),
   " Produce a text document";
   "--dvi", arg_set (fun p -> { { p with targetlang = LaTeX }

--- a/tools/coqdoc/common.ml
+++ b/tools/coqdoc/common.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (* Misc types **********************************************************************)
-type target_language = LaTeX | HTML | TeXmacs | Raw
+type target_language = LaTeX | HTML | TeXmacs | AlectryonMarkdown | Raw
 type output_t = StdOut | MultFiles | File of string
 type coq_module = string
 type file_t = Vernac_file of string * coq_module | Latex_file of string

--- a/tools/coqdoc/common.mli
+++ b/tools/coqdoc/common.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (* Misc types **********************************************************************)
-type target_language = LaTeX | HTML | TeXmacs | Raw
+type target_language = LaTeX | HTML | TeXmacs | AlectryonMarkdown | Raw
 type output_t = StdOut | MultFiles | File of string
 type coq_module = string
 type file_t = Vernac_file of string * coq_module | Latex_file of string

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -1119,6 +1119,122 @@ module TeXmacs = struct
 
 end
 
+(*s Alectryon Markdown output *)
+
+module AlectryonMarkdown = struct
+
+  let header () = ()
+
+  let trailer () = ()
+
+  let nbsp () = output_char ' '
+
+  let char = output_char
+
+  let latex_char = output_char
+  let latex_string = output_string
+
+  let html_char _ = ()
+  let html_string _ = ()
+
+  let raw_ident s =
+    for i = 0 to String.length s - 1 do char s.[i] done
+
+  let start_module () = ()
+
+  let start_latex_math () = output_string "{math}`"
+  let stop_latex_math () = output_string "`"
+
+  let start_verbatim inline =
+    if inline then output_char '`' else output_string "```\n"
+  let stop_verbatim inline =
+    if inline then output_char '`' else output_string "```\n"
+
+
+  let url addr name =
+    match name with
+    | Some n -> printf "[%s](%s)" n addr
+    | None -> printf "%s" addr
+
+  let start_quote () = printf "\""
+  let stop_quote () = printf "\""
+
+  let indentation n =
+      for _i = 1 to n do printf " " done
+
+  let keyword s loc = raw_ident s
+  let ident s loc = raw_ident s
+
+  let sublexer c l = char c
+  let sublexer_in_doc c = char c
+
+  let initialize () =
+    Tokens.token_tree := ref Tokens.empty_ttree;
+    Tokens.outfun := (fun _ _ _ _ -> failwith "Useless")
+
+  let proofbox () = Html.proofbox ()
+
+  let item n =
+    indentation ((n - 1) * 2);
+    if (n mod 2) = 1 then printf "-" else printf "*"
+  let stop_item () = ()
+  let reach_item_level _ = ()
+
+  let start_doc () = ()
+  let end_doc () = ()
+
+  let start_emph () = printf "_"
+  let stop_emph () = printf "_"
+
+  let start_details summary =
+    match summary with
+    | Some summary -> printf ":::{dropdown} %s\n" summary
+    | None -> output_string ":::{dropdown}\n"
+
+  let stop_details () = output_string "\n:::\n"
+
+  let start_comment () = printf "(*"
+  let end_comment () = printf "*)"
+
+  let start_coq () =
+    output_string "```{coq}\n"
+  let end_coq () =
+    output_string "```\n"
+
+  let section_kind =
+    function
+      | 1 -> "# "
+      | 2 -> "## "
+      | 3 -> "### "
+      | 4 -> "#### "
+      | _ -> assert false
+
+  let section lev f =
+    output_string (section_kind lev);
+    f ();
+    output_string "\n"
+
+  let rule () = printf "\n---\n"
+
+  let paragraph () = printf "\n\n"
+
+  let line_break () = printf "\n"
+
+  let empty_line_of_code () = printf "\n"
+
+  let start_inline_coq () = printf "`"
+  let end_inline_coq () = printf "`"
+
+  let start_inline_coq_block () =
+    (* Note: ```coq is different from ```{coq}
+       The former does not send its code to Alectryon. *)
+    line_break (); printf "```coq\n"
+  let end_inline_coq_block () = printf "```"
+
+  let make_multi_index () = ()
+  let make_index () = output_string "```{show-index}\n```"
+  let make_toc () = output_string ":::{toc}\n:context: page\n:::\n"
+end
 
 (*s Raw output *)
 
@@ -1227,96 +1343,100 @@ end
 
 (*s Generic output *)
 
-let select f1 f2 f3 f4 x =
-  match !prefs.targetlang with LaTeX -> f1 x | HTML -> f2 x | TeXmacs -> f3 x | Raw -> f4 x
+let select f1 f2 f3 f4 f5 x =
+  match !prefs.targetlang with
+  | LaTeX -> f1 x
+  | HTML -> f2 x
+  | TeXmacs -> f3 x
+  | AlectryonMarkdown -> f4 x
+  | Raw -> f5 x
 
 let push_in_preamble = Latex.push_in_preamble
 
-let header = select Latex.header Html.header TeXmacs.header Raw.header
-let trailer = select Latex.trailer Html.trailer TeXmacs.trailer Raw.trailer
+let header = select Latex.header Html.header TeXmacs.header AlectryonMarkdown.header Raw.header
+let trailer = select Latex.trailer Html.trailer TeXmacs.trailer AlectryonMarkdown.trailer Raw.trailer
 
 let start_module =
-  select Latex.start_module Html.start_module TeXmacs.start_module Raw.start_module
+  select Latex.start_module Html.start_module TeXmacs.start_module AlectryonMarkdown.start_module Raw.start_module
 
-let start_doc = select Latex.start_doc Html.start_doc TeXmacs.start_doc Raw.start_doc
-let end_doc = select Latex.end_doc Html.end_doc TeXmacs.end_doc Raw.end_doc
+let start_doc = select Latex.start_doc Html.start_doc TeXmacs.start_doc AlectryonMarkdown.start_doc Raw.start_doc
+let end_doc = select Latex.end_doc Html.end_doc TeXmacs.end_doc AlectryonMarkdown.end_doc Raw.end_doc
 
-let start_comment = select Latex.start_comment Html.start_comment TeXmacs.start_comment Raw.start_comment
-let end_comment = select Latex.end_comment Html.end_comment TeXmacs.end_comment Raw.end_comment
+let start_comment = select Latex.start_comment Html.start_comment TeXmacs.start_comment AlectryonMarkdown.start_comment Raw.start_comment
+let end_comment = select Latex.end_comment Html.end_comment TeXmacs.end_comment AlectryonMarkdown.end_comment Raw.end_comment
 
-let start_coq = select Latex.start_coq Html.start_coq TeXmacs.start_coq Raw.start_coq
-let end_coq = select Latex.end_coq Html.end_coq TeXmacs.end_coq Raw.end_coq
+let start_coq = select Latex.start_coq Html.start_coq TeXmacs.start_coq AlectryonMarkdown.start_coq Raw.start_coq
+let end_coq = select Latex.end_coq Html.end_coq TeXmacs.end_coq AlectryonMarkdown.end_coq Raw.end_coq
 
 let start_inline_coq =
-  select Latex.start_inline_coq Html.start_inline_coq TeXmacs.start_inline_coq Raw.start_inline_coq
+  select Latex.start_inline_coq Html.start_inline_coq TeXmacs.start_inline_coq AlectryonMarkdown.start_inline_coq Raw.start_inline_coq
 let end_inline_coq =
-  select Latex.end_inline_coq Html.end_inline_coq TeXmacs.end_inline_coq Raw.end_inline_coq
+  select Latex.end_inline_coq Html.end_inline_coq TeXmacs.end_inline_coq AlectryonMarkdown.end_inline_coq Raw.end_inline_coq
 
 let start_inline_coq_block =
   select Latex.start_inline_coq_block Html.start_inline_coq_block
-    TeXmacs.start_inline_coq_block Raw.start_inline_coq_block
+    TeXmacs.start_inline_coq_block AlectryonMarkdown.start_inline_coq_block Raw.start_inline_coq_block
 let end_inline_coq_block =
-  select Latex.end_inline_coq_block Html.end_inline_coq_block TeXmacs.end_inline_coq_block Raw.end_inline_coq_block
+  select Latex.end_inline_coq_block Html.end_inline_coq_block TeXmacs.end_inline_coq_block AlectryonMarkdown.end_inline_coq_block Raw.end_inline_coq_block
 
-let indentation = select Latex.indentation Html.indentation TeXmacs.indentation Raw.indentation
-let paragraph = select Latex.paragraph Html.paragraph TeXmacs.paragraph Raw.paragraph
-let line_break = select Latex.line_break Html.line_break TeXmacs.line_break Raw.line_break
+let indentation = select Latex.indentation Html.indentation TeXmacs.indentation AlectryonMarkdown.indentation Raw.indentation
+let paragraph = select Latex.paragraph Html.paragraph TeXmacs.paragraph AlectryonMarkdown.paragraph Raw.paragraph
+let line_break = select Latex.line_break Html.line_break TeXmacs.line_break AlectryonMarkdown.line_break Raw.line_break
 let empty_line_of_code = select
-  Latex.empty_line_of_code Html.empty_line_of_code TeXmacs.empty_line_of_code Raw.empty_line_of_code
+  Latex.empty_line_of_code Html.empty_line_of_code TeXmacs.empty_line_of_code AlectryonMarkdown.empty_line_of_code Raw.empty_line_of_code
 
-let section = select Latex.section Html.section TeXmacs.section Raw.section
-let item = select Latex.item Html.item TeXmacs.item Raw.item
-let stop_item = select Latex.stop_item Html.stop_item TeXmacs.stop_item Raw.stop_item
-let reach_item_level = select Latex.reach_item_level Html.reach_item_level TeXmacs.reach_item_level Raw.reach_item_level
-let rule = select Latex.rule Html.rule TeXmacs.rule Raw.rule
+let section = select Latex.section Html.section TeXmacs.section AlectryonMarkdown.section Raw.section
+let item = select Latex.item Html.item TeXmacs.item AlectryonMarkdown.item Raw.item
+let stop_item = select Latex.stop_item Html.stop_item TeXmacs.stop_item AlectryonMarkdown.stop_item Raw.stop_item
+let reach_item_level = select Latex.reach_item_level Html.reach_item_level TeXmacs.reach_item_level AlectryonMarkdown.reach_item_level Raw.reach_item_level
+let rule = select Latex.rule Html.rule TeXmacs.rule AlectryonMarkdown.rule Raw.rule
 
-let nbsp = select Latex.nbsp Html.nbsp TeXmacs.nbsp Raw.nbsp
-let char = select Latex.char Html.char TeXmacs.char Raw.char
-let keyword = select Latex.keyword Html.keyword TeXmacs.keyword Raw.keyword
-let ident = select Latex.ident Html.ident TeXmacs.ident Raw.ident
-let sublexer = select Latex.sublexer Html.sublexer TeXmacs.sublexer Raw.sublexer
-let sublexer_in_doc = select Latex.sublexer_in_doc Html.sublexer_in_doc TeXmacs.sublexer_in_doc Raw.sublexer_in_doc
-let initialize = select Latex.initialize Html.initialize TeXmacs.initialize Raw.initialize
+let nbsp = select Latex.nbsp Html.nbsp TeXmacs.nbsp AlectryonMarkdown.nbsp Raw.nbsp
+let char = select Latex.char Html.char TeXmacs.char AlectryonMarkdown.char Raw.char
+let keyword = select Latex.keyword Html.keyword TeXmacs.keyword AlectryonMarkdown.keyword Raw.keyword
+let ident = select Latex.ident Html.ident TeXmacs.ident AlectryonMarkdown.ident Raw.ident
+let sublexer = select Latex.sublexer Html.sublexer TeXmacs.sublexer AlectryonMarkdown.sublexer Raw.sublexer
+let sublexer_in_doc = select Latex.sublexer_in_doc Html.sublexer_in_doc TeXmacs.sublexer_in_doc AlectryonMarkdown.sublexer_in_doc Raw.sublexer_in_doc
+let initialize = select Latex.initialize Html.initialize TeXmacs.initialize AlectryonMarkdown.initialize Raw.initialize
 
-let proofbox = select Latex.proofbox Html.proofbox TeXmacs.proofbox Raw.proofbox
+let proofbox = select Latex.proofbox Html.proofbox TeXmacs.proofbox AlectryonMarkdown.proofbox Raw.proofbox
 
-let latex_char = select Latex.latex_char Html.latex_char TeXmacs.latex_char Raw.latex_char
+let latex_char = select Latex.latex_char Html.latex_char TeXmacs.latex_char AlectryonMarkdown.latex_char Raw.latex_char
 let latex_string =
-  select Latex.latex_string Html.latex_string TeXmacs.latex_string Raw.latex_string
-let html_char = select Latex.html_char Html.html_char TeXmacs.html_char Raw.html_char
-let html_string =
-  select Latex.html_string Html.html_string TeXmacs.html_string Raw.html_string
+  select Latex.latex_string Html.latex_string TeXmacs.latex_string AlectryonMarkdown.latex_string Raw.latex_string
+let html_char = select Latex.html_char Html.html_char TeXmacs.html_char AlectryonMarkdown.html_char Raw.html_char
+let html_string = select Latex.html_string Html.html_string TeXmacs.html_string AlectryonMarkdown.html_string Raw.html_string
 
 let start_emph =
-  select Latex.start_emph Html.start_emph TeXmacs.start_emph Raw.start_emph
+  select Latex.start_emph Html.start_emph TeXmacs.start_emph AlectryonMarkdown.start_emph Raw.start_emph
 let stop_emph =
-  select Latex.stop_emph Html.stop_emph TeXmacs.stop_emph Raw.stop_emph
+  select Latex.stop_emph Html.stop_emph TeXmacs.stop_emph AlectryonMarkdown.stop_emph Raw.stop_emph
 
 let start_details =
-  select Latex.start_details Html.start_details TeXmacs.start_details Raw.start_details
+  select Latex.start_details Html.start_details TeXmacs.start_details AlectryonMarkdown.start_details Raw.start_details
 let stop_details =
-  select Latex.stop_details Html.stop_details TeXmacs.stop_details Raw.stop_details
+  select Latex.stop_details Html.stop_details TeXmacs.stop_details AlectryonMarkdown.stop_details Raw.stop_details
 
 let start_latex_math =
-  select Latex.start_latex_math Html.start_latex_math TeXmacs.start_latex_math Raw.start_latex_math
+  select Latex.start_latex_math Html.start_latex_math TeXmacs.start_latex_math AlectryonMarkdown.start_latex_math Raw.start_latex_math
 let stop_latex_math =
-  select Latex.stop_latex_math Html.stop_latex_math TeXmacs.stop_latex_math Raw.stop_latex_math
+  select Latex.stop_latex_math Html.stop_latex_math TeXmacs.stop_latex_math AlectryonMarkdown.stop_latex_math Raw.stop_latex_math
 
 let start_verbatim =
-  select Latex.start_verbatim Html.start_verbatim TeXmacs.start_verbatim Raw.start_verbatim
+  select Latex.start_verbatim Html.start_verbatim TeXmacs.start_verbatim AlectryonMarkdown.start_verbatim Raw.start_verbatim
 let stop_verbatim =
-  select Latex.stop_verbatim Html.stop_verbatim TeXmacs.stop_verbatim Raw.stop_verbatim
+  select Latex.stop_verbatim Html.stop_verbatim TeXmacs.stop_verbatim AlectryonMarkdown.stop_verbatim Raw.stop_verbatim
 let verbatim_char inline =
-  select (if inline then Latex.char else output_char) Html.char TeXmacs.char Raw.char
+  select (if inline then Latex.char else output_char) Html.char TeXmacs.char AlectryonMarkdown.char Raw.char
 let hard_verbatim_char = output_char
 
 let url =
-  select Latex.url Html.url TeXmacs.url Raw.url
+  select Latex.url Html.url TeXmacs.url AlectryonMarkdown.url Raw.url
 
 let start_quote =
-  select Latex.start_quote Html.start_quote TeXmacs.start_quote Raw.start_quote
+  select Latex.start_quote Html.start_quote TeXmacs.start_quote AlectryonMarkdown.start_quote Raw.start_quote
 let stop_quote =
-  select Latex.stop_quote Html.stop_quote TeXmacs.stop_quote Raw.stop_quote
+  select Latex.stop_quote Html.stop_quote TeXmacs.stop_quote AlectryonMarkdown.stop_quote Raw.stop_quote
 
 let inf_rule_dumb assumptions (midsp,midln,midnm) conclusions =
   start_verbatim false;
@@ -1331,8 +1451,8 @@ let inf_rule_dumb assumptions (midsp,midln,midnm) conclusions =
      List.iter dumb_line conclusions);
   stop_verbatim false
 
-let inf_rule = select inf_rule_dumb Html.inf_rule inf_rule_dumb inf_rule_dumb
+let inf_rule = select inf_rule_dumb Html.inf_rule inf_rule_dumb inf_rule_dumb inf_rule_dumb
 
-let make_multi_index = select Latex.make_multi_index Html.make_multi_index TeXmacs.make_multi_index Raw.make_multi_index
-let make_index = select Latex.make_index Html.make_index TeXmacs.make_index Raw.make_index
-let make_toc = select Latex.make_toc Html.make_toc TeXmacs.make_toc Raw.make_toc
+let make_multi_index = select Latex.make_multi_index Html.make_multi_index TeXmacs.make_multi_index AlectryonMarkdown.make_multi_index Raw.make_multi_index
+let make_index = select Latex.make_index Html.make_index TeXmacs.make_index AlectryonMarkdown.make_index Raw.make_index
+let make_toc = select Latex.make_toc Html.make_toc TeXmacs.make_toc AlectryonMarkdown.make_toc Raw.make_toc

--- a/tools/coqdoc/rocqdoc_main.ml
+++ b/tools/coqdoc/rocqdoc_main.ml
@@ -23,8 +23,9 @@ let banner () =
 let target_full_name f =
   match !prefs.targetlang with
     | HTML -> f ^ ".html"
+    | AlectryonMarkdown -> f ^ ".myst"
     | Raw -> f ^ ".txt"
-    | _ -> f ^ ".tex"
+    | LaTeX | TeXmacs -> f ^ ".tex"
 
 (*s The following function produces the output. The default output is
     the \LaTeX\ document: in that case, we just call [Web.produce_document].


### PR DESCRIPTION
This PR adds a Markdown backend to `rocq doc` for Alectryon. The implementation is very primitive, in particular it currently doesn't handle empty code blocks and whitespace correctly.

- [x] Added / updated **test-suite**.
- [x] Added **changelog**.
- [x] Added / updated **documentation**.