### PR TITLE
Let Dune overwrite `test_suite_config.inc` in `make test-suite`

### DIFF
--- a/test-suite/dune
+++ b/test-suite/dune
@@ -9,6 +9,7 @@
 
 (rule
  (targets test_suite_config.inc)
+ (mode (promote (until-clean)))
  (action (with-stdout-to %{targets} (run tools/coq_config_to_make.exe %{bin:coqc}))))
 
 (rule


### PR DESCRIPTION
When running `make test-suite`, `dune` complains if `test_suite_config.inc` is present in the source tree, ~which sometimes happens when `make test-suite` is unsuccessful~. Since `test_suite_config.inc` is auto-generated, this PR lets Dune overwrite it.