### PR TITLE
Always provide primitive eta when `check_eliminations` is disabled

### DIFF
--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -231,7 +231,7 @@ module NotPrimRecordReason = struct
 end
 
 (* Checks whether the record can have primitive projections, and if so, whether it has eta *)
-let check_record data =
+let check_record ~ignore_elim data =
   let open NotPrimRecordReason in
   List.fold_left (fun res (_, (_, splayed_lc), info, _) ->
       if Result.is_error res then res
@@ -257,6 +257,7 @@ let check_record data =
         match res with
         | Some reason -> Result.Error reason
         | None -> (* Otherwise, we allow primitive projections but check if it has eta *)
+            if ignore_elim then Result.Ok AlwaysEta else
             match info.record_arg_info with
             | HasRelevantArg -> Result.Ok AlwaysEta
             | MaybeRelevantArg ->
@@ -586,7 +587,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
     | None | Some None -> data, record, None (* NotRecord or FakeRecord *)
     | Some (Some _) -> (* PrimRecord *)
       (* We check if it can actually have primitive projections & eta *)
-      match check_record data with
+      match check_record ~ignore_elim:(Environ.ignore_elim_constraints env_ar_par) data with
       | Result.Ok has_eta ->
         let has_eta = match mie.mind_entry_finite with
           | BiFinite -> has_eta


### PR DESCRIPTION
## Summary

When `Unset Elimination Checking` is active, records with irrelevant (SProp) fields in relevant sorts (Prop, Type, Set) are now given primitive eta, bypassing the usual elimination restriction checks.

This is motivated by the Lean-to-Rocq import pipeline, where Lean structures unconditionally have eta regardless of field relevance. Without this change, imported records with irrelevant fields lose eta, causing definitional equalities that hold in Lean to fail in Rocq.

Related issue: https://github.com/rocq-community/rocq-lean-import/issues/63

- [ ] Added / updated **test-suite**.