### PR TITLE
Compute rocqdep dependencies on demand.

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -289,7 +289,7 @@ let find_dependencies st basename =
 
 let compute_deps st =
   let mk_dep (name, _orig_path) = Dep_info.make ~name ~deps:(find_dependencies st name) in
-  st.vAccu.acc |> CList.rev_map mk_dep
+  List.rev st.vAccu.acc |> List.to_seq |> Seq.map mk_dep
 
 let rec treat_file ~separator_hack vAccu old_dirname old_name =
   let name = Filename.basename old_name

--- a/tools/coqdep/lib/common.mli
+++ b/tools/coqdep/lib/common.mli
@@ -21,4 +21,4 @@ val treat_file_command_line : State.t -> string -> State.t
 
 val sort : State.t -> unit
 
-val compute_deps : State.t -> Dep_info.t list
+val compute_deps : State.t -> Dep_info.t Seq.t

--- a/tools/coqdep/lib/rocqdep_main.ml
+++ b/tools/coqdep/lib/rocqdep_main.ml
@@ -50,7 +50,7 @@ let coqdep args =
   if args.Args.sort then
     sort st
   else
-    compute_deps st |> List.iter (Makefile.print_dep Format.std_formatter)
+    compute_deps st |> Seq.iter (Makefile.print_dep Format.std_formatter)
 
 let main args =
   try

--- a/tools/dune_rule_gen/dep_info.ml
+++ b/tools/dune_rule_gen/dep_info.ml
@@ -10,7 +10,7 @@ type t = CD.Dep_info.Dep.t list Dep_map.t
 
 (* What a pita OCaml's stdlib missing basic stuff ... *)
 let from_list l =
-  List.fold_left (fun map { CD.Dep_info.name; deps } ->
+  Seq.fold_left (fun map { CD.Dep_info.name; deps } ->
       let name = Path.make name in
       let path = Path.add_extension ~ext:".v" name in
       Dep_map.add path deps map) Dep_map.empty l


### PR DESCRIPTION
In the compute_deps function, we now return a Seq.t rather than a list. This does not change the behaviour since elements are still processed in the same order and the state becomes irrelevant after the function has returned. Yet, this is much better for memory consumption as the main caller only looks at elements pointwise and discards them immediately.

On huge repositories this prevents the memory to grow linearly once the init phase is over, i.e. very quickly w.r.t. the rest of the computation. In particular, on the 700k file example by Jason Gross, this reduces the memory peak from ~10Gio to ~2.5Gio. We could do better, but as a 4-line patch I think this is not bad.