### PR TITLE
Use native OCaml lexer engine for rocqdep library.

### DIFF
--- a/tools/coqdep/lib/dune
+++ b/tools/coqdep/lib/dune
@@ -3,4 +3,8 @@
  (public_name rocq-runtime.coqdeplib)
  (libraries rocq-runtime.boot rocq-runtime.lib findlib.internal))
 
-(ocamllex lexer)
+(rule
+ (target lexer.ml)
+ (deps   lexer.mll)
+ (action (chdir %{workspace_root}
+          (run %{bin:ocamllex} -ml -q -o %{target} %{deps}))))


### PR DESCRIPTION
This patch simply calls ocamllex with the -ml flag to generate the rocqdep lexer. Contrarily to the default behaviour, this compiles the lexer directly to OCaml code rather than going through a runtime implemented in C.

As explained by the [ocamllex documentation](https://ocaml.org/manual/5.4/lexyacc.html#ss:ocamllex-options), "this option improves performance when using the native compiler, but decreases it when using the bytecode compiler". As in practice we never use the bytecode version of rocqdep, OCaml lexer compilation is thus a better choice for the standard Rocq usage.

On the typewise-isomorphism repository, this makes rocqdep about twice as fast, which means that the native engine is about 4 times as fast than the C engine.
