### PR TITLE
Avoid conflict between global sorts defined in separate modules

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -185,7 +185,7 @@ let v_level = v_tuple "level" [|v_int;v_raw_level|]
 let v_expr = v_tuple "levelexpr" [|v_level;v_int|]
 let v_univ = v_list v_expr
 
-let v_qglobal = v_pair v_dp v_id
+let v_qglobal = v_tuple "qglobal" [|v_dp; v_int|]
 
 (* perhaps the "Unif" constructor should be forbidden in vo files *)
 let v_qvar = v_sum "qvar" 0 [|[|v_int|];[|v_int|];[|v_string;v_int|]|]

--- a/dev/ci/user-overlays/21957-SkySkimmer-sort-conflict.sh
+++ b/dev/ci/user-overlays/21957-SkySkimmer-sort-conflict.sh
@@ -1,0 +1,1 @@
+overlay rocq_lsp https://github.com/SkySkimmer/rocq-lsp sort-conflict 21957

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -134,16 +134,13 @@ let new_univ_global () =
 let fresh_level () =
   Univ.Level.make (new_univ_global ())
 
-let new_sort_id =
+let new_unif_sort_id =
   let cnt = ref 0 in
   fun () -> incr cnt; !cnt
 
-let new_sort_global id =
-  Sorts.QGlobal.make (Global.current_dirpath ()) id
-
 let fresh_sort_quality () =
   let s = if Flags.async_proofs_is_worker() then !Flags.async_proofs_worker_id else "" in
-  Sorts.QVar.make_unif s (new_sort_id ())
+  Sorts.QVar.make_unif s (new_unif_sort_id ())
 
 let fresh_instance auctx : _ in_sort_context_set =
   let qlen, ulen = AbstractContext.size auctx in

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -55,7 +55,6 @@ exception UniverseLengthMismatch of univ_length_mismatch
 (** Side-effecting functions creating new universe levels. *)
 
 val new_univ_global : unit -> UGlobal.t
-val new_sort_global : Id.t -> Sorts.QGlobal.t
 val fresh_level : unit -> Level.t
 val fresh_sort_quality : unit -> Sorts.QVar.t
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -558,24 +558,36 @@ let push_context_set ~strict cst senv =
       univ = Univ.ContextSet.union cst senv.univ;
       sections }
 
-let push_qualities (qs,qcsts) senv =
-  if Sorts.QGlobal.Set.is_empty qs && Sorts.ElimConstraints.is_empty qcsts then
+let current_modpath senv = senv.modpath
+let current_dirpath senv = Names.ModPath.dp (current_modpath senv)
+
+let new_global_sort senv =
+  if is_modtype senv then
+    CErrors.user_err (Pp.str "Cannot declare global sort qualities inside module types.")
+  else if Option.has_some senv.sections then
+    CErrors.user_err (Pp.str "Cannot declare global sort qualities inside sections.")
+  else
+  let module QG = Sorts.QGlobal in
+  let uid = QG.Set.cardinal senv.qualities in
+  let s = QG.make (current_dirpath senv) uid in
+  let qualities = QG.Set.add s senv.qualities in
+  let env = Environ.push_qualities (Sorts.Quality.Set.singleton (QGlobal s)) senv.env in
+  s, { senv with
+       env;
+       qualities;
+     }
+
+let merge_elim_constraints qcsts senv =
+  if Sorts.ElimConstraints.is_empty qcsts then
     senv
   else if is_modtype senv then
     CErrors.user_err (Pp.str "Cannot declare global sort qualities inside module types.")
   else if Option.has_some senv.sections then
     CErrors.user_err (Pp.str "Cannot declare global sort qualities inside sections.")
   else
-    let qs' =
-      Sorts.QGlobal.Set.fold (fun q acc -> Sorts.Quality.Set.add (QGlobal q) acc)
-        qs
-        Sorts.Quality.Set.empty
-    in
-    let env = Environ.push_qualities qs' senv.env in
-    let env = Environ.merge_elim_constraints ~rigid:true qcsts env in
+    let env = Environ.merge_elim_constraints ~rigid:true qcsts senv.env in
     { senv with
       env;
-      qualities = Sorts.QGlobal.Set.union qs senv.qualities;
       elims = Sorts.ElimConstraints.union qcsts senv.elims;
     }
 
@@ -1546,10 +1558,6 @@ let module_of_library lib = lib.comp_mod
 let univs_of_library lib = lib.comp_sorts, lib.comp_univs
 
 let retroknowledge_of_library lib = lib.comp_retro
-
-(** FIXME: MS: remove?*)
-let current_modpath senv = senv.modpath
-let current_dirpath senv = Names.ModPath.dp (current_modpath senv)
 
 let start_library dir senv =
   (* When starting a library, the current environment should be initial

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -157,7 +157,9 @@ val push_context_set :
 
 (** Adding global sort qualities *)
 
-val push_qualities : Sorts.QGlobal.Set.t * Sorts.ElimConstraints.t -> safe_transformer0
+val new_global_sort : Sorts.QGlobal.t safe_transformer
+
+val merge_elim_constraints : Sorts.ElimConstraints.t -> safe_transformer0
 
 (* (\** Generator of universes *\) *)
 (* val next_universe : int safe_transformer *)

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -15,40 +15,40 @@ module QGlobal = struct
 
   type t = {
     library : DirPath.t;
-    id : Id.t
+    (* uid is unique for the library *)
+    uid : int;
   }
 
-  let make library id = { library ; id }
+  let make library uid = { library; uid }
 
-  let repr x = (x.library, x.id)
+  let repr x = (x.library, x.uid)
 
   let equal u1 u2 =
-    Id.equal u1.id u2.id &&
+    Int.equal u1.uid u2.uid &&
     DirPath.equal u1.library u2.library
 
-  let hash u = Hashset.Combine.combine (Id.hash u.id) (DirPath.hash u.library)
+  let hash u = Hashset.Combine.combine (Int.hash u.uid) (DirPath.hash u.library)
 
   let compare u1 u2 =
-    let c = Id.compare u1.id u2.id in
+    let c = Int.compare u1.uid u2.uid in
     if c <> 0 then c
     else
       DirPath.compare u1.library u2.library
 
-  let to_string { library = d ; id } =
-    DirPath.to_string d ^ "." ^ Id.to_string id
+  let to_string { library = d; uid } =
+    Printf.sprintf "%s.%d" (DirPath.to_string d) uid
 
   let raw_pr id = Pp.str @@ Printf.sprintf "γ%s" (to_string id)
 
   module Hstruct = struct
     type nonrec t = t
 
-    let hashcons ({ library; id } as v) =
+    let hashcons ({ library; uid } as v) =
       let hl, l' = DirPath.hcons library in
-      let hid, id' =  Id.hcons id in
-      let v = if l' == library && id' == id then v else { library = l'; id = id' } in
-      Hashset.Combine.combine hl hid, v
+      let v = if l' == library then v else { library = l'; uid } in
+      Hashset.Combine.combine hl uid, v
 
-    let eq a b = a.library == b.library && a.id == b.id
+    let eq a b = a.library == b.library && a.uid == b.uid
   end
 
   module Hasher = Hashcons.Make(Hstruct)

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -15,8 +15,8 @@ sig
 
   type t
 
-  val make : Names.DirPath.t -> Names.Id.t -> t
-  val repr : t -> Names.DirPath.t * Names.Id.t
+  val make : Names.DirPath.t -> int -> t
+  val repr : t -> Names.DirPath.t * int
   val equal : t -> t -> bool
   val hash : t -> int
   val compare : t -> t -> int

--- a/library/global.ml
+++ b/library/global.ml
@@ -83,7 +83,8 @@ let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let push_section_context c = globalize0 (Safe_typing.push_section_context c)
 let add_univ_constraints c = globalize0 (Safe_typing.push_context_set ~strict:true (Univ.Level.Set.empty, c))
 let push_context_set c = globalize0 (Safe_typing.push_context_set ~strict:true c)
-let push_qualities c = globalize0 (Safe_typing.push_qualities c)
+let new_global_sort () = globalize Safe_typing.new_global_sort
+let merge_elim_constraints csts = globalize0 (Safe_typing.merge_elim_constraints csts)
 
 let set_impredicative_set c = globalize0 (Safe_typing.set_impredicative_set c)
 let set_indices_matter b = globalize0 (Safe_typing.set_indices_matter b)

--- a/library/global.mli
+++ b/library/global.mli
@@ -68,7 +68,8 @@ val add_univ_constraints : Univ.UnivConstraints.t -> unit
 val push_context_set : Univ.ContextSet.t -> unit
 
 (** Extra sort qualities *)
-val push_qualities : Sorts.QGlobal.Set.t * Sorts.ElimConstraints.t -> unit
+val new_global_sort : unit -> Sorts.QGlobal.t
+val merge_elim_constraints : Sorts.ElimConstraints.t -> unit
 
 (** Non-interactive modules and module types *)
 

--- a/test-suite/bugs/bug_21717.v
+++ b/test-suite/bugs/bug_21717.v
@@ -1,0 +1,11 @@
+Module M.
+  Sort s.
+  Fail Sort s.
+End M.
+Module N.
+  Sort s.
+End N.
+Sort s.
+
+Check fun A:Type@{M.s;Set} => A:Type@{M.s;Set}.
+Fail Check fun A:Type@{M.s;Set} => A:Type@{N.s;Set}.

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -216,16 +216,12 @@ let do_universe ~poly l =
 
 let do_sort_mono l =
   let l = List.map (fun {CAst.v=id} ->
-      let q = UnivGen.new_sort_global id in
+      let q = Global.new_global_sort () in
       q, (id, Sorts.Quality.QGlobal q))
       l
   in
   let src = UnqualifiedQuality in
-  let () = input_sort_names (src, List.map snd l) in
-  let qs = List.fold_left  (fun qs (qv, _) -> Sorts.QGlobal.(Set.add qv qs))
-      Sorts.QGlobal.Set.empty l
-  in
-  Global.push_qualities (qs, Sorts.ElimConstraints.empty)
+  input_sort_names (src, List.map snd l)
 
 let do_sort_poly l =
   let in_section = Lib.sections_are_opened () in
@@ -275,7 +271,7 @@ let do_constraint ~poly l =
   match poly with
   | false ->
     let qcst, ucst = constraints in
-    let () = Global.push_qualities (Sorts.QGlobal.Set.empty, qcst) in
+    let () = Global.merge_elim_constraints qcst in
     Global.push_context_set (Univ.Level.Set.empty, ucst)
   | true ->
     let uctx = UVars.UContext.make


### PR DESCRIPTION
We add a int uid to QGlobal.t, generated by safe_typing when adding the sort.

The APIs change from combined
`Global.push_qualities : QGlobal.Set.t * ElimConstraints.t -> unit` to separate `Global.new_global_sort : Id.t -> QGlobal.t` and `Global.merge_elim_constraints : ElimConstraints.t -> unit`.

Fix #21717

Overlays:
- https://github.com/rocq-community/rocq-lsp/pull/1086