### PR TITLE
Fix ci-refman artifact handling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -492,7 +492,7 @@ doc:refman:deploy:
     - if [ $CI_COMMIT_REF_NAME = "master" ] ; then rm -rf _deploy/$CI_COMMIT_REF_NAME/stdlib ; fi
     - mkdir -p _deploy/$CI_COMMIT_REF_NAME
     - cp -rv _build/default/_doc/_html _deploy/$CI_COMMIT_REF_NAME/api
-    - cp -rv _build_ci/refman/refman-html _deploy/$CI_COMMIT_REF_NAME/refman
+    - cp -rv saved_build_ci/refman/refman-html _deploy/$CI_COMMIT_REF_NAME/refman
     - cp -rv _build/default/doc/corelib/html _deploy/$CI_COMMIT_REF_NAME/corelib
     - if [ $CI_COMMIT_REF_NAME = "master" ] ; then cp -rv saved_build_ci/stdlib/_build/default/doc/refman-html _deploy/$CI_COMMIT_REF_NAME/refman-stdlib ; fi
     - if [ $CI_COMMIT_REF_NAME = "master" ] ; then cp -rv saved_build_ci/stdlib/_build/default/doc/stdlib/html _deploy/$CI_COMMIT_REF_NAME/stdlib ; fi
@@ -1336,6 +1336,7 @@ doc:ci-refman:
   - library:ci-mathcomp
   - library:ci-mczify
   stage: build-3+
+  after_script: [] # disable save build_ci
   artifacts:
     paths:
       - _build_ci/refman/refman-html


### PR DESCRIPTION
on master _build_ci got moved to saved_build_ci so the path in the deploy job was incorrect.

Alternatively we could set save_build_ci and change the path in the deploy job.
