### PR TITLE
Optimize various hotspots in rocqdep

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -158,6 +158,16 @@ let with_in_channel ~fname f =
   in
   Util.try_finally f chan close_in chan
 
+let with_in_descr ~fname f =
+  let descr =
+    try Unix.openfile fname [O_RDONLY] 0o000
+    with Unix.Unix_error (_, _, msg) -> Error.cannot_open fname msg
+  in
+  Util.try_finally f descr Unix.close descr
+
+let lexbuf_from_descr ?with_positions ic =
+  Lexing.from_function ?with_positions (fun buf n -> Unix.read ic buf 0 n)
+
 module State = struct
   type t = {
     loadpath : Loadpath.State.t;
@@ -191,13 +201,13 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
 
   (* Reading file contents *)
   let f = basename ^ ".v" in
-  with_in_channel ~fname:f @@ fun chan ->
+  with_in_descr ~fname:f @@ fun chan ->
   (* For lexing efficiency purposes, we ignore the positions in this function.
      This will force us to reparse the file in case of error to get a proper
      location, but in practice such errors should be exceedingly rare with
      rocqdep. This lexer is indeed basically able to handle random nonsense
      thrown at it. *)
-  let buf = Lexing.from_channel ~with_positions:false chan in
+  let buf = lexbuf_from_descr ~with_positions:false chan in
   let open Lexer in
   let rec loop () =
     match coq_action buf with

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -51,6 +51,28 @@
     let s = Lexing.lexeme lexbuf in
     check_valid lexbuf (String.sub s 1 (String.length s - 1))
 
+  let fast_skip_to_dot lexbuf =
+    let open Lexing in
+    (* partial backtrack, we need to consider the character discarded by '_' *)
+    let () = lexbuf.lex_curr_pos <- lexbuf.lex_last_pos in
+    let rec ignore_to_dot curr len buf =
+      if len <= curr then curr
+      else match Bytes.unsafe_get buf curr with
+      | '.' -> curr
+      | '(' ->
+        if curr + 1 < len && Bytes.unsafe_get buf (curr + 1) != '*' then
+          ignore_to_dot (curr + 1) len buf
+        else
+          curr
+      | _ -> ignore_to_dot (curr + 1) len buf
+    in
+    let () = lexbuf.Lexing.lex_start_pos <- lexbuf.lex_curr_pos in
+    let pos = ignore_to_dot lexbuf.lex_curr_pos lexbuf.lex_buffer_len lexbuf.lex_buffer in
+    if pos > lexbuf.lex_curr_pos then
+      let () = lexbuf.lex_curr_pos <- pos in
+      let () = lexbuf.lex_last_pos <- pos - 1 in
+      ()
+
 }
 
 let space = [' ' '\t' '\n' '\r']
@@ -212,6 +234,12 @@ and require_file from = parse
       { syntax_error lexbuf }
 
 and skip_to_dot = parse
+  | eof
+      { syntax_error lexbuf }
+  | _
+      { fast_skip_to_dot lexbuf; slow_skip_to_dot lexbuf }
+
+and slow_skip_to_dot = parse
   | "(*"
       { comment lexbuf; skip_to_dot lexbuf }
   | dot { () }

--- a/tools/coqdep/lib/loadpath.ml
+++ b/tools/coqdep/lib/loadpath.ml
@@ -195,10 +195,8 @@ let get_worker_path st =
     w
 
 let singleton f =
-  let f = Filename.make f in
   { point = f; files = FileSet.singleton f }
 let add_set f l =
-  let f = Filename.make f in
   { point = f; files = FileSet.add f l.files }
 
 let insert_key root (full,f) m =
@@ -245,6 +243,7 @@ let add_paths recur root table phys_dir log_dir basename =
   let name = log_dir@[basename] in
   let file = System.(phys_dir // basename) in
   let paths = cuts recur name in
+  let file = Filename.make file in
   let iter n = safe_add table root (n, file) in
   List.iter iter paths
 

--- a/tools/coqdep/lib/loadpath.ml
+++ b/tools/coqdep/lib/loadpath.ml
@@ -75,18 +75,29 @@ let register_dir_logpath, find_dir_logpath =
     (see discussion at PR #14718)
 *)
 
+type 'a subdir =
+| SubEmpty
+| SubNode of 'a subdir * 'a subdir * 'a
+
+let rec iter_subdir f = function
+| SubEmpty -> ()
+| SubNode (hd, tl, cur) ->
+  let () = iter_subdir f hd in
+  let () = iter_subdir f tl in
+  List.iter f cur
+
 let add_directory recur add_file phys_dir log_dir =
   let root = (phys_dir, log_dir) in
   let rec aux phys_dir log_dir =
     if System.exists_dir phys_dir then
       let () = register_dir_logpath phys_dir log_dir in
       let curdirfiles = ref [] in
-      let subdirfiles = ref [] in
+      let subdirfiles = ref SubEmpty in
       let f = function
       | System.FileDir (phys_f,f) ->
         if recur then
           let (ncurdirfiles, nsubdirfiles) = aux phys_f (log_dir @ [f]) in
-          subdirfiles := !subdirfiles @ nsubdirfiles @ ncurdirfiles
+          subdirfiles := SubNode (!subdirfiles, nsubdirfiles, ncurdirfiles)
       | System.FileRegular f ->
         curdirfiles := (phys_dir, log_dir, f) :: !curdirfiles
       in
@@ -94,10 +105,10 @@ let add_directory recur add_file phys_dir log_dir =
       (!curdirfiles, !subdirfiles)
     else
       let () = System.warn_cannot_open_dir phys_dir in
-      ([], [])
+      ([], SubEmpty)
   in
   let (curdirfiles, subdirfiles) = aux phys_dir log_dir in
-  List.iter (fun (phys_dir, log_dir, f) -> add_file root phys_dir log_dir f) subdirfiles;
+  iter_subdir (fun (phys_dir, log_dir, f) -> add_file root phys_dir log_dir f) subdirfiles;
   List.iter (fun (phys_dir, log_dir, f) -> add_file root phys_dir log_dir f) curdirfiles
 
 (** [get_extension f l] checks whether [f] has one of the extensions

--- a/tools/coqdep/lib/makefile.ml
+++ b/tools/coqdep/lib/makefile.ml
@@ -52,25 +52,36 @@ let set_dyndep = function
   | "var" -> option_dynlink := Variable
   | o -> CErrors.user_err Pp.(str "Incorrect -dyndep option: " ++ str o)
 
+type pp = { pp : formatter -> unit }
+
+let pp_of_string s = { pp = fun fmt -> pp_print_string fmt s }
+
 let mldep_to_make base =
   match !option_dynlink with
   | No -> []
-  | Byte -> [sprintf "%s.cma" base]
-  | Opt -> [sprintf "%s.cmxs" base]
+  | Byte -> [pp_of_string @@ sprintf "%s.cma" base]
+  | Opt -> [pp_of_string @@ sprintf "%s.cmxs" base]
   | Both ->
-    [sprintf "%s.cma" base; sprintf "%s.cmxs" base]
+    [pp_of_string @@ sprintf "%s.cma" base; pp_of_string @@ sprintf "%s.cmxs" base]
   | Variable ->
-    [sprintf "%s%s" base "$(DYNLIB)"]
+    [pp_of_string @@ sprintf "%s%s" base "$(DYNLIB)"]
 
 let string_of_dep ~suffix = let open Dep_info.Dep in
   function
-  | Require basename -> [escape basename ^ suffix]
-  | Ml base -> mldep_to_make (escape base)
-  | Other s -> [escape s]
+  | Require basename -> List.to_seq [{ pp = fun fmt -> fprintf fmt "%s%s" (escape basename) suffix }]
+  | Ml base -> List.to_seq @@ mldep_to_make (escape base)
+  | Other s -> List.to_seq @@ [pp_of_string @@ escape s]
 
-let string_of_dependency_list ~suffix deps =
-  List.map (string_of_dep ~suffix) deps
-  |> List.concat |> String.concat " "
+let pp_concat pp fmt s = match Seq.uncons s with
+| None -> ()
+| Some (hd, s) ->
+  let () = pp fmt hd in
+  Seq.iter (fun data -> fprintf fmt " %a" pp data) s
+
+let pp_dependency_list ~suffix fmt deps =
+  let deps = List.to_seq deps in
+  let deps = Seq.concat_map (fun dep -> string_of_dep ~suffix dep) deps in
+  pp_concat (fun fmt s -> s.pp fmt) fmt deps
 
 let option_noglob = ref false
 let option_write_vos = ref false
@@ -80,9 +91,9 @@ let set_write_vos vos = option_write_vos := vos
 let print_dep fmt { Dep_info.name; deps } =
   let ename = escape name in
     let glob = if !option_noglob then "" else ename^".glob " in
-  fprintf fmt "%s.vo %s%s.v.beautified %s.required_vo: %s.v %s\n" ename glob ename ename ename
-    (string_of_dependency_list ~suffix:".vo" deps);
+  fprintf fmt "%s.vo %s%s.v.beautified %s.required_vo: %s.v %a\n" ename glob ename ename ename
+    (pp_dependency_list ~suffix:".vo") deps;
   if !option_write_vos then
-    fprintf fmt "%s.vos %s.vok %s.required_vos: %s.v %s\n" ename ename ename ename
-      (string_of_dependency_list ~suffix:".vos" deps);
+    fprintf fmt "%s.vos %s.vok %s.required_vos: %s.v %a\n" ename ename ename ename
+      (pp_dependency_list ~suffix:".vos") deps;
   fprintf fmt "%!"


### PR DESCRIPTION
This collection of small, mostly unrelated commits makes rocqdep both faster and less memory-consuming on extreme repositories.