### PR TITLE
Remove vernacstate cache

### DIFF
--- a/dev/ci/user-overlays/21975-SkySkimmer-no-cache.sh
+++ b/dev/ci/user-overlays/21975-SkySkimmer-no-cache.sh
@@ -1,0 +1,3 @@
+overlay vsrocq https://github.com/SkySkimmer/vsrocq no-cache 21975
+
+overlay rocq_lsp https://github.com/SkySkimmer/rocq-lsp no-cache 21975

--- a/ide/rocqide/idetop.ml
+++ b/ide/rocqide/idetop.ml
@@ -448,12 +448,14 @@ let get_options () =
 
 let set_options options =
   let open Goptions in
-  let iter (name, value) = match import_option_value value with
-  | BoolValue b -> set_bool_option_value name b
-  | IntValue i -> set_int_option_value name i
-  | StringValue s -> set_string_option_value name s
-  | StringOptValue (Some s) -> set_string_option_value name s
-  | StringOptValue None -> unset_option_value_gen name
+  let iter (name, value) =
+    Goptions.disable_summary name;
+    match import_option_value value with
+    | BoolValue b -> set_bool_option_value name b
+    | IntValue i -> set_int_option_value name i
+    | StringValue s -> set_string_option_value name s
+    | StringOptValue (Some s) -> set_string_option_value name s
+    | StringOptValue None -> unset_option_value_gen name
   in
   List.iter iter options
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -588,3 +588,5 @@ let declare_string_option ?preprocess osig =
 
 let declare_stringopt_option ?preprocess osig =
   declare_option ?preprocess ~kind:StringOptKind osig
+
+let disable_summary key = Summary.disable_summary (nickname key)

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -250,3 +250,6 @@ val declare_string_option: ?preprocess:(string -> string) ->
                            string option_sig -> unit
 val declare_stringopt_option: ?preprocess:(string option -> string option) ->
                               string option option_sig -> unit
+
+(** For rocqide *)
+val disable_summary : option_name -> unit

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -70,6 +70,24 @@ let declare_summary_tag sumname ?make_marshallable decl =
 let declare_summary sumname ?make_marshallable decl =
   ignore(declare_summary_tag sumname ?make_marshallable decl)
 
+let disable_summary sumname =
+  match Dyn.name (mangle sumname) with
+  | None -> CErrors.anomaly Pp.(str "Unknown dyn for disable_dummary: " ++ str sumname)
+  | Some (Any tag) ->
+    let map =
+      if DynMap.mem tag !sum_map_interp then sum_map_interp
+      else if DynMap.mem tag !sum_map_synterp then sum_map_synterp
+      else assert false
+    in
+    let disable_decl d = {
+      stage = d.stage;
+      freeze_function = d.freeze_function;
+      unfreeze_function = (fun _ -> ());
+      init_function = (fun () -> ());
+    }
+    in
+    map := DynMap.modify tag disable_decl !map
+
 module ID = struct type 'a t = 'a end
 module Frozen = Dyn.Map(ID)
 module HMap = Dyn.HMap(Decl)(ID)

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -166,3 +166,6 @@ module MakeObservable
 
 (** {6 Debug} *)
 val dump : unit -> (int * string) list
+
+(** For rocqide *)
+val disable_summary : string -> unit

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -843,10 +843,6 @@ module State : sig
 
   val assign : Stateid.t -> partial_state -> unit
 
-  (* Handlers for initial state, prior to document creation. *)
-  val register_root_state : unit -> unit
-  val restore_root_state : unit -> unit
-
   val purify : ('a -> 'b) -> 'a -> 'b
 
 end = struct (* {{{ *)
@@ -983,15 +979,6 @@ end = struct (* {{{ *)
       if cache then freeze_invalid id ie;
       !Hooks.unreachable_state ~doc id ie;
       Exninfo.iraise ie
-
-  let init_state = ref None
-
-  let register_root_state () =
-    init_state := Some (Vernacstate.freeze_full_state ())
-
-  let restore_root_state () =
-    cur_id := Stateid.dummy;
-    Vernacstate.unfreeze_full_state (Option.get !init_state)
 
   (* Protect against state changes *)
   let purify f x =
@@ -2234,13 +2221,12 @@ let init_process stm_flags =
   if !Flags.async_proofs_worker_id = "master" && (cur_opt()).async_proofs_n_tacworkers > 0 then
     Partac.enable_par ~spawn_args:stm_flags.spawn_args ~nworkers:(cur_opt()).async_proofs_n_tacworkers
 
-let init_core () =
-  State.register_root_state ()
+let has_doc = ref false
 
 let new_doc { doc_type ; injections } =
 
-  (* We must reset the whole state before creating a document! *)
-  State.restore_root_state ();
+  assert (not !has_doc);
+  has_doc := true;
 
   let doc =
     let ps = Procq.freeze () in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -985,12 +985,10 @@ end = struct (* {{{ *)
     let st = freeze () in
     try
       let res = f x in
-      Vernacstate.Interp.invalidate_cache ();
       unfreeze st;
       res
     with e ->
       let e = Exninfo.capture e in
-      Vernacstate.Interp.invalidate_cache ();
       unfreeze st;
       Exninfo.iraise e
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -71,9 +71,6 @@ type doc
 (** [init_process] performs some low-level initialization, call early *)
 val init_process : AsyncOpts.stm_opt -> unit
 
-(** [init_core] snapshots the initial system state *)
-val init_core : unit -> unit
-
 (** [new_doc opt] Creates a new document with options [opt] *)
 val new_doc  : stm_init_options -> doc * Stateid.t
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -64,8 +64,6 @@ let init_toplevel { parse_extra; init_extra; usage; initial_args } args =
   Stm.init_process (snd customopts);
   let () = Coqinit.init_runtime ~usage opts in
   let () = Coqinit.init_document opts in
-  (* This state will be shared by all the documents *)
-  Stm.init_core ();
   let customstate = init_extra ~opts customopts (Coqargs.injection_commands opts) in
   opts, customopts, customstate
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -24,7 +24,6 @@ let with_interp_state ~unfreeze_transient st =
   let with_local_state synterp_st f =
     unfreeze_transient synterp_st;
     let v = f () in
-    Vernacstate.Interp.invalidate_cache ();
     Vernacstate.unfreeze_full_state st;
     (), v
   in
@@ -154,7 +153,6 @@ let interp_gen ~verbosely ~st ~interp_fn cmd =
   with exn ->
     let exn = Exninfo.capture exn in
     let exn = locate_if_not_already ?loc:cmd.CAst.loc exn in
-    Vernacstate.Interp.invalidate_cache ();
     Exninfo.iraise exn
 
 (* Regular interp *)

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -97,7 +97,6 @@ module LemmaStack = struct
 
 end
 
-let s_cache = ref None
 let s_lemmas = ref None
 let s_program = ref (NeList.singleton Declare.OblState.empty)
 
@@ -112,23 +111,8 @@ type t = {
   opaques : Opaques.Summary.t;     (* opaque proof terms *)
 }
 
-let invalidate_cache () =
-  s_cache := None
-
-let update_cache rf v =
-  rf := Some v; v
-
-let do_if_not_cached rf f v =
-  match !rf with
-  | None ->
-    rf := Some v; f v
-  | Some vc when vc != v ->
-    rf := Some v; f v
-  | Some _ ->
-    ()
-
 let freeze_interp_state () =
-  { system = update_cache s_cache (System.freeze ());
+  { system = System.freeze ();
     lemmas = !s_lemmas;
     program = !s_program;
     opaques = Opaques.Summary.freeze ();
@@ -138,7 +122,7 @@ let make_shallow s =
   { s with system = System.Stm.make_shallow s.system }
 
 let unfreeze_interp_state { system; lemmas; program; opaques } =
-  do_if_not_cached s_cache System.unfreeze system;
+  System.unfreeze system;
   s_lemmas := lemmas;
   s_program := program;
   Opaques.Summary.unfreeze opaques

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -62,9 +62,6 @@ module Interp : sig
   val freeze_interp_state : unit -> t
   val unfreeze_interp_state : t -> unit
 
-  (* WARNING: Do not use, it will go away in future releases *)
-  val invalidate_cache : unit -> unit
-
 end
 
 type t =


### PR DESCRIPTION
Knowing when to call invalidate is tricky so if bench agrees it's
better to remove this.

Indeed in master the cache is handled unsoundly (skips unfreeze of a state which isn't the currently installed state) which hides some bugs:
- STM restore_root_state would overwrite Flags.quiet set in init_extra (but unsound cache makes it a noop)
- rocqide would overwrite user printing options with the default (but unsound cache prevents the overwrite)

Overlays:
- https://github.com/rocq-prover/vsrocq/pull/1245
- https://github.com/rocq-community/rocq-lsp/pull/1090