### PR TITLE
`Strict Resolution` has precedence over `Hint Mode`

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -263,19 +263,16 @@ and e_my_find_search db_list local_db secvars hdc complete env sigma concl0 =
   let prods, concl = EConstr.decompose_prod_decls sigma concl0 in
   let nprods = List.length prods in
   let allowed_evars =
-    let all = Evarsolve.AllowedEvars.all in
     match hdc with
     | Some (hd,_) ->
       begin match Typeclasses.class_info env hd with
-      | Some cl ->
-        if cl.cl_strict then
+      | Some cl when cl.cl_strict ->
           let undefined = lazy (Evarutil.undefined_evars_of_term sigma concl) in
           let allowed evk = not (Evar.Set.mem evk (Lazy.force undefined)) in
-          Evarsolve.AllowedEvars.from_pred allowed
-        else all
-      | None -> all
+          Some (Evarsolve.AllowedEvars.from_pred allowed)
+      | _ -> None
       end
-    | _ -> all
+    | _ -> None
   in
   let tac_of_hint (flags,h) =
     let name = FullHint.name h in
@@ -328,9 +325,14 @@ and e_my_find_search db_list local_db secvars hdc complete env sigma concl0 =
     let hintl =
       CList.map
         (fun (db, m, tacs) ->
-           let allowed_evars = match m with
-             | NoMode -> allowed_evars
-             | WithMode evars -> evars
+           let all = Evarsolve.AllowedEvars.all in
+           let allowed_evars = match allowed_evars, m with
+             | _, NoMode -> Option.default all allowed_evars
+             (* [allowed_evars] from [Strict Resolution] take precedence over
+                the (necessarily less restrictive) set of allowed evars from
+                [Hint Mode =] *)
+             | Some allowed_evars, WithMode _ -> allowed_evars
+             | None, WithMode evars -> evars
            in
           let flags = auto_unif_flags ~allowed_evars (Hint_db.transparent_state db) in
           m, List.map (fun x -> tac_of_hint (flags, x)) tacs)

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -88,6 +88,20 @@ Module Plus.
   Defined.
 End Plus.
 
+Module StrictFrozen.
+  #[local] Set Typeclasses Strict Resolution.
+  Class C (a : True) (b : True) := {}.
+  Hint Mode C - = : typeclass_instances.
+
+  Instance c : C I I := {}.
+
+  Goal exists a, C a I.
+  Proof.
+    eexists ?[a].
+    Fail apply _.
+  Abort.
+End StrictFrozen.
+
 Module Frozen.
   Record bi := {
       car :> Type;


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Follow-up to #21911 fixing a bad interaction between `Strict Resolution` and mixed `=` and `-` modes.


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
