### PR TITLE
Expose userord-based sets for unfoldable globals in hint databases.

### DIFF
--- a/dev/ci/user-overlays/21999-ppedrot-hints-unfolds-use-env-set.sh
+++ b/dev/ci/user-overlays/21999-ppedrot-hints-unfolds-use-env-set.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/equations hints-unfolds-use-env-set 21999

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -961,6 +961,9 @@ module PRmap = HMap.Make(Projection.Repr.CanOrd)
 module PRset = PRmap.Set
 module PRpred = Predicate.Make(Projection.Repr.CanOrd)
 
+module PRmap_env = HMap.Make(Projection.Repr.UserOrd)
+module PRset_env = PRmap_env.Set
+
 module GlobRefInternal = struct
 
   type t =

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -620,6 +620,9 @@ end
 module PRset : CSig.USetS with type elt = Projection.Repr.t
 module PRmap : Map.UExtS with type key = Projection.Repr.t and module Set := PRset
 
+module PRset_env : CSig.USetS with type elt = Projection.Repr.t
+module PRmap_env : Map.UExtS with type key = Projection.Repr.t and module Set := PRset_env
+
 (** Predicate on projection representation (ignoring unfolding state) *)
 module PRpred : Predicate.S with type elt = Projection.Repr.t
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -414,7 +414,7 @@ let autounfold db cls =
       with Not_found -> raise (UnknownDatabase dbname)
     in
     let (db_ids, db_csts, db_prjs) = Hint_db.unfolds db in
-    (Id.Set.fold cons db_ids ids, Cset.fold cons db_csts csts, PRset.fold cons db_prjs prjs)) ([], [], []) db
+    (Id.Set.fold cons db_ids ids, Cset_env.fold cons db_csts csts, PRset_env.fold cons db_prjs prjs)) ([], [], []) db
   with
   | (ids, csts, prjs) -> Proofview.Goal.enter begin fun gl ->
       let cls = concrete_clause_of (fun () -> Tacmach.pf_ids_of_hyps gl) cls in
@@ -434,10 +434,10 @@ let autounfold_tac db cls =
   in
   autounfold dbs cls
 
-let transparent_constant csts prjs c =
+let transparent_constant env csts prjs c =
   match Structures.PrimitiveProjections.find_opt c with
-  | None -> Cset.mem c csts
-  | Some p -> PRset.mem p prjs
+  | None -> Cset_env.mem (Environ.QConstant.canonize env c) csts
+  | Some p -> PRset_env.mem (Environ.QProjection.Repr.canonize env p) prjs
 
 let unfold_head env sigma (ids, csts, prjs) c =
   (* TODO use prjs *)
@@ -447,7 +447,7 @@ let unfold_head env sigma (ids, csts, prjs) c =
         (match Environ.named_body id env with
         | Some b -> true, EConstr.of_constr b
         | None -> false, c)
-    | Const (cst, u) when transparent_constant csts prjs cst ->
+    | Const (cst, u) when transparent_constant env csts prjs cst ->
         let u = EInstance.kind sigma u in
         true, EConstr.of_constr (Environ.constant_value_in env (cst, u))
     | App (f, args) ->
@@ -484,7 +484,7 @@ let autounfold_one db cl =
         with Not_found -> user_err (str "Unknown database " ++ str dbname ++ str ".")
       in
       let (ids, csts, prjs) = Hint_db.unfolds db in
-        (Id.Set.union ids i, Cset.union csts c, PRset.union prjs p)) (Id.Set.empty, Cset.empty, PRset.empty) db
+        (Id.Set.union ids i, Cset_env.union csts c, PRset_env.union prjs p)) (Id.Set.empty, Cset_env.empty, PRset_env.empty) db
   in
   let did, c' = unfold_head env sigma st
     (match cl with Some (id, _) -> Tacmach.pf_get_hyp_typ id gl | None -> concl)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -608,7 +608,7 @@ val set_transparent_state : t -> TransparentState.t -> t
 val add_cut : Environ.env -> hints_path -> t -> t
 val add_mode : Environ.env -> GlobRef.t -> hint_mode array -> t -> t
 val cut : t -> hints_path
-val unfolds : t -> Id.Set.t * Cset.t * PRset.t
+val unfolds : t -> Id.Set.t * Cset_env.t * PRset_env.t
 val add_modes : Modes.t -> t -> t
 val modes : t -> Modes.t
 val find_mode : env -> GlobRef.t -> t -> hint_mode array list
@@ -620,7 +620,7 @@ struct
   type t = {
     hintdb_state : TransparentState.t;
     hintdb_cut : hints_path;
-    hintdb_unfolds : Id.Set.t * Cset.t * PRset.t;
+    hintdb_unfolds : Id.Set.t * Cset_env.t * PRset_env.t;
     hintdb_max_id : int;
     use_dn : bool;
     hintdb_map : search_entry GlobRef.Map_env.t;
@@ -635,7 +635,7 @@ struct
 
   let empty ?name st use_dn = { hintdb_state = st;
                           hintdb_cut = PathEmpty;
-                          hintdb_unfolds = (Id.Set.empty, Cset.empty, PRset.empty);
+                          hintdb_unfolds = (Id.Set.empty, Cset_env.empty, PRset_env.empty);
                           hintdb_max_id = 0;
                           use_dn = use_dn;
                           hintdb_map = GlobRef.Map_env.empty;
@@ -775,9 +775,13 @@ struct
       | Evaluable.EvalVarRef id ->
         { ts with tr_var = Id.Pred.add id ts.tr_var }, (Id.Set.add id ids, csts, prjs)
       | Evaluable.EvalConstRef cst ->
-        { ts with tr_cst = Cpred.add cst ts.tr_cst }, (ids, Cset.add cst csts, prjs)
+        (* TODO: do we really want to canonize? *)
+        let cst = QConstant.canonize env cst in
+        { ts with tr_cst = Cpred.add cst ts.tr_cst }, (ids, Cset_env.add cst csts, prjs)
       | Evaluable.EvalProjectionRef p ->
-        { ts with tr_prj = PRpred.add p ts.tr_prj }, (ids, csts, PRset.add p prjs)
+        (* TODO: do we really want to canonize? *)
+        let p = QProjection.Repr.canonize env p in
+        { ts with tr_prj = PRpred.add p ts.tr_prj }, (ids, csts, PRset_env.add p prjs)
       in
       let db = { db with hintdb_unfolds = unfs } in
       if db.use_dn then rebuild_db state db else db

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -155,7 +155,7 @@ module Hint_db :
     val add_cut : env -> hints_path -> t -> t
     val cut : t -> hints_path
 
-    val unfolds : t -> Id.Set.t * Cset.t * PRset.t
+    val unfolds : t -> Id.Set.t * Cset_env.t * PRset_env.t
 
     val add_modes : Modes.t -> t -> t
     val modes : t -> Modes.t


### PR DESCRIPTION
To preserve the previous behaviour, we canonicalize the references before storing them in the set. (As usual, it's not clear we really want this, but for the time being at least it's clear we canonize and this PR remove implicit canord sets.)

Overlays:
- https://github.com/rocq-prover/equations/pull/715