### PR TITLE
Correctly expand included modules in Declaremods "with Module".

### DIFF
--- a/test-suite/bugs/bug_19994.v
+++ b/test-suite/bugs/bug_19994.v
@@ -1,0 +1,28 @@
+Module Type WRAP.
+  Parameter t : Set.
+End WRAP.
+
+Module Type PARAMS.
+  Declare Module Arg : WRAP.
+End PARAMS.
+
+Module Type JOKER. (* also breaks if you remove `Type` *)
+End JOKER.
+
+Module Type COMBINED := PARAMS <+ JOKER. (* Fix 1: Remove `<+ JOKER` *)
+
+Module Inst <: WRAP.
+  Inductive t_ := Q | R. (* Fix 2: Move this definition away *)
+  Definition t := t_.
+End Inst.
+
+Module Type RECOMBINED := COMBINED with Module Arg := Inst.
+
+Module Type LOCK_DEFS(Mod : RECOMBINED). (* also breaks if you remove `Type` *)
+  Goal Mod.Arg.t -> True.
+    intros.
+    (* Fix 3: run `destruct (H : Inst.t)` instead *)
+    destruct H. (* Error: Anomaly "Uncaught exception Not_found." Please report at http://coq.inria.fr/bugs/. *)
+    all: constructor.
+  Qed.
+End LOCK_DEFS.

--- a/test-suite/bugs/bug_20254.v
+++ b/test-suite/bugs/bug_20254.v
@@ -1,0 +1,32 @@
+Module Type A.
+  Parameter t: Type.
+  Parameter len : t -> nat.
+  Parameter len2 : t -> nat.
+End A.
+
+Module A_impl.
+  Definition t : Type := list nat.
+  (* Adding incr to A fixes the anomaly *)
+  Definition incr (n: nat) := S n.
+  Definition len (m: t) := incr (length m).
+  Definition len2 (m: t) := length m.
+End A_impl.
+
+Module Type B.
+  Declare Module M : A.
+End B.
+
+Module Type Bp.
+  Include B.
+End Bp.
+
+Module Bp_inst.
+  (* Using instead "Include B with Module M := A_impl" also fixes the anomaly *)
+  Include Bp with Module M := A_impl.
+End Bp_inst.
+
+(* This Print works *)
+Print Bp_inst.M.len2.
+
+(* This Print raises an anomaly *)
+Print Bp_inst.M.len.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -700,6 +700,8 @@ let get_applications mexpr =
 let rec replace_module_object idl mp0 objs0 mp1 objs1 =
   match idl, objs0 with
   | _,[] -> []
+  | idl, (IncludeObject aobjs) :: tail ->
+    replace_module_object idl mp0 (expand_aobjs aobjs @ tail) mp1 objs1
   | id::idl,(ModuleObject (id', sobjs))::tail when Id.equal id id' ->
     begin
       let mp_id = MPdot(mp0, id) in


### PR DESCRIPTION
The function computing the libobjects of a module generated through the "with Module" construction was treating module inclusion as a plain libobject, even though it actually stood for its expansion. We fix this by expanding the IncludeObject entry on the fly.

Fixes #20254: Anomaly by including a module type in a module.
Fixes #19994: Anomaly when destructing an inductive type as a resolvable opaque reference.