### PR TITLE
Deprecate the canord-based PRset and PRmap modules from the Names API.

### DIFF
--- a/kernel/conv_oracle.ml
+++ b/kernel/conv_oracle.ml
@@ -34,6 +34,9 @@ let is_transparent = function
 | Level 0 -> true
 | _ -> false
 
+module PRmap = HMap.Make(Projection.Repr.CanOrd)
+(* TODO: should we hand-canonize without the env, or just change the semantics? *)
+
 type oracle = {
   var_opacity : level Id.Map.t;
   cst_opacity : level Cmap.t;

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -618,7 +618,13 @@ module Projection : sig
 end
 
 module PRset : CSig.USetS with type elt = Projection.Repr.t
-module PRmap : Map.UExtS with type key = Projection.Repr.t and module Set := PRset
+[@@ocaml.deprecated "(9.3) This will switch to user ordering at some point in \
+the future. In the meantime either use the _env variant or the Q-variant from \
+Environ, depending on the desired semantics."]
+module PRmap : Map.UExtS with type key = Projection.Repr.t and module Set := PRset [@@ocaml.warning "-3"]
+[@@ocaml.deprecated "(9.3) This will switch to user ordering at some point in \
+the future. In the meantime either use the _env variant or the Q-variant from \
+Environ, depending on the desired semantics."]
 
 module PRset_env : CSig.USetS with type elt = Projection.Repr.t
 module PRmap_env : Map.UExtS with type key = Projection.Repr.t and module Set := PRset_env


### PR DESCRIPTION
There is still one place in conversion oracles where we need to emulate the old behaviour, but this is before the introduction of environments in the chain of dependences so we cannot use the Q-variant. Thus we simply redefine the CanOrd map module internally. This is a net gain since this is abstracted away while removing the tempting CanOrd API from the public Names module.