### PR TITLE
Reduce the exposure of QualityOrSet.t type in the Retyping API.

### DIFF
--- a/dev/ci/user-overlays/22016-ppedrot-reduce-sort-quality-of.sh
+++ b/dev/ci/user-overlays/22016-ppedrot-reduce-sort-quality-of.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/ppedrot/equations reduce-sort-quality-of 22016

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -70,11 +70,11 @@ type flag = info * scheme
 (*s [flag_of_type] transforms a type [t] into a [flag].
   Really important function. *)
 
-let info_of_quality = let open UnivGen.QualityOrSet in function
-  | Qual (QConstant QSProp | QConstant QProp) -> Logic
-  | Set | Qual (QConstant QType | QVar _ | QGlobal _) -> Info
+let info_of_quality = let open Sorts.Quality in function
+  | QConstant QSProp | QConstant QProp -> Logic
+  | QConstant QType | QVar _ | QGlobal _ -> Info
 
-let info_of_sort s = info_of_quality (UnivGen.QualityOrSet.of_sort s)
+let info_of_sort s = info_of_quality (Sorts.quality s)
 
 let rec flag_of_type env sg t : flag =
   let t = whd_all env sg t in

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -60,7 +60,7 @@ let functional_induction with_clean c princl pat =
                   ( str "Cannot find induction information on "
                   ++ Termops.pr_global_env env (ConstRef c') )
             in
-            match Retyping.get_sort_quality_of env sigma concl with
+            match Retyping.get_sort_quality_or_set_of env sigma concl with
             | Qual (QConstant QSProp) -> finfo.sprop_lemma
             | Qual (QConstant QProp) -> finfo.prop_lemma
             | Set -> finfo.rec_lemma
@@ -79,7 +79,7 @@ let functional_induction with_clean c princl pat =
               let princ_name =
                 Elimschemes.make_elimination_ident
                   (Constant.label c')
-                  (Retyping.get_sort_quality_of env sigma concl)
+                  (Retyping.get_sort_quality_or_set_of env sigma concl)
               in
               let princ_ref =
                 match

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -122,7 +122,7 @@ let rec make_form env sigma atom_env term =
   match EConstr.kind sigma cciterm with
     Prod(_,a,b) ->
      if noccurn sigma 1 b &&
-          QualityOrSet.is_prop (Retyping.get_sort_quality_of env sigma a)
+          Sorts.Quality.is_qprop (Retyping.get_sort_quality_of env sigma a)
      then
        let fa = make_form env sigma atom_env a in
        let fb = make_form env sigma atom_env b in
@@ -160,7 +160,7 @@ let rec make_hyps env sigma atom_env lenv = function
      let hrec=
        make_hyps env sigma atom_env (typ::lenv) rest in
      if List.exists (fun c -> Termops.local_occur_var sigma id.binder_name c) lenv ||
-          (not (QualityOrSet.is_prop (Retyping.get_sort_quality_of env sigma typ)))
+          (not (Sorts.Quality.is_qprop (Retyping.get_sort_quality_of env sigma typ)))
      then
        hrec
      else
@@ -275,7 +275,7 @@ let rtauto_tac =
     Rocqlib.check_required_library ["Stdlib";"rtauto";"Rtauto"];
     let gamma={next=1;env=[]} in
     let () =
-      if not (QualityOrSet.is_prop (Retyping.get_sort_quality_of env sigma concl))
+      if not (Sorts.Quality.is_qprop (Retyping.get_sort_quality_of env sigma concl))
       then user_err (Pp.str "Goal should be in Prop.") in
     let glf = make_form env sigma gamma concl in
     let hyps = make_hyps env sigma gamma [concl] hyps in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -490,7 +490,7 @@ let abs_evars_pirrel env sigma0 (sigma, c0) =
     let evi = Evd.find_undefined sigma k in
     (* FIXME? this is not the right environment in general *)
     let k_ty = Retyping.get_sort_quality_of env sigma (Evd.evar_concl evi) in
-    let is_prop = UnivGen.QualityOrSet.is_prop k_ty in
+    let is_prop = Sorts.Quality.is_qprop k_ty in
     let t = abs_evar n k in
     (k, (n, t, is_prop, Evd.evar_relevance evi)) :: put evlist t
   | _ -> EConstr.fold sigma put evlist c in

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -447,7 +447,7 @@ let pirrel_rewrite ?(under=false) ?(map_redex=id_map_redex) pred rdx rdx_ty c_so
          let miss = Util.List.map_filter (fun (t, name) ->
              let evs = Evar.Set.elements (Evarutil.undefined_evars_of_term sigma t) in
              let open_evs = List.filter (fun k ->
-                 not @@ UnivGen.QualityOrSet.is_prop (Retyping.get_sort_quality_of
+                 not @@ Sorts.Quality.is_qprop (Retyping.get_sort_quality_of
                    env sigma (Evd.evar_concl (Evd.find_undefined sigma k))))
                  evs in
              if open_evs <> [] then Some name else None)

--- a/pretyping/combinators.ml
+++ b/pretyping/combinators.ml
@@ -81,7 +81,7 @@ let telescope env sigma ctx =
   let ctx, _ = List.fold_right_map (fun d env ->
       let s = Retyping.get_sort_quality_of env sigma (RelDecl.get_type d) in
       let env = EConstr.push_rel d env in
-      (d, UnivGen.QualityOrSet.quality s), env) ctx env
+      (d, s), env) ctx env
   in
   let sigma, telescope_type, letcontext, telescope_value = telescope sigma ctx in
   sigma, letcontext, { telescope_type; telescope_value }

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -985,16 +985,16 @@ and detype_binder d flags bk avoid env sigma decl c =
       let c = detype d (nongoal flags) avoid env sigma (Option.get body) in
       (* Heuristic: we display the type if in Prop *)
       let s =
-        if !Flags.in_debugger then UnivGen.QualityOrSet.qtype
+        if !Flags.in_debugger then Sorts.Quality.qtype
         else
           (* It can fail if ty is an evar, or if run inside ocamldebug or the
              OCaml toplevel since their printers don't have access to the proper sigma/env *)
           try Retyping.get_sort_quality_of (snd env) sigma ty
-          with Retyping.RetypeError _ -> UnivGen.QualityOrSet.qtype
+          with Retyping.RetypeError _ -> Sorts.Quality.qtype
       in
       let t =
         (* XXX also sprop? *)
-        if flags.flg.nonpropositional_letin_types || UnivGen.QualityOrSet.is_prop s
+        if flags.flg.nonpropositional_letin_types || Sorts.Quality.is_qprop s
         then Some (detype d (nongoal flags) avoid env sigma ty)
         else None
       in

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -339,7 +339,7 @@ let retype ?metas ?(polyprop=true) sigma =
 
   in type_of, sort_of, type_of_global_reference_knowing_parameters
 
-let get_sort_quality_of ?(polyprop=true) env sigma t =
+let get_sort_quality_or_set_of ?(polyprop=true) env sigma t =
   let type_of,_,type_of_global_reference_knowing_parameters = retype ~polyprop sigma in
   let rec sort_quality_of env t =
     let open UnivGen in
@@ -360,6 +360,9 @@ let get_sort_quality_of ?(polyprop=true) env sigma t =
     | _ ->
       ESorts.quality_or_set sigma (decomp_sort env sigma (type_of env t))
   in sort_quality_of env t
+
+let get_sort_quality_of ?polyprop env sigma t =
+  UnivGen.QualityOrSet.quality @@ get_sort_quality_or_set_of ?polyprop env sigma t
 
 let get_sort_of ?(polyprop=true) env sigma t =
   let _,f,_ = retype ~polyprop sigma in anomaly_on_error (f env) t

--- a/pretyping/retyping.mli
+++ b/pretyping/retyping.mli
@@ -38,8 +38,11 @@ val get_type_of_constr : ?polyprop:bool -> ?lax:bool
 val get_sort_of :
   ?polyprop:bool -> env -> evar_map -> types -> ESorts.t
 
-val get_sort_quality_of :
+val get_sort_quality_or_set_of :
   ?polyprop:bool -> env -> evar_map -> types -> UnivGen.QualityOrSet.t
+
+val get_sort_quality_of :
+  ?polyprop:bool -> env -> evar_map -> types -> Sorts.Quality.t
 
 (** Makes an unsafe judgment from a constr *)
 val get_judgment_of : env -> evar_map -> constr -> unsafe_judgment

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -28,7 +28,7 @@ let general_elim_using mk_elim (ind, u, args) id = match mk_elim with
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Proofview.Goal.sigma gl in
-    let sort = Retyping.get_sort_quality_of env sigma (Proofview.Goal.concl gl) in
+    let sort = Retyping.get_sort_quality_or_set_of env sigma (Proofview.Goal.concl gl) in
     let flags = Unification.elim_flags () in
     let gr = Elimschemes.lookup_eliminator env ind sort in
     let sigma, elim = Evd.fresh_global env sigma gr in

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -203,7 +203,7 @@ let elim_type dty rectype a1 a2 =
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let (ind, _) = Tacred.reduce_to_atomic_ind env sigma dty.op in
-  let s = Retyping.get_sort_quality_of env sigma concl in
+  let s = Retyping.get_sort_quality_or_set_of env sigma concl in
   let elimc = Elimschemes.lookup_eliminator env (fst ind) s in
   (* Eliminator type is expected to have (potentially non-dependent) shape
       [forall A B (P : I A B -> Type), P _ -> P _ -> forall (s : I A B), P s ] *)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -902,8 +902,8 @@ let find_positions env sigma ~keep_proofs ~no_discr ~eqsort ~goalsort t1 t2 =
       if keep_head_inductive sigma ty1 then true
       else
         let s = get_sort_quality_of env sigma ty1 in
-        (keep_proofs || not (UnivGen.QualityOrSet.equal s UnivGen.QualityOrSet.prop)) &&
-        not (UnivGen.QualityOrSet.equal s UnivGen.QualityOrSet.sprop) &&
+        (keep_proofs || not (Sorts.Quality.equal s Sorts.Quality.qprop)) &&
+        not (Sorts.Quality.equal s Sorts.Quality.qsprop) &&
         allowed_elim
     in
     if keep then [(List.rev posn,t1,t2)] else []
@@ -916,7 +916,7 @@ let find_positions env sigma ~keep_proofs ~no_discr ~eqsort ~goalsort t1 t2 =
     let hd1,args1 = whd_all_stack env sigma t1 in
     let hd2,args2 = whd_all_stack env sigma t2 in
     let ty1 = get_type_of env sigma t1 in
-    let s1 = UnivGen.QualityOrSet.quality @@ get_sort_quality_of env sigma ty1 in
+    let s1 = get_sort_quality_of env sigma ty1 in
     let g = Environ.qualities env in
     let allowed_elim_on_sort = eliminates_to g s s1 in
     match (EConstr.kind sigma hd1, EConstr.kind sigma hd2) with
@@ -964,7 +964,7 @@ let find_positions env sigma ~keep_proofs ~no_discr ~eqsort ~goalsort t1 t2 =
   in
   try
     let ty1 = get_type_of env sigma t1 in
-    let s = UnivGen.QualityOrSet.quality @@ get_sort_quality_of env sigma ty1 in
+    let s = get_sort_quality_of env sigma ty1 in
     Inr (findrec [] s t1 t2)
   with DiscrFound (path, d) ->
     Inl (path, d)

--- a/tactics/induction.ml
+++ b/tactics/induction.ml
@@ -1095,7 +1095,7 @@ let apply_induction_in_context with_evars inhyps elim indvars names =
     in
     let statuslists,lhyp0,toclear,deps,avoid,dep_in_hyps = cook_sign hyp0 inhyps indvars env sigma in
     let tmpcl = it_mkNamedProd_or_LetIn sigma concl deps in
-    let s = Retyping.get_sort_quality_of env sigma tmpcl in
+    let s = Retyping.get_sort_quality_or_set_of env sigma tmpcl in
     let deps_cstr =
       List.fold_left
         (fun a decl -> if NamedDecl.is_local_assum decl then (mkVar (NamedDecl.get_id decl))::a else a) [] deps in

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -96,7 +96,7 @@ let make_inv_predicate env evd indf realargs id status concl =
             match dflt_concl with
               | Some concl -> concl (*assumed it's some [x1..xn,H:I(x1..xn)]C*)
               | None ->
-                let sort = get_sort_quality_of env !evd concl in
+                let sort = get_sort_quality_or_set_of env !evd concl in
                 let sort = evd_comb1 Evd.fresh_sort_in_quality evd sort in
                 let p = make_arity env !evd true indf sort in
                 let evd',(p,ptyp) = Unification.abstract_list_all env

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -968,8 +968,8 @@ let fold_match ?(force=false) env sigma c =
     in
     let sk =
       (* not sure how correct this is *)
-      if UnivGen.QualityOrSet.is_prop sortp then
-        if UnivGen.QualityOrSet.is_prop sortc then
+      if Sorts.Quality.is_qprop sortp then
+        if Sorts.Quality.is_qprop sortc then
           if dep then case_dep
           else case_nodep
         else (

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -586,13 +586,13 @@ let elimination_sort_of_goal gl =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let c = Proofview.Goal.concl gl in
-  Retyping.get_sort_quality_of env sigma c
+  Retyping.get_sort_quality_or_set_of env sigma c
 
 let elimination_sort_of_hyp id gl =
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let c = Tacmach.pf_get_hyp_typ id gl in
-  Retyping.get_sort_quality_of env sigma c
+  Retyping.get_sort_quality_or_set_of env sigma c
 
 let elimination_sort_of_clause id gl = match id with
 | None -> elimination_sort_of_goal gl

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1432,7 +1432,7 @@ let default_elim with_evars clear_flag (c,_ as cx) =
       let (ind,u) = eval_to_quantified_ind env sigma t in
       if is_nonrec env ind then raise IsNonrec;
       let sigma, elim = find_ind_eliminator env sigma ind
-                          (Retyping.get_sort_quality_of env sigma concl) in
+                          (Retyping.get_sort_quality_or_set_of env sigma concl) in
       Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
       (general_elim with_evars clear_flag cx (ElimConstant (mkConstU elim, UnknownPosition)))
     end)
@@ -1497,7 +1497,7 @@ let make_projection env sigma params cstr sign elim i n c (ind, u) =
       then
         let (_, mip) as specif = Inductive.lookup_mind_specif env ind in
         let t = lift (i + 1 - n) t in
-        let ksort = Retyping.get_sort_quality_of (push_rel_context sign env) sigma t in
+        let ksort = Retyping.get_sort_quality_or_set_of (push_rel_context sign env) sigma t in
         if UnivGen.QualityOrSet.eliminates_to (Inductiveops.elim_sort specif) ksort then
           let arity = List.firstn mip.mind_nrealdecls mip.mind_arity_ctxt in
           let mknas ctx = Array.of_list (List.rev_map get_annot ctx) in
@@ -2927,7 +2927,7 @@ let exfalso =
     let sigma = Proofview.Goal.sigma gl in
     let (sigma, f) = Evd.fresh_global env sigma (Rocqlib.lib_ref "core.False.type") in
     let (ind, _) = reduce_to_atomic_ind env sigma f in
-    let s = Retyping.get_sort_quality_of env sigma (Proofview.Goal.concl gl) in
+    let s = Retyping.get_sort_quality_or_set_of env sigma (Proofview.Goal.concl gl) in
     let sigma, elimc = find_ind_eliminator env sigma (fst ind) s in
     let elimc = mkConstU elimc in
     let elimt = Retyping.get_type_of env sigma elimc in

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -495,7 +495,7 @@ let build_combined_scheme env schemes =
   *)
   let inprop =
     let inprop (_,t) =
-      UnivGen.QualityOrSet.is_prop
+      Sorts.Quality.is_qprop
         (Retyping.get_sort_quality_of env sigma (EConstr.of_constr t))
     in
     List.for_all inprop defs


### PR DESCRIPTION
This horrendous type should never have escaped from its very specific use-case, namely to be able to have separate induction principles for predicates returning a Set or a Type. We expose a proper retyping primitive giving direct access to the quality, which is what most users actually rely on.

Overlays:
- https://github.com/rocq-prover/equations/pull/718