### PR TITLE
Generalize Print to print multiple arguments

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22017-GeneralizePrint-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22017-GeneralizePrint-Changed.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  Generalize Print command to print multiples definitions
+  (`#22017 <https://github.com/rocq-prover/rocq/pull/22017>`_,
+  by Elsa Rabu).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -11,14 +11,16 @@ Displaying
 
 .. _Print:
 
-.. cmd:: Print {? Term } @reference {? @univ_name_list }
+.. cmd:: Print {? Term } {+, @reference {? @univ_name_list } }
 
    .. insertprodn univ_name_list univ_name_list
 
    .. prodn::
       univ_name_list ::= @%{ {* @name } {? ; {* @name } } %}
 
-   Displays definitions of terms, including opaque terms, for the object :n:`@reference`.
+   Displays definitions of terms, including opaque terms, for one or more object :n:`@reference`\s.
+   When multiple comma-separted :n: `@reference`\s are given, their information is printed
+   in order with a blank line between each.
 
    * :n:`Term` - a syntactic marker to allow printing a term
      that is the same as one of the various :n:`Print` commands.  For example,

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1220,7 +1220,7 @@ printable: [
 | WITH "Visibility" OPT scope_name
 | REPLACE [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT ne_string
 | WITH OPT "Sorted" "Universes" OPT printunivs_subgraph OPT [ [ "With" | "Without" ] "Constraint" "Sources" ] OPT ne_string
-| DELETE "Term" smart_global OPT univ_name_list  (* readded in commands *)
+| DELETE "Term" LIST1 [ smart_global OPT univ_name_list ] SEP ","  (* readded in commands *)
 | REPLACE "Hint"
 | WITH "Hint" OPT [ "*" | smart_global ]
 | DELETE "Hint" smart_global
@@ -1361,8 +1361,8 @@ command: [
 (* show the locate options as separate commands *)
 | DELETE "Locate" locatable
 | locatable
-| REPLACE "Print" smart_global OPT univ_name_list
-| WITH "Print" OPT "Term" smart_global OPT univ_name_list
+| REPLACE "Print" LIST1 [ smart_global OPT univ_name_list ] SEP ","
+| WITH "Print" OPT "Term" LIST1 [ smart_global OPT univ_name_list ] SEP ","
 
 | REPLACE "Declare" "Scope" IDENT
 | WITH "Declare" "Scope" scope_name

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -552,7 +552,7 @@ command: [
 | "Locate" locatable
 | "Type" lconstr
 | "Print" printable
-| "Print" smart_global OPT univ_name_list
+| "Print" LIST1 [ smart_global OPT univ_name_list ] SEP ","
 | "Print" "Module" "Type" global
 | "Print" "Module" global
 | "Print" "Namespace" dirpath
@@ -1411,7 +1411,7 @@ query_command: [
 ]
 
 printable: [
-| "Term" smart_global OPT univ_name_list
+| "Term" LIST1 [ smart_global OPT univ_name_list ] SEP ","
 | "All"
 | "Section" global
 | "Grammar" OPT "Tree" LIST0 IDENT

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -795,7 +795,7 @@ command: [
 | "Print" "Strategies"
 | "Print" "Registered"
 | "Print" "Registered" "Schemes"
-| "Print" OPT "Term" reference OPT univ_name_list
+| "Print" OPT "Term" LIST1 [ reference OPT univ_name_list ] SEP ","
 | "Print" "Module" "Type" qualid
 | "Print" "Module" qualid
 | "Print" "Namespace" dirpath

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -126,6 +126,41 @@ Arguments nat_sind P%_function_scope O S%_function_scope n%_nat_scope
 nat_sind is transparent
 Expands to: Constant Corelib.Init.Datatypes.nat_sind
 Declared in library Corelib.Init.Datatypes, line 187, characters 0-54
+nat_rect =
+fun (P : nat -> Type) (O : P 0) (S : forall n : nat, P n -> P (S n)) =>
+fix F (n : nat) : P n :=
+  match n as n0 return P n0 with
+  | 0 => O
+  | Datatypes.S n0 => S n0 (F n0)
+  end
+     : forall P : nat -> Type,
+       P 0 -> (forall n : nat, P n -> P (S n)) -> forall n : nat, P n
+
+Arguments nat_rect P%_function_scope O S%_function_scope n%_nat_scope
+
+nat_ind =
+fun (P : nat -> Prop) (O : P 0) (S : forall n : nat, P n -> P (S n)) =>
+fix F (n : nat) : P n :=
+  match n as n0 return P n0 with
+  | 0 => O
+  | Datatypes.S n0 => S n0 (F n0)
+  end
+     : forall P : nat -> Prop,
+       P 0 -> (forall n : nat, P n -> P (S n)) -> forall n : nat, P n
+
+Arguments nat_ind P%_function_scope O S%_function_scope n%_nat_scope
+
+nat_sind =
+fun (P : nat -> SProp) (O : P 0) (S : forall n : nat, P n -> P (S n)) =>
+fix F (n : nat) : P n :=
+  match n as n0 return P n0 with
+  | 0 => O
+  | Datatypes.S n0 => S n0 (F n0)
+  end
+     : forall P : nat -> SProp,
+       P 0 -> (forall n : nat, P n -> P (S n)) -> forall n : nat, P n
+
+Arguments nat_sind P%_function_scope O S%_function_scope n%_nat_scope
 n:nat
 
 Hypothesis of the goal context.
@@ -169,7 +204,7 @@ fst is a projection of prod
 Arguments fst (A B)%_type_scope p
 fst is transparent
 Expands to: Constant PrintInfos.AboutProj.fst
-Declared in library PrintInfos, line 60, characters 21-24
+Declared in library PrintInfos, line 61, characters 21-24
 fst : forall A B : Type, prod A B -> A
 
 fst is not universe polymorphic
@@ -177,4 +212,4 @@ fst is a primitive projection of prod
 Arguments fst (A B)%_type_scope p
 fst is transparent
 Expands to: Constant PrintInfos.AboutPrimProj.fst
-Declared in library PrintInfos, line 66, characters 21-24
+Declared in library PrintInfos, line 67, characters 21-24

--- a/test-suite/output/PrintInfos.v
+++ b/test-suite/output/PrintInfos.v
@@ -33,6 +33,7 @@ Arguments eq_refl {A} {x}, {A} x.
 Print eq_refl.
 
 About nat_rect, nat_ind, nat_sind.
+Print nat_rect, nat_ind, nat_sind.
 
 Definition newdef := fun x:nat => x.
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1112,7 +1112,8 @@ GRAMMAR EXTEND Gram
 
       (* Printing (careful factorization of entries) *)
       | IDENT "Print"; p = printable -> { VernacSynPure (VernacPrint p) }
-      | IDENT "Print"; qid = smart_global; l = OPT univ_name_list -> { VernacSynPure (VernacPrint (PrintName (qid,l))) }
+      | IDENT "Print"; items = LIST1 [ qid = smart_global; l = OPT univ_name_list -> { (qid,l) } ] SEP "," ->
+          { VernacSynPure (VernacPrint (PrintName (items))) }
       | IDENT "Print"; IDENT "Module"; "Type"; qid = global ->
           { VernacSynPure (VernacPrint (PrintModuleType qid)) }
       | IDENT "Print"; IDENT "Module"; qid = global ->
@@ -1169,7 +1170,7 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   printable:
-    [ [ IDENT "Term"; qid = smart_global; l = OPT univ_name_list -> { PrintName (qid,l) }
+    [ [ IDENT "Term"; items = LIST1 [ qid = smart_global; l = OPT univ_name_list -> { (qid,l) } ] SEP "," -> { PrintName (items) }
       | IDENT "All" -> { PrintFullContext }
       | IDENT "Section"; s = global -> { PrintSectionContext s }
       | IDENT "Grammar"; tree = OPT [ IDENT "Tree" -> { () } ]; ent = LIST0 IDENT ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -689,8 +689,9 @@ let pr_printable = function
     keyword cmd ++ pr_opt pr_subgraph g ++ pr_opt pr_with_src with_sources ++ pr_opt str fopt
   | PrintSorts ->
     keyword "Print Sorts"
-  | PrintName (qid,udecl) ->
-    keyword "Print" ++ spc()  ++ pr_smart_global qid ++ pr_full_univ_name_list udecl
+  | PrintName (items) ->
+    keyword "Print" ++ spc()  ++ prlist_with_sep pr_comma
+        ( fun (qid,udecl) -> pr_smart_global qid ++ pr_full_univ_name_list udecl) items
   | PrintModuleType qid ->
     keyword "Print Module Type" ++ spc() ++ pr_qualid qid
   | PrintModule qid ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2291,8 +2291,10 @@ let vernac_print =
   | PrintMLModules -> no_state Mltop.print_ml_modules
   | PrintDebugGC -> no_state Mltop.print_gc
   | PrintDebugDelta qid -> no_state @@ fun () -> vernac_print_debug_delta qid
-  | PrintName (qid,udecl) -> with_proof_env_and_opaques @@ fun ~opaque_access env sigma ->
-    Prettyp.print_name opaque_access env sigma qid udecl
+  | PrintName (items) -> with_proof_env_and_opaques @@ fun ~opaque_access env sigma ->
+    let pp_one (qid,udecl) =
+      Prettyp.print_name opaque_access env sigma qid udecl
+    in prlist_with_sep (fun () -> fnl () ++ fnl ()) pp_one items
   | PrintGraph -> no_state Prettyp.print_graph
   | PrintClasses -> no_state Prettyp.print_classes
   | PrintTypeclasses -> no_state Prettyp.print_typeclasses

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -54,7 +54,7 @@ type printable =
   | PrintMLModules
   | PrintDebugGC
   | PrintDebugDelta of qualid option
-  | PrintName of qualid or_by_notation * UnivNames.univ_name_list option
+  | PrintName of (qualid or_by_notation * UnivNames.univ_name_list option) list
   | PrintGraph
   | PrintClasses
   | PrintTypeclasses


### PR DESCRIPTION
Generalize the `Print` and `Print Term` command to print multiples definitions


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->

  - [x] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
