### PR TITLE
Have {find,drop}_uniform_parameters work with mutual fixpoints correctly

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1390,12 +1390,11 @@ let find_uniform_parameters recindx nargs bodies =
   (* Ensure that the structural argument is not uniform,
      so that it stays in [non_absorbed_stack] *)
   let min_indx = Array.fold_left min nargs recindx in
-  (* We work only on the i-th body but are in the context of n bodies *)
-  let rec aux i k nuniformparams c =
+  let rec aux k nuniformparams c =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
-      let fold accu c = fold_constr_with_binders succ (aux i) k accu c in
+      let fold accu c = fold_constr_with_binders succ aux k accu c in
       let nuniformparams = List.fold_left fold nuniformparams l in
       (* A recursive reference to any one of the mutual fixpoints *)
       if n > k && n <= k + nbodies then
@@ -1411,9 +1410,9 @@ let find_uniform_parameters recindx nargs bodies =
           ) 0 l
       else
         nuniformparams
-    | _ -> fold_constr_with_binders succ (aux i) k nuniformparams c
+    | _ -> fold_constr_with_binders succ aux k nuniformparams c
   in
-  Array.fold_left_i (fun i -> aux i 0) min_indx bodies
+  Array.fold_left (aux 0) min_indx bodies
 
 (** Given a fixpoint [fix f x y z n {struct n} := phi(f x y u t, ..., f x y u' t')]
     with [z] not uniform we build in context [x:A, y:B(x), z:C(x,y)] a term
@@ -1423,19 +1422,19 @@ let find_uniform_parameters recindx nargs bodies =
 
 let drop_uniform_parameters nuniformparams bodies =
   let nbodies = Array.length bodies in
-  let rec aux i k c =
+  let rec aux k c =
     let f, l = decompose_app_list c in
     match kind f with
     | Rel n ->
-      let l = List.map (fun c -> aux i k c) l in
-      (* A recursive reference to the i-th body *)
-      if Int.equal n (nbodies + k - i) then
+      let l = List.map (fun c -> aux k c) l in
+      (* A recursive reference to any one of the mutual fixpoints *)
+      if n > k && n <= k + nbodies then
         let new_args = List.skipn nuniformparams l in
         Term.applist (f, new_args)
       else Term.applist (f, l)
-    | _ -> map_with_binders succ (aux i) k c
+    | _ -> map_with_binders succ aux k c
   in
-  Array.mapi (fun i -> aux i 0) bodies
+  Array.map (aux 0) bodies
 
 let filter_fix_stack_domain ?evars nr decrarg stack nuniformparams =
   let rec aux i nuniformparams stack =

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -644,3 +644,87 @@ Fixpoint test_size (t : test) : nat :=
   let 'Test ts := t in S (Pmap_fold (fun t' => plus (test_size t')) 0%nat ts).
 
 End TestIntersection.
+
+
+Module NestedUniform.
+
+(* Uniform arguments are passed as-is to nested fixpoints' bodies *)
+
+Fixpoint Valid1 (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S k =>
+    (fix f (a : nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => Valid1 a  (* a=k, subterm of n *)
+       | S m' => g a m'
+       end
+     with g (a : nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => 0
+       | S m' => h a m'
+       end
+     with h (a : nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => 0
+       | S m' => f a m'
+       end
+     for f) k k
+  end.
+
+(* Uniform arguments are checked in context of the nested fixpoints' bodies,
+   not in an of themselves *)
+
+Fixpoint Valid2 (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S k =>
+    (fix f (h : nat -> nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => h k  (* h = Valid2, k is a subterm *)
+       | S m' => f h m' + g h m'
+       end
+     with g (h : nat -> nat) (p : nat) {struct p} : nat :=
+       match p with
+       | 0 => h k
+       | S p' => f h p' + g h p'
+       end
+     for f) Valid2 k
+  end.
+
+
+Fail Fixpoint Bad1 (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S k =>
+    (fix f (a : nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => Bad1 (S a) (* [S a] not a subterm *)
+       | S m' => g a m'
+       end
+     with g (b : nat) (p : nat) {struct p} : nat :=
+       match p with
+       | 0 => 0
+       | S p' => f b p'
+       end
+     for f) k k
+  end.
+
+Fail Fixpoint Bad2 (n : nat) : nat :=
+  match n with
+  | 0 => 0
+  | S k =>
+    (fix f (h : nat) (m : nat) {struct m} : nat :=
+       match m with
+       | 0 => Bad2 h
+       | S m' => g (h + 0) m' (* First argument is not uniform *)
+       end
+     with g (h : nat) (p : nat) {struct p} : nat :=
+       match p with
+       | 0 => 0
+       | S p' => f h p'
+       end
+     for f) k k
+  end.
+
+End NestedUniform.


### PR DESCRIPTION
The only meaningful change is that drop_uniform_parameters used to not drop uniform arguments of cross calls. I wonder if this can be exploited.
I'm also worried about what happens when the context of a fixpoint is not only assumptions, and a local definition is considered uniform.