### PR TITLE
[experiment] Fast path when applying a clenv without metas.

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1637,6 +1637,12 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
     debug_tactic_unification (fun () -> str "Leaving unification with failure");
     Exninfo.iraise e
 
+let ground_unification env sigma pb flags m n =
+  let flags = flags.core_unify_flags in
+  match flags.modulo_conv_on_closed_terms with
+  | Some convflags -> careful_infer_conv ~pb ~ts:convflags env sigma m n
+  | _ -> constr_cmp pb env sigma flags m n
+
 let unify_0 ~metas env sigma pb flags c1 c2 =
   unify_0_with_initial_metas { subst_sigma = sigma; subst_metas = []; subst_evars = []; subst_metam = metas } true env pb flags (c1, Unknown) (c2, Unknown)
 

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -152,3 +152,6 @@ val pose_all_metas_as_evars : metas:Meta.t -> env -> evar_map -> constr -> evar_
    (exported for inv.ml) *)
 val abstract_list_all :
   env -> evar_map -> constr -> constr -> constr list -> evar_map * (constr * types)
+
+val ground_unification : env -> evar_map -> conv_pb -> unify_flags ->
+  constr -> constr -> evar_map option

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -451,10 +451,18 @@ let clenv_unify_meta_types ?(flags=default_unify_flags ()) clenv =
     Exninfo.iraise (ClenvCannotUnify (env, sigma, clenv, t1, t2, reason), info)
 
 let clenv_unique_resolver ?(flags=default_unify_flags ()) clenv concl =
-  let metas = meta_handler clenv.metam in
-  let (hd, _) = decompose_app clenv.evd (whd_nored ~metas clenv.env clenv.evd (fst clenv.templtyp)) in
-  let clenv = if isMeta clenv.evd hd then clenv_unify_meta_types ~flags clenv else clenv in
-  clenv_unify CUMUL ~flags (clenv_type clenv) concl clenv
+  if Metaset.is_empty (snd clenv.templtyp) && not (has_undefined_evars clenv.evd (clenv_type clenv)) && not (has_undefined_evars clenv.evd concl) then
+    let typ = clenv_type clenv in
+    match Unification.ground_unification clenv.env clenv.evd CUMUL flags typ concl with
+    | None ->
+      raise (ClenvCannotUnify (clenv.env, clenv.evd, clenv, typ, concl, None))
+    | Some sigma ->
+      update_clenv_evd clenv sigma clenv.metam
+  else
+    let metas = meta_handler clenv.metam in
+    let (hd, _) = decompose_app clenv.evd (whd_nored ~metas clenv.env clenv.evd (fst clenv.templtyp)) in
+    let clenv = if isMeta clenv.evd hd then clenv_unify_meta_types ~flags clenv else clenv in
+    clenv_unify CUMUL ~flags (clenv_type clenv) concl clenv
 
 let adjust_meta_source ~metas evd mv = function
   | loc,Evar_kinds.VarInstance id ->


### PR DESCRIPTION
Applying clenv without metas is a very common occurrence, and it relies on the general unification algorithm even though we know statically that no actual unification is possible.