### PR TITLE
Make dune a build-time only dependency

### DIFF
--- a/coq-core.opam
+++ b/coq-core.opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/coqide-server.opam
+++ b/coqide-server.opam
@@ -21,7 +21,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -28,6 +28,7 @@
  (depends
   (ocaml (>= 4.14.0))
   (ocamlfind (and (>= 1.9.1) (or (>= 1.9.8) (<> :os-family "windows"))))
+  (dune :build)
   (zarith (>= 1.11))
   (conf-linux-libc-dev (= :os "linux")))
  (conflicts
@@ -57,6 +58,7 @@ prelude, now living in the rocq-core package."))
  (name rocq-devtools)
  (depends
   (rocq-runtime (= :version))
+  (dune :build)
   (yojson (>= 2.0))
   camlzip)
  (synopsis "Development tools for Rocq")
@@ -77,6 +79,7 @@ This package includes tools to help when developing Rocq projects
 (package
  (name coq-core)
  (depends
+  (dune :build)
   (rocq-runtime (= :version)))
  (synopsis "Compatibility binaries for Coq after the Rocq renaming")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
@@ -96,6 +99,7 @@ through previous Coq commands like coqc coqtop,..."))
 (package
  (name rocq-core)
  (depends
+  (dune :build)
   (rocq-runtime (= :version)))
  (synopsis "The Rocq Prover with its prelude")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
@@ -116,6 +120,7 @@ Corelib.* and Ltac2.* namespaces."))
 (package
  (name coqide-server)
  (depends
+  (dune :build)
   (rocq-runtime (= :version)))
  (synopsis "The Rocq Prover, XML protocol server")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
@@ -131,6 +136,7 @@ structured way."))
 (package
  (name rocqide)
  (depends
+  (dune :build)
   (ocamlfind :build)
   (conf-findutils :build)
   conf-adwaita-icon-theme

--- a/rocq-core.opam
+++ b/rocq-core.opam
@@ -26,7 +26,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/rocq-devtools.opam
+++ b/rocq-devtools.opam
@@ -25,8 +25,8 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
   "rocq-runtime" {= version}
+  "dune" {>= "3.8" & build}
   "yojson" {>= "2.0"}
   "camlzip"
   "odoc" {with-doc}

--- a/rocq-runtime.opam
+++ b/rocq-runtime.opam
@@ -29,9 +29,9 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
   "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
+  "dune" {>= "3.8" & build}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}
   "odoc" {with-doc}

--- a/rocqide.opam
+++ b/rocqide.opam
@@ -19,7 +19,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "ocamlfind" {build}
   "conf-findutils" {build}
   "conf-adwaita-icon-theme"


### PR DESCRIPTION
We don't need to recompile Rocq every time dune is updated.

Fix #22025
