### PR TITLE
Internal tweaks to the Hints API

### DIFF
--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1762,11 +1762,11 @@ let pr_searchtable env sigma =
   in
   Hintdbmap.fold fold !searchtable (mt ())
 
-type 'a hint_ast =
-  | Res_pf     of 'a (* Hint Apply *)
-  | ERes_pf    of 'a (* Hint EApply *)
-  | Give_exact of 'a
-  | Res_pf_THEN_trivial_fail of 'a (* Hint Immediate *)
+type hint_ast =
+  | Res_pf     of hint (* Hint Apply *)
+  | ERes_pf    of hint (* Hint EApply *)
+  | Give_exact of hint
+  | Res_pf_THEN_trivial_fail of hint (* Hint Immediate *)
   | Unfold_nth of Evaluable.t (* Hint Unfold *)
   | Extern of Pattern.constr_pattern option * Gentactic.glob_generic_tactic (* Hint Extern *)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -95,6 +95,9 @@ let empty_hint_info =
 (*           The Type of Constructions Autotactic Hints                 *)
 (************************************************************************)
 
+module Internal =
+struct
+
 type 'a hint_ast =
   | Res_pf     of 'a (* Hint Apply *)
   | ERes_pf    of 'a (* Hint EApply *)
@@ -103,6 +106,9 @@ type 'a hint_ast =
   | Unfold_nth of Evaluable.t (* Hint Unfold *)
   | Extern of Pattern.constr_pattern option * Gentactic.glob_generic_tactic (* Hint Extern *)
 
+end
+
+open Internal
 
 type 'a hints_path_atom_gen =
   | PathHints of 'a list
@@ -1756,6 +1762,22 @@ let pr_searchtable env sigma =
   in
   Hintdbmap.fold fold !searchtable (mt ())
 
+type 'a hint_ast =
+  | Res_pf     of 'a (* Hint Apply *)
+  | ERes_pf    of 'a (* Hint EApply *)
+  | Give_exact of 'a
+  | Res_pf_THEN_trivial_fail of 'a (* Hint Immediate *)
+  | Unfold_nth of Evaluable.t (* Hint Unfold *)
+  | Extern of Pattern.constr_pattern option * Gentactic.glob_generic_tactic (* Hint Extern *)
+
+let to_user_ast = function
+| Internal.Res_pf h -> Res_pf h
+| Internal.ERes_pf h -> ERes_pf h
+| Internal.Give_exact h -> Give_exact h
+| Internal.Res_pf_THEN_trivial_fail h -> Res_pf_THEN_trivial_fail h
+| Internal.Unfold_nth h -> Unfold_nth h
+| Internal.Extern (pat, tac) -> Extern (pat, tac)
+
 module FullHint =
 struct
   type t = full_hint
@@ -1765,7 +1787,7 @@ struct
   | None -> None
   | Some (ConstrPattern p | SyntacticPattern p) -> Some p
   | Some DefaultPattern -> None
-  let run (h : t) k = k h.code.obj
+  let run (h : t) k = k (to_user_ast h.code.obj)
   let print env sigma (h : t) = pr_hint env sigma h.code
   let name (h : t) = h.name
 
@@ -1774,7 +1796,7 @@ struct
   | Unfold_nth _ -> Some 1
   | Extern _ -> None
 
-  let repr (h : t) = h.code.obj
+  let repr (h : t) = to_user_ast h.code.obj
 end
 
 let connect_hint_clenv h gl =

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -31,15 +31,15 @@ val hint_cat : Libobject.category
 
 (** Pre-created hint databases *)
 
-type 'a hint_ast =
-  | Res_pf     of 'a (* Hint Apply *)
-  | ERes_pf    of 'a (* Hint EApply *)
-  | Give_exact of 'a
-  | Res_pf_THEN_trivial_fail of 'a (* Hint Immediate *)
+type hint
+
+type hint_ast =
+  | Res_pf     of hint (* Hint Apply *)
+  | ERes_pf    of hint (* Hint EApply *)
+  | Give_exact of hint
+  | Res_pf_THEN_trivial_fail of hint (* Hint Immediate *)
   | Unfold_nth of Evaluable.t (* Hint Unfold *)
   | Extern of Pattern.constr_pattern option * Gentactic.glob_generic_tactic (* Hint Extern *)
-
-type hint
 
 val hint_as_term : hint -> UnivGen.sort_context_set option * constr
 
@@ -57,14 +57,14 @@ sig
   val priority : t -> int
   val pattern : t -> Pattern.constr_pattern option
   val database : t -> string option
-  val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
+  val run : t -> (hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> GlobRef.t option
   val print : env -> evar_map -> t -> Pp.t
   val subgoals : t -> int option
 
   (** This function is for backward compatibility only, not to use in newly
     written code. *)
-  val repr : t -> hint hint_ast
+  val repr : t -> hint_ast
 end
 
 (** The head may not be bound. *)


### PR DESCRIPTION
This is a sub-patch of a PR of mine that allows decoupling the internal details of Hints with the API exposed for the hint AST. This will allow modifying the internals without having to write overlays.