### PR TITLE
Test for uniform parameters with correct bounds

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1168,7 +1168,7 @@ let has_constant_parameters env nvars k ((mind, _), _) args =
   let mib = Environ.lookup_mind mind env in
   let auxnpar = mib.mind_nparams_rec in
   let (lpar, _) = List.chop auxnpar args in
-  List.for_all (fun c -> noccur_with_meta (1 + k) (nvars + k) c) lpar
+  List.for_all (fun c -> noccur_with_meta (1 + k) nvars c) lpar
 
 (* [restrict_spec env spec p] restricts the size information in spec to what is
    allowed to flow out of a match with predicate p in environment env. *)


### PR DESCRIPTION
`noccur_with_meta` (just like `noccur`) tests for occurrence between its first argument and *the sum of the first argument and* the second argument. Hence why, under some number of binders, only the first argument needs to be bumped.

In context, `has_constant_parameters` is only used as a fast-path, short-circuiting pruning when it returns `true`.
This erroneous bump means that it returns `true` less often, instead testing against variable occurrence in a larger span.
This issue was thus not critical, only going through pruning more often than necessary.