### PR TITLE
Fix contract_case anomaly: reimplement with evar-aware decomposition

### DIFF
--- a/doc/changelog/01-kernel/22058-einductive-contract-case-Fixed.rst
+++ b/doc/changelog/01-kernel/22058-einductive-contract-case-Fixed.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``EConstr.contract_case`` no longer anomalies when Case branches
+  contain evar-backed Lambda bodies (e.g., from ``Constr.in_context``)
+  (`#22058 <https://github.com/rocq-prover/rocq/issues/22058>`_,
+  by Jason Gross).

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -423,6 +423,21 @@ let decompose_lambda_n_decls sigma n =
   in
   lamdec_rec Context.Rel.empty n
 
+let decompose_lambda_n_decls_opt sigma n c =
+  let open Rel.Declaration in
+  if n < 0 then
+    anomaly Pp.(str "decompose_lambda_n_decls_opt: integer parameter must be positive.");
+  let rec lamdec_rec l n c =
+    if Int.equal n 0 then Some (l, c)
+    else
+      match kind sigma c with
+      | Lambda (x,t,c)  -> lamdec_rec (Context.Rel.add (LocalAssum (x,t)) l) (n-1) c
+      | LetIn (x,b,t,c) -> lamdec_rec (Context.Rel.add (LocalDef (x,b,t)) l) (n-1) c
+      | Cast (c,_,_)    -> lamdec_rec l n c
+      | _ -> None
+  in
+  lamdec_rec Context.Rel.empty n c
+
 let rec to_lambda sigma n prod =
   if Int.equal n 0 then
     prod
@@ -594,6 +609,12 @@ let iter sigma f c =
     List.iter (fun c -> f c) args
   | _ -> Constr.iter f c
 
+(* Note: these case-related functions are evar-aware wrappers of
+   Inductive.expand_case / contract_case / etc. They live here rather
+   than in a separate EInductive module because iter_with_full_binders
+   (below) calls annotate_case, which would create a circular
+   dependency: EInductive -> EConstr (for EConstr.kind etc.) and
+   EConstr -> EInductive (for annotate_case). *)
 let expand_case env _sigma (ci, u, pms, p, iv, c, bl) =
   let u = EInstance.unsafe_to_instance u in
   let pms = unsafe_to_constr_array pms in
@@ -644,20 +665,42 @@ let expand_branch env _sigma u pms (ind, i) (nas, _br) =
   in
   ans
 
-let contract_case env _sigma (ci, (p,r), iv, c, bl) =
-  let p = unsafe_to_constr p in
-  let r = ERelevance.unsafe_to_relevance r in
-  let iv = unsafe_to_case_invert iv in
-  let c = unsafe_to_constr c in
-  let bl = unsafe_to_constr_array bl in
-  let (ci, u, pms, p, iv, c, bl) = Inductive.contract_case env (ci, (p,r), iv, c, bl) in
-  let u = EInstance.make u in
-  let pms = of_constr_array pms in
-  let p = of_return p in
-  let iv = of_case_invert iv in
-  let c = of_constr c in
-  let bl = of_branches bl in
-  (ci, u, pms, p, iv, c, bl)
+let contract_case env sigma (ci, (p,rp), iv, c, br) =
+  let open Context.Rel.Declaration in
+  let open Declarations in
+  let (mib, mip) = Inductive.lookup_mind_specif env ci.ci_ind in
+  let (arity, p) =
+    match decompose_lambda_n_decls_opt sigma (mip.mind_nrealdecls + 1) p with
+    | Some v -> v
+    | None ->
+      anomaly Pp.(str "contract_case: not enough abstractions in return predicate.")
+  in
+  let (u, pms) = match arity with
+  | LocalAssum (_, ty) :: _ ->
+    let (ind, args) = decompose_app sigma ty in
+    let (ind, u) = destInd sigma ind in
+    let () = assert (Environ.QInd.equal env ind ci.ci_ind) in
+    let pms = Array.sub args 0 mib.mind_nparams in
+    let dummy = List.make mip.mind_nrealdecls Constr.mkProp in
+    let pms = Array.map (fun c -> of_constr (CVars.substl dummy (unsafe_to_constr c))) pms in
+    (u, pms)
+  | _ -> assert false
+  in
+  let p =
+    let nas = Array.of_list (List.rev_map get_annot arity) in
+    ((nas, p), rp)
+  in
+  let map i br =
+    let (ctx, br) =
+      match decompose_lambda_n_decls_opt sigma mip.mind_consnrealdecls.(i) br with
+      | Some v -> v
+      | None ->
+        anomaly Pp.(fmt "contract_case: not enough abstractions in branch %d." i)
+    in
+    let nas = Array.of_list (List.rev_map get_annot ctx) in
+    (nas, br)
+  in
+  (ci, u, pms, p, iv, c, Array.mapi map br)
 
 let iter_with_full_binders env sigma g f n c =
   let open Context.Rel.Declaration in

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -313,6 +313,11 @@ val decompose_lambda_n_assum : Evd.evar_map -> int -> t -> rel_context * t
      @raise UserError if the term doesn't have enough lambdas/letins. *)
 val decompose_lambda_n_decls : Evd.evar_map -> int -> t -> rel_context * t
 
+(** Like [decompose_lambda_n_decls] but returns [None] instead of raising
+    an anomaly when there are not enough abstractions. *)
+val decompose_lambda_n_decls_opt : Evd.evar_map -> int -> t ->
+  (rel_context * t) option
+
 val prod_decls : Evd.evar_map -> t -> rel_context
 
 val to_lambda : Evd.evar_map -> int -> t -> t

--- a/test-suite/bugs/bug_22058.v
+++ b/test-suite/bugs/bug_22058.v
@@ -1,0 +1,27 @@
+(* Test for bug #22058: contract_case anomaly on evar-backed Case branches *)
+From Ltac2 Require Import Ltac2 Constr.
+
+Ltac2 make_evar_backed_branch () : constr :=
+  Constr.in_context @a constr:(nat) (fun () =>
+    let inner :=
+      Constr.in_context @b constr:(nat) (fun () =>
+        let a := Control.hyp @a in
+        let b := Control.hyp @b in
+        Control.refine (fun () => constr:(Nat.add $a $b))) in
+    Control.refine (fun () => inner)).
+
+Goal True.
+  let template := constr:(fun (p : nat * nat) => let '(a, b) := p in a + b) in
+  match Unsafe.kind template with
+  | Unsafe.Lambda _ body =>
+    match Unsafe.kind body with
+    | Unsafe.Case ci retrel iv scrut _branches =>
+      let new_branch := make_evar_backed_branch () in
+      let branches := Array.make 1 new_branch in
+      let _ := Constr.Unsafe.make (Unsafe.Case ci retrel iv scrut branches) in
+      ()
+    | _ => ()
+    end
+  | _ => ()
+  end.
+Abort.


### PR DESCRIPTION
## Summary

Fix `contract_case` anomaly on evar-backed Case branches (#22058).

`EConstr.contract_case` previously delegated to the kernel's `Inductive.contract_case` via `unsafe_to_constr` (the identity function), which does not resolve evars. When branches contain evar-backed Lambda bodies (e.g., from `Constr.in_context`), raw `Constr.kind` sees `Evar` instead of `Lambda`, causing `contract_case` to anomaly.

This PR reimplements `EConstr.contract_case` using `EConstr.kind sigma`, following the established pattern of `EConstr.decompose_lambda_decls` et al. A separate `EInductive` module was considered but would create a circular dependency (`EInductive` → `EConstr` for `kind`/`decompose_app`/etc., `EConstr` → `EInductive` for `annotate_case` via `iter_with_full_binders`), so the implementation stays in `EConstr`.

Also adds `EConstr.decompose_lambda_n_decls_opt`, an `option`-returning variant that mirrors `Term.decompose_lambda_n_decls_opt` but uses `EConstr.kind sigma`.

This is an alternative to #22059 — both fix the same anomaly, but this PR reimplements the operation rather than patching `unsafe_to_constr` usage.

Closes #22058

## Test plan

- [ ] `test-suite/bugs/bug_22058.v` exercises the evar-backed branch reproducer
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)