### PR TITLE
Store template inductive data abstracted w.r.t. template levels.

### DIFF
--- a/dev/ci/user-overlays/22070-ppedrot-kernel-abstract-univ-inductive.sh
+++ b/dev/ci/user-overlays/22070-ppedrot-kernel-abstract-univ-inductive.sh
@@ -1,0 +1,5 @@
+overlay elpi https://github.com/ppedrot/coq-elpi kernel-abstract-univ-inductive 22070
+
+overlay equations https://github.com/ppedrot/equations kernel-abstract-univ-inductive 22070
+
+overlay paramcoq https://github.com/ppedrot/paramcoq kernel-abstract-univ-inductive 22070

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -266,11 +266,17 @@ let push_relevances infos nas =
 let identity_of_ctx (ctx:Constr.rel_context) =
   Context.Rel.instance mkRel 0 ctx
 
+let get_template_instance mib u = match mib.mind_template with
+| None -> u
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty u) in
+  templ.template_defaults
+
 (* ind -> fun args => ind args *)
 let eta_expand_ind env (ind,u as pind) =
   let mib = Environ.lookup_mind (fst ind) env in
   let mip = mib.mind_packets.(snd ind) in
-  let ctx = Vars.subst_instance_context u mip.mind_arity_ctxt in
+  let ctx = Vars.subst_instance_context (get_template_instance mib u) mip.mind_arity_ctxt in
   let args = identity_of_ctx ctx in
   let c = mkApp (mkIndU pind, args) in
   let c = Term.it_mkLambda_or_LetIn c ctx in
@@ -279,7 +285,7 @@ let eta_expand_ind env (ind,u as pind) =
 let eta_expand_constructor env ((ind,ctor),u as pctor) =
   let mib = Environ.lookup_mind (fst ind) env in
   let mip = mib.mind_packets.(snd ind) in
-  let ctx = Vars.subst_instance_context u (fst mip.mind_nf_lc.(ctor-1)) in
+  let ctx = Vars.subst_instance_context (get_template_instance mib u) (fst mip.mind_nf_lc.(ctor-1)) in
   let args = identity_of_ctx ctx in
   let c = mkApp (mkConstructU pctor, args) in
   let c = Term.it_mkLambda_or_LetIn c ctx in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -308,6 +308,13 @@ let ind_relevance kn env = match Indmap_env.find_opt kn env.irr_inds with
     [instantiate_context u subst nas ctx] applies both [u] and [subst] to [ctx]
     while replacing names using [nas] (order reversed)
 *)
+
+let get_template_instance mib u = match mib.mind_template with
+| None -> u
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty u) in
+  templ.template_defaults
+
 let instantiate_context u subst nas ctx =
   let open Context.Rel.Declaration in
   let get_binder i na =
@@ -333,11 +340,15 @@ let instantiate_context u subst nas ctx =
 
 let expand_arity (mib, mip) (ind, u) params nas =
   let open Context.Rel.Declaration in
+  let u = get_template_instance mib u in
   let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
   let params = Vars.subst_of_rel_context_instance paramdecl params in
   let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
   let self =
-    let u = UVars.Instance.abstract_instance (UVars.Instance.length u) in
+    let u =
+      if Option.has_some mib.mind_template then UVars.Instance.empty
+      else UVars.Instance.abstract_instance (UVars.Instance.length u)
+    in
     let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
     mkApp (mkIndU (ind, u), args)
   in
@@ -346,6 +357,7 @@ let expand_arity (mib, mip) (ind, u) params nas =
   instantiate_context u params nas realdecls
 
 let expand_branch_contexts (mib, mip) u params br =
+  let u = get_template_instance mib u in
   let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
   let paramsubst = Vars.subst_of_rel_context_instance paramdecl params in
   let build_one_branch i (nas, _) (ctx, _) =

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -341,7 +341,7 @@ let make_template_univ_names (u:UVars.Instance.t) : UVars.bound_names =
   {quals = Array.make qlen Anonymous; univs = Array.make ulen Anonymous}
 
 let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
-| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> mie, None, None
+| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> None, None
 | Template_ind_entry {uctx; default_univs} ->
   let ((template_qvars, _), (template_univs, _ as template_uctx) as template_context) =
     UVars.UContext.to_context_set uctx
@@ -500,7 +500,7 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
     qsubst, usubst
   in
 
-  mie, Some template_usubst, Some {
+  Some template_usubst, Some {
     template_param_arguments;
     template_context;
     template_concl;
@@ -547,7 +547,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   assert (List.is_empty (Environ.rel_context env));
 
   (* universes *)
-  let mie, template_usubst, template = get_template mie in
+  let template_usubst, template = get_template mie in
 
   let env_univs =
     match mie.mind_entry_universes with

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -336,14 +336,10 @@ let check_no_increment ~template_univs u =
     CErrors.user_err
       Pp.(str "Template polymorphism with conclusion strictly larger than a bound universe not supported.")
 
-let make_template_univ_names (u:UVars.Instance.t) : UVars.bound_names =
-  let qlen, ulen = UVars.Instance.length u in
-  {quals = Array.make qlen Anonymous; univs = Array.make ulen Anonymous}
-
 let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
 | Monomorphic_ind_entry | Polymorphic_ind_entry _ -> None, None
 | Template_ind_entry {uctx; default_univs} ->
-  let ((template_qvars, _), (template_univs, _ as template_uctx) as template_context) =
+  let ((template_qvars, _), (template_univs, _ as template_uctx)) =
     UVars.UContext.to_context_set uctx
   in
   let params = mie.mind_entry_params in
@@ -354,11 +350,8 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
   in
   let () = check_unbounded_from_below template_uctx in
 
-  let template_context =
-    UVars.UContext.of_context_set make_template_univ_names template_context
-  in
   let template_abstract, template_context =
-    let inst, ctx = UVars.abstract_universes template_context in
+    let inst, ctx = UVars.abstract_universes uctx in
     UVars.make_instance_subst inst, ctx
   in
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -159,8 +159,8 @@ let check_indices_matter env_params info indices =
     (info, relies_on_indices_not_mattering)
 
 (* env_ar contains the inductives before the current ones in the block, and no parameters *)
-let check_arity ~template env_params env_ar ind =
-  let {utj_val=arity;utj_type=_} = Typeops.infer_type env_params ind.mind_entry_arity in
+let check_arity ~template env_params env_ar (na, arity) =
+  let {utj_val=arity;utj_type=_} = Typeops.infer_type env_params arity in
   let indices, ind_sort = Reduction.dest_arity env_params arity in
   let univ_info = {
     ind_squashed=None;
@@ -175,7 +175,7 @@ let check_arity ~template env_params env_ar ind =
      full_arity is used as argument or subject to cast, an upper
      universe will be generated *)
   let arity = it_mkProd_or_LetIn arity (Environ.rel_context env_params) in
-  let x = Context.make_annot (Name ind.mind_entry_typename) (Sorts.relevance_of_sort ind_sort) in
+  let x = Context.make_annot (Name na) (Sorts.relevance_of_sort ind_sort) in
   push_rel (LocalAssum (x, arity)) env_ar,
   (arity, indices, univ_info)
 
@@ -337,7 +337,7 @@ let check_no_increment ~template_univs u =
       Pp.(str "Template polymorphism with conclusion strictly larger than a bound universe not supported.")
 
 let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes with
-| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> None, None
+| Monomorphic_ind_entry | Polymorphic_ind_entry _ -> None
 | Template_ind_entry {uctx; default_univs} ->
   let ((template_qvars, _), (template_univs, _ as template_uctx)) =
     UVars.UContext.to_context_set uctx
@@ -464,71 +464,25 @@ let get_template (mie:mutual_inductive_entry) = match mie.mind_entry_universes w
       assums
   in
 
-  (* Substitution from the template binders to the default univs (and qtype for the qvars)
-     XXX can this be simplified by composing template_abstract and default_univs?
-     don't forget to check the default_univs qualities are all QType if so *)
-  let template_usubst : UVars.sort_level_subst =
+  (* don't forget to check the default_univs qualities are all QType *)
+  let () =
     let bind_instance = UVars.UContext.instance uctx in
     let () = if not UVars.(eq_sizes (Instance.length bind_instance) (Instance.length default_univs))
-      then CErrors.anomaly Pp.(str "Inorrect default template universes declaration.")
+      then CErrors.anomaly Pp.(str "Incorrect default template universes declaration.")
     in
     let bind_qs, bind_us = UVars.Instance.to_array bind_instance in
-    let default_qs, default_us = UVars.Instance.to_array default_univs in
-    let qsubst = Array.fold_left2 (fun qsubst bind_q default_q ->
-        let open Sorts.Quality in
-        match bind_q, default_q with
-        | (QConstant _ | QGlobal _), _ -> assert false
-        | QVar bind_q, QConstant QType ->
-          Sorts.QVar.Map.add bind_q default_q qsubst
-        | QVar _, _ -> CErrors.anomaly Pp.(str "Default template quality must be QType."))
-        Sorts.QVar.Map.empty
-        bind_qs default_qs
-    in
-    let usubst = Array.fold_left2 (fun usubst bind_u default_u ->
-        assert (not @@ Level.is_set bind_u);
-        Level.Map.add bind_u default_u usubst)
-        Level.Map.empty
-        bind_us default_us
-    in
-    qsubst, usubst
+    let default_qs, _ = UVars.Instance.to_array default_univs in
+    let () = assert (Array.for_all Sorts.Quality.is_qvar bind_qs) in
+    let () = assert (Array.for_all Sorts.Quality.is_qtype default_qs) in
+    assert (Array.for_all (fun bind_u -> not @@ Level.is_set bind_u) bind_us)
   in
 
-  Some template_usubst, Some {
+  Some {
     template_param_arguments;
     template_context;
     template_concl;
     template_defaults = default_univs;
   }
-
-let abstract_packets env usubst ((arity,lc),(indices,splayed_lc),univ_info,relies_on_indices_not_mattering) =
-  if not (List.is_empty univ_info.missing)
-  then raise (InductiveError (env, MissingUnivConstraints (univ_info.missing,univ_info.ind_univ)));
-  let arity = Vars.subst_univs_level_constr usubst arity in
-  let lc = Array.map (Vars.subst_univs_level_constr usubst) lc in
-  let indices = Vars.subst_univs_level_context usubst indices in
-  let splayed_lc = Array.map (fun (args,out) ->
-      let args = Vars.subst_univs_level_context usubst args in
-      let out = Vars.subst_univs_level_constr usubst out in
-      args,out)
-      splayed_lc
-  in
-  let ind_univ = UVars.subst_sort_level_sort usubst univ_info.ind_univ in
-
-  let arity = {user_arity = arity; sort = ind_univ} in
-
-  let squashed = Option.map (function
-      | AlwaysSquashed -> AlwaysSquashed
-      | SometimesSquashed qs ->
-        let qs = Sorts.Quality.Set.fold (fun q qs ->
-            Sorts.Quality.Set.add (UVars.subst_sort_level_quality usubst q) qs)
-            qs
-            Sorts.Quality.Set.empty
-        in
-        SometimesSquashed qs)
-      univ_info.ind_squashed
-  in
-
-  (arity,lc), (indices,splayed_lc), squashed, relies_on_indices_not_mattering
 
 let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   let () = match mie.mind_entry_inds with
@@ -540,17 +494,24 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   assert (List.is_empty (Environ.rel_context env));
 
   (* universes *)
-  let template_usubst, template = get_template mie in
+  let template = get_template mie in
 
-  let env_univs =
-    match mie.mind_entry_universes with
-    | Template_ind_entry {uctx; default_univs=_} ->
-      Environ.Internal.push_template_context uctx env
-    | Monomorphic_ind_entry -> env
-    | Polymorphic_ind_entry ctx ->
-      let () = check_ucontext ctx env in
-      let env = push_context ctx env in
-      env
+  (* Abstract universes *)
+  let env_univs, usubst, univs = match mie.mind_entry_universes with
+  | Monomorphic_ind_entry ->
+    env, UVars.empty_sort_subst, Monomorphic
+  | Template_ind_entry { uctx; _ } ->
+    let (inst, _) = UVars.abstract_universes uctx in
+    let usubst = UVars.make_instance_subst inst in
+    let template = Option.get template in
+    let env = Environ.Internal.push_template_context (AbstractContext.repr template.template_context) env in
+    env, usubst, Monomorphic
+  | Polymorphic_ind_entry uctx ->
+    let (inst, auctx) = UVars.abstract_universes uctx in
+    let usubst = UVars.make_instance_subst inst in
+    let () = check_ucontext (AbstractContext.repr auctx) env in
+    let env = Environ.push_context (AbstractContext.repr auctx) env in
+    env, usubst, Polymorphic auctx
   in
 
   let has_template_poly = match mie.mind_entry_universes with
@@ -559,10 +520,15 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   in
 
   (* Params *)
-  let env_params, params = Typeops.check_context env_univs mie.mind_entry_params in
+  let params = Vars.subst_univs_level_context usubst mie.mind_entry_params in
+  let env_params, params = Typeops.check_context env_univs params in
 
   (* Arities *)
-  let env_ar, data = List.fold_left_map (check_arity ~template:has_template_poly env_params) env_univs mie.mind_entry_inds in
+  let check_arity env_univs mib =
+    let arity = Vars.subst_univs_level_constr usubst mib.mind_entry_arity in
+    check_arity ~template:has_template_poly env_params env_univs (mib.mind_entry_typename, arity)
+  in
+  let env_ar, data = List.fold_left_map check_arity env_univs mie.mind_entry_inds in
   let env_ar_par = push_rel_context params env_ar in
 
   (* Constructors *)
@@ -570,10 +536,11 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
     | Some (Some _) -> true
     | Some None | None -> false
   in
-  let data = List.map2 (fun ind data ->
-      check_constructors ~env_params ~env_ar_par isrecord params ind.mind_entry_lc data)
-      mie.mind_entry_inds data
+  let map ind data =
+    let ctyp = List.map (fun t -> Vars.subst_univs_level_constr usubst t) ind.mind_entry_lc in
+    check_constructors ~env_params ~env_ar_par isrecord params ctyp data
   in
+  let data = List.map2 map mie.mind_entry_inds data in
 
   let record = mie.mind_entry_record in
   let data, record, not_prim_reason_or_has_eta = match record with
@@ -590,10 +557,11 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
       | Result.Error _ as reason ->
         (* if someone tried to declare a record as SProp but it can't
            be primitive we must squash. *)
-        let data = List.map (fun (a, b, univs, im) ->
-            a, b, compute_elim_squash env_ar_par Sorts.prop univs, im)
-            data
+        let map (a, b, univs, im) =
+          let univs = compute_elim_squash env_ar_par Sorts.prop univs in
+          (a, b, univs, im)
         in
+        let data = List.map map data in
         data, Some None, Some reason (* back to FakeRecord with a reason why *)
   in
 
@@ -605,7 +573,7 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
         CErrors.user_err Pp.(str "Inductive cannot be both monomorphic and universe cumulative.")
       | Polymorphic_ind_entry uctx ->
         (* no variance for qualities *)
-        let _qualities, univs = Instance.to_array @@ UContext.instance uctx in
+        let _qualities, univs = Instance.to_array @@ subst_sort_level_instance usubst @@ UContext.instance uctx in
         let univs = Array.map2 (fun a b -> a,b) univs variances in
         let univs = match sec_univs with
           | None -> univs
@@ -616,33 +584,22 @@ let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
             Array.append sec_univs univs
         in
         let variances = InferCumulativity.infer_inductive ~env_params ~env_ar_par
-            ~arities:(List.map (fun e -> e.mind_entry_arity) mie.mind_entry_inds)
-            ~ctors:(List.map (fun e -> e.mind_entry_lc) mie.mind_entry_inds)
+            ~arities:(List.map (fun e -> Vars.subst_univs_level_constr usubst e.mind_entry_arity) mie.mind_entry_inds)
+            ~ctors:(List.map (fun e -> List.map (fun c -> Vars.subst_univs_level_constr usubst c) e.mind_entry_lc) mie.mind_entry_inds)
             univs
         in
         Some variances
   in
 
-  (* Abstract universes *)
-  let usubst, univs = match mie.mind_entry_universes with
-  | Monomorphic_ind_entry ->
-    UVars.empty_sort_subst, Monomorphic
-  | Template_ind_entry _ ->
-    let usubst = Option.get template_usubst in
-    usubst, Monomorphic
-  | Polymorphic_ind_entry uctx ->
-    let (inst, auctx) = UVars.abstract_universes uctx in
-    let inst = UVars.make_instance_subst inst in
-    (inst, Polymorphic auctx)
+  let check_packet env (_, _, univ_info, _) =
+    if not (List.is_empty univ_info.missing)
+    then raise (InductiveError (env, MissingUnivConstraints (univ_info.missing,univ_info.ind_univ)));
   in
-  let params = Vars.subst_univs_level_context usubst params in
-  let data = List.map (abstract_packets env usubst) data in
-
-  let env_ar_par =
-    let ctx = Environ.rel_context env_ar_par in
-    let ctx = Vars.subst_univs_level_context usubst ctx in
-    let env = Environ.pop_rel_context (Environ.nb_rel env_ar_par) env_ar_par in
-    Environ.push_rel_context ctx env
+  let () = List.iter (fun pkt -> check_packet env pkt) data in
+  let map ((arity, lc), b, univs, relies_on_indices_not_mattering) =
+    let arity = { user_arity = arity; sort = univs.ind_univ } in
+    ((arity, lc), b, univs.ind_squashed, relies_on_indices_not_mattering)
   in
+  let data = List.map map data in
 
   env_ar_par, univs, template, variance, record, not_prim_reason_or_has_eta, params, Array.of_list data

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -516,7 +516,18 @@ let build_inductive env ~sec_univs names prv univs template variance
     let consnrealargs =
       Array.map (fun (d,_) -> Context.Rel.nhyps d)
         splayed_lc in
-    let mind_relevance = Sorts.relevance_of_sort arity.IndTyping.sort in
+    let mind_relevance = match template with
+    | None -> Sorts.relevance_of_sort arity.IndTyping.sort
+    | Some templ ->
+      match templ.template_concl with
+      | Sorts.Prop | Sorts.Set | Sorts.Type _ -> Sorts.Relevant
+      | Sorts.SProp -> Sorts.Irrelevant
+      | Sorts.VSort _ ->
+        (* Template inductive types are currently either constant or always
+          relevant, otherwise we'd need the template parameters to compute the relevance *)
+        Sorts.Relevant
+      | Sorts.GSort _ -> assert false
+    in
     let mind_record = match isrecord with
       | Some (Some rid) ->
         (** The elimination criterion ensures that all projections can be defined. *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -52,7 +52,14 @@ let find_coinductive ?evars env c =
 
 let inductive_params (mib,_) = mib.mind_nparams
 
+let get_template_instance mib u = match mib.mind_template with
+| None -> u
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty u) in
+  templ.template_defaults
+
 let inductive_paramdecls (mib,u) =
+  let u = get_template_instance mib u in
   Vars.subst_instance_context u mib.mind_params_ctxt
 
 let inductive_nnonrecparams mib = mib.mind_nparams - mib.mind_nparams_rec
@@ -85,8 +92,9 @@ let instantiate_params t u args sign =
   substl subs ty
 
 let full_constructor_instantiate (_,u,(mib,_),params) t =
+  let u = get_template_instance mib u in
   let inst_ind = subst_instance_constr u t in
-   instantiate_params inst_ind u params mib.mind_params_ctxt
+  instantiate_params inst_ind u params mib.mind_params_ctxt
 
 (************************************************************************)
 (************************************************************************)
@@ -376,14 +384,16 @@ let constrained_type_of_constructor cstru ind =
 let type_of_constructor_knowing_parameters cstr specif args =
   type_of_constructor_gen cstr specif args
 
-let arities_of_constructors (_,u) (_,mip) =
+let arities_of_constructors (_, u) (mib, mip) =
+  let u = get_template_instance mib u in
   let map (ctx, c) =
     let cty = Term.it_mkProd_or_LetIn c ctx in
     subst_instance_constr u cty
   in
   Array.map map mip.mind_nf_lc
 
-let type_of_constructors (_,u) (_,mip) =
+let type_of_constructors (_, u) (mib, mip) =
+  let u = get_template_instance mib u in
   Array.map (subst_instance_constr u) mip.mind_user_lc
 
 let abstract_constructor_type_relatively_to_inductive_types_context ntyps mind t =
@@ -1803,8 +1813,14 @@ let sorts_of_mutfix env minds names =
   if Array.exists ind_ignores_elim_constraints minds then None
   else
     Some (Array.fold_left_i (fun i sorts (ind, inst) ->
-        let _, mip = lookup_mind_specif env ind in
-        let ind_sort = UVars.subst_instance_sort inst mip.mind_sort in
+        let mib, mip = lookup_mind_specif env ind in
+        let ind_sort = match mib.mind_template with
+        | None -> UVars.subst_instance_sort inst mip.mind_sort
+        | Some templ ->
+          let () = assert (UVars.Instance.is_empty inst) in
+          (* suspect, this is always Type currently *)
+          UVars.subst_instance_sort templ.template_defaults mip.mind_sort
+        in
         let u = Sorts.univ_of_sort ind_sort in
         (* This is an approximation: a [Relevant] variable might be of sort [Prop]
            or [Type]. As we only care about the quality, we have to be conservative

--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -205,6 +205,8 @@ val check_cofix : ?evars:evar_handler -> env -> cofixpoint -> unit
 
 val abstract_mind_lc : int -> int -> MutInd.t -> (rel_context * constr) array -> constr array
 
+val get_template_instance : mutual_inductive_body -> Instance.t -> Instance.t
+
 module Template : sig
   val bind_kind : Sorts.t -> int option * int option
   val template_subst_sort : template_subst -> Sorts.t -> Sorts.t

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1862,7 +1862,10 @@ let check_register_ind (type t) ind (r : t CPrimitives.prim_ind) (mb, ob as spec
     check_nparams 2;
     check_nconstr 1;
     check_name 0 "pair";
-    let c = ob.mind_user_lc.(0) in
+    let c = match mb.mind_template with
+    | None -> ob.mind_user_lc.(0)
+    | Some templ -> Vars.subst_instance_constr templ.template_defaults ob.mind_user_lc.(0)
+    in
     let s =  Pp.str "the constructor does not have the expected type" in
     begin match Term.decompose_prod c with
       | ([_,b;_,a;_,_B;_,_A], codom) ->

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -219,6 +219,12 @@ let inductive_nalldecls env ind =
 
 (* Others *)
 
+let get_template_instance mib u = match mib.mind_template with
+| None -> u
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty (EConstr.Unsafe.to_instance u)) in
+  EInstance.make templ.template_defaults
+
 let inductive_paramdecls env (ind,u) =
   let u = EConstr.Unsafe.to_instance u in
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
@@ -226,6 +232,7 @@ let inductive_paramdecls env (ind,u) =
 
 let inductive_alldecls env (ind,u) =
   let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let u = get_template_instance mib u in
   Vars.subst_instance_context u (EConstr.of_rel_context mip.mind_arity_ctxt)
 
 let inductive_alltags env ind =

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -237,6 +237,8 @@ val control_only_guard : env -> Evd.evar_map -> EConstr.types -> unit
 val paramdecls_fresh_template : evar_map -> mutual_inductive_body * einstance ->
   evar_map * rel_context * Inductive.template_subst option
 
+val get_template_instance : mutual_inductive_body -> einstance -> einstance
+
 module Internal : sig
   (* FIXME hack for the [QVar]s, see the implementation for more information. *)
   val nf_relevance : Evd.evar_map -> Sorts.relevance -> Sorts.relevance

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -27,11 +27,10 @@ open Context.Rel.Declaration
 module GR = Names.GlobRef
 
 let fresh_template_context env0 sigma ind (mib, _ as spec) ?(refresh_all=false) args =
-  let templ = match mib.Declarations.mind_template with
-  | None -> assert false
-  | Some t -> Array.of_list t.template_param_arguments
-  in
-  let ctx = List.rev (EConstr.of_rel_context mib.Declarations.mind_params_ctxt) in
+  let template = Option.get mib.Declarations.mind_template in
+  let templ = Array.of_list template.template_param_arguments in
+  let ctx = CVars.subst_instance_context template.template_defaults mib.Declarations.mind_params_ctxt in
+  let ctx = List.rev (EConstr.of_rel_context ctx) in
   let rec freshen i env sigma accu sorts = function
   | [] -> sigma, List.rev sorts
   | LocalAssum (na, t) as decl :: ctx ->

--- a/tactics/allScheme.ml
+++ b/tactics/allScheme.ml
@@ -76,6 +76,12 @@ let check_strpos_context env uparams default cxt =
         aux (push_rel decl env) (List.map2 (&&) strpos_decl strpos) tel
   in aux env default (List.rev cxt)
 
+let get_inductive_sort (mib, mip) u = match mib.mind_template with
+| None -> UVars.subst_instance_sort u mip.mind_sort
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty u) in
+  UVars.subst_instance_sort templ.template_defaults mip.mind_sort
+
 module Cache =
 struct
 
@@ -621,7 +627,7 @@ let compute_one_return_sort mib ind is_nested u sub_temp fresh_sorts_ql =
   (* Recover the sort of the original inductive type *)
   let* sigma = get_sigma in
   let u = EInstance.kind sigma u in
-  let ind_sort = UVars.subst_instance_sort u ind.mind_sort in
+  let ind_sort = get_inductive_sort (mib, ind) u in
   let ind_sort =
     match sub_temp, mib.mind_template with
     | Some sub_temp, Some temp -> Template.template_subst_sort sub_temp temp.template_concl
@@ -1087,7 +1093,8 @@ let generate_all_theorem_aux kn kn_nested focus u mib uparams strpos nuparams : 
     closure_uparams_preds_hold_gen ~mk_pred_hold:true (build_binder fid Lambda) uparams strpos fresh_sorts in
   (* Evd.ustate 2. Fixpoint *)
   let* u_all = array_mapi (fun pos_ind _ -> fresh_inductive_instance (kn_nested, pos_ind)) mib.mind_packets in
-  let relevance_ind ind = Vars.subst_instance_relevance u @@ relevance_of_sort @@ ESorts.make ind.mind_sort in
+  let* sigma = get_sigma in
+  let relevance_ind ind = relevance_of_sort @@ ESorts.make (get_inductive_sort (mib, ind) (EInstance.kind sigma u)) in
   let fix_name pos_ind ind = make_annot (Name (Id.of_string "F")) (relevance_ind ind) in
   let fix_type pos_ind ind = return_type kn kn_nested pos_ind u u_all.(pos_ind) mib key_uparams key_uparams_preds nuparams in
   let fix_rarg pos_ind ind = (mib.mind_nparams - mib.mind_nparams_rec) + ind.mind_nrealargs in

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -91,6 +91,12 @@ let build_dependent_inductive ind (mib,mip) =
        Context.Rel.instance_list mkRel mip.mind_nrealdecls mib.mind_params_ctxt
        @ Context.Rel.instance_list mkRel 0 realargs)
 
+let maybe_template_instance (mib, mip) u = match mib.mind_template with
+| None -> u
+| Some templ ->
+  let () = assert (UVars.Instance.is_empty u) in
+  templ.template_defaults
+
 let named_hd env t na = named_hd env (Evd.from_env env) (EConstr.of_constr t) na
 let name_assumption env = function
 | LocalAssum (na,t) -> LocalAssum (map_annot (named_hd env t) na, t)
@@ -139,6 +145,7 @@ let error msg = user_err Pp.(str msg)
 
 let get_sym_eq_data env (ind,u) =
   let (mib,mip as specif) = lookup_mind_specif env ind in
+  let u = maybe_template_instance specif u in
   if not (Int.equal (Array.length mib.mind_packets) 1) ||
     not (Int.equal (Array.length mip.mind_nf_lc) 1) then
     error "Not an inductive type with a single constructor.";
@@ -174,6 +181,7 @@ let get_sym_eq_data env (ind,u) =
 
 let get_non_sym_eq_data env (ind,u) =
   let (mib,mip as specif) = lookup_mind_specif env ind in
+  let u = maybe_template_instance specif u in
   if not (Int.equal (Array.length mib.mind_packets) 1) ||
     not (Int.equal (Array.length mip.mind_nf_lc) 1) then
     error "Not an inductive type with a single constructor.";
@@ -802,6 +810,7 @@ let build_congr env (eq,refl,ctx) ind =
   let (ind,u as indu), ctx = with_context_set ctx
     (UnivGen.fresh_inductive_instance env ind) in
   let (mib,mip) = lookup_mind_specif env ind in
+  let u = maybe_template_instance (mib, mip) u in
   if not (Int.equal (Array.length mib.mind_packets) 1) || not (Int.equal (Array.length mip.mind_nf_lc) 1) then
     error "Not an inductive type with a single constructor.";
   if not (Int.equal mip.mind_nrealargs 1) then


### PR DESCRIPTION
All accesses to terms and sorts from a template inductive block need first to substitute the bound levels by the default template instance, just like polymorphic inductive types. Thanks to the invariants on template types, there is actually little additional work to do, because template levels can only appear in the type of parameters (not in lets!) or in the conclusion.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/1028
- https://github.com/rocq-prover/equations/pull/721
- https://github.com/rocq-community/paramcoq/pull/156