### PR TITLE
Makefile.ci use wildcard instead of exhaustive list of CI_TARGETS

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -42,72 +42,7 @@ CI_PLATFORM_FULL= \
     ci-stdlib \
     ci-unicoq
 
-CI_TARGETS= \
-    $(CI_PLATFORM_FULL) \
-    ci-argosy \
-    ci-async_test \
-    ci-atbr \
-    ci-autosubst \
-    ci-autosubst_ocaml \
-    ci-bbv \
-    ci-bedrock2 \
-    ci-bedrock2_examples \
-    ci-category_theory \
-    ci-ceres \
-    ci-coinduction \
-    ci-color \
-    ci-compcert \
-    ci-coqtail \
-    ci-coqutil \
-    ci-cross_crypto \
-    ci-rocq_lsp \
-    ci-coq_performance_tests \
-    ci-coq_tools \
-    ci-deriving \
-    ci-elpi_test \
-    ci-hb_test \
-    ci-engine_bench \
-    ci-equations_test \
-    ci-fcsl_pcm \
-    ci-fiat_crypto \
-    ci-fiat_crypto_legacy \
-    ci-fiat_crypto_ocaml \
-    ci-fiat_parsers \
-    ci-fourcolor \
-    ci-http \
-    ci-itree \
-    ci-itree_io \
-    ci-jasmin \
-    ci-json \
-    ci-kami \
-    ci-lean_importer \
-    ci-ltac2_compiler \
-    ci-mathcomp_test \
-    ci-metarocq \
-    ci-neural_net_interp \
-    ci-oddorder \
-    ci-paco \
-    ci-parsec \
-    ci-perennial \
-    ci-quickchick_test \
-    ci-refman \
-    ci-rewriter \
-    ci-riscv_coq \
-    ci-rupicola \
-    ci-sf \
-    ci-smtcoq \
-    ci-smtcoq_trakt \
-    ci-stalmarck \
-    ci-stdlib_doc \
-    ci-stdlib_test \
-    ci-tactician \
-    ci-tlc \
-    ci-trakt \
-    ci-unimath \
-    ci-verdi_raft \
-    ci-vsrocq \
-    ci-vst \
-    ci-waterproof
+CI_TARGETS:=$(filter-out ci-common,$(patsubst dev/ci/scripts/%.sh,%,$(wildcard dev/ci/scripts/ci-*.sh)))
 
 CI_VIRTUAL_TARGETS= \
     ci-elpi_hb \

--- a/dev/ci/README-users.md
+++ b/dev/ci/README-users.md
@@ -81,9 +81,8 @@ as "plugins"] do have some special requirements:
 ### Add your project by submitting a pull request
 
 Add a new `ci-mydev.sh` script to [`dev/ci/scripts`](scripts); set the corresponding
-variables in [`ci-basic-overlay.sh`](ci-basic-overlay.sh); add the
-corresponding target to [`Makefile.ci`](../../Makefile.ci) and a new job to
-[`.gitlab-ci.yml`](../../.gitlab-ci.yml) so that this new target is run.
+variables in [`ci-basic-overlay.sh`](ci-basic-overlay.sh); add dependency information (if nontrivial) to [`Makefile.ci`](../../Makefile.ci) and a new job to
+[`.gitlab-ci.yml`](../../.gitlab-ci.yml) so that this new script is run.
 Have a look at [#17241](https://github.com/rocq-prover/rocq/pull/17241/files) for an
 example. **Do not hesitate to submit an incomplete pull request if you need
 help to finish it.**
@@ -94,8 +93,8 @@ Some important points:
   [`ci-basic-overlay.sh`](ci-basic-overlay.sh).
 
 - Let `$job` be the name of the new job as used for the name of
-  the added script file `dev/ci/scripts/ci-$job.sh`. Then the added target
-  in `Makefile.ci` must be named `ci-$job` and the added job in
+  the added script file `dev/ci/scripts/ci-$job.sh`. This implicitly adds a target
+  in `Makefile.ci` named `ci-$job` and the added job in
   `.gitlab-ci.yml` must be named `library:$job` or
   `plugin:$job`. `$job` must be a valid shell variable name,
   typically this means replacing dashs (`-`) with underscores (`_`).


### PR DESCRIPTION
Fix ci-mathcomp in local build (ci-micromega wasn't added to the list)
