### PR TITLE
Do not accept erasable subterm in the types of letin and lambda abstraction

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1610,15 +1610,15 @@ let check_one_fix ?evars renv recpos trees def =
                 if evaluable_constant kn renv.env then Some (constant_value_in renv.env cu, [])
                 else None)
 
-        | Lambda (x,a,b) ->
+        | Lambda (na,ty,body) ->
             begin
-              let needreduce, rs = check_rec_call renv rs a in
+              let needreduce_ty, rs = check_rec_call renv rs ty in
               match stack with
               | elt :: stack ->
-                let renv, stack, b = pop_argument ?evars needreduce renv elt stack x a b in
+                let renv, stack, b = pop_argument ?evars needreduce_ty renv elt stack na ty body in
                 check_rec_call_stack renv stack rs b
               | [] ->
-                check_rec_call_stack (push_var_renv renv (redex_level rs) (x,a)) [] rs b
+                check_rec_call_stack (push_var_renv renv (redex_level rs) (na,ty)) [] rs body
             end
 
         | Prod (x,a,u) ->
@@ -1662,17 +1662,17 @@ let check_one_fix ?evars renv recpos trees def =
               | LocalAssum _ -> None
               | LocalDef (_,c,_) -> Some (c, []))
 
-        | LetIn (x,c,t,b) ->
-            let needreduce_c, rs = check_rec_call renv rs c in
-            let needreduce_t, rs = check_rec_call renv rs t in
+        | LetIn (na,def,ty,body) ->
+            let needreduce_def, rs = check_rec_call renv rs def in
+            let needreduce_ty, rs = check_rec_call renv rs ty in
             begin
-              match needreduce_of_stack stack ||| needreduce_c ||| needreduce_t with
+              match needreduce_of_stack stack ||| needreduce_def ||| needreduce_ty with
               | NoNeedReduce ->
                   (* Stack do not require to beta-reduce; let's look if the body of the let needs *)
-                  let spec = lazy_subterm_specif ?evars renv [] c in
+                  let spec = lazy_subterm_specif ?evars renv [] def in
                   let stack = lift1_stack stack in
-                  check_rec_call_stack (push_let renv (x,c,t,spec)) stack rs b
-              | NeedReduce _ -> check_rec_call_stack renv stack rs (subst1 c b)
+                  check_rec_call_stack (push_let renv (na,def,ty,spec)) stack rs body
+              | NeedReduce _ -> check_rec_call_stack renv stack rs (subst1 def body)
             end
 
         | Cast (c,_,t) ->

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1612,10 +1612,10 @@ let check_one_fix ?evars renv recpos trees def =
 
         | Lambda (na,ty,body) ->
             begin
-              let needreduce_ty, rs = check_rec_call renv rs ty in
+              let rs = check_inert_subterm_rec_call renv rs ty in
               match stack with
               | elt :: stack ->
-                let renv, stack, b = pop_argument ?evars needreduce_ty renv elt stack na ty body in
+                let renv, stack, b = pop_argument ?evars NoNeedReduce renv elt stack na ty body in
                 check_rec_call_stack renv stack rs b
               | [] ->
                 check_rec_call_stack (push_var_renv renv (redex_level rs) (na,ty)) [] rs body
@@ -1664,9 +1664,9 @@ let check_one_fix ?evars renv recpos trees def =
 
         | LetIn (na,def,ty,body) ->
             let needreduce_def, rs = check_rec_call renv rs def in
-            let needreduce_ty, rs = check_rec_call renv rs ty in
+            let rs = check_inert_subterm_rec_call renv rs ty in
             begin
-              match needreduce_of_stack stack ||| needreduce_def ||| needreduce_ty with
+              match needreduce_of_stack stack ||| needreduce_def with
               | NoNeedReduce ->
                   (* Stack do not require to beta-reduce; let's look if the body of the let needs *)
                   let spec = lazy_subterm_specif ?evars renv [] def in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Types of local functions and letins are currently checked for reduction
I do not understand what is the point, or any case where it would actually be useful.
I would therefore like to remove support so that the guard condition is more uniform 
as this currently not allowed for other term constructors like fix, case or cast.

I am doing a quick benchmark to figure it out if it is actually used, and welcome good arguments for supporting it outside that it is technically possible 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
