### PR TITLE
Stop explicitly starting memprof limits

### DIFF
--- a/clib/memprof_coq.memprof.ml
+++ b/clib/memprof_coq.memprof.ml
@@ -6,8 +6,6 @@ let is_interrupted () = Memprof_limits.is_interrupted () [@@inline]
 
 let limit_allocations = Memprof_limits.limit_allocations
 
-let start_memprof_limits = Memprof_limits.start_memprof_limits
-
 module Resource_bind = Memprof_limits.Resource_bind
 
 (* Not exported by memprof limits :( *)

--- a/clib/memprof_coq.mli
+++ b/clib/memprof_coq.mli
@@ -5,8 +5,6 @@ val is_interrupted : unit -> bool
 
 val limit_allocations : limit:Int64.t -> (unit -> 'a) -> ('a * Int64.t, exn) result
 
-val start_memprof_limits : unit -> unit
-
 module Masking : sig
 
   val with_resource :

--- a/clib/memprof_coq.std.ml
+++ b/clib/memprof_coq.std.ml
@@ -4,8 +4,6 @@ let is_interrupted _ = false [@@inline]
 
 let limit_allocations ~limit:_ f = Ok (f(), 0L)
 
-let start_memprof_limits () = ()
-
 module Resource_bind = struct
   let ( let& ) f scope = f ~scope
 end

--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,7 @@
  (conflicts
   (coq (< 8.17))
   (coq-core (< 8.21)))
- (depopts rocq-native memprof-limits memtrace)
+ (depopts rocq-native (memprof-limits (>= 0.3.0)) memtrace)
  (synopsis "The Rocq Prover -- Core Binaries and Tools")
  (description "The Rocq Prover is an interactive theorem prover, or proof assistant. It provides
 a formal language to write mathematical definitions, executable

--- a/rocq-runtime.opam
+++ b/rocq-runtime.opam
@@ -36,7 +36,11 @@ depends: [
   "conf-linux-libc-dev" {os = "linux"}
   "odoc" {with-doc}
 ]
-depopts: ["rocq-native" "memprof-limits" "memtrace"]
+depopts: [
+  "rocq-native"
+  "memprof-limits" {>= "0.3.0"}
+  "memtrace"
+]
 conflicts: [
   "coq" {< "8.17"}
   "coq-core" {< "8.21"}

--- a/sysinit/coqinit.ml
+++ b/sysinit/coqinit.ml
@@ -153,7 +153,6 @@ let init_runtime ~usage opts =
   let open Coqargs in
   Vernacextend.static_linking_done ();
   Option.iter (fun file -> init_profile ~file) opts.config.profile;
-  Memprof_coq.start_memprof_limits ();
   Lib.init ();
   if opts.post.memory_stat then at_exit print_memory_stat;
 


### PR DESCRIPTION
Since memprof 0.3 it should init itself when needed.

This appears to fix ocamldebug bugged backtracking (as long as memprof doesn't need to init itself).
