### PR TITLE
Move check_hyps_inclusion out of the kernel

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -1299,6 +1299,18 @@ let constant_value_in env sigma (kn, u) =
     let r = Environ.lookup_rewrite_rules kn env in
     raise (NotEvaluableConst (HasRules (u, b, r)))
 
+(* Checks if a context of variables can be instantiated by the
+   variables of the current env. *)
+let check_hyps_inclusion env c sign =
+  sign |> List.iter @@ fun d ->
+  let id = NamedDecl.get_id d in
+  let ok =
+    match var_status ~check:false id env with
+    | SecVar -> true
+    | ProofVar -> false
+  in
+  if not ok then Type_errors.error_reference_variables env id c
+
 (** Kind of type *)
 
 type kind_of_type =

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -445,6 +445,10 @@ val lookup_rel : int -> env -> rel_declaration
 val lookup_named : variable -> env -> named_declaration
 val lookup_named_val : variable -> named_context_val -> named_declaration
 
+(** [check_hyps_inclusion env gr hyps] Check that [hyps] are included in [env]
+    and fails with error otherwise. *)
+val check_hyps_inclusion : env -> Names.GlobRef.t -> Constr.named_context -> unit
+
 val lookup_constant : env -> Evd.evar_map -> Constant.t -> Declarations.constant_body
 val constant_value_in : env -> Evd.evar_map -> Constant.t * EInstance.t -> constr
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -24,7 +24,6 @@ open Inductive
 open Type_errors
 
 module RelDecl = Context.Rel.Declaration
-module NamedDecl = Context.Named.Declaration
 
 exception NotConvertible
 exception NotConvertibleVect of int
@@ -167,20 +166,6 @@ let type_of_variable env id =
   with Not_found ->
     error_unbound_var env id
 
-(* Management of context of variables. *)
-
-(* Checks if a context of variables can be instantiated by the
-   variables of the current env. *)
-let check_hyps_inclusion env c sign =
-  sign |> List.iter @@ fun d ->
-  let id = NamedDecl.get_id d in
-  let ok =
-    match var_status ~check:false id env with
-    | SecVar -> true
-    | ProofVar -> false
-  in
-  if not ok then error_reference_variables env id c
-
 (* Instantiation of terms on real arguments. *)
 
 (* Make a type polymorphic if an arity *)
@@ -189,16 +174,12 @@ let check_hyps_inclusion env c sign =
 
 let type_of_constant env (kn,_u as cst) =
   let () = check_constant env kn in
-  let cb = lookup_constant kn env in
-  let () = check_hyps_inclusion env (GlobRef.ConstRef kn) cb.const_hyps in
   let ty, cu = constant_type env cst in
   let () = check_poly_constraints cu env in
     ty
 
 let type_of_constant_in env (kn,_u as cst) =
   let () = check_constant env kn in
-  let cb = lookup_constant kn env in
-  let () = check_hyps_inclusion env (GlobRef.ConstRef kn) cb.const_hyps in
   constant_type_in env cst
 
 (* Type of a lambda-abstraction. *)
@@ -400,7 +381,6 @@ let type_of_inductive_knowing_parameters env (ind,u as indu) args argst =
   let () = check_mind env (fst ind) in
   let (mib,_mip) as spec = lookup_mind_specif env ind in
   let () = assert (Option.has_some mib.mind_template) in
-  let () = check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps in
   let param_univs = make_param_univs env indu spec args argst in
   let t, cst = Inductive.type_of_inductive_knowing_parameters (spec,u) param_univs in
   let () = check_poly_constraints cst env in
@@ -409,7 +389,6 @@ let type_of_inductive_knowing_parameters env (ind,u as indu) args argst =
 let type_of_inductive env (ind,u) =
   let () = check_mind env (fst ind) in
   let (mib,mip) = lookup_mind_specif env ind in
-  check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
   let t,cst = Inductive.constrained_type_of_inductive ((mib,mip),u) in
   check_poly_constraints cst env;
   t
@@ -421,7 +400,6 @@ let type_of_constructor_knowing_parameters env (c, u as cu) args argst =
   let () = check_mind env (fst ind) in
   let (mib, _ as spec) = lookup_mind_specif env ind in
   let () = assert (Option.has_some mib.mind_template) in
-  let () = check_hyps_inclusion env (GlobRef.ConstructRef c) mib.mind_hyps in
   let param_univs = make_param_univs env (ind, u) spec args argst in
   let t, cst = Inductive.type_of_constructor_knowing_parameters cu spec param_univs in
   let () = check_poly_constraints cst env in
@@ -430,8 +408,7 @@ let type_of_constructor_knowing_parameters env (c, u as cu) args argst =
 let type_of_constructor env (c,_u as cu) =
   let ind = inductive_of_constructor c in
   let () = check_mind env (fst ind) in
-  let (mib, _ as specif) = lookup_mind_specif env ind in
-  let () = check_hyps_inclusion env (GlobRef.ConstructRef c) mib.mind_hyps in
+  let specif = lookup_mind_specif env ind in
   let t,cst = constrained_type_of_constructor cu specif in
   let () = check_poly_constraints cst env in
   t

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -71,9 +71,6 @@ val type_of_global_in_context : env -> GlobRef.t -> types * UVars.AbstractContex
 
 (** {6 Miscellaneous. } *)
 
-(** Check that hyps are included in env and fails with error otherwise *)
-val check_hyps_inclusion : env -> GlobRef.t -> Constr.named_context -> unit
-
 (** Types for primitives *)
 
 val type_of_int : env -> types

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -25,13 +25,13 @@ open Context.Rel.Declaration
 let type_of_inductive env (ind,u) =
  let u = EConstr.Unsafe.to_instance u in
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
- Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
+ EConstr.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif,u) in
  EConstr.of_constr @@ Arguments_renaming.rename_type env t (IndRef ind)
 
 let e_type_of_inductive env sigma (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
- Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
+ EConstr.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
  let t = Inductive.type_of_inductive (specif, EConstr.Unsafe.to_instance u) in
  EConstr.of_constr (Arguments_renaming.rename_type env t (IndRef ind))
 
@@ -40,14 +40,14 @@ let type_of_constructor env (cstr,u) =
  let u = EConstr.Unsafe.to_instance u in
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
- Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
+ EConstr.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,u) specif in
  EConstr.of_constr @@ Arguments_renaming.rename_type env t (ConstructRef cstr)
 
 let e_type_of_constructor env sigma (cstr,u) =
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
- Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
+ EConstr.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
  let t = Inductive.type_of_constructor (cstr,EConstr.Unsafe.to_instance u) specif in
  EConstr.of_constr (Arguments_renaming.rename_type env t (ConstructRef cstr))
 

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -136,7 +136,7 @@ let betazetaevar_applist sigma n c l =
 
 let type_of_constant env sigma (c,u) =
   let cb = lookup_constant env sigma c in
-  let () = Typeops.check_hyps_inclusion env (GlobRef.ConstRef c) cb.const_hyps in
+  let () = check_hyps_inclusion env (GlobRef.ConstRef c) cb.const_hyps in
   let ty = CVars.subst_instance_constr (EConstr.Unsafe.to_instance u) cb.const_type in
   EConstr.of_constr (rename_type env ty (GlobRef.ConstRef c))
 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -138,7 +138,7 @@ let judge_of_applied ~check env sigma funj argjv =
 (* XXX check_hyps_inclusion should now be cheap enough to always do *)
 let judge_of_applied_inductive_knowing_parameters ~check env sigma (ind, u) argjv =
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
-  let () = if check then Typeops.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
+  let () = if check then EConstr.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
   let sigma, paramstyp = fresh_template_context env sigma ind specif argjv in
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_inductive_knowing_parameters (specif, u0) paramstyp in
@@ -148,7 +148,7 @@ let judge_of_applied_inductive_knowing_parameters ~check env sigma (ind, u) argj
 
 let judge_of_applied_constructor_knowing_parameters ~check env sigma ((ind, _ as cstr), u) argjv =
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
-  let () = if check then Typeops.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
+  let () = if check then EConstr.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
   let sigma, paramstyp = fresh_template_context env sigma ind specif argjv in
   let u0 = EInstance.kind sigma u in
   let ty, csts = Inductive.type_of_constructor_knowing_parameters (cstr, u0) specif paramstyp in
@@ -414,7 +414,7 @@ let judge_of_letin env sigma name defj typj j =
 let type_of_constant env sigma (c,u) =
   let open Declarations in
   let cb = EConstr.lookup_constant env sigma c in
-  let () = Typeops.check_hyps_inclusion env (GR.ConstRef c) cb.const_hyps in
+  let () = EConstr.check_hyps_inclusion env (GR.ConstRef c) cb.const_hyps in
   let u = EInstance.kind sigma u in
   let uctx = Declareops.constant_polymorphic_context cb in
   let csts = UVars.AbstractContext.instantiate u uctx in
@@ -425,7 +425,7 @@ let type_of_constant env sigma (c,u) =
 let type_of_inductive env sigma (ind,u) =
   let open Declarations in
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
-  let () = Typeops.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
+  let () = EConstr.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_inductive (specif,u) in
   let sigma = Evd.add_poly_constraints ~src:UState.Internal sigma csts in
@@ -434,7 +434,7 @@ let type_of_inductive env sigma (ind,u) =
 let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let open Declarations in
   let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
-  let () = Typeops.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
+  let () = EConstr.check_hyps_inclusion env (GR.IndRef ind) mib.mind_hyps in
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_constructor (ctor,u) specif in
   let sigma = Evd.add_poly_constraints ~src:UState.Internal sigma csts in


### PR DESCRIPTION
In the kernel we check the section variables used in another way (eg Constant_typing.check_section_variables)
