### PR TITLE
Abstract the val variant of context datatypes.

### DIFF
--- a/dev/ci/user-overlays/22090-ppedrot-abstract-context-val.sh
+++ b/dev/ci/user-overlays/22090-ppedrot-abstract-context-val.sh
@@ -1,0 +1,1 @@
+overlay rocq_lsp https://github.com/ppedrot/rocq-lsp abstract-context-val 22090

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -1278,7 +1278,7 @@ let map_named_val :
   | Refl, Refl -> map_named_val
 
 let identity_subst_val : named_context_val -> t SList.t = fun ctx ->
-  SList.defaultn (List.length ctx.Environ.env_named_ctx) SList.empty
+  SList.defaultn (Environ.nb_named ctx) SList.empty
 
 let fresh_global ?loc ?rigid ?names env sigma reference =
   let (evd,t) = Evd.fresh_global ?loc ?rigid ?names env sigma reference in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -316,7 +316,7 @@ let push_rel_decl_to_named_context
   in
   match extract_if_neq id na with
   | Some id0 ->
-    if Id.Map.mem id0 ext.ext_ctx.env_named_map && is_section_variable_sign ext.ext_ctx id0 then
+    if Environ.mem_named_ctxt id0 ext.ext_ctx && is_section_variable_sign ext.ext_ctx id0 then
       (* spiwack: if [id0] is a section variable renaming it is
           incorrect. We revert to a less robust behaviour where
           the new binder has name [id]. Which amounts to the same

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -308,7 +308,7 @@ let evar_instance_array empty push info args =
     else match args with
     | SList.Nil -> assert false
     | SList.Cons (c, args) ->
-      let d = Range.get info.evar_hyps.env_named_idx pos in
+      let d = Environ.lookup_named_ctxt_pos pos info.evar_hyps in
       let id = NamedDecl.get_id d in
       push id c (instpush (pos + 1) (n - 1) filter args)
     | SList.Default (m, args) ->
@@ -320,7 +320,7 @@ let evar_instance_array empty push info args =
     let rec instance pos args = match args with
     | SList.Nil -> empty
     | SList.Cons (c, args) ->
-      let d = Range.get info.evar_hyps.env_named_idx pos in
+      let d = Environ.lookup_named_ctxt_pos pos info.evar_hyps in
       let id = NamedDecl.get_id d in
       push id c (instance (pos + 1) args)
     | SList.Default (n, args) -> instance (pos + n) args
@@ -1436,7 +1436,7 @@ let define_with_evar evk body evd =
 let restrict evk filter ?candidates ?src evd =
   let evk' = new_untyped_evar () in
   let evar_info = EvMap.find evk evd.undf_evars in
-  let len = Range.length evar_info.evar_hyps.env_named_idx in
+  let len = Environ.nb_named evar_info.evar_hyps in
   let id_inst = Filter.filter_slist filter (SList.defaultn len SList.empty) in
   let evar_info' =
     { evar_info with evar_filter = filter;

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -398,11 +398,7 @@ end = struct
       let env = info.i_cache.i_env in
       match ref with
       | RelKey n ->
-        let i = n - 1 in
-        let d =
-          try Range.get (Environ.rel_context_val env).env_rel_map i
-          with Invalid_argument _ -> raise Not_found
-        in
+        let d = Environ.lookup_rel n env in
         shortcut_irrelevant info (RelDecl.get_relevance d);
         let body =
           match d with

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -172,6 +172,10 @@ let lookup_rel n env =
   try Range.get env.env_rel_context.env_rel_map (n - 1)
   with Invalid_argument _ -> raise Not_found
 
+let lookup_rel_ctxt n ctx =
+  try Range.get ctx.env_rel_map (n - 1)
+  with Invalid_argument _ -> raise Not_found
+
 let rel_skipn n ctx = {
   env_rel_ctx = Util.List.skipn n ctx.env_rel_ctx;
   env_rel_map = Range.skipn n ctx.env_rel_map;
@@ -274,6 +278,11 @@ let lookup_named id env =
 
 let lookup_named_ctxt id ctxt =
   Id.Map.find id ctxt.env_named_map
+
+let lookup_named_ctxt_pos n ctxt =
+  try Range.get ctxt.env_named_idx n with Invalid_argument _ -> raise Not_found
+
+let nb_named ctx = Range.length ctx.env_named_idx
 
 let record_global_hyps add kn hyps acc =
   if CList.is_empty hyps then acc
@@ -1289,8 +1298,8 @@ module Internal = struct
       env_inductives : mutual_inductive_body Mindmap_env.t;
       env_modules : module_body ModPath.Map.t;
       env_modtypes : module_type_body ModPath.Map.t;
-      env_named_context : named_context_val;
-      env_rel_context   : rel_context_val;
+      env_named_context : named_context;
+      env_rel_context   : rel_context;
       env_universes : UGraph.t;
       env_qualities : Sorts.Quality.Set.t;
       env_symb_pats : machine_rewrite_rule list Cmap_env.t;
@@ -1302,8 +1311,8 @@ module Internal = struct
       env_inductives = Mindmap_env.map (fun (mib, _, _) -> mib) env.env_inductives;
       env_modtypes = env.env_modtypes;
       env_modules = env.env_modules;
-      env_named_context = env.env_named_context;
-      env_rel_context = env.env_rel_context;
+      env_named_context = env.env_named_context.env_named_ctx;
+      env_rel_context = env.env_rel_context.env_rel_ctx;
       env_universes = env.env_universes;
       env_qualities = QGraph.domain env.env_qualities;
       env_symb_pats = env.symb_pats;

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -37,19 +37,9 @@ type link_info =
 
 type key = int CEphemeron.key option ref
 
-type named_context_val = private {
-  env_named_ctx : Constr.named_context;
-  env_named_map : Constr.named_declaration Id.Map.t;
-  (** Identifier-indexed version of [env_named_ctx] *)
-  env_named_idx : Constr.named_declaration Range.t;
-  (** Same as env_named_ctx but with a fast-access list. *)
-  env_named_secvars : Id.Set.t;
-}
+type named_context_val
 
-type rel_context_val = private {
-  env_rel_ctx : Constr.rel_context;
-  env_rel_map : Constr.rel_declaration Range.t;
-}
+type rel_context_val
 
 type env
 (** Type of global environments. *)
@@ -101,6 +91,7 @@ val empty_rel_context_val : rel_context_val
 (** Looks up in the context of local vars referred by indice ([rel_context])
    raises [Not_found] if the index points out of the context *)
 val lookup_rel    : int -> env -> Constr.rel_declaration
+val lookup_rel_ctxt : int -> rel_context_val -> Constr.rel_declaration
 val evaluable_rel : int -> env -> bool
 val env_of_rel     : int -> env -> env
 
@@ -146,6 +137,8 @@ val mem_named : variable -> env -> bool
 
 val lookup_named     : variable -> env -> Constr.named_declaration
 val lookup_named_ctxt : variable -> named_context_val -> Constr.named_declaration
+val lookup_named_ctxt_pos : int -> named_context_val -> Constr.named_declaration
+val nb_named : named_context_val -> int
 val evaluable_named  : variable -> env -> bool
 val named_type : variable -> env -> types
 val named_body : variable -> env -> constr option
@@ -534,8 +527,8 @@ module Internal : sig
       env_inductives : mutual_inductive_body Mindmap_env.t;
       env_modules : module_body ModPath.Map.t;
       env_modtypes : module_type_body ModPath.Map.t;
-      env_named_context : named_context_val;
-      env_rel_context   : rel_context_val;
+      env_named_context : named_context;
+      env_rel_context   : rel_context;
       env_universes : UGraph.t;
       env_qualities : Sorts.Quality.Set.t;
       env_symb_pats : machine_rewrite_rule list Cmap_env.t;

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1481,10 +1481,10 @@ let register_constr {map; spec_name; term_name; fresh; proofs} c thm =
     ; proofs = Set (tname, c) :: Pose (sname, thm) :: proofs } )
 
 let fresh_subscript env =
-  let ctx = (Environ.named_context_val env).Environ.env_named_map in
+  let ctx = Environ.ids_of_named_context_val (Environ.named_context_val env) in
   Nameops.Subscript.succ
-    (Names.Id.Map.fold
-       (fun id _ s ->
+    (Names.Id.Set.fold
+       (fun id s ->
          let _, s' = Nameops.get_subscript id in
          let cmp = Nameops.Subscript.compare s s' in
          if cmp = 0 then s else if cmp < 0 then s' else s)

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1272,7 +1272,7 @@ let tclINTRO ~id ~conclusion:k = Goal.enter begin fun gl ->
        let ids = Environ.named_context_val env in
        mk_anon_id ssr_anon_hyp ids
   in
-  if Id.Map.mem id already_used.Environ.env_named_map then
+  if Environ.mem_named_ctxt id already_used then
     errorstrm Pp.(Id.print id ++ str" already used");
   unsafe_intro env (set_decl_id id decl) ~relevance t <*>
   (if no_red then tclUNIT () else tclFULL_BETAIOTA) <*>

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1369,7 +1369,7 @@ let project_evar_on_evar force unify flags env evd aliases k2 pbty (evk1,argsv1 
   if Option.is_empty pbty && SList.is_default argsv2 &&
     (* This ensures that the named context of [evk2] is a permutation of the one
        from [env]. In particular its filter must be trivial. *)
-    Int.equal (SList.length argsv2) (Range.length (Environ.named_context_val env).env_named_idx) &&
+    Int.equal (SList.length argsv2) (Environ.(nb_named @@ named_context_val env)) &&
     SList.Skip.for_all (fun arg -> noccur_evar env evd evk2 arg && closed0 evd arg) argsv1 &&
     let evi2 = Evd.find_undefined evd evk2 in Option.is_empty (Evd.evar_candidates evi2)
   then

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -152,7 +152,7 @@ let move_location_eq m1 m2 = match m1, m2 with
 | MoveFirst, MoveFirst -> true
 | _ -> false
 
-let mem_id_context id ctx = Id.Map.mem id ctx.Environ.env_named_map
+let mem_id_context id ctx = Environ.mem_named_ctxt id ctx
 
 let split_sign env sigma hfrom l =
   let () = if not (mem_id_context hfrom l) then error_no_such_hypothesis env sigma hfrom in


### PR DESCRIPTION
The internal details were barely used and should have been considered bad practice anyway. A good part of the reason for keeping the type transparent was likely to please serapi but this is now unnecessary.

Overlays:
- https://github.com/rocq-community/rocq-lsp/pull/1096
- https://github.com/rocq-community/micromega-plugin/pull/6