### PR TITLE
Parse Ltac2 matches at level 0.

### DIFF
--- a/doc/changelog/06-Ltac2-language/22092-ltac2-match-level-Changed.rst
+++ b/doc/changelog/06-Ltac2-language/22092-ltac2-match-level-Changed.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  Parse ``match`` expressions at level 0 instead of level 5
+  (`#22092 <https://github.com/rocq-prover/rocq/pull/22092>`_,
+  by Rodolphe Lepigre).

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2093,8 +2093,12 @@ SPLICE: [
 ltac2_expr5: [
 | REPLACE "let" OPT "rec" LIST1 ltac2_let_clause SEP "with" "in" ltac2_expr6      (* Ltac2 plugin *)
 | WITH "let" OPT "rec" ltac2_let_clause LIST0 ( "with" ltac2_let_clause ) "in" ltac2_expr6 TAG Ltac2
-| MOVETO simple_tactic "match" ltac2_expr5 "with" ltac2_branches "end"      (* Ltac2 plugin *)
 | MOVETO simple_tactic "if" ltac2_expr5 "then" ltac2_expr5 "else" ltac2_expr5      (* Ltac2 plugin *)
+| DELETE simple_tactic
+]
+
+ltac2_expr0: [
+| MOVETO simple_tactic "match" ltac2_expr5 "with" ltac2_branches "end"      (* Ltac2 plugin *)
 | DELETE simple_tactic
 ]
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -2750,7 +2750,6 @@ ltac2_expr6: [
 ltac2_expr5: [
 | "fun" LIST1 G_LTAC2_input_fun type_cast "=>" ltac2_expr6      (* ltac2 plugin *)
 | "let" rec_flag LIST1 G_LTAC2_let_clause SEP "with" "in" ltac2_expr6      (* ltac2 plugin *)
-| "match" ltac2_expr5 "with" G_LTAC2_branches "end"      (* ltac2 plugin *)
 | "if" ltac2_expr5 "then" ltac2_expr5 "else" ltac2_expr5      (* ltac2 plugin *)
 | ltac2_expr4      (* ltac2 plugin *)
 ]
@@ -2785,6 +2784,7 @@ ltac2_expr0: [
 | list_literal      (* ltac2 plugin *)
 | "{" test_qualid_with_or_lpar_or_rbrac ltac2_expr0 "with" tac2rec_fieldexprs "}"      (* ltac2 plugin *)
 | "{" tac2rec_fieldexprs "}"      (* ltac2 plugin *)
+| "match" ltac2_expr5 "with" G_LTAC2_branches "end"      (* ltac2 plugin *)
 | ltac2_atom      (* ltac2 plugin *)
 ]
 

--- a/plugins/ltac2/g_ltac2.mlg
+++ b/plugins/ltac2/g_ltac2.mlg
@@ -200,8 +200,6 @@ GRAMMAR EXTEND Gram
           lc = LIST1 let_clause SEP "with"; "in";
           e = ltac2_expr LEVEL "6" ->
         { CAst.make ~loc @@ CTacLet (isrec, lc, e) }
-      | "match"; e = ltac2_expr LEVEL "5"; "with"; bl = branches; "end" ->
-        { CAst.make ~loc @@ CTacCse (e, bl) }
       | "if"; e = ltac2_expr LEVEL "5"; "then"; e1 = ltac2_expr LEVEL "5"; "else"; e2 = ltac2_expr LEVEL "5" ->
         { CAst.make ~loc @@ CTacIft (e, e1, e2) }
       ]
@@ -234,6 +232,8 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CTacRec (Some e, a) }
       | "{"; a = tac2rec_fieldexprs; "}" ->
         { CAst.make ~loc @@ CTacRec (None, a) }
+      | "match"; e = ltac2_expr LEVEL "5"; "with"; bl = branches; "end" ->
+        { CAst.make ~loc @@ CTacCse (e, bl) }
       | a = ltac2_atom -> { a } ]
     ]
   ;


### PR DESCRIPTION
For context: [#Ltac2 > ✔ List cons notation warning](https://rocq-prover.zulipchat.com/#narrow/channel/278935-Ltac2/topic/.E2.9C.94.20List.20cons.20notation.20warning/with/599787700).