### PR TITLE
[fix] ssrmatching/equality and univ poly handling

### DIFF
--- a/doc/changelog/07-ssreflect/22096-fix-ssr-univpoly-Fixed.rst
+++ b/doc/changelog/07-ssreflect/22096-fix-ssr-univpoly-Fixed.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Handling of universe polymorphism by ssrmatching (e.g. :tacn:`unlock` and :tacn:`rw` tactics),
+  now recording appropriate universe unifications.
+  (`#22096 <https://github.com/rocq-prover/rocq/pull/22096>`_,
+  fixes `#22086 <https://github.com/rocq-prover/rocq/issues/22086>`_,
+  by Matthieu Sozeau).

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -287,7 +287,7 @@ let unfoldintac occ rdx t (kt,_) =
       try find_T env c h ~k:(fun env c _ _ -> body env t c)
       with NoMatch when easy -> c
       | NoMatch | NoProgress -> errorstrm Pp.(str"No occurrence of "
-        ++ pr_econstr_pat env sigma0 t ++ spc() ++ str "in " ++ Printer.pr_econstr_env env sigma c)),
+        ++ pr_econstr_pat env sigma t ++ spc() ++ str "in " ++ Printer.pr_econstr_env env sigma0 c)),
     (fun () -> try ignore @@ end_T () with
       | NoMatch when easy -> ()
       | NoMatch -> anomaly "unfoldintac")
@@ -296,14 +296,14 @@ let unfoldintac occ rdx t (kt,_) =
       if const then
         let rec aux c =
           match EConstr.kind sigma0 c with
-          | Const _ when EConstr.eq_constr sigma0 c t -> body env t t
-          | App (f,a) when EConstr.eq_constr sigma0 f t -> EConstr.mkApp (body env f f,a)
+          | Const _ when EConstr.eq_constr_nounivs sigma0 c t -> body env c c
+          | App (f,a) when EConstr.eq_constr_nounivs sigma0 f t -> EConstr.mkApp (body env t t,a)
           | Proj _ when same_proj env sigma0 c t -> body env t c
           | _ ->
             let c = Reductionops.whd_betaiotazeta env sigma0 c in
             match EConstr.kind sigma0 c with
-            | Const _ when EConstr.eq_constr sigma0 c t -> body env t t
-            | App (f,a) when EConstr.eq_constr sigma0 f t -> EConstr.mkApp (body env f f,a)
+            | Const _ when EConstr.eq_constr_nounivs sigma0 c t -> body env c c
+            | App (f,a) when EConstr.eq_constr_nounivs sigma0 f t -> EConstr.mkApp (body env t t,a)
             | Proj _ when same_proj env sigma0 c t -> body env t c
             | Const f -> aux (body env c c)
             | App (f, a) -> aux (EConstr.mkApp (body env f f, a))
@@ -760,14 +760,16 @@ let ssrrewritetac ?under ?map_redex ist rwargs =
 (** The "unlock" tactic *)
 
 let unfoldtac occ ko t kt =
+  let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let concl = Proofview.Goal.concl gl in
   let concl = Evarutil.nf_evar sigma concl in
-  let cl, c = fill_occ_term env sigma concl occ (fst (strip_unfold_term env t kt)) in
+  let cl, sigma, c = fill_occ_term env sigma concl occ (fst (strip_unfold_term env t kt)) in
   let cl' = EConstr.Vars.subst1 (Tacred.unfoldn [OnlyOccurrences [1], get_evalref env sigma c] env sigma c) cl in
   let f = if ko = None then RedFlags.betaiotazeta else RedFlags.betaiota in
+  Proofview.Unsafe.tclEVARS sigma <*>
   convert_concl ~check:true (Reductionops.clos_norm_flags f env sigma cl')
   end
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -160,12 +160,18 @@ exception NoProgress
 
 let unif_EQ env sigma p c =
   let env = Environ.set_universes (Evd.universes sigma) env in
-  Reductionops.is_conv env sigma p c
+  Reductionops.infer_conv env sigma p c
+
+let unif_EQ_ref env ise p c =
+  match unif_EQ env !ise p c with
+  | None -> false
+  | Some ise' -> ise := ise'; true
 
 let unif_EQ_args env sigma pa a =
   let n = Array.length pa in
-  let rec loop i = (i = n) || unif_EQ env sigma pa.(i) a.(i) && loop (i + 1) in
-  loop 0
+  let ise = ref sigma in
+  let rec loop i = (i = n) || unif_EQ_ref env ise pa.(i) a.(i) && loop (i + 1) in
+  if loop 0 then Some !ise else None
 
 let unif_HO env ise p c =
   try Evarconv.unify_delay env ise p c
@@ -696,7 +702,9 @@ let match_upats_HO ~on_instance upats env sigma0 ise c =
         begin if !i0 < np then i0 := np; true end in
       if skip then () else try
         let ise' = match u.up_k with
-        | KpatFixed | KpatConst -> ise
+        | KpatFixed -> ise
+        | KpatConst -> (* Ensure universe instances are unified *)
+          unif_HO env ise u.up_f f
         | KpatEvar _ ->
           let open EConstr in
           let pka = Evd.expand_existential ise @@ destEvar ise u.up_f in
@@ -804,6 +812,13 @@ let subst_occ { nocc; max_occ; occ_set; use_occ; skip_occ } =
   if !nocc = max_occ then skip_occ := use_occ;
   if !nocc <= max_occ then occ_set.(!nocc - 1) else not use_occ
 
+let match_constr_universes env sigma x y =
+  match EConstr.eq_constr_universes env sigma x y with
+  | None -> None
+  | Some pbs ->
+      try Some (Evd.add_constraints sigma pbs)
+      with UGraph.UniverseInconsistency _ | Evd.UniversesDiffer | QGraph.EliminationError _ -> None
+
 let match_EQ env sigma (ise, u) =
   let open EConstr in
   match u.up_k with
@@ -812,14 +827,17 @@ let match_EQ env sigma (ise, u) =
     let env' =
       EConstr.push_rel (Context.Rel.Declaration.LocalAssum(x, t)) env in
     let match_let f = match EConstr.kind ise f with
-    | LetIn (_, v, _, b) -> unif_EQ env sigma pv v && unif_EQ env' sigma pb b
-    | _ -> false in match_let
-  | KpatFixed -> fun c -> EConstr.eq_constr_nounivs sigma u.up_f c
-  | KpatConst -> fun c -> EConstr.eq_constr_nounivs sigma u.up_f c
+    | LetIn (_, v, _, b) ->
+      begin match unif_EQ env sigma pv v with
+      | Some sigma' -> unif_EQ env' sigma' pb b
+      | None -> None end
+    | _ -> None in match_let
+  | KpatFixed -> fun c -> match_constr_universes env sigma u.up_f c
+  | KpatConst -> fun c -> match_constr_universes env sigma u.up_f c
   | KpatLam -> fun c ->
       (match EConstr.kind sigma c with
       | Lambda _ -> unif_EQ env sigma u.up_f c
-      | _ -> false)
+      | _ -> None)
   | _ -> unif_EQ env sigma u.up_f
 
 let p2t p = EConstr.mkApp(p.up_f,p.up_a)
@@ -899,18 +917,26 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
     | NoProgress when (not raise_NoMatch) ->
       ssrfail env ise upats_origin upats SsrProgressFail
     | NoProgress -> raise NoMatch);
-  let _, sigma, _, ({up_f = pf; up_a = pa} as u) = match instances with
+  let expl, sigma, uc, ({up_f = pf; up_a = pa} as u) = match instances with
   | Some _ -> assert_done_multires upat_that_matched
   | None -> List.hd (pi3(assert_done upat_that_matched))
   in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
   if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c) else
-  let match_EQ = match_EQ env sigma (ise, u) in
+  let evd = ref (Evd.set_ustate sigma uc) in
+  let match_EQ f = match_EQ env !evd (ise, u) f in
   let pn = Array.length pa in
   let rec subst_loop (env,h as acc) c' =
     if !(occ_state.skip_occ) then c' else
     let f, a = splay_app sigma c' in
-    if Array.length a >= pn && match_EQ f && unif_EQ_args env sigma pa a then
+    let test () = match match_EQ f with
+      | Some sigma ->
+        (match unif_EQ_args env sigma pa a with
+         | Some sigma -> evd := sigma; true
+         | None -> false)
+      | None -> false
+    in
+    if Array.length a >= pn && test () then
       let open EConstr in
       let a1, a2 = Array.chop (Array.length pa) a in
       let fa1 = mkApp (f, a1) in
@@ -929,7 +955,12 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
       let self acc c = subst_loop acc c in
       let f' = map_constr_with_binders_left_to_right env sigma inc_h self acc f in
       mkApp (f', Array.map_left (subst_loop acc) a) in
-      subst_loop (env,h) c
+  let c' = subst_loop (env,h) c in
+  let () = (* Fixup !upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
+    match !upat_that_matched with
+    | Some (env, n, _ :: tl) -> upat_that_matched := Some (env, n, (expl, sigma, Evd.ustate !evd, u) :: tl)
+    | _ -> assert false
+  in c'
 
 let conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats { max_occ; nocc } : conclude = fun () ->
   let env, (c, sigma, uc, ({up_f = pf; up_a = pa} as u)) =
@@ -1485,12 +1516,12 @@ let fill_occ_term env sigma0 cl occ (sigma, t) =
   try
     let changed, sigma', uc, t', cl, _= pf_fill_occ env cl occ sigma0 t (sigma, t) 1 in
     if changed then CErrors.user_err Pp.(str "matching impacts evars")
-    else cl, t'
+    else cl, Evd.set_ustate sigma' uc, t'
   with NoMatch -> try
       let changed, sigma', uc, t' =
         unif_end env sigma0 (create_evar_defs sigma) t (fun _ -> true) in
       if changed then raise NoMatch
-      else cl, t'
+      else cl, Evd.set_ustate sigma' uc, t'
     with e when CErrors.noncritical e ->
       errorstrm (str "partial term " ++ pr_econstr_pat env sigma t
                  ++ str " does not match any subterm of the goal")

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -210,7 +210,7 @@ val mk_tpattern_matcher :
  * [concl] where [occ] occurrences of [t] have been replaced
  * by [Rel 1] and the instance of [t] *)
 
-val fill_occ_term : Environ.env -> Evd.evar_map -> EConstr.t -> occ -> evar_map * EConstr.t -> EConstr.t * EConstr.t
+val fill_occ_term : Environ.env -> Evd.evar_map -> EConstr.t -> occ -> evar_map * EConstr.t -> EConstr.t * Evd.evar_map * EConstr.t
 
 (** Helpers to make stateful closures. Example: a [find_P] function may be
     called many times, but the pattern instantiation phase is performed only the

--- a/test-suite/bugs/ssrew_poly.v
+++ b/test-suite/bugs/ssrew_poly.v
@@ -1,0 +1,21 @@
+From Corelib Require Import ssreflect.
+Set Universe Polymorphism.
+Axiom foo@{i} : unit.
+Set Printing Universes.
+
+Axiom lemma@{i} : foo@{i} = tt.
+
+Monomorphic Universes i j.
+Monomorphic Constraint i < j.
+
+Lemma works : foo@{i} = foo@{j}.
+Proof.
+  (* This separately rewrites each foo@{_} call, no issue *)
+  rewrite !{1}lemma. reflexivity.
+Qed.
+Lemma test : foo@{i} = foo@{j}.
+Proof.
+  (* This can only capture a single foo@{_} call *)
+  rewrite lemma.
+  Fail reflexivity.
+Abort.


### PR DESCRIPTION
These patches enforce recording appropriate universe unifications in [unfold], [unlock] and [rw].

The matching phase for multiple occcurrences of a pattern is now done accumulating the necessary universe constraints.

Fixes #22086

It should only be a bugfix, in the case one used these tactics in univ-poly mode, Qed would have failed because of missing constraints.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.