### PR TITLE
Fix program typing bug

### DIFF
--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -228,8 +228,8 @@ let encapsulate_Fix_sub env sigma recname ctx body ccl (extradecl, rel, relargty
   let body_ctx = RelDecl.LocalDef (make_annot (Name recname) ERelevance.relevant, curryfier_body, curryfier_ty) :: fix_sub_F_sub_ctx in
   let intern_body_lam = it_mkLambda_or_LetIn body body_ctx in
   (* Instantiate the argument Fix_sub_F of Fix_sub with the body of the fixpoint *)
-  let sigma, fix_sub = Typing.solve_evars env sigma fix_sub in
-  sigma, tupled_ctx, tuple_value, mkApp (fix_sub, [|intern_body_lam|])
+  let sigma, fix_sub = Typing.solve_evars env sigma (mkApp (fix_sub, [|intern_body_lam|])) in
+  sigma, tupled_ctx, tuple_value, fix_sub
 
 let build_wellfounded env sigma poly udecl {CAst.v=recname; loc} ctx body ccl impls rel_measure =
   let len = Context.Rel.length ctx in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -187,7 +187,7 @@ let encapsulate_Fix_sub env sigma recname ctx body ccl (extradecl, rel, relargty
     let sigma = Evd.set_obligation_evar sigma (fst (destEvar sigma wf_proof)) in
     let ccl_pred = mkLambda (make_annot (Name argname) ERelevance.relevant, tuple_type, tupled_ccl) in
     let def = mkApp (fix_sub_term, [| tuple_type ; rel_measure ; wf_proof ; ccl_pred |]) in
-    Typing.solve_evars env sigma def in
+    sigma, def in
   let arg = RelDecl.LocalAssum (make_annot (Name argname) ERelevance.relevant, tuple_type) in
   let argid' = Id.of_string (Id.to_string argname ^ "'") in
   let sigma, wfa =


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Fix a missing typechecking of the whole term in Program's wf fixpoint elaboration, that could missing some universe constraints.

<!-- Remove anything that doesn't apply in the following checklist. -->

Should be a trivial fix, reproducing requires a univ-poly stdlib, too expensive here.