### PR TITLE
[fix] move univ poly option to synterp phase (fixes issue in VsRocq + elpi)

### DIFF
--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -281,7 +281,7 @@ let is_universe_polymorphism =
   let b = ref false in
   let () = let open Goptions in
     declare_bool_option
-      { optstage = Summary.Stage.Interp;
+      { optstage = Summary.Stage.Synterp;
         optdepr  = None;
         optkey   = universe_polymorphism_option_name;
         optread  = (fun () -> !b);

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -361,9 +361,12 @@ let synterp_extra_dep ?loc from file id =
   let from = Libnames.add_dirpath_suffix hd tl in
   ComExtraDeps.declare_extra_dep ?loc ~from ~file id
 
-let synterp_begin_section ({v=id} as lid) =
+let synterp_begin_section ~poly ({v=id} as lid) =
   Dumpglob.dump_definition lid true "sec";
-  Lib.Synterp.open_section id
+  Lib.Synterp.open_section id;
+  (* If there was no polymorphism attribute this just sets the option
+     to its current value ie noop. *)
+  Goptions.set_bool_option_value_gen ~stage:Summary.Stage.Synterp ~locality:OptLocal ["Universe"; "Polymorphism"] poly
 
 let with_synterp_state =
   let with_local_state () f =
@@ -403,7 +406,7 @@ let rec synterp ~intern ?loc ~atts v =
     | VernacInclude in_asts ->
       EVernacInclude (synterp_include in_asts)
     | VernacBeginSection lid ->
-      synterp_begin_section lid;
+      synterp_begin_section ~poly:(only_polymorphism atts) lid;
       EVernacBeginSection lid
     | VernacEndSegment lid ->
       synterp_end_segment lid;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1606,12 +1606,8 @@ let vernac_include l = Declaremods.Interp.declare_include l
 
 (* Sections *)
 
-let vernac_begin_section ~poly {v=id} =
-  Lib.Interp.open_section id;
-  (* If there was no polymorphism attribute this just sets the option
-     to its current value ie noop. *)
-  set_bool_option_value_gen ~locality:OptLocal ["Universe"; "Polymorphism"] poly
-
+let vernac_begin_section {v=id} =
+  Lib.Interp.open_section id
 let vernac_end_section {CAst.loc; v} =
   Declaremods.Interp.close_section ()
 
@@ -2675,7 +2671,7 @@ let translate_vernac_synterp ?loc ~atts v = let open Vernactypes in match v with
   (* Gallina extensions *)
   | EVernacBeginSection lid ->
     vernac_begin_segment ~interactive:true (fun () ->
-        vernac_begin_section ~poly:(only_polymorphism atts) lid)
+        vernac_begin_section lid)
 
   | EVernacEndSegment lid ->
     unsupported_attributes atts;


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This bugfix makes VsRocq's synterp phase aware of the univ poly status. This fixes an issue in elpi which can otherwise get inconsistent synterp and interp views depending on the univ-poly flag.