### PR TITLE
Avoid empty GIT_DEPTH for linter job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,7 +388,7 @@ lint:
   script: dev/lint-repository.sh
   extends: .auto-use-tags
   variables:
-    GIT_DEPTH: "" # we need an unknown amount of history for per-commit linting
+    GIT_DEPTH: "50" # we need an unknown amount of history for per-commit linting, hopefully 50 is enough
     OPAM_VARIANT: "+flambda"
 
 # pkg:opam:


### PR DESCRIPTION
This job is commonly failing in git clone recently and this setting is the only thing that's different from other jobs AFAICT
