### PR TITLE
Process attributes after Qed/Defined

### DIFF
--- a/test-suite/misc/attributes.sh
+++ b/test-suite/misc/attributes.sh
@@ -20,3 +20,7 @@ if ! [ -e theories/attr.vo ]; then
   >&2 echo Missing attr.vo after successful compilation
   exit 1
 fi
+
+# Check the messages emitted by the #[print] and #[error] attribute hooks.
+rocq c -q -Q theories Attributes -I src theories/attr.v > attr.out.real 2>&1
+diff -u --strip-trailing-cr ../attr.out attr.out.real

--- a/test-suite/misc/attributes/attr.out
+++ b/test-suite/misc/attributes/attr.out
@@ -1,0 +1,17 @@
+generated Attributes.attr.foo
+
+generated Attributes.attr.bar
+
+failing attribute
+generated Attributes.attr.lem
+
+generated Attributes.attr.thm
+
+generated Attributes.attr.even_triv
+
+generated Attributes.attr.odd_triv
+
+failing attribute
+generated Attributes.attr.lem_adm
+
+failing attribute

--- a/test-suite/misc/attributes/theories/attr.v
+++ b/test-suite/misc/attributes/theories/attr.v
@@ -9,6 +9,46 @@ Definition bar : False -> False := fun x => x.
 Fail #[error]
 Definition baz : False -> False := fun x => x.
 
+(* Programmable-attribute hooks must also fire when a Lemma/Theorem is
+   completed (at Qed/Defined), not only for Definition. *)
+#[print]
+Lemma lem : True.
+Proof. exact I. Qed.
+
+#[print]
+Theorem thm : True.
+Proof. exact I. Defined.
+
+(* Mutual proofs: the #[print] hook fires once per declared constant. *)
+Inductive even : nat -> Prop :=
+| even_O : even 0
+| even_S : forall n, odd n -> even (S n)
+with odd : nat -> Prop :=
+| odd_S : forall n, even n -> odd (S n).
+
+#[print]
+Lemma even_triv : forall n, even n -> True
+with odd_triv : forall n, odd n -> True.
+Proof. - intros; exact I. - intros; exact I. Qed.
+
+(* The error hook fires at completion time, so it is Qed that must fail. *)
+#[error]
+Lemma lem_err : True.
+Proof. exact I. Fail Qed.
+Abort.
+
+(* The hook also fires when a proof is Admitted (the constant is declared
+   as an axiom). *)
+#[print]
+Lemma lem_adm : True.
+Proof. Admitted.
+
+(* The error hook likewise fires on Admitted, so it is Admitted that fails. *)
+#[error]
+Lemma lem_adm_err : True.
+Proof. Fail Admitted.
+Abort.
+
 (* par marshals th summary, enforcing that it doesn't contain closures *)
 Lemma parfoo : True /\ True.
 Proof.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -563,7 +563,7 @@ let finish_regular env sigma use_inference_hook fix =
   let sigma = Pretyping.(solve_remaining_evars ?hook:inference_hook all_no_fail_flags env sigma) in
   sigma, ground_fixpoint env sigma fix, [], None
 
-let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) ?scope ?clearbody ~kind ~poly ?typing_flags ?user_warns ?using (rec_order, fixl)
+let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) ?scope ?clearbody ~kind ?hook ~poly ?typing_flags ?user_warns ?using (rec_order, fixl)
   : Declare.OblState.t option * Declare.Proof.t option =
   let env = Global.env () in
   let env = Environ.update_typing_flags ?typing_flags env in
@@ -571,7 +571,7 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
   check_recursive ~kind env sigma fix;
 
   if refine then
-    let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ?typing_flags ?user_warns ~ntns:fix.fixntns () in
+    let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ?hook ?typing_flags ?user_warns ~ntns:fix.fixntns () in
     let cinfo = build_recthms fix in
     let possible_guard = (possible_guard, fix.fixrs) in
     let lemma = Declare.Proof.start_mutual_definitions_refine ~info ~cinfo ~bodies:fix.fixdefs ~possible_guard ?using sigma in
@@ -582,10 +582,15 @@ let do_mutually_recursive ?pm ~refine ~program_mode ?(use_inference_hook=false) 
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
   let sigma = Evd.minimize_universes ~poly sigma in
 
-  let sigma, ({fixdefs=bodies;fixrs;fixtypes;fixwfs} as fix), obls, hook =
+  let sigma, ({fixdefs=bodies;fixrs;fixtypes;fixwfs} as fix), obls, wf_hook =
     match pm with
     | Some pm -> finish_obligations env sigma rec_sign possible_guard poly udecl fix
     | None -> finish_regular env sigma use_inference_hook fix in
+  (* Combine the internal well-founded/obligation hook with any external one. *)
+  let hook = match wf_hook, hook with
+    | None, h | h, None -> h
+    | Some h1, Some h2 -> Some (Declare.Hook.seq h1 h2)
+  in
   let info = Declare.Info.make ?scope ?clearbody ~kind ~poly ~udecl ?hook ?typing_flags ?user_warns ~ntns:fix.fixntns () in
   let cinfo = build_recthms fix in
   match pm with

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -33,6 +33,8 @@ val do_mutually_recursive
      (* Hide body if in sections *)
   -> kind:Decls.logical_kind
      (* Logical kind: Theorem, Definition, Fixpoint, etc.*)
+  -> ?hook:Declare.Hook.t
+     (* Declaration hook run when the constants are completed *)
   -> poly:PolyFlags.t
      (* Use universe /sort polymorphism and cumulativity *)
   -> ?typing_flags:Declarations.typing_flags

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -44,6 +44,9 @@ module Hook = struct
   let call_g ?hook x s = Option.cata (fun hook -> hcall hook x s) s hook
   let call ?hook x = Option.iter (fun hook -> hcall hook x ()) hook
 
+  let seq h1 h2 = make (fun st -> call ~hook:h1 st; call ~hook:h2 st)
+  let seqs hs = make (fun st -> List.iter (fun hook -> call ~hook st) hs)
+
 end
 
 let warn_using_fallback_loc = CWarnings.create ~name:"using-fallback-loc" ~category:CWarnings.CoreCategories.internal ~default:Disabled

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -66,6 +66,8 @@ module Hook : sig
   val make_g : (S.t -> 'a -> 'a) -> 'a g
   val make : (S.t -> unit) -> t
   val call : ?hook:t -> S.t -> unit
+  val seq : t -> t -> t
+  val seqs : t list -> t
 end
 
 (** {2 One-go, non-interactive declaration API } *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -848,7 +848,7 @@ let vernac_definition_hook ~hooks ~canonical_instance ~local ~poly ~reversible k
   in
   match hooks with
   | [] -> None
-  | _ -> Some (Declare.Hook.make (fun st -> List.iter (fun hook -> Declare.Hook.call ~hook st) hooks))
+  | _ -> Some (Declare.Hook.seqs hooks)
 
 let default_thm_id = Id.of_string "Unnamed_thm"
 
@@ -927,14 +927,19 @@ let vernac_start_proof ~atts kind l =
     List.iter (fun ((id, _), _) -> Dumpglob.dump_definition id false "prf") l;
   let DefAttributes.{
     scope; locality=local; poly; program=program_mode;
-    user_warns; typing_flags; using; clearbody;
+    user_warns; typing_flags; using; clearbody; hooks
     } = atts
   in
+  (* Run programmable-attribute hooks when the theorem/lemma is completed,
+     just as for [Definition]. The special coercion/canonical hooks of
+     [vernac_definition_hook] do not apply to proofs, so we only fold the
+     attribute-provided hooks. *)
+  let hook = match hooks with [] -> None | _ -> Some (Declare.Hook.seqs hooks) in
   List.iter (fun ((id, _), _) -> check_name_freshness scope id) l;
   match l with
   | [] -> assert false
   | [({v=name; loc},udecl),(bl,typ)] ->
-    ComDefinition.do_definition_interactive ?loc
+    ComDefinition.do_definition_interactive ?loc ?hook
       ~typing_flags ~program_mode ~name ~poly ?clearbody ~scope
       ~kind:(Decls.IsProof kind) ?user_warns ?using udecl bl typ
   | ((lid,_),_) :: _ ->
@@ -942,7 +947,7 @@ let vernac_start_proof ~atts kind l =
         { fname; binders; rtype; body_def = None; univs; notations = []}) l in
     let pm, proof =
       ComFixpoint.do_mutually_recursive ~refine:false ~program_mode ~use_inference_hook:program_mode
-        ~scope ?clearbody ~kind:(Decls.IsProof kind) ~poly ?typing_flags
+        ?hook ~scope ?clearbody ~kind:(Decls.IsProof kind) ~poly ?typing_flags
         ?user_warns ?using (CUnknownRecOrder, fix) in
     assert (Option.is_empty pm);
     Option.get proof


### PR DESCRIPTION
This PR extends the handling of attributes so that handlers are executed when the term is completed, e.g. at the `Qed` or `Defined`.

It uses this feature to implement a plugin that provides an attribute `#[hint(db=...,cost=...,visibility=...)]`. This should be either incorporated into core Rocq or introduced as a separate plugin.

For now, I'm just looking for feedback, the commits should be independently reviewable. The last commit contains the hint attribute implementation and could probably use more testing.

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.