### PR TITLE
git ls-remote --heads instead of --branches

### DIFF
--- a/dev/ci/scripts/ci-common.sh
+++ b/dev/ci/scripts/ci-common.sh
@@ -144,7 +144,7 @@ git_download()
     mkdir -p "$dest"
     pushd "$dest"
     local commit
-    commit=$(git ls-remote --branches "$giturl" "refs/heads/$ref" | cut -f 1)
+    commit=$(git ls-remote --head "$giturl" "refs/heads/$ref" | cut -f 1)
     if [[ "$commit" == "" ]]; then
       # $ref must have been a tag or hash, not a branch
       commit="$ref"


### PR DESCRIPTION
--branches isn't available on the git version we have in CI it seems so we should use the old deprecated flag.
