### PR TITLE
Deprecate non boolean if syntax

### DIFF
--- a/doc/changelog/02-specification-language/22123-deprecate-if-Deprecated.rst
+++ b/doc/changelog/02-specification-language/22123-deprecate-if-Deprecated.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  the non boolean `if g then t else e` syntax.
+  Use `if g is <first_constructor> then t else e` instead
+  (`#22123 <https://github.com/rocq-prover/rocq/pull/22123>`_,
+  by Pierre Roux).

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -128,7 +128,7 @@ use the :g:`dec` combinator to get the correct hypotheses as in:
 .. rocqtop:: all
 
    Program Definition id (n : nat) : { x : nat | x = n } :=
-     if sumbool_of_bool (Nat.leb n 0) then 0
+     if sumbool_of_bool (Nat.leb n 0) is left _ then 0
      else S (pred n).
 
 The :g:`let` tupling construct :g:`let (x1, ..., xn) := t in b` does not

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -42,9 +42,11 @@ Pattern-matching on boolean values: the if expression
    if_dthen ::= @pattern {? in @pattern } {? return @term100 } then @term
    if_else ::= else @term
 
-For inductive types with exactly two constructors and for pattern matching
-expressions that do not depend on the arguments of the constructors, it is possible
-to use a ``if … then … else`` notation. For instance, the definition
+The `if g is c then t else e` syntax is syntactic sugar for `match g
+with c => t | _ => e end`.
+
+For the ``bool`` type (i.e., what is registered as `core.bool.type`), it is possible
+to use a ``if … then … else`` notation. For instance, the definitions
 
 .. rocqtop:: all
 
@@ -54,34 +56,42 @@ to use a ``if … then … else`` notation. For instance, the definition
    | false => true
    end.
 
+.. rocqtop:: reset all
+
+   Definition not (b:bool) := if b is true then false else true.
+
 can be alternatively written
 
 .. rocqtop:: reset all
 
    Definition not (b:bool) := if b then false else true.
 
-More generally, for an inductive type with constructors :n:`@ident__1`
-and :n:`@ident__2`, the following terms are equal:
+.. deprecated:: 9.3
 
-:n:`if @term__0 {? {? as @name } return @term } then @term__1 else @term__2`
+   More generally, for an inductive type with constructors :n:`@ident__1`
+   and :n:`@ident__2`, the following terms are equal:
 
-:n:`match @term__0 {? {? as @name } return @term } with | @ident__1 {* _ } => @term__1 | @ident__2 {* _ } => @term__2 end`
+   :n:`if @term__0 {? {? as @name } return @term } then @term__1 else @term__2`
 
-.. example::
+   :n:`match @term__0 {? {? as @name } return @term } with | @ident__1 {* _ } => @term__1 | @ident__2 {* _ } => @term__2 end`
 
-  .. rocqtop:: all
+   .. example::
 
-     Check (fun x (H:{x=0}+{x<>0}) =>
-     match H with
-     | left _ => true
-     | right _ => false
-     end).
+      .. rocqtop:: all
 
-Notice that the printing uses the :g:`if` syntax because :g:`sumbool` is
-declared as such (see :ref:`controlling-match-pp`).
+         Check (fun x (H:{x=0}+{x<>0}) =>
+         match H with
+         | left _ => true
+         | right _ => false
+         end).
 
-The `if g is c then t else e` syntax is syntactic sugar for `match g
-with c => t | _ => e end`.
+   Notice that the printing uses the :g:`if` syntax because :g:`sumbool` is
+   declared as such (see :ref:`controlling-match-pp`).
+
+   .. warn:: The "if <c> then _" syntax for non boolean guard is deprecated. Use "if <c> is <first_constructor> then _" instead.
+
+      The "if _ then _ else" syntax is reserved for the special
+      ``bool`` type, use an explicit ``is`` for other inductive types.
 
 .. _irrefutable-patterns:
 

--- a/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
+++ b/doc/sphinx/proofs/writing-proofs/reasoning-inductives.rst
@@ -1149,7 +1149,7 @@ Helper tactics
       .. rocqtop:: in extra-stdlib
 
          Goal forall (P Q : Prop) (Hp : {P} + {~P}) (Hq : {Q} + {~Q}),
-             P -> ~Q -> (if Hp then true else false) = (if Hq then false else true).
+             P -> ~Q -> (if Hp is left _ then true else false) = (if Hq is left _ then false else true).
          Proof.
 
       .. rocqtop:: all extra-stdlib

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1403,6 +1403,16 @@ struct
     let pretype tycon env sigma c = eval_pretyper self ~flags tycon env sigma c in
     Cases.compile_cases ?loc ~program_mode:flags.program_mode sty (pretype, sigma) tycon env (po,tml,eqns)
 
+  let warn_nonbool_if =
+    let quickfix ~loc (cloc, pp) =
+      let qf loc = let loc = Loc.after loc 0 0 in [Quickfix.make ~loc pp] in
+      Option.cata qf [] cloc in
+    CWarnings.create ~name:"non-boolean-if" ~category:Deprecation.Version.v9_3
+      ~quickfix
+      (fun _ ->
+         strbrk "The \"if <c> then _\" syntax for non boolean guard is deprecated. "
+         ++ strbrk "Use \"if <c> is <first_constructor> then _\" instead.")
+
   let pretype_if self (c, (na, po), b1, b2) =
     fun ?loc ~flags tycon env sigma ->
     let open Context.Rel.Declaration in
@@ -1417,6 +1427,15 @@ struct
     let () = if not (Int.equal (Array.length cstrs) 2) then
         CErrors.user_err ?loc (str "If is only for inductive types with two constructors.")
     in
+    let () =
+      let indf_is_bool =
+        match dest_ind_family indf with _, _ :: _ -> false | (ind, _), [] ->
+          match Rocqlib.lib_ref_opt "core.bool.type" with
+          | None -> false
+          | Some bool -> GlobRef.CanOrd.equal (IndRef ind) bool in
+      if not indf_is_bool then
+        let cloc = loc_of_glob_constr c in
+        warn_nonbool_if ?loc (cloc, Pp.str " is " ++ Id.print cstrs.(0).cs_name) in
     let arsgn, indr =
       let arsgn = get_arity !!env indf in
       (* Make dependencies from arity signature impossible *)

--- a/test-suite/output/If.out
+++ b/test-suite/output/If.out
@@ -1,5 +1,11 @@
 if true then 1 else 0
      : nat
+File "./output/If.v", line 3, characters 6-24:
+Warning: The "if <c> then _" syntax for non boolean guard is deprecated. Use
+"if <c> is <first_constructor> then _" instead.
+[non-boolean-if,deprecated-since-9.3,deprecated,default]
+Quickfix:
+Replace File "./output/If.v", line 3, characters 10-10 with  is O
 if 4 is 0 then 1 else 0
      : nat
 if 4 is S n then n else 0

--- a/test-suite/output/sort_poly_elab.v
+++ b/test-suite/output/sort_poly_elab.v
@@ -675,7 +675,7 @@ Module Records.
   Record R11 := {
     R11f1 : bool ;
     R11f2 : let r := {| R10f1 := true; R10f2 := eq_refl true ; R10f3 := R11f1 |} in
-         if R10f3 bool r then
+         if R10f3 bool r is true then
           bool
         else
           bool ;
@@ -702,7 +702,7 @@ Module Records.
     R12f1 : bool ;
     R12f2 : let f' :=
           fix F n :=
-            if R12f1 then n else O
+            if R12f1 is true then n else O
         in
         match f' O with
         | O => bool

--- a/theories/Corelib/Init/Specif.v
+++ b/theories/Corelib/Init/Specif.v
@@ -959,7 +959,7 @@ Section Choice_lemmas.
      {f:S -> bool | forall x:S, f x = true /\ R1 x \/ f x = false /\ R2 x}.
   Proof.
     intro H.
-    exists (fun z:S => if H z then true else false).
+    exists (fun z:S => if H z is left _ then true else false).
     intro z; destruct (H z); auto.
   Defined.
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Deprecate the non boolean `if t then _ else _` syntax (in favour of `if t is <first_constructor> then _ else _`).

Depends on: ~https://github.com/rocq-prover/rocq/pull/21609, https://github.com/rocq-prover/rocq/pull/22124~ (merged)

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
<!-- Fixes / closes #???? -->


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [x] Documented any new / changed **user messages**.
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~
