### PR TITLE
Printing for `if <term> is <pattern> then _ else _` syntax

### DIFF
--- a/dev/ci/user-overlays/22124-proux01-if-printing.sh
+++ b/dev/ci/user-overlays/22124-proux01-if-printing.sh
@@ -1,0 +1,1 @@
+overlay mtac2 https://github.com/proux01/Mtac2 rocq22124 22124

--- a/doc/changelog/02-specification-language/22124-if-printing-Removed.rst
+++ b/doc/changelog/02-specification-language/22124-if-printing-Removed.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  table ``Printing If``
+  (`#22124 <https://github.com/rocq-prover/rocq/pull/22124>`_,
+  by Pierre Roux).

--- a/doc/sphinx/language/extensions/match.rst
+++ b/doc/sphinx/language/extensions/match.rst
@@ -319,19 +319,6 @@ written using the :ref:`let-tuple syntax <let-tuple>`.
    Use the :cmd:`Add` and :cmd:`Remove` commands to update this set.
 
 
-Printing matching on booleans
-+++++++++++++++++++++++++++++
-
-If an inductive type is isomorphic to the boolean type, pattern matching
-can be written using ``if`` … ``then`` … ``else`` ….  This table controls
-which types are written this way:
-
-.. table:: Printing If @qualid
-
-   This :term:`table` specifies a set of qualids for which pattern matching is displayed using
-   ``if`` … ``then`` … ``else`` ….  Use the :cmd:`Add` and :cmd:`Remove`
-   commands to update this set.
-
 This example emphasizes what the printing settings offer.
 
 .. example::
@@ -361,7 +348,7 @@ Printing regular match syntax
 
    When enabled, this flag makes printing avoid the alternate case
    analysis syntaxes (with :ref:`if <if-then-else>` and :ref:`let
-   <irrefutable-patterns>`), overriding :table:`Printing If` and
+   <irrefutable-patterns>`), overriding
    :table:`Printing Let` and disregarding the syntax used to input the
    case analysis (so e.g. `let 'tt := tt in tt` will be printed using `match`).
 

--- a/ide/rocqide/rocq_commands.ml
+++ b/ide/rocqide/rocq_commands.ml
@@ -15,7 +15,6 @@ let commands = [
    "Add Field";
    "Add Morphism";
    "Add Printing Constructor";
-   "Add Printing If";
    "Add Printing Let";
    "Add Printing Record";
    "Add Ring A Aplus Amult Aone Azero Ainv Aeq T [ c1 ... cn ]. ";
@@ -94,7 +93,6 @@ let commands = [
    "Record";
    "Remark";
    "Remove Printing Constructor";
-   "Remove Printing If";
    "Remove Printing Let";
    "Remove Printing Record";
    "Require";
@@ -128,7 +126,6 @@ let commands = [
      "Syntactic Definition";
      "Syntax";];
   [
-   "Test Printing If";
    "Test Printing Let";
    "Test Printing Synth";
    "Test Printing Wildcard";
@@ -194,7 +191,6 @@ let state_preserving = [
   "Print Scopes.";
   "Print Section";
 
-  "Print Table Printing If.";
   "Print Table Printing Let.";
   "Print Tables.";
   "Print Term";
@@ -219,7 +215,6 @@ let state_preserving = [
   "Show Proof";
   "Show Tree";
 
-  "Test Printing If";
   "Test Printing Let";
   "Test Printing Synth";
   "Test Printing Wildcard";

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -249,7 +249,7 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CIf (c, po, b1, b2) }
       | "if"; c = term LEVEL "200"; "is"; db1 = if_dthen; b2 = if_else ->
         { let b1, (na, t), rt = db1 in
-          CAst.make ~loc @@ CCases (MatchStyle, rt, [c, na, t], [b1; b2]) }
+          CAst.make ~loc @@ CCases (IfStyle, rt, [c, na, t], [b1; b2]) }
       | "fix"; c = fix_decls -> { let (id,dcls) = c in CAst.make ~loc @@ CFix (id,dcls) }
       | "cofix"; c = cofix_decls -> { let (id,dcls) = c in CAst.make ~loc @@ CCoFix (id,dcls) } ]
     | "9"

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -222,19 +222,9 @@ let encode_inductive env r =
 
 (* Parameterization of the translation from constr to ast      *)
 
-(* Tables for Cases printing under a "if" form, a "let" form,  *)
-
-let has_two_constructors lc =
-  Int.equal (Array.length lc) 2 (* & lc.(0) = 0 & lc.(1) = 0 *)
+(* Table for Cases printing under a "let" form,  *)
 
 let isomorphic_to_tuple lc = Int.equal (Array.length lc) 1
-
-let encode_bool env ({CAst.loc} as r) =
-  let (x,lc) = encode_inductive env r in
-  if not (has_two_constructors lc) then
-    user_err ?loc
-      (str "This type has not exactly two constructors.");
-  x
 
 let encode_tuple env ({CAst.loc} as r) =
   let (x,lc) = encode_inductive env r in
@@ -242,18 +232,6 @@ let encode_tuple env ({CAst.loc} as r) =
     user_err ?loc
       (str "This type cannot be seen as a tuple type.");
   x
-
-module PrintingCasesIf =
-  PrintingFlags.PrintingInductiveMake (struct
-    let encode = encode_bool
-    let field = "If"
-    let title = "Types leading to pretty-printing of Cases using a `if' form:"
-    let member_message s b =
-      str "Cases on elements of " ++ s ++
-      str
-        (if b then " are printed using a `if' form"
-         else " are not printed using a `if' form")
-  end)
 
 module PrintingCasesLet =
   PrintingFlags.PrintingInductiveMake (struct
@@ -268,7 +246,6 @@ module PrintingCasesLet =
          else " are not printed using a `let' form")
   end)
 
-module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
 (** univ and sort detyping *)
@@ -616,6 +593,9 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
       n, aliastyp, Some typ
   in
   let constructs = Array.init (Array.length bl) (fun i -> (ci.ci_ind,i+1)) in
+  let ci_bool =
+    match Rocqlib.lib_ref_opt "core.bool.type" with None -> false
+    | Some bool -> GlobRef.CanOrd.equal (IndRef ci.ci_ind) bool in
   let tag =
     let tag = ci.ci_pp_info.style in
     if flags.flg.always_regular_match_style then
@@ -624,7 +604,7 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
       tag
     else if PrintingLet.active ci.ci_ind then
       LetStyle
-    else if PrintingIf.active ci.ci_ind then
+    else if ci_bool then
       IfStyle
     else
       tag
@@ -641,7 +621,7 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
     let (nal,d) = it_destRLambda_or_LetIn_names constagsl.(0) bl'.(0) in
     GLetTuple (nal,(alias,pred),tomatch,d)
   | IfStyle, None ->
-      if Array.for_all (fun br -> is_nondep_branch sigma br) bl then
+      if ci_bool && Array.for_all (fun br -> is_nondep_branch sigma br) bl then
         let map i br =
           let ctx, body = RobustExpand.branch (snd env) sigma (ci.ci_ind, i + 1) univs params br in
           EConstr.it_mkLambda_or_LetIn body ctx
@@ -653,7 +633,13 @@ let detype_case ~flags computable detype detype_eqns avoid env sigma (ci, univs,
         GIf (tomatch,(alias,pred), nondepbrs.(0), nondepbrs.(1))
       else
         let eqnl = detype_eqns constructs (ci, univs, params, bl) in
-        GCases (tag,pred,[tomatch,(alias,aliastyp)],eqnl)
+        if Array.length bl = 2 && is_nondep_branch sigma bl.(0)
+           && not (is_nondep_branch sigma bl.(1)) then
+          (* print `match k with 0 => 0 | S n => n end` as
+             as `if k is S n then n else 0`, not `if k is 0 then 0 else n` *)
+          GCases (tag,pred,[tomatch,(alias,aliastyp)],List.rev eqnl)
+        else
+          GCases (tag,pred,[tomatch,(alias,aliastyp)],eqnl)
   | _ ->
       let eqnl = detype_eqns constructs (ci, univs, params, bl) in
       GCases (tag,pred,[tomatch,(alias,aliastyp)],eqnl)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -731,6 +731,18 @@ let pr ~flags pr sep lev_after inherited a =
                  pr_case_type (pr_dangling_with_for mt pr) rtntypopt ++
                  spc () ++ keyword "in" ++ pr spc lev_after ltop b)))
       lletpattern
+  | CCases(Constr.IfStyle,rtntypopt,[c,as_clause,in_clause],[{v=([[p]],b1)};{v=(_,b2)}]) ->
+    return (fun lev_after ->
+        hv 0 (
+          hov 1 (keyword "if" ++ spc () ++ pr mt no_after ltop c
+                 ++ pr_as_in ~flags (pr mt no_after ltop) as_clause in_clause
+                 ++ spc () ++ keyword "is" ++ spc ()
+                 ++ pr_patt ~flags (pr mt no_after ltop) no_after ltop p) ++
+          spc () ++
+          hov 0 (keyword "then"
+                 ++ pr (fun () -> brk (1,1)) no_after ltop b1) ++ spc () ++
+          hov 0 (keyword "else" ++ pr (fun () -> brk (1,1)) lev_after ltop b2)))
+      lif
   | CCases(_,rtntypopt,c,eqns) ->
     return (fun lev_after ->
         v 0

--- a/test-suite/output/ArgumentsScope.out
+++ b/test-suite/output/ArgumentsScope.out
@@ -28,7 +28,7 @@ negb is not universe polymorphic
 Arguments negb b%_bool_scope
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 86, characters 11-15
 a : bool -> bool
 
 a is not universe polymorphic
@@ -43,7 +43,7 @@ negb is not universe polymorphic
 Arguments negb b
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 86, characters 11-15
 negb' : bool -> bool
 
 negb' is not universe polymorphic
@@ -68,7 +68,7 @@ negb is not universe polymorphic
 Arguments negb b
 negb is transparent
 Expands to: Constant Corelib.Init.Datatypes.negb
-Declared in library Corelib.Init.Datatypes, line 88, characters 11-15
+Declared in library Corelib.Init.Datatypes, line 86, characters 11-15
 negb' : bool -> bool
 
 negb' is not universe polymorphic

--- a/test-suite/output/If.out
+++ b/test-suite/output/If.out
@@ -1,0 +1,50 @@
+if true then 1 else 0
+     : nat
+if 4 is 0 then 1 else 0
+     : nat
+if 4 is S n then n else 0
+     : nat
+if 4 is 0 then 0 else 1
+     : nat
+if 4 is 0 then 1 else 0
+     : nat
+match A with
+| A => 0
+| _ => 1
+end
+     : nat
+if B is C then 1 else 0
+     : nat
+match B return nat with
+| A => O
+| B => O
+| C => S O
+end
+     : nat
+if B is C then 1 else 0
+     : nat
+match B with
+| C => 1
+| _ => 0
+end
+     : nat
+if B is C then 1 else 0
+     : nat
+match A1 with
+| A1 => 1
+| A2 => 0
+end
+     : nat
+if A1 is A1 then 1 else 0
+     : nat
+if A1 is A1 then 0 else 1
+     : nat
+if Or is Sr _ then 1 else 0
+     : nat
+if Or is Sr _ then 0 else 1
+     : nat
+test =
+fun x : {True} + {True} => match x with
+                           | left t | right t => t
+                           end
+     : {True} + {True} -> True

--- a/test-suite/output/If.v
+++ b/test-suite/output/If.v
@@ -1,0 +1,35 @@
+Check if true then 1 else 0.  (* boolean if *)
+
+Check if 4 then 1 else 0.  (* non boolean if, printed as if _ is *)
+
+Check if 4 is S n then n else 0.
+Check if 4 is S n then 1 else 0.
+Check if 4 is O then 1 else 0.
+
+Variant T := A | B | C.
+Check match A with A => 0 | _ => 1 end.  (* printed as match, not if *)
+Check if B is C then 1 else 0.  (* printed as if *)
+Set Printing All.
+Check if B is C then 1 else 0.  (* printed as match *)
+Unset Printing All.
+Check if B is C then 1 else 0.  (* printed as if *)
+Set Printing Regular Matches.
+Check if B is C then 1 else 0.  (* printed as match *)
+Unset Printing Regular Matches.
+Check if B is C then 1 else 0.  (* printed as if *)
+
+Variant T2 := A1 | A2.
+Check match A1 with A2 => 0 | _ => 1 end.  (* printed as match, not if *)
+Check if A1 is A1 then 1 else 0.  (* printed as if *)
+Check if A1 is A2 then 1 else 0.  (* printed as if *)
+
+Inductive natr := Sr of natr | Or.
+
+Check if Or is Sr _ then 1 else 0.
+Check if Or is Or then 1 else 0.
+
+Lemma test : sumbool True True -> True.
+Proof.
+  refine (fun x : sumbool True True => if x is left _ then _ else _);assumption.
+Defined.
+Print test.  (* printed as match (cannot use if) *)

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -17,13 +17,13 @@ option : Type -> Type
 option is template universe polymorphic
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 211, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 209, characters 10-16
 option : Type@{option.u0} -> Type@{max(Set,option.u0)}
 
 option is template universe polymorphic on option.u0 (cannot be instantiated to Prop)
 Arguments option A%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.option
-Declared in library Corelib.Init.Datatypes, line 211, characters 10-16
+Declared in library Corelib.Init.Datatypes, line 209, characters 10-16
 File "./output/Inductive.v", line 27, characters 4-13:
 The command has indeed failed with message:
 Parameters should be syntactically the same for each inductive type.

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -63,7 +63,7 @@ comparison : Set
 
 comparison is not universe polymorphic
 Expands to: Inductive Corelib.Init.Datatypes.comparison
-Declared in library Corelib.Init.Datatypes, line 369, characters 10-20
+Declared in library Corelib.Init.Datatypes, line 367, characters 10-20
 Inductive comparison : Set :=
     Eq : comparison | Lt : comparison | Gt : comparison.
 bar : foo
@@ -105,7 +105,7 @@ nat_rect is not universe polymorphic
 Arguments nat_rect P%_function_scope O S%_function_scope n%_nat_scope
 nat_rect is transparent
 Expands to: Constant Corelib.Init.Datatypes.nat_rect
-Declared in library Corelib.Init.Datatypes, line 187, characters 0-54
+Declared in library Corelib.Init.Datatypes, line 185, characters 0-54
 
 nat_ind :
 forall P : nat -> Prop,
@@ -115,7 +115,7 @@ nat_ind is not universe polymorphic
 Arguments nat_ind P%_function_scope O S%_function_scope n%_nat_scope
 nat_ind is transparent
 Expands to: Constant Corelib.Init.Datatypes.nat_ind
-Declared in library Corelib.Init.Datatypes, line 187, characters 0-54
+Declared in library Corelib.Init.Datatypes, line 185, characters 0-54
 
 nat_sind :
 forall P : nat -> SProp,
@@ -125,7 +125,7 @@ nat_sind is not universe polymorphic
 Arguments nat_sind P%_function_scope O S%_function_scope n%_nat_scope
 nat_sind is transparent
 Expands to: Constant Corelib.Init.Datatypes.nat_sind
-Declared in library Corelib.Init.Datatypes, line 187, characters 0-54
+Declared in library Corelib.Init.Datatypes, line 185, characters 0-54
 nat_rect =
 fun (P : nat -> Type) (O : P 0) (S : forall n : nat, P n -> P (S n)) =>
 fix F (n : nat) : P n :=

--- a/test-suite/output/bug_20754.out
+++ b/test-suite/output/bug_20754.out
@@ -5,4 +5,4 @@ prod : Type -> Type -> Type
 prod is template universe polymorphic
 Arguments prod (A B)%_type_scope
 Expands to: Inductive Corelib.Init.Datatypes.prod
-Declared in library Corelib.Init.Datatypes, line 257, characters 10-14
+Declared in library Corelib.Init.Datatypes, line 255, characters 10-14

--- a/test-suite/success/options.v
+++ b/test-suite/success/options.v
@@ -23,9 +23,7 @@ Remove Printing Coercion i.
 Test Printing Coercion for i.
 
 Test Printing Let.
-Test Printing If.
 Remove Printing Let sig.
-Remove Printing If bool.
 
 Unset Printing Synth.
 Set Printing Synth.

--- a/theories/Corelib/Init/Datatypes.v
+++ b/theories/Corelib/Init/Datatypes.v
@@ -40,8 +40,6 @@ Inductive bool : Set :=
   | true : bool
   | false : bool.
 
-Add Printing If bool.
-
 Declare Scope bool_scope.
 Delimit Scope bool_scope with bool.
 Bind Scope bool_scope with bool.

--- a/theories/Corelib/Init/Specif.v
+++ b/theories/Corelib/Init/Specif.v
@@ -910,8 +910,6 @@ Inductive sumbool (A B:Prop) : Set :=
   | right : B -> {A} + {B}
  where "{ A } + { B }" := (sumbool A B) : type_scope.
 
-Add Printing If sumbool.
-
 Arguments left {A B} _, [A] B _.
 Arguments right {A B} _ , A [B] _.
 
@@ -925,8 +923,6 @@ Inductive sumor (A:Type) (B:Prop) : Type :=
   | inleft : A -> A + {B}
   | inright : B -> A + {B}
  where "A + { B }" := (sumor A B) : type_scope.
-
-Add Printing If sumor.
 
 Arguments inleft {A B} _ , [A] B _.
 Arguments inright {A B} _ , A [B] _.


### PR DESCRIPTION
Add printing for the syntax introduced (only parsing) in https://github.com/rocq-prover/rocq/pull/21609 .
All `if _ then _ else _` and `if _ is _ then _ else _` are printed as `if _ is _ then _ else _` except for boolean guards which remain printed as `if _ then _ else _`.

~Depends on: #21609~ (merged)

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [x] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [x] Added **changelog**.
- [x] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] ~Documented any new / changed **user messages**.~
  - [ ] ~Updated **documented syntax** by running `make doc_gram_rsts`.~

#### Overlays (to be merged before the current PR)

* [x] https://github.com/HoTT/Coq-HoTT/pull/2370
* [ ] https://github.com/Mtac2/Mtac2/pull/438