### PR TITLE
Fix de Bruijn index bug in inductive_of_mutfix.find_ind

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1784,7 +1784,6 @@ let inductive_of_mutfix ?evars env ((nvect, bodynum), (names, types, bodies as r
       let () = if not (noccur_with_meta k nbfix ty) then
         anomaly ~label:"check_one_fix" (Pp.str "Bad occurrence of recursive call.")
       in
-      let env = push_rel (LocalAssum (na, ty)) env in
       if Int.equal k (recarg + 1) then
         (* get the inductive type of the fixpoint *)
         let (mind, _) =
@@ -1792,12 +1791,14 @@ let inductive_of_mutfix ?evars env ((nvect, bodynum), (names, types, bodies as r
           with Not_found ->
             raise_err env i (RecursionNotOnInductiveType ty)
         in
-        let mib, _ = lookup_mind_specif env (out_punivs mind)in
+        let mib, _ = lookup_mind_specif env (out_punivs mind) in
         let () = if mib.mind_finite != Finite then
           raise_err env i (RecursionNotOnInductiveType ty)
         in
+        let env = push_rel (LocalAssum (na, ty)) env in
         (mind, (env, body))
       else
+        let env = push_rel (LocalAssum (na, ty)) env in
         find_ind env i recarg (k+1) body
     | _ -> raise_err env i (NotEnoughAbstractionInFixBody recarg)
   in

--- a/test-suite/bugs/bug_22125.v
+++ b/test-suite/bugs/bug_22125.v
@@ -1,0 +1,16 @@
+(* Test that fixpoints whose structural argument type involves
+   a let-bound variable are accepted by the guard checker *)
+Section S.
+Let T := list nat.
+Fixpoint my_length_sec (l : T) : nat :=
+  match l with
+  | nil => O
+  | cons _ l' => S (my_length_sec l')
+  end.
+End S.
+
+Definition my_length (T:=list nat) := fix my_length (l : T) : nat :=
+  match l with
+  | nil => O
+  | cons _ l' => S (my_length l')
+  end.


### PR DESCRIPTION
## Summary
- Fix a de Bruijn index off-by-one in `inductive_of_mutfix.find_ind` that caused `rocq check` (and the kernel guard checker) to fail on fixpoints whose structural argument type contains a de Bruijn reference (e.g., a section `Let`-bound type alias).
- The bug was introduced by a46bbfb1ee (9.3) ("Reorder and cleanup in inductive_of_mutfix.find_ind"), which moved `push_rel` before the `find_inductive` call. Since `ty` is valid in the pre-push context, de Bruijn indices in `ty` were resolved to wrong bindings in the post-push environment.
- Added a regression test (`test-suite/coqchk/bug_22125.v`).

Fixes #22125.

## Test plan
- [x] Minimal reproduction: `Section S. Let T := list nat. Fixpoint my_length (l : T) ... End S.` now passes `rocqchk`
- [x] All existing `coqchk` tests pass
- [x] Guard checker success/failure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)