### PR TITLE
Purify the internals of ssrmatching

### DIFF
--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -688,22 +688,20 @@ let ssrinstancesofrule ist dir arg =
   let rigid ev = Evd.mem sigma0 ev in
   let rule = interp_term env0 sigma0 ist arg in
   let r_sigma, rules = rwprocess_rule env0 dir rule in
-  let find, conclude =
-    let upats_origin = dir, (snd rule) in
+  let find =
     let rpat pats (d, r, lhs, rhs) =
       let r = Reductionops.nf_evar r_sigma r in
       let lhs = Reductionops.nf_evar r_sigma lhs in
       mk_tpattern ~ok:(rw_progress rhs) ~rigid env0 r d lhs pats
     in
     let rpats = List.fold_left rpat (empty_tpatterns r_sigma) rules in
-    mk_tpattern_matcher ~all_instances:true ~raise_NoMatch:true sigma0 None ~upats_origin rpats in
+    find_all_instances sigma0 rpats
+  in
   let print env p c _ = Feedback.msg_info Pp.(hov 1 (str"instance:" ++ spc() ++ pr_econstr_env env r_sigma p ++ spc() ++ str "matches:" ++ spc() ++ pr_econstr_env env r_sigma c)); c in
-  Feedback.msg_info Pp.(str"BEGIN INSTANCES");
-  try
-    while true do
-      ignore(find env0 (Reductionops.nf_evar sigma0 concl0) 1 ~k:print)
-    done; raise NoMatch
-  with NoMatch -> Feedback.msg_info Pp.(str"END INSTANCES"); Tacticals.tclIDTAC
+  let () = Feedback.msg_info Pp.(str"BEGIN INSTANCES") in
+  let () = find env0 (Reductionops.nf_evar sigma0 concl0) 1 ~k:print in
+  let () = Feedback.msg_info Pp.(str"END INSTANCES") in
+  Tacticals.tclIDTAC
   end
 
 let ipat_rewrite occ dir c = Proofview.Goal.enter begin fun gl ->

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -888,6 +888,43 @@ let has_instances = function
 
 exception NoMatchTC
 
+let subst_tpattern env sigma ise uc u occ_state c h k =
+  let {up_f = pf; up_a = pa} = u in
+  let evd = ref (Evd.set_ustate sigma uc) in
+  let match_EQ f = match_EQ env !evd (ise, u) f in
+  let pn = Array.length pa in
+  let rec subst_loop (env,h as acc) c' =
+    if !(occ_state.skip_occ) then c' else
+    let f, a = splay_app sigma c' in
+    let test () = match match_EQ f with
+      | Some sigma ->
+        (match unif_EQ_args env sigma pa a with
+         | Some sigma -> evd := sigma; true
+         | None -> false)
+      | None -> false
+    in
+    if Array.length a >= pn && test () then
+      let open EConstr in
+      let a1, a2 = Array.chop (Array.length pa) a in
+      let fa1 = mkApp (f, a1) in
+      let f' = if subst_occ occ_state then k env u.up_t fa1 h else fa1 in
+      mkApp (f', Array.map_left (subst_loop acc) a2)
+    else
+      let open EConstr in
+      (* TASSI: clear letin values to avoid unfolding *)
+      let inc_h rd (env,h') =
+        let ctx_item =
+          match rd with
+          | Context.Rel.Declaration.LocalAssum _ as x -> x
+          | Context.Rel.Declaration.LocalDef (x,_,y) ->
+              Context.Rel.Declaration.LocalAssum(x,y) in
+        EConstr.push_rel ctx_item env, h' + 1 in
+      let self acc c = subst_loop acc c in
+      let f' = map_constr_with_binders_left_to_right env sigma inc_h self acc f in
+      mkApp (f', Array.map_left (subst_loop acc) a) in
+  let c = subst_loop (env, h) c in
+  Evd.ustate !evd, c
+
 let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : find_P =
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
@@ -921,7 +958,7 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
     env, 0, ans
   | Some r -> r
   in
-  let expl, sigma, uc, ({up_f = pf; up_a = pa} as u) = match instances with
+  let expl, sigma, uc, u = match instances with
   | None -> List.hd (pi3 upat_that_matched)
   | Some _ ->
     let (e, n, xs) = upat_that_matched in
@@ -933,47 +970,16 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
     end
   in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
-  if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c) else
-  let evd = ref (Evd.set_ustate sigma uc) in
-  let match_EQ f = match_EQ env !evd (ise, u) f in
-  let pn = Array.length pa in
-  let rec subst_loop (env,h as acc) c' =
-    if !(occ_state.skip_occ) then c' else
-    let f, a = splay_app sigma c' in
-    let test () = match match_EQ f with
-      | Some sigma ->
-        (match unif_EQ_args env sigma pa a with
-         | Some sigma -> evd := sigma; true
-         | None -> false)
-      | None -> false
+  if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c)
+  else
+    let uc, c = subst_tpattern env sigma ise uc u occ_state c h k in
+    (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
+    let () =
+      let (env, n, xs) = upat_that_matched in
+      let n = if Option.has_some instances then n + 1 else n in
+      upat_that_matched_ref := Some (env, n, (expl, sigma, uc, u) :: List.tl xs)
     in
-    if Array.length a >= pn && test () then
-      let open EConstr in
-      let a1, a2 = Array.chop (Array.length pa) a in
-      let fa1 = mkApp (f, a1) in
-      let f' = if subst_occ occ_state then k env u.up_t fa1 h else fa1 in
-      mkApp (f', Array.map_left (subst_loop acc) a2)
-    else
-      let open EConstr in
-      (* TASSI: clear letin values to avoid unfolding *)
-      let inc_h rd (env,h') =
-        let ctx_item =
-          match rd with
-          | Context.Rel.Declaration.LocalAssum _ as x -> x
-          | Context.Rel.Declaration.LocalDef (x,_,y) ->
-              Context.Rel.Declaration.LocalAssum(x,y) in
-        EConstr.push_rel ctx_item env, h' + 1 in
-      let self acc c = subst_loop acc c in
-      let f' = map_constr_with_binders_left_to_right env sigma inc_h self acc f in
-      mkApp (f', Array.map_left (subst_loop acc) a) in
-  let c' = subst_loop (env,h) c in
-  (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
-  let () =
-    let (env, n, xs) = upat_that_matched in
-    let n = if Option.has_some instances then n + 1 else n in
-    upat_that_matched_ref := Some (env, n, (expl, sigma, Evd.ustate !evd, u) :: List.tl xs)
-  in
-  c'
+    c
 
 let conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats { max_occ; nocc } : conclude = fun () ->
   let env, (c, sigma, uc, ({up_f = pf; up_a = pa} as u)) =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -762,13 +762,6 @@ let do_once r f = match !r with Some _ -> () | None -> r := Some (f ())
 let assert_done r =
   match !r with Some x -> x | None -> CErrors.anomaly (str"do_once never called.")
 
-let assert_done_multires r =
-  match !r with
-  | None -> CErrors.anomaly (str"do_once never called.")
-  | Some (e, n, xs) ->
-      r := Some (e, n+1,xs);
-      try List.nth xs n with Failure _ -> raise NoMatch
-
 type subst = Environ.env -> EConstr.t -> EConstr.t -> int -> EConstr.t
 type find_P =
   Environ.env -> EConstr.t -> int ->
@@ -895,9 +888,11 @@ let has_instances = function
 
 let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : find_P =
   fun env c h ~k ->
-  do_once upat_that_matched (fun () ->
+  let upat_that_matched_ref = upat_that_matched in
+  let upat_that_matched = match !upat_that_matched_ref with
+  | None ->
     let failed_because_of_TC = ref false in
-    try
+    begin try
       let () = match instances with
       | None when not disable_FO -> match_upats_FO upats env sigma0 ise c
       | _ -> ()
@@ -916,10 +911,20 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
       else ssrfail env ise upats_origin upats SsrMatchFail
     | NoProgress when (not raise_NoMatch) ->
       ssrfail env ise upats_origin upats SsrProgressFail
-    | NoProgress -> raise NoMatch);
+    | NoProgress -> raise NoMatch
+    end
+  | Some r -> r
+  in
   let expl, sigma, uc, ({up_f = pf; up_a = pa} as u) = match instances with
-  | Some _ -> assert_done_multires upat_that_matched
-  | None -> List.hd (pi3(assert_done upat_that_matched))
+  | None -> List.hd (pi3 upat_that_matched)
+  | Some _ ->
+    let (e, n, xs) = upat_that_matched in
+    begin match List.nth_opt xs n with
+    | None ->
+      let () = upat_that_matched_ref := Some (e, n + 1, xs) in
+      raise NoMatch
+    | Some r -> r
+    end
   in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
   if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c) else
@@ -956,11 +961,13 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
       let f' = map_constr_with_binders_left_to_right env sigma inc_h self acc f in
       mkApp (f', Array.map_left (subst_loop acc) a) in
   let c' = subst_loop (env,h) c in
-  let () = (* Fixup !upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
-    match !upat_that_matched with
-    | Some (env, n, _ :: tl) -> upat_that_matched := Some (env, n, (expl, sigma, Evd.ustate !evd, u) :: tl)
-    | _ -> assert false
-  in c'
+  (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
+  let () =
+    let (env, n, xs) = upat_that_matched in
+    let n = if Option.has_some instances then n + 1 else n in
+    upat_that_matched_ref := Some (env, n, (expl, sigma, Evd.ustate !evd, u) :: List.tl xs)
+  in
+  c'
 
 let conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats { max_occ; nocc } : conclude = fun () ->
   let env, (c, sigma, uc, ({up_f = pf; up_a = pa} as u)) =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -921,14 +921,14 @@ let subst_tpattern env sigma ise uc u occ_state c h k =
   let c = subst_loop (env, h) c in
   Evd.ustate !evd, c
 
-let find_tpattern_instances ~instances ~upat_that_matched ~upats sigma0 ise occ_state : EConstr.t find_P =
+let find_tpattern_instances ~instances ~upat_that_matched ~upats sigma0 ise occ_state : unit find_P =
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
   let upat_that_matched = match !upat_that_matched_ref with
   | None ->
+    let on_instance x = instances := !instances @ [x] in
     let ans =
       try
-        let on_instance x = instances := !instances @ [x] in
         let _ : bool = match_upats_HO ~on_instance upats env sigma0 ise c in
         raise NoMatch
       with
@@ -945,34 +945,31 @@ let find_tpattern_instances ~instances ~upat_that_matched ~upats sigma0 ise occ_
     | None -> raise NoMatch
     | Some r -> r
   in
-  let uc, c = subst_tpattern env sigma ise uc u occ_state c h k in
+  let uc, _c = subst_tpattern env sigma ise uc u occ_state c h k in
   (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
-  let () =
-    let (env, n, xs) = upat_that_matched in
-    upat_that_matched_ref := Some (env, n + 1, (expl, sigma, uc, u) :: List.tl xs)
-  in
-  c
+  let (env, n, xs) = upat_that_matched in
+  upat_that_matched_ref := Some (env, n + 1, (expl, sigma, uc, u) :: List.tl xs)
 
 let find_all_instances sigma0 { tpat_sigma = ise; tpat_pats = upats } : unit find_P =
   let occ_state = create_occ_state None in
   let upat_that_matched = ref None in
   let find = find_tpattern_instances ~instances:(ref []) ~upat_that_matched ~upats sigma0 ise occ_state in
   fun env concl h ~k ->
-  try
-    while true do
-      ignore (find env concl h ~k)
-    done; raise NoMatch
-  with NoMatch -> ()
+  let rec loop () = match find env concl h ~k with
+  | () -> loop ()
+  | exception NoMatch -> ()
+  in
+  loop ()
 
 let find_tpattern ~disable_FO ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : EConstr.t find_P =
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
   let upat_that_matched = match !upat_that_matched_ref with
   | None ->
+    let on_instance x = raise (FoundUnif x) in
     let ans =
       try
         let () = if not disable_FO then match_upats_FO upats env sigma0 ise c in
-        let on_instance x = raise (FoundUnif x) in
         if match_upats_HO ~on_instance upats env sigma0 ise c then raise NoMatchTC else raise NoMatch
       with
       | FoundUnif sigma_u -> sigma_u
@@ -986,25 +983,25 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~upat_that_matched ~upats_origin ~u
         if raise_NoMatch then raise NoMatch
         else ssrfail env ise upats_origin upats SsrProgressFail
     in
-    env, 0, [ans]
+    env, ans
   | Some r -> r
   in
-  let expl, sigma, uc, u = List.hd (pi3 upat_that_matched) in
+  let expl, sigma, uc, u = snd upat_that_matched in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
   if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c)
   else
     let uc, c = subst_tpattern env sigma ise uc u occ_state c h k in
     (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
     let () =
-      let (env, n, xs) = upat_that_matched in
-      upat_that_matched_ref := Some (env, n, (expl, sigma, uc, u) :: List.tl xs)
+      let (env, xs) = upat_that_matched in
+      upat_that_matched_ref := Some (env, (expl, sigma, uc, u))
     in
     c
 
 let conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats { max_occ; nocc } : conclude = fun () ->
   let env, (c, sigma, uc, ({up_f = pf; up_a = pa} as u)) =
     match !upat_that_matched with
-    | Some (env,_,x) -> env,List.hd x | None when raise_NoMatch -> raise NoMatch
+    | Some (env, x) -> env, x | None when raise_NoMatch -> raise NoMatch
     | None -> CErrors.anomaly (str"companion function never called.") in
   let p' = EConstr.mkApp (pf, pa) in
   if max_occ <= !nocc then p', u.up_dir, (c, sigma, uc, u.up_t)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -921,45 +921,21 @@ let subst_tpattern env sigma ise uc u occ_state c h k =
   let c = subst_loop (env, h) c in
   Evd.ustate !evd, c
 
-let find_tpattern_instances ~instances ~upat_that_matched ~upats sigma0 ise occ_state : unit find_P =
-  fun env c h ~k ->
-  let upat_that_matched_ref = upat_that_matched in
-  let upat_that_matched = match !upat_that_matched_ref with
-  | None ->
-    let on_instance x = instances := !instances @ [x] in
-    let ans =
-      try
-        let _ : bool = match_upats_HO ~on_instance upats env sigma0 ise c in
-        raise NoMatch
-      with
-      | (NoMatch|NoProgress) when not (List.is_empty !instances) -> uniquize !instances
-      | NoMatch -> raise NoMatch
-      | NoProgress -> raise NoMatch
-    in
-    env, 0, ans
-  | Some r -> r
-  in
-  let expl, sigma, uc, u =
-    let (e, n, xs) = upat_that_matched in
-    match List.nth_opt xs n with
-    | None -> raise NoMatch
-    | Some r -> r
-  in
-  let uc, _c = subst_tpattern env sigma ise uc u occ_state c h k in
-  (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
-  let (env, n, xs) = upat_that_matched in
-  upat_that_matched_ref := Some (env, n + 1, (expl, sigma, uc, u) :: List.tl xs)
-
 let find_all_instances sigma0 { tpat_sigma = ise; tpat_pats = upats } : unit find_P =
   let occ_state = create_occ_state None in
-  let upat_that_matched = ref None in
-  let find = find_tpattern_instances ~instances:(ref []) ~upat_that_matched ~upats sigma0 ise occ_state in
-  fun env concl h ~k ->
-  let rec loop () = match find env concl h ~k with
-  | () -> loop ()
-  | exception NoMatch -> ()
+  fun env c h ~k ->
+  let instances = ref [] in
+  let on_instance x = instances := !instances @ [x] in
+  let () = match match_upats_HO ~on_instance upats env sigma0 ise c with
+  | (_ : bool) -> ()
+  | exception (NoMatch | NoProgress) -> ()
   in
-  loop ()
+  let ans = uniquize !instances in
+  let iter (expl, sigma, uc, u) =
+    let _, _ = subst_tpattern env sigma ise uc u occ_state c h k in
+    ()
+  in
+  List.iter iter ans
 
 let find_tpattern ~disable_FO ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : EConstr.t find_P =
   fun env c h ~k ->

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -926,6 +926,7 @@ let subst_tpattern env sigma ise uc u occ_state c h k =
   Evd.ustate !evd, c
 
 let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : find_P =
+  let () = if Option.has_some instances then assert (raise_NoMatch && not !(occ_state.skip_occ)) in
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
   let upat_that_matched = match !upat_that_matched_ref with
@@ -962,12 +963,9 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
   | None -> List.hd (pi3 upat_that_matched)
   | Some _ ->
     let (e, n, xs) = upat_that_matched in
-    begin match List.nth_opt xs n with
-    | None ->
-      let () = upat_that_matched_ref := Some (e, n + 1, xs) in
-      raise NoMatch
+    match List.nth_opt xs n with
+    | None -> raise NoMatch
     | Some r -> r
-    end
   in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
   if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c)

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -886,33 +886,39 @@ let has_instances = function
 | None -> false
 | Some instances -> not (List.is_empty !instances)
 
+exception NoMatchTC
+
 let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : find_P =
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
   let upat_that_matched = match !upat_that_matched_ref with
   | None ->
-    let failed_because_of_TC = ref false in
-    begin try
-      let () = match instances with
-      | None when not disable_FO -> match_upats_FO upats env sigma0 ise c
-      | _ -> ()
-      in
-      let on_instance = match instances with
-      | None -> fun x -> raise (FoundUnif x)
-      | Some r -> fun x -> r := !r @ [x]
-      in
-      failed_because_of_TC:=match_upats_HO ~on_instance upats env sigma0 ise c;
-      raise NoMatch
-    with FoundUnif sigma_u -> env,0,[sigma_u]
-    | (NoMatch|NoProgress) when has_instances instances ->
-      env, 0, uniquize (!(Option.get instances))
-    | NoMatch when (not raise_NoMatch) ->
-      if !failed_because_of_TC then ssrfail env ise upats_origin upats SsrTCFail
-      else ssrfail env ise upats_origin upats SsrMatchFail
-    | NoProgress when (not raise_NoMatch) ->
-      ssrfail env ise upats_origin upats SsrProgressFail
-    | NoProgress -> raise NoMatch
-    end
+    let ans =
+      try
+        let () = match instances with
+        | None when not disable_FO -> match_upats_FO upats env sigma0 ise c
+        | _ -> ()
+        in
+        let on_instance = match instances with
+        | None -> fun x -> raise (FoundUnif x)
+        | Some r -> fun x -> r := !r @ [x]
+        in
+        if match_upats_HO ~on_instance upats env sigma0 ise c then raise NoMatchTC else raise NoMatch
+      with
+      | FoundUnif sigma_u -> [sigma_u]
+      | (NoMatch|NoMatchTC|NoProgress) when has_instances instances ->
+        uniquize (!(Option.get instances))
+      | NoMatch ->
+        if raise_NoMatch then raise NoMatch
+        else ssrfail env ise upats_origin upats SsrMatchFail
+      | NoMatchTC ->
+        if raise_NoMatch then raise NoMatch
+        else ssrfail env ise upats_origin upats SsrTCFail
+      | NoProgress ->
+        if raise_NoMatch then raise NoMatch
+        else ssrfail env ise upats_origin upats SsrProgressFail
+    in
+    env, 0, ans
   | Some r -> r
   in
   let expl, sigma, uc, ({up_f = pf; up_a = pa} as u) = match instances with

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -763,10 +763,10 @@ let assert_done r =
   match !r with Some x -> x | None -> CErrors.anomaly (str"do_once never called.")
 
 type subst = Environ.env -> EConstr.t -> EConstr.t -> int -> EConstr.t
-type find_P =
+type 'a find_P =
   Environ.env -> EConstr.t -> int ->
-  k:subst ->
-     EConstr.t
+  k:subst -> 'a
+
 type conclude = unit ->
   EConstr.t * ssrdir * (bool * Evd.evar_map * UState.t * EConstr.t)
 
@@ -882,10 +882,6 @@ end
 let ssrfail env sigma upats_origin upats e =
   raise (SsrMatchingFailure (env, sigma, upats_origin, upats, e))
 
-let has_instances = function
-| None -> false
-| Some instances -> not (List.is_empty !instances)
-
 exception NoMatchTC
 
 let subst_tpattern env sigma ise uc u occ_state c h k =
@@ -925,27 +921,61 @@ let subst_tpattern env sigma ise uc u occ_state c h k =
   let c = subst_loop (env, h) c in
   Evd.ustate !evd, c
 
-let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : find_P =
-  let () = if Option.has_some instances then assert (raise_NoMatch && not !(occ_state.skip_occ)) in
+let find_tpattern_instances ~instances ~upat_that_matched ~upats sigma0 ise occ_state : EConstr.t find_P =
   fun env c h ~k ->
   let upat_that_matched_ref = upat_that_matched in
   let upat_that_matched = match !upat_that_matched_ref with
   | None ->
     let ans =
       try
-        let () = match instances with
-        | None when not disable_FO -> match_upats_FO upats env sigma0 ise c
-        | _ -> ()
-        in
-        let on_instance = match instances with
-        | None -> fun x -> raise (FoundUnif x)
-        | Some r -> fun x -> r := !r @ [x]
-        in
+        let on_instance x = instances := !instances @ [x] in
+        let _ : bool = match_upats_HO ~on_instance upats env sigma0 ise c in
+        raise NoMatch
+      with
+      | (NoMatch|NoProgress) when not (List.is_empty !instances) -> uniquize !instances
+      | NoMatch -> raise NoMatch
+      | NoProgress -> raise NoMatch
+    in
+    env, 0, ans
+  | Some r -> r
+  in
+  let expl, sigma, uc, u =
+    let (e, n, xs) = upat_that_matched in
+    match List.nth_opt xs n with
+    | None -> raise NoMatch
+    | Some r -> r
+  in
+  let uc, c = subst_tpattern env sigma ise uc u occ_state c h k in
+  (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
+  let () =
+    let (env, n, xs) = upat_that_matched in
+    upat_that_matched_ref := Some (env, n + 1, (expl, sigma, uc, u) :: List.tl xs)
+  in
+  c
+
+let find_all_instances sigma0 { tpat_sigma = ise; tpat_pats = upats } : unit find_P =
+  let occ_state = create_occ_state None in
+  let upat_that_matched = ref None in
+  let find = find_tpattern_instances ~instances:(ref []) ~upat_that_matched ~upats sigma0 ise occ_state in
+  fun env concl h ~k ->
+  try
+    while true do
+      ignore (find env concl h ~k)
+    done; raise NoMatch
+  with NoMatch -> ()
+
+let find_tpattern ~disable_FO ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state : EConstr.t find_P =
+  fun env c h ~k ->
+  let upat_that_matched_ref = upat_that_matched in
+  let upat_that_matched = match !upat_that_matched_ref with
+  | None ->
+    let ans =
+      try
+        let () = if not disable_FO then match_upats_FO upats env sigma0 ise c in
+        let on_instance x = raise (FoundUnif x) in
         if match_upats_HO ~on_instance upats env sigma0 ise c then raise NoMatchTC else raise NoMatch
       with
-      | FoundUnif sigma_u -> [sigma_u]
-      | (NoMatch|NoMatchTC|NoProgress) when has_instances instances ->
-        uniquize (!(Option.get instances))
+      | FoundUnif sigma_u -> sigma_u
       | NoMatch ->
         if raise_NoMatch then raise NoMatch
         else ssrfail env ise upats_origin upats SsrMatchFail
@@ -956,17 +986,10 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
         if raise_NoMatch then raise NoMatch
         else ssrfail env ise upats_origin upats SsrProgressFail
     in
-    env, 0, ans
+    env, 0, [ans]
   | Some r -> r
   in
-  let expl, sigma, uc, u = match instances with
-  | None -> List.hd (pi3 upat_that_matched)
-  | Some _ ->
-    let (e, n, xs) = upat_that_matched in
-    match List.nth_opt xs n with
-    | None -> raise NoMatch
-    | Some r -> r
-  in
+  let expl, sigma, uc, u = List.hd (pi3 upat_that_matched) in
 (*   pp(lazy(str"sigma@tmatch=" ++ pr_evar_map None sigma)); *)
   if !(occ_state.skip_occ) then ((*ignore(k env u.up_t 0);*) c)
   else
@@ -974,7 +997,6 @@ let find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upat
     (* Fixup upat_that_matched to record universe unifications for followup EQ matches in later occurrences of a pattern *)
     let () =
       let (env, n, xs) = upat_that_matched in
-      let n = if Option.has_some instances then n + 1 else n in
       upat_that_matched_ref := Some (env, n, (expl, sigma, uc, u) :: List.tl xs)
     in
     c
@@ -989,14 +1011,13 @@ let conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats { m
   else ssrfail env sigma upats_origin upats (SsrOccMissing (!nocc, max_occ, p'))
 
 (* upats_origin makes a better error message only            *)
-let mk_tpattern_matcher ?(all_instances=false)
+let mk_tpattern_matcher
   ?(raise_NoMatch=false) ?upats_origin sigma0 occ { tpat_sigma = ise; tpat_pats = upats }
 =
   let occ_state = create_occ_state occ in
   let upat_that_matched = ref None in
-  let instances = if all_instances then Some (ref []) else None in
   let disable_FO = occ = Some(true,[1]) in
-  find_tpattern ~disable_FO ~raise_NoMatch ~instances ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state,
+  find_tpattern ~disable_FO ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats sigma0 ise occ_state,
   conclude_tpattern ~raise_NoMatch ~upat_that_matched ~upats_origin ~upats occ_state
 
 type ('inpat, 'term) ssrpattern =
@@ -1604,17 +1625,13 @@ let ssrinstancesof arg =
   let pat = match cpat with T x -> x | _ -> errorstrm (str"Not supported") in
   let rigid ev = Evd.mem sigma ev in
   let tpat = mk_tpattern ~rigid env pat L2R pat (empty_tpatterns sigma0) in
-  let find, conclude =
-    mk_tpattern_matcher ~all_instances:true ~raise_NoMatch:true sigma None tpat
-  in
+  let find = find_all_instances sigma tpat in
   let print env p c _ = ppnl (hov 1 (str"instance:" ++ spc() ++ pr_econstr_env env (Proofview.Goal.sigma gl) p ++ spc()
                                      ++ str "matches:" ++ spc() ++ pr_econstr_env env (Proofview.Goal.sigma gl) c)); c in
-  ppnl (str"BEGIN INSTANCES");
-  try
-    while true do
-      ignore(find env concl 1 ~k:print)
-    done; raise NoMatch
-  with NoMatch -> ppnl (str"END INSTANCES"); Tacticals.tclIDTAC
+  let () = ppnl (str"BEGIN INSTANCES") in
+  let () = find env concl 1 ~k:print in
+  let () = ppnl (str"END INSTANCES") in
+  Tacticals.tclIDTAC
   end
 
 module Internal =

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -159,8 +159,8 @@ val mk_tpattern :
     [true] and if the pattern did not match
   @raise UserEerror if the raise_NoMatch flag given to [mk_tpattern_matcher] is
     [false] and if the pattern did not match *)
-type find_P =
-  Environ.env -> EConstr.t -> int -> k:subst -> EConstr.t
+type 'a find_P =
+  Environ.env -> EConstr.t -> int -> k:subst -> 'a
 
 (** [conclude ()] asserts that all mentioned occurrences have been visited.
   @return the instance of the pattern, the evarmap after the pattern
@@ -176,10 +176,9 @@ type conclude =
     be passed to tune the [UserError] eventually raised (useful if the
     pattern is coming from the LHS/RHS of an equation) *)
 val mk_tpattern_matcher :
-  ?all_instances:bool ->
   ?raise_NoMatch:bool ->
   ?upats_origin:ssrdir * EConstr.t ->
-  evar_map -> occ -> tpatterns -> find_P * conclude
+  evar_map -> occ -> tpatterns -> EConstr.t find_P * conclude
 
 (** Example of [mk_tpattern_matcher] to implement
     [rewrite \{occ\}\[in t\]rules].
@@ -205,6 +204,8 @@ val mk_tpattern_matcher :
   let concl = eval_pattern env0 sigma0 concl0 pat occ find_R in
   let (d, r), rdx = conclude concl in
 ]} *)
+
+val find_all_instances : Evd.evar_map -> tpatterns -> unit find_P
 
 (* convenience shortcut: [fill_occ_term env concl sigma occ (sigma,t)] returns
  * [concl] where [occ] occurrences of [t] have been replaced


### PR DESCRIPTION
We remove a lot of dubious control flow based on references and exceptions and make explicit a lot of hidden invariants in the code around `Ssrmatching.mk_tpattern_matcher`. This should be backwards compatible. I kept the commits separate since this is a tricky piece of code and I'd rather find easily where I potentially broke the observable behaviour.