### PR TITLE
Fast path for kernel reduction in VM reification.

### DIFF
--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -28,7 +28,19 @@ module NamedDecl = Context.Named.Declaration
 (* Calcul de la forme normal d'un terme    *)
 (*******************************************)
 
-let e_whd_all = Reductionops.clos_whd_flags RedFlags.all
+let e_whd_all env sigma t = match EConstr.kind sigma t with
+| Sort _ | Meta _ | Ind _ | Construct _ | Prod _| Lambda _ | Fix _
+| CoFix _ | Int _ | Float _ | String _ | Array _ as kind ->
+  EConstr.of_kind kind (* ensure head evar normalization *)
+| App (c, _) as kind ->
+  begin match EConstr.kind sigma c with
+  | Ind _ | Construct _ | Meta _ | Int _ | Float _ | String _ | Array _ -> EConstr.of_kind kind
+  | Sort _ | Rel _ | Var _ | Evar _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
+  | Const _ | Case _ | Fix _ | CoFix _ | Proj _ ->
+    Reductionops.clos_whd_flags RedFlags.all env sigma t
+  end
+| Rel _ | Evar _ | Cast _ | LetIn _ | Case _ | Proj _ | Const _ | Var _ ->
+  Reductionops.clos_whd_flags RedFlags.all env sigma t
 
 let crazy_type =  mkSet
 


### PR DESCRIPTION
We do not call normalization when the argument is already in head normal form. Note that for some reason the code still relies on the term being evar-expanded, so we do implement this carefully.

This fast path seems to be quite important for VM normalization, as most constructors of inductive types already have a type in head normal form. On a micro-benchmark designed to measure VM reification of big first-order terms, this gives a 20% speedup.

Here is the code of the micro-benchmark:
```coq
Inductive tree := leaf | node : tree -> tree -> tree.

Fixpoint big (n : nat) :=
match n with
| 0 => leaf
| S n =>
  let t := big n in
  node t t
end.

Inductive hide A := Hide : A -> hide A.

Arguments Hide {A _}.

Definition test := Eval lazy in @Hide tree (big 22).

Time Eval vm_compute in test.
```