### PR TITLE
Reduce definitional UIP pattern matching when the global return type is convertible with the type in the (unique) branch

### DIFF
--- a/doc/changelog/01-kernel/22150-definitional_UIP_on_motives-Changed.rst
+++ b/doc/changelog/01-kernel/22150-definitional_UIP_on_motives-Changed.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Check convertibility of the motive applied to indices instead of directly convertibility of indices
+  (when `Set Definitional UIP` is enabled).
+  This is a stronger reduction rule that subsumes the previous one and is justified by a proof using logical relations
+  (`#22150 <https://github.com/rocq-prover/rocq/pull/22150>`_,
+  by nicolas tabareau).

--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -238,9 +238,21 @@ by proof irrelevance :g:`e` is convertible to :g:`srefl 0` and then by
 congruence :g:`hidden_arrow` is convertible to `nat -> nat`.
 
 The special reduction reduces any match on a type which uses
-definitional UIP when the indices are convertible to those of the
-constructor. For `seq`, this means a match on a value of type `seq x
-y` reduces if and only if `x` and `y` are convertible.
+definitional UIP when the motive applied to the current indices is convertible
+to the motive applied to indices of the constructor.
+
+For :g:`seq`, this means a match on a value of type :g:`seq x y`
+reduces if and only if :g:`P x` and :g:`P y` are convertible,
+where :g:`P` is the motive.
+
+In particular, we do always reduce when the predicate is constant.
+
+.. rocqdoc::
+
+   Definition transport_constant A B (x y:A) (e:seq x y) v
+      : transport (fun _ => B) e v = v
+      := @eq_refl B v.
+
 
 Such matches are indicated in the printed representation by inserting
 a cast around the discriminee:
@@ -252,9 +264,8 @@ a cast around the discriminee:
 Non Termination with UIP
 ++++++++++++++++++++++++
 
-The special reduction rule of UIP combined with an impredicative sort
-(including `SProp`)
-breaks termination of reduction
+The special reduction rule of UIP combined with an impredicative
+proof relevant sort (i.e., `Prop`) breaks termination of reduction
 :cite:`abel19:failur_normal_impred_type_theor`:
 
 .. rocqtop:: all

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -2058,10 +2058,8 @@ let rec knr info tab ~pat_state m stk =
            kni info tab ~pat_state a (Zprimitive(op,c,rargs,nargs)::s)
              end
      | (depth, _, _, stk) -> knr_ret info tab ~pat_state (m,zshift depth stk))
-  | FCaseInvert (ci, u, pms, _p,iv,_c,v,env) when red_set info.i_flags fMATCH ->
-    let pms = mk_clos_vect env pms in
-    let u = usubst_instance env u in
-    begin match case_inversion info tab ci u pms iv v with
+  | FCaseInvert (ci, u, pms, ((_pnas, p), _r), iv, _c, v, env) when red_set info.i_flags fMATCH ->
+    begin match case_inversion info tab ci u pms p iv v env with
       | Some c -> knit info tab ~pat_state env c stk
       | None -> knr_ret info tab ~pat_state (m, stk)
     end
@@ -2094,29 +2092,32 @@ and knit info tab ~pat_state e t stk =
   let (ht,s) = knht info e t stk in
   knr info tab ~pat_state ht s
 
-and case_inversion info tab ci u params indices v = match v with
+and case_inversion info tab ci u pms p indices brs env = match brs with
 | [||] -> None (* empty type *)
 | [| [||], v |] ->
   (* No binders / lets at all in the unique branch *)
   let open Declarations in
   if Array.is_empty indices then Some v
   else
-    let env = info_env info in
-    let ind = ci.ci_ind in
-    let psubst = subs_consn params 0 ci.ci_npar (subs_id 0) in
-    let mib = Environ.lookup_mind (fst ind) env in
-    let mip = mib.mind_packets.(snd ind) in
+    let u = usubst_instance env u in
+    let pms = mk_clos_vect env pms in
+    let psubst = subs_consn pms 0 ci.ci_npar (subs_id 0) in
+
+    let mib = Environ.lookup_mind (fst ci.ci_ind) (info_env info) in
+    let mip = mib.mind_packets.(snd ci.ci_ind) in
     (* indtyping enforces 1 ctor with no letins in the context *)
-    let _, expect = mip.mind_nf_lc.(0) in
-    let _ind, expect_args = destApp expect in
+    let _, indargs = mip.mind_nf_lc.(0) in
+    let _, allargs = destApp indargs in
+    let _, branch_indices = Array.chop ci.ci_npar allargs in
+    let branch_indices = Array.map (fun c -> mk_clos (psubst, u) c) branch_indices in
+    let branch_subs = usubs_cons mk_irrelevant (usubs_consv branch_indices env) in
+    let external_subs = usubs_cons mk_irrelevant (usubs_consv indices env) in
+    let branch_type = mk_clos branch_subs p in
+    let external_type = mk_clos external_subs p in
+
     let tab = if info.i_cache.i_mode == Conversion then tab else Table.create () in
     let info = {info with i_cache = { info.i_cache with i_mode = Conversion}; i_flags=all} in
-    let check_index i index =
-      let expected = expect_args.(ci.ci_npar + i) in
-      let expected = mk_clos (psubst,u) expected in
-      !conv info tab expected index
-    in
-    if Array.for_all_i check_index 0 indices
+    if !conv info tab branch_type external_type
     then Some v else None
 | _ -> assert false
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -200,6 +200,7 @@ let check_constructors ~env_params ~env_ar_par isrecord params lc (arity,indices
       if (Environ.typing_flags env_ar_par).allow_uip
            && fst (splayed_lc.(0)) = []
            && List.for_all Context.Rel.Declaration.is_local_assum params
+           && List.for_all Context.Rel.Declaration.is_local_assum indices
            && Sorts.is_sprop univ_info.ind_univ
       then univ_info
       (* 1 constructor with arguments must squash if SProp / sort poly

--- a/test-suite/failure/sprop_uip.v
+++ b/test-suite/failure/sprop_uip.v
@@ -1,0 +1,9 @@
+Set Definitional UIP.
+
+Inductive test : let x := nat in x -> SProp := T : test 0.
+
+Fail Definition bla (e : test 1) := match e in test x1 x2 return x1 with T => 0 end.
+
+Inductive test' : nat -> SProp := T' : test' 0.
+
+Definition bla (e : test' 1) := match e in test' x1 return nat with T' => 0 end.

--- a/test-suite/success/sprop_uip.v
+++ b/test-suite/success/sprop_uip.v
@@ -33,9 +33,8 @@ Definition transport_refl_id {A} (P : A -> Type) {x : A} (u : P x)
   : P (transport (fun _ => A) (srefl _ : seq (id_unit tt) tt) x)
   := u.
 
-(** We don't ALWAYS reduce (this uses a constant transport so that the
-    equation is well-typed) *)
-Fail Definition transport_block A B (x y:A) (e:seq x y) v
+(** In particular, we do always reduce when the predicate is constant *)
+Definition transport_constant A B (x y:A) (e:seq x y) v
   : transport (fun _ => B) e v = v
   := @eq_refl B v.
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR implement the rule 

$J ~ A ~ x ~ P ~ t ~ y ~ e \equiv t$

when $P ~ x  ~ refl \equiv P ~ y ~ e$, instead of just $x \equiv y$

This allows the following to type check.

```
Definition transport_block A B (x y:A) (e:seq x y) v
  : transport (fun _ => B) e v = v
  := @eq_refl B v.
```

