### PR TITLE
Parameterize application handling of map_constr_with_binders_left_to_right.

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -538,7 +538,7 @@ let map_left2 f a g b =
     r, s
   end
 
-let map_constr_with_binders_left_to_right env sigma g f l c =
+let map_constr_with_binders_left_to_right ~partial_app env sigma g f l c =
   let open RelDecl in
   let open EConstr in
   match EConstr.kind sigma c with
@@ -565,8 +565,8 @@ let map_constr_with_binders_left_to_right env sigma g f l c =
       let b' = f (g (LocalDef (na,bo,t)) l) b in
         if bo' == bo && t' == t && b' == b then c
         else mkLetIn (na, bo', t', b')
-  | App (c,[||]) -> assert false
-  | App (t,al) ->
+  | App (t, al) ->
+    if partial_app then
       (*Special treatment to be able to recognize partially applied subterms*)
       let a = al.(Array.length al - 1) in
       let app = (mkApp (t, Array.sub al 0 (Array.length al - 1))) in
@@ -574,6 +574,11 @@ let map_constr_with_binders_left_to_right env sigma g f l c =
       let a' = f l a in
         if app' == app && a' == a then c
         else mkApp (app', [| a' |])
+    else
+      let t' = f l t in
+      let al' = Array.Smart.map (fun c -> f l c) al in
+      if t' == t && al' == al then c
+      else mkApp (t', al')
   | Proj (p,r,b) ->
     let b' = f l b in
       if b' == b then c

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -41,6 +41,7 @@ val it_mkLambda_or_LetIn_from_no_LetIn : Constr.constr -> Constr.rel_context -> 
 (** {6 Generic iterators on constr} *)
 
 val map_constr_with_binders_left_to_right :
+  partial_app:bool ->
   Environ.env -> Evd.evar_map ->
   (rel_declaration -> 'a -> 'a) ->
   ('a -> constr -> constr) ->

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -916,7 +916,7 @@ let subst_tpattern env sigma ise uc u occ_state c h k =
               Context.Rel.Declaration.LocalAssum(x,y) in
         EConstr.push_rel ctx_item env, h' + 1 in
       let self acc c = subst_loop acc c in
-      let f' = map_constr_with_binders_left_to_right env sigma inc_h self acc f in
+      let f' = map_constr_with_binders_left_to_right ~partial_app:true env sigma inc_h self acc f in
       mkApp (f', Array.map_left (subst_loop acc) a) in
   let c = subst_loop (env, h) c in
   Evd.ustate !evd, c

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1618,7 +1618,7 @@ let apply_on_subterm env evd fixed f test c t =
           let args = Evd.expand_existential !evdref (evk, args) in
           let args = List.Smart.map (applyrec acc) args in
           EConstr.mkLEvar !evdref (evk, args)
-      | _ -> map_constr_with_binders_left_to_right env !evdref
+      | _ -> map_constr_with_binders_left_to_right ~partial_app:true env !evdref
               (fun d (env,(k,c)) -> (push_rel d env, (k+1,lift 1 c)))
               applyrec acc t
     else
@@ -1633,7 +1633,7 @@ let apply_on_subterm env evd fixed f test c t =
                 evdref := evd'; t')
      else (
        debug_ho_unification (fun () -> Pp.str "failed");
-       map_constr_with_binders_left_to_right env !evdref
+       map_constr_with_binders_left_to_right ~partial_app:true env !evdref
         (fun d (env,(k,c)) -> (push_rel d env, (k+1,lift 1 c)))
         applyrec acc t))
   in
@@ -1724,7 +1724,7 @@ let thin_evars env sigma sign c =
        if not (Id.Set.mem id ctx) then raise (TypingFailed !sigma)
        else t
     | _ ->
-       map_constr_with_binders_left_to_right env !sigma
+       map_constr_with_binders_left_to_right ~partial_app:true env !sigma
         (fun d (env,acc) -> (push_rel d env, acc+1))
         applyrec (env,acc) t
   in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1724,7 +1724,7 @@ let thin_evars env sigma sign c =
        if not (Id.Set.mem id ctx) then raise (TypingFailed !sigma)
        else t
     | _ ->
-       map_constr_with_binders_left_to_right ~partial_app:true env !sigma
+       map_constr_with_binders_left_to_right ~partial_app:false env !sigma
         (fun d (env,acc) -> (push_rel d env, acc+1))
         applyrec (env,acc) t
   in

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -70,7 +70,7 @@ type ('a, 'b) testing_function = {
    (b,l), b=true means no occurrence except the ones in l and b=false,
    means all occurrences except the ones in l *)
 
-let replace_term_occ_gen_modulo env sigma like_first test bywhat cl count t =
+let replace_term_occ_gen_modulo env sigma ~partial_app ~like_first test bywhat cl count t =
   let count = ref count in
   let rec substrec (nested, k) t =
     if Locusops.occurrences_done !count then t else
@@ -105,7 +105,7 @@ let replace_term_occ_gen_modulo env sigma like_first test bywhat cl count t =
     | Result.Error () ->
       subst_below (nested, k) t
   and subst_below k t =
-    map_constr_with_binders_left_to_right env sigma (fun d (nested, k) -> (nested, k + 1)) substrec k t
+    map_constr_with_binders_left_to_right ~partial_app env sigma (fun d (nested, k) -> (nested, k + 1)) substrec k t
   in
   let t' = substrec (false, 0) t in
   (!count, t')
@@ -114,14 +114,14 @@ let replace_term_occ_modulo env evd occs test bywhat t =
   let occs',like_first =
     match occs with AtOccs occs -> occs,false | LikeFirst -> AllOccurrences,true in
   proceed_with_occurrences
-    (replace_term_occ_gen_modulo env evd like_first test bywhat None) occs' t
+    (replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat None) occs' t
 
 let replace_term_occ_decl_modulo env evd occs test bywhat d =
   let (plocs,hyploc),like_first =
     match occs with AtOccs occs -> occs,false | LikeFirst -> (AllOccurrences,InHyp),true in
   proceed_with_occurrences
     (map_named_declaration_with_hyploc
-       (replace_term_occ_gen_modulo env evd like_first test bywhat)
+       (replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat)
        hyploc)
     plocs d
 
@@ -153,6 +153,6 @@ let subst_closed_term_occ_decl env evd occs c d =
   let bywhat () = mkRel 1 in
   proceed_with_occurrences
     (map_named_declaration_with_hyploc
-       (fun _ -> replace_term_occ_gen_modulo env evd like_first test bywhat None)
+       (fun _ -> replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat None)
        hyploc) plocs d,
   test.testing_state

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -137,7 +137,7 @@ let make_eq_univs_test env evd c =
       with Evd.UniversesDiffer | UGraph.UniverseInconsistency _ -> Result.Error ()
     );
   merge_fun = (fun evd _ -> Result.Ok evd);
-  with_partial_apps = true;
+  with_partial_apps = (isApp evd c || isProj evd c); (* Proj is handled like application *)
   testing_state = evd;
   last_found = None
 }

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -61,6 +61,7 @@ exception SubtermUnificationError of subterm_unification_error
 type ('a, 'b) testing_function = {
   match_fun : int -> 'a -> EConstr.constr -> ('b, unit) Result.t;
   merge_fun : 'b -> 'a -> ('a, unit) Result.t;
+  with_partial_apps : bool;
   mutable testing_state : 'a;
   mutable last_found : position_reporting option
 }
@@ -70,7 +71,7 @@ type ('a, 'b) testing_function = {
    (b,l), b=true means no occurrence except the ones in l and b=false,
    means all occurrences except the ones in l *)
 
-let replace_term_occ_gen_modulo env sigma ~partial_app ~like_first test bywhat cl count t =
+let replace_term_occ_gen_modulo env sigma ~like_first test bywhat cl count t =
   let count = ref count in
   let rec substrec (nested, k) t =
     if Locusops.occurrences_done !count then t else
@@ -105,7 +106,7 @@ let replace_term_occ_gen_modulo env sigma ~partial_app ~like_first test bywhat c
     | Result.Error () ->
       subst_below (nested, k) t
   and subst_below k t =
-    map_constr_with_binders_left_to_right ~partial_app env sigma (fun d (nested, k) -> (nested, k + 1)) substrec k t
+    map_constr_with_binders_left_to_right ~partial_app:test.with_partial_apps env sigma (fun d (nested, k) -> (nested, k + 1)) substrec k t
   in
   let t' = substrec (false, 0) t in
   (!count, t')
@@ -114,14 +115,14 @@ let replace_term_occ_modulo env evd occs test bywhat t =
   let occs',like_first =
     match occs with AtOccs occs -> occs,false | LikeFirst -> AllOccurrences,true in
   proceed_with_occurrences
-    (replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat None) occs' t
+    (replace_term_occ_gen_modulo env evd ~like_first test bywhat None) occs' t
 
 let replace_term_occ_decl_modulo env evd occs test bywhat d =
   let (plocs,hyploc),like_first =
     match occs with AtOccs occs -> occs,false | LikeFirst -> (AllOccurrences,InHyp),true in
   proceed_with_occurrences
     (map_named_declaration_with_hyploc
-       (replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat)
+       (replace_term_occ_gen_modulo env evd ~like_first test bywhat)
        hyploc)
     plocs d
 
@@ -136,6 +137,7 @@ let make_eq_univs_test env evd c =
       with Evd.UniversesDiffer | UGraph.UniverseInconsistency _ -> Result.Error ()
     );
   merge_fun = (fun evd _ -> Result.Ok evd);
+  with_partial_apps = true;
   testing_state = evd;
   last_found = None
 }
@@ -153,6 +155,6 @@ let subst_closed_term_occ_decl env evd occs c d =
   let bywhat () = mkRel 1 in
   proceed_with_occurrences
     (map_named_declaration_with_hyploc
-       (fun _ -> replace_term_occ_gen_modulo env evd ~partial_app:true ~like_first test bywhat None)
+       (fun _ -> replace_term_occ_gen_modulo env evd ~like_first test bywhat None)
        hyploc) plocs d,
   test.testing_state

--- a/pretyping/find_subterm.mli
+++ b/pretyping/find_subterm.mli
@@ -22,12 +22,16 @@ exception SubtermUnificationError of subterm_unification_error
 (** A testing function is typically a unification function returning a
     substitution or failing with Error, together with a function to merge
     substitutions and an initial substitution;
+    [with_partial_apps] controls whether partial application prefixes are
+    considered, i.e. if [match_fun] may return [Ok] for some [App] argument,
+    one must set it to true;
     last_found is used for error messages and it has to be initialized
     with None. *)
 
 type ('a, 'b) testing_function = {
   match_fun : int -> 'a -> constr -> ('b, unit) Result.t;
   merge_fun : 'b -> 'a -> ('a, unit) Result.t;
+  with_partial_apps : bool;
   mutable testing_state : 'a;
   mutable last_found : position_reporting option
 }

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1164,7 +1164,7 @@ let matches_head env sigma c t =
     parameters. This is a temporary fix while rewrite etc... are not up to equivalence
     of the projection and its eta expanded form.
 *)
-let change_map_constr_with_binders_left_to_right changed g f (env, l as acc) sigma c =
+let change_map_constr_with_binders_left_to_right ~partial_app changed g f (env, l as acc) sigma c =
   match EConstr.kind sigma c with
   | Proj (p, r, v) -> (* Treat specially for partial applications *)
     let t = Retyping.expand_projection env sigma p v [] in
@@ -1180,7 +1180,7 @@ let change_map_constr_with_binders_left_to_right changed g f (env, l as acc) sig
     else
       let () = changed := true in
       mkApp (app', [| a' |])
-  | _ -> map_constr_with_binders_left_to_right env sigma g f acc c
+  | _ -> map_constr_with_binders_left_to_right ~partial_app env sigma g f acc c
 
 let e_contextually byhead (occs,c) f = begin fun env sigma t ->
   let count = ref (Locusops.initialize_occurrence_counter occs) in
@@ -1220,7 +1220,7 @@ let e_contextually byhead (occs,c) f = begin fun env sigma t ->
     | App (f,l) when byhead -> mkApp (f, Array.map_left (traverse nested envc) l)
     | Proj (p,r,c) when byhead -> mkProj (p,r,traverse nested envc c)
     | _ ->
-        change_map_constr_with_binders_left_to_right changed
+        change_map_constr_with_binders_left_to_right ~partial_app:true changed
           (fun d (env,c) -> (push_rel d env, Patternops.lift_pattern 1 c))
           (traverse nested) envc sigma t
   in
@@ -1260,7 +1260,7 @@ let substlin env sigma evalref occs c =
         count := count';
         if ok then Lazy.force v else c
       | None ->
-        map_constr_with_binders_left_to_right env sigma
+        map_constr_with_binders_left_to_right ~partial_app:true env sigma
           (fun _ () -> ())
           substrec () c
   in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2079,7 +2079,22 @@ let default_matching_flags sigma =
 
 exception PatternNotFound
 
+(* true if cannot be found as a prefix of an application, i.e.
+   c args is only well-typed whenever args is empty *)
+let get_head_kind env sigma c =
+  let ty = get_type_of env sigma c in
+  let hd, _ = decompose_app sigma ty in
+  match EConstr.kind sigma hd with
+  | Sort _ | Ind _ -> true
+  | _ ->
+    let ty = whd_all env sigma ty in
+    let hd, _ = decompose_app sigma ty in
+    match EConstr.kind sigma hd with
+    | Sort _ | Ind _ -> true
+    | _ -> false
+
 let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
+  let not_app_prefix = get_head_kind env sigma c in
   let flags =
     if from_prefix_of_ind then
       let flags = default_matching_flags (Option.default Evd.empty pending) in
@@ -2131,7 +2146,8 @@ let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
     end
   | None -> Result.Ok (Some c1)
   in
-  { match_fun = matching_fun; merge_fun = merge_fun; with_partial_apps = true;
+  let with_partial_apps = not (not_app_prefix || from_prefix_of_ind) in
+  { match_fun = matching_fun; merge_fun = merge_fun; with_partial_apps;
     testing_state = None; last_found = None },
   (fun test -> match test.testing_state with
   | None -> None

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2131,7 +2131,7 @@ let make_pattern_test from_prefix_of_ind is_correct_type env sigma (pending,c) =
     end
   | None -> Result.Ok (Some c1)
   in
-  { match_fun = matching_fun; merge_fun = merge_fun;
+  { match_fun = matching_fun; merge_fun = merge_fun; with_partial_apps = true;
     testing_state = None; last_found = None },
   (fun test -> match test.testing_state with
   | None -> None


### PR DESCRIPTION
We add a flag to not recurse on each prefix of applications, which is a potential quadratic behaviour. Some callers now rely on this flag to skip useless subapplication nodes.