### PR TITLE
Add test that VM is not stronger than regular conversion on empty sprop inductive

### DIFF
--- a/test-suite/bugs/bug_19041.v
+++ b/test-suite/bugs/bug_19041.v
@@ -4,4 +4,6 @@ Goal forall (x:T true) (y:T false), match x return bool with end = match y retur
 Proof.
   intros.
   Fail reflexivity.
+  match goal with |- ?a = ?b => vm_cast_no_check (eq_refl a) end.
+  Fail Qed.
 Abort.


### PR DESCRIPTION


There is a risk of forgetting this if we ever implement proof irrelevance in the VM so let's add a test.
