### PR TITLE
feat: add Set Printing All Assumptions flag

### DIFF
--- a/dev/ci/user-overlays/22164-JasonGross-print-assumptions-all-flags.sh
+++ b/dev/ci/user-overlays/22164-JasonGross-print-assumptions-all-flags.sh
@@ -1,0 +1,1 @@
+overlay metarocq https://github.com/JasonGross/metacoq print-assumptions-all-flags 22164

--- a/doc/changelog/08-vernac-commands-and-options/22164-print-assumptions-all-flags-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22164-print-assumptions-all-flags-Added.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  ``Printing All Assumptions`` flag making :cmd:`Print Assumptions` report
+  theory assumptions (impredicativity of :g:`Set`, rewrite rules, disabled
+  universe checking, indices not mattering) according to each definition's
+  typing flags in addition to the settings of the current environment
+  (`#22164 <https://github.com/rocq-prover/rocq/pull/22164>`_,
+  by Jason Gross).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -454,6 +454,21 @@ Requests to the environment
    The message "Closed under the global context" indicates that all the theorems and
    definitions have no dependencies.
 
+.. flag:: Printing All Assumptions
+
+   Turn this :term:`flag` on to make :cmd:`Print Assumptions` report
+   theory assumptions (impredicativity of :g:`Set`, rewrite rules,
+   disabled universe checking, indices not mattering) according to the
+   typing flags each dependency was typechecked with, in addition to
+   the settings of the current environment.  For instance, a definition
+   typechecked with ``-impredicative-set`` is reported as assuming the
+   impredicativity of :g:`Set` even when it is imported into a
+   predicative environment, and an inductive type relying on indices
+   not mattering is reported even when :flag:`Indices Matter` is off in
+   the current environment (without this flag, such inductive types are
+   reported only when :flag:`Indices Matter` is currently on, since an
+   environment where indices do not matter subsumes that assumption).
+
 .. cmd:: Print Opaque Dependencies {+ @reference }
 
    Displays the assumptions and opaque constants that :n:`@reference` depends on.

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -610,6 +610,12 @@ let pr_ne_evar_set ?(flags=current_combined()) hd tl sigma l =
 (* Printer function for sets of Assumptions.assumptions.
    It is used primarily by the Print Assumptions command. *)
 
+let { Goptions.get = print_all_assumptions } =
+  Goptions.declare_bool_option_and_ref
+    ~key:["Printing";"All";"Assumptions"]
+    ~value:false
+    ()
+
 type axiom =
   | Constant of Constant.t
   | Positive of MutInd.t
@@ -668,10 +674,29 @@ end
 module ContextObjectSet = Set.Make (OrderedContextObject)
 module ContextObjectMap = Map.Make (OrderedContextObject)
 
-let pr_assumptionset ?(flags=current_combined()) env sigma s =
+type theory_assumptions = {
+  has_impredicative_set : bool;
+  has_rewrite_rules : bool;
+  has_type_in_type : bool;
+}
+
+let pr_assumptionset ?(flags=current_combined()) env sigma theory_info s =
+  let print_all = print_all_assumptions () in
+  let dominated_by_env ax =
+    match ax with
+    | IndicesNotMattering _ -> not print_all && not (indices_matter env)
+    | _ -> false
+  in
+  let s = ContextObjectMap.filter (fun k _v -> match k with
+    | Axiom (ax, _) -> not (dominated_by_env ax)
+    | _ -> true) s
+  in
+  let show_theory_impredicative_set = (print_all && theory_info.has_impredicative_set) || is_impredicative_set env in
+  let show_theory_rewrite_rules = (print_all && theory_info.has_rewrite_rules) || rewrite_rules_allowed env in
+  let show_theory_type_in_type = (print_all && theory_info.has_type_in_type) || type_in_type env in
   if ContextObjectMap.is_empty s &&
-       not (rewrite_rules_allowed env) &&
-       not (is_impredicative_set env) then
+       not show_theory_rewrite_rules &&
+       not show_theory_impredicative_set then
     str "Closed under the global context"
   else
     let safe_pr_constant env kn =
@@ -751,17 +776,17 @@ let pr_assumptionset ?(flags=current_combined()) env sigma s =
       ContextObjectMap.fold fold s ([], [], [], [])
     in
     let theory =
-      if is_impredicative_set env then
+      if show_theory_impredicative_set then
         [str "Set is impredicative"]
       else []
     in
     let theory =
-      if rewrite_rules_allowed env then
+      if show_theory_rewrite_rules then
         str "Rewrite rules are allowed (subject reduction might be broken)" :: theory
       else theory
     in
     let theory =
-      if type_in_type env then
+      if show_theory_type_in_type then
         str "Type hierarchy is collapsed (logic is inconsistent)" :: theory
       else theory
     in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -226,6 +226,9 @@ val pr_ne_evar_set : ?flags:PrintingFlags.t ->
   Evar.Set.t -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)
+
+val print_all_assumptions : unit -> bool
+
 type axiom =
   | Constant of Constant.t (* An axiom or a constant. *)
   | Positive of MutInd.t (* A mutually inductive definition which has been assumed positive. *)
@@ -244,8 +247,14 @@ module ContextObjectSet : CSet.ExtS with type elt = context_object
 module ContextObjectMap : CMap.ExtS
   with type key = context_object and module Set := ContextObjectSet
 
+type theory_assumptions = {
+  has_impredicative_set : bool;
+  has_rewrite_rules : bool;
+  has_type_in_type : bool;
+}
+
 val pr_assumptionset : ?flags:PrintingFlags.t ->
-  env -> evar_map -> types ContextObjectMap.t -> Pp.t
+  env -> evar_map -> theory_assumptions -> types ContextObjectMap.t -> Pp.t
 
 val pr_typing_flags : Declarations.typing_flags -> Pp.t
 

--- a/test-suite/output/PrintAllAssumptions.out
+++ b/test-suite/output/PrintAllAssumptions.out
@@ -1,0 +1,3 @@
+Closed under the global context
+Theory:
+Set is impredicative

--- a/test-suite/output/PrintAllAssumptions.v
+++ b/test-suite/output/PrintAllAssumptions.v
@@ -1,0 +1,10 @@
+(** Test for Set Printing All Assumptions *)
+Require Import TestSuite.impred_set_prereq.
+
+(** Without the flag, impredicative_set is not in the current env,
+    so Print Assumptions hides the theory dependency *)
+Print Assumptions impred_def.
+
+(** With the flag, per-definition theory info is shown *)
+Set Printing All Assumptions.
+Print Assumptions impred_def.

--- a/test-suite/output/indices_matter.out
+++ b/test-suite/output/indices_matter.out
@@ -3,3 +3,6 @@ M.X relies on indices not mattering.
 Axioms:
 M.X relies on indices not mattering.
 Closed under the global context
+Closed under the global context
+Axioms:
+M.X relies on indices not mattering.

--- a/test-suite/output/indices_matter.v
+++ b/test-suite/output/indices_matter.v
@@ -10,3 +10,11 @@ Module SetIndicesMatter.
   Unset Indices Matter.
   Print Assumptions M.X.
 End SetIndicesMatter.
+
+(* Test Set Printing All Assumptions *)
+Module PrintingAllAssumptions.
+  Unset Indices Matter.
+  Print Assumptions M.X.
+  Set Printing All Assumptions.
+  Print Assumptions M.X.
+End PrintingAllAssumptions.

--- a/test-suite/prerequisite/impred_set_prereq.v
+++ b/test-suite/prerequisite/impred_set_prereq.v
@@ -1,0 +1,2 @@
+(* -*- coq-prog-args: ("-impredicative-set"); -*- *)
+Definition impred_def : Set := forall X : Set, X -> X.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -374,6 +374,13 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
   (* Only keep the transitive dependencies *)
   let (_, graph, ax2ty) = traverse access grs in
   let open GlobRef in
+  let has_impredicative_set = ref false in
+  let has_rewrite_rules = ref false in
+  let has_type_in_type = ref false in
+  let collect_theory_flags (tf : Declarations.typing_flags) =
+    if tf.impredicative_set then has_impredicative_set := true;
+    if not tf.check_universes then has_type_in_type := true
+  in
   let fold obj contents accu = match obj with
   | VarRef id ->
     let decl = Global.lookup_named id in
@@ -383,6 +390,11 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
     else accu
   | ConstRef kn ->
       let cb = lookup_constant kn in
+      collect_theory_flags cb.const_typing_flags;
+      begin match cb.const_body with
+        | Symbol _ -> has_rewrite_rules := true
+        | _ -> ()
+      end;
       let accu =
         if cb.const_typing_flags.check_guarded then accu
         else
@@ -409,6 +421,7 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
       accu
   | IndRef (m,_) | ConstructRef ((m,_),_) ->
       let mind = lookup_mind m in
+      collect_theory_flags mind.mind_typing_flags;
       let accu =
         if mind.mind_typing_flags.check_positive then accu
         else
@@ -434,11 +447,17 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) access st grs =
           ContextObjectMap.add (Axiom (UIP m, l)) Constr.mkProp accu
       in
       let accu =
-        if not (Environ.indices_matter (Global.env ())) then accu
-        else if not (Array.exists (fun mip -> mip.mind_relies_on_indices_not_mattering) mind.mind_packets) then accu
+        if not (Array.exists (fun mip -> mip.mind_relies_on_indices_not_mattering) mind.mind_packets) then accu
         else
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (IndicesNotMattering m, l)) Constr.mkProp accu
       in
       accu
-  in GlobRef.Map_env.fold fold graph ContextObjectMap.empty
+  in
+  let map = GlobRef.Map_env.fold fold graph ContextObjectMap.empty in
+  let theory = {
+    has_impredicative_set = !has_impredicative_set;
+    has_rewrite_rules = !has_rewrite_rules;
+    has_type_in_type = !has_type_in_type;
+  } in
+  (theory, map)

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -31,4 +31,5 @@ val traverse :
    {!traverse} also applies. *)
 val assumptions :
   ?add_opaque:bool -> ?add_transparent:bool -> Global.indirect_accessor ->
-  TransparentState.t -> GlobRef.t list -> types ContextObjectMap.t
+  TransparentState.t -> GlobRef.t list ->
+  theory_assumptions * types ContextObjectMap.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2364,9 +2364,9 @@ let vernac_print =
     (* Prints all the axioms and section variables used by a term *)
     let st = Conv_oracle.get_transp_state (Environ.oracle env) in
     let grs = List.map smart_global rs in
-    let nassums =
+    let (theory, nassums) =
       Assumptions.assumptions opaque_access st ~add_opaque:o ~add_transparent:t grs in
-    Printer.pr_assumptionset env sigma nassums
+    Printer.pr_assumptionset env sigma theory nassums
   | PrintStrategy r -> no_state @@ fun () -> print_strategy r
   | PrintRegistered -> no_state print_registered
   | PrintRegisteredSchemes -> no_state print_registered_schemes


### PR DESCRIPTION
## Summary
- Adds a new `Set Printing All Assumptions` flag that makes `Print Assumptions` report theory assumptions (impredicative set, rewrite rules, type-in-type, indices not mattering) based on **per-definition typing flags** rather than the current environment settings.
- Previously, theory assumptions were only shown based on the global environment state, e.g., a definition typed with `-impredicative-set` would not show "Set is impredicative" when imported into a predicative environment, and `IndicesNotMattering` was hidden when `Indices Matter` was not set.
- When the flag is on, `IndicesNotMattering` is shown regardless of the current `Indices Matter` setting, and the Theory section reflects per-definition flags found during dependency traversal.

## Overlays
- MetaRocq/metarocq#1287

## Test plan
- [x] Added test in `test-suite/output/PrintAllAssumptions.v` for cross-compilation impredicative set detection
- [x] Extended `test-suite/output/indices_matter.v` to test `Set Printing All Assumptions` with `IndicesNotMattering`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw