### PR TITLE
Do not forward make flags to coq-makefile test

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -748,7 +748,7 @@ $(patsubst %/run.sh,%.log,$(wildcard coq-makefile/*/run.sh precomputed-time-test
 	  export COQBIN=$(BIN);\
 	  export COQPREFIX=$(COQPREFIX);\
 	  cd $* && \
-	  $(call WITH_TIMER,$@,bash run.sh 2>&1,../../$@.time); \
+	  MAKEFLAGS= $(call WITH_TIMER,$@,bash run.sh 2>&1,../../$@.time); \
 	if [ $$? = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $< ... Ok"; \


### PR DESCRIPTION
If we forward the ambient flags to the `make` call in the test, `-B` leads to different output from files being re-built inside the test case.

Without the fix, running `make -B -C test-suite coq-makefile`:
```
cat test-suite/coq-makefile/expand-directories2.log
--- actual	2026-06-29 15:01:20.858234891 +0200
+++ expected	2026-06-29 15:01:20.857792391 +0200
@@ -1,6 +1,3 @@
 ROCQ DEP VFILES
-ROCQ DEP VFILES
-ROCQ DEP VFILES
 ROCQ compile b.v
 ROCQ compile x/a.v
-ROCQ DEP VFILES
==========> FAILURE <==========
    coq-makefile/expand-directories2/run.sh ... Error!
```

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If there is a user-visible change and testing is not prohibitively expensive: -->
- [ ] Added / updated **test-suite**.

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**.
- [ ] Added / updated **documentation**.
  <!-- Check if the following applies, otherwise remove these lines. -->
  - [ ] Documented any new / changed **user messages**.
  - [ ] Updated **documented syntax** by running `make doc_gram_rsts`.

<!-- If this breaks external libraries or plugins in CI: -->
- [ ] Opened **overlay** pull requests.

<!--
# Turn this off if you don't want coq-bot suggestions to run the minimizer
# (you can always call the minimizer with @coqbot minimize anyway)
offer-minimizer: on
-->

<!-- Pointers to relevant developer documentation:

Contributing guide: https://github.com/rocq-prover/rocq/blob/master/CONTRIBUTING.md

Test-suite: https://github.com/rocq-prover/rocq/blob/master/test-suite/README.md

Changelog: https://github.com/rocq-prover/rocq/blob/master/doc/changelog/README.md

Building the doc: https://github.com/rocq-prover/rocq/blob/master/doc/README.md
Sphinx: https://github.com/rocq-prover/rocq/blob/master/doc/sphinx/README.rst
doc_gram: https://github.com/rocq-prover/rocq/blob/master/doc/tools/docgram/README.md

Overlays: https://github.com/rocq-prover/rocq/blob/master/dev/ci/user-overlays/README.md
