### PR TITLE
unification: protect CS resolution against call on illtyped terms

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1567,7 +1567,10 @@ let rec unify_0_with_initial_metas (subst : subst0) conv_at_top env pb flags m n
           (fun (substn,ks,m,test) b ->
             if match n with Some n -> Int.equal m n | None -> false then
               (* Enforce unification of type of the projected parameter and the projection's argument type *)
-              let t2ty = Retyping.get_type_of ~metas:(metasfn substn) (fst curenvnb) sigma t2 in
+              let t2ty =
+                try Retyping.get_type_of ~lax:true ~metas:(metasfn substn) (fst curenvnb) sigma t2
+                with Retyping.RetypeError _ -> error_cannot_unify (fst curenvnb) sigma (cM,cN)
+              in
               let test substn = unirec_rec curenvnb CUMUL opt substn t2ty (substl ks b) in
               (substn,t2::ks, m-1, test)
             else


### PR DESCRIPTION
I found this one porting Iris to HB, but I could not minimize it.

My impression is that setoid_rewrite calls legacy unification on terms of different types.
One of the terms has lambdas, the eta rule kicks in and the other term gets applied to some variables.
In turn the call to retyping fails with an anomaly since the head symbol type does not have enough Prods to eat all arguments.

My patch is to make the error non-fatal, apparently there are many other code paths in unificaiton.ml that do the same.