### PR TITLE
clib/hashset.ml micro-optimization ported from ocaml/stdlib/weak.ml

### DIFF
--- a/clib/hashset.ml
+++ b/clib/hashset.ml
@@ -44,6 +44,14 @@ module Make (E : EqType) =
 
   let emptybucket = Weak.create 0
 
+  (* Since the addition of ephemerons in OCaml 4.03 (2016),
+     a weak object reserves 2 slots instead of 1 (Link, Data),
+     which must be taken into account to compute the maximum
+     size for a weak array. We can compute this dynamically,
+     in a way that should be portable across OCaml versions,
+     from the size of [emptybucket] above. *)
+  let additional_values = Obj.size (Obj.repr emptybucket)
+
   type t = {
     mutable table : elt Weak.t array;
     mutable hashes : int array array;
@@ -154,7 +162,7 @@ module Make (E : EqType) =
     let sz = Weak.length bucket in
     let rec loop i =
       if i >= sz then begin
-        let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - 1) in
+        let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values) in
         if newsz <= sz then failwith "Weak.Make: hash bucket cannot grow more";
         let newbucket = Weak.create newsz in
         let newhashes = Array.make newsz 0 in

--- a/clib/hashset.ml
+++ b/clib/hashset.ml
@@ -160,31 +160,28 @@ module Make (E : EqType) =
     let bucket = t.table.(index) in
     let hashes = t.hashes.(index) in
     let sz = Weak.length bucket in
-    let rec loop i =
-      if i >= sz then begin
-        let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values) in
-        if newsz <= sz then failwith "Weak.Make: hash bucket cannot grow more";
-        let newbucket = Weak.create newsz in
-        let newhashes = Array.make newsz 0 in
-        Weak.blit bucket 0 newbucket 0 sz;
-        Array.blit hashes 0 newhashes 0 sz;
-        setter newbucket sz d;
-        newhashes.(sz) <- h;
-        t.table.(index) <- newbucket;
-        t.hashes.(index) <- newhashes;
-        if sz <= t.limit && newsz > t.limit then begin
-          t.oversize <- t.oversize + 1;
-          for _i = 0 to over_limit do test_shrink_bucket t done;
-        end;
-        if t.oversize > Array.length t.table / over_limit then resize t
-      end else if Weak.check bucket i then begin
-        loop (i + 1)
-      end else begin
-        setter bucket i d;
-        hashes.(i) <- h
-      end
-    in
-    loop 0
+    let i = ref 0 in
+    while !i < sz && Weak.check bucket !i do incr i done;
+    if !i < sz then begin
+      setter bucket !i d;
+      Array.unsafe_set hashes !i h;
+    end else begin
+      let newsz = min (3 * sz / 2 + 3) (Sys.max_array_length - additional_values) in
+      if newsz <= sz then failwith "Weak.Make: hash bucket cannot grow more";
+      let newbucket = Weak.create newsz in
+      let newhashes = Array.make newsz 0 in
+      Weak.blit bucket 0 newbucket 0 sz;
+      Array.blit hashes 0 newhashes 0 sz;
+      setter newbucket sz d;
+      newhashes.(sz) <- h;
+      t.table.(index) <- newbucket;
+      t.hashes.(index) <- newhashes;
+      if sz <= t.limit && newsz > t.limit then begin
+        t.oversize <- t.oversize + 1;
+        for _i = 0 to over_limit do test_shrink_bucket t done;
+      end;
+      if t.oversize > Array.length t.table / over_limit then resize t;
+    end
 
   external unsafe_weak_get : 'a Weak.t -> int -> 'a option = "caml_weak_get"
 


### PR DESCRIPTION
This is a port into clib/hashset.ml of a performance optimization on the stdlib Weak module ( https://github.com/gasche/coq/pull/new/hashset-optims ). (I also include a small correctness fix to the array overflow check that probably does not matter in practice, as a first commit.)

I would expect the effect of this change to be relatively small (it avoids short-lived closure allocations, one for each hashconsed element, coming from the call of `add_aux` in the `resize` function), but it is worth benchmarking.

One benefit of this PR is that it completes my small audit of the differences between hashset and the weak hash tables of the OCaml stdlib, up to OCaml 5.5. The other upstream changes were not relevant or not applicable to hashset.ml, and the present PR (1) might bring a small performance improvement and (2) brings the code structure closer to each other and thus easier to diff to detect other changes to backport in the future.