### PR TITLE
clib/int.ml micro-optim: use '%compare' rather than 'caml_int_compare'

### DIFF
--- a/clib/int.ml
+++ b/clib/int.ml
@@ -11,8 +11,7 @@
 type t = int
 
 external equal : int -> int -> bool = "%eq"
-
-external compare : int -> int -> int = "caml_int_compare"
+external compare : int -> int -> int = "%compare"
 
 let hash i = i land 0x3FFFFFFF
 

--- a/clib/int.mli
+++ b/clib/int.mli
@@ -13,8 +13,8 @@
 type t = int
 
 external equal : t -> t -> bool = "%eq"
+external compare : t -> t -> int = "%compare"
 
-external compare : t -> t -> int = "caml_int_compare"
 
 val hash : t -> int
 


### PR DESCRIPTION
'caml_int_compare' will always generate a C call, which is slower than the intermediate-representation code generated for '%compare' since OCaml 4.11 ( https://github.com/ocaml/ocaml/pull/2324 ).

This might be noticeable given that Int.compare is used in Int.Map, which is in turn used by kernel/hConstr.ml.
