### PR TITLE
Allow adding individual references to the Search Blacklist table.

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22193-blacklist-search-table-Added.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22193-blacklist-search-table-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  The Search Blacklist table now accepts plain references, that
+  are excluded from the Search results
+  (`#22193 <https://github.com/rocq-prover/rocq/pull/22193>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -410,12 +410,12 @@ described elsewhere
    (except for those from the current module or its parents).
    Unsetting this :term:`flag` will include such lemmas in the results.
 
-.. table:: Search Blacklist @string
+.. table:: Search Blacklist {| @reference | @string }
 
    This :term:`table` specifies a set of strings used to exclude lemmas from the results of :cmd:`Search`,
-   :cmd:`SearchPattern` and :cmd:`SearchRewrite` queries.  A lemma whose
+   :cmd:`SearchPattern` and :cmd:`SearchRewrite` queries. A lemma present in the table or whose
    fully qualified name contains any of the strings will be excluded from the
-   search results.  The default blacklisted substrings are ``_subterm``, ``_subproof`` and
+   search results. The default blacklisted substrings are ``_subterm``, ``_subproof`` and
    ``Private_``.
 
    Use the :cmd:`Add` and :cmd:`Remove` commands to update the set of

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -42,10 +42,14 @@ type option_state = {
 
 let nickname table = String.concat " " table
 
-let error_no_table_of_this_type ~kind key =
+let error_no_table key =
   CErrors.user_err
-    Pp.(str ("There is no " ^ kind ^ "-valued table with this name: \""
-      ^ nickname key ^ "\"."))
+    Pp.(str ("There is no table with this name: \"" ^ nickname key ^ "\"."))
+
+let error_table_value_not_supported ~kind key =
+  CErrors.user_err
+    Pp.(str ("The table \"" ^ nickname key ^ "\" does not support "
+      ^ kind ^ " values."))
 
 let error_undeclared_key key =
   CErrors.user_err
@@ -62,24 +66,39 @@ type 'a table_of_A =  {
   print : unit -> unit;
 }
 
+let tables = ref []
+
+let get_table k = String.List.assoc (nickname k) !tables
+
+let map_table_value f table = {
+  add = (fun env local x -> table.add env local (f x));
+  remove = (fun env local x -> table.remove env local (f x));
+  mem = (fun env x -> table.mem env (f x));
+  print = table.print;
+}
+
+let get_string_table k = map_table_value (fun s -> StringRefValue s) (get_table k)
+
+let get_ref_table k = map_table_value (fun r -> QualidRefValue r) (get_table k)
+
 let opts_cat = Libobject.create_category "options"
 
+module type TableArg =
+sig
+  type t
+  module Set : CSig.USetS with type elt = t
+  val encode : Environ.env -> table_value -> t
+  val subst : Mod_subst.substitution -> t -> t
+  val check_local : Libobject.locality -> t -> unit
+  val discharge : t -> t
+  val printer : t -> Pp.t
+  val key : option_name
+  val title : string
+  val member_message : t -> bool -> Pp.t
+end
+
 module MakeTable =
-  functor
-   (A : sig
-          type t
-          type key
-          module Set : CSig.USetS with type elt = t
-          val table : (string * key table_of_A) list ref
-          val encode : Environ.env -> key -> t
-          val subst : Mod_subst.substitution -> t -> t
-          val check_local : Libobject.locality -> t -> unit
-          val discharge : t -> t
-          val printer : t -> Pp.t
-          val key : option_name
-          val title : string
-          val member_message : t -> bool -> Pp.t
-        end) ->
+  functor (A : TableArg) ->
   struct
     type option_mark =
       | GOadd
@@ -88,7 +107,7 @@ module MakeTable =
     let nick = nickname A.key
 
     let () =
-      if String.List.mem_assoc nick !A.table then
+      if String.List.mem_assoc nick !tables then
         CErrors.anomaly
           Pp.(strbrk "Sorry, this table name (" ++ str nick
             ++ strbrk ") is already used.")
@@ -138,16 +157,12 @@ module MakeTable =
        print = (fun () -> print_table A.title A.printer !t);
      }
 
-    let () = A.table := (nick, table_of_A)::!A.table
+    let () = tables := (nick, table_of_A)::!tables
 
     let v () = !t
     let active x = A.Set.mem x !t
     let set local x b = if b then add_option local x else remove_option local x
   end
-
-let string_table = ref []
-
-let get_string_table k = String.List.assoc (nickname k) !string_table
 
 module type StringConvertArg =
 sig
@@ -159,10 +174,10 @@ end
 module StringConvert = functor (A : StringConvertArg) ->
 struct
   type t = string
-  type key = string
   module Set = CString.Set
-  let table = string_table
-  let encode _env x = x
+  let encode _env = function
+    | StringRefValue x -> x
+    | QualidRefValue _ -> error_table_value_not_supported ~kind:"reference" A.key
   let subst _ x = x
   let check_local _ _ = ()
   let discharge x = x
@@ -174,10 +189,6 @@ end
 
 module MakeStringTable =
   functor (A : StringConvertArg) -> MakeTable (StringConvert(A))
-
-let ref_table = ref []
-
-let get_ref_table k = String.List.assoc (nickname k) !ref_table
 
 module type RefConvertArg =
 sig
@@ -196,10 +207,10 @@ end
 module RefConvert = functor (A : RefConvertArg) ->
 struct
   type t = A.t
-  type key = Libnames.qualid
   module Set = A.Set
-  let table = ref_table
-  let encode = A.encode
+  let encode env = function
+    | QualidRefValue qid -> A.encode env qid
+    | StringRefValue _ -> error_table_value_not_supported ~kind:"string" A.key
   let subst = A.subst
   let check_local = A.check_local
   let discharge = A.discharge
@@ -215,19 +226,11 @@ module MakeRefTable =
 type iter_table_aux = { aux : 'a. 'a table_of_A -> Environ.env -> 'a -> unit }
 
 let iter_table env f key lv =
-  let aux = function
-    | StringRefValue s ->
-       begin
-         try f.aux (get_string_table key) env s
-         with Not_found -> error_no_table_of_this_type ~kind:"string" key
-       end
-    | QualidRefValue locqid ->
-       begin
-         try f.aux (get_ref_table key) env locqid
-         with Not_found -> error_no_table_of_this_type ~kind:"qualid" key
-       end
+  let table =
+    try get_table key
+    with Not_found -> error_no_table key
   in
-  List.iter aux lv
+  List.iter (fun v -> f.aux table env v) lv
 
 (****************************************************************************)
 (* 2- Flags.                                                              *)
@@ -265,10 +268,9 @@ let check_key key = try
   CErrors.user_err Pp.(str "Sorry, this option name ("
     ++ str (nickname key) ++ str ") is already used.")
 with Not_found ->
-  if String.List.mem_assoc (nickname key) !string_table
-    || String.List.mem_assoc (nickname key) !ref_table
-  then CErrors.user_err Pp.(str "Sorry, this option name ("
-    ++ str (nickname key) ++ str ") is already used.")
+  if String.List.mem_assoc (nickname key) !tables then
+    CErrors.user_err Pp.(str "Sorry, this option name ("
+      ++ str (nickname key) ++ str ") is already used.")
 
 let declare_raw name v = value_tab := OptionMap.add name (AnyOpt v) !value_tab
 
@@ -569,10 +571,7 @@ let print_tables () =
   str "Tables:" ++ fnl () ++
     List.fold_right
       (fun (nickkey,_) p -> p ++ str "  " ++ str nickkey ++ fnl ())
-      !string_table (mt ()) ++
-    List.fold_right
-      (fun (nickkey,_) p -> p ++ str "  " ++ str nickkey ++ fnl ())
-      !ref_table (mt ()) ++
+      !tables (mt ()) ++
     fnl ()
 
 (* Compat *)

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -83,10 +83,22 @@ let get_ref_table k = map_table_value (fun r -> QualidRefValue r) (get_table k)
 
 let opts_cat = Libobject.create_category "options"
 
+module type ArgSet =
+sig
+  type elt
+  type t
+  val empty : t
+  val is_empty : t -> bool
+  val add : elt -> t -> t
+  val remove : elt -> t -> t
+  val mem : elt -> t -> bool
+  val elements : t -> elt list
+end
+
 module type TableArg =
 sig
   type t
-  module Set : CSig.USetS with type elt = t
+  module Set : ArgSet with type elt = t
   val encode : Environ.env -> table_value -> t
   val subst : Mod_subst.substitution -> t -> t
   val check_local : Libobject.locality -> t -> unit

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -61,6 +61,18 @@ type table_value =
   | StringRefValue of string
   | QualidRefValue of Libnames.qualid
 
+module type ArgSet =
+sig
+  type elt
+  type t
+  val empty : t
+  val is_empty : t -> bool
+  val add : elt -> t -> t
+  val remove : elt -> t -> t
+  val mem : elt -> t -> bool
+  val elements : t -> elt list
+end
+
 (** The functor [MakeTable] declares a table.  Vernacular [Add],
     [Remove], and [Test] commands pass each argument as a [table_value];
     [encode] maps such values to stored elements, possibly globalizing
@@ -69,7 +81,7 @@ type table_value =
     [encode]. *)
 module type TableArg = sig
   type t
-  module Set : CSig.USetS with type elt = t
+  module Set : ArgSet with type elt = t
   val encode : Environ.env -> table_value -> t
   val subst : Mod_subst.substitution -> t -> t
 

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -57,14 +57,42 @@ type option_locality = OptDefault | OptLocal | OptExport | OptGlobal
 
 (** {6 Tables. } *)
 
-(** The functor [MakeStringTable] declares a table containing objects
-   of type [string]; the function [member_message] say what to print
-   when invoking the "Test Toto Titi foo." command; at the end [title]
-   is the table name printed when invoking the "Print Toto Titi."
-   command; [active] is roughly the internal version of the vernacular
-   "Test ...": it tells if a given object is in the table; [elements]
-   returns the list of elements of the table *)
+type table_value =
+  | StringRefValue of string
+  | QualidRefValue of Libnames.qualid
 
+(** The functor [MakeTable] declares a table.  Vernacular [Add],
+    [Remove], and [Test] commands pass each argument as a [table_value];
+    [encode] maps such values to stored elements, possibly globalizing
+    qualified identifiers with the supplied environment.  Tables that do
+    not support one of the constructors should raise a user error from
+    [encode]. *)
+module type TableArg = sig
+  type t
+  module Set : CSig.USetS with type elt = t
+  val encode : Environ.env -> table_value -> t
+  val subst : Mod_subst.substitution -> t -> t
+
+  val check_local : Libobject.locality -> t -> unit
+  val discharge : t -> t
+  (** Elements which cannot be discharged should only be added with Local *)
+
+  val printer : t -> Pp.t
+  val key : option_name
+  val title : string
+  val member_message : t -> bool -> Pp.t
+end
+
+module MakeTable :
+  functor (A : TableArg) ->
+sig
+  val v : unit -> A.Set.t
+  val active : A.t -> bool
+  val set : Libobject.locality -> A.t -> bool -> unit
+end
+
+(** [MakeStringTable] is a specialization of [MakeTable] for tables whose
+    vernacular arguments are strings. *)
 module MakeStringTable :
   functor
     (_ : sig
@@ -77,16 +105,9 @@ sig
   val active : string -> bool
 end
 
-(** The functor [MakeRefTable] declares a new table of objects of type
-   [A.t] practically denoted by [reference]; the encoding function
-   [encode : env -> reference -> A.t] is typically a globalization function,
-   possibly with some restriction checks; the function
-   [member_message] say what to print when invoking the "Test Toto
-   Titi foo." command; at the end [title] is the table name printed
-   when invoking the "Print Toto Titi." command; [active] is roughly
-   the internal version of the vernacular "Test ...": it tells if a
-   given object is in the table.  *)
-
+(** [MakeRefTable] is a specialization of [MakeTable] for tables whose
+    vernacular arguments are qualified identifiers.  The encoding function
+    is typically a globalization function, possibly with extra checks. *)
 module type RefConvertArg = sig
   type t
   module Set : CSig.USetS with type elt = t
@@ -185,6 +206,10 @@ type 'a table_of_A =  {
   print : unit -> unit;
 }
 
+val get_table :
+  option_name -> table_value table_of_A
+
+(** Compatibility views of [get_table]. *)
 val get_string_table :
   option_name -> string table_of_A
 val get_ref_table :
@@ -209,10 +234,6 @@ type option_value =
   | IntValue    of int option
   | StringValue of string
   | StringOptValue of string option
-
-type table_value =
-  | StringRefValue of string
-  | QualidRefValue of Libnames.qualid
 
 (** [get_option_value key] returns [None] if option with name [key] was not found. *)
 val get_option_value : option_name -> (unit -> option_value) option

--- a/test-suite/output/undeclared_key.out
+++ b/test-suite/output/undeclared_key.out
@@ -3,16 +3,16 @@ The command has indeed failed with message:
 There is no flag, option or table with this name: "Search Blacklists".
 File "./output/undeclared_key.v", line 2, characters 0-35:
 The command has indeed failed with message:
-There is no qualid-valued table with this name: "Search Blacklist".
+The table "Search Blacklist" does not support reference values.
 File "./output/undeclared_key.v", line 3, characters 0-22:
 Warning: There is no flag or option with this name: "Search Blacklists".
 [unknown-option,default]
 File "./output/undeclared_key.v", line 4, characters 0-40:
 The command has indeed failed with message:
-There is no string-valued table with this name: "Search Blacklists".
+There is no table with this name: "Search Blacklists".
 File "./output/undeclared_key.v", line 5, characters 0-39:
 The command has indeed failed with message:
-There is no qualid-valued table with this name: "Search Blacklist".
+The table "Search Blacklist" does not support reference values.
 File "./output/undeclared_key.v", line 6, characters 0-36:
 The command has indeed failed with message:
-There is no qualid-valued table with this name: "Search Blacklist".
+The table "Search Blacklist" does not support reference values.

--- a/test-suite/output/undeclared_key.out
+++ b/test-suite/output/undeclared_key.out
@@ -1,18 +1,18 @@
 File "./output/undeclared_key.v", line 1, characters 0-28:
 The command has indeed failed with message:
 There is no flag, option or table with this name: "Search Blacklists".
-File "./output/undeclared_key.v", line 2, characters 0-35:
+File "./output/undeclared_key.v", line 2, characters 31-34:
 The command has indeed failed with message:
-The table "Search Blacklist" does not support reference values.
+The reference foo was not found in the current environment.
 File "./output/undeclared_key.v", line 3, characters 0-22:
 Warning: There is no flag or option with this name: "Search Blacklists".
 [unknown-option,default]
 File "./output/undeclared_key.v", line 4, characters 0-40:
 The command has indeed failed with message:
 There is no table with this name: "Search Blacklists".
-File "./output/undeclared_key.v", line 5, characters 0-39:
+File "./output/undeclared_key.v", line 5, characters 35-38:
 The command has indeed failed with message:
-The table "Search Blacklist" does not support reference values.
-File "./output/undeclared_key.v", line 6, characters 0-36:
+The reference foo was not found in the current environment.
+File "./output/undeclared_key.v", line 6, characters 32-35:
 The command has indeed failed with message:
-The table "Search Blacklist" does not support reference values.
+The reference foo was not found in the current environment.

--- a/test-suite/output/undeclared_key.out
+++ b/test-suite/output/undeclared_key.out
@@ -16,3 +16,9 @@ The reference foo was not found in the current environment.
 File "./output/undeclared_key.v", line 6, characters 32-35:
 The command has indeed failed with message:
 The reference foo was not found in the current environment.
+File "./output/undeclared_key.v", line 7, characters 0-28:
+The command has indeed failed with message:
+The table "Printing Let" does not support string values.
+File "./output/undeclared_key.v", line 8, characters 0-31:
+The command has indeed failed with message:
+The table "Printing Let" does not support string values.

--- a/test-suite/output/undeclared_key.v
+++ b/test-suite/output/undeclared_key.v
@@ -4,3 +4,5 @@ Set Search Blacklists.
 Fail Remove Search Blacklists "bar" foo.
 Fail Remove Search Blacklist "bar" foo.
 Fail Add Search Blacklist "bar" foo.
+Fail Add Printing Let "bar".
+Fail Remove Printing Let "bar".

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -49,13 +49,32 @@ type t =
 | Pattern of string
 | Reference of GlobRef.t
 
-let compare v1 v2 = match v1, v2 with
-| Pattern s1, Pattern s2 -> String.compare s1 s2
-| Reference r1, Reference r2 -> GlobRef.UserOrd.compare r1 r2
-| Pattern _, Reference _ -> -1
-| Reference _, Pattern _ -> 1
+module Set =
+struct
 
-module Set = Set.Make(struct type nonrec t = t let compare = compare end)
+type elt = t
+type t = GlobRef.Set_env.t * String.Set.t
+let empty = (GlobRef.Set_env.empty, String.Set.empty)
+let is_empty (gset, sset) = GlobRef.Set_env.is_empty gset && String.Set.is_empty sset
+
+let add v (gset, sset) = match v with
+| Pattern s -> (gset, String.Set.add s sset)
+| Reference r -> (GlobRef.Set_env.add r gset, sset)
+
+let remove v (gset, sset) = match v with
+| Pattern s -> (gset, String.Set.remove s sset)
+| Reference r -> (GlobRef.Set_env.remove r gset, sset)
+
+let mem v (gset, sset) = match v with
+| Pattern s -> String.Set.mem s sset
+| Reference r -> GlobRef.Set_env.mem r gset
+
+let elements (gset, sset) =
+  let sset = List.map (fun s -> Pattern s) (String.Set.elements sset) in
+  let gset = List.map (fun r -> Reference r) (GlobRef.Set_env.elements gset) in
+  sset @ gset
+
+end
 
 let encode env v = match v with
 | Goptions.StringRefValue s -> Pattern s
@@ -241,14 +260,9 @@ let blacklist_filter : filter_function = fun ref kind env sigma typ ->
   if blacklist_locals() && is_local_ref ref then false
   else
     let name = full_name_of_reference ref in
-    let is_not_bl entry = match entry with
-    | SearchBlacklistArg.Pattern str -> not (String.string_contains ~where:name ~what:str)
-    | SearchBlacklistArg.Reference _ -> true
-    in
-    let blacklist = SearchBlacklist.v () in
-    let ref = SearchBlacklistArg.Reference ref in
-    (* XXX very inefficient *)
-    not (SearchBlacklistArg.Set.mem ref blacklist) && SearchBlacklistArg.Set.for_all is_not_bl blacklist
+    let is_not_bl str = not (String.string_contains ~where:name ~what:str) in
+    let (gref_blacklist, str_blacklist) = SearchBlacklist.v () in
+    not (GlobRef.Set_env.mem ref gref_blacklist) && String.Set.for_all is_not_bl str_blacklist
 
 let module_filter : _ -> filter_function = fun mods ref kind env sigma typ ->
   let sp = Nametab.path_of_global ref in

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -42,14 +42,61 @@ type glob_search_request =
   | GlobSearchLiteral of glob_search_item
   | GlobSearchDisjConj of (bool * glob_search_request) list list
 
-module SearchBlacklist =
-  Goptions.MakeStringTable
-    (struct
-      let key = ["Search";"Blacklist"]
-      let title = "Current search blacklist : "
-      let member_message s b =
-        str "Search blacklist does " ++ (if b then mt () else str "not ") ++ str "include " ++ str s
-     end)
+module SearchBlacklistArg =
+struct
+
+type t =
+| Pattern of string
+| Reference of GlobRef.t
+
+let compare v1 v2 = match v1, v2 with
+| Pattern s1, Pattern s2 -> String.compare s1 s2
+| Reference r1, Reference r2 -> GlobRef.UserOrd.compare r1 r2
+| Pattern _, Reference _ -> -1
+| Reference _, Pattern _ -> 1
+
+module Set = Set.Make(struct type nonrec t = t let compare = compare end)
+
+let encode env v = match v with
+| Goptions.StringRefValue s -> Pattern s
+| Goptions.QualidRefValue qid ->
+  let r = Nametab.global qid in
+  let r = Environ.QGlobRef.canonize env r in
+  Reference r
+
+let subst subs v = match v with
+| Pattern _ -> v
+| Reference r ->
+  let r' = Globnames.subst_global_reference subs r in
+  if r == r' then v else Reference r'
+
+let check_local_ref local = function
+| GlobRef.ConstRef _ | ConstructRef _ | IndRef _ -> ()
+| VarRef x -> match local with
+  | Libobject.Local -> ()
+  | Export | SuperGlobal ->
+    let local = if local = Export then "export" else "global" in
+    CErrors.user_err
+      Pp.(Id.print x ++ str " cannot be added with locality " ++ str local ++ str ".")
+
+let check_local local v = match v with
+| Pattern _ -> ()
+| Reference r -> check_local_ref local r
+
+let discharge v = v
+
+let printer = function
+| Pattern s -> quote (str s)
+| Reference r -> Printer.pr_global r
+
+let key = ["Search";"Blacklist"]
+let title = "Current search blacklist : "
+let member_message s b =
+  str "Search blacklist does " ++ (if b then mt () else str "not ") ++ str "include " ++ printer s
+
+end
+
+module SearchBlacklist = Goptions.MakeTable(SearchBlacklistArg)
 
 let { Goptions.get = blacklist_locals } =
   Goptions.declare_bool_option_and_ref ~key:["Search";"Blacklist";"Locals"] ~value:true ()
@@ -194,8 +241,14 @@ let blacklist_filter : filter_function = fun ref kind env sigma typ ->
   if blacklist_locals() && is_local_ref ref then false
   else
     let name = full_name_of_reference ref in
-    let is_not_bl str = not (String.string_contains ~where:name ~what:str) in
-    CString.Set.for_all is_not_bl (SearchBlacklist.v ())
+    let is_not_bl entry = match entry with
+    | SearchBlacklistArg.Pattern str -> not (String.string_contains ~where:name ~what:str)
+    | SearchBlacklistArg.Reference _ -> true
+    in
+    let blacklist = SearchBlacklist.v () in
+    let ref = SearchBlacklistArg.Reference ref in
+    (* XXX very inefficient *)
+    not (SearchBlacklistArg.Set.mem ref blacklist) && SearchBlacklistArg.Set.for_all is_not_bl blacklist
 
 let module_filter : _ -> filter_function = fun mods ref kind env sigma typ ->
   let sp = Nametab.path_of_global ref in

--- a/vernac/vernacoptions.ml
+++ b/vernac/vernacoptions.ml
@@ -49,9 +49,7 @@ let vernac_remove_option local = iter_table { aux = fun table env x -> table.rem
 let vernac_mem_option = iter_table { aux = fun table -> table.mem }
 
 let vernac_print_option key =
-  try (get_ref_table key).print ()
-  with Not_found ->
-  try (get_string_table key).print ()
+  try (get_table key).print ()
   with Not_found ->
   try print_option_value key
   with Not_found -> error_undeclared_key key


### PR DESCRIPTION
In addition to a filtering based on strings appearing in the name, we now allow to add actual references to the Search blacklist mechanism. Such references will excluded from the set of results of a Search command.