### PR TITLE
Support sort instance on Univ abbreviation

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1352,10 +1352,11 @@ let find_projection_data c =
   | GRef (GlobRef.ConstRef cst,us) -> Some (cst, us, [], Structure.projection_nparams (Global.env ()) cst)
   | _ -> None
 
-let glob_sort_of_level (level: glob_level) : glob_sort =
+let glob_sort_of_level level gu =
   match level with
-  | UAnonymous _ as l -> None, l
-  | UNamed id -> None, UNamed [id, 0]
+  | None -> gu
+  | Some (UAnonymous _ as l) -> l
+  | Some UNamed id -> UNamed [id, 0]
 
 (* Is it a global reference or a syntactic definition? *)
 let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
@@ -1390,11 +1391,22 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
           DAst.make ?loc @@ GApp (DAst.make ?loc:loc' @@ GRef (ref, us), arg)
         | _ -> err ()
         end
-      | Some ([],[s]), GSort gs when Glob_ops.(glob_sort_eq glob_Type_sort gs) ->
-        DAst.make ?loc @@ GSort (glob_sort_of_level s)
-      | Some ([],[_old_level]), GSort _new_sort ->
-        (* TODO: add old_level and new_sort to the error message *)
-        user_err ?loc (str "Cannot change universe level of notation " ++ pr_qualid qid)
+      | Some (qs, us), GSort (gq, gu) ->
+        let q_err () = user_err ?loc (str "Wrong sort instance length, should be <= 1") in
+        let q = match qs with [] -> None | [q] -> Some q | _ -> q_err () in
+        let u_err () = user_err ?loc (str "Wrong universe instance length, should be <= 1") in
+        let u = match us with [] -> None | [u] -> Some u | _ -> u_err () in
+        let gs_has_fixed_level = match gu with UAnonymous _ -> false | UNamed _ -> true in
+        let gs_has_fixed_sort = Option.has_some gq || gs_has_fixed_level in
+        let () = if gs_has_fixed_sort && Option.has_some q then
+          (* TODO: add old_level and new_sort to the error message *)
+          user_err ?loc (str "Cannot change sort quality of abbreviation " ++ pr_qualid qid)
+        in
+        let () = if Option.has_some u && gs_has_fixed_level then
+          (* TODO: add old_level and new_sort to the error message *)
+          user_err ?loc (str "Cannot change universe level of abbreviation " ++ pr_qualid qid)
+        in
+        DAst.make ?loc @@ GSort (q, glob_sort_of_level u gu)
       | Some _, _ -> err ()
       in
       c, None, args2

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -130,6 +130,22 @@ where
   x0 cannot be used)
 s
      : s
+s
+     : s
+s
+     : s
+Prop
+     : s
+Prop
+     : s
+s
+     : s
+File "./output/Notations.v", line 236, characters 11-13:
+The command has indeed failed with message:
+Cannot change sort quality of abbreviation s'
+File "./output/Notations.v", line 237, characters 11-13:
+The command has indeed failed with message:
+Cannot change universe level of abbreviation s'
 10
      : nat
 fun _ : nat => 9

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -221,8 +221,20 @@ Check (fun x => match x with | nil => NONE | h :' t => SOME3 _ t end).
    universe than the actual one; but it would be the same anyway
    without a notation *)
 
+Universe u.
+
 Abbreviation s := Type.
 Check s.
+Check s@{u}.
+Check s@{Type;u}.
+Check s@{Prop;}.
+Check s@{Prop;u}.
+
+Abbreviation s' := Type@{u}.
+
+Check s'.
+Fail Check s'@{Prop;}.
+Fail Check s'@{u}.
 
 (* Test bug #2835: notations were not uniformly managed under prod and lambda *)
 


### PR DESCRIPTION
For `Abbreviation U := Type`, support `U@{s?;l?}`, `Abbreviation U := Type@{q;_}` supports `U@{l}`.
If the sort is fixed in the abbreviation, no sort substitution is allowed.
If the universe level is given in the abbreviation, no sort or universe level substitution is allowed.

To be superseded when levels and sorts can be bound in regular notations (unless we want to keep this simple support for abbreviations?)