### PR TITLE
changed |= to | when displaying universes constraints

### DIFF
--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -99,7 +99,7 @@ let pr_sort_context printer ((vs, us), cst as ctx) =
       if Sorts.QVar.Set.is_empty vs then mt ()
       else Sorts.QVar.Set.pr printer.Sorts.prq.prvar vs ++ pr_semicolon ()
     in
-    hov 0 (h (vs ++ Level.Set.pr printer.pru us ++ str " |=") ++ brk(1,2) ++ h (PConstraints.pr printer cst))
+    hov 0 (h (vs ++ Level.Set.pr printer.pru us ++ str " |") ++ brk(1,2) ++ h (PConstraints.pr printer cst))
 
 type univ_length_mismatch = {
   gref : GlobRef.t;

--- a/kernel/uVars.ml
+++ b/kernel/uVars.ml
@@ -315,7 +315,7 @@ struct
 
   let pr printer ?variance (_, (univs, csts) as uctx) =
     if is_empty uctx then mt() else
-      h (Instance.pr printer ?variance univs ++ str " |= ") ++ h (v 0 (PConstraints.pr printer csts))
+      h (Instance.pr printer ?variance univs ++ str " | ") ++ h (v 0 (PConstraints.pr printer csts))
 
   let hcons ({quals = qnames; univs = unames}, (univs, csts)) =
     let hqnames, qnames = Hashcons.hashcons_array Names.Name.hcons qnames in

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -572,7 +572,7 @@ struct
 
   let pr prl (univs, cst as ctx) =
     if is_empty ctx then mt() else
-      hov 0 (h (Level.Set.pr prl univs ++ str " |=") ++ brk(1,2) ++ h (UnivConstraints.pr prl cst))
+      hov 0 (h (Level.Set.pr prl univs ++ str " |") ++ brk(1,2) ++ h (UnivConstraints.pr prl cst))
 
   let constraints (_univs, cst) = cst
   let levels (univs, _cst) = univs

--- a/test-suite/output/DeclareSort.out
+++ b/test-suite/output/DeclareSort.out
@@ -34,7 +34,7 @@ Arguments foo _%_type_scope
 Expands to: Constant DeclareSort.foo
 Declared in library DeclareSort, line 19, characters 8-11
 foo@{S2 ; } : Type@{S1 ; Set} -> Type@{S2 ; Set}
-(* S2 ;  |=  *)
+(* S2 ;  |  *)
 
 foo is universe polymorphic
 Arguments foo _%_type_scope
@@ -42,14 +42,14 @@ Expands to: Constant DeclareSort.foo
 Declared in library DeclareSort, line 19, characters 8-11
 foo@{SProp ; } : Type@{S1 ; Set} -> SProp
      : Type@{S1 ; Set} -> SProp
-(* {DeclareSort.25} |= Set < DeclareSort.25
+(* {DeclareSort.25} | Set < DeclareSort.25
 Minimized universes:
  DeclareSort.25 := Set+1
 Normalized constraints:
   *)
 foo@{Type ; } : Type@{S1 ; Set} -> Set
      : Type@{S1 ; Set} -> Set
-(* {DeclareSort.26} |= Set < DeclareSort.26
+(* {DeclareSort.26} | Set < DeclareSort.26
 Minimized universes:
  DeclareSort.26 := Set+1
 Normalized constraints:

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -48,7 +48,7 @@ sunit may only be eliminated to produce values whose type is SProp.
 Expands to: Inductive Inductive.sunit
 Declared in library Inductive, line 38, characters 10-15
 sempty@{q ; } : Type@{q ; Set}
-(* q ;  |=  *)
+(* q ;  |  *)
 
 sempty is universe polymorphic
 sempty@{q ; } may only be eliminated to produce values whose type is in sort quality q,
@@ -60,7 +60,7 @@ Expands to: Inductive Inductive.sempty
 Declared in library Inductive, line 44, characters 22-28
 ssig@{q1 q2 q3 ; a b} :
 forall A : Type@{q1 ; a}, (A -> Type@{q2 ; b}) -> Type@{q3 ; max(a,b)}
-(* q1 q2 q3 ; a b |=  *)
+(* q1 q2 q3 ; a b |  *)
 
 ssig is universe polymorphic
 ssig@{q1 q2 q3 ; a b} may only be eliminated to produce values whose type is in sort quality q3,
@@ -72,7 +72,7 @@ Arguments ssig A%_type_scope B%_function_scope
 Expands to: Inductive Inductive.ssig
 Declared in library Inductive, line 48, characters 22-26
 BoxP@{q ; a} : Type@{q ; a} -> Prop
-(* q ; a |=  *)
+(* q ; a |  *)
 
 BoxP is universe polymorphic
 BoxP@{q ; a} may only be eliminated to produce values whose type is SProp or Prop,

--- a/test-suite/output/NumberNotationsUnivPoly.out
+++ b/test-suite/output/NumberNotationsUnivPoly.out
@@ -13,7 +13,7 @@ where
 foo@{v v'} =
 fun (v : A@{v}) (v' : A@{v'}) => (0 : B@{v} v, 1 : B@{v'} v')
      : forall (v : A@{v}) (v' : A@{v'}), B@{v} v * B@{v'} v'
-(* v v' |= v <= prod.u0
-           v' <= prod.u1 *)
+(* v v' | v <= prod.u0
+          v' <= prod.u1 *)
 
 Arguments foo v v'

--- a/test-suite/output/PrintMatch.out
+++ b/test-suite/output/PrintMatch.out
@@ -7,7 +7,7 @@ end
      : forall (A : Type@{u}) (a : A)
          (P : forall a0 : A, eqT@{u} a a0 -> Type@{u0}),
        P a (reflT@{u} a) -> forall (a0 : A) (e : eqT@{u} a a0), P a0 e
-(* u u0 |=  *)
+(* u u0 |  *)
 
 Arguments eqT_rect A%_type_scope a P%_function_scope reflT a0 e
 seq_rect =

--- a/test-suite/output/ShowUnivs.out
+++ b/test-suite/output/ShowUnivs.out
@@ -1,6 +1,6 @@
 UNIVERSES:
- {w v u} |= u <= v
-            v <= w
+ {w v u} | u <= v
+           v <= w
 ALGEBRAIC UNIVERSES:
  {}
 FLEXIBLE UNIVERSES:
@@ -14,10 +14,10 @@ WEAK CONSTRAINTS:
  
 
 Normalized constraints:
- {w v u} |= u <= v
-            v <= w
+ {w v u} | u <= v
+           v <= w
 UNIVERSES:
- {ShowUnivs.28 ShowUnivs.27 ShowUnivs.26 ShowUnivs.25 ShowUnivs.24} |=
+ {ShowUnivs.28 ShowUnivs.27 ShowUnivs.26 ShowUnivs.25 ShowUnivs.24} |
    ShowUnivs.25 < ShowUnivs.26
    ShowUnivs.26 < ShowUnivs.27
    ShowUnivs.26 <= ShowUnivs.28
@@ -45,4 +45,4 @@ WEAK CONSTRAINTS:
  
 
 Normalized constraints:
- {ShowUnivs.26 ShowUnivs.25} |= ShowUnivs.25 < ShowUnivs.26
+ {ShowUnivs.26 ShowUnivs.25} | ShowUnivs.25 < ShowUnivs.26

--- a/test-suite/output/SortQuality.out
+++ b/test-suite/output/SortQuality.out
@@ -6,13 +6,13 @@ A
      : Type@{s ; _}
 A
      : Type@{s ; u}
-(* {s}; {u} |= 
+(* {s}; {u} | 
 Normalized constraints:
- {s}; {u} |=  *)
+ {s}; {u} |  *)
 A
      : Type@{s ; u}
-(* {s}; {u} |= 
+(* {s}; {u} | 
 Normalized constraints:
- {s}; {u} |=  *)
+ {s}; {u} |  *)
 A
      : Type@{s ; _}

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -1,8 +1,8 @@
 Inductive Empty@{uu} : Type@{uu} :=  .
-(* uu |=  *)
+(* uu |  *)
 Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
   { punwrap : A }.
-(* uu |=  *)
+(* uu |  *)
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
@@ -10,7 +10,7 @@ Arguments pwrap A%_type_scope punwrap
 Arguments punwrap A%_type_scope p
 Record PWrap@{uu} (A : Type@{uu}) : Type@{uu} := pwrap
   { punwrap : A }.
-(* uu |=  *)
+(* uu |  *)
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
@@ -18,7 +18,7 @@ Arguments pwrap A%_type_scope punwrap
 Arguments punwrap A%_type_scope p
 Record RWrap@{uu} (A : Type@{uu}) : Type@{uu} := rwrap
   { runwrap : A }.
-(* uu |=  *)
+(* uu |  *)
 
 Arguments RWrap A%_type_scope
 Arguments rwrap A%_type_scope runwrap
@@ -26,38 +26,38 @@ Arguments runwrap A%_type_scope r
 runwrap@{uu} =
 fun (A : Type@{uu}) (r : RWrap@{uu} A) => let (runwrap) := r in runwrap
      : forall A : Type@{uu}, RWrap@{uu} A -> A
-(* uu |=  *)
+(* uu |  *)
 
 runwrap is a projection of RWrap
 Arguments runwrap A%_type_scope r
 Wrap@{uu} = fun A : Type@{uu} => A
      : Type@{uu} -> Type@{uu}
-(* uu |=  *)
+(* uu |  *)
 
 Arguments Wrap A%_type_scope
 wrap@{uu} =
 fun (A : Type@{uu}) (Wrap : Wrap@{uu} A) => Wrap
      : forall {A : Type@{uu}}, Wrap@{uu} A -> A
-(* uu |=  *)
+(* uu |  *)
 
 Arguments wrap {A}%_type_scope {Wrap}
 bar@{uu} = nat
      : Wrap@{uu} Set
-(* uu |= Set < uu *)
+(* uu | Set < uu *)
 foo@{uu u v} =
 Type@{u} -> Type@{v} -> Type@{uu}
      : Type@{max(uu+1,u+1,v+1)}
-(* uu u v |=  *)
+(* uu u v |  *)
 Type@{i} -> Type@{j}
      : Type@{max(i+1,j+1)}
-(* {j i} |= 
+(* {j i} | 
 Normalized constraints:
- {j i} |=  *)
+ {j i} |  *)
      = Type@{i} -> Type@{j}
      : Type@{max(i+1,j+1)}
-(* {j i} |= 
+(* {j i} | 
 Normalized constraints:
- {j i} |=  *)
+ {j i} |  *)
 mono = Type@{mono.uu}
      : Type@{mono.uu+1}
 mono
@@ -87,27 +87,27 @@ Universe uu already bound.
 foo@{E M N} =
 Type@{M} -> Type@{N} -> Type@{E}
      : Type@{max(E+1,M+1,N+1)}
-(* E M N |=  *)
+(* E M N |  *)
 foo@{uu u v} =
 Type@{u} -> Type@{v} -> Type@{uu}
      : Type@{max(uu+1,u+1,v+1)}
-(* uu u v |=  *)
+(* uu u v |  *)
 foo@{uu u IMPORTANT} =
 Type@{u} -> Type@{IMPORTANT} -> Type@{uu}
      : Type@{max(uu+1,u+1,IMPORTANT+1)}
-(* uu u IMPORTANT |=  *)
+(* uu u IMPORTANT |  *)
 Inductive Empty@{E} : Type@{E} :=  .
-(* E |=  *)
+(* E |  *)
 Record PWrap@{E} (A : Type@{E}) : Type@{E} := pwrap
   { punwrap : A }.
-(* E |=  *)
+(* E |  *)
 
 PWrap has primitive projections with eta conversion.
 Arguments PWrap A%_type_scope
 Arguments pwrap A%_type_scope punwrap
 Arguments punwrap A%_type_scope p
 punwrap@{K} : forall A : Type@{K}, PWrap@{K} A -> A
-(* K |=  *)
+(* K |  *)
 
 punwrap is universe polymorphic
 punwrap is a primitive projection of PWrap
@@ -125,7 +125,7 @@ File "./output/UnivBinders.v", line 108, characters 0-33:
 The command has indeed failed with message:
 This object does not support universe names.
 insec0@{i i0} : Type@{i} -> Type@{i} -> Type@{i0} -> Type@{i}
-(* i i0 |=  *)
+(* i i0 |  *)
 
 insec0 is universe polymorphic
 Arguments insec0 (foo bar baz)%_type_scope
@@ -137,45 +137,45 @@ The command has indeed failed with message:
 Cannot enforce v < u because u < gU < gV < v
 insec@{v} = Type@{uu} -> Type@{v}
      : Type@{max(uu+1,v+1)}
-(* v |=  *)
+(* v |  *)
 Inductive insecind@{k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{k}.
-(* k |=  *)
+(* k |  *)
 
 Arguments inseccstr _%_type_scope
 insec@{uu v} = Type@{uu} -> Type@{v}
      : Type@{max(uu+1,v+1)}
-(* uu v |=  *)
+(* uu v |  *)
 Inductive insecind@{uu k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{uu k}.
-(* uu k |=  *)
+(* uu k |  *)
 
 Arguments inseccstr _%_type_scope
 insec2@{u} = Prop
      : Type@{Set+1}
-(* u |=  *)
+(* u |  *)
 inmod@{uu} = Type@{uu}
      : Type@{uu+1}
-(* uu |=  *)
+(* uu |  *)
 SomeMod.inmod@{uu} = Type@{uu}
      : Type@{uu+1}
-(* uu |=  *)
+(* uu |  *)
 inmod@{uu} = Type@{uu}
      : Type@{uu+1}
-(* uu |=  *)
+(* uu |  *)
 Applied.infunct@{uu v} =
 inmod@{uu} -> Type@{v}
      : Type@{max(uu+1,v+1)}
-(* uu v |=  *)
+(* uu v |  *)
 axfoo@{i u u0} : Type@{u} -> Type@{i}
-(* i u u0 |=  *)
+(* i u u0 |  *)
 
 axfoo is universe polymorphic
 Arguments axfoo _%_type_scope
 Expands to: Constant UnivBinders.axfoo
 Declared in library UnivBinders, line 159, characters 6-11
 axbar@{i u u0} : Type@{u0} -> Type@{i}
-(* i u u0 |=  *)
+(* i u u0 |  *)
 
 axbar is universe polymorphic
 Arguments axbar _%_type_scope
@@ -194,11 +194,11 @@ Arguments axbar' _%_type_scope
 Expands to: Constant UnivBinders.axbar'
 Declared in library UnivBinders, line 160, characters 30-36
 *** [ axfoo@{i u u0} : Type@{u} -> Type@{i} ]
-(* i u u0 |=  *)
+(* i u u0 |  *)
 
 Arguments axfoo _%_type_scope
 *** [ axbar@{i u u0} : Type@{u0} -> Type@{i} ]
-(* i u u0 |=  *)
+(* i u u0 |  *)
 
 Arguments axbar _%_type_scope
 *** [ axfoo' : Type@{axfoo'.u0} -> Type@{axfoo'.i} ]
@@ -214,22 +214,22 @@ allowed to mention a universe binder (which will be shared by the whole
 block).
 foo@{i} = Type@{M.i} -> Type@{i}
      : Type@{max(M.i+1,i+1)}
-(* i |=  *)
+(* i |  *)
 Type@{u0} -> Type@{UnivBinders.86}
      : Type@{max(u0+1,UnivBinders.86+1)}
-(* {UnivBinders.86} |= 
+(* {UnivBinders.86} | 
 Normalized constraints:
- {UnivBinders.86} |=  *)
+ {UnivBinders.86} |  *)
 bind_univs.mono = Type@{bind_univs.mono.u}
      : Type@{bind_univs.mono.u+1}
 bind_univs.poly@{u} = Type@{u}
      : Type@{u+1}
-(* u |=  *)
+(* u |  *)
 Inductive MutualR1@{u} (A : Type@{u}) : Prop := Build_MutualR1
   { p1 : MutualR2@{u} A }
   with MutualR2@{u} (A : Type@{u}) : Prop := Build_MutualR2
   { p2 : MutualR1@{u} A }.
-(* u |=  *)
+(* u |  *)
 
 Arguments MutualR1 A%_type_scope
 Arguments Build_MutualR1 A%_type_scope p1
@@ -241,7 +241,7 @@ Inductive MutualI1@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1 : MutualI2@{u u0} A -> MutualI1@{u u0} A
   with MutualI2@{u u0} (A : Type@{u}) : Type@{u0} :=
     C2 : MutualI1@{u u0} A -> MutualI2@{u u0} A.
-(* u u0 |=  *)
+(* u u0 |  *)
 
 Arguments MutualI1 A%_type_scope
 Arguments C1 A%_type_scope p1
@@ -251,7 +251,7 @@ CoInductive MutualR1'@{u} (A : Type@{u}) : Prop := Build_MutualR1'
   { p1' : MutualR2'@{u} A }
   with MutualR2'@{u} (A : Type@{u}) : Prop := Build_MutualR2'
   { p2' : MutualR1'@{u} A }.
-(* u |=  *)
+(* u |  *)
 
 Arguments MutualR1' A%_type_scope
 Arguments Build_MutualR1' A%_type_scope p1'
@@ -263,7 +263,7 @@ CoInductive MutualI1'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C1' : MutualI2'@{u u0} A -> MutualI1'@{u u0} A
   with MutualI2'@{u u0} (A : Type@{u}) : Type@{u0} :=
     C2' : MutualI1'@{u u0} A -> MutualI2'@{u u0} A.
-(* u u0 |=  *)
+(* u u0 |  *)
 
 Arguments MutualI1' A%_type_scope
 Arguments C1' A%_type_scope p1
@@ -307,6 +307,6 @@ id@{SProp ; Set}
 id3@{s ; u} =
 fun (A : Type@{s ; u}) (a : A) => a
      : forall A : Type@{s ; u}, A -> A
-(* s ; u |= Set < u *)
+(* s ; u | Set < u *)
 
 Arguments id3 A%_type_scope a

--- a/test-suite/output/UnivNotations.out
+++ b/test-suite/output/UnivNotations.out
@@ -15,15 +15,15 @@ UnivNotations.24).
   forall A : Type, A -> ! A
 foo Type@{UnivNotations.27} nat
      : Type@{foo.u1}
-(* {UnivNotations.27} |= UnivNotations.27 < foo.u0
-                         Set <= UnivNotations.27
+(* {UnivNotations.27} | UnivNotations.27 < foo.u0
+                        Set <= UnivNotations.27
 Normalized constraints:
- {UnivNotations.27} |= UnivNotations.27 < foo.u0 *)
+ {UnivNotations.27} | UnivNotations.27 < foo.u0 *)
 foo Type@{s ; Set} S
      : Type@{foo.u1}
-(* {} |= Set < foo.u0
+(* {} | Set < foo.u0
 Normalized constraints:
- {} |= Set < foo.u0 *)
+ {} | Set < foo.u0 *)
 1 goal
   
   ============================

--- a/test-suite/output/check_minim_univs.out
+++ b/test-suite/output/check_minim_univs.out
@@ -1,7 +1,7 @@
 abc@{α4 ; check_minim_univs.24}
      : Type@{check_minim_univs.24+1}
-(* {α4}; {check_minim_univs.24} |= 
+(* {α4}; {check_minim_univs.24} | 
 Collapsed sorts:
  α4 := Type
 Normalized constraints:
- {check_minim_univs.24} |=  *)
+ {check_minim_univs.24} |  *)

--- a/test-suite/output/nested_eliminators.out
+++ b/test-suite/output/nested_eliminators.out
@@ -10,7 +10,7 @@ list_all@{α ; u u0} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                forall l : list A,
                list_all@{α ; u u0} A PA l ->
                list_all@{α ; u u0} A PA (cons A a l).
-(* α ; *u *u0 |=  *)
+(* α ; *u *u0 |  *)
 
 Arguments list_all A%_type_scope PA%_function_scope l
 Arguments nil_all A%_type_scope PA%_function_scope
@@ -18,7 +18,7 @@ Arguments cons_all A%_type_scope PA%_function_scope a _ l _
 list_all_forall@{α ; u u0} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) -> forall l : list A, list_all@{α ; u u0} A PA l
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 list_all_forall is universe polymorphic
 Arguments list_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -37,7 +37,7 @@ list_all_all@{α α0 ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                    list_all_all@{α α0 ; u u0 u1} A PA PPA l l0 ->
                    list_all_all@{α α0 ; u u0 u1} A PA PPA 
                      (cons A a l) (cons_all@{α ; u u0} A PA a p l l0).
-(* α α0 ; *u *u0 *u1 |=  *)
+(* α α0 ; *u *u0 *u1 |  *)
 
 Arguments list_all_all A%_type_scope (PA PPA)%_function_scope l l0
 Arguments nil_all_all A%_type_scope (PA PPA)%_function_scope
@@ -48,7 +48,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (l : list A) (l0 : list_all@{α ; u u0} A PA l),
 list_all_all@{α α0 ; u u0 u1} A PA PPA l l0
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 list_all_all_forall is universe polymorphic
 Arguments list_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope 
@@ -87,12 +87,12 @@ RoseTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                  list_all@{Type ; u2 u1} (RoseTree A)
                    (RoseTree_all@{α ; u u0 u1 u2} A PA) l ->
                  RoseTree_all@{α ; u u0 u1 u2} A PA (RTnode A l).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments RoseTree_all A%_type_scope PA%_function_scope r
 Arguments RTleaf_all A%_type_scope PA%_function_scope a _
@@ -101,10 +101,10 @@ RoseTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall r : RoseTree A, RoseTree_all@{α ; u u0 u1 u2} A PA r
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 RoseTree_all_forall is universe polymorphic
 Arguments RoseTree_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -127,7 +127,7 @@ RoseTreeMut_all@{α ; u} (A : Type@{RoseTreeMut.u0})
                       forall r : RoseTreeMut A,
                       RoseTreeMut_all@{α ; u} A PA r ->
                       forest_all@{α ; u} A PA (forest_cons A a r).
-(* α ; *u |=  *)
+(* α ; *u |  *)
 
 Arguments RoseTreeMut_all A%_type_scope PA%_function_scope r
 Arguments node_mut_all A%_type_scope PA%_function_scope f _
@@ -138,7 +138,7 @@ RoseTreeMut_all_forall@{α ; u} :
 forall (A : Type@{RoseTreeMut.u0}) (PA : A -> Type@{α ; u}),
 (forall a : A, PA a) ->
 forall r : RoseTreeMut A, RoseTreeMut_all@{α ; u} A PA r
-(* α ; u |=  *)
+(* α ; u |  *)
 
 RoseTreeMut_all_forall is universe polymorphic
 Arguments RoseTreeMut_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -168,7 +168,7 @@ RoseTreeMut_all_all@{α α0 ; u u0} (A : Type@{RoseTreeMut.u0})
                           forest_all_all@{α α0 ; u u0} A PA PPA
                             (forest_cons A a r)
                             (forest_cons_all@{α ; u} A PA a p r r0).
-(* α α0 ; *u *u0 |=  *)
+(* α α0 ; *u *u0 |  *)
 
 Arguments RoseTreeMut_all_all A%_type_scope (PA PPA)%_function_scope r r0
 Arguments node_mut_all_all A%_type_scope (PA PPA)%_function_scope f f _
@@ -182,7 +182,7 @@ forall (A : Type@{RoseTreeMut.u0}) (PA : A -> Type@{α ; u})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (r : RoseTreeMut A) (r0 : RoseTreeMut_all@{α ; u} A PA r),
 RoseTreeMut_all_all@{α α0 ; u u0} A PA PPA r r0
-(* α α0 ; u u0 |=  *)
+(* α α0 ; u u0 |  *)
 
 RoseTreeMut_all_all_forall is universe polymorphic
 Arguments RoseTreeMut_all_all_forall A%_type_scope
@@ -206,7 +206,7 @@ RoseTreeMut_all@{α ; u} (A : Type@{RoseTreeMut.u0})
                       forall r : RoseTreeMut A,
                       RoseTreeMut_all@{α ; u} A PA r ->
                       forest_all@{α ; u} A PA (forest_cons A a r).
-(* α ; *u |=  *)
+(* α ; *u |  *)
 
 Arguments RoseTreeMut_all A%_type_scope PA%_function_scope r
 Arguments node_mut_all A%_type_scope PA%_function_scope f _
@@ -216,7 +216,7 @@ Arguments forest_cons_all A%_type_scope PA%_function_scope a _ r _
 forest_all_forall@{α ; u} :
 forall (A : Type@{RoseTreeMut.u0}) (PA : A -> Type@{α ; u}),
 (forall a : A, PA a) -> forall f : forest A, forest_all@{α ; u} A PA f
-(* α ; u |=  *)
+(* α ; u |  *)
 
 forest_all_forall is universe polymorphic
 Arguments forest_all_forall A%_type_scope (PA HPA)%_function_scope f
@@ -246,7 +246,7 @@ RoseTreeMut_all_all@{α α0 ; u u0} (A : Type@{RoseTreeMut.u0})
                           forest_all_all@{α α0 ; u u0} A PA PPA
                             (forest_cons A a r)
                             (forest_cons_all@{α ; u} A PA a p r r0).
-(* α α0 ; *u *u0 |=  *)
+(* α α0 ; *u *u0 |  *)
 
 Arguments RoseTreeMut_all_all A%_type_scope (PA PPA)%_function_scope r r0
 Arguments node_mut_all_all A%_type_scope (PA PPA)%_function_scope f f _
@@ -260,7 +260,7 @@ forall (A : Type@{RoseTreeMut.u0}) (PA : A -> Type@{α ; u})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (f : forest A) (f0 : forest_all@{α ; u} A PA f),
 forest_all_all@{α α0 ; u u0} A PA PPA f f0
-(* α α0 ; u u0 |=  *)
+(* α α0 ; u u0 |  *)
 
 forest_all_all_forall is universe polymorphic
 Arguments forest_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope 
@@ -294,12 +294,12 @@ RoseRoseTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                      (RoseRoseTree_all@{α ; u u0 u1 u2} A PA))
                   p ->
                 RoseRoseTree_all@{α ; u u0 u1 u2} A PA (Nnode A p).
-(* α ; *u *u0 =u1 =u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 =u1 =u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments RoseRoseTree_all A%_type_scope PA%_function_scope r
 Arguments Nleaf_all A%_type_scope PA%_function_scope a _
@@ -308,10 +308,10 @@ RoseRoseTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall r : RoseRoseTree A, RoseRoseTree_all@{α ; u u0 u1 u2} A PA r
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 RoseRoseTree_all_forall is universe polymorphic
 Arguments RoseRoseTree_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -343,12 +343,12 @@ ArrowTree1_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                      (ArrowTree1_all@{α ; u u0 u1 u2} A PA) 
                      (l H)) ->
                   ArrowTree1_all@{α ; u u0 u1 u2} A PA (ATnode1 A l).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments ArrowTree1_all A%_type_scope PA%_function_scope a
 Arguments ATleaf1_all A%_type_scope PA%_function_scope a _
@@ -357,10 +357,10 @@ ArrowTree1_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall a : ArrowTree1 A, ArrowTree1_all@{α ; u u0 u1 u2} A PA a
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 ArrowTree1_all_forall is universe polymorphic
 Arguments ArrowTree1_all_forall A%_type_scope (PA HPA)%_function_scope a
@@ -393,12 +393,12 @@ ArrowTree2_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                      ArrowTree2_all@{α ; u u0 u1 u2} A PA (H H0))
                     l ->
                   ArrowTree2_all@{α ; u u0 u1 u2} A PA (ATnode2 A l).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments ArrowTree2_all A%_type_scope PA%_function_scope a
 Arguments ATleaf2_all A%_type_scope PA%_function_scope a _
@@ -407,10 +407,10 @@ ArrowTree2_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall a : ArrowTree2 A, ArrowTree2_all@{α ; u u0 u1 u2} A PA a
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 ArrowTree2_all_forall is universe polymorphic
 Arguments ArrowTree2_all_forall A%_type_scope (PA HPA)%_function_scope a
@@ -446,12 +446,12 @@ ArrowTree3_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                       ArrowTree3_all@{α ; u u0 u1 u2} A PA (H0 H1))
                      (l H)) ->
                   ArrowTree3_all@{α ; u u0 u1 u2} A PA (ATnode3 A l).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments ArrowTree3_all A%_type_scope PA%_function_scope a
 Arguments ATleaf3_all A%_type_scope PA%_function_scope a _
@@ -460,10 +460,10 @@ ArrowTree3_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall a : ArrowTree3 A, ArrowTree3_all@{α ; u u0 u1 u2} A PA a
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 ArrowTree3_all_forall is universe polymorphic
 Arguments ArrowTree3_all_forall A%_type_scope (PA HPA)%_function_scope a
@@ -478,7 +478,7 @@ prod_all@{α α0 ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                PA a ->
                forall b : B,
                PB b -> prod_all@{α α0 ; u u0 u1 u2} A PA B PB (pair A B a b).
-(* α α0 ; *u *u0 *u1 *u2 |=  *)
+(* α α0 ; *u *u0 *u1 *u2 |  *)
 
 Arguments prod_all A%_type_scope PA%_function_scope 
   B%_type_scope PB%_function_scope p
@@ -490,7 +490,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u1}),
 forall (B : Type@{u0}) (PB : B -> Type@{α0 ; u2}),
 (forall b : B, PB b) ->
 forall p : prod A B, prod_all@{α α0 ; u u0 u1 u2} A PA B PB p
-(* α α0 ; u u0 u1 u2 |=  *)
+(* α α0 ; u u0 u1 u2 |  *)
 
 prod_all_forall is universe polymorphic
 Arguments prod_all_forall A%_type_scope (PA HPA)%_function_scope
@@ -512,7 +512,7 @@ prod_all_all@{α α0 α1 α2 ; u u0 u1 u2 u3 u4} (A : Type@{u})
                    prod_all_all@{α α0 α1 α2 ; u u0 u1 u2 u3 u4} A PA PPA B PB
                      PPB (pair A B a b)
                      (pair_all@{α α0 ; u u0 u1 u2} A PA B PB a p b p0).
-(* α α0 α1 α2 ; *u *u0 *u1 *u2 *u3 *u4 |=  *)
+(* α α0 α1 α2 ; *u *u0 *u1 *u2 *u3 *u4 |  *)
 
 Arguments prod_all_all A%_type_scope (PA PPA)%_function_scope 
   B%_type_scope (PB PPB)%_function_scope p p0
@@ -528,7 +528,7 @@ forall (B : Type@{u0}) (PB : B -> Type@{α0 ; u2})
 (forall (b : B) (p : PB b), PPB b p) ->
 forall (p : prod A B) (p0 : prod_all@{α α0 ; u u0 u1 u2} A PA B PB p),
 prod_all_all@{α α0 α1 α2 ; u u0 u1 u2 u3 u4} A PA PPA B PB PPB p p0
-(* α α0 α1 α2 ; u u0 u1 u2 u3 u4 |=  *)
+(* α α0 α1 α2 ; u u0 u1 u2 u3 u4 |  *)
 
 prod_all_all_forall is universe polymorphic
 Arguments prod_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope
@@ -560,12 +560,12 @@ PairTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                   (PairTree A) (PairTree_all@{α ; u u0 u1 u2} A PA)
                   (PairTree A) (PairTree_all@{α ; u u0 u1 u2} A PA) p ->
                 PairTree_all@{α ; u u0 u1 u2} A PA (Pnode A p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments PairTree_all A%_type_scope PA%_function_scope p
 Arguments Pleaf_all A%_type_scope PA%_function_scope a _
@@ -574,10 +574,10 @@ PairTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall p : PairTree A, PairTree_all@{α ; u u0 u1 u2} A PA p
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 PairTree_all_forall is universe polymorphic
 Arguments PairTree_all_forall A%_type_scope (PA HPA)%_function_scope p
@@ -609,12 +609,12 @@ LeftTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                   (LeftTree A) (LeftTree_all@{α ; u u0 u1 u2} A PA) nat
                   (fun _ : nat => unit) p ->
                 LeftTree_all@{α ; u u0 u1 u2} A PA (Lnode A p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments LeftTree_all A%_type_scope PA%_function_scope l
 Arguments Lleaf_all A%_type_scope PA%_function_scope a _
@@ -623,10 +623,10 @@ LeftTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall l : LeftTree A, LeftTree_all@{α ; u u0 u1 u2} A PA l
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 LeftTree_all_forall is universe polymorphic
 Arguments LeftTree_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -658,12 +658,12 @@ LeftTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                   (LeftTree A) (LeftTree_all@{α ; u u0 u1 u2} A PA) nat
                   (fun _ : nat => unit) p ->
                 LeftTree_all@{α ; u u0 u1 u2} A PA (Lnode A p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments LeftTree_all A%_type_scope PA%_function_scope l
 Arguments Lleaf_all A%_type_scope PA%_function_scope a _
@@ -672,10 +672,10 @@ LeftTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall l : LeftTree A, LeftTree_all@{α ; u u0 u1 u2} A PA l
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 LeftTree_all_forall is universe polymorphic
 Arguments LeftTree_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -688,7 +688,7 @@ prod_all_10@{α ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u1})
     pair_all_10 : forall a : A,
                   PA a ->
                   forall b : B, prod_all_10@{α ; u u0 u1} A PA B (pair a b).
-(* α ; *u *u0 *u1 |=  *)
+(* α ; *u *u0 *u1 |  *)
 
 Arguments prod_all_10 A%_type_scope PA%_function_scope B%_type_scope p
 Arguments pair_all_10 A%_type_scope PA%_function_scope B%_type_scope a _ b
@@ -696,7 +696,7 @@ prod_all_forall_10@{α ; u u0 u1} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u1}),
 (forall a : A, PA a) ->
 forall (B : Type@{u0}) (p : prod A B), prod_all_10@{α ; u u0 u1} A PA B p
-(* α ; u u0 u1 |=  *)
+(* α ; u u0 u1 |  *)
 
 prod_all_forall_10 is universe polymorphic
 Arguments prod_all_forall_10 A%_type_scope (PA HPA)%_function_scope
@@ -716,7 +716,7 @@ prod_all_10_all@{α α0 ; u u0 u1 u2} (A : Type@{u})
                       forall b : B,
                       prod_all_10_all@{α α0 ; u u0 u1 u2} A PA PPA B
                         (pair a b) (pair_all_10@{α ; u u0 u1} A PA B a p b).
-(* α α0 ; *u *u0 *u1 *u2 |=  *)
+(* α α0 ; *u *u0 *u1 *u2 |  *)
 
 Arguments prod_all_10_all A%_type_scope (PA PPA)%_function_scope
   B%_type_scope p p0
@@ -729,7 +729,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u1})
 forall (B : Type@{u0}) (p : prod A B)
   (p0 : prod_all_10@{α ; u u0 u1} A PA B p),
 prod_all_10_all@{α α0 ; u u0 u1 u2} A PA PPA B p p0
-(* α α0 ; u u0 u1 u2 |=  *)
+(* α α0 ; u u0 u1 u2 |  *)
 
 prod_all_10_all_forall is universe polymorphic
 Arguments prod_all_10_all_forall A%_type_scope (PA PPA HPPA)%_function_scope
@@ -760,12 +760,12 @@ LeftTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                 prod_all_10@{Type ; u2 Set u1} (LeftTree A)
                   (LeftTree_all@{α ; u u0 u1 u2} A PA) nat p ->
                 LeftTree_all@{α ; u u0 u1 u2} A PA (Lnode A p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments LeftTree_all A%_type_scope PA%_function_scope l
 Arguments Lleaf_all A%_type_scope PA%_function_scope a _
@@ -774,10 +774,10 @@ LeftTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall l : LeftTree A, LeftTree_all@{α ; u u0 u1 u2} A PA l
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 LeftTree_all_forall is universe polymorphic
 Arguments LeftTree_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -809,12 +809,12 @@ RightTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                   (fun _ : nat => unit) (RightTree A)
                   (RightTree_all@{α ; u u0 u1 u2} A PA) p ->
                 RightTree_all@{α ; u u0 u1 u2} A PA (Rnode A p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments RightTree_all A%_type_scope PA%_function_scope r
 Arguments Rleaf_all A%_type_scope PA%_function_scope a _
@@ -823,10 +823,10 @@ RightTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall r : RightTree A, RightTree_all@{α ; u u0 u1 u2} A PA r
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 RightTree_all_forall is universe polymorphic
 Arguments RightTree_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -842,7 +842,7 @@ vec_all@{α ; u u0} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                 forall (n : nat) (v : vec A n),
                 vec_all@{α ; u u0} A PA n v ->
                 vec_all@{α ; u u0} A PA (S n) (vcons A a n v).
-(* α ; *u *u0 |=  *)
+(* α ; *u *u0 |  *)
 
 Arguments vec_all A%_type_scope PA%_function_scope n v
 Arguments vnil_all A%_type_scope PA%_function_scope
@@ -851,7 +851,7 @@ vec_all_forall@{α ; u u0} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall (n : nat) (v : vec A n), vec_all@{α ; u u0} A PA n v
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 vec_all_forall is universe polymorphic
 Arguments vec_all_forall A%_type_scope (PA HPA)%_function_scope n v
@@ -873,7 +873,7 @@ vec_all_all@{α α0 ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                     vec_all_all@{α α0 ; u u0 u1} A PA PPA 
                       (S n) (vcons A a n v)
                       (vcons_all@{α ; u u0} A PA a p n v v0).
-(* α α0 ; *u *u0 *u1 |=  *)
+(* α α0 ; *u *u0 *u1 |  *)
 
 Arguments vec_all_all A%_type_scope (PA PPA)%_function_scope n v v0
 Arguments vnil_all_all A%_type_scope (PA PPA)%_function_scope
@@ -884,7 +884,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (n : nat) (v : vec A n) (v0 : vec_all@{α ; u u0} A PA n v),
 vec_all_all@{α α0 ; u u0 u1} A PA PPA n v v0
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 vec_all_all_forall is universe polymorphic
 Arguments vec_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope 
@@ -913,12 +913,12 @@ VecTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                  vec_all@{Type ; u2 u1} (VecTree A)
                    (VecTree_all@{α ; u u0 u1 u2} A PA) n p ->
                  VecTree_all@{α ; u u0 u1 u2} A PA (VNnode A n p).
-(* α ; *u *u0 *u1 *u2 |= Set <= u1
-                         Set <= u2
-                         u <= u1
-                         u <= u2
-                         u0 <= u1
-                         u2 <= u1 *)
+(* α ; *u *u0 *u1 *u2 | Set <= u1
+                        Set <= u2
+                        u <= u1
+                        u <= u2
+                        u0 <= u1
+                        u2 <= u1 *)
 
 Arguments VecTree_all A%_type_scope PA%_function_scope v
 Arguments VNleaf_all A%_type_scope PA%_function_scope a _
@@ -927,10 +927,10 @@ VecTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall v : VecTree A, VecTree_all@{α ; u u0 u1 u2} A PA v
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u2
-                     u0 <= u1
-                     u2 <= u1 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u2
+                    u0 <= u1
+                    u2 <= u1 *)
 
 VecTree_all_forall is universe polymorphic
 Arguments VecTree_all_forall A%_type_scope (PA HPA)%_function_scope v
@@ -954,7 +954,7 @@ All2i_all@{α ; u u0 u1 u2} (A : Type@{u}) (B : Type@{u0})
                      All2i_all@{α ; u u0 u1 u2} A B R PR n 
                        (cons a lA) (cons b lB)
                        (All2i_cons A B R n a b lA lB r a0).
-(* α ; *u *u0 *u1 *u2 |=  *)
+(* α ; *u *u0 *u1 *u2 |  *)
 
 Arguments All2i_all (A B)%_type_scope (R PR)%_function_scope n l l a
 Arguments All2i_nil_all (A B)%_type_scope (R PR)%_function_scope n
@@ -966,7 +966,7 @@ forall (A : Type@{u}) (B : Type@{u0}) (R : nat -> A -> B -> Type@{u1})
 (forall (n : nat) (a : A) (b : B) (r : R n a b), PR n a b r) ->
 forall (n : nat) (l : list A) (l0 : list B) (a : All2i A B R n l l0),
 All2i_all@{α ; u u0 u1 u2} A B R PR n l l0 a
-(* α ; u u0 u1 u2 |=  *)
+(* α ; u u0 u1 u2 |  *)
 
 All2i_all_forall is universe polymorphic
 Arguments All2i_all_forall (A B)%_type_scope (R PR HPR)%_function_scope 
@@ -1001,7 +1001,7 @@ All2i_all_all@{α α0 ; u u0 u1 u2 u3} (A : Type@{u})
                            (All2i_cons A B R n a b lA lB r a0)
                            (All2i_cons_all@{α ; u u0 u1 u2} A B R PR n a b lA
                               lB r p a0 a1).
-(* α α0 ; *u *u0 *u1 *u2 *u3 |=  *)
+(* α α0 ; *u *u0 *u1 *u2 *u3 |  *)
 
 Arguments All2i_all_all (A B)%_type_scope (R PR PPR)%_function_scope 
   n l l a a0
@@ -1018,7 +1018,7 @@ forall (A : Type@{u}) (B : Type@{u0}) (R : nat -> A -> B -> Type@{u1})
 forall (n : nat) (l : list A) (l0 : list B) (a : All2i A B R n l l0)
   (a0 : All2i_all@{α ; u u0 u1 u2} A B R PR n l l0 a),
 All2i_all_all@{α α0 ; u u0 u1 u2 u3} A B R PR PPR n l l0 a a0
-(* α α0 ; u u0 u1 u2 u3 |=  *)
+(* α α0 ; u u0 u1 u2 u3 |  *)
 
 All2i_all_all_forall is universe polymorphic
 Arguments All2i_all_all_forall (A B)%_type_scope
@@ -1068,7 +1068,7 @@ All2i_bis_all@{α α0 ; u u0 u1 u2 u3 u4} (A : Type@{u})
                          All2i_bis_all@{α α0 ; u u0 u1 u2 u3 u4} A B C PC R
                            PR n (cons a lA) (cons b lB)
                            (All2i_bis_cons A B C R n a b lA lB r a0).
-(* α α0 ; *u *u0 *u1 *u2 *u3 *u4 |=  *)
+(* α α0 ; *u *u0 *u1 *u2 *u3 *u4 |  *)
 
 Arguments All2i_bis_all (A B C)%_type_scope (PC R PR)%_function_scope n l l a
 Arguments All2i_bis_nil_all (A B C)%_type_scope (PC R PR)%_function_scope 
@@ -1084,7 +1084,7 @@ forall (R : nat -> A -> B -> Type@{u2})
 (forall (n : nat) (a : A) (b : B) (r : R n a b), PR n a b r) ->
 forall (n : nat) (l : list A) (l0 : list B) (a : All2i_bis A B C R n l l0),
 All2i_bis_all@{α α0 ; u u0 u1 u2 u3 u4} A B C PC R PR n l l0 a
-(* α α0 ; u u0 u1 u2 u3 u4 |=  *)
+(* α α0 ; u u0 u1 u2 u3 u4 |  *)
 
 All2i_bis_all_forall is universe polymorphic
 Arguments All2i_bis_all_forall (A B C)%_type_scope
@@ -1130,8 +1130,7 @@ All2i_bis_all_all@{α α0 α1 α2 ; u u0 u1 u2 u3 u4 u5 u6}
                                (All2i_bis_cons A B C R n a b lA lB r a0)
                                (All2i_bis_cons_all@{α α0 ; u u0 u1 u2 u3 u4}
                                   A B C PC R PR n a b lA lB r p a0 a1).
-(* α α0 α1 α2 ; *u *u0 *u1 *u2 *u3 *u4 *u5 *u6 |= 
-    *)
+(* α α0 α1 α2 ; *u *u0 *u1 *u2 *u3 *u4 *u5 *u6 |  *)
 
 Arguments All2i_bis_all_all (A B C)%_type_scope
   (PC PPC R PR PPR)%_function_scope n l l a a0
@@ -1154,7 +1153,7 @@ forall (n : nat) (l : list A) (l0 : list B) (a : All2i_bis A B C R n l l0)
   (a0 : All2i_bis_all@{α α0 ; u u0 u1 u2 u3 u4} A B C PC R PR n l l0 a),
 All2i_bis_all_all@{α α0 α1 α2 ; u u0 u1 u2 u3 u4 u5 u6} A B C PC PPC R PR PPR
   n l l0 a a0
-(* α α0 α1 α2 ; u u0 u1 u2 u3 u4 u5 u6 |=  *)
+(* α α0 α1 α2 ; u u0 u1 u2 u3 u4 u5 u6 |  *)
 
 All2i_bis_all_all_forall is universe polymorphic
 Arguments All2i_bis_all_all_forall (A B C)%_type_scope
@@ -1187,7 +1186,7 @@ sig_all@{α α0 ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                 PA x ->
                 forall p : P x,
                 PP x p -> sig_all@{α α0 ; u u0 u1} A PA P PP (exist A P x p).
-(* α α0 ; *u *u0 *u1 |=  *)
+(* α α0 ; *u *u0 *u1 |  *)
 
 Arguments sig_all A%_type_scope (PA P PP)%_function_scope s
 Arguments exist_all A%_type_scope (PA P PP)%_function_scope x _ p _
@@ -1197,7 +1196,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 forall (P : A -> Prop) (PP : forall a : A, P a -> Type@{α0 ; u1}),
 (forall (a : A) (p : P a), PP a p) ->
 forall s : sig A P, sig_all@{α α0 ; u u0 u1} A PA P PP s
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 sig_all_forall is universe polymorphic
 Arguments sig_all_forall A%_type_scope (PA HPA P PP HPP)%_function_scope s
@@ -1211,7 +1210,7 @@ sig_all_10@{α ; u u0} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                    PA x ->
                    forall p : P x,
                    sig_all_10@{α ; u u0} A PA P (exist A P x p).
-(* α ; *u *u0 |=  *)
+(* α ; *u *u0 |  *)
 
 Arguments sig_all_10 A%_type_scope (PA P)%_function_scope s
 Arguments exist_all_10 A%_type_scope (PA P)%_function_scope x _ p
@@ -1219,7 +1218,7 @@ sig_all_forall_10@{α ; u u0} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) ->
 forall (P : A -> Prop) (s : sig A P), sig_all_10@{α ; u u0} A PA P s
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 sig_all_forall_10 is universe polymorphic
 Arguments sig_all_forall_10 A%_type_scope (PA HPA P)%_function_scope s
@@ -1231,7 +1230,7 @@ sig_all_01@{α ; u u0} (A : Type@{u}) (P : A -> Prop)
 (PP : forall a : A, P a -> Type@{α ; u0}) : sig A P -> Type@{max(u,u0)} :=
     exist_all_01 : forall (x : A) (p : P x),
                    PP x p -> sig_all_01@{α ; u u0} A P PP (exist A P x p).
-(* α ; *u *u0 |=  *)
+(* α ; *u *u0 |  *)
 
 Arguments sig_all_01 A%_type_scope (P PP)%_function_scope s
 Arguments exist_all_01 A%_type_scope (P PP)%_function_scope x p _
@@ -1240,7 +1239,7 @@ forall (A : Type@{u}) (P : A -> Prop)
   (PP : forall a : A, P a -> Type@{α ; u0}),
 (forall (a : A) (p : P a), PP a p) ->
 forall s : sig A P, sig_all_01@{α ; u u0} A P PP s
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 sig_all_forall_01 is universe polymorphic
 Arguments sig_all_forall_01 A%_type_scope (P PP HPP)%_function_scope s
@@ -1258,7 +1257,7 @@ NestRel_all@{α α0 ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                 (and_all@{α0 α0 ; u1 u1} (R x x) (PR x x) (R x x) (PR x x))
                 True (fun _ : True => unit) o ->
               NestRel_all@{α α0 ; u u0 u1 u2} A PA R PR (mkR A R x o).
-(* α α0 ; *u *u0 =u1 *u2 |=  *)
+(* α α0 ; *u *u0 =u1 *u2 |  *)
 
 Arguments NestRel_all A%_type_scope (PA R PR)%_function_scope n
 Arguments mkR_all A%_type_scope (PA R PR)%_function_scope x _ o _
@@ -1268,7 +1267,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 forall (R : A -> A -> Prop) (PR : forall a a0 : A, R a a0 -> Type@{α0 ; u1}),
 (forall (a a0 : A) (r : R a a0), PR a a0 r) ->
 forall n : NestRel A R, NestRel_all@{α α0 ; u u0 u1 u2} A PA R PR n
-(* α α0 ; u u0 u1 u2 |=  *)
+(* α α0 ; u u0 u1 u2 |  *)
 
 NestRel_all_forall is universe polymorphic
 Arguments NestRel_all_forall A%_type_scope (PA HPA R PR HPR)%_function_scope
@@ -1288,7 +1287,7 @@ ex_all@{α α0 ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                    forall p : P x,
                    PP x p ->
                    ex_all@{α α0 ; u u0 u1} A PA P PP (ex_intro A P x p).
-(* α α0 ; *u *u0 *u1 |=  *)
+(* α α0 ; *u *u0 *u1 |  *)
 
 Arguments ex_all A%_type_scope (PA P PP)%_function_scope e
 Arguments ex_intro_all A%_type_scope (PA P PP)%_function_scope x _ p _
@@ -1298,7 +1297,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 forall (P : A -> Prop) (PP : forall a : A, P a -> Type@{α0 ; u1}),
 (forall (a : A) (p : P a), PP a p) ->
 forall e : ex A P, ex_all@{α α0 ; u u0 u1} A PA P PP e
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 ex_all_forall is universe polymorphic
 Arguments ex_all_forall A%_type_scope (PA HPA P PP HPP)%_function_scope e
@@ -1320,7 +1319,7 @@ Declared in library nested_eliminators, line 298, characters 2-131
 adequate_all@{α ; u u0} :
 forall (L : language) (φ : unit -> Type@{u}),
 (forall u : unit, φ u -> Type@{α ; u0}) -> adequate L φ -> Prop
-(* α ; *u *u0 |=  *)
+(* α ; *u *u0 |  *)
 
 adequate_all is universe polymorphic
 Arguments adequate_all L (φ Pφ)%_function_scope a
@@ -1329,7 +1328,7 @@ Declared in library nested_eliminators, line 298, characters 2-131
 casenat_all@{α ; u} :
 forall P : nat -> Set,
 (forall n : nat, P n -> Type@{α ; u}) -> casenat P -> Type@{max(Set,u)}
-(* α ; *u |=  *)
+(* α ; *u |  *)
 
 casenat_all is universe polymorphic
 Arguments casenat_all (P PP)%_function_scope c
@@ -1341,7 +1340,7 @@ forall (A : nat -> Set) (PZ : Set),
 forall PS : forall n : nat, A n -> Set,
 (forall (n : nat) (a : A n), PS n a -> Type@{α0 ; u0}) ->
 casenat' A PZ PS -> Type@{max(Set,u,u0)}
-(* α α0 ; *u *u0 |=  *)
+(* α α0 ; *u *u0 |  *)
 
 casenat'_all is universe polymorphic
 Arguments casenat'_all A%_function_scope PZ%_type_scope
@@ -1360,7 +1359,7 @@ list_all@{α ; u u0} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                forall l : list@{u} A,
                list_all@{α ; u u0} A PA l ->
                list_all@{α ; u u0} A PA (cons@{u} A a l).
-(* α ; =u *u0 |=  *)
+(* α ; =u *u0 |  *)
 
 Arguments list_all A%_type_scope PA%_function_scope l
 Arguments nil_all A%_type_scope PA%_function_scope
@@ -1368,7 +1367,7 @@ Arguments cons_all A%_type_scope PA%_function_scope a _ l _
 list_all_forall@{α ; u u0} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u0}),
 (forall a : A, PA a) -> forall l : list@{u} A, list_all@{α ; u u0} A PA l
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 list_all_forall is universe polymorphic
 Arguments list_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -1388,7 +1387,7 @@ list_all_all@{α α0 ; u u0 u1} (A : Type@{u}) (PA : A -> Type@{α ; u0})
                    list_all_all@{α α0 ; u u0 u1} A PA PPA l l0 ->
                    list_all_all@{α α0 ; u u0 u1} A PA PPA 
                      (cons@{u} A a l) (cons_all@{α ; u u0} A PA a p l l0).
-(* α α0 ; =u *u0 *u1 |=  *)
+(* α α0 ; =u *u0 *u1 |  *)
 
 Arguments list_all_all A%_type_scope (PA PPA)%_function_scope l l0
 Arguments nil_all_all A%_type_scope (PA PPA)%_function_scope
@@ -1399,7 +1398,7 @@ forall (A : Type@{u}) (PA : A -> Type@{α ; u0})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (l : list@{u} A) (l0 : list_all@{α ; u u0} A PA l),
 list_all_all@{α α0 ; u u0 u1} A PA PPA l l0
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 list_all_all_forall is universe polymorphic
 Arguments list_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope 
@@ -1424,7 +1423,7 @@ forall (A : Type@{u}) (P : RoseTree@{u u0} A -> Prop),
 (forall l : list@{u0} (RoseTree@{u u0} A),
  list_all@{Prop ; u0 Set} (RoseTree@{u u0} A) P l -> P (RTnode@{u u0} A l)) ->
 forall r : RoseTree@{u u0} A, P r
-(* u u0 |= u <= u0 *)
+(* u u0 | u <= u0 *)
 
 RoseTree_ind is universe polymorphic
 Arguments RoseTree_ind A%_type_scope (P RTleaf RTnode)%_function_scope r
@@ -1441,9 +1440,9 @@ RoseTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                  list_all@{Type ; u0 u2} (RoseTree@{u u0} A)
                    (RoseTree_all@{α ; u u0 u1 u2} A PA) l ->
                  RoseTree_all@{α ; u u0 u1 u2} A PA (RTnode@{u u0} A l).
-(* α ; =u =u0 *u1 *u2 |= u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 *u2 | u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments RoseTree_all A%_type_scope PA%_function_scope r
 Arguments RTleaf_all A%_type_scope PA%_function_scope a _
@@ -1452,9 +1451,9 @@ RoseTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u1}),
 (forall a : A, PA a) ->
 forall r : RoseTree@{u u0} A, RoseTree_all@{α ; u u0 u1 u2} A PA r
-(* α ; u u0 u1 u2 |= u <= u0
-                     u0 <= u2
-                     u1 <= u2 *)
+(* α ; u u0 u1 u2 | u <= u0
+                    u0 <= u2
+                    u1 <= u2 *)
 
 RoseTree_all_forall is universe polymorphic
 Arguments RoseTree_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -1469,9 +1468,9 @@ forall (A : Type@{u}) (P : RoseRoseTree@{u u0} A -> Prop),
    (list_all@{Prop ; u0 Set} (RoseRoseTree@{u u0} A) P) p ->
  P (Nnode@{u u0} A p)) ->
 forall r : RoseRoseTree@{u u0} A, P r
-(* u u0 u1 |= Set <= u1
-              u <= u0
-              u0 <= u1 *)
+(* u u0 u1 | Set <= u1
+             u <= u0
+             u0 <= u1 *)
 
 RoseRoseTree_ind is universe polymorphic
 Arguments RoseRoseTree_ind A%_type_scope (P Nleaf Nnode)%_function_scope r
@@ -1490,10 +1489,10 @@ RoseRoseTree_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                      (RoseRoseTree_all@{α ; u u0 u1 u2} A PA))
                   p ->
                 RoseRoseTree_all@{α ; u u0 u1 u2} A PA (Nnode@{u u0} A p).
-(* α ; =u =u0 *u1 =u2 |= Set <= u2
-                         u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 =u2 | Set <= u2
+                        u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments RoseRoseTree_all A%_type_scope PA%_function_scope r
 Arguments Nleaf_all A%_type_scope PA%_function_scope a _
@@ -1502,10 +1501,10 @@ RoseRoseTree_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u1}),
 (forall a : A, PA a) ->
 forall r : RoseRoseTree@{u u0} A, RoseRoseTree_all@{α ; u u0 u1 u2} A PA r
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u0
-                     u0 <= u2
-                     u1 <= u2 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u0
+                    u0 <= u2
+                    u1 <= u2 *)
 
 RoseRoseTree_all_forall is universe polymorphic
 Arguments RoseRoseTree_all_forall A%_type_scope (PA HPA)%_function_scope r
@@ -1522,7 +1521,7 @@ forall (A : Type@{u}) (P : ArrowTree3@{u u0} A -> Prop),
     (l H)) ->
  P (ATnode3@{u u0} A l)) ->
 forall a : ArrowTree3@{u u0} A, P a
-(* u u0 |= u <= u0 *)
+(* u u0 | u <= u0 *)
 
 ArrowTree3_ind is universe polymorphic
 Arguments ArrowTree3_ind A%_type_scope (P ATleaf3 ATnode3)%_function_scope a
@@ -1543,10 +1542,10 @@ ArrowTree3_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                       ArrowTree3_all@{α ; u u0 u1 u2} A PA (H0 H1))
                      (l H)) ->
                   ArrowTree3_all@{α ; u u0 u1 u2} A PA (ATnode3@{u u0} A l).
-(* α ; =u =u0 *u1 *u2 |= Set <= u2
-                         u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 *u2 | Set <= u2
+                        u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments ArrowTree3_all A%_type_scope PA%_function_scope a
 Arguments ATleaf3_all A%_type_scope PA%_function_scope a _
@@ -1555,10 +1554,10 @@ ArrowTree3_all_forall@{α ; u u0 u1 u2} :
 forall (A : Type@{u}) (PA : A -> Type@{α ; u1}),
 (forall a : A, PA a) ->
 forall a : ArrowTree3@{u u0} A, ArrowTree3_all@{α ; u u0 u1 u2} A PA a
-(* α ; u u0 u1 u2 |= Set <= u2
-                     u <= u0
-                     u0 <= u2
-                     u1 <= u2 *)
+(* α ; u u0 u1 u2 | Set <= u2
+                    u <= u0
+                    u0 <= u2
+                    u1 <= u2 *)
 
 ArrowTree3_all_forall is universe polymorphic
 Arguments ArrowTree3_all_forall A%_type_scope (PA HPA)%_function_scope a
@@ -1583,9 +1582,9 @@ fix F (t : trie@{u u0} A) : P t :=
         array_all@{Type ; u0 u1 u2} (trie@{u u0} A) P a0 ->
         P (TNode@{u u0} A a a0)) ->
        forall t : trie@{u u0} A, P t
-(* u u0 u1 u2 |= Set <= u2
-                 u <= u0
-                 u1 <= u2 *)
+(* u u0 u1 u2 | Set <= u2
+                u <= u0
+                u1 <= u2 *)
 
 Arguments trie_rect A%_type_scope P%_function_scope 
   TLeaf TNode%_function_scope t
@@ -1599,10 +1598,10 @@ trie_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                 array_all@{Type ; u0 u2 u2} (trie@{u u0} A)
                   (trie_all@{α ; u u0 u1 u2} A PA) a0 ->
                 trie_all@{α ; u u0 u1 u2} A PA (TNode@{u u0} A a a0).
-(* α ; =u =u0 *u1 *u2 |= Set <= u2
-                         u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 *u2 | Set <= u2
+                        u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments trie_all A%_type_scope PA%_function_scope t
 Arguments TLeaf_all A%_type_scope PA%_function_scope
@@ -1638,9 +1637,9 @@ fix F (a : ArrowTrie@{u u0} A) : P a :=
            (l H)) ->
         P (ATNode@{u u0} A a l)) ->
        forall a : ArrowTrie@{u u0} A, P a
-(* u u0 u1 u2 |= Set <= u2
-                 u <= u0
-                 u1 <= u2 *)
+(* u u0 u1 u2 | Set <= u2
+                u <= u0
+                u1 <= u2 *)
 
 Arguments ArrowTrie_rect A%_type_scope P%_function_scope 
   ATLeaf ATNode%_function_scope a
@@ -1658,10 +1657,10 @@ ArrowTrie_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                        (ArrowTrie_all@{α ; u u0 u1 u2} A PA))
                     (l H)) ->
                  ArrowTrie_all@{α ; u u0 u1 u2} A PA (ATNode@{u u0} A a l).
-(* α ; =u =u0 *u1 *u2 |= Set <= u2
-                         u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 *u2 | Set <= u2
+                        u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments ArrowTrie_all A%_type_scope PA%_function_scope a
 Arguments ATLeaf_all A%_type_scope PA%_function_scope
@@ -1691,9 +1690,9 @@ fix F (a : ArrayTrie@{u u0} A) : P a :=
           (array_all@{Type ; u0 u1 u2} (ArrayTrie@{u u0} A) P) a0 ->
         P (AyTNode@{u u0} A a a0)) ->
        forall a : ArrayTrie@{u u0} A, P a
-(* u u0 u1 u2 |= Set <= u2
-                 u <= u0
-                 u1 <= u2 *)
+(* u u0 u1 u2 | Set <= u2
+                u <= u0
+                u1 <= u2 *)
 
 Arguments ArrayTrie_rect A%_type_scope P%_function_scope 
   AyTLeaf AyTNode%_function_scope a
@@ -1710,10 +1709,10 @@ ArrayTrie_all@{α ; u u0 u1 u2} (A : Type@{u}) (PA : A -> Type@{α ; u1})
                        (ArrayTrie_all@{α ; u u0 u1 u2} A PA))
                     a0 ->
                   ArrayTrie_all@{α ; u u0 u1 u2} A PA (AyTNode@{u u0} A a a0).
-(* α ; =u =u0 *u1 *u2 |= Set <= u2
-                         u <= u0
-                         u0 <= u2
-                         u1 <= u2 *)
+(* α ; =u =u0 *u1 *u2 | Set <= u2
+                        u <= u0
+                        u0 <= u2
+                        u1 <= u2 *)
 
 Arguments ArrayTrie_all A%_type_scope PA%_function_scope a
 Arguments AyTLeaf_all A%_type_scope PA%_function_scope
@@ -1727,7 +1726,7 @@ list_all@{α α0 ; u u0 u1} (A : Type@{α ; u}) (PA : A -> Type@{α0 ; u1})
                forall l : list@{α ; u u0} A,
                list_all@{α α0 ; u u0 u1} A PA l ->
                list_all@{α α0 ; u u0 u1} A PA (cons@{α ; u u0} A a l).
-(* α α0 ; =u =u0 *u1 |= u <= u0 *)
+(* α α0 ; =u =u0 *u1 | u <= u0 *)
 
 Arguments list_all A%_type_scope PA%_function_scope l
 Arguments nil_all A%_type_scope PA%_function_scope
@@ -1736,7 +1735,7 @@ list_all_forall@{α α0 ; u u0 u1} :
 forall (A : Type@{α ; u}) (PA : A -> Type@{α0 ; u1}),
 (forall a : A, PA a) ->
 forall l : list@{α ; u u0} A, list_all@{α α0 ; u u0 u1} A PA l
-(* α α0 ; u u0 u1 |= u <= u0 *)
+(* α α0 ; u u0 u1 | u <= u0 *)
 
 list_all_forall is universe polymorphic
 Arguments list_all_forall A%_type_scope (PA HPA)%_function_scope l
@@ -1758,7 +1757,7 @@ list_all_all@{α α0 α1 ; u u0 u1 u2} (A : Type@{α ; u})
                    list_all_all@{α α0 α1 ; u u0 u1 u2} A PA PPA
                      (cons@{α ; u u0} A a l)
                      (cons_all@{α α0 ; u u0 u1} A PA a p l l0).
-(* α α0 α1 ; =u =u0 *u1 *u2 |= u <= u0 *)
+(* α α0 α1 ; =u =u0 *u1 *u2 | u <= u0 *)
 
 Arguments list_all_all A%_type_scope (PA PPA)%_function_scope l l0
 Arguments nil_all_all A%_type_scope (PA PPA)%_function_scope
@@ -1769,7 +1768,7 @@ forall (A : Type@{α ; u}) (PA : A -> Type@{α0 ; u1})
 (forall (a : A) (p : PA a), PPA a p) ->
 forall (l : list@{α ; u u0} A) (l0 : list_all@{α α0 ; u u0 u1} A PA l),
 list_all_all@{α α0 α1 ; u u0 u1 u2} A PA PPA l l0
-(* α α0 α1 ; u u0 u1 u2 |= u <= u0 *)
+(* α α0 α1 ; u u0 u1 u2 | u <= u0 *)
 
 list_all_all_forall is universe polymorphic
 Arguments list_all_all_forall A%_type_scope (PA PPA HPPA)%_function_scope 
@@ -1793,7 +1792,7 @@ forall P : SRT@{u} -> SProp,
 (forall l : list@{SProp ; u u} SRT@{u},
  list_all@{SProp SProp ; u u u0} SRT@{u} P l -> P (SRTnode@{u} l)) ->
 forall s : SRT@{u}, P s
-(* u u0 |=  *)
+(* u u0 |  *)
 
 SRT_sind is universe polymorphic
 Arguments SRT_sind (P SRTnode)%_function_scope s
@@ -1854,7 +1853,7 @@ Nester_all@{α ; u} :
 forall X : unit -> P unit,
 (forall u u0 : unit, X u u0 -> Type@{α ; u}) ->
 Nester X -> Type@{max(P.u1,u)}
-(* α ; *u |=  *)
+(* α ; *u |  *)
 
 Nester_all is universe polymorphic
 Arguments Nester_all (X PX)%_function_scope n

--- a/test-suite/output/prim_array.out
+++ b/test-suite/output/prim_array.out
@@ -4,8 +4,8 @@
      : array nat
 [| | 0 : nat |]@{prim_array.26}
      : array@{prim_array.26} nat
-(* {prim_array.26 prim_array.25} |= Set <= prim_array.25
-                                    Set <= prim_array.26
+(* {prim_array.26 prim_array.25} | Set <= prim_array.25
+                                   Set <= prim_array.26
 Minimized universes:
  prim_array.26 := Set
  prim_array.25 := Set
@@ -13,7 +13,7 @@ Normalized constraints:
   *)
 [| bool; list nat | nat : Set |]@{prim_array.29}
      : array@{prim_array.29} Set
-(* {prim_array.29 prim_array.28 prim_array.27} |=
+(* {prim_array.29 prim_array.28 prim_array.27} |
      Set < prim_array.27
      Set < prim_array.29
      Set <= prim_array.28
@@ -21,4 +21,4 @@ Minimized universes:
  prim_array.28 := Set
  prim_array.27 := Set+1
 Normalized constraints:
- {prim_array.29} |= Set < prim_array.29 *)
+ {prim_array.29} | Set < prim_array.29 *)

--- a/test-suite/output/sort_poly_elab.out
+++ b/test-suite/output/sort_poly_elab.out
@@ -1,12 +1,12 @@
 qsort@{α ; u} : Type@{u+1}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 qsort is universe polymorphic
 qsort is transparent
 Expands to: Constant sort_poly_elab.Reduction.qsort
 Declared in library sort_poly_elab, line 10, characters 13-18
 qsort'@{α ; u u0} : Type@{u}
-(* α ; u u0 |= u0 < u *)
+(* α ; u u0 | u0 < u *)
 
 qsort' is universe polymorphic
 qsort' is transparent
@@ -16,7 +16,7 @@ Declared in library sort_poly_elab, line 14, characters 13-19
 :
 @eq Type@{sort_poly_elab.26} q1 tU@{Type ; }
      : @eq Type@{sort_poly_elab.26} q1 tU@{Type ; }
-(* {sort_poly_elab.27 sort_poly_elab.26 sort_poly_elab.25} |=
+(* {sort_poly_elab.27 sort_poly_elab.26 sort_poly_elab.25} |
      U < sort_poly_elab.26
      sort_poly_elab.26 < sort_poly_elab.25
      sort_poly_elab.26 < sort_poly_elab.27
@@ -24,12 +24,12 @@ Minimized universes:
  sort_poly_elab.27 := sort_poly_elab.26+1
  sort_poly_elab.25 := sort_poly_elab.26+1
 Normalized constraints:
- {sort_poly_elab.26} |= U < sort_poly_elab.26 *)
+ {sort_poly_elab.26} | U < sort_poly_elab.26 *)
 @eq_refl Type@{sort_poly_elab.29} q2
 :
 @eq Type@{sort_poly_elab.29} q2 tU@{Type ; }
      : @eq Type@{sort_poly_elab.29} q2 tU@{Type ; }
-(* {sort_poly_elab.30 sort_poly_elab.29 sort_poly_elab.28} |=
+(* {sort_poly_elab.30 sort_poly_elab.29 sort_poly_elab.28} |
      U < sort_poly_elab.29
      sort_poly_elab.29 < sort_poly_elab.28
      sort_poly_elab.29 < sort_poly_elab.30
@@ -37,12 +37,12 @@ Minimized universes:
  sort_poly_elab.30 := sort_poly_elab.29+1
  sort_poly_elab.28 := sort_poly_elab.29+1
 Normalized constraints:
- {sort_poly_elab.29} |= U < sort_poly_elab.29 *)
+ {sort_poly_elab.29} | U < sort_poly_elab.29 *)
 @eq_refl Type@{sort_poly_elab.32} q3
 :
 @eq Type@{sort_poly_elab.32} q3 tU@{Type ; }
      : @eq Type@{sort_poly_elab.32} q3 tU@{Type ; }
-(* {sort_poly_elab.33 sort_poly_elab.32 sort_poly_elab.31} |=
+(* {sort_poly_elab.33 sort_poly_elab.32 sort_poly_elab.31} |
      U < sort_poly_elab.32
      sort_poly_elab.32 < sort_poly_elab.31
      sort_poly_elab.32 < sort_poly_elab.33
@@ -50,9 +50,9 @@ Minimized universes:
  sort_poly_elab.33 := sort_poly_elab.32+1
  sort_poly_elab.31 := sort_poly_elab.32+1
 Normalized constraints:
- {sort_poly_elab.32} |= U < sort_poly_elab.32 *)
+ {sort_poly_elab.32} | U < sort_poly_elab.32 *)
 exfalso@{α ; u} : forall (A : Type@{α ; u}) (_ : False), A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 exfalso is universe polymorphic
 Arguments exfalso A%_type_scope H
@@ -61,7 +61,7 @@ Expands to: Constant sort_poly_elab.Reduction.exfalso
 Declared in library sort_poly_elab, line 32, characters 13-20
 iter@{α ; u} :
 forall (A : Type@{α ; u}) (_ : forall _ : A, A) (_ : nat) (_ : A), A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 iter is universe polymorphic
 Arguments iter A%_type_scope f%_function_scope n%_nat_scope x
@@ -69,7 +69,7 @@ iter is transparent
 Expands to: Constant sort_poly_elab.Reduction.iter
 Declared in library sort_poly_elab, line 39, characters 11-15
 Box@{α α0 ; u} : forall _ : Type@{α ; u}, Type@{α0 ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 Box is universe polymorphic
 Box@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α0,
@@ -82,7 +82,7 @@ Expands to: Inductive sort_poly_elab.Conversion.Box
 Declared in library sort_poly_elab, line 54, characters 12-15
 t1@{α α0 ; u} :
 forall (A : Type@{α ; u}) (_ : A) (_ : A), Box@{α α0 ; u} A
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 t1 is universe polymorphic
 Arguments t1 A%_type_scope x y
@@ -91,7 +91,7 @@ Expands to: Constant sort_poly_elab.Conversion.t1
 Declared in library sort_poly_elab, line 58, characters 13-15
 t2@{α α0 ; u} :
 forall (A : Type@{α ; u}) (_ : A) (_ : A), Box@{α α0 ; u} A
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 t2 is universe polymorphic
 Arguments t2 A%_type_scope x y
@@ -99,7 +99,7 @@ t2 is transparent
 Expands to: Constant sort_poly_elab.Conversion.t2
 Declared in library sort_poly_elab, line 62, characters 13-15
 t1'@{α ; u} : forall (A : Type@{α ; u}) (_ : A) (_ : A), A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 t1' is universe polymorphic
 Arguments t1' A%_type_scope x y
@@ -107,7 +107,7 @@ t1' is transparent
 Expands to: Constant sort_poly_elab.Conversion.t1'
 Declared in library sort_poly_elab, line 66, characters 13-16
 t2'@{α ; u} : forall (A : Type@{α ; u}) (_ : A) (_ : A), A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 t2' is universe polymorphic
 Arguments t2' A%_type_scope x y
@@ -154,7 +154,7 @@ fun A : SProp =>
        @eq (forall (_ : A) (_ : A), Box@{SProp Type ; sort_poly_elab.62} A)
          (t1@{SProp Type ; sort_poly_elab.62} A)
          (t2@{SProp Type ; sort_poly_elab.62} A)
-(* {sort_poly_elab.64 sort_poly_elab.63 sort_poly_elab.62 sort_poly_elab.61} |=
+(* {sort_poly_elab.64 sort_poly_elab.63 sort_poly_elab.62 sort_poly_elab.61} |
      sort_poly_elab.62 <= sort_poly_elab.61
      sort_poly_elab.62 <= sort_poly_elab.64
      sort_poly_elab.63 = sort_poly_elab.62
@@ -163,7 +163,7 @@ Minimized universes:
  sort_poly_elab.63 := sort_poly_elab.62
  sort_poly_elab.61 := sort_poly_elab.62
 Normalized constraints:
- {sort_poly_elab.62} |=  *)
+ {sort_poly_elab.62} |  *)
 fun A : SProp =>
 @eq_refl (Box@{SProp Type ; sort_poly_elab.66} (forall (_ : A) (_ : A), A))
   (box@{SProp Type ; sort_poly_elab.66} (forall (_ : A) (_ : A), A)
@@ -181,7 +181,7 @@ fun A : SProp =>
          (box@{SProp Type ; sort_poly_elab.66} (forall (_ : A) (_ : A), A)
             (t2'@{SProp ; sort_poly_elab.69} A))
 (* {sort_poly_elab.70 sort_poly_elab.69 sort_poly_elab.68 sort_poly_elab.67
-    sort_poly_elab.66 sort_poly_elab.65} |=
+    sort_poly_elab.66 sort_poly_elab.65} |
      sort_poly_elab.66 <= sort_poly_elab.65
      sort_poly_elab.66 <= sort_poly_elab.70
      sort_poly_elab.68 = sort_poly_elab.66
@@ -190,9 +190,9 @@ Minimized universes:
  sort_poly_elab.68 := sort_poly_elab.66
  sort_poly_elab.65 := sort_poly_elab.66
 Normalized constraints:
- {sort_poly_elab.69 sort_poly_elab.67 sort_poly_elab.66} |=  *)
+ {sort_poly_elab.69 sort_poly_elab.67 sort_poly_elab.66} |  *)
 ignore@{α ; u} : forall {A : Type@{α ; u}} (_ : A), unit
-(* α ; u |=  *)
+(* α ; u |  *)
 
 ignore is universe polymorphic
 Arguments ignore {A}%_type_scope x
@@ -206,7 +206,7 @@ forall A : Type@{α1 ; u},
      (t1@{α1 α ; u} A))
   (@ignore@{α0 ; u} (forall (_ : A) (_ : A), Box@{α1 α0 ; u} A)
      (t2@{α1 α0 ; u} A))
-(* α α0 α1 ; u |=  *)
+(* α α0 α1 ; u |  *)
 
 unfold_ignore is universe polymorphic
 Arguments unfold_ignore A%_type_scope
@@ -215,7 +215,7 @@ Expands to: Constant sort_poly_elab.Conversion.unfold_ignore
 Declared in library sort_poly_elab, line 95, characters 13-26
 t@{α ; u} :
 forall (A : SProp) (_ : A) (_ : A), Box@{SProp α ; u} A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 t is universe polymorphic
 Arguments t A%_type_scope x y
@@ -223,7 +223,7 @@ t is transparent
 Expands to: Constant sort_poly_elab.Conversion.t
 Declared in library sort_poly_elab, line 104, characters 13-14
 v@{α ; u} : forall (A : Type@{α ; u}) (_ : bool), A
-(* α ; u |=  *)
+(* α ; u |  *)
 
 v is universe polymorphic
 Arguments v A%_type_scope _%_bool_scope
@@ -244,7 +244,7 @@ x : P (v@{SProp ; sort_poly_elab.92} A false)
          (_ : P (v@{SProp ; sort_poly_elab.90} A true)),
        P (v@{SProp ; sort_poly_elab.92} A false)
 (* {α63}; {sort_poly_elab.92 sort_poly_elab.91 sort_poly_elab.90
-           sort_poly_elab.89 sort_poly_elab.88 sort_poly_elab.87} |=
+           sort_poly_elab.89 sort_poly_elab.88 sort_poly_elab.87} |
      sort_poly_elab.91 < sort_poly_elab.89
      sort_poly_elab.88 <= sort_poly_elab.87
      sort_poly_elab.89 <= sort_poly_elab.87
@@ -254,9 +254,9 @@ Minimized universes:
  sort_poly_elab.89 := sort_poly_elab.91+1
  sort_poly_elab.87 := max(sort_poly_elab.88, sort_poly_elab.91+1)
 Normalized constraints:
- {sort_poly_elab.92 sort_poly_elab.91 sort_poly_elab.90 sort_poly_elab.88} |=  *)
+ {sort_poly_elab.92 sort_poly_elab.91 sort_poly_elab.90 sort_poly_elab.88} |  *)
 zog@{α ; u} : forall _ : Type@{α ; u}, Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 zog is universe polymorphic
 Arguments zog A%_type_scope
@@ -264,7 +264,7 @@ zog is transparent
 Expands to: Constant sort_poly_elab.Inference.zog
 Declared in library sort_poly_elab, line 118, characters 13-16
 zag@{α ; u} : forall _ : Type@{α ; u}, Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 zag is universe polymorphic
 Arguments zag A%_type_scope
@@ -272,7 +272,7 @@ zag is transparent
 Expands to: Constant sort_poly_elab.Inference.zag
 Declared in library sort_poly_elab, line 123, characters 13-16
 zig@{α ; u} : forall _ : Type@{α ; u}, Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 zig is universe polymorphic
 Arguments zig A%_type_scope
@@ -288,7 +288,7 @@ The term "A" has type "Type@{s ; Set}" while it is expected to have type
 (universe inconsistency: Cannot enforce Type@{s; Set} <= 
 Type@{s'; Set}).
 implicit@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 implicit is universe polymorphic
 implicit@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -299,7 +299,7 @@ implicit@{α ; u} may only be eliminated to produce values whose type is in sort
 Expands to: Inductive sort_poly_elab.Inductives.implicit
 Declared in library sort_poly_elab, line 137, characters 12-20
 foo1@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo1 is universe polymorphic
 foo1@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -318,7 +318,7 @@ The command has indeed failed with message:
 Elimination constraints are not implied by the ones declared: 
 s -> Prop
 foo1_False@{s ; u} : forall _ : foo1@{s ; u}, False
-(* s ; u |= s -> Prop *)
+(* s ; u | s -> Prop *)
 
 foo1_False is universe polymorphic
 Arguments foo1_False x
@@ -326,7 +326,7 @@ foo1_False is transparent
 Expands to: Constant sort_poly_elab.Inductives.foo1_False
 Declared in library sort_poly_elab, line 152, characters 13-23
 foo1_False'@{α ; u} : forall _ : foo1@{α ; u}, False
-(* α ; u |= α -> Prop *)
+(* α ; u | α -> Prop *)
 
 foo1_False' is universe polymorphic
 Arguments foo1_False' x
@@ -334,7 +334,7 @@ foo1_False' is transparent
 Expands to: Constant sort_poly_elab.Inductives.foo1_False'
 Declared in library sort_poly_elab, line 157, characters 13-24
 foo2@{α ; u} : Type@{α ; u+1}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo2 is universe polymorphic
 foo2@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -349,7 +349,7 @@ The command has indeed failed with message:
 The reference foo2_rect was not found in the current environment.
 Did you mean bool_rect, sig2_rect, prod_rect, ex2_rect or bool_rec?
 foo3@{α α0 ; u} : forall _ : Type@{α0 ; u}, Type@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 foo3 is universe polymorphic
 foo3@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -365,7 +365,7 @@ The command has indeed failed with message:
 The reference foo3_rect was not found in the current environment.
 Did you mean bool_rect, prod_rect or bool_rec?
 foo5@{α ; u} : forall _ : Type@{α ; u}, Prop
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo5 is universe polymorphic
 foo5@{α ; u} may only be eliminated to produce values whose type is SProp or Prop,
@@ -377,7 +377,7 @@ foo5_ind'@{α ; u} :
 forall (A : Type@{α ; u}) (P : Prop) (_ : forall _ : A, P)
   (_ : foo5@{α ; u} A),
 P
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo5_ind' is universe polymorphic
 Arguments foo5_ind' (A P)%_type_scope _%_function_scope _
@@ -388,7 +388,7 @@ foo5_Prop_rect@{α ; u} :
 forall (A : Prop) (P : forall _ : foo5@{Prop ; Set} A, Type@{α ; u})
   (_ : forall a : A, P (Foo5@{Prop ; Set} A a)) (f : foo5@{Prop ; Set} A),
 P f
-(* α ; u |= Prop -> α *)
+(* α ; u | Prop -> α *)
 
 foo5_Prop_rect is universe polymorphic
 Arguments foo5_Prop_rect A%_type_scope (P H)%_function_scope f
@@ -399,7 +399,7 @@ foo5_Prop_rect'@{α ; u} :
 forall (A : Prop) (P : forall _ : foo5@{Prop ; Set} A, Type@{α ; u})
   (_ : forall a : A, P (Foo5@{Prop ; Set} A a)) (f : foo5@{Prop ; Set} A),
 P f
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo5_Prop_rect' is universe polymorphic
 Arguments foo5_Prop_rect' A%_type_scope (P H)%_function_scope f
@@ -407,7 +407,7 @@ foo5_Prop_rect' is transparent
 Expands to: Constant sort_poly_elab.Inductives.foo5_Prop_rect'
 Declared in library sort_poly_elab, line 193, characters 13-28
 foo6@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 foo6 is universe polymorphic
 foo6@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -426,7 +426,7 @@ foo6_rect@{α α0 ; u u0} :
 forall (P : forall _ : foo6@{α ; u}, Type@{α0 ; u0}) 
   (_ : P Foo6@{α ; u}) (f : foo6@{α ; u}),
 P f
-(* α α0 ; u u0 |= α -> α0 *)
+(* α α0 ; u u0 | α -> α0 *)
 
 foo6_rect is universe polymorphic
 Arguments foo6_rect P%_function_scope H f
@@ -437,7 +437,7 @@ foo6_prop_rect@{α ; u u0} :
 forall (P : forall _ : foo6@{Prop ; u}, Type@{α ; u0})
   (_ : P Foo6@{Prop ; u}) (f : foo6@{Prop ; u}),
 P f
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 foo6_prop_rect is universe polymorphic
 Arguments foo6_prop_rect P%_function_scope H f
@@ -448,7 +448,7 @@ foo6_type_rect@{α ; u u0} :
 forall (P : forall _ : foo6@{Type ; u}, Type@{α ; u0})
   (_ : P Foo6@{Type ; u}) (f : foo6@{Type ; u}),
 P f
-(* α ; u u0 |=  *)
+(* α ; u u0 |  *)
 
 foo6_type_rect is universe polymorphic
 Arguments foo6_type_rect P%_function_scope H f
@@ -456,7 +456,7 @@ foo6_type_rect is transparent
 Expands to: Constant sort_poly_elab.Inductives.foo6_type_rect
 Declared in library sort_poly_elab, line 227, characters 13-27
 foo7@{α ; } : Type@{α ; Set}
-(* α ;  |=  *)
+(* α ;  |  *)
 
 foo7 is universe polymorphic
 foo7@{α ; } may only be eliminated to produce values whose type is in sort quality α,
@@ -490,7 +490,7 @@ forall (P : forall _ : foo7@{Prop ; }, Type@{α ; u})
   (_ : P Foo7_1@{Prop ; }) (_ : P Foo7_2@{Prop ; }) 
   (f : foo7@{Prop ; }),
 P f
-(* α ; u |= Prop -> α *)
+(* α ; u | Prop -> α *)
 
 foo7_prop_rect is universe polymorphic
 Arguments foo7_prop_rect P%_function_scope H H' f
@@ -500,7 +500,7 @@ Declared in library sort_poly_elab, line 248, characters 13-27
 sigma@{α α0 α1 ; u u0} :
 forall (A : Type@{α ; u}) (_ : forall _ : A, Type@{α0 ; u0}),
 Type@{α1 ; max(u,u0)}
-(* α α0 α1 ; u u0 |=  *)
+(* α α0 α1 ; u u0 |  *)
 
 sigma is universe polymorphic
 sigma@{α α0 α1 ; u u0} may only be eliminated to produce values whose type is in sort quality α1,
@@ -517,7 +517,7 @@ forall (A : Type@{α0 ; u}) (B : forall _ : A, Type@{α1 ; u0})
   (_ : forall (x : A) (b : B x), P (pair@{α0 α1 α ; u u0} A B x b))
   (s : sigma@{α0 α1 α ; u u0} A B),
 P s
-(* α α0 α1 α2 ; u u0 u1 |= α -> α2 *)
+(* α α0 α1 α2 ; u u0 u1 | α -> α2 *)
 
 sigma_srect is universe polymorphic
 Arguments sigma_srect A%_type_scope (B P H)%_function_scope s
@@ -528,7 +528,7 @@ pr1@{α α0 α1 ; u u0} :
 forall {A : Type@{α1 ; u}} {B : forall _ : A, Type@{α ; u0}}
   (_ : sigma@{α1 α α0 ; u u0} A B),
 A
-(* α α0 α1 ; u u0 |= α0 -> α1 *)
+(* α α0 α1 ; u u0 | α0 -> α1 *)
 
 pr1 is universe polymorphic
 Arguments pr1 {A}%_type_scope {B}%_function_scope s
@@ -539,8 +539,8 @@ pr2@{α α0 α1 ; u u0} :
 forall {A : Type@{α1 ; u}} {B : forall _ : A, Type@{α ; u0}}
   (s : sigma@{α1 α α0 ; u u0} A B),
 B (@pr1@{α α0 α1 ; u u0} A B s)
-(* α α0 α1 ; u u0 |= α0 -> α
-                     α0 -> α1 *)
+(* α α0 α1 ; u u0 | α0 -> α
+                    α0 -> α1 *)
 
 pr2 is universe polymorphic
 Arguments pr2 {A}%_type_scope {B}%_function_scope s
@@ -549,7 +549,7 @@ Expands to: Constant sort_poly_elab.Inductives.pr2
 Declared in library sort_poly_elab, line 278, characters 13-16
 π2 not a defined object.
 seq@{α ; u} : forall (A : Type@{α ; u}) (_ : A) (_ : A), Prop
-(* α ; u |=  *)
+(* α ; u |  *)
 
 seq is universe polymorphic
 Arguments seq A%_type_scope a _
@@ -561,11 +561,11 @@ forall (A : Type@{α1 ; u0}) (B : forall _ : A, Type@{α ; u1})
 seq@{α0 ; u} (sigma@{α1 α α0 ; u0 u1} A B) s
   (pair@{α1 α α0 ; u0 u1} A B (@pr1@{α α0 α1 ; u0 u1} A B s)
      (@pr2@{α α0 α1 ; u0 u1} A B s))
-(* α α0 α1 ; u u0 u1 |= α0 -> α
-                        α0 -> α1
-                        α0 -> Prop,
-                        u0 <= u
-                        u1 <= u *)
+(* α α0 α1 ; u u0 u1 | α0 -> α
+                       α0 -> α1
+                       α0 -> Prop,
+                       u0 <= u
+                       u1 <= u *)
 
 eta is universe polymorphic
 Arguments eta A%_type_scope B%_function_scope s
@@ -574,7 +574,7 @@ Expands to: Constant sort_poly_elab.Inductives.eta
 Declared in library sort_poly_elab, line 298, characters 13-16
 sum@{α α0 α1 ; u u0} :
 forall (_ : Type@{α ; u}) (_ : Type@{α0 ; u0}), Type@{α1 ; max(Set,u,u0)}
-(* α α0 α1 ; u u0 |=  *)
+(* α α0 α1 ; u u0 |  *)
 
 sum is universe polymorphic
 sum@{α α0 α1 ; u u0} may only be eliminated to produce values whose type is in sort quality α1,
@@ -596,7 +596,7 @@ forall (A : Type@{α0 ; u}) (B : Type@{α1 ; u0})
   (_ : forall b : B, P (@inr@{α0 α1 α ; u u0} A B b))
   (x : sum@{α0 α1 α ; u u0} A B),
 P x
-(* α α0 α1 α2 ; u u0 u1 |= α -> α2 *)
+(* α α0 α1 α2 ; u u0 u1 | α -> α2 *)
 
 sum_elim is universe polymorphic
 Arguments sum_elim (A B)%_type_scope (P fl fr)%_function_scope x
@@ -612,7 +612,7 @@ idT@{α α0 α1 ; u u0} :
 forall (A : Type@{α0 ; u}) (B : Type@{α1 ; u0})
   (_ : sum@{α0 α1 α ; u u0} A B),
 sum@{α0 α1 Type ; u u0} A B
-(* α α0 α1 ; u u0 |= α -> Type *)
+(* α α0 α1 ; u u0 | α -> Type *)
 
 idT is universe polymorphic
 Arguments idT (A B)%_type_scope x
@@ -623,7 +623,7 @@ idP@{α α0 α1 ; u u0} :
 forall (A : Type@{α0 ; u}) (B : Type@{α1 ; u0})
   (_ : sum@{α0 α1 α ; u u0} A B),
 sum@{α0 α1 Prop ; u u0} A B
-(* α α0 α1 ; u u0 |= α -> Prop *)
+(* α α0 α1 ; u u0 | α -> Prop *)
 
 idP is universe polymorphic
 Arguments idP (A B)%_type_scope x
@@ -634,7 +634,7 @@ idS@{α α0 α1 ; u u0} :
 forall (A : Type@{α0 ; u}) (B : Type@{α1 ; u0})
   (_ : sum@{α0 α1 α ; u u0} A B),
 sum@{α0 α1 SProp ; u u0} A B
-(* α α0 α1 ; u u0 |= α -> SProp *)
+(* α α0 α1 ; u u0 | α -> SProp *)
 
 idS is universe polymorphic
 Arguments idS (A B)%_type_scope x
@@ -645,7 +645,7 @@ idV@{α α0 α1 α2 ; u u0} :
 forall (A : Type@{α1 ; u}) (B : Type@{α2 ; u0})
   (_ : sum@{α1 α2 α ; u u0} A B),
 sum@{α1 α2 α0 ; u u0} A B
-(* α α0 α1 α2 ; u u0 |= α -> α0 *)
+(* α α0 α1 α2 ; u u0 | α -> α0 *)
 
 idV is universe polymorphic
 Arguments idV (A B)%_type_scope x
@@ -659,7 +659,7 @@ because it would identify Type and Prop which is inconsistent.
 This is introduced by the constraints Prop -> Type
 list@{α α0 ; u} :
 forall _ : Type@{α ; u}, Type@{α0 ; max(Set,u)}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 list is universe polymorphic
 list@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α0,
@@ -677,7 +677,7 @@ forall (A : Type@{α0 ; u}) (P : forall _ : list@{α0 α ; u} A, Type@{α1 ; u0}
        P (@cons@{α0 α ; u} A x l))
   (l : list@{α0 α ; u} A),
 P l
-(* α α0 α1 ; u u0 |= α -> α1 *)
+(* α α0 α1 ; u u0 | α -> α1 *)
 
 list_elim is universe polymorphic
 Arguments list_elim A%_type_scope P%_function_scope fn fc%_function_scope l
@@ -686,7 +686,7 @@ Expands to: Constant sort_poly_elab.Inductives.list_elim
 Declared in library sort_poly_elab, line 408, characters 13-22
 list_idT@{α α0 ; u} :
 forall {A : Type@{α0 ; u}} (_ : list@{α0 α ; u} A), list@{α0 Type ; u} A
-(* α α0 ; u |= α -> Type *)
+(* α α0 ; u | α -> Type *)
 
 list_idT is universe polymorphic
 Arguments list_idT {A}%_type_scope l
@@ -695,7 +695,7 @@ Expands to: Constant sort_poly_elab.Inductives.list_idT
 Declared in library sort_poly_elab, line 419, characters 11-19
 list_idP@{α α0 ; u} :
 forall {A : Type@{α0 ; u}} (_ : list@{α0 α ; u} A), list@{α0 Prop ; u} A
-(* α α0 ; u |= α -> Prop *)
+(* α α0 ; u | α -> Prop *)
 
 list_idP is universe polymorphic
 Arguments list_idP {A}%_type_scope l
@@ -704,7 +704,7 @@ Expands to: Constant sort_poly_elab.Inductives.list_idP
 Declared in library sort_poly_elab, line 427, characters 11-19
 list_idS@{α α0 ; u} :
 forall {A : Type@{α0 ; u}} (_ : list@{α0 α ; u} A), list@{α0 SProp ; u} A
-(* α α0 ; u |= α -> SProp *)
+(* α α0 ; u | α -> SProp *)
 
 list_idS is universe polymorphic
 Arguments list_idS {A}%_type_scope l
@@ -715,7 +715,7 @@ map@{α α0 α1 α2 ; u u0} :
 forall (A : Type@{α2 ; u}) (B : Type@{α0 ; u0}) (_ : forall _ : A, B)
   (_ : list@{α2 α ; u} A),
 list@{α0 α1 ; u0} B
-(* α α0 α1 α2 ; u u0 |= α -> α1 *)
+(* α α0 α1 α2 ; u u0 | α -> α1 *)
 
 map is universe polymorphic
 Arguments map (A B)%_type_scope f%_function_scope l
@@ -723,7 +723,7 @@ map is transparent
 Expands to: Constant sort_poly_elab.Inductives.map
 Declared in library sort_poly_elab, line 443, characters 11-14
 False'@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 False' is universe polymorphic
 False'@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -735,7 +735,7 @@ Expands to: Inductive sort_poly_elab.Inductives.False'
 Declared in library sort_poly_elab, line 457, characters 12-18
 False'_False@{α ; u} :
 forall _ : False'@{α ; u}, False
-(* α ; u |= α -> Prop *)
+(* α ; u | α -> Prop *)
 
 False'_False is universe polymorphic
 Arguments False'_False x
@@ -743,7 +743,7 @@ False'_False is transparent
 Expands to: Constant sort_poly_elab.Inductives.False'_False
 Declared in library sort_poly_elab, line 461, characters 13-25
 bool@{α ; } : Type@{α ; Set}
-(* α ;  |=  *)
+(* α ;  |  *)
 
 bool is universe polymorphic
 bool@{α ; } may only be eliminated to produce values whose type is in sort quality α,
@@ -754,7 +754,7 @@ bool@{α ; } may only be eliminated to produce values whose type is in sort qual
 Expands to: Inductive sort_poly_elab.Inductives.bool
 Declared in library sort_poly_elab, line 468, characters 12-16
 bool_to_Prop@{α ; } : forall _ : bool@{α ; }, Prop
-(* α ;  |= α -> Type *)
+(* α ;  | α -> Type *)
 
 bool_to_Prop is universe polymorphic
 Arguments bool_to_Prop b
@@ -763,7 +763,7 @@ Expands to: Constant sort_poly_elab.Inductives.bool_to_Prop
 Declared in library sort_poly_elab, line 471, characters 13-25
 bool_to_True_conj@{α ; } :
 forall _ : bool@{α ; }, or True True
-(* α ;  |= α -> Prop *)
+(* α ;  | α -> Prop *)
 
 bool_to_True_conj is universe polymorphic
 Arguments bool_to_True_conj b
@@ -771,7 +771,7 @@ bool_to_True_conj is transparent
 Expands to: Constant sort_poly_elab.Inductives.bool_to_True_conj
 Declared in library sort_poly_elab, line 480, characters 13-30
 bool_to_Prop'@{α ; } : forall _ : bool@{α ; }, Prop
-(* α ;  |= α -> Type *)
+(* α ;  | α -> Type *)
 
 bool_to_Prop' is universe polymorphic
 Arguments bool_to_Prop' b
@@ -795,13 +795,13 @@ match true@{Test ; } return testind'@{Test ; } with
 | false => testctor'@{Test ; }
 end
      : testind'@{Test ; }
-(* {sort_poly_elab.354} |= Set <= sort_poly_elab.354
+(* {sort_poly_elab.354} | Set <= sort_poly_elab.354
 Minimized universes:
  sort_poly_elab.354 := Set
 Normalized constraints:
   *)
 unit@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 unit is universe polymorphic
 unit@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -812,7 +812,7 @@ unit@{α ; u} may only be eliminated to produce values whose type is in sort qua
 Expands to: Inductive sort_poly_elab.Inductives.unit
 Declared in library sort_poly_elab, line 518, characters 12-16
 FooNat@{α ; } : Type@{α ; Set}
-(* α ;  |=  *)
+(* α ;  |  *)
 
 FooNat is universe polymorphic
 FooNat@{α ; } may only be eliminated to produce values whose type is in sort quality α,
@@ -824,7 +824,7 @@ Expands to: Inductive sort_poly_elab.Inductives.FooNat
 Declared in library sort_poly_elab, line 526, characters 12-18
 Foo@{α α0 ; } :
 forall _ : FooNat@{α ; }, FooNat@{α0 ; }
-(* α α0 ;  |= α -> α0 *)
+(* α α0 ;  | α -> α0 *)
 
 Foo is universe polymorphic
 Arguments Foo n
@@ -833,7 +833,7 @@ Expands to: Constant sort_poly_elab.Inductives.Foo
 Declared in library sort_poly_elab, line 531, characters 13-16
 Foo@{Type Prop ; }
      : forall _ : FooNat@{Type ; }, FooNat@{Prop ; }
-(* {} |= Type -> Prop
+(* {} | Type -> Prop
 Normalized constraints:
   *)
 File "./output/sort_poly_elab.v", line 540, characters 2-30:
@@ -846,7 +846,7 @@ The command has indeed failed with message:
 The record R1 could not be defined as a primitive record because it has no
 projections. [non-primitive-record,records,default]
 R2@{α ; u} : forall _ : SProp, Type@{α ; u}
-(* α ; u |= α -> SProp *)
+(* α ; u | α -> SProp *)
 
 R2 is universe polymorphic
 R2 has primitive projections with eta conversion depending on sort instantiation.
@@ -855,7 +855,7 @@ Expands to: Inductive sort_poly_elab.Records.R2
 Declared in library sort_poly_elab, line 551, characters 9-11
 R3@{α α0 ; u} :
 forall _ : Type@{α ; u}, Type@{α0 ; u}
-(* α α0 ; u |= α0 -> α *)
+(* α α0 ; u | α0 -> α *)
 
 R3 is universe polymorphic
 R3 has primitive projections with eta conversion depending on sort instantiation.
@@ -863,7 +863,7 @@ Arguments R3 A%_type_scope
 Expands to: Inductive sort_poly_elab.Records.R3
 Declared in library sort_poly_elab, line 555, characters 9-11
 R4@{s ; } : forall _ : Type@{s ; Set}, Type@{s ; Set}
-(* s ;  |=  *)
+(* s ;  |  *)
 
 R4 is universe polymorphic
 R4 has primitive projections with eta conversion.
@@ -875,7 +875,7 @@ The command has indeed failed with message:
 The record R5 could not be defined as a primitive record because it is
 squashed. [non-primitive-record,records,default]
 R5@{α ; u} : forall _ : Type@{α ; u}, SProp
-(* α ; u |= SProp -> α *)
+(* α ; u | SProp -> α *)
 
 R5 is universe polymorphic
 R5@{α ; u} may only be eliminated to produce values whose type is SProp.
@@ -883,7 +883,7 @@ Arguments R5 A%_type_scope
 Expands to: Inductive sort_poly_elab.Records.R5
 Declared in library sort_poly_elab, line 566, characters 11-13
 R6@{s ; } : forall _ : Type@{s ; Set}, Set
-(* s ;  |=  *)
+(* s ;  |  *)
 
 R6 is universe polymorphic
 R6 has primitive projections with eta conversion.
@@ -902,7 +902,7 @@ fun (A : SProp) (x y : R6@{SProp ; } A) =>
          (Conversion.box@{SProp Type ; sort_poly_elab.365} A (R6f1 _ x))
          (Conversion.box@{SProp Type ; sort_poly_elab.365} A (R6f1 _ y))
 (* {sort_poly_elab.367 sort_poly_elab.366 sort_poly_elab.365
-    sort_poly_elab.364} |=
+    sort_poly_elab.364} |
      sort_poly_elab.365 <= sort_poly_elab.364
      sort_poly_elab.365 <= sort_poly_elab.367
      sort_poly_elab.366 = sort_poly_elab.365
@@ -911,7 +911,7 @@ Minimized universes:
  sort_poly_elab.366 := sort_poly_elab.365
  sort_poly_elab.364 := sort_poly_elab.365
 Normalized constraints:
- {sort_poly_elab.365} |=  *)
+ {sort_poly_elab.365} |  *)
 File "./output/sort_poly_elab.v", line 577, characters 10-17:
 The command has indeed failed with message:
 In environment
@@ -952,7 +952,7 @@ while it is expected to have type
 and "Conversion.box@{Type Type ; sort_poly_elab.373} nat (R6f2 _ y)").
 R7@{α α0 ; u} :
 forall _ : Type@{α ; u}, Type@{α0 ; max(Set,u)}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 R7 is universe polymorphic
 R7@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α0,
@@ -965,7 +965,7 @@ Expands to: Inductive sort_poly_elab.Records.R7
 Declared in library sort_poly_elab, line 582, characters 38-40
 R7f1@{α α0 ; u} :
 forall (A : Type@{α ; u}) (_ : R7@{α α0 ; u} A), A
-(* α α0 ; u |= α0 -> α *)
+(* α α0 ; u | α0 -> α *)
 
 R7f1 is universe polymorphic
 R7f1 is a projection of R7
@@ -975,7 +975,7 @@ Expands to: Constant sort_poly_elab.Records.R7f1
 Declared in library sort_poly_elab, line 582, characters 55-59
 R7f2@{α α0 ; u} :
 forall (A : Type@{α ; u}) (_ : R7@{α α0 ; u} A), nat
-(* α α0 ; u |= α0 -> Type *)
+(* α α0 ; u | α0 -> Type *)
 
 R7f2 is universe polymorphic
 R7f2 is a projection of R7
@@ -986,7 +986,7 @@ Declared in library sort_poly_elab, line 582, characters 65-69
 Rsigma@{s ; u v} :
 forall (A : Type@{s ; u}) (_ : forall _ : A, Type@{s ; v}),
 Type@{s ; max(u,v)}
-(* s ; u v |=  *)
+(* s ; u v |  *)
 
 Rsigma is universe polymorphic
 Rsigma has primitive projections with eta conversion.
@@ -999,7 +999,7 @@ forall (A : Type@{α ; u}) (B : forall _ : A, Type@{α ; u0})
   (_ : forall (x : A) (b : B x), P (Rpair@{α ; u u0} A B x b))
   (s : Rsigma@{α ; u u0} A B),
 P s
-(* α α0 ; u u0 u1 |=  *)
+(* α α0 ; u u0 u1 |  *)
 
 Rsigma_srect is universe polymorphic
 Arguments Rsigma_srect A%_type_scope (B P H)%_function_scope s
@@ -1008,7 +1008,7 @@ Expands to: Constant sort_poly_elab.Records.Rsigma_srect
 Declared in library sort_poly_elab, line 598, characters 13-25
 sexists@{α ; u} :
 forall (A : Type@{α ; u}) (_ : forall _ : A, Prop), Prop
-(* α ; u |=  *)
+(* α ; u |  *)
 
 sexists is universe polymorphic
 sexists@{α ; u} may only be eliminated to produce values whose type is SProp or Prop,
@@ -1022,13 +1022,13 @@ sexists_ind@{α410 ; sort_poly_elab.396}
          (_ : forall (a : A) (_ : B a), P)
          (_ : sexists@{α410 ; sort_poly_elab.396} A B),
        P
-(* {α410}; {sort_poly_elab.396} |= 
+(* {α410}; {sort_poly_elab.396} | 
 Collapsed sorts:
  α410 := Type
 Normalized constraints:
- {sort_poly_elab.396} |=  *)
+ {sort_poly_elab.396} |  *)
 R8@{α α0 ; u} : Type@{α ; u+1}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 R8 is universe polymorphic
 R8@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -1040,7 +1040,7 @@ Expands to: Inductive sort_poly_elab.Records.R8
 Declared in library sort_poly_elab, line 622, characters 9-11
 R8f1@{α α0 ; u} :
 forall _ : R8@{α α0 ; u}, Type@{α0 ; u}
-(* α α0 ; u |= α -> Type *)
+(* α α0 ; u | α -> Type *)
 
 R8f1 is universe polymorphic
 R8f1 is a projection of R8
@@ -1050,8 +1050,8 @@ Expands to: Constant sort_poly_elab.Records.R8f1
 Declared in library sort_poly_elab, line 623, characters 4-8
 R8f2@{α α0 ; u} :
 forall r : R8@{α α0 ; u}, R8f1@{α α0 ; u} r
-(* α α0 ; u |= α -> α0
-               α -> Type *)
+(* α α0 ; u | α -> α0
+              α -> Type *)
 
 R8f2 is universe polymorphic
 R8f2 is a projection of R8
@@ -1060,7 +1060,7 @@ R8f2 is transparent
 Expands to: Constant sort_poly_elab.Records.R8f2
 Declared in library sort_poly_elab, line 624, characters 4-8
 R9@{α α0 α1 ; } : Type@{α ; Set}
-(* α α0 α1 ;  |=  *)
+(* α α0 α1 ;  |  *)
 
 R9 is universe polymorphic
 R9@{α α0 α1 ; } may only be eliminated to produce values whose type is in sort quality α,
@@ -1072,7 +1072,7 @@ Expands to: Inductive sort_poly_elab.Records.R9
 Declared in library sort_poly_elab, line 642, characters 9-11
 R9f1@{α α0 α1 ; } :
 forall _ : R9@{α α0 α1 ; }, bool@{α0 ; }
-(* α α0 α1 ;  |= α -> α0 *)
+(* α α0 α1 ;  | α -> α0 *)
 
 R9f1 is universe polymorphic
 R9f1 is a projection of R9
@@ -1082,7 +1082,7 @@ Expands to: Constant sort_poly_elab.Records.R9f1
 Declared in library sort_poly_elab, line 643, characters 4-8
 R9f2@{α α0 α1 ; } :
 forall _ : R9@{α α0 α1 ; }, bool@{α1 ; }
-(* α α0 α1 ;  |= α -> α1 *)
+(* α α0 α1 ;  | α -> α1 *)
 
 R9f2 is universe polymorphic
 R9f2 is a projection of R9
@@ -1092,7 +1092,7 @@ Expands to: Constant sort_poly_elab.Records.R9f2
 Declared in library sort_poly_elab, line 644, characters 4-8
 R10@{α α0 α1 α2 ; u u0} :
 forall _ : Type@{α0 ; u}, Type@{α ; max(Set,u,u0)}
-(* α α0 α1 α2 ; u u0 |=  *)
+(* α α0 α1 α2 ; u u0 |  *)
 
 R10 is universe polymorphic
 R10@{α α0 α1 α2 ; u u0} may only be eliminated to produce values whose type is in sort quality α,
@@ -1105,7 +1105,7 @@ Expands to: Inductive sort_poly_elab.Records.R10
 Declared in library sort_poly_elab, line 656, characters 9-12
 R10f1@{α α0 α1 α2 ; u u0} :
 forall (A : Type@{α0 ; u}) (_ : R10@{α α0 α1 α2 ; u u0} A), A
-(* α α0 α1 α2 ; u u0 |= α -> α0 *)
+(* α α0 α1 α2 ; u u0 | α -> α0 *)
 
 R10f1 is universe polymorphic
 R10f1 is a projection of R10
@@ -1117,8 +1117,8 @@ R10f2@{α α0 α1 α2 ; u u0} :
 forall (A : Type@{α0 ; u}) (r : R10@{α α0 α1 α2 ; u u0} A),
 @eq@{α0 α1 ; u u0} A (R10f1@{α α0 α1 α2 ; u u0} A r)
   (R10f1@{α α0 α1 α2 ; u u0} A r)
-(* α α0 α1 α2 ; u u0 |= α -> α0
-                        α -> α1 *)
+(* α α0 α1 α2 ; u u0 | α -> α0
+                       α -> α1 *)
 
 R10f2 is universe polymorphic
 R10f2 is a projection of R10
@@ -1128,7 +1128,7 @@ Expands to: Constant sort_poly_elab.Records.R10f2
 Declared in library sort_poly_elab, line 658, characters 4-9
 R10f3@{α α0 α1 α2 ; u u0} :
 forall (A : Type@{α0 ; u}) (_ : R10@{α α0 α1 α2 ; u u0} A), bool@{α2 ; }
-(* α α0 α1 α2 ; u u0 |= α -> α2 *)
+(* α α0 α1 α2 ; u u0 | α -> α2 *)
 
 R10f3 is universe polymorphic
 R10f3 is a projection of R10
@@ -1138,8 +1138,8 @@ Expands to: Constant sort_poly_elab.Records.R10f3
 Declared in library sort_poly_elab, line 659, characters 4-9
 R11@{α α0 α1 α2 α3 α4 α5 ; u} :
 Type@{α ; Set}
-(* α α0 α1 α2 α3 α4 α5 ; u |= α0 -> α3
-                              α3 -> Type *)
+(* α α0 α1 α2 α3 α4 α5 ; u | α0 -> α3
+                             α3 -> Type *)
 
 R11 is universe polymorphic
 R11@{α α0 α1 α2 α3 α4 α5 ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -1151,9 +1151,9 @@ Expands to: Inductive sort_poly_elab.Records.R11
 Declared in library sort_poly_elab, line 675, characters 9-12
 R11f1@{α α0 α1 α2 α3 α4 α5 ; u} :
 forall _ : R11@{α α0 α1 α2 α3 α4 α5 ; u}, bool@{α3 ; }
-(* α α0 α1 α2 α3 α4 α5 ; u |= α -> α3
-                              α0 -> α3
-                              α3 -> Type *)
+(* α α0 α1 α2 α3 α4 α5 ; u | α -> α3
+                             α0 -> α3
+                             α3 -> Type *)
 
 R11f1 is universe polymorphic
 R11f1 is a projection of R11
@@ -1172,10 +1172,10 @@ match R10f3@{α0 α1 α2 α3 ; Set u} bool@{α1 ; } r0 return Type@{α4 ; Set} w
 | true => bool@{α4 ; }
 | false => bool@{α4 ; }
 end
-(* α α0 α1 α2 α3 α4 α5 ; u |= α -> α3
-                              α -> α4
-                              α0 -> α3
-                              α3 -> Type *)
+(* α α0 α1 α2 α3 α4 α5 ; u | α -> α3
+                             α -> α4
+                             α0 -> α3
+                             α3 -> Type *)
 
 R11f2 is universe polymorphic
 R11f2 is a projection of R11
@@ -1185,9 +1185,9 @@ Expands to: Constant sort_poly_elab.Records.R11f2
 Declared in library sort_poly_elab, line 677, characters 4-9
 R11f3@{α α0 α1 α2 α3 α4 α5 ; u} :
 forall _ : R11@{α α0 α1 α2 α3 α4 α5 ; u}, bool@{α5 ; }
-(* α α0 α1 α2 α3 α4 α5 ; u |= α -> α5
-                              α0 -> α3
-                              α3 -> Type *)
+(* α α0 α1 α2 α3 α4 α5 ; u | α -> α5
+                             α0 -> α3
+                             α3 -> Type *)
 
 R11f3 is universe polymorphic
 R11f3 is a projection of R11
@@ -1196,7 +1196,7 @@ R11f3 is transparent
 Expands to: Constant sort_poly_elab.Records.R11f3
 Declared in library sort_poly_elab, line 682, characters 4-9
 R12@{α α0 ; } : Type@{α ; Set}
-(* α α0 ;  |= α0 -> Type *)
+(* α α0 ;  | α0 -> Type *)
 
 R12 is universe polymorphic
 R12@{α α0 ; } may only be eliminated to produce values whose type is in sort quality α,
@@ -1208,8 +1208,8 @@ Expands to: Inductive sort_poly_elab.Records.R12
 Declared in library sort_poly_elab, line 701, characters 9-12
 R12f1@{α α0 ; } :
 forall _ : R12@{α α0 ; }, bool@{α0 ; }
-(* α α0 ;  |= α -> α0
-              α0 -> Type *)
+(* α α0 ;  | α -> α0
+             α0 -> Type *)
 
 R12f1 is universe polymorphic
 R12f1 is a projection of R12
@@ -1230,9 +1230,9 @@ match f' O return Set with
 | O => bool@{Type ; }
 | S _ => nat
 end
-(* α α0 ;  |= α -> α0
-              α -> Type
-              α0 -> Type *)
+(* α α0 ;  | α -> α0
+             α -> Type
+             α0 -> Type *)
 
 R12f2 is universe polymorphic
 R12f2 is a projection of R12
@@ -1242,9 +1242,9 @@ Expands to: Constant sort_poly_elab.Records.R12f2
 Declared in library sort_poly_elab, line 703, characters 4-9
 R13@{α α0 α1 α2 ; u u0} :
 Type@{α ; max(Set,u+1,u0+1)}
-(* α α0 α1 α2 ; u u0 |= α1 -> Type
-                        α2 -> Type,
-                        u0 <= u *)
+(* α α0 α1 α2 ; u u0 | α1 -> Type
+                       α2 -> Type,
+                       u0 <= u *)
 
 R13 is universe polymorphic
 R13@{α α0 α1 α2 ; u u0} may only be eliminated to produce values whose type is in sort quality α,
@@ -1256,10 +1256,10 @@ Expands to: Inductive sort_poly_elab.Records.R13
 Declared in library sort_poly_elab, line 718, characters 9-12
 R13f1@{α α0 α1 α2 ; u u0} :
 forall _ : R13@{α α0 α1 α2 ; u u0}, Type@{α0 ; u}
-(* α α0 α1 α2 ; u u0 |= α -> Type
-                        α1 -> Type
-                        α2 -> Type,
-                        u0 <= u *)
+(* α α0 α1 α2 ; u u0 | α -> Type
+                       α1 -> Type
+                       α2 -> Type,
+                       u0 <= u *)
 
 R13f1 is universe polymorphic
 R13f1 is a projection of R13
@@ -1269,10 +1269,10 @@ Expands to: Constant sort_poly_elab.Records.R13f1
 Declared in library sort_poly_elab, line 719, characters 4-9
 R13f2@{α α0 α1 α2 ; u u0} :
 forall _ : R13@{α α0 α1 α2 ; u u0}, Type@{α0 ; u0}
-(* α α0 α1 α2 ; u u0 |= α -> Type
-                        α1 -> Type
-                        α2 -> Type,
-                        u0 <= u *)
+(* α α0 α1 α2 ; u u0 | α -> Type
+                       α1 -> Type
+                       α2 -> Type,
+                       u0 <= u *)
 
 R13f2 is universe polymorphic
 R13f2 is a projection of R13
@@ -1282,10 +1282,10 @@ Expands to: Constant sort_poly_elab.Records.R13f2
 Declared in library sort_poly_elab, line 720, characters 4-9
 R13f3@{α α0 α1 α2 ; u u0} :
 forall _ : R13@{α α0 α1 α2 ; u u0}, bool@{α1 ; }
-(* α α0 α1 α2 ; u u0 |= α -> α1
-                        α1 -> Type
-                        α2 -> Type,
-                        u0 <= u *)
+(* α α0 α1 α2 ; u u0 | α -> α1
+                       α1 -> Type
+                       α2 -> Type,
+                       u0 <= u *)
 
 R13f3 is universe polymorphic
 R13f3 is a projection of R13
@@ -1303,12 +1303,12 @@ match b return Type@{α0 ; u} with
     end
 | false => bool@{α0 ; }
 end
-(* α α0 α1 α2 ; u u0 |= α -> α0
-                        α -> α1
-                        α -> Type
-                        α1 -> Type
-                        α2 -> Type,
-                        u0 <= u *)
+(* α α0 α1 α2 ; u u0 | α -> α0
+                       α -> α1
+                       α -> Type
+                       α1 -> Type
+                       α2 -> Type,
+                       u0 <= u *)
 
 R13f4 is universe polymorphic
 R13f4 is a projection of R13
@@ -1317,7 +1317,7 @@ R13f4 is transparent
 Expands to: Constant sort_poly_elab.Records.R13f4
 Declared in library sort_poly_elab, line 722, characters 4-9
 C1@{α α0 ; u} : forall _ : Type@{α ; u}, Type@{α0 ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1 is universe polymorphic
 C1@{α α0 ; u} may only be eliminated to produce values whose type is in sort quality α0,
@@ -1330,7 +1330,7 @@ Expands to: Inductive sort_poly_elab.Classes.C1
 Declared in library sort_poly_elab, line 757, characters 8-10
 C1f1@{α α0 ; u} :
 forall {A : Type@{α ; u}} {_ : C1@{α α0 ; u} A}, A
-(* α α0 ; u |= α0 -> α *)
+(* α α0 ; u | α0 -> α *)
 
 C1f1 is universe polymorphic
 C1f1 is a projection of C1
@@ -1339,41 +1339,41 @@ C1f1 is transparent
 Expands to: Constant sort_poly_elab.Classes.C1f1
 Declared in library sort_poly_elab, line 758, characters 4-8
 C1I1@{α α0 ; u} : C1@{α α0 ; u} unit@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1I1 is universe polymorphic
 C1I1 is transparent
 Expands to: Constant sort_poly_elab.Classes.C1I1
 Declared in library sort_poly_elab, line 765, characters 11-15
 C1ProgramI1@{α α0 ; u} : C1@{α α0 ; u} unit@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1ProgramI1 is universe polymorphic
 C1ProgramI1 is transparent
 Expands to: Constant sort_poly_elab.Classes.C1ProgramI1
 Declared in library sort_poly_elab, line 768, characters 19-30
 C1RefineI1@{α α0 ; u} : C1@{α α0 ; u} unit@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1RefineI1 is universe polymorphic
 C1RefineI1 is transparent
 Expands to: Constant sort_poly_elab.Classes.C1RefineI1
 Declared in library sort_poly_elab, line 775, characters 11-21
 C1InteractiveI1@{α α0 ; u} : C1@{α α0 ; u} unit@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1InteractiveI1 is universe polymorphic
 C1InteractiveI1 is transparent
 Expands to: Constant sort_poly_elab.Classes.C1InteractiveI1
 Declared in library sort_poly_elab, line 781, characters 11-26
 C1AxiomaticI1@{α α0 ; u} : C1@{α α0 ; u} unit@{α ; u}
-(* α α0 ; u |=  *)
+(* α α0 ; u |  *)
 
 C1AxiomaticI1 is universe polymorphic
 Expands to: Constant sort_poly_elab.Classes.C1AxiomaticI1
 Declared in library sort_poly_elab, line 785, characters 9-22
 C1InductiveI1@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 C1InductiveI1 is universe polymorphic
 C1InductiveI1@{α ; u} may only be eliminated to produce values whose type is in sort quality α,
@@ -1387,7 +1387,7 @@ File "./output/sort_poly_elab.v", line 798, characters 0-76:
 The command has indeed failed with message:
 Sort metavariables must be collapsed to Type in universe monomorphic constructions.
 Attr@{α ; u} : Type@{α ; u}
-(* α ; u |=  *)
+(* α ; u |  *)
 
 Attr is universe polymorphic
 Attr@{α ; u} may only be eliminated to produce values whose type is in sort quality α,

--- a/test-suite/output/sort_poly_elab.v
+++ b/test-suite/output/sort_poly_elab.v
@@ -150,13 +150,13 @@ Module Inductives.
 
   (* Explicitly allowing extending the constraints *)
   Definition foo1_False@{s;+|+} (x : foo1@{s;_}) : False := match x return False with end.
-  (* s ; u |= s -> Prop *)
+  (* s ; u | s -> Prop *)
   About foo1_False.
 
   (* Fully implicit qualities and constraints *)
   Definition foo1_False' (x : foo1) : False := match x return False with end.
   (* foo1_False'@{α ; u |} : foo1@{α ; u} -> False *)
-  (* α ; u |= α -> Prop *)
+  (* α ; u | α -> Prop *)
   About foo1_False'.
 
   Inductive foo2 := Foo2 : Type -> foo2.
@@ -185,9 +185,9 @@ Module Inductives.
     : P f
     := match f with Foo5 _ a => H a end.
   (* foo5_Prop_rect@{α ; u} :
-    forall (A : Prop) (P : foo5@{Prop ; Set} A -> Type@{α ; u}),
-    (forall a : A, P (Foo5@{Prop ; Set} A a)) -> forall f : foo5@{Prop ; Set} A, P f *)
-  (* α ; u |= Prop -> α *)
+    forall (A : Prop) (P : foo5@{Type ; Set} A -> Type@{α ; u}),
+    (forall a : A, P (Foo5@{Type ; Set} A a)) -> forall f : foo5@{Type ; Set} A, P f *)
+  (* α ; u | Prop -> α *)
   About foo5_Prop_rect.
 
   Definition foo5_Prop_rect' (A : Prop) (P : foo5 A -> Type)
@@ -198,7 +198,7 @@ Module Inductives.
   (* foo5_Prop_rect'@{α ; u} :
     forall (A : Prop) (P : foo5@{Prop ; Set} A -> Type@{α ; u}),
     (forall a : A, P (Foo5@{Prop ; Set} A a)) -> forall f : foo5@{Prop ; Set} A, P f *)
-  (* α ; u |=  *)
+  (* α ; u |  *)
   About foo5_Prop_rect'.
 
   Inductive foo6 : Type := Foo6.
@@ -212,7 +212,7 @@ Module Inductives.
     : P f
     := match f with Foo6 => H end.
   (* foo6_rect@{α α0 ; u u0} : forall P : foo6@{α0 ; u} -> Type@{α ; u0}, P Foo6@{α0 ; u} -> forall f : foo6@{α0 ; u}, P f *)
-  (* α α0 ; u u0 |= α0 -> α *)
+  (* α α0 ; u u0 | α0 -> α *)
   About foo6_rect.
 
   Definition foo6_prop_rect (P:foo6 -> Type)
@@ -221,7 +221,7 @@ Module Inductives.
     : P f
     := match f with Foo6 => H end.
   (* foo6_prop_rect@{α ; u u0} : forall P : foo6@{Prop ; u} -> Type@{α ; u0}, P Foo6@{Prop ; u} -> forall f : foo6@{Prop ; u}, P f *)
-  (* α ; u u0 |=  *)
+  (* α ; u u0 |  *)
   About foo6_prop_rect.
 
   Definition foo6_type_rect (P:foo6 -> Type)
@@ -230,7 +230,7 @@ Module Inductives.
     : P f
     := match f with Foo6 => H end.
   (* foo6_type_rect@{α ; u u0} : forall P : foo6@{Type ; u} -> Type@{α ; u0}, P Foo6@{Type ; u} -> forall f : foo6@{Type ; u}, P f *)
-  (* α ; u u0 |=  *)
+  (* α ; u u0 |  *)
   About foo6_type_rect.
 
   Inductive foo7 : Type := Foo7_1 | Foo7_2.
@@ -266,25 +266,25 @@ Module Inductives.
     (s:sigma A B)
     : P s
     := match s with pair _ _ x b => H x b end.
-  (* α α0 α1 α2 ; u u0 u1 |= α2 -> α *)
+  (* α α0 α1 α2 ; u u0 u1 | α2 -> α *)
   About sigma_srect.
 
   (* Elimination constraints are added *)
   Definition pr1 {A B} (s:sigma A B) : A
     := match s with pair _ _ x _ => x end.
-  (* α α0 α1 ; u u0 |= α1 -> α *)
+  (* α α0 α1 ; u u0 | α1 -> α *)
   About pr1.
 
   Definition pr2 {A B} (s:sigma A B) : B (pr1 s)
     := match s with pair _ _ _ y => y end.
-  (* α α0 α1 ; u u0 |= α1 -> α
+  (* α α0 α1 ; u u0 | α1 -> α
                        α1 -> α0 *)
   About pr2.
 
 
   Definition π1 {A:Type} {P:A -> Type} (p : sigma@{Type _ _;_ _} A P) : A :=
     match p return A with pair _ _ a _ => a end.
-  (* α α0 ; u u0 |= α0 -> Type *)
+  (* α α0 ; u u0 | α0 -> Type *)
   About π2.
 
   (*********************************************)
@@ -308,7 +308,7 @@ Module Inductives.
   | inl : A -> sum A B
   | inr : B -> sum A B.
   (* sum@{α α0 α1 ; u u0} : Type@{α ; u} -> Type@{α0 ; u0} -> Type@{α1 ; max(Set,u,u0)} *)
-  (* α α0 α1 ; u u0 |=  *)
+  (* α α0 α1 ; u u0 |  *)
   About sum.
 
   Arguments inl {A B} _ , [A] B _.
@@ -332,7 +332,7 @@ Module Inductives.
     | inl a => fl a
     | inr b => fr b
     end.
-  (* α α0 α1 α2 ; u u0 u1 |= α2 -> α *)
+  (* α α0 α1 α2 ; u u0 u1 | α2 -> α *)
   About sum_elim.
 
   Definition sum_sind := sum_elim@{Type Type Type SProp;_ _ _}.
@@ -359,7 +359,7 @@ Module Inductives.
     | inl a => inl a
     | inr b => inr b
     end.
-  (* α α0 α1 ; u u0 |= α -> Type *)
+  (* α α0 α1 ; u u0 | α -> Type *)
   About idT.
 
   (* Implicit qualities and constraints are elaborated *)
@@ -369,7 +369,7 @@ Module Inductives.
     | inl a => inl a
     | inr b => inr b
     end.
-  (* α α0 α1 ; u u0 |= α -> Prop *)
+  (* α α0 α1 ; u u0 | α -> Prop *)
   About idP.
 
   (* Implicit qualities and constraints are elaborated *)
@@ -379,7 +379,7 @@ Module Inductives.
     | inl a => inl a
     | inr b => inr b
     end.
-  (* α α0 α1 ; u u0 |= α -> Prop *)
+  (* α α0 α1 ; u u0 | α -> Prop *)
   About idS.
 
   (* Implicit qualities and constraints are elaborated *)
@@ -389,7 +389,7 @@ Module Inductives.
     | inl a => inl a
     | inr b => inr b
     end.
-  (* α α0 α1 α2 ; u u0 |= α -> α2 *)
+  (* α α0 α1 α2 ; u u0 | α -> α2 *)
   About idV.
 
   Fail Compute idV@{Prop Type Prop Type;Set Set} (inl I).
@@ -413,7 +413,7 @@ Module Inductives.
       | nil => fn
       | cons x l => fc x l (F l)
       end.
-  (* α α0 α1 ; u u0 |= α1 -> α *)
+  (* α α0 α1 ; u u0 | α1 -> α *)
   About list_elim.
 
   Fixpoint list_idT {A : Type} (l : list A) : list@{_ Type;_} A :=
@@ -421,7 +421,7 @@ Module Inductives.
     | nil => nil
     | cons x l => cons x (list_idT l)
     end.
-  (* α α0 ; u |= α -> Type *)
+  (* α α0 ; u | α -> Type *)
   About list_idT.
 
   Fixpoint list_idP {A : Type} (l : list A) : list@{_ Prop;_} A :=
@@ -429,7 +429,7 @@ Module Inductives.
     | nil => nil
     | cons x l => cons x (list_idP l)
     end.
-  (* α α0 ; u |= α -> Prop *)
+  (* α α0 ; u | α -> Prop *)
   About list_idP.
 
   Fixpoint list_idS {A : Type} (l : list A) : list@{_ SProp;_} A :=
@@ -437,7 +437,7 @@ Module Inductives.
     | nil => nil
     | cons x l => cons x (list_idS l)
     end.
-  (* α α0 ; u |= α -> SProp *)
+  (* α α0 ; u | α -> SProp *)
   About list_idS.
 
   Fixpoint map A B f (l : list A) : list B :=
@@ -448,7 +448,7 @@ Module Inductives.
   (* map@{α α0 α1 α2 ; u u0} :
       forall (A : Type@{α ; u}) (B : Type@{α1 ; u0}) (_ : forall _ : A, B)
       (_ : list@{α α0 ; u} A), list@{α1 α2 ; u0} B *)
-  (* α α0 α1 α2 ; u u0 |= α0 -> α2 *)
+  (* α α0 α1 α2 ; u u0 | α0 -> α2 *)
   About map.
 
   (*********************************************)
@@ -459,7 +459,7 @@ Module Inductives.
   About False'.
 
   Definition False'_False (x : False') : False := match x return False with end.
-  (* α ; u |= α -> Prop *)
+  (* α ; u | α -> Prop *)
   About False'_False.
 
   (*********************************************)
@@ -474,7 +474,7 @@ Module Inductives.
     - exact True.
     - exact False.
   Defined.
-  (* α ;  |= α -> Type *)
+  (* α ;  | α -> Type *)
   About bool_to_Prop.
 
   Definition bool_to_True_conj (b : bool) : True \/ True.
@@ -483,7 +483,7 @@ Module Inductives.
     - exact (or_introl I).
     - exact (or_intror I).
   Defined.
-  (* α ;  |= α -> Prop *)
+  (* α ;  | α -> Prop *)
   About bool_to_True_conj.
 
   (* Using Program *)
@@ -493,7 +493,7 @@ Module Inductives.
     - exact True.
     - exact False.
   Defined.
-  (* α ;  |= α -> Type *)
+  (* α ;  | α -> Type *)
   About bool_to_Prop'.
 
   #[universes(polymorphic=no)]
@@ -554,7 +554,7 @@ Module Records.
 
   Record R3 (A:Type) : Type := { R3f1 : A }.
   (* R3@{α α0 ; u} : forall _ : Type@{α ; u}, Type@{α0 ; u} *)
-  (* α α0 ; u |= α0 -> α *)
+  (* α α0 ; u | α0 -> α *)
   About R3.
 
   Record R4@{s; |} (A:Type@{s;Set}) : Type@{s;Set} := { R4f1 : A}.
@@ -565,7 +565,7 @@ Module Records.
   #[warnings="-non-primitive-record"]
     Record R5 (A:Type) : SProp := { R5f1 : A}.
   (* R5@{α ; u} : forall _ : Type@{α ; u}, SProp *)
-  (* α ; u |= SProp -> α *)
+  (* α ; u | SProp -> α *)
   About R5.
 
   Record R6@{s; |+} (A:Type@{s;Set}) : Set := { R6f1 : A; R6f2 : nat }.
@@ -582,9 +582,9 @@ Module Records.
   #[projections(primitive=no)] Record R7 (A:Type) := { R7f1 : A; R7f2 : nat }.
   (* Record R7@{α α0 ; u |} (A : Type@{α ; u}) : Type@{α0 ; max(Set,u)}  *)
   (* R7f1@{α α0 ; u |} : forall A : Type@{α ; u}, R7@{α α0 ; u} A -> A
-      α α0 ; u |= α0 -> α *)
+      α α0 ; u | α0 -> α *)
   (* R7f2@{α α0 ; u |} : forall A : Type@{α ; u}, R7@{α α0 ; u} A -> nat
-      α α0 ; u |= α0 -> Type *)
+      α α0 ; u | α0 -> Type *)
   About R7.
   About R7f1.
   About R7f2.
@@ -625,9 +625,9 @@ Module Records.
   }.
   (* Record R8@{α α0 ; u |} : Type@{α ; u+1}. *)
   (* R8f1@{α α0 ; u |} : R8@{α α0 ; u} -> Type@{α0 ; u}
-      α α0 ; u |= α -> Type *)
+      α α0 ; u | α -> Type *)
   (* R8f2@{α α0 ; u |} : forall r : R8@{α α0 ; u}, R8f1@{α α0 ; u} r
-      α α0 ; u |= α -> α0
+      α α0 ; u | α -> α0
                   α -> Type *)
   About R8.
   About R8f1.
@@ -645,9 +645,9 @@ Module Records.
   }.
   (* R9@{α α0 α1 ; } : Type@{α ; Set} *)
   (* R9f1@{α α0 α1 ; } : forall _ : R9@{α α0 α1 ; }, bool@{α0 ; } *)
-        (* α α0 α1 ;  |= α -> α0 *)
+        (* α α0 α1 ;  | α -> α0 *)
   (* R9f2@{α α0 α1 ; } : forall _ : R9@{α α0 α1 ; }, bool@{α1 ; } *)
-        (* α α0 α1 ;  |= α -> α1 *)
+        (* α α0 α1 ;  | α -> α1 *)
   About R9.
   About R9f1.
   About R9f2.
@@ -660,13 +660,13 @@ Module Records.
   }.
   (* R10@{α α0 α1 α2 ; u u0} : forall _ : Type@{α0 ; u}, Type@{α ; max(Set,u,u0)} *)
   (* R10f1@{α α0 α1 α2 ; u u0} : forall (A : Type@{α0 ; u}) (_ : R@{α α0 α1 α2 ; u u0} A), A *)
-     (* α α0 α1 α2 ; u u0 |= α -> α0 *)
+     (* α α0 α1 α2 ; u u0 | α -> α0 *)
   (* R10f2@{α α0 α1 α2 ; u u0} : forall (A : Type@{α0 ; u}) (r : R@{α α0 α1 α2 ; u u0} A),
                               @eq@{α0 α1 ; u u0} A (x@{α α0 α1 α2 ; u u0} A r) (x@{α α0 α1 α2 ; u u0} A r) *)
-     (* α α0 α1 α2 ; u u0 |= α -> α0
+     (* α α0 α1 α2 ; u u0 | α -> α0
                              α -> α1 *)
   (* R10f3@{α α0 α1 α2 ; u u0} : forall (A : Type@{α0 ; u}) (_ : R@{α α0 α1 α2 ; u u0} A), bool@{α2 ; } *)
-     (* α α0 α1 α2 ; u u0 |= α -> α2 *)
+     (* α α0 α1 α2 ; u u0 | α -> α2 *)
   About R10.
   About R10f1.
   About R10f2.
@@ -682,15 +682,15 @@ Module Records.
     R11f3 : bool
   }.
   (* R11@{α α0 α1 α2 α3 α4 α5 ; u} : Type@{α ; Set} *)
-       (* α α0 α1 α2 α3 α4 α5 ; u |= α0 -> α3
+       (* α α0 α1 α2 α3 α4 α5 ; u | α0 -> α3
                                      α3 -> Type *)
   (* R11f2 : ... *)
-    (* α α0 α1 α2 α3 α4 α5 ; u |= α -> α3
+    (* α α0 α1 α2 α3 α4 α5 ; u | α -> α3
                               α -> α4
                               α0 -> α3
                               α3 -> Type *)
   (* R11f3 : ... *)
-    (* α α0 α1 α2 α3 α4 α5 ; u |= α -> α5
+    (* α α0 α1 α2 α3 α4 α5 ; u | α -> α5
                               α0 -> α3
                               α3 -> Type *)
   About R11.
@@ -729,16 +729,16 @@ Module Records.
           end
     }.
    (* R13@{α α0 α1 α2 ; u u0} : Type@{α ; max(Set,u+1,u0+1)} *)
-       (* α α0 α1 α2 ; u u0 |= α1 -> Type
+       (* α α0 α1 α2 ; u u0 | α1 -> Type
                                α2 -> Type,
                                u0 <= u *)
   (* R13f3@{α α0 α1 α2 ; u u0} : forall _ : R'@{α α0 α1 α2 ; u u0}, bool@{α1 ; }  *)
-      (* α α0 α1 α2 ; u u0 |= α -> α1
+      (* α α0 α1 α2 ; u u0 | α -> α1
                               α1 -> Type
                               α2 -> Type,
                               u0 <= u *)
   (* R13f4@{α α0 α1 α2 ; u u0} : ... *)
-      (* α α0 α1 α2 ; u u0 |= α -> α0
+      (* α α0 α1 α2 ; u u0 | α -> α0
                               α -> α1
                               α -> Type
                               α1 -> Type

--- a/test-suite/output/unidecls.out
+++ b/test-suite/output/unidecls.out
@@ -90,7 +90,7 @@ Arg.u < Fn.v
 
 id@{unidecls.17} nat
      : nat -> nat
-(* {unidecls.17} |= Set <= unidecls.17
+(* {unidecls.17} | Set <= unidecls.17
 Minimized universes:
  unidecls.17 := Set
 Normalized constraints:


### PR DESCRIPTION
after discussions at Rocq n share, we changed the |= symbol to | when displaying universes constraints in accordance to the convention
For instance About returns (* α α0 α1 α2 ; u u0 u1 | α2 -> α *)