### PR TITLE
Implement `{| foo with fields |}` for terms

### DIFF
--- a/dev/ci/user-overlays/22207-SkySkimmer-record-with.sh
+++ b/dev/ci/user-overlays/22207-SkySkimmer-record-with.sh
@@ -1,0 +1,5 @@
+overlay tactician https://github.com/SkySkimmer/coq-tactician record-with 22207
+
+overlay quickchick https://github.com/SkySkimmer/QuickChick record-with 22207
+
+overlay rocq_lsp https://github.com/SkySkimmer/rocq-lsp record-with 22207

--- a/doc/changelog/02-specification-language/22207-record-with-Added.rst
+++ b/doc/changelog/02-specification-language/22207-record-with-Added.rst
@@ -2,4 +2,4 @@
   :n:`%{| @term1 with @record_declaration |%}` to provide default values for omitted fields in a record value
   (`#22207 <https://github.com/rocq-prover/rocq/pull/22207>`_,
   fixes `#14438 <https://github.com/rocq-prover/rocq/issues/14438>`_,
-  by Gaëtan Gilbert).
+  by Gaëtan Gilbert and Clément Pit-Claudel).

--- a/doc/changelog/02-specification-language/22207-record-with-Added.rst
+++ b/doc/changelog/02-specification-language/22207-record-with-Added.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  :n:`%{| @term1 with @record_declaration |%}` to provide default values for omitted fields in a record value
+  (`#22207 <https://github.com/rocq-prover/rocq/pull/22207>`_,
+  fixes `#14438 <https://github.com/rocq-prover/rocq/issues/14438>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -341,7 +341,7 @@ Command summary
       or :n:`@constructor` with a right-hand-side that
       is not itself a Class has no effect (apart from emitting this warning).
 
-.. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {* @field_val } %} | := @term } }
+.. cmd:: Instance {? @ident_decl {* @binder } } : @type {? @hint_info } {? {| := %{ {? @record_declaration } %} | := @term } }
 
    Declares a typeclass instance named :token:`ident_decl` of the typeclass
    :n:`@type` with the specified parameters and with

--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -261,7 +261,8 @@ Constructing records
    .. insertprodn term_record field_val
 
    .. prodn::
-      term_record ::= %{%| {? {+; @field_val } {? ; } } %|%}
+      term_record ::= %{%| {? @term1 with } {? @record_declaration } %|%}
+      record_declaration ::= {+; @field_val }
       field_val ::= @qualid {* @binder } := @term
 
    Instances of record types can be constructed using either *record form*
@@ -271,6 +272,7 @@ Constructing records
 
    In the record form, the fields can be given in any order.  Fields that can be
    inferred by unification or by using obligations (see :ref:`programs`) may be omitted.
+   If :n:`@term1 with` is provided, missing fields are taken from :n:`@term1`.
 
    In application form, all fields of the record must be passed, in order,
    as arguments to the constructor.

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -390,13 +390,17 @@ term1: [
 | MOVETO term_projection term1 ".(" "@" global univ_annot LIST0 ( term9 ) ")"
 ]
 
+full_record_declaration: [
+| DELETE test_record_nowith record_declaration
+| REPLACE term1 "with" record_declaration
+| WITH OPT [ term1 "with" ] record_declaration
+]
+
 term0: [
 | DELETE reference univ_annot
-| REPLACE "{|" record_declaration bar_cbrace
-| WITH "{|" OPT [ LIST1 field_def SEP ";" OPT ";" ] bar_cbrace
 | MOVETO number_or_string NUMBER
 | MOVETO number_or_string string
-| MOVETO term_record "{|" OPT [ LIST1 field_def SEP ";" OPT ";" ] bar_cbrace
+| MOVETO term_record "{|" full_record_declaration bar_cbrace
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"
 | MOVETO term_ltac "ltac" ":" "(" ltac_expr5 ")"
@@ -416,8 +420,8 @@ cofix_decls: [
 | WITH cofix_body OPT ( LIST1 ( "with" cofix_body ) "for" identref )
 ]
 
-fields_def: [
-| REPLACE field_def ";" fields_def
+record_declaration: [
+| REPLACE field_def ";" record_declaration
 | WITH LIST1 field_def SEP ";"
 | DELETE field_def
 ]
@@ -1626,13 +1630,6 @@ tac2type_body: [
 | DELETE "::=" tac2typ_knd      (* Ltac2 plugin *)
 ]
 
-record_declaration: [
-| DELETE fields_def
-| LIST0 field_def
-]
-
-fields_def: [ | DELETENT ]
-
 scheme: [
 | DELETE scheme_kind
 | REPLACE identref ":=" scheme_kind
@@ -2315,7 +2312,7 @@ SPLICE: [
 | mode
 | mult_pattern
 | open_constr
-| record_declaration
+| full_record_declaration
 | tactic
 | uconstr
 | impl_ident_head

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -139,7 +139,7 @@ term0: [
 | NUMBER
 | string
 | "(" term200 ")"
-| "{|" record_declaration bar_cbrace
+| "{|" full_record_declaration bar_cbrace
 | "`{" term200 "}"
 | test_array_opening "[" "|" array_elems "|" lconstr type_cstr test_array_closing "|" "]" univ_annot
 | "`(" term200 ")"
@@ -158,12 +158,13 @@ array_elems: [
 | LIST0 lconstr SEP ";"
 ]
 
-record_declaration: [
-| fields_def
+full_record_declaration: [
+| test_record_nowith record_declaration
+| term1 "with" record_declaration
 ]
 
-fields_def: [
-| field_def ";" fields_def
+record_declaration: [
+| field_def ";" record_declaration
 | field_def
 |
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -570,7 +570,11 @@ of_type_inst: [
 ]
 
 term_record: [
-| "{|" OPT [ LIST1 field_val SEP ";" OPT ";" ] "|}"
+| "{|" OPT [ term1 "with" ] OPT record_declaration "|}"
+]
+
+record_declaration: [
+| LIST1 field_val SEP ";"
 ]
 
 field_val: [
@@ -990,7 +994,7 @@ command: [
 | "Identity" "Coercion" ident ":" coercion_class ">->" coercion_class
 | "Coercion" reference OPT [ ":" coercion_class ">->" coercion_class ]
 | "Context" LIST1 binder
-| "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" LIST0 field_val "}" | ":=" term ]
+| "Instance" OPT ( ident_decl LIST0 binder ) ":" type OPT hint_info OPT [ ":=" "{" OPT record_declaration "}" | ":=" term ]
 | "Existing" "Instance" qualid OPT hint_info
 | "Existing" "Instances" LIST1 qualid OPT [ "|" natural ]
 | "Existing" "Class" qualid

--- a/interp/constrexpr.mli
+++ b/interp/constrexpr.mli
@@ -148,7 +148,7 @@ and constr_expr_r =
   | CApp     of constr_expr * (constr_expr * explicitation CAst.t option) list
   | CProj    of explicit_flag * (qualid * instance_expr option)
               * (constr_expr * explicitation CAst.t option) list * constr_expr
-  | CRecord  of (qualid * constr_expr) list
+  | CRecord  of constr_expr option * (qualid * constr_expr) list
 
   (* representation of the "let" and "match" constructs *)
   | CCases of Constr.case_style   (* determines whether this value represents "let" or "match" construct *)

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -224,10 +224,11 @@ module EqGen (A:sig val constr_expr_eq : constr_expr -> constr_expr -> bool end)
         Option.equal instance_expr_eq u1 u2 &&
         List.equal args_eq al1 al2 &&
         constr_expr_eq c1 c2
-      | CRecord l1, CRecord l2 ->
+      | CRecord (def1,l1), CRecord (def2,l2) ->
         let field_eq (r1, e1) (r2, e2) =
           qualid_eq r1 r2 && constr_expr_eq e1 e2
         in
+        Option.equal constr_expr_eq def1 def2 &&
         List.equal field_eq l1 l2
       | CCases(_,r1,a1,brl1), CCases(_,r2,a2,brl2) ->
         (* Don't care about the case_style *)
@@ -378,7 +379,9 @@ let fold_constr_expr_with_binders g f n acc = CAst.with_val (function
       List.fold_left (fun acc bl -> fold_local_binders g f n acc (CAst.make @@ CHole (None)) bl) acc bll
     | CGeneralization (_,c) -> f n acc c
     | CDelimiters (_,_,a) -> f n acc a
-    | CRecord l -> List.fold_left (fun acc (id, c) -> f n acc c) acc l
+    | CRecord (def,l) ->
+      let acc = Option.fold_left (f n) acc def in
+      List.fold_left (fun acc (id, c) -> f n acc c) acc l
     | CCases (sty,rtnpo,al,bl) ->
       let ids = ids_of_cases_tomatch al in
       let acc = Option.fold_left (f (Id.Set.fold g ids n)) acc rtnpo in
@@ -492,7 +495,7 @@ let map_constr_expr_with_binders g f e = CAst.map (function
                     List.map (fun bl -> snd (fold_map_local_binders f g e bl)) bll))
     | CGeneralization (b,c) -> CGeneralization (b,f e c)
     | CDelimiters (depth,s,a) -> CDelimiters (depth,s,f e a)
-    | CRecord l -> CRecord (List.map (fun (id, c) -> (id, f e c)) l)
+    | CRecord (def,l) -> CRecord (Option.map (f e) def, List.map (fun (id, c) -> (id, f e c)) l)
     | CCases (sty,rtnpo,a,bl) ->
       let bl = List.map (fun {CAst.v=(patl,rhs);loc} ->
           let ids = ids_of_pattern_list patl in
@@ -644,7 +647,7 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
                                 b),[])
   | CPrim p ->
      CPatPrim p
-  | CRecord l ->
+  | CRecord (None,l) ->
      CPatRecord (List.map (fun (r,p) -> (r,coerce_to_cases_pattern_expr p)) l)
   | CDelimiters (depth,s,p) ->
      CPatDelimiters (depth,s,coerce_to_cases_pattern_expr p)
@@ -655,7 +658,7 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CFix _ | CCoFix _ | CApp _ | CProj _ | CCases _ | CLetTuple _ | CIf _
   | CPatVar _ | CEvar _
   | CNotation (_,_,(_,_,_,_::_))
-  | CHole (Some _) | CGenarg _ | CGenargGlob _ ->
+  | CRecord (Some _, _) | CHole (Some _) | CGenarg _ | CGenargGlob _ ->
     CErrors.user_err ?loc
                       (str "This expression should be coercible to a pattern.")
   | CArray _ ->

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -921,7 +921,7 @@ let rec extern depth0 inctx scopes (eenv:extern_env) r =
              let args = extern_args (extern depth true) eenv args in
              (* Try a "{|...|}" record notation *)
              (match extern_record ~flags ref args with
-             | Some l -> CRecord l
+             | Some l -> CRecord (None, l)
              | None ->
              (* Otherwise... *)
                extern_applied_ref ~flags inctx

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2175,7 +2175,7 @@ module Interner = struct
   ; app : t -> (constr_expr * (constr_expr * explicitation CAst.t option) list) fn
   ; proj : t -> (explicit_flag * (qualid * instance_expr option)
               * (constr_expr * explicitation CAst.t option) list * constr_expr) fn
-  ; record : t -> ((qualid * constr_expr) list) fn
+  ; record : t -> (constr_expr option * (qualid * constr_expr) list) fn
   ; cases : t -> (Constr.case_style * constr_expr option * case_expr list * branch_expr list) fn
   ; lettuple : t -> (lname list * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; if_ : t -> (constr_expr * (lname option * constr_expr option) * constr_expr * constr_expr) fn
@@ -2212,8 +2212,8 @@ module Interner = struct
       self.app self genv env lvar ?loc (f, args)
     | CProj (expl, f, args, c) ->
       self.proj self genv env lvar ?loc (expl, f, args, c)
-    | CRecord fs ->
-      self.record self genv env lvar ?loc fs
+    | CRecord (def,fs) ->
+      self.record self genv env lvar ?loc (def, fs)
     | CCases (sty, rtnpo, tms, eqns) ->
       self.cases self genv env lvar ?loc (sty, rtnpo, tms, eqns)
     | CLetTuple (nal, (na,po), b, c) ->
@@ -2611,20 +2611,41 @@ let app self genv env lvar ?loc (f, args) =
 let proj self genv env lvar ?loc (expl, f, args, c) =
   intern_proj self genv env lvar ?loc expl f args c []
 
-let record self genv env lvar ?loc fs =
+let record self genv env lvar ?loc (def,fs) =
   let st = Evar_kinds.Define (not (Program.get_proofs_transparency ())) in
-  let fields =
-    sort_fields genv ~complete:true loc fs
-      (fun _idx fieldname constructorname ->
-         let open Evar_kinds in
-         let fieldinfo : Evar_kinds.record_field =
-           {fieldname=Option.get fieldname; recordname=inductive_of_constructor constructorname}
-         in
-         CAst.make ?loc @@ CHole (Some
-                                    (GQuestionMark { Evar_kinds.default_question_mark with
-                                                     Evar_kinds.qm_obligation=st;
-                                                     Evar_kinds.qm_record_field=Some fieldinfo
-                                                   })))
+  let used_default = Stdlib.ref false in
+  let completer _idx fieldname constructorname =
+    let fieldname = Option.get fieldname in
+    match def with
+    | None ->
+      let open Evar_kinds in
+      let fieldinfo : Evar_kinds.record_field =
+        {fieldname; recordname=inductive_of_constructor constructorname}
+      in
+      CAst.make ?loc @@
+      CHole (Some
+               (GQuestionMark { Evar_kinds.default_question_mark with
+                                Evar_kinds.qm_obligation=st;
+                                Evar_kinds.qm_record_field=Some fieldinfo
+                              }))
+    | Some def ->
+      (* duplicating internalization of the default value is not ideal *)
+      used_default := true;
+      let fieldname =
+        Libnames.qualid_of_path @@ Nametab.XRefs.to_path (TrueGlobal (ConstRef fieldname))
+      in
+      let mib = Environ.lookup_mind (fst @@ fst constructorname) genv in
+      let hole = CAst.make ?loc @@ CHole None in
+      let params = List.make mib.mind_nparams (hole, None) in
+      CAst.make ?loc @@ CProj (true, (fieldname, None), params, def)
+  in
+  let fields = sort_fields genv ~complete:true loc fs completer in
+  let () = match def with
+    | None -> ()
+    | Some def ->
+      (* could do a warning, but then any nonsense in [def] would be ignored which seems not nice *)
+      if not !used_default then
+        CErrors.user_err ?loc:def.loc Pp.(fmt "All the fields are explicitly listed in this record:@ the 'with' clause is useless.")
   in
   begin
     match fields with

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -113,7 +113,7 @@ module Interner : sig
   ; app : t -> (constr_expr * (constr_expr * explicitation CAst.t option) list) fn
   ; proj : t -> (explicit_flag * (qualid * instance_expr option)
               * (constr_expr * explicitation CAst.t option) list * constr_expr) fn
-  ; record : t -> ((qualid * constr_expr) list) fn
+  ; record : t -> (constr_expr option * (qualid * constr_expr) list) fn
   ; cases : t -> (Constr.case_style * constr_expr option * case_expr list * branch_expr list) fn
   ; lettuple : t -> (lname list * (lname option * constr_expr option) * constr_expr * constr_expr) fn
   ; if_ : t -> (constr_expr * (lname option * constr_expr option) * constr_expr * constr_expr) fn

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -93,7 +93,7 @@ let test_sort_qvar =
   end
 
 let test_record_nowith =
-let open Procq.Lookahead in
+  let open Procq.Lookahead in
   to_entry "test_record_nowith" begin
     lk_kw "}" <+> lk_kw "|}" <+> (lk_ident >> lk_list lk_field >> lk_except_kws ["with"; ".("])
   end

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -92,6 +92,13 @@ let test_sort_qvar =
     lk_ident >> lk_list lk_field >> lk_kw ";"
   end
 
+let test_record_nowith =
+let open Procq.Lookahead in
+  to_entry "test_record_nowith" begin
+    lk_kw "}" <+> lk_kw "|}" <+> (lk_ident >> lk_list lk_field >> lk_except_kws ["with"; ".("])
+  end
+
+
 let warn_old_sort_syntax =
   CWarnings.create ~name:"deprecated-sort-poly-syntax" ~category:Deprecation.Version.v9_1
     Pp.(fun () -> fmt "Separating sorts from universes with \"|\" is deprecated.@ Use \";\" instead.")
@@ -280,7 +287,7 @@ GRAMMAR EXTEND Gram
             | CPrim (Number (NumTok.SPlus,n)) ->
                 CAst.make ~loc @@ CNotation(None,(InConstrEntry,"( _ )"),([c],[],[],[]))
             | _ -> c) }
-      | "{|"; c = record_declaration; bar_cbrace -> { c }
+      | "{|"; c = full_record_declaration; bar_cbrace -> { c }
       | "`{"; c = term LEVEL "200"; "}" ->
         { CAst.make ~loc @@ CGeneralization (MaxImplicit, c) }
       | test_array_opening; "["; "|"; ls = array_elems; "|"; def = lconstr; ty = type_cstr; test_array_closing; "|"; "]"; u = univ_annot ->
@@ -303,11 +310,15 @@ GRAMMAR EXTEND Gram
   array_elems:
     [ [ fs = LIST0 lconstr SEP ";" -> { fs } ]]
   ;
-  record_declaration:
-    [ [ fs = fields_def -> { CAst.make ~loc @@ CRecord fs } ] ]
+  full_record_declaration:
+    [ [ test_record_nowith; fs = record_declaration ->
+        { CAst.make ~loc @@ CRecord (None,fs) }
+      | def = term LEVEL "1"; "with"; fs = record_declaration ->
+        { CAst.make ~loc @@ CRecord (Some def,fs) }
+    ] ]
   ;
-  fields_def:
-    [ RIGHTA [ f = field_def; ";"; fs = fields_def -> { f :: fs }
+  record_declaration:
+    [ RIGHTA [ f = field_def; ";"; fs = record_declaration -> { f :: fs }
       | f = field_def -> { [f] }
       | -> { [] } ] ]
   ;

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -243,6 +243,11 @@ struct
   | Some (Tok.IDENT ident) when not (List.mem_f String.equal ident idents) -> Some (n + 1)
   | _ -> None
 
+  let lk_except_kws bad n kwstate strm =
+    match LStream.peek_nth kwstate n strm with
+    | Some (Tok.KEYWORD kw) when List.mem_f String.equal kw bad -> None
+    | _ -> Some (n + 1)
+
   let lk_nat n kwstate strm = match LStream.peek_nth kwstate n strm with
   | Some (Tok.NUMBER p) when NumTok.Unsigned.is_nat p -> Some (n + 1)
   | _ -> None

--- a/parsing/procq.mli
+++ b/parsing/procq.mli
@@ -40,6 +40,7 @@ module Lookahead : sig
   val lk_name : t
   val lk_qualid : t
   val lk_ident_except : string list -> t
+  val lk_except_kws : string list -> t
   val lk_ident_list : t
 end
 
@@ -191,7 +192,7 @@ module Constr :
     val one_closed_binder : kinded_cases_pattern_expr Entry.t
     val binders_fixannot : (local_binder_expr list * fixpoint_order_expr option) Entry.t
     val typeclass_constraint : (lname * bool * constr_expr) Entry.t
-    val record_declaration : constr_expr Entry.t
+    val record_declaration : (Libnames.qualid * constr_expr) list Entry.t
     val arg : (constr_expr * explicitation CAst.t option) Entry.t
     val type_cstr : constr_expr Entry.t
   end

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1994,8 +1994,8 @@ let rec add_args id new_args =
     | (CHole _ | CGenarg _ | CGenargGlob _ | CPatVar _ | CEvar _ | CPrim _ | CSort _) as b -> b
     | CCast (b1, k, b2) ->
       CCast (add_args id new_args b1, k, add_args id new_args b2)
-    | CRecord pars ->
-      CRecord (List.map (fun (e, o) -> (e, add_args id new_args o)) pars)
+    | CRecord (def,pars) ->
+      CRecord (Option.map (add_args id new_args) def, List.map (fun (e, o) -> (e, add_args id new_args o)) pars)
     | CNotation _ -> CErrors.anomaly ~label:"add_args " (Pp.str "CNotation.")
     | CGeneralization _ ->
       CErrors.anomaly ~label:"add_args " (Pp.str "CGeneralization.")

--- a/plugins/ltac/comRewrite.ml
+++ b/plugins/ltac/comRewrite.ml
@@ -70,7 +70,7 @@ let declare_instance a aeq n s = declare_an_instance n s [a;aeq]
 
 let anew_instance atts binders (name,t) fields =
   let _id = Classes.new_instance ~poly:atts.poly ~locality:atts.locality
-    name binders t (true, CAst.make @@ CRecord (fields))
+    name binders t (true, CAst.make @@ CRecord (None, fields))
     Hints.empty_hint_info
   in
   ()

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -325,19 +325,24 @@ let pr_evar pr id l =
      { a; b;
        c }
 *)
-let pr_record left right pr = function
-  | [] -> str left ++ str " " ++ str right
+let pr_record_default = function
+  | None -> mt()
+  | Some def -> def ++ str " with" ++ spc()
+
+let pr_record left right def pr = function
+  | [] -> assert (Option.is_empty def); str left ++ str " " ++ str right
   | l ->
     hv 0 (
       str left ++
       brk (1,String.length left) ++
+      pr_record_default def ++
       hv 0 (prlist_with_sep pr_semicolon pr l) ++
       brk (1,0) ++
       str right)
 
-let pr_record_body left right pr l =
+let pr_record_body left right pr def l =
   let pr_defined_field (id, c) = hov 2 (pr_reference id ++ str" :=" ++ pr c) in
-  pr_record left right pr_defined_field l
+  pr_record left right def pr_defined_field l
 
 let las = lapp
 let lpator = 0
@@ -361,7 +366,7 @@ and pr_patt ~flags sep pr lev_after inh p =
     pr_with_comments ?loc:p.CAst.loc (sep() ++ pp) in
   match CAst.(p.v) with
   | CPatRecord l ->
-    return (fun lev_after -> pr_record_body "{|" "|}" (pr_patt ~flags spc pr no_after lpattop) l) lpatrec
+    return (fun lev_after -> pr_record_body "{|" "|}" (pr_patt ~flags spc pr no_after lpattop) None l) lpatrec
 
   | CPatAlias (p, na) ->
     return (fun lev_after -> pr_patt ~flags mt pr lev_after (LevelLe las) p ++ str " as " ++ pr_lname na) las
@@ -721,8 +726,9 @@ let pr ~flags pr sep lev_after inherited a =
     return (fun lev_after -> pr_appexpl (pr mt) lev_after (f,us) l) lapp
   | CApp (a,l) ->
     return (fun lev_after -> pr_app (pr mt) lev_after a l) lapp
-  | CRecord l ->
-    return (fun lev_after -> pr_record_body "{|" "|}" (pr spc no_after ltop) l) latom
+  | CRecord (def,l) ->
+    let def = Option.map (pr mt no_after (LevelLe lproj)) def in
+    return (fun lev_after -> pr_record_body "{|" "|}" (pr spc no_after ltop) def l) latom
   | CCases (Constr.LetPatternStyle,rtntypopt,[c,as_clause,in_clause],[{v=([[p]],b)}]) ->
     return (fun lev_after ->
         hv 0 (

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -46,8 +46,8 @@ val pr_guard_annot
   -> fixpoint_order_expr option
   -> Pp.t
 
-val pr_record : string -> string -> ('a -> Pp.t) -> 'a list -> Pp.t
-val pr_record_body : string -> string -> ('a -> Pp.t) -> (Libnames.qualid * 'a) list -> Pp.t
+val pr_record : string -> string -> Pp.t option -> ('a -> Pp.t) -> 'a list -> Pp.t
+val pr_record_body : string -> string -> ('a -> Pp.t) -> Pp.t option -> (Libnames.qualid * 'a) list -> Pp.t
 val pr_binders : flags:flags -> Environ.env -> Evd.evar_map -> local_binder_expr list -> Pp.t
 val pr_constr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
 val pr_lconstr_pattern_expr : flags:flags -> Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t

--- a/test-suite/output/PrintGrammar.out
+++ b/test-suite/output/PrintGrammar.out
@@ -127,7 +127,7 @@ Entry term is
     LIST1 (term LEVEL "200") SEP ","; ")"
   | "("; term LEVEL "200"; ","; term LEVEL "200"; ")"
   | "("; term LEVEL "200"; ")"
-  | "{|"; record_declaration; '|}'
+  | "{|"; full_record_declaration; '|}'
   | "`{"; term LEVEL "200"; "}"
   | "`("; term LEVEL "200"; ")"
   | NUMBER

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -52,7 +52,7 @@ Entry term is
     "+"; "*"]; "|"; term LEVEL "200"; "]"
   | "["; term LEVEL "10"; "|"; term LEVEL "200"; "]"
   | "("; term LEVEL "200"; ")"
-  | "{|"; record_declaration; '|}'
+  | "{|"; full_record_declaration; '|}'
   | "`{"; term LEVEL "200"; "}"
   | "`("; term LEVEL "200"; ")"
   | NUMBER

--- a/test-suite/output/PrintGrammarTree.out
+++ b/test-suite/output/PrintGrammarTree.out
@@ -57,7 +57,7 @@ Entry term is
       term LEVEL "200"; "]"
     | "|"; term LEVEL "200"; "]" ]
   | "("; term LEVEL "200"; ")"
-  | "{|"; record_declaration; '|}'
+  | "{|"; full_record_declaration; '|}'
   | "`{"; term LEVEL "200"; "}"
   | "`("; term LEVEL "200"; ")"
   | NUMBER

--- a/test-suite/success/record_syntax.v
+++ b/test-suite/success/record_syntax.v
@@ -53,3 +53,18 @@ Record Foo := { foo : nat * nat -> nat -> nat }.
 Definition foo_ := {| foo '(x,y) n := x+y+n |}.
 
 End F.
+
+Module RecordWith.
+
+  Record R A := { x : nat; y : A; z := x; e : z = 0 }.
+
+  Definition atunit : R (unit -> unit) :=
+    {| x := 0; y (_:match tt with tt => unit end) := tt; e := eq_refl |}.
+
+  Definition bli (a:R (R unit)) := {| a.(y _) with y := true |}.
+
+  Fail Check fun (a:R (R unit)) => {| a.(y _) with y := true; z := _ |}.
+
+  Fail Check {| atunit with x := 0; y := 0; e := eq_refl |}.
+
+End RecordWith.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -459,7 +459,8 @@ let do_instance_type_ctx_instance props k env' ctx' sigma ~program_mode subst =
     res, sigma
 
 let interp_props ~program_mode env' cty k ctx ctx' subst sigma = function
-  | (true, { CAst.v = CRecord fs; loc }) ->
+  | (true, { CAst.v = CRecord (def,fs); loc }) ->
+    let () = assert (Option.is_empty def) in
     check_duplicate ?loc fs;
     let subst, sigma = do_instance_type_ctx_instance fs k env' ctx' sigma ~program_mode subst in
     let term, termtype =

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -911,7 +911,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Instance"; namesup = instance_name; ":";
          t = term LEVEL "200";
          info = hint_info ;
-         props = [ ":="; "{"; r = record_declaration; "}" -> { Some (true,r) } |
+         props = [ ":="; "{"; r = record_declaration; "}" -> { Some (true,CAst.make ~loc @@ CRecord (None, r)) } |
              ":="; c = lconstr -> { Some (false,c) } | -> { None } ] ->
            { VernacSynPure (VernacInstance (fst namesup,snd namesup,t,props,info)) }
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -613,7 +613,7 @@ let pr_record_field (x, { rfu_attrs = attr ; rfu_coercion = coe ; rfu_instance =
   prx ++ prpri ++ prlist pr_where_notation ntn
 
 let pr_record_decl c fs obinder =
-  pr_opt pr_lident c ++ pr_record "{" "}" pr_record_field fs ++
+  pr_opt pr_lident c ++ pr_record "{" "}" None pr_record_field fs ++
   pr_opt (fun id -> str "as " ++ pr_lident id) obinder
 
 let pr_printable = function
@@ -1071,7 +1071,9 @@ let pr_synpure_vernac_expr v =
         str":" ++ spc () ++
         pr_constr cl ++ pr_hint_info pr_constr_pattern_expr info ++
         (match props with
-         | Some (true, { v = CRecord l}) -> spc () ++ str":=" ++ spc () ++ pr_record_body "{" "}" pr_lconstr l
+         | Some (true, { v = CRecord (None,l)}) ->
+           spc () ++ str":=" ++ spc () ++
+           pr_record_body "{" "}" pr_lconstr None l
          | Some (true,_) -> assert false
          | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
          | None -> mt()))


### PR DESCRIPTION
Overlays:
- https://github.com/rocq-community/rocq-lsp/pull/1101
- https://github.com/coq-tactician/coq-tactician/pull/140
- https://github.com/QuickChick/QuickChick/pull/433