### PR TITLE
Fix Search confusing is:Hypothesis and is:Axiom

### DIFF
--- a/dev/ci/user-overlays/22209-CalosciMatteo-BugSearchKind.sh
+++ b/dev/ci/user-overlays/22209-CalosciMatteo-BugSearchKind.sh
@@ -1,0 +1,1 @@
+overlay rocq_lsp https://github.com/CalosciMatteo/rocq-lsp BugSearchKind 22209

--- a/test-suite/output/Search_bug21821.out
+++ b/test-suite/output/Search_bug21821.out
@@ -1,0 +1,4 @@
+X: Type
+X2: Type
+Y: Type
+Y2: Type

--- a/test-suite/output/Search_bug21821.v
+++ b/test-suite/output/Search_bug21821.v
@@ -1,0 +1,16 @@
+Section K.
+Axiom X : Type.
+Parameter X2 : Type.
+Hypothesis Y : Type.
+Variable Y2 : Type.
+
+Search is:Axiom.
+  (* Shows "X: Type" *)
+Search is:Parameter.
+  (* Shows "X2: Type" *)
+Search is:Hypothesis.
+  (* Should show "Y: Type"*)
+Search is:Variable.
+  (* Should show "Y2: Type"*)
+
+End K.

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -98,9 +98,9 @@ let interp_search_item env sigma =
         Notation.interp_notation_as_global_reference
           ~head:false (fun _ -> true) s sc in
       GlobSearchSubPattern (where,head,Pattern.PRef ref)
-  | SearchKind k ->
+  | SearchKind (d,k) ->
      match kind_searcher env k with
-     | Inl k -> GlobSearchKind k
+     | Inl k -> GlobSearchKind (d,k)
      | Inr f -> GlobSearchFilter f
 
 let rec interp_search_request env sigma = function

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1300,12 +1300,12 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   logical_kind:
-    [ [ k = thm_token -> { IsProof k }
-      | k = assumption_token -> { IsAssumption (snd k) }
-      | k = IDENT "Context" -> { IsAssumption Context }
-      | k = extended_def_token -> { IsDefinition k }
-      | IDENT "Primitive" -> { IsPrimitive }
-      | IDENT "Symbol" -> { IsSymbol } ] ]
+    [ [ k = thm_token -> { (NoDischarge, IsProof k) }
+      | k = assumption_token -> { (fst k, IsAssumption (snd k)) }
+      | k = IDENT "Context" -> { (NoDischarge, IsAssumption Context) }
+      | k = extended_def_token -> { (NoDischarge, IsDefinition k) }
+      | IDENT "Primitive" -> { (NoDischarge, IsPrimitive) }
+      | IDENT "Symbol" -> { (NoDischarge, IsSymbol) } ] ]
   ;
   extended_def_token:
     [ [ k = def_token -> { snd k }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -272,11 +272,32 @@ let pr_delimiter_depth = function
 
 let pr_scope_delimiter (d, sc) = pr_delimiter_depth d ++ str sc
 
+let pr_assumption_token many discharge kind =
+  match discharge, kind with
+  | (NoDischarge,Decls.Logical) ->
+    keyword (if many then "Axioms" else "Axiom")
+  | (NoDischarge,Decls.Definitional) ->
+    keyword (if many then "Parameters" else "Parameter")
+  | (NoDischarge,Decls.Conjectural) -> str"Conjecture"
+  | (DoDischarge,Decls.Logical) ->
+    keyword (if many then "Hypotheses" else "Hypothesis")
+  | (DoDischarge,Decls.Definitional) ->
+    keyword (if many then "Variables" else "Variable")
+  | (DoDischarge,Decls.Conjectural) ->
+    anomaly (Pp.str "Don't know how to beautify a local conjecture.")
+  | (_,Decls.Context) ->
+    anomaly (Pp.str "Context is used only internally.")
+
+let pr_logical_token discharge kind =
+  match kind with
+  | Decls.IsAssumption k -> pr_assumption_token false discharge k
+  | _ -> str (string_of_logical_kind kind)
+
 let pr_search_item = function
   | SearchSubPattern (where,p) ->
     pr_search_where where ++ pr_constr_pattern_expr p
   | SearchString (where,s,sc) -> pr_search_where where ++ qs s ++ pr_opt pr_scope_delimiter sc
-  | SearchKind kind -> str "is:" ++ str (string_of_logical_kind kind)
+  | SearchKind (discharge, kind) -> str "is:" ++ pr_logical_token discharge kind
 
 let rec pr_search_request = function
   | SearchLiteral a -> pr_search_item a
@@ -467,22 +488,6 @@ let pr_class_rawexpr = function
   | FunClass -> keyword "Funclass"
   | SortClass -> keyword "Sortclass"
   | RefClass qid -> pr_smart_global qid
-
-let pr_assumption_token many discharge kind =
-  match discharge, kind with
-  | (NoDischarge,Decls.Logical) ->
-    keyword (if many then "Axioms" else "Axiom")
-  | (NoDischarge,Decls.Definitional) ->
-    keyword (if many then "Parameters" else "Parameter")
-  | (NoDischarge,Decls.Conjectural) -> str"Conjecture"
-  | (DoDischarge,Decls.Logical) ->
-    keyword (if many then "Hypotheses" else "Hypothesis")
-  | (DoDischarge,Decls.Definitional) ->
-    keyword (if many then "Variables" else "Variable")
-  | (DoDischarge,Decls.Conjectural) ->
-    anomaly (Pp.str "Don't know how to beautify a local conjecture.")
-  | (_,Decls.Context) ->
-    anomaly (Pp.str "Context is used only internally.")
 
 let pr_params pr_c (xl,(c,t)) =
   hov 2 (prlist_with_sep sep pr_lident xl ++ spc() ++

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -22,9 +22,9 @@ open Vernacexpr
 module NamedDecl = Context.Named.Declaration
 
 type filter_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> bool
+  GlobRef.t -> (Vernacexpr.discharge * Decls.logical_kind) option -> env -> Evd.evar_map -> constr -> bool
 type display_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> unit
+  GlobRef.t -> (Vernacexpr.discharge * Decls.logical_kind) option -> env -> Evd.evar_map -> constr -> unit
 
 (* This option restricts the output of [SearchPattern ...], etc.
 to the names of the symbols matching the
@@ -35,7 +35,7 @@ without having to parse through the types of all symbols. *)
 type glob_search_item =
   | GlobSearchSubPattern of glob_search_where * bool * constr_pattern
   | GlobSearchString of string
-  | GlobSearchKind of Decls.logical_kind
+  | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
   | GlobSearchFilter of (GlobRef.t -> bool)
 
 type glob_search_request =
@@ -142,9 +142,12 @@ let handle h (Libobject.Dyn.Dyn (tag, o)) = match DynHandle.find tag h with
 | exception Not_found -> ()
 
 (* General search over declarations *)
-let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> unit) =
-  List.iter (fun d -> fn (GlobRef.VarRef (NamedDecl.get_id d)) None env sigma (NamedDecl.get_type d))
-    (Environ.named_context env);
+let generic_search env sigma (fn : GlobRef.t -> (Vernacexpr.discharge * Decls.logical_kind) option -> env -> Evd.evar_map -> constr -> unit) =
+  List.iter (fun d ->
+    let id = NamedDecl.get_id d in
+    let kind = try Some (DoDischarge, Decls.variable_kind id) with Not_found -> None in
+    fn (GlobRef.VarRef id) kind env sigma (NamedDecl.get_type d))
+  (Environ.named_context env);
   let iter_obj prefix lobj = match lobj with
     | AtomicObject o ->
       let handler =
@@ -154,7 +157,7 @@ let generic_search env sigma (fn : GlobRef.t -> Decls.logical_kind option -> env
           let gr = GlobRef.ConstRef cst in
           let (typ, _) = Typeops.type_of_global_in_context (Global.env ()) gr in
           let kind = Declare.Internal.Constant.kind obj in
-          fn gr (Some kind) env sigma typ
+          fn gr (Some (NoDischarge, kind)) env sigma typ
         end @@
         DynHandle.add DeclareInd.Internal.objInductive begin fun (id,_) ->
           let kn = KerName.make prefix.obj_mp id in
@@ -189,7 +192,7 @@ module ConstrPriority = struct
 
   (* The priority is memoised here. Because of the very localised use
      of this module, it is not worth it making a convenient interface. *)
-  type t = GlobRef.t * Decls.logical_kind option * Environ.env * Evd.evar_map * Constr.t * priority
+  type t = GlobRef.t * (Vernacexpr.discharge * Decls.logical_kind) option * Environ.env * Evd.evar_map * Constr.t * priority
   and priority = int
 
   (** A measure of the size of a term *)

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -19,7 +19,7 @@ open Vernacexpr
 type glob_search_item =
   | GlobSearchSubPattern of glob_search_where * bool * constr_pattern
   | GlobSearchString of string
-  | GlobSearchKind of Decls.logical_kind
+  | GlobSearchKind of (Vernacexpr.discharge * Decls.logical_kind)
   | GlobSearchFilter of (GlobRef.t -> bool)
 
 type glob_search_request =
@@ -27,9 +27,9 @@ type glob_search_request =
   | GlobSearchDisjConj of (bool * glob_search_request) list list
 
 type filter_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> bool
+  GlobRef.t -> (Vernacexpr.discharge * Decls.logical_kind) option -> env -> Evd.evar_map -> constr -> bool
 type display_function =
-  GlobRef.t -> Decls.logical_kind option -> env -> Evd.evar_map -> constr -> unit
+  GlobRef.t -> (Vernacexpr.discharge * Decls.logical_kind) option -> env -> Evd.evar_map -> constr -> unit
 
 (** {6 Generic filter functions} *)
 

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -12,6 +12,8 @@ open Names
 open Constrexpr
 open Libnames
 
+type discharge = DoDischarge | NoDischarge
+
 (** Vernac expressions, produced by the parser *)
 type coercion_class = FunClass | SortClass | RefClass of qualid or_by_notation
 
@@ -84,7 +86,7 @@ type glob_search_where = InHyp | InConcl | Anywhere
 type search_item =
   | SearchSubPattern of (glob_search_where * bool) * constr_pattern_expr
   | SearchString of (glob_search_where * bool) * string * scope_delimiter option
-  | SearchKind of Decls.logical_kind
+  | SearchKind of (discharge * Decls.logical_kind)
 
 type search_request =
   | SearchLiteral of search_item
@@ -348,8 +350,6 @@ type extend_name = {
   (* Index of the extension in the VERNAC EXTEND statement. Each parsing branch
      is given an offset, starting from zero. *)
 }
-
-type discharge = DoDischarge | NoDischarge
 
 type hint_info_expr = Constrexpr.constr_pattern_expr Typeclasses.hint_info_gen
 


### PR DESCRIPTION
Fixes #21821

- [x] Added / updated **test-suite**.

Changed the type `type filter_function` to also include the Discharge/NoDischarge information.
Updated `generic_search`, distinguishing if a variable in a `Environ.named_context` is a section variable.

Overlays:
- https://github.com/rocq-community/rocq-lsp/pull/1106

