### PR TITLE
turn off async proofs for all output tests

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -103,7 +103,9 @@ coqtop := $(BIN)rocq repl -q -test-mode -R prerequisite TestSuite
 
 coqidetop := $(BIN)coqidetop
 
-coqc_interactive := $(coqc) -test-mode
+# async proofs off because the output order ends up different with and without async
+coqc_interactive := $(coqc) -test-mode -async-proofs off
+
 coqdep := $(BIN)rocq dep
 
 # This is the convention for coq_makefile

--- a/test-suite/output/Error_msg_diffs.out
+++ b/test-suite/output/Error_msg_diffs.out
@@ -1,4 +1,4 @@
-File "./output/Error_msg_diffs.v", line 34, characters 5-16:
+File "./output/Error_msg_diffs.v", line 33, characters 5-16:
 The command has indeed failed with message:
 In environment
 T : [33;1mType[0m

--- a/test-suite/output/Error_msg_diffs.v
+++ b/test-suite/output/Error_msg_diffs.v
@@ -1,5 +1,4 @@
-(* coq-prog-args: ("-color" "on" "-diffs" "on" "-async-proofs" "off") *)
-(* Re: -async-proofs off, see https://github.com/rocq-prover/rocq/issues/9671 *)
+(* coq-prog-args: ("-color" "on" "-diffs" "on") *)
 (* Shows diffs in an error message for an "Unable to unify" error *)
 Require Import ListDef.
 

--- a/test-suite/output/Qf_stdlib.out
+++ b/test-suite/output/Qf_stdlib.out
@@ -1,8 +1,8 @@
-File "./output/Qf_stdlib.v", line 16, characters 6-22:
+File "./output/Qf_stdlib.v", line 12, characters 6-22:
 Warning: Coq.Init.Nat.add has been replaced by Corelib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 16, characters 6-22 with Corelib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 12, characters 6-22 with Corelib.Init.Nat.add
 Nat.add : nat -> nat -> nat
 
 Nat.add is not universe polymorphic
@@ -10,10 +10,10 @@ Arguments Nat.add (n m)%_nat_scope
 Nat.add is transparent
 Expands to: Constant Corelib.Init.Nat.add
 Declared in library Corelib.Init.Nat, line 47, characters 9-12
-File "./output/Qf_stdlib.v", line 17, characters 6-22:
+File "./output/Qf_stdlib.v", line 13, characters 6-22:
 Warning: Coq.Init.Nat.add has been replaced by Corelib.Init.Nat.add.
 [deprecated-dirpath-Coq,deprecated-since-9.0,deprecated,default]
 Quickfix:
-Replace File "./output/Qf_stdlib.v", line 17, characters 6-22 with Corelib.Init.Nat.add
+Replace File "./output/Qf_stdlib.v", line 13, characters 6-22 with Corelib.Init.Nat.add
 Nat.add
      : nat -> nat -> nat

--- a/test-suite/output/Qf_stdlib.v
+++ b/test-suite/output/Qf_stdlib.v
@@ -1,7 +1,3 @@
-(* -*- coq-prog-args: ("-async-proofs" "off"); -*- *)
-(* async proofs off because the output order ends up different with
-   and without async *)
-
 (* Example from coq-lsp: we need to test 3 methods where the quickfix
   can come from for the Coq -> Stdlib transition:
 

--- a/test-suite/output/bug_5222.out
+++ b/test-suite/output/bug_5222.out
@@ -2,7 +2,7 @@
   
   ============================
   True = (nil : T1 nat)
-File "./output/bug_5222.v", line 16, characters 2-40:
+File "./output/bug_5222.v", line 14, characters 2-40:
 Warning: C2 does not respect the uniform inheritance condition.
 [uniform-inheritance,coercions,default]
 1 goal

--- a/test-suite/output/bug_5222.v
+++ b/test-suite/output/bug_5222.v
@@ -1,5 +1,3 @@
-(* coq-prog-args: ("-async-proofs" "off") *)
-
 Definition T1 (X : Type) : Type := list X.
 Coercion C1 (X: Type) (A : T1 X) : Prop := True.
 (* Works fine. *)

--- a/test-suite/output/unification.out
+++ b/test-suite/output/unification.out
@@ -1,4 +1,4 @@
-File "./output/unification.v", line 9, characters 35-39:
+File "./output/unification.v", line 7, characters 35-39:
 The command has indeed failed with message:
 In environment
 x : T
@@ -7,7 +7,7 @@ a : T
 Unable to unify "T" with "?X@{x0:=x; x:=C a}" (cannot instantiate 
 "?X" because "T" is not in its scope: available arguments are 
 "x" "C a").
-File "./output/unification.v", line 12, characters 12-14:
+File "./output/unification.v", line 10, characters 12-14:
 The command has indeed failed with message:
 The term "id" has type "ID" while it is expected to have type 
 "Type -> ?T" (cannot instantiate "?T" because "A" is not in its scope).

--- a/test-suite/output/unification.v
+++ b/test-suite/output/unification.v
@@ -1,5 +1,3 @@
-(* coq-prog-args: ("-async-proofs" "off") *)
-
 (* Unification error tests *)
 
 Module A.


### PR DESCRIPTION
async makes output non reproducible so turn it off
