### PR TITLE
Use empty variants for `Util.Empty`

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -47,8 +47,9 @@ let is_blank = function
 
 module Empty =
 struct
-  type t = { abort : 'a. 'a }
-  let abort (x : t) = x.abort
+  (* See https://ocaml.org/manual/emptyvariants.html *)
+  type t = |
+  let abort (x : t) = match x with _ -> .
 end
 
 (* Strings *)


### PR DESCRIPTION
OCaml supports [empty variants](https://ocaml.org/manual/emptyvariants.html) since OCaml 4.07, which better describe the `Util.Empty.t` type. This is a small cleanup; I'm not sure it has any impact on performance (my guess would be that there's none).