### PR TITLE
rocqdep improve location handling

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22231-coqdep-warn-loc-Changed.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22231-coqdep-warn-loc-Changed.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  `rocq dep` errors have more readable locations, and warnings have locations
+  (`#22231 <https://github.com/rocq-prover/rocq/pull/22231>`_,
+  fixes `#10815 <https://github.com/rocq-prover/rocq/issues/10815>`_,
+  by Gaëtan Gilbert).

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -102,13 +102,9 @@ let msg_debug   ?loc x = feedback_logger ?loc Debug x
 (* Helper for tools willing to understand only the messages *)
 let console_feedback_listener fmt =
   let open Format in
-  let pp_loc fmt loc = let open Loc in match loc with
-    | None     -> fprintf fmt ""
-    | Some loc ->
-      let where =
-        match loc.fname with InFile { file } -> file | ToplevelInput -> "Toplevel input" in
-      fprintf fmt "\"%s\", line %d, characters %d-%d:@\n"
-        where loc.line_nb (loc.bp-loc.bol_pos) (loc.ep-loc.bol_pos) in
+  let pp_loc fmt = function
+    | None     -> ()
+    | Some loc -> Pp.pp_with fmt Pp.(Loc.pr loc ++ str ":" ++ fnl()) in
   let checker_feed (fb : feedback) =
   match fb.contents with
   | Processed   -> ()

--- a/test-suite/misc/coqdep-require-filter-categories.sh
+++ b/test-suite/misc/coqdep-require-filter-categories.sh
@@ -7,7 +7,7 @@ cd misc/coqdep-require-filter-categories
 code=0
 $coqdep -worker @ROCQWORKER@ -R . 'Bla' ./*.v > stdout 2> stderr || code=$?
 
-diff stdout.ref stdout
-diff stderr.ref stderr
+diff -u stdout.ref stdout
+diff -u stderr.ref stderr
 
 exit $code

--- a/test-suite/misc/coqdep-require-filter-categories/fA.v
+++ b/test-suite/misc/coqdep-require-filter-categories/fA.v
@@ -1,1 +1,2 @@
-Require Import Prelude(something(..)) nonexistent.
+(* a
+ comment *) Require Import Prelude(something(..)) nonexistent.

--- a/test-suite/misc/coqdep-require-filter-categories/stderr.ref
+++ b/test-suite/misc/coqdep-require-filter-categories/stderr.ref
@@ -1,3 +1,4 @@
-Warning: in file fA.v, library
+File "fA.v", line 2, characters 50-61:
+Warning: library
          nonexistent is required and has not been found in the loadpath!
          [module-not-found,filesystem,default]

--- a/test-suite/misc/external-deps/file1.notfound.deps
+++ b/test-suite/misc/external-deps/file1.notfound.deps
@@ -1,4 +1,5 @@
-Warning: in file misc/external-deps/file1.v, external file d1 is required
+File "misc/external-deps/file1.v", line 2, characters 51-55:
+Warning: external file d1 is required
          from root foo.bar and has not been found in the loadpath!
          [module-not-found,filesystem,default]
 misc/external-deps/file1.vo misc/external-deps/file1.glob misc/external-deps/file1.v.beautified misc/external-deps/file1.required_vo: misc/external-deps/file1.v @ROCQWORKER@

--- a/test-suite/misc/external-deps/file1.v
+++ b/test-suite/misc/external-deps/file1.v
@@ -1,1 +1,2 @@
-Comments From foo.bar Extra Dependency "d1".
+(* a
+ comment *) Comments From foo.bar Extra Dependency "d1".

--- a/test-suite/misc/external-deps/file2.notfound.deps
+++ b/test-suite/misc/external-deps/file2.notfound.deps
@@ -1,4 +1,5 @@
-Warning: in file misc/external-deps/file2.v, external file d1 is required
+File "misc/external-deps/file2.v", line 1, characters 30-34:
+Warning: external file d1 is required
          from root foo.bar and has not been found in the loadpath!
          [module-not-found,filesystem,default]
 misc/external-deps/file2.vo misc/external-deps/file2.glob misc/external-deps/file2.v.beautified misc/external-deps/file2.required_vo: misc/external-deps/file2.v @ROCQWORKER@

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -152,12 +152,6 @@ let coq_to_stdlib from strl =
   | Some from -> Some (tr_qualid from), strl
   | None -> None, List.map tr_qualid strl
 
-let with_in_channel ~fname f =
-  let chan = try open_in fname
-    with Sys_error msg -> Error.cannot_open fname msg
-  in
-  Util.try_finally f chan close_in chan
-
 let with_in_descr ~fname f =
   let descr =
     try Unix.openfile fname [O_RDONLY] 0o000
@@ -176,8 +170,6 @@ module State = struct
   }
   let loadpath x = x.loadpath
 end
-
-exception SyntaxErrorInFile of string
 
 (* recursive because of Load *)
 let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basename =
@@ -203,19 +195,16 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
   let f = basename ^ ".v" in
   with_in_descr ~fname:f @@ fun chan ->
   (* For lexing efficiency purposes, we ignore the positions in this function.
-     This will force us to reparse the file in case of error to get a proper
-     location, but in practice such errors should be exceedingly rare with
-     rocqdep. This lexer is indeed basically able to handle random nonsense
-     thrown at it. *)
+     We can still get accurate character counts, we're just missing newline info. *)
   let buf = lexbuf_from_descr ~with_positions:false chan in
   let open Lexer in
   let rec loop () =
     match coq_action buf with
     | exception Fin_fichier ->
       DepSet.elements !dependencies
-    | exception Syntax_error _ ->
+    | exception Syntax_error (i,j) ->
       (* The locations are garbage due to with_positions:false, ignore them *)
-      raise (SyntaxErrorInFile f)
+      Error.cannot_parse f (i, j)
     | tok ->  match tok with
       | Require (from, strl) ->
         let from, strl = coq_to_stdlib from strl in
@@ -287,25 +276,6 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
         loop ()
   in
   loop ()
-
-(* Reparse the file to get the error location *)
-let get_parse_error f =
-  with_in_channel ~fname:f @@ fun chan ->
-  let buf = Lexing.from_channel chan in
-  let rec loop () = match Lexer.coq_action buf with
-  | _tok -> loop ()
-  | exception Lexer.Syntax_error (i, j) -> (i, j)
-  | exception Lexer.Fin_fichier ->
-    (* may technically happen due to race conditions, return a dummy value *)
-    (0, 0)
-  in
-  loop ()
-
-let find_dependencies st basename =
-  try find_dependencies st basename
-  with SyntaxErrorInFile f ->
-    let (i, j) = get_parse_error f in
-    Error.cannot_parse f (i, j)
 
 let compute_deps st =
   let mk_dep name = Dep_info.make ~name ~deps:(find_dependencies st name) in

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (* count newlines to get a nice error location instead of raw chars *)
-let get_loc f start end_ =
+let get_loc f { Lexer.loc_start = start; loc_end = end_ } =
   let ch = open_in f in
   let rec loop lnum bol read =
     if read = start then lnum, bol
@@ -66,9 +66,8 @@ type what = Library | External
 let str_of_what = function Library -> "library" | External -> "external file"
 
 let warning_module_notfound =
-  let warn (what, from, f, s) =
+  let warn (what, from, s) =
     let open Pp in
-    str "in file " ++ str f ++ str ", " ++
     str (str_of_what what) ++ spc () ++ str (String.concat "." s) ++ str " is required" ++
     pr_opt (fun pth -> str "from root " ++ str (String.concat "." pth)) from ++
     str " and has not been found in the loadpath!"
@@ -171,7 +170,7 @@ let coq_to_stdlib from strl =
     | l -> l in
   match from with
   | Some from -> Some (tr_qualid from), strl
-  | None -> None, List.map tr_qualid strl
+  | None -> None, List.map (Util.on_snd tr_qualid) strl
 
 let with_in_descr ~fname f =
   let descr =
@@ -223,13 +222,13 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
     match coq_action buf with
     | exception Fin_fichier ->
       DepSet.elements !dependencies
-    | exception Syntax_error (i,j) ->
+    | exception Syntax_error loc ->
       (* The locations are garbage due to with_positions:false, ignore them *)
-      Error.cannot_parse ~loc:(get_loc f i j)
+      Error.cannot_parse ~loc:(get_loc f loc)
     | tok ->  match tok with
       | Require (from, strl) ->
         let from, strl = coq_to_stdlib from strl in
-        let decl str =
+        let decl (loc, str) =
           if should_visit_v_and_mark from str then begin
             let files = safe_assoc loadpath from f str in
             let files = match from, files with
@@ -242,7 +241,7 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
                   add_dep (Dep_info.Dep.Require file_str)) files
             | None ->
               if not (Loadpath.is_in_coqlib loadpath ?from str) then
-                warning_module_notfound (Library, from, f, str)
+                warning_module_notfound ~loc:(get_loc f loc) (Library, from, str)
           end
         in
         List.iter decl strl;
@@ -286,13 +285,13 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
            in
            List.iter decl l);
         loop ()
-      | External(from,str) ->
+      | External(loc,from,str) ->
         begin match safe_assoc loadpath ~what:External (Some from) f [str] with
         | Some (file :: _) -> add_dep (Dep_info.Dep.Other (canonize ~separator_hack vAccu file))
         | Some [] -> assert false
         | None ->
           if not (Loadpath.is_other_in_coqlib loadpath ~from [str]) then
-            warning_module_notfound (External, Some from, f, [str])
+            warning_module_notfound ~loc:(get_loc f loc) (External, Some from, [str])
         end;
         loop ()
   in
@@ -357,7 +356,7 @@ let sort {State.vAccu; separator_hack; loadpath} =
           match Lexer.coq_action lb with
           | Lexer.Require (from, sl) ->
                 List.iter
-                  (fun s ->
+                  (fun (_,s) ->
                     match safe_assoc loadpath from ~warn_clashes:false file s with
                     | None -> ()
                     | Some l -> List.iter loop l)

--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -8,6 +8,27 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(* count newlines to get a nice error location instead of raw chars *)
+let get_loc f start end_ =
+  let ch = open_in f in
+  let rec loop lnum bol read =
+    if read = start then lnum, bol
+    else match input_char ch with
+      | '\n' -> loop (lnum+1) (read+1) (read+1)
+      | _ -> loop lnum bol (read+1)
+  in
+  let lnum, bol = loop 1 0 0 in
+  { Loc.fname = InFile { dirpath=None; file=f };
+    line_nb = lnum;
+    bol_pos = bol;
+    bp = start;
+    ep = end_;
+
+    (* not used by printing *)
+    line_nb_last = 0;
+    bol_pos_last = 0;
+  }
+
 (** Rocq files specifies on the command line:
     - first string is the full filename, with only its extension removed
     - second string is the absolute version of the previous (via getcwd)
@@ -204,7 +225,7 @@ let rec find_dependencies ({State.vAccu; separator_hack; loadpath} as st) basena
       DepSet.elements !dependencies
     | exception Syntax_error (i,j) ->
       (* The locations are garbage due to with_positions:false, ignore them *)
-      Error.cannot_parse f (i, j)
+      Error.cannot_parse ~loc:(get_loc f i j)
     | tok ->  match tok with
       | Require (from, strl) ->
         let from, strl = coq_to_stdlib from strl in

--- a/tools/coqdep/lib/error.ml
+++ b/tools/coqdep/lib/error.ml
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-exception CannotParseFile of string * (int * int)
+exception CannotParseFile
 exception CannotParseProjectFile of string * string
 
 exception CannotOpenFile of string * string
@@ -16,9 +16,8 @@ exception CannotOpenProjectFile of string
 
 
 let () = CErrors.register_handler @@ function
-  | CannotParseFile (s,(i,j)) ->
-    Some Pp.(str "File \"" ++ str s ++ str "\"," ++ str "characters" ++ spc ()
-      ++ int i ++ str "-" ++ int j ++ str ":" ++ spc () ++ str "Syntax error")
+  | CannotParseFile ->
+    Some Pp.(str "Syntax error")
 
   | CannotParseProjectFile (file, msg) ->
     Some Pp.(str "Project file" ++ spc () ++ str  "\"" ++ str file ++ str "\":" ++ spc ()
@@ -33,7 +32,7 @@ let () = CErrors.register_handler @@ function
 
   | _ -> None
 
-let cannot_parse s ij = raise @@ CannotParseFile (s, ij)
+let cannot_parse ~loc = Loc.raise ~loc @@ CannotParseFile
 let cannot_open_project_file msg = raise @@ CannotOpenProjectFile msg
 let cannot_parse_project_file file msg = raise @@ CannotParseProjectFile (file, msg)
 let cannot_open s msg = raise @@ CannotOpenFile (s, msg)

--- a/tools/coqdep/lib/error.mli
+++ b/tools/coqdep/lib/error.mli
@@ -8,12 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-exception CannotParseFile of string * (int * int)
-exception CannotParseProjectFile of string * string
-exception CannotOpenFile of string * string
-exception CannotOpenProjectFile of string
-
-val cannot_parse : string -> int * int -> 'a
+val cannot_parse : loc:Loc.t -> 'a
 val cannot_open_project_file : string -> 'a
 val cannot_parse_project_file : string -> string -> 'a
 val cannot_open : string -> string -> 'a

--- a/tools/coqdep/lib/lexer.mli
+++ b/tools/coqdep/lib/lexer.mli
@@ -12,13 +12,15 @@ type qualid = string list
 
 type load = Logical of string | Physical of string
 
+type loc = { loc_start : int; loc_end : int }
+
 type coq_token =
-  | Require of qualid option * qualid list
+  | Require of qualid option * (loc * qualid) list
   | Declare of string list
   | Load of load
-  | External of qualid * string
+  | External of loc * qualid * string
 
 exception Fin_fichier
-exception Syntax_error of int * int
+exception Syntax_error of loc
 
 val coq_action : Lexing.lexbuf -> coq_token

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -13,18 +13,20 @@
   open Filename
   open Lexing
 
+  type loc = { loc_start : int; loc_end : int }
+
   type qualid = string list
 
   type load = Logical of string | Physical of string
 
   type coq_token =
-    | Require of qualid option * qualid list
+    | Require of qualid option * (loc * qualid) list
     | Declare of string list
     | Load of load
-    | External of qualid * string
+    | External of loc * qualid * string
 
   exception Fin_fichier
-  exception Syntax_error of int*int
+  exception Syntax_error of loc
 
   let unquote_string s =
     String.sub s 1 (String.length s - 2)
@@ -36,10 +38,18 @@
   let backtrack lexbuf = lexbuf.lex_curr_pos <- lexbuf.lex_start_pos;
     lexbuf.lex_curr_p <- lexbuf.lex_start_p
 
+  let loc_start lexbuf = lexbuf.lex_abs_pos + lexbuf.lex_start_pos
+  let loc_end lexbuf = lexbuf.lex_abs_pos + lexbuf.lex_curr_pos
+
+  let loc lexbuf = { loc_start=loc_start lexbuf; loc_end=loc_end lexbuf}
+
   let syntax_error lexbuf =
     (* abs_pos is position of the start of the buffer in the file
        start/curr_pos are positions in the buffer *)
-    raise (Syntax_error (lexbuf.lex_abs_pos + lexbuf.lex_start_pos, lexbuf.lex_abs_pos + lexbuf.lex_curr_pos))
+    raise (Syntax_error ({
+        loc_start = loc_start lexbuf;
+        loc_end = loc_end lexbuf;
+      }))
 
   let check_valid lexbuf s =
     match Unicode.ident_refutation s with
@@ -144,8 +154,9 @@ and extra_dep_rule from = parse
   | eof
       { syntax_error lexbuf }
   | '"' ([^ '"']+ as f) '"' (*'"'*)
-      { skip_to_dot lexbuf;
-        External (from,f) }
+      { let loc = loc lexbuf in
+        skip_to_dot lexbuf;
+        External (loc,from,f) }
 
 and require_modifiers from = parse
   | "(*"
@@ -220,8 +231,10 @@ and require_file from = parse
   | space+
       { require_file from lexbuf }
   | coq_ident
-      { let name = coq_qual_id_tail [get_ident lexbuf] lexbuf in
-        let qid = coq_qual_id_list [name] lexbuf in
+      { let loc_start = loc_start lexbuf in
+        let name = coq_qual_id_tail [get_ident lexbuf] lexbuf in
+        let loc_end = loc_end lexbuf in
+        let qid = coq_qual_id_list [{loc_start;loc_end},name] lexbuf in
         parse_dot lexbuf;
         Require (from, qid) }
   | eof
@@ -268,8 +281,10 @@ and coq_qual_id_list module_names = parse
   | space+
       { coq_qual_id_list module_names lexbuf }
   | coq_ident
-      { let name = coq_qual_id_tail [get_ident lexbuf] lexbuf in
-        coq_qual_id_list (name :: module_names) lexbuf
+      { let loc_start = loc_start lexbuf in
+        let name = coq_qual_id_tail [get_ident lexbuf] lexbuf in
+        let loc_end = loc_end lexbuf in
+        coq_qual_id_list (({loc_start;loc_end},name) :: module_names) lexbuf
       }
   | eof
       { syntax_error lexbuf }

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -76,16 +76,10 @@
 }
 
 let space = [' ' '\t' '\n' '\r']
-let lowercase = ['a'-'z']
-let uppercase = ['A'-'Z']
-let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
-let caml_up_ident = uppercase identchar*
-let caml_low_ident = lowercase identchar*
 
 (* This is an overapproximation, we check correctness afterwards *)
 let coq_ident = ['A'-'Z' 'a'-'z' '_' '\128'-'\255'] ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9' '\128'-'\255']*
 let coq_field = '.' coq_ident
-let coq_qual_id_rex = coq_ident coq_field+
 
 let dot = '.' ( space+ | eof)
 

--- a/tools/coqdep/lib/lexer.mll
+++ b/tools/coqdep/lib/lexer.mll
@@ -37,7 +37,9 @@
     lexbuf.lex_curr_p <- lexbuf.lex_start_p
 
   let syntax_error lexbuf =
-    raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
+    (* abs_pos is position of the start of the buffer in the file
+       start/curr_pos are positions in the buffer *)
+    raise (Syntax_error (lexbuf.lex_abs_pos + lexbuf.lex_start_pos, lexbuf.lex_abs_pos + lexbuf.lex_curr_pos))
 
   let check_valid lexbuf s =
     match Unicode.ident_refutation s with

--- a/tools/coqdep/lib/rocqdep_main.ml
+++ b/tools/coqdep/lib/rocqdep_main.ml
@@ -56,5 +56,7 @@ let main args =
   try
     coqdep args
   with exn ->
-    Format.eprintf "*** Error: @[%a@]@\n%!" Pp.pp_with (CErrors.print exn);
+    let exn = Exninfo.capture exn in
+    let loc = Loc.get_loc (snd exn) in
+    Feedback.msg_notice ?loc Pp.(str "Error: " ++ CErrors.iprint exn);
     exit 1

--- a/tools/dune_rule_gen/gen_rules.ml
+++ b/tools/dune_rule_gen/gen_rules.ml
@@ -122,14 +122,9 @@ let main () =
   Format.pp_print_flush fmt ();
   ()
 
-let pr_feedback (fb : Feedback.feedback) =
-  match fb.contents with
-  | Message (_,_,_,msg) -> Format.eprintf "%a" Pp.pp_with msg
-  | _ -> () [@@warning "-4"]
-
 let () =
   Printexc.record_backtrace true;
-  let _ : int = Feedback.add_feeder pr_feedback in
+  let _ : int = Feedback.add_feeder (Feedback.console_feedback_listener Format.err_formatter) in
   try main ()
   with exn ->
     Format.eprintf "[gen_rules] Fatal error:@ @[<2>%a@]@\n%!" Pp.pp_with (CErrors.print exn);


### PR DESCRIPTION
We print nice locations (with line number) instead of raw char counts for syntax errors.
We also print locations for module not found warnings (fix #10815)