### PR TITLE
Fix #21816: Error: Ill-formed constant (wrong canonical name).

### DIFF
--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -601,7 +601,7 @@ let update_delta_resolver resolver1 resolver2 =
   in
   let kn_apply_rslv kkey hint1 rslv =
     let hint = match hint1 with
-      | Equiv kequ -> solve_delta_kn resolver2 kequ
+      | Equiv kequ -> Equiv (kn_of_delta resolver2 kequ)
       | Inline (_,Some _) -> hint1
       | Inline (_,None) ->
         (try Deltamap.find_kn kkey resolver2 with Not_found -> hint1)

--- a/test-suite/bugs/bug_21816.v
+++ b/test-suite/bugs/bug_21816.v
@@ -1,0 +1,21 @@
+Axiom R : Set.
+
+Module Type Typ.
+  Parameter Inline(10) t : Type.
+End Typ.
+
+Module Make_UDTF (M:Typ).
+  Include M.
+End Make_UDTF.
+
+Module R_as_UBE.
+ Definition t := R.
+End R_as_UBE.
+
+Module FOO := Make_UDTF R_as_UBE.
+
+Module BAR.
+ Include FOO.
+End BAR.
+
+Definition boom := BAR.t.


### PR DESCRIPTION
We tweak Mod_subst.add_delta_resolver by trying to preserve equivalence information instead of replacing it with inlining information. Kernel-wise this cannot be worse than the previous version, as the inlined body should be convertible to the equivalent name. Meanwhile, it fixes #21816 which stemmed from the upper layers that relied on the composition of substitutions to compute libobjects in one go.

This fix was suggested by Claude Opus. I am not 100% convinced there is not an other design issue somewhere high up in Declaremods that could have been solved differently, especially without touching the kernel at all. But as explained above, this change should not hurt kernel consistenty. (Famous last words.)