### PR TITLE
bench use ocaml 4.14.2

### DIFF
--- a/dev/bench/bench.sh
+++ b/dev/bench/bench.sh
@@ -35,8 +35,8 @@ check_variable () {
 
 : "${coq_pr_number:=}"
 : "${coq_pr_comment_id:=}"
-: "${new_ocaml_version:=4.14.1}"
-: "${old_ocaml_version:=4.14.1}"
+: "${new_ocaml_version:=4.14.2}"
+: "${old_ocaml_version:=4.14.2}"
 : "${new_ocaml_flambda:=0}"
 : "${old_ocaml_flambda:=0}"
 : "${new_coq_repository:=${CI_REPOSITORY_URL:-.}}"


### PR DESCRIPTION
4.14.2 is needed for newer gcc, which the second bench machine has 