### PR TITLE
Fix Corelib detection on `dune exec -- rocq` with dune 3.24

### DIFF
--- a/boot/env.ml
+++ b/boot/env.ml
@@ -64,9 +64,36 @@ let rocqbin =
     | Some p -> p
     | None -> canonical_path_name (Filename.dirname Sys.executable_name)
 
+(** Locate the dune workspace root containing the given path, if any. *)
+let dune_workspace_root : string -> string option = fun path ->
+  let rec workspace_root path =
+    let parent = Filename.dirname path in
+    if parent = path then
+      None
+    else if Filename.basename path = "_build" then
+      Some parent
+    else
+      workspace_root parent
+  in
+  match workspace_root path with
+  | None -> None
+  | Some root ->
+      (* Check that this indeed looks like a dune workspace. *)
+      let ok =
+        let has file = Sys.file_exists (Filename.concat root file) in
+        List.exists has ["dune-project"; "dune-workspace"]
+      in
+      if ok then Some root else None
+
 (** The following only makes sense when executables are running from
     source tree (e.g. during build or in local mode). *)
 let rocqroot =
+  match dune_workspace_root rocqbin with
+  | Some dir ->
+      let dir = Filename.concat dir "_build" in
+      let dir = Filename.concat dir "install" in
+      Filename.concat dir "default"
+  | None ->
   let rec search = function
     | [] ->
       (* couldn't recognize the layout, guess the executable is 1 dir below the root


### PR DESCRIPTION
See [#Dune devs &amp; users > dune exec changed?](https://rocq-prover.zulipchat.com/#narrow/channel/240550-Dune-devs-.26-users/topic/dune.20exec.20changed.3F/with/607417684).

CC @SkySkimmer
