### PR TITLE
Fix dune runtest for dune 3.24

### DIFF
--- a/test-suite/dune
+++ b/test-suite/dune
@@ -10,7 +10,8 @@
 (rule
  (targets test_suite_config.inc)
  (mode (promote (until-clean)))
- (action (with-stdout-to %{targets} (run tools/coq_config_to_make.exe %{bin:rocq}))))
+ (deps (package rocq-runtime))
+ (action (with-stdout-to %{targets} (run tools/coq_config_to_make.exe rocq))))
 
 (rule
  (targets summary.log)


### PR DESCRIPTION
cf https://github.com/ocaml/dune/issues/15458#issuecomment-4934344267 (the `%{pkg` suggestion can't be used until we depend on 3.24)
