### PR TITLE
Fix file descriptor leak in coqdep warning locations

### DIFF
--- a/tools/coqdep/lib/common.ml
+++ b/tools/coqdep/lib/common.ml
@@ -17,7 +17,7 @@ let get_loc f { Lexer.loc_start = start; loc_end = end_ } =
       | '\n' -> loop (lnum+1) (read+1) (read+1)
       | _ -> loop lnum bol (read+1)
   in
-  let lnum, bol = loop 1 0 0 in
+  let lnum, bol = Fun.protect ~finally:(fun () -> close_in ch) (fun () -> loop 1 0 0) in
   { Loc.fname = InFile { dirpath=None; file=f };
     line_nb = lnum;
     bol_pos = bol;


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

`get_loc` in `tools/coqdep/lib/common.ml` opens the source file to convert character offsets into line numbers for warning locations, and never closes it — leaking one file descriptor per located warning.

On warning-heavy projects this kills coqdep with `Sys_error "Too many open files"` under the default 1024-fd soft limit. Observed in the wild on VST (thousands of module-not-found warnings over ~2900 files): coqdep dies partway, and because VST pipes coqdep through `grep -v ... || true`, the truncated `.depend` silently poisons parallel builds with missing dependency edges.

Reproduction: `bash -c 'ulimit -n 64; coqdep -vos -Q sepcomp VST.sepcomp $(find sepcomp -name "*.v")'` in a VST checkout dies after ~60 warnings; with this fix it completes (990 warnings, no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
