### PR TITLE
Fix coq-makefile/package-install test under native-enabled configurations

### DIFF
--- a/test-suite/coq-makefile/package-install/run.sh
+++ b/test-suite/coq-makefile/package-install/run.sh
@@ -120,14 +120,16 @@ test -z "$(find ../tmp -path '*/user-contrib/Foo/A.vo' | head -n 1)"
 
 echo 'Print LoadPath.' > Empty.v
 
-rocq c -boot -noinit Empty.v
+# -native-compiler no: with -boot, native compilation would additionally
+# require -nI pointing to the kernel, which is beside the point here
+rocq c -native-compiler no -boot -noinit Empty.v
 
-if rocq c -boot Empty.v; then
+if rocq c -native-compiler no -boot Empty.v; then
   >&2 echo -boot without -noinit should have failed
   exit 1
 fi
 
-rocq c -boot -package rocq-core Empty.v > loadpaths.package
+rocq c -native-compiler no -boot -package rocq-core Empty.v > loadpaths.package
 grep -q "Corelib" loadpaths.package
 grep -qv "user-contrib" loadpaths.package
 grep -qv "Ltac2" loadpaths.package


### PR DESCRIPTION
Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

The loadpath checks added to `test-suite/coq-makefile/package-install/run.sh` in #22258 invoke `rocq c -boot` (without `-nI`). In configurations where the native compiler is enabled by default, compiling the test file then fails with

```
Error: Native compute with -boot: you must also give -nI pointing to the kernel.
```

(with `-boot`, `Nativelib.include_dirs` is populated only from `-nI` — see `Coqinit.init_load_paths` — and the error is raised by `Nativelib.get_include_dirs`). This makes the `package-install` test fail on every PR based on current master in native-enabled test lanes, while staying green in non-native ones.

Fix: pass `-native-compiler no` to those invocations — they test loadpath handling, not native compilation. Verified the test still passes in a non-native build; the flag is accepted in all configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
