### PR TITLE
Introduce a function to get LStream locations relatively to the head.

### DIFF
--- a/dev/ci/user-overlays/22289-ppedrot-lstream-relative-location.sh
+++ b/dev/ci/user-overlays/22289-ppedrot-lstream-relative-location.sh
@@ -1,0 +1,1 @@
+overlay elpi https://github.com/ppedrot/coq-elpi lstream-relative-location 22289

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1580,7 +1580,7 @@ module Parsable = struct
          the max peek is at least the current position) *)
       let _ = LStream.peek gstate.kwstate ts in
       let loc' = LStream.max_peek_loc ts in
-      let loc = LStream.get_loc (LStream.count ts) ts in
+      let loc = LStream.get_relative_loc 0 ts in
       Loc.merge loc loc'
     in
     match efun ts with

--- a/gramlib/lStream.ml
+++ b/gramlib/lStream.ml
@@ -51,8 +51,10 @@ let interval_loc bp ep strm =
     let loc2 = strm.fun_loc ep in
     Loc.merge loc1 loc2
 
-let get_loc n strm =
-  strm.fun_loc (n + 1)
+let get_relative_loc n strm =
+  let () = assert (0 <= n) in
+  let pos = Stream.count strm.strm in
+  strm.fun_loc (pos + n + 1)
 
 let peek e strm =
   let a = Stream.peek e strm.strm in

--- a/gramlib/lStream.mli
+++ b/gramlib/lStream.mli
@@ -29,9 +29,11 @@ val max_peek_loc : ('e,'a) t -> Loc.t
     been peeked yet *)
 val interval_loc : int -> int -> ('e,'a) t -> Loc.t
 
-(** Return location of an already peeked element at some position counting from 0;
-    fails if the element has not been peeked yet *)
-val get_loc : int -> ('e,'a) t -> Loc.t
+(** Return location of an already peeked element at some position counting from
+    {!count}; fails if the element has not been peeked yet. That is,
+    [get_loc 0 s] is the first location after {!current_loc}. The position must
+    be positive. *)
+val get_relative_loc : int -> ('e,'a) t -> Loc.t
 
 (** Lifted usual function on streams *)
 

--- a/parsing/procq.ml
+++ b/parsing/procq.ml
@@ -203,13 +203,12 @@ struct
 
   let rec contiguous n m strm =
     n == m ||
-    let (_, ep) = Loc.unloc (LStream.get_loc n strm) in
-    let (bp, _) = Loc.unloc (LStream.get_loc (n + 1) strm) in
+    let (_, ep) = Loc.unloc (LStream.get_relative_loc n strm) in
+    let (bp, _) = Loc.unloc (LStream.get_relative_loc (n + 1) strm) in
     Int.equal ep bp && contiguous (succ n) m strm
 
   let check_no_space m _kwstate strm =
-    let n = LStream.count strm in
-    if contiguous n (n+m-1) strm then Some m else None
+    if contiguous 0 (m - 1) strm then Some m else None
 
   let to_entry s (lk : t) =
     let run kwstate strm = match lk 0 kwstate strm with None -> Error () | Some _ -> Ok () in


### PR DESCRIPTION
All callers only care about the positions of elements yet to come, and the current implementation is fundamentally leaky in terms of memory consumption as we keep all locations from the past. Being able to only look at stuff yet to come adds a clear separation between locations that ought to have been garbage collected and stuff that is still in the stream.

The last source of location lookbehind is LStream.interval_loc which is used internally by the parsing engine.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/1069