### PR TITLE
pptactic: register printer for wit_identref

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1330,6 +1330,7 @@ let () =
   register_basic_print0 wit_smart_global
     (pr_or_by_notation pr_qualid) (pr_or_var (pr_located pr_global)) pr_global;
   register_basic_print0 wit_ident pr_id pr_id pr_id;
+  register_basic_print0 wit_identref pr_lident pr_lident pr_id;
   register_basic_print0 wit_hyp pr_lident pr_lident pr_id;
   register_print0 wit_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env [@warning "-3"];
   register_print0 wit_simple_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env;


### PR DESCRIPTION
## Summary

Fixes #16807.

`wit_identref` (a located identifier, used by commands such as `Derive`) had no printer registered in the genarg printing system. This caused `coqc -time` to emit `<genarg:identref>` instead of the actual identifier name:

```
Chars 34 - 74 [Derive~<genarg:identref>~SuchT...] 0. secs (0.u,0.s)
```

**Fix:** Add one line to the registration block in `plugins/ltac/pptactic.ml`, alongside the existing `wit_ident` and `wit_hyp` printers:

```ocaml
register_basic_print0 wit_ident    pr_id     pr_id     pr_id;
register_basic_print0 wit_identref pr_lident pr_lident pr_id;   (* new *)
register_basic_print0 wit_hyp      pr_lident pr_lident pr_id;
```

`wit_identref` carries a `lident` (a located `Id.t`), so `pr_lident` is the correct printer for the raw/glob levels, and `pr_id` for the top level (same pattern as `wit_hyp`).

## Test plan

```coq
(* foo.v *)
Require Import Coq.derive.Derive.
Derive foo SuchThat (foo = 1) As foo_eq.
Proof. subst foo; reflexivity. Qed.
```

```
$ coqc -q -time foo.v
# Before fix:
Chars 34 - 74 [Derive~<genarg:identref>~SuchT...] 0. secs

# After fix:
Chars 34 - 74 [Derive~foo~SuchThat~(foo~=~1)~...] 0. secs
```

- [ ] `make test-suite` passes
- [ ] `coqc -time` on a `Derive` command shows the actual identifier

🤖 Generated with [Claude Code](https://claude.ai/claude-code)