### PR TITLE
CI: use edge Docker image for MLtac2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1176,9 +1176,9 @@ plugin:plugin-tutorial:
     - make -j "$NJOBS" plugin-tutorial
 
 plugin:ci-mltac2:
-  extends: .ci-template
+  extends: .ci-template-flambda
   needs:
-  - build:base
+  - build:edge+flambda
 
 plugin:ci-quickchick:
   extends: .ci-template-flambda


### PR DESCRIPTION
We'd like to use `ppx_optcomp` for MLtac2 to support Rocq 9.0-9.2, and AFAIU `ppx_optcomp` is only included in the edge Docker image by default.