### PR TITLE
Improve the arity error message for destructuring let

### DIFF
--- a/doc/changelog/02-specification-language/22314-lettuple-arity-error-Changed.rst
+++ b/doc/changelog/02-specification-language/22314-lettuple-arity-error-Changed.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  the error message for a destructuring ``let`` with the wrong number of
+  variables now mentions the destructured term and its type, as well as the
+  number of variables given
+  (`#22314 <https://github.com/rocq-prover/rocq/pull/22314>`_,
+  fixes `#7833 <https://github.com/rocq-prover/rocq/issues/7833>`_,
+  by Onyeka Obi).

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -41,6 +41,8 @@ let of_type_error = map_ptype_error ERelevance.make EConstr.of_constr
 type pretype_error =
   (* Old Case *)
   | CantFindCaseType of constr
+  (* Destructuring let *)
+  | LetTupleArity of unsafe_judgment * int * int
   (* Type inference unification *)
   | ActualTypeNotCoercible of unsafe_judgment * types * unification_error
   (* Tactic unification *)
@@ -111,6 +113,9 @@ let error_number_branches ?loc env sigma cj expn =
 
 let error_case_not_inductive ?loc env sigma cj =
   raise_type_error ?loc (env, sigma, CaseNotInductive cj)
+
+let error_lettuple_arity ?loc env sigma cj expn given =
+  raise_pretype_error ?loc (env, sigma, LetTupleArity (cj, expn, given))
 
 let error_ill_typed_rec_body ?loc env sigma i na jl tys =
   raise_type_error ?loc (env, sigma, IllTypedRecBody (i, na, jl, tys))

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -46,6 +46,11 @@ type pretype_error =
   | CantFindCaseType of constr
   (** Old Case *)
 
+  | LetTupleArity of unsafe_judgment * int * int
+  (** Destructuring let with the wrong number of variables: judgment of the
+      destructured term, number of variables expected by the constructor,
+      number of variables given *)
+
   | ActualTypeNotCoercible of unsafe_judgment * types * unification_error
   (** Type inference unification *)
 
@@ -100,6 +105,8 @@ val error_case_not_inductive : ?loc:Loc.t -> env -> evar_map -> unsafe_judgment 
 val error_ill_formed_branch : ?loc:Loc.t -> env -> evar_map -> constr -> pconstructor -> constr -> constr -> 'b
 
 val error_number_branches : ?loc:Loc.t -> env -> evar_map -> unsafe_judgment -> int -> 'b
+
+val error_lettuple_arity : ?loc:Loc.t -> env -> evar_map -> unsafe_judgment -> int -> int -> 'b
 
 val error_ill_typed_rec_body : ?loc:Loc.t -> env -> evar_map -> int ->
       Name.t binder_annot array -> unsafe_judgment array -> types array -> 'b

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1325,8 +1325,7 @@ struct
         str " with one constructor.");
     let cs = cstrs.(0) in
     if not (Int.equal (List.length nal) cs.cs_nargs) then
-      user_err ?loc:loc (str "Destructing let on this type expects " ++
-        int cs.cs_nargs ++ str " variables.");
+      error_lettuple_arity ?loc !!env sigma cj cs.cs_nargs (List.length nal);
     let fsign, record =
       match Environ.get_projections !!env ind with
       | None ->

--- a/test-suite/output/bug_7833.out
+++ b/test-suite/output/bug_7833.out
@@ -1,0 +1,12 @@
+File "./output/bug_7833.v", line 7, characters 2-45:
+The command has indeed failed with message:
+Destructing let on term "p" of type "point2d"
+expects 2 variables, but 3 were given.
+File "./output/bug_7833.v", line 10, characters 2-19:
+The command has indeed failed with message:
+Destructing let on term "p" of type "point2d"
+expects 2 variables, but 1 was given.
+File "./output/bug_7833.v", line 15, characters 2-22:
+The command has indeed failed with message:
+Destructing let on term "b" of type "box"
+expects 1 variable, but 2 were given.

--- a/test-suite/output/bug_7833.v
+++ b/test-suite/output/bug_7833.v
@@ -1,0 +1,15 @@
+(* Destructuring let with the wrong number of variables should name the
+   destructured term and its type (#7833). *)
+
+Definition point2d : Type := nat * nat.
+
+Fail Definition abs (p : point2d) : nat :=
+  let (x, y, z) := p in x * x + y * y + z * z.
+
+Fail Definition proj1 (p : point2d) : nat :=
+  let (x) := p in x.
+
+Inductive box : Type := Box : nat -> box.
+
+Fail Definition unbox (b : box) : nat :=
+  let (x, y) := b in x.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -339,6 +339,16 @@ let explain_number_branches env sigma cj expn =
   str "of type" ++ brk(1,1) ++ pct ++ spc () ++
   str "expects " ++  int expn ++ str " branches."
 
+let explain_lettuple_arity env sigma cj expn given =
+  let env = make_all_name_different env sigma in
+  let pc = pr_leconstr_env env sigma cj.uj_val in
+  let pct = pr_leconstr_env env sigma cj.uj_type in
+  str "Destructing let on term" ++ brk(1,1) ++ pc ++ spc () ++
+  str "of type" ++ brk(1,1) ++ pct ++ spc () ++
+  str "expects " ++ int expn ++ str (String.plural expn " variable") ++
+  str ", but " ++ int given ++
+  str (if Int.equal given 1 then " was" else " were") ++ str " given."
+
 let explain_ill_formed_case_params env sigma =
   str "Ill formed case parameters (bugged tactic?)."
 
@@ -1138,6 +1148,7 @@ let rec explain_pretype_error env sigma err =
   let env = make_all_name_different env sigma in
   match err with
   | CantFindCaseType c -> explain_cant_find_case_type env sigma c
+  | LetTupleArity (cj, expn, given) -> explain_lettuple_arity env sigma cj expn given
   | ActualTypeNotCoercible (j,t,e) ->
     let {uj_val = c; uj_type = actty} = j in
     let (env, c, actty, expty), e = contract3' env sigma c actty t e in


### PR DESCRIPTION
Fixes / closes #7833

##### Explanation

The arity error for a destructuring `let` used to be a bare `user_err` in the
pretyper:

```
Destructing let on this type expects 2 variables.
```

It now names the destructured term and its type, and reports the number of
variables actually given:

```
Destructing let on term "p" of type "point2d"
expects 2 variables, but 3 were given.
```

As requested in the review of the earlier attempt #7943, no `Printer` call is
made inside pretyping: the error is a new `Pretype_errors.pretype_error`
constructor (`LetTupleArity`, carrying the judgment of the destructured term
plus the expected and given variable counts) raised through a new
`error_lettuple_arity` helper and rendered in `Himsg`, mirroring the
neighboring `CaseNotInductive` / `NumberBranches` plumbing.

API note: `Pretype_errors.pretype_error` gains the `LetTupleArity`
constructor, so external plugin code matching exhaustively on
`pretype_error` needs a new arm.  In-tree code needed no change besides
`Himsg`.

The new output test covers both plural renderings in each position
("expects 1 variable" / "expects 2 variables", "1 was given" / "3 were
given").

- [x] Added / updated **test-suite** (`test-suite/output/bug_7833.v`).
- [x] Added **changelog**.

<sub>Drafted with AI assistance;  the change and its verification (full build,
output test-suite, mutation check on the new test) were reviewed and run
locally by me.</sub>
