### PR TITLE
Fix Windows CI: work around Cygwin pkgconf 3.0.4-1 personality path bug

### DIFF
--- a/.github/workflows/ci-github.yml
+++ b/.github/workflows/ci-github.yml
@@ -55,6 +55,20 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml }}
           dune-cache: true
 
+      # Cygwin's pkgconf 3.0.4-1 (2026-07-26) compiles its personality search
+      # path as /usr/lib/pkgconfig/personality.d:/usr/share/pkgconfig/personality.d
+      # but still installs the mingw-w64 personality files under
+      # /etc/pkgconfig/personality.d, so `pkgconf --personality=<triplet>`
+      # silently falls back to the native personality and the
+      # conf-mingw-w64-{gmp,zlib}-* opam packages fail their probes.  pkgconf
+      # also searches $XDG_DATA_DIRS/pkgconfig/personality.d, so prepending /etc
+      # restores the lookup.  Drop this once Cygwin ships a fixed pkgconf
+      # packaging.
+      - name: 🩹 Work around Cygwin pkgconf 3.0.4-1 personality path bug
+        if: matrix.os == 'windows-latest'
+        run: |
+          "XDG_DATA_DIRS=/etc:/usr/local/share:/usr/share" >> $env:GITHUB_ENV
+
       - name: 🐫🐪🐫 Get Rocq dependencies
         run: opam install --deps-only ${{ matrix.packages }}
 


### PR DESCRIPTION
Fixes the Windows job of "Github CI", red on every PR since 2026-07-26 ~09:00 UTC.

##### What broke

The "Get Rocq dependencies" step fails while installing the opam conf
packages `conf-mingw-w64-gmp-i686`, `conf-mingw-w64-gmp-x86_64`, and
`conf-mingw-w64-zlib-x86_64`: their build check
`pkgconf --personality=<triplet>-w64-mingw32 <lib>` exits 1.

Root cause is a packaging bug in Cygwin's pkgconf **3.0.4-1** (released
2026-07-26 07:46;  the last green run here, Jul 25, still got 2.5.1-1):

- `libpkgconf7` (2.5.1-1) was compiled with personality search path
  `/etc/pkgconfig/personality.d`, which is where the package installs
  `x86_64-w64-mingw32.personality` / `i686-w64-mingw32.personality`.
- `libpkgconf8` (3.0.4-1) is compiled with
  `/usr/lib/pkgconfig/personality.d:/usr/share/pkgconfig/personality.d`
  (visible with `strings` on the DLLs), **but the package still installs
  the personality files under `/etc/pkgconfig/personality.d`**.

When pkgconf cannot find a personality it silently falls back to the
native one (`libpkgconf/personality.c` returns
`pkgconf_cross_personality_default()`), so the probe looks for `gmp.pc`
in native Cygwin paths, finds nothing, and exits 1 with no error output.

Nothing on the rocq side changed (same setup-ocaml v3.7.0 SHA, same opam
2.5.2 in the green and red runs), and neither did the opam-repository
conf packages or the cygwin mingw64-gmp/zlib packages (unchanged since
2023). An independent report of the same failure exists in
ahrefs/ocannl CI;  the adjacent setup-ocaml thread is
ocaml/setup-ocaml#1102.

##### The workaround

pkgconf 3.x also searches `$XDG_DATA_DIRS/pkgconfig/personality.d`
before the compiled-in path, so exporting

```
XDG_DATA_DIRS=/etc:/usr/local/share:/usr/share
```

for the Windows job makes it find the personality files at their actual
location (`/etc/pkgconfig/personality.d`). This touches nothing in the
Cygwin installation, keeps the default XDG entries, is a no-op for the
other jobs (the step is `windows-latest`-gated), and becomes a harmless
no-op once Cygwin ships a fixed pkgconf packaging, at which point it can
be dropped.

I've reported the packaging bug to the Cygwin mailing list.  Since
`pull_request` runs build the merge ref, merging this unblocks the
Windows job on every open PR on re-run, with no rebases needed.
