### PR TITLE
clarify ssreflect rewrite deprecation message

### DIFF
--- a/plugins/ssrrewrite/ssrrewrite.mlg
+++ b/plugins/ssrrewrite/ssrrewrite.mlg
@@ -21,7 +21,7 @@ open Ssreflect_plugin.Ssrtacs
 let warn_deprecated_rewrite =
   CWarnings.create ~name:"rewrite-rw" ~category:Deprecation.Version.v9_3
     ~quickfix:(fun ~loc () -> [Quickfix.make ~loc (Pp.str "rw")])
-    (fun () -> Pp.str "The 'rewrite' tactic has been renamed 'rw'.")
+    (fun () -> Pp.str "The ssreflect 'rewrite' tactic has been renamed 'rw' (available from Rocq 9.3).")
 
 let warn_deprecated_rewrite ?loc () =
   (* 7 = length "rewrite" *)

--- a/test-suite/output/warn_ssr_rewrite.out
+++ b/test-suite/output/warn_ssr_rewrite.out
@@ -1,10 +1,12 @@
 File "./output/warn_ssr_rewrite.v", line 4, characters 14-21:
-Warning: The 'rewrite' tactic has been renamed 'rw'.
+Warning:
+The ssreflect 'rewrite' tactic has been renamed 'rw' (available from Rocq 9.3).
 [rewrite-rw,deprecated-since-9.3,deprecated,default]
 Quickfix:
 Replace File "./output/warn_ssr_rewrite.v", line 4, characters 14-21 with rw
 File "./output/warn_ssr_rewrite.v", line 12, characters 2-9:
-Warning: The 'rewrite' tactic has been renamed 'rw'.
+Warning:
+The ssreflect 'rewrite' tactic has been renamed 'rw' (available from Rocq 9.3).
 [rewrite-rw,deprecated-since-9.3,deprecated,default]
 Quickfix:
 Replace File "./output/warn_ssr_rewrite.v", line 12, characters 2-9 with rw


### PR DESCRIPTION
When seeing that message in an existing development, it is far from clear that it refers to ssreflect rewrite rather than Rocq rewrite, so let's have the message say that explicitly.

Also, when getting a deprecation message, it is extremely useful to know the minimum Rocq version I need to fix the deprecation. Otherwise I may accidentally use a tactic that's not even supported yet in the minimal Rocq version that my library supports.

If possible it'd be great if this change could also be backported to the 9.3 branch.