### PR TITLE
Conversion cache experiment (packing the mark and fid in one word)

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -75,13 +75,45 @@ type table_key = Constant.t UVars.puniverses tableKey
 
 type evar_repack = Evar.t * constr list -> constr
 
-type fconstr = {
-  mutable mark : red_state;
-  mutable term: fterm;
-  (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
-     in-place [update], reset by copies. *)
-  mutable fid : int;
-}
+module FCell : sig
+  type 'a t
+
+  val make : red_state -> 'a -> 'a t
+  val get_red_state : 'a t -> red_state
+  val fterm_of : 'a t -> 'a
+  val get_fid : 'a t -> int
+  val set_ntrl : 'a t -> unit
+  val update : 'a t -> 'a t -> unit
+  val set_term : 'a t -> 'a -> unit
+end = struct
+  type 'a t = {
+    mutable mark : red_state;
+    mutable term : 'a;
+    (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
+       in-place [update], reset by copies. *)
+    mutable fid : int;
+  }
+
+  let make mark term = {mark; term; fid = 0}
+  let get_red_state {mark; _} = mark
+  let fterm_of {term; _} = term
+
+  let fid_counter = ref 0
+  let get_fid v =
+    if v.fid != 0 then v.fid
+    else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+
+  let set_ntrl v = v.mark <- Ntrl
+
+  (* Could issue a warning if no is still Red, pointing out that we loose
+     sharing. *)
+  let update v vs =
+    v.mark <- vs.mark; v.term <- vs.term
+
+  let set_term v t = v.term <- t
+end
+
+type fconstr = fterm FCell.t
 
 and fterm =
   | FRel of int
@@ -116,21 +148,9 @@ and usubs = subs_content subs UVars.puniverses
 
 and finvert = fconstr array
 
+include FCell
+
 let get_invert fiv = fiv
-
-let fterm_of v = v.term
-
-let fid_counter = ref 0
-let get_fid v =
-  if v.fid != 0 then v.fid
-  else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
-
-let set_ntrl v = v.mark <- Ntrl
-
-(* Could issue a warning if no is still Red, pointing out that we loose
-   sharing. *)
-let update v1 mark t =
-  v1.mark <- mark; v1.term <- t
 
 type 'a evar_expansion =
 | EvarDefined of 'a
@@ -247,19 +267,17 @@ let usubs_shft (n,(e,u)) = subs_shft (n, e), u
    lft_fconstr always create a new cell, while lift_fconstr avoids it
    when the lift is 0. *)
 let rec lft_fconstr n ft =
-  match ft.term with
+  match fterm_of ft with
     | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FString _|FIrrelevant) -> ft
-    | FRel i -> {fid = 0; mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {fid = 0; mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
-    | FFix(fx,e) ->
-      {fid = 0; mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
-    | FCoFix(cfx,e) ->
-      {fid = 0; mark =Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
+    | FRel i -> make (get_red_state ft) (FRel(i+n))
+    | FLambda(k,tys,f,e) -> make Cstr (FLambda(k,tys,f,usubs_shft(n,e)))
+    | FFix(fx,e) -> make Cstr (FFix(fx,usubs_shft(n,e)))
+    | FCoFix(cfx,e) -> make Cstr (FCoFix(cfx,usubs_shft(n,e)))
     | FLIFT(k,m) -> lft_fconstr (n+k) m
-    | FConstruct (c,args) -> {fid = 0; mark =Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
+    | FConstruct (c,args) -> make Cstr (FConstruct(c,Array.Fun1.map lft_fconstr n args))
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
-    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {fid = 0; mark =ft.mark; term=FLIFT(n,ft)}
+    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> make (get_red_state ft) (FLIFT(n,ft))
 let lift_fconstr k f =
   if Int.equal k 0 then f else lft_fconstr k f
 
@@ -268,9 +286,9 @@ let clos_rel e i =
     | Inl (n, Regular mt) -> Regular (lift_fconstr n mt)
     | Inl (_, HigherOrder (0, mt)) -> Regular mt
     | Inl (_, HigherOrder (nargs, mt)) -> HigherOrder (nargs, mt)
-    | Inr (k, None) -> Regular {fid = 0; mark =Ntrl; term= FRel k}
+    | Inr (k, None) -> Regular (make Ntrl (FRel k))
     | Inr (k, Some p) ->
-      Regular (lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)})
+      Regular (lift_fconstr (k-p) (make Red (FFlex (RelKey p))))
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -281,7 +299,7 @@ let compact_stack head stk =
            lost by the update operation *)
         let h' = lft_fconstr depth head in
         (** The stack contains [Zupdate] marks only if in sharing mode *)
-        let () = update m h'.mark h'.term in
+        let () = update m h' in
         strip_rec depth s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zapp _ | Zprimitive _) :: _ | []) as stk -> zshift depth stk
   in
@@ -290,9 +308,9 @@ let compact_stack head stk =
 (* Put an update mark in the stack, only if needed *)
 let zupdate info m s =
   let share = info.i_cache.i_share in
-  if share && is_red m.mark then
+  if share && is_red (get_red_state m) then
     let s' = compact_stack m s in
-    let _ = m.term <- FLOCKED in
+    let _ = set_term m FLOCKED in
     Zupdate(m)::s'
   else s
 
@@ -329,11 +347,11 @@ let usubs_liftn n (e,u) = subs_liftn n e, u
 
 (* t must be a FLambda and binding list cannot be empty *)
 let destFLambda clos_fun t =
-  match [@ocaml.warning "-4"] t.term with
+  match [@ocaml.warning "-4"] fterm_of t with
   | FLambda(_,[(na,ty)],b,e) ->
     (usubst_binder e na,clos_fun e ty,clos_fun (usubs_lift e) b)
   | FLambda(n,(na,ty)::tys,b,e) ->
-    (usubst_binder e na,clos_fun e ty,{fid = 0; mark =t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
+    (usubst_binder e na,clos_fun e ty,make (get_red_state t) (FLambda(n-1,tys,b,usubs_lift e)))
   | _ -> assert false
 
 (* Optimization: do not enclose variables in a closure.
@@ -345,26 +363,26 @@ let mk_clos (e:usubs) t =
       | Regular v -> v
       | HigherOrder _ -> CErrors.anomaly Pp.(str "Uncaught pattern variable")
       end
-    | Var x -> {fid = 0; mark = Red; term = FFlex (VarKey x) }
-    | Const c -> {fid = 0; mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
+    | Var x -> make Red (FFlex (VarKey x))
+    | Const c -> make Red (FFlex (ConstKey (usubst_punivs e c)))
     | Sort s ->
       let s = usubst_sort e s in
-      {fid = 0; mark = Ntrl; term = FAtom (mkSort s) }
-    | Meta _ -> {fid = 0; mark = Ntrl; term = FAtom t }
-    | Ind kn -> {fid = 0; mark = Ntrl; term = FInd (usubst_punivs e kn) }
-    | Construct kn -> {fid = 0; mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
-    | Int i -> {fid = 0; mark = Cstr; term = FInt i}
-    | Float f -> {fid = 0; mark = Cstr; term = FFloat f}
-    | String s -> {fid = 0; mark = Cstr; term = FString s}
+      make Ntrl (FAtom (mkSort s))
+    | Meta _ -> make Ntrl (FAtom t)
+    | Ind kn -> make Ntrl (FInd (usubst_punivs e kn))
+    | Construct kn -> make Cstr (FConstruct (usubst_punivs e kn,[||]))
+    | Int i -> make Cstr (FInt i)
+    | Float f -> make Cstr (FFloat f)
+    | String s -> make Cstr (FString s)
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {fid = 0; mark = Red; term = FCLOS(t,e)}
+        make Red (FCLOS(t,e))
   (* Invariant, pattern variables under apps are deferred to knht by being wrapped in FCLOS *)
 
 let injectu c u = mk_clos (subs_id 0, u) c
 
 let inject c = injectu c UVars.Instance.empty
 
-let mk_irrelevant = { fid = 0; mark = Cstr; term = FIrrelevant }
+let mk_irrelevant = make Cstr FIrrelevant
 
 let is_irrelevant info r = match info.i_cache.i_mode with
 | Reduction -> false
@@ -537,7 +555,7 @@ let rec subst_constr (subst,usubst as e) c =
     where [comp_subs lfts σ] returns a constr substitution,
     that can be applied to [v] *)
 let rec to_constr lfts v =
-  match v.term with
+  match fterm_of v with
     | FRel i -> mkRel (reloc_rel i lfts)
     | FFlex (RelKey p) -> mkRel (reloc_rel p lfts)
     | FFlex (VarKey x) -> mkVar x
@@ -670,72 +688,65 @@ let lift_union k = function
   | HigherOrder (n, v) -> HigherOrder (n+k, v)
 
 let rec resubst subs v =
-  match v.term with
+  match fterm_of v with
   | FRel i ->
     begin match clos_rel subs i with
     | Regular v -> v
     | HigherOrder _ -> CErrors.anomaly Pp.(str "Uncaught pattern variable")
     end
   | FApp (f,ve) ->
-    begin match [@ocaml.warning "-4"] f.term with
+    begin match [@ocaml.warning "-4"] fterm_of f with
     | FRel i ->
       let args = Array.Fun1.map resubst subs ve in
       begin match clos_rel subs i with
-      | Regular t -> { v with fid = 0; term = FApp (t, args) }
+      | Regular t -> make (get_red_state v) (FApp (t, args))
       | HigherOrder (nargs, term) ->
         let subs', args = Array.chop nargs args in
         let subs' = Array.fold_left (fun s v -> subs_cons (Regular v) s) (subs_id 0) subs' in
         let head = resubst subs' term in
-        { v with fid = 0; term = FApp (head, args) }
+        make (get_red_state v) (FApp (head, args))
       end
     | _ ->
-      { v with fid = 0; term =
-          FApp (resubst subs f,
-                Array.Fun1.map resubst subs ve) }
+      make (get_red_state v) (FApp (resubst subs f, Array.Fun1.map resubst subs ve))
     end
   | FCaseT (ci, u, pms, p, c, ve, env) ->
     let env = comp_subs subs env in
-    { v with fid = 0; term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
+    make (get_red_state v) (FCaseT (ci, u, pms, p, resubst subs c, ve, env))
   | FCaseInvert (ci, u, pms, p, indices, c, ve, env) ->
     let env = comp_subs subs env in
     let indices = Array.Fun1.map resubst subs indices in
-    { v with fid = 0; term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
+    make (get_red_state v) (FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env))
   | FFix (fx, e) ->
     let e = comp_subs subs e in
-    { v with fid = 0; term = FFix (fx, e) }
+    make (get_red_state v) (FFix (fx, e))
   | FCoFix (cfx, e) ->
     let e = comp_subs subs e in
-    { v with fid = 0; term = FCoFix (cfx, e) }
+    make (get_red_state v) (FCoFix (cfx, e))
   | FProj (p, r, c) ->
-    { v with fid = 0; term =
-      FProj (p, r, resubst subs c) }
+    make (get_red_state v) (FProj (p, r, resubst subs c))
   | FLambda (len, tys, f, e) ->
     let e = comp_subs subs e in
-    { v with fid = 0; term = FLambda (len, tys, f, e) }
+    make (get_red_state v) (FLambda (len, tys, f, e))
   | FProd (n, t, c, e) ->
     let e = comp_subs subs e in
-    { v with fid = 0; term = FProd (n, resubst subs t, c, e) }
+    make (get_red_state v) (FProd (n, resubst subs t, c, e))
   | FLetIn (n, b, t, f, e) ->
     let e = comp_subs subs e in
-    { v with fid = 0; term =
-      FLetIn (n, resubst subs b, resubst subs t, f, e) }
+    make (get_red_state v) (FLetIn (n, resubst subs b, resubst subs t, f, e))
   | FEvar (ev, args, env, repack) ->
     let env = comp_subs subs env in
-    { v with fid = 0; term =
-      FEvar (ev, args, env, repack) }
+    make (get_red_state v) (FEvar (ev, args, env, repack))
   | FLIFT (k, a) ->
     resubst (subs_popn k subs) a
 
   | FArray (u, t, ty) ->
     let t = Parray.map (resubst subs) t in
     let ty = resubst subs ty in
-    { v with fid = 0; term =
-      FArray (u, t, ty) }
+    make (get_red_state v) (FArray (u, t, ty))
 
   | FCLOS (t,env) ->
     let env = comp_subs subs env in
-    { v with fid = 0; term =
-      FCLOS (t, env) }
+    make (get_red_state v) (FCLOS (t, env))
 
   | FFlex (RelKey _) -> v (* outside the substitution *)
   | FFlex (ConstKey _ | VarKey _) | FInd _ | FConstruct _ | FAtom _ | FInt _ | FFloat _ | FString _ -> v
@@ -759,38 +770,35 @@ let rec fstrong unfreeze_fun lfts v =
 
 let mkFApp h args =
   if CArray.is_empty args then h
-  else match[@warning "-4"] h.term with
+  else match[@warning "-4"] fterm_of h with
     | FConstruct (c, args0) ->
       let args = if CArray.is_empty args0 then args else Array.append args0 args in
-      {fid = 0; mark =Cstr; term=FConstruct(c, args)}
+      make Cstr (FConstruct(c, args))
     | _ ->
       (* don't bother collapsing FApp nodes *)
-      {fid = 0; mark =neutr h.mark; term=FApp(h,args)}
+      make (neutr (get_red_state h)) (FApp(h,args))
 
 let rec zip m stk =
   match stk with
     | [] -> m
     | Zapp args :: s -> zip (mkFApp m args) s
     | ZcaseT(ci, u, pms, p, br, e)::s ->
-        let t = FCaseT(ci, u, pms, p, m, br, e) in
-        let mark = (neutr m.mark) in
-        zip {fid = 0; mark; term=t} s
+        zip (make (neutr (get_red_state m)) (FCaseT(ci, u, pms, p, m, br, e))) s
     | Zproj (p,r) :: s ->
-        let mark = (neutr m.mark) in
-        zip {fid = 0; mark; term=FProj(Projection.make p true,r,m)} s
+        zip (make (neutr (get_red_state m)) (FProj(Projection.make p true,r,m))) s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
     | Zshift(n)::s ->
         zip (lift_fconstr n m) s
     | Zupdate(rf)::s ->
       (** The stack contains [Zupdate] marks only if in sharing mode *)
-        let () = update rf m.mark m.term in
+        let () = update rf m in
         zip rf s
     | Zprimitive(_op,c,rargs,kargs)::s ->
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {fid = 0; mark = Red; term = FFlex (ConstKey c)} in
+      let f = make Red (FFlex (ConstKey c)) in
       (* don't need to mkFApp because not a constructor *)
-      zip {fid = 0; mark =(neutr m.mark); term = FApp (f, Array.of_list args)} s
+      zip (make (neutr (get_red_state m)) (FApp (f, Array.of_list args))) s
 
 let fapp_stack (m,stk) = zip m stk
 
@@ -814,7 +822,7 @@ let strip_update_shift_absorb_app head stk =
         strip_rec (mkFApp h args) s
     | Zupdate(m)::s ->
       (** The stack contains [Zupdate] marks only if in sharing mode *)
-        let () = update m h.mark h.term in
+        let () = update m h in
         strip_rec m s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
       (* depth and rstk only matter for cofix *)
@@ -831,7 +839,7 @@ let strip_update_shift_app_red head stk =
         strip_rec (Zapp args :: rstk) (mkFApp h args) depth s
     | Zupdate(m)::s ->
       (** The stack contains [Zupdate] marks only if in sharing mode *)
-        let () = update m h.mark h.term in
+        let () = update m h in
         strip_rec rstk m depth s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
       (* depth and rstk only matter for cofix *)
@@ -840,11 +848,11 @@ let strip_update_shift_app_red head stk =
   strip_rec [] head 0 stk
 
 let strip_update_shift_app head stack =
-  assert (not (is_red head.mark));
+  assert (not (is_red (get_red_state head)));
   strip_update_shift_app_red head stack
 
 let get_nth_arg head n stk =
-  assert (not (is_red head.mark));
+  assert (not (is_red (get_red_state head)));
   let rec strip_rec rstk h n = function
     | Zshift(k) as e :: s ->
         strip_rec (e::rstk) (lift_fconstr k h) n s
@@ -861,7 +869,7 @@ let get_nth_arg head n stk =
           (Some (stk', args.(n)), append_stack aft s')
     | Zupdate(m)::s ->
         (** The stack contains [Zupdate] mark only if in sharing mode *)
-        let () = update m h.mark h.term in
+        let () = update m h in
         strip_rec rstk m n s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as s -> (None, List.rev rstk @ s) in
   strip_rec [] head n stk
@@ -882,7 +890,7 @@ let usubs_consv v s =
 let rec get_args n tys f e = function
     | Zupdate r :: s ->
         (** The stack contains [Zupdate] mark only if in sharing mode *)
-        let () = update r Cstr (FLambda(n,tys,f,e)) in
+        let () = update r (make Cstr (FLambda(n,tys,f,e))) in (* FIXME optimize? *)
         get_args n tys f e s
     | Zshift k :: s ->
         get_args n tys f (usubs_shft (k,e)) s
@@ -896,7 +904,7 @@ let rec get_args n tys f e = function
           let etys = List.skipn na tys in
           get_args (n-na) etys f (usubs_consn l 0 na e) s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {fid = 0; mark =Cstr; term=FLambda(n,tys,f,e)}, stk)
+      (Inr (make Cstr (FLambda(n,tys,f,e))), stk)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack info na = function
@@ -906,7 +914,7 @@ let rec eta_expand_stack info na = function
   | [] ->
     let arg =
       if is_irrelevant info na.binder_relevance then mk_irrelevant
-      else {fid = 0; mark = Ntrl; term = FRel 1}
+      else make Ntrl (FRel 1)
     in
     [Zshift 1; Zapp [|arg|]]
 
@@ -937,13 +945,13 @@ let get_native_args op c stk =
            Zapp (Array.of_list eargs) :: s')
         | rnargs, kargs, _ ->
           (* head of h is not constructor -> no need to mkFApp *)
-          strip_rec rnargs {fid = 0; mark = h.mark;term=FApp(h, args)} depth kargs s'
+          strip_rec rnargs (make (get_red_state h) (FApp(h, args))) depth kargs s'
       end
     | Zupdate(m) :: s ->
-      let () = update m h.mark h.term in
+      let () = update m h in
       strip_rec rnargs m depth  kargs s
     | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {fid = 0; mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
+  in strip_rec [] (make Red (FFlex(ConstKey c))) 0 kargs stk
 
 let get_native_args1 op c stk =
   match get_native_args op c stk with
@@ -1057,8 +1065,8 @@ let eta_expand_ind_stack env (ind,u) args m' =
       then raise Not_found (* partially applied constructor (missing non-param arguments) *)
     in
     let hstack = Array.map (fun (p,r) ->
-        { fid = 0; mark = Red; (* right can't be a constructor though *)
-          term = FProj (Projection.make p true, UVars.subst_instance_relevance u r, right) })
+        make Red (* right can't be a constructor though *)
+          (FProj (Projection.make p true, UVars.subst_instance_relevance u r, right)))
         projs
     in
     [Zapp argss], [Zapp hstack]
@@ -1077,13 +1085,11 @@ let contract_fix_vect fix =
     match [@ocaml.warning "-4"] fix with
       | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { fid = 0; mark = Cstr;
-                       term = FFix (((reci,j),rdcl),env) }),
+           (fun j -> make Cstr (FFix (((reci,j),rdcl),env))),
            env, Array.length bds)
       | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { fid = 0; mark = Cstr;
-                       term = FCoFix ((j,rdcl),env) }),
+           (fun j -> make Cstr (FCoFix ((j,rdcl),env))),
            env, Array.length bds)
       | _ -> assert false
   in
@@ -1113,31 +1119,31 @@ module FNativeEntries =
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { fid = 0; mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
+      make Cstr (FConstruct (UVars.in_punivs c, [||]))
 
     let get = Array.get
 
     let get_int () e =
-      match [@ocaml.warning "-4"] e.term with
+      match [@ocaml.warning "-4"] fterm_of e with
       | FInt i -> i
       | _ -> assert false
 
     let get_float () e =
-      match [@ocaml.warning "-4"] e.term with
+      match [@ocaml.warning "-4"] fterm_of e with
       | FFloat f -> f
       | _ -> assert false
 
     let get_string () e =
-      match [@ocaml.warning "-4"] e.term with
+      match [@ocaml.warning "-4"] fterm_of e with
       | FString s -> s
       | _ -> assert false
 
     let get_parray () e =
-      match [@ocaml.warning "-4"] e.term with
+      match [@ocaml.warning "-4"] fterm_of e with
       | FArray (_u,t,_ty) -> t
       | _ -> assert false
 
-    let dummy = {fid = 0; mark = Ntrl; term = FRel 0}
+    let dummy = make Ntrl (FRel 0)
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -1147,7 +1153,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fint := make Ntrl (FFlex (ConstKey (UVars.in_punivs c)))
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -1157,7 +1163,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        ffloat := make Ntrl (FFlex (ConstKey (UVars.in_punivs c)))
       | None -> defined_float := false
 
     let defined_string = ref false
@@ -1167,7 +1173,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_string with
       | Some c ->
         defined_string := true;
-        fstring := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fstring := make Ntrl (FFlex (ConstKey (UVars.in_punivs c)))
       | None -> defined_string := false
 
     let defined_bool = ref false
@@ -1218,7 +1224,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { fid = 0; mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
+        fcmp := make Ntrl (FInd (UVars.in_punivs icmp))
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1327,15 +1333,15 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { fid = 0; mark = Cstr; term = FInt i }
+      make Cstr (FInt i)
 
     let mkFloat env f =
       check_float env;
-      { fid = 0; mark = Cstr; term = FFloat f }
+      make Cstr (FFloat f)
 
     let mkString env s =
       check_string env;
-      { fid = 0; mark = Cstr; term = FString s }
+      make Cstr (FString s)
 
     let mkBool env b =
       check_bool env;
@@ -1420,7 +1426,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { fid = 0; mark = Cstr; term = FArray (u,t,ty)}
+      make Cstr (FArray (u,t,ty))
 
   end
 
@@ -1439,7 +1445,7 @@ let rec skip_irrelevant_stack info stk = match stk with
 | Zprimitive _ :: _ -> assert false (* no irrelevant primitives so far *)
 | Zupdate m :: s ->
   (** The stack contains [Zupdate] marks only if in sharing mode *)
-  let () = update m mk_irrelevant.mark mk_irrelevant.term in
+  let () = update m mk_irrelevant in
   skip_irrelevant_stack info s
 
 let is_irrelevant_constructor infos ((ind,_),u) =
@@ -1451,7 +1457,7 @@ let is_irrelevant_constructor infos ((ind,_),u) =
    constructor, cofix, letin, constant), or a neutral term (product,
    inductive) *)
 let rec knh info m stk =
-  match m.term with
+  match fterm_of m with
     | FLIFT(k,a) -> knh info a (zshift k stk)
     | FCLOS(t,e) -> knht info e t (zupdate info m stk)
     | FLOCKED -> assert false
@@ -1517,30 +1523,27 @@ and knht info e t stk =
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { fid = 0; mark = Red; term }, stk
+        make Red term, stk
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { fid = 0; mark = Cstr; term = FFix (fx, e) } stk
+        knh info (make Cstr (FFix (fx, e))) stk
     | Cast(a,_,_) -> knht info e a stk
     | Proj (p, r, c) ->
       let r = usubst_relevance e r in
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else begin match unfold_projection info p r with
-      | None -> ({ fid = 0; mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
+      | None -> make Red (FProj (p, r, mk_clos e c)), stk
       | Some s -> knht info e c (s :: stk)
       end
     | Construct _ -> knh info (mk_clos e t) stk
     | (Ind _|Const _|Var _|Meta _ | Sort _ | Int _|Float _|String _) -> (mk_clos e t, stk)
-    | CoFix cfx ->
-      { fid = 0; mark = Cstr; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { fid = 0; mark = Cstr ; term = mk_lambda e t }, stk
-    | Prod (n, t, c) ->
-      { fid = 0; mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
-    | LetIn (n,b,t,c) ->
-      { fid = 0; mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
+    | CoFix cfx -> make Cstr (FCoFix (cfx,e)), stk
+    | Lambda _ -> make Cstr (mk_lambda e t), stk
+    | Prod (n, t, c) -> make Ntrl (FProd (n, mk_clos e t, c, e)), stk
+    | LetIn (n,b,t,c) -> make Red (FLetIn (n, mk_clos e b, mk_clos e t, c, e)), stk
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk
@@ -1550,15 +1553,14 @@ and knht info e t stk =
           (mk_irrelevant, skip_irrelevant_stack info stk)
         else
           let repack = info.i_cache.i_sigma.evar_repack in
-          { fid = 0; mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
+          make Ntrl (FEvar (evk, args, e, repack)), stk
       end
     | Array(u,t,def,ty) ->
       let u = usubst_instance e u in
       let len = Array.length t in
       let ty = mk_clos e ty in
       let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
-      let term = FArray (u,t,ty) in
-      knh info { fid = 0; mark = Cstr; term } stk
+      knh info (make Cstr (FArray (u,t,ty))) stk
 
 (************************************************************************)
 
@@ -1734,7 +1736,7 @@ and try_unfoldfix red info tab ~pat_state (b, m, stk) =
   match [@ocaml.warning "-4"] stack with
   | Zfix (fx, par) :: s ->
     let stk' = par @ append_stack [|rarg|] s in
-    let (fxe,fxbd) = contract_fix_vect fx.term in
+    let (fxe,fxbd) = contract_fix_vect (fterm_of fx) in
     red.red_knit info tab ~pat_state fxe fxbd stk'
   | _ -> red.red_ret info tab ~pat_state ~failed:true (m, stk)
 
@@ -1761,12 +1763,12 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
       match_main red info tab ~pat_state states loc
   | Zshift k :: s -> match_elim red info tab ~pat_state next depth states elims (lift_fconstr k head) s
   | Zupdate m :: s ->
-      let () = update m head.mark head.term in
+      let () = update m head in
       match_elim red info tab ~pat_state next depth states elims head s
   | ZcaseT (ci, u, pms, ((pctx, p), _ as pred), brs, e) :: s ->
       let t = FCaseT (ci, u, pms, pred, head, brs, e) in
-      let mark = neutr head.mark in
-      let head = {fid = 0; mark; term=t} in
+      let mark = neutr (get_red_state head) in
+      let head = make mark t in
       let prets, pbrss, elims, states = extract_or_kill4 (function [@ocaml.warning "-4"]
       | PECase (pind, pret, pbrs) :: es, subst ->
         if not @@ QInd.equal (info_env info) pind ci.ci_ind then None else
@@ -1805,8 +1807,8 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
       let loc = LocArg { patterns = prets; depth = pdepth + depth; arg = mk_clos pred_e p; next = loc } in
       match_main red info tab ~pat_state states loc
   | Zproj (proj', r) :: s ->
-      let mark = (neutr head.mark) in
-      let head = {fid = 0; mark; term=FProj(Projection.make proj' true, r, head)} in
+      let mark = neutr (get_red_state head) in
+      let head = make mark (FProj(Projection.make proj' true, r, head)) in
       let elims, states = extract_or_kill2 (function [@ocaml.warning "-4"]
       | PEProj proj :: es, subst ->
         if not @@ QProjection.Repr.equal (info_env info) proj proj' then None else
@@ -1841,7 +1843,7 @@ and match_arg : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth -> 
     match_main red info tab ~pat_state states next
 
 and match_head red info tab ~pat_state next depth states patterns t stk =
-  match [@ocaml.warning "-4"] t.term with
+  match [@ocaml.warning "-4"] fterm_of t with
   | FInd (ind', u) ->
     let elims, states = extract_or_kill2 (function [@ocaml.warning "-4"]
     | (PHInd (ind, pu), elims), psubst ->
@@ -1976,7 +1978,7 @@ let match_symbol red info tab ~pat_state fl (u, b, r) stk =
       | None -> Dead, Ignore
     ) (Array.of_list r)
   in
-  let m = { fid = 0; mark = Red; term = FFlex fl } in
+  let m = make Red (FFlex fl) in
   let loc = LocStart { elims; depth=0; head = m; stack = stk; next = Return (unfold_fix, m, stk) } in
   match_main red info tab ~pat_state states loc
 
@@ -1989,7 +1991,7 @@ type 'a depth = 'a RedPattern.depth
 
 (* Computes a weak head normal form from the result of knh. *)
 let rec knr info tab ~pat_state m stk =
-  match m.term with
+  match fterm_of m with
   | FLambda(n,tys,f,e) when red_set info.i_flags fBETA ->
       (match get_args n tys f e stk with
           Inl e', s -> knit info tab ~pat_state e' f s
@@ -2019,7 +2021,7 @@ let rec knr info tab ~pat_state m stk =
       knit info tab ~pat_state e br s
     | Zfix (fx, par) :: s when use_fix ->
       let stk' = par @ append_stack [|m|] s in
-      let (fxe, fxbd) = contract_fix_vect fx.term in
+      let (fxe, fxbd) = contract_fix_vect (fterm_of fx) in
       knit info tab ~pat_state fxe fxbd stk'
     | Zproj (p, _) :: s when use_match ->
       let rargs = drop_parameters (Projection.Repr.npars p) args in
@@ -2037,7 +2039,7 @@ let rec knr info tab ~pat_state m stk =
     else if red_set info.i_flags fCOFIX then
       (match strip_update_shift_app m stk with
         | (_, _, args, (((ZcaseT _|Zproj _)::_) as stk')) ->
-            let (fxe,fxbd) = contract_fix_vect m.term in
+            let (fxe,fxbd) = contract_fix_vect (fterm_of m) in
             knit info tab ~pat_state fxe fxbd (args@stk')
         | (_, _, args, ((Zapp _ | Zfix _ | Zshift _ | Zupdate _ | Zprimitive _) :: _ | [] as s)) ->
             knr_ret info tab ~pat_state (m,args@s))
@@ -2147,9 +2149,9 @@ let kh info tab v stk = fapp_stack(kni info tab v stk)
    2- tries to rebuild the term. If a closure still has to be computed,
       calls itself recursively. *)
 
-let is_val v = match v.term with
+let is_val v = match fterm_of v with
 | FAtom _ | FRel _   | FInd _ | FConstruct (_,[||]) | FInt _ | FFloat _ | FString _ -> true
-| FFlex _ -> v.mark == Ntrl
+| FFlex _ -> get_red_state v == Ntrl
 | FConstruct _ | FApp _ | FProj _ | FFix _ | FCoFix _ | FCaseT _ | FCaseInvert _ | FLambda _
 | FProd _ | FLetIn _ | FEvar _ | FArray _ | FLIFT _ | FCLOS _ -> false
 | FIrrelevant | FLOCKED -> assert false
@@ -2168,7 +2170,7 @@ and klt info tab e t = match kind t with
   | Inl (n, Regular mt) -> kl info tab @@ lift_fconstr n mt
   | Inl (_, HigherOrder (nargs, term)) -> assert (Int.equal nargs 0); kl info tab term
   | Inr (k, None) -> if Int.equal k i then t else mkRel k
-  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)}
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) (make Red (FFlex(RelKey p)))
   end
 | App (hd, args) ->
   let is_stuck = match kind hd with
@@ -2220,7 +2222,7 @@ and klt info tab e t = match kind t with
    otherwise. *)
 and norm_head info tab m =
   if is_val m then term_of_fconstr m else
-    match m.term with
+    match fterm_of m with
       | FLambda(_n,tys,f,e) ->
         let fold (e, info, ctxt) (na, ty) =
           let na = usubst_binder e na in
@@ -2308,7 +2310,7 @@ let whd_val info tab v = term_of_fconstr (kh info tab v [])
 let norm_val info tab v = kl info tab v
 let norm_term info tab e t = klt info tab e t
 
-let whd_stack infos tab m stk = match m.mark with
+let whd_stack infos tab m stk = match get_red_state m with
 | Ntrl ->
   (** No need to perform [kni] nor to unlock updates because
       every head subterm of [m] is [Ntrl] *)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -83,32 +83,43 @@ module FCell : sig
   val fterm_of : 'a t -> 'a
   val get_fid : 'a t -> int
   val set_ntrl : 'a t -> unit
+  val set_cstr : 'a t -> unit
   val update : 'a t -> 'a t -> unit
   val set_term : 'a t -> 'a -> unit
 end = struct
   type 'a t = {
-    mutable mark : red_state;
+    mutable mark : int;
+    (** We use 2 bits to store a [red_state], and the rest for a stable cell
+        id for the conversion cache (0 = unassigned). The id is preserved by
+        in-place [update], but reset by copies. *)
     mutable term : 'a;
-    (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
-       in-place [update], reset by copies. *)
-    mutable fid : int;
   }
 
-  let make mark term = {mark; term; fid = 0}
-  let get_red_state {mark; _} = mark
+  let red_state_mask = 0b11
+  let fid_mask = lnot red_state_mask
+
+  let make mark term = {mark = Obj.magic mark; term}
+  let get_red_state {mark; _} = Obj.magic (mark land red_state_mask)
   let fterm_of {term; _} = term
 
   let fid_counter = ref 0
   let get_fid v =
-    if v.fid != 0 then v.fid
-    else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+    let fid = v.mark lsr 2 in
+    if fid != 0 then fid else begin
+      incr fid_counter;
+      v.mark <- v.mark lor (!fid_counter lsl 2);
+      !fid_counter
+    end
 
-  let set_ntrl v = v.mark <- Ntrl
+  let set_ntrl v =
+    v.mark <- v.mark land fid_mask
 
-  (* Could issue a warning if no is still Red, pointing out that we loose
-     sharing. *)
+  let set_cstr v =
+    v.mark <- (v.mark land fid_mask) lor 1
+
   let update v vs =
-    v.mark <- vs.mark; v.term <- vs.term
+    v.mark <- (v.mark land fid_mask) lor (vs.mark land red_state_mask);
+    v.term <- vs.term
 
   let set_term v t = v.term <- t
 end
@@ -890,7 +901,7 @@ let usubs_consv v s =
 let rec get_args n tys f e = function
     | Zupdate r :: s ->
         (** The stack contains [Zupdate] mark only if in sharing mode *)
-        let () = update r (make Cstr (FLambda(n,tys,f,e))) in (* FIXME optimize? *)
+        let () = set_cstr r; set_term r (FLambda(n,tys,f,e)) in
         get_args n tys f e s
     | Zshift k :: s ->
         get_args n tys f (usubs_shft (k,e)) s

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -78,6 +78,9 @@ type evar_repack = Evar.t * constr list -> constr
 type fconstr = {
   mutable mark : red_state;
   mutable term: fterm;
+  (* Stable cell id for the conversion cache; 0 = unassigned. Preserved by
+     in-place [update], reset by copies. *)
+  mutable fid : int;
 }
 
 and fterm =
@@ -116,6 +119,12 @@ and finvert = fconstr array
 let get_invert fiv = fiv
 
 let fterm_of v = v.term
+
+let fid_counter = ref 0
+let get_fid v =
+  if v.fid != 0 then v.fid
+  else begin incr fid_counter; v.fid <- !fid_counter; !fid_counter end
+
 let set_ntrl v = v.mark <- Ntrl
 
 (* Could issue a warning if no is still Red, pointing out that we loose
@@ -240,17 +249,17 @@ let usubs_shft (n,(e,u)) = subs_shft (n, e), u
 let rec lft_fconstr n ft =
   match ft.term with
     | (FInd _|FConstruct (_,[||])|FFlex(ConstKey _|VarKey _)|FInt _|FFloat _|FString _|FIrrelevant) -> ft
-    | FRel i -> {mark=ft.mark;term=FRel(i+n)}
-    | FLambda(k,tys,f,e) -> {mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
+    | FRel i -> {fid = 0; mark=ft.mark;term=FRel(i+n)}
+    | FLambda(k,tys,f,e) -> {fid = 0; mark=Cstr; term=FLambda(k,tys,f,usubs_shft(n,e))}
     | FFix(fx,e) ->
-      {mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
+      {fid = 0; mark=Cstr; term=FFix(fx,usubs_shft(n,e))}
     | FCoFix(cfx,e) ->
-      {mark=Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
+      {fid = 0; mark =Cstr; term=FCoFix(cfx,usubs_shft(n,e))}
     | FLIFT(k,m) -> lft_fconstr (n+k) m
-    | FConstruct (c,args) -> {mark=Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
+    | FConstruct (c,args) -> {fid = 0; mark =Cstr; term=FConstruct(c,Array.Fun1.map lft_fconstr n args)}
     | FLOCKED -> assert false
     | FFlex (RelKey _) | FAtom _ | FApp _ | FProj _ | FCaseT _ | FCaseInvert _ | FProd _
-    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {mark=ft.mark; term=FLIFT(n,ft)}
+    | FLetIn _ | FEvar _ | FCLOS _ | FArray _ -> {fid = 0; mark =ft.mark; term=FLIFT(n,ft)}
 let lift_fconstr k f =
   if Int.equal k 0 then f else lft_fconstr k f
 
@@ -259,9 +268,9 @@ let clos_rel e i =
     | Inl (n, Regular mt) -> Regular (lift_fconstr n mt)
     | Inl (_, HigherOrder (0, mt)) -> Regular mt
     | Inl (_, HigherOrder (nargs, mt)) -> HigherOrder (nargs, mt)
-    | Inr (k, None) -> Regular {mark=Ntrl; term= FRel k}
+    | Inr (k, None) -> Regular {fid = 0; mark =Ntrl; term= FRel k}
     | Inr (k, Some p) ->
-      Regular (lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)})
+      Regular (lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)})
 
 (* since the head may be reducible, we might introduce lifts of 0 *)
 let compact_stack head stk =
@@ -324,7 +333,7 @@ let destFLambda clos_fun t =
   | FLambda(_,[(na,ty)],b,e) ->
     (usubst_binder e na,clos_fun e ty,clos_fun (usubs_lift e) b)
   | FLambda(n,(na,ty)::tys,b,e) ->
-    (usubst_binder e na,clos_fun e ty,{mark=t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
+    (usubst_binder e na,clos_fun e ty,{fid = 0; mark =t.mark;term=FLambda(n-1,tys,b,usubs_lift e)})
   | _ -> assert false
 
 (* Optimization: do not enclose variables in a closure.
@@ -336,26 +345,26 @@ let mk_clos (e:usubs) t =
       | Regular v -> v
       | HigherOrder _ -> CErrors.anomaly Pp.(str "Uncaught pattern variable")
       end
-    | Var x -> {mark = Red; term = FFlex (VarKey x) }
-    | Const c -> {mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
+    | Var x -> {fid = 0; mark = Red; term = FFlex (VarKey x) }
+    | Const c -> {fid = 0; mark = Red; term = FFlex (ConstKey (usubst_punivs e c)) }
     | Sort s ->
       let s = usubst_sort e s in
-      {mark = Ntrl; term = FAtom (mkSort s) }
-    | Meta _ -> {mark = Ntrl; term = FAtom t }
-    | Ind kn -> {mark = Ntrl; term = FInd (usubst_punivs e kn) }
-    | Construct kn -> {mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
-    | Int i -> {mark = Cstr; term = FInt i}
-    | Float f -> {mark = Cstr; term = FFloat f}
-    | String s -> {mark = Cstr; term = FString s}
+      {fid = 0; mark = Ntrl; term = FAtom (mkSort s) }
+    | Meta _ -> {fid = 0; mark = Ntrl; term = FAtom t }
+    | Ind kn -> {fid = 0; mark = Ntrl; term = FInd (usubst_punivs e kn) }
+    | Construct kn -> {fid = 0; mark = Cstr; term = FConstruct (usubst_punivs e kn,[||]) }
+    | Int i -> {fid = 0; mark = Cstr; term = FInt i}
+    | Float f -> {fid = 0; mark = Cstr; term = FFloat f}
+    | String s -> {fid = 0; mark = Cstr; term = FString s}
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _|Array _) ->
-        {mark = Red; term = FCLOS(t,e)}
+        {fid = 0; mark = Red; term = FCLOS(t,e)}
   (* Invariant, pattern variables under apps are deferred to knht by being wrapped in FCLOS *)
 
 let injectu c u = mk_clos (subs_id 0, u) c
 
 let inject c = injectu c UVars.Instance.empty
 
-let mk_irrelevant = { mark = Cstr; term = FIrrelevant }
+let mk_irrelevant = { fid = 0; mark = Cstr; term = FIrrelevant }
 
 let is_irrelevant info r = match info.i_cache.i_mode with
 | Reduction -> false
@@ -672,47 +681,47 @@ let rec resubst subs v =
     | FRel i ->
       let args = Array.Fun1.map resubst subs ve in
       begin match clos_rel subs i with
-      | Regular t -> { v with term = FApp (t, args) }
+      | Regular t -> { v with fid = 0; term = FApp (t, args) }
       | HigherOrder (nargs, term) ->
         let subs', args = Array.chop nargs args in
         let subs' = Array.fold_left (fun s v -> subs_cons (Regular v) s) (subs_id 0) subs' in
         let head = resubst subs' term in
-        { v with term = FApp (head, args) }
+        { v with fid = 0; term = FApp (head, args) }
       end
     | _ ->
-      { v with term =
+      { v with fid = 0; term =
           FApp (resubst subs f,
                 Array.Fun1.map resubst subs ve) }
     end
   | FCaseT (ci, u, pms, p, c, ve, env) ->
     let env = comp_subs subs env in
-    { v with term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseT (ci, u, pms, p, resubst subs c, ve, env) }
   | FCaseInvert (ci, u, pms, p, indices, c, ve, env) ->
     let env = comp_subs subs env in
     let indices = Array.Fun1.map resubst subs indices in
-    { v with term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
+    { v with fid = 0; term = FCaseInvert (ci, u, pms, p, indices, resubst subs c, ve, env) }
   | FFix (fx, e) ->
     let e = comp_subs subs e in
-    { v with term = FFix (fx, e) }
+    { v with fid = 0; term = FFix (fx, e) }
   | FCoFix (cfx, e) ->
     let e = comp_subs subs e in
-    { v with term = FCoFix (cfx, e) }
+    { v with fid = 0; term = FCoFix (cfx, e) }
   | FProj (p, r, c) ->
-    { v with term =
+    { v with fid = 0; term =
       FProj (p, r, resubst subs c) }
   | FLambda (len, tys, f, e) ->
     let e = comp_subs subs e in
-    { v with term = FLambda (len, tys, f, e) }
+    { v with fid = 0; term = FLambda (len, tys, f, e) }
   | FProd (n, t, c, e) ->
     let e = comp_subs subs e in
-    { v with term = FProd (n, resubst subs t, c, e) }
+    { v with fid = 0; term = FProd (n, resubst subs t, c, e) }
   | FLetIn (n, b, t, f, e) ->
     let e = comp_subs subs e in
-    { v with term =
+    { v with fid = 0; term =
       FLetIn (n, resubst subs b, resubst subs t, f, e) }
   | FEvar (ev, args, env, repack) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FEvar (ev, args, env, repack) }
   | FLIFT (k, a) ->
     resubst (subs_popn k subs) a
@@ -720,12 +729,12 @@ let rec resubst subs v =
   | FArray (u, t, ty) ->
     let t = Parray.map (resubst subs) t in
     let ty = resubst subs ty in
-    { v with term =
+    { v with fid = 0; term =
       FArray (u, t, ty) }
 
   | FCLOS (t,env) ->
     let env = comp_subs subs env in
-    { v with term =
+    { v with fid = 0; term =
       FCLOS (t, env) }
 
   | FFlex (RelKey _) -> v (* outside the substitution *)
@@ -753,10 +762,10 @@ let mkFApp h args =
   else match[@warning "-4"] h.term with
     | FConstruct (c, args0) ->
       let args = if CArray.is_empty args0 then args else Array.append args0 args in
-      {mark=Cstr; term=FConstruct(c, args)}
+      {fid = 0; mark =Cstr; term=FConstruct(c, args)}
     | _ ->
       (* don't bother collapsing FApp nodes *)
-      {mark=neutr h.mark; term=FApp(h,args)}
+      {fid = 0; mark =neutr h.mark; term=FApp(h,args)}
 
 let rec zip m stk =
   match stk with
@@ -765,10 +774,10 @@ let rec zip m stk =
     | ZcaseT(ci, u, pms, p, br, e)::s ->
         let t = FCaseT(ci, u, pms, p, m, br, e) in
         let mark = (neutr m.mark) in
-        zip {mark; term=t} s
+        zip {fid = 0; mark; term=t} s
     | Zproj (p,r) :: s ->
         let mark = (neutr m.mark) in
-        zip {mark; term=FProj(Projection.make p true,r,m)} s
+        zip {fid = 0; mark; term=FProj(Projection.make p true,r,m)} s
     | Zfix(fx,par)::s ->
         zip fx (par @ append_stack [|m|] s)
     | Zshift(n)::s ->
@@ -779,9 +788,9 @@ let rec zip m stk =
         zip rf s
     | Zprimitive(_op,c,rargs,kargs)::s ->
       let args = List.rev_append rargs (m::List.map snd kargs) in
-      let f = {mark = Red; term = FFlex (ConstKey c)} in
+      let f = {fid = 0; mark = Red; term = FFlex (ConstKey c)} in
       (* don't need to mkFApp because not a constructor *)
-      zip {mark=(neutr m.mark); term = FApp (f, Array.of_list args)} s
+      zip {fid = 0; mark =(neutr m.mark); term = FApp (f, Array.of_list args)} s
 
 let fapp_stack (m,stk) = zip m stk
 
@@ -887,7 +896,7 @@ let rec get_args n tys f e = function
           let etys = List.skipn na tys in
           get_args (n-na) etys f (usubs_consn l 0 na e) s
     | ((ZcaseT _ | Zproj _ | Zfix _ | Zprimitive _) :: _ | []) as stk ->
-      (Inr {mark=Cstr; term=FLambda(n,tys,f,e)}, stk)
+      (Inr {fid = 0; mark =Cstr; term=FLambda(n,tys,f,e)}, stk)
 
 (* Eta expansion: add a reference to implicit surrounding lambda at end of stack *)
 let rec eta_expand_stack info na = function
@@ -897,7 +906,7 @@ let rec eta_expand_stack info na = function
   | [] ->
     let arg =
       if is_irrelevant info na.binder_relevance then mk_irrelevant
-      else {mark = Ntrl; term = FRel 1}
+      else {fid = 0; mark = Ntrl; term = FRel 1}
     in
     [Zshift 1; Zapp [|arg|]]
 
@@ -928,13 +937,13 @@ let get_native_args op c stk =
            Zapp (Array.of_list eargs) :: s')
         | rnargs, kargs, _ ->
           (* head of h is not constructor -> no need to mkFApp *)
-          strip_rec rnargs {mark = h.mark;term=FApp(h, args)} depth kargs s'
+          strip_rec rnargs {fid = 0; mark = h.mark;term=FApp(h, args)} depth kargs s'
       end
     | Zupdate(m) :: s ->
       let () = update m h.mark h.term in
       strip_rec rnargs m depth  kargs s
     | (Zprimitive _ | ZcaseT _ | Zproj _ | Zfix _) :: _ | [] -> assert false
-  in strip_rec [] {mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
+  in strip_rec [] {fid = 0; mark = Red; term = FFlex(ConstKey c)} 0 kargs stk
 
 let get_native_args1 op c stk =
   match get_native_args op c stk with
@@ -1048,7 +1057,7 @@ let eta_expand_ind_stack env (ind,u) args m' =
       then raise Not_found (* partially applied constructor (missing non-param arguments) *)
     in
     let hstack = Array.map (fun (p,r) ->
-        { mark = Red; (* right can't be a constructor though *)
+        { fid = 0; mark = Red; (* right can't be a constructor though *)
           term = FProj (Projection.make p true, UVars.subst_instance_relevance u r, right) })
         projs
     in
@@ -1068,12 +1077,12 @@ let contract_fix_vect fix =
     match [@ocaml.warning "-4"] fix with
       | FFix (((reci,i),(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FFix (((reci,j),rdcl),env) }),
            env, Array.length bds)
       | FCoFix ((i,(_,_,bds as rdcl)),env) ->
           (bds.(i),
-           (fun j -> { mark = Cstr;
+           (fun j -> { fid = 0; mark = Cstr;
                        term = FCoFix ((j,rdcl),env) }),
            env, Array.length bds)
       | _ -> assert false
@@ -1104,7 +1113,7 @@ module FNativeEntries =
 
     let mk_construct c =
       (* All constructors used in primitive functions are relevant *)
-      { mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
+      { fid = 0; mark = Cstr; term = FConstruct (UVars.in_punivs c, [||]) }
 
     let get = Array.get
 
@@ -1128,7 +1137,7 @@ module FNativeEntries =
       | FArray (_u,t,_ty) -> t
       | _ -> assert false
 
-    let dummy = {mark = Ntrl; term = FRel 0}
+    let dummy = {fid = 0; mark = Ntrl; term = FRel 0}
 
     let current_retro = ref Retroknowledge.empty
     let defined_int = ref false
@@ -1138,7 +1147,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_int63 with
       | Some c ->
         defined_int := true;
-        fint := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fint := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_int := false
 
     let defined_float = ref false
@@ -1148,7 +1157,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_float64 with
       | Some c ->
         defined_float := true;
-        ffloat := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        ffloat := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_float := false
 
     let defined_string = ref false
@@ -1158,7 +1167,7 @@ module FNativeEntries =
       match retro.Retroknowledge.retro_string with
       | Some c ->
         defined_string := true;
-        fstring := { mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
+        fstring := { fid = 0; mark = Ntrl; term = FFlex (ConstKey (UVars.in_punivs c)) }
       | None -> defined_string := false
 
     let defined_bool = ref false
@@ -1209,7 +1218,7 @@ module FNativeEntries =
         fLt := mk_construct cLt;
         fGt := mk_construct cGt;
         let (icmp, _) = cEq in
-        fcmp := { mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
+        fcmp := { fid = 0; mark = Ntrl; term = FInd (UVars.in_punivs icmp) }
       | None -> defined_cmp := false
 
     let defined_f_cmp = ref false
@@ -1318,15 +1327,15 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = Cstr; term = FInt i }
+      { fid = 0; mark = Cstr; term = FInt i }
 
     let mkFloat env f =
       check_float env;
-      { mark = Cstr; term = FFloat f }
+      { fid = 0; mark = Cstr; term = FFloat f }
 
     let mkString env s =
       check_string env;
-      { mark = Cstr; term = FString s }
+      { fid = 0; mark = Cstr; term = FString s }
 
     let mkBool env b =
       check_bool env;
@@ -1411,7 +1420,7 @@ module FNativeEntries =
 
     let mkArray env u t ty =
       check_array env;
-      { mark = Cstr; term = FArray (u,t,ty)}
+      { fid = 0; mark = Cstr; term = FArray (u,t,ty)}
 
   end
 
@@ -1508,30 +1517,30 @@ and knht info e t stk =
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
         let term = FCaseInvert (ci, u, pms, p, (Array.map (mk_clos e) indices), mk_clos e t, br, e) in
-        { mark = Red; term }, stk
+        { fid = 0; mark = Red; term }, stk
     | Fix (((_, n), (lna, _, _)) as fx) ->
       if is_irrelevant info (usubst_relevance e (lna.(n)).binder_relevance) then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else
-        knh info { mark = Cstr; term = FFix (fx, e) } stk
+        knh info { fid = 0; mark = Cstr; term = FFix (fx, e) } stk
     | Cast(a,_,_) -> knht info e a stk
     | Proj (p, r, c) ->
       let r = usubst_relevance e r in
       if is_irrelevant info r then
         (mk_irrelevant, skip_irrelevant_stack info stk)
       else begin match unfold_projection info p r with
-      | None -> ({ mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
+      | None -> ({ fid = 0; mark = Red; term = FProj (p, r, mk_clos e c) }, stk)
       | Some s -> knht info e c (s :: stk)
       end
     | Construct _ -> knh info (mk_clos e t) stk
     | (Ind _|Const _|Var _|Meta _ | Sort _ | Int _|Float _|String _) -> (mk_clos e t, stk)
     | CoFix cfx ->
-      { mark = Cstr; term = FCoFix (cfx,e) }, stk
-    | Lambda _ -> { mark = Cstr ; term = mk_lambda e t }, stk
+      { fid = 0; mark = Cstr; term = FCoFix (cfx,e) }, stk
+    | Lambda _ -> { fid = 0; mark = Cstr ; term = mk_lambda e t }, stk
     | Prod (n, t, c) ->
-      { mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Ntrl; term = FProd (n, mk_clos e t, c, e) }, stk
     | LetIn (n,b,t,c) ->
-      { mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
+      { fid = 0; mark = Red; term = FLetIn (n, mk_clos e b, mk_clos e t, c, e) }, stk
     | Evar ev ->
       begin match info.i_cache.i_sigma.evar_expand ev with
       | EvarDefined c -> knht info e c stk
@@ -1541,7 +1550,7 @@ and knht info e t stk =
           (mk_irrelevant, skip_irrelevant_stack info stk)
         else
           let repack = info.i_cache.i_sigma.evar_repack in
-          { mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
+          { fid = 0; mark = Ntrl; term = FEvar (evk, args, e, repack) }, stk
       end
     | Array(u,t,def,ty) ->
       let u = usubst_instance e u in
@@ -1549,7 +1558,7 @@ and knht info e t stk =
       let ty = mk_clos e ty in
       let t = Parray.init (Uint63.of_int len) (fun i -> mk_clos e t.(i)) (mk_clos e def) in
       let term = FArray (u,t,ty) in
-      knh info { mark = Cstr; term } stk
+      knh info { fid = 0; mark = Cstr; term } stk
 
 (************************************************************************)
 
@@ -1757,7 +1766,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
   | ZcaseT (ci, u, pms, ((pctx, p), _ as pred), brs, e) :: s ->
       let t = FCaseT (ci, u, pms, pred, head, brs, e) in
       let mark = neutr head.mark in
-      let head = {mark; term=t} in
+      let head = {fid = 0; mark; term=t} in
       let prets, pbrss, elims, states = extract_or_kill4 (function [@ocaml.warning "-4"]
       | PECase (pind, pret, pbrs) :: es, subst ->
         if not @@ QInd.equal (info_env info) pind ci.ci_ind then None else
@@ -1797,7 +1806,7 @@ and match_elim : 'a. ('a, 'a depth) reduction -> _ -> _ -> pat_state:'a depth ->
       match_main red info tab ~pat_state states loc
   | Zproj (proj', r) :: s ->
       let mark = (neutr head.mark) in
-      let head = {mark; term=FProj(Projection.make proj' true, r, head)} in
+      let head = {fid = 0; mark; term=FProj(Projection.make proj' true, r, head)} in
       let elims, states = extract_or_kill2 (function [@ocaml.warning "-4"]
       | PEProj proj :: es, subst ->
         if not @@ QProjection.Repr.equal (info_env info) proj proj' then None else
@@ -1967,7 +1976,7 @@ let match_symbol red info tab ~pat_state fl (u, b, r) stk =
       | None -> Dead, Ignore
     ) (Array.of_list r)
   in
-  let m = { mark = Red; term = FFlex fl } in
+  let m = { fid = 0; mark = Red; term = FFlex fl } in
   let loc = LocStart { elims; depth=0; head = m; stack = stk; next = Return (unfold_fix, m, stk) } in
   match_main red info tab ~pat_state states loc
 
@@ -2159,7 +2168,7 @@ and klt info tab e t = match kind t with
   | Inl (n, Regular mt) -> kl info tab @@ lift_fconstr n mt
   | Inl (_, HigherOrder (nargs, term)) -> assert (Int.equal nargs 0); kl info tab term
   | Inr (k, None) -> if Int.equal k i then t else mkRel k
-  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {mark=Red;term=FFlex(RelKey p)}
+  | Inr (k, Some p) -> kl info tab @@ lift_fconstr (k-p) {fid = 0; mark =Red;term=FFlex(RelKey p)}
   end
 | App (hd, args) ->
   let is_stuck = match kind hd with

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -112,6 +112,11 @@ val mk_clos_vect : usubs -> constr array -> fconstr array
 val zip : fconstr -> stack -> fconstr
 
 val fterm_of : fconstr -> fterm
+
+(** Stable id of a cell, lazily assigned; survives in-place reduction
+    updates. Used by the conversion cache. *)
+val get_fid : fconstr -> int
+
 val term_of_fconstr : fconstr -> constr
 val term_of_process : fconstr -> stack -> constr
 val destFLambda :

--- a/kernel/conversion.ml
+++ b/kernel/conversion.ml
@@ -194,12 +194,25 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
+(* Conversion result cache. Within one conversion session the same pair of
+   cells is typically compared many times over, because beta-substitution
+   shares payload cells across all the occurrences of a variable. Entries
+   record the outcome (success or failure) for a pair of cells, identified
+   by their stable ids, at a given lift pair and conversion problem. Only
+   sound for checked conversion, where results are deterministic and no
+   universe constraints are accumulated. *)
+type conv_cache = {
+  cc_tbl : (int * int * int, (lift * lift * bool) list ref) Hashtbl.t;
+  mutable cc_size : int;
+}
+
 type 'e conv_tab = {
   cnv_inf : clos_infos;
   cnv_typ : bool; (* true if the input terms were well-typed *)
   lft_tab : clos_tab;
   rgt_tab : clos_tab;
   err_ret : 'e -> payload;
+  cnv_cache : conv_cache option;
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
@@ -399,12 +412,68 @@ let assert_reduced_constructor s =
   if not @@ CList.is_empty s then
     CErrors.anomaly Pp.(str "conversion was given unreduced term (FConstruct).")
 
+let rec strip_flift k v = match fterm_of v with
+| FLIFT (n, v') -> strip_flift (k + n) v'
+| _ -> (k, v)
+
+(* Optional cap on cached entries per session (ROCQ_CONV_CACHE_MAX; 0 means
+   unlimited). Unbounded by default: like [clos_tab], the table is
+   session-scoped, so its lifetime bounds memory. *)
+let cc_max_size =
+  match int_of_string (Sys.getenv "ROCQ_CONV_CACHE_MAX") with
+  | 0 -> max_int
+  | n -> n
+  | exception _ -> max_int
+
+(* The cache is enabled by default; set ROCQ_CONV_CACHE=0 to disable. *)
+let cc_enabled =
+  match Sys.getenv "ROCQ_CONV_CACHE" with
+  | "0" -> false
+  | _ -> true
+  | exception Not_found -> true
+
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
   let fast = fast_test lft1 term1 lft2 term2 in
   if fast then cuniv
   else
-    eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    match infos.cnv_cache with
+    | None ->
+      eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv
+    | Some cache ->
+      let (k1, v1) = strip_flift 0 term1 in
+      let (k2, v2) = strip_flift 0 term2 in
+      let l1 = el_shft k1 lft1 in
+      let l2 = el_shft k2 lft2 in
+      let pb = match cv_pb with CONV -> 0 | CUMUL -> 1 in
+      let key = (CClosure.get_fid v1, CClosure.get_fid v2, pb) in
+      let bucket = Hashtbl.find_opt cache.cc_tbl key in
+      let cached = match bucket with
+      | None -> None
+      | Some entries ->
+        let rec find = function
+        | [] -> None
+        | (l1', l2', r) :: rest ->
+          if eq_lift l1' l1 && eq_lift l2' l2 then Some r else find rest
+        in
+        find !entries
+      in
+      begin match cached with
+      | Some true -> cuniv
+      | Some false -> raise NotConvertible
+      | None ->
+        let add r =
+          if cache.cc_size < cc_max_size then begin
+            cache.cc_size <- cache.cc_size + 1;
+            match bucket with
+            | Some entries -> entries := (l1, l2, r) :: !entries
+            | None -> Hashtbl.add cache.cc_tbl key (ref [(l1, l2, r)])
+          end
+        in
+        match eqappr cv_pb l2r infos (lft1, (term1,[])) (lft2, (term2,[])) cuniv with
+        | cuniv -> add true; cuniv
+        | exception NotConvertible -> add false; raise NotConvertible
+      end
 
 (* Conversion between [lft1](hd1 v1) and [lft2](hd2 v2) *)
 and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
@@ -979,18 +1048,24 @@ and convert_list l2r infos lft1 lft2 v1 v2 cuniv = match v1, v2 with
   convert_list l2r infos lft1 lft2 v1 v2 cuniv
 | _, _ -> raise NotConvertible
 
-let clos_gen_conv (type err) ~typed trans cv_pb l2r evars env graph univs t1 t2 =
+let clos_gen_conv (type err) ~typed ~use_cache trans cv_pb l2r evars env graph univs t1 t2 =
   NewProfile.profile "Conversion" begin fun () ->
       let reds = RedFlags.red_add_transparent RedFlags.betaiotazeta trans in
       let infos = create_conv_infos ~univs:graph ~evars reds env in
       let module Error = struct type payload += Error of err end in
       let box e = Error.Error e in
+      let cache =
+        if use_cache && cc_enabled then
+          Some { cc_tbl = Hashtbl.create 16; cc_size = 0 }
+        else None
+      in
       let infos = {
         cnv_inf = infos;
         cnv_typ = typed;
         lft_tab = create_tab ();
         rgt_tab = create_tab ();
         err_ret = box;
+        cnv_cache = cache;
       } in
       try Result.Ok (ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs)
       with
@@ -1039,7 +1114,7 @@ let () =
       let box = Empty.abort in
       let state = info_univs infos in
       let qual_equal q1 q2 = CClosure.eq_quality infos q1 q2 in
-      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; } in
+      let infos = { cnv_inf = infos; cnv_typ = true; lft_tab = tab; rgt_tab = tab; err_ret = box; cnv_cache = None; } in
       let state', _ = ccnv CONV false infos el_id el_id a b (state, checked_universes_gen qual_equal) in
       assert (state==state');
       true
@@ -1057,7 +1132,7 @@ let gen_conv ~typed cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars
     else eq_constr_univs univs t1 t2
   in
     if b then Result.Ok ()
-    else match clos_gen_conv ~typed reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
+    else match clos_gen_conv ~typed ~use_cache:true reds cv_pb l2r evars env univs (state, checked_universes) t1 t2 with
     | Result.Ok (_ : 'a * ('a, Empty.t) universe_compare)-> Result.Ok ()
     | Result.Error None -> Result.Error ()
     | Result.Error (Some e) -> Empty.abort e
@@ -1067,7 +1142,7 @@ let conv_leq = gen_conv ~typed:false CUMUL
 
 let generic_conv cv_pb ~l2r reds env ?(evars=default_evar_handler env) state t1 t2 =
   let graph = Environ.universes env in
-  match clos_gen_conv ~typed:false reds cv_pb l2r evars env graph state t1 t2 with
+  match clos_gen_conv ~typed:false ~use_cache:false reds cv_pb l2r evars env graph state t1 t2 with
   | Result.Ok (s, _) -> Result.Ok s
   | Result.Error e -> Result.Error e
 


### PR DESCRIPTION
This adds two commits on top of https://github.com/rocq-prover/rocq/pull/22309:
- A refactoring of `CClosure` to give `fconstr` an abstract interface,
- Packing the `fid` field together with the `mark` field, to avoid allocating one extra word per `fconstr` cell.