### PR TITLE
CI: fetch Iris and std++ from github mirrors

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -121,19 +121,25 @@ project corn "https://github.com/coq-community/corn" "master"
 ########################################################################
 
 # NB: stdpp and Iris refs are gotten from the opam files in the Iris and
-# iris_examples repos respectively. So just getting a fix landed in stdpp or
-# Iris is not enough. Ping @RalfJung and @robbertkrebbers if you need the
-# versions of stdpp or Iris to be bumped.
-project stdpp "https://gitlab.mpi-sws.org/iris/stdpp" ""
+# iris_examples repos respectively. Those will be updated automatically within
+# 24h after a change lands in stdpp or Iris. Ping @RalfJung and @robbertkrebbers
+# if that does not work for some reason.
+# The URL below is a mirror; use https://gitlab.mpi-sws.org/iris/stdpp for issues
+# and PRs.
+project stdpp "https://github.com/rocq-iris/stdpp" ""
 # Contact @RalfJung, @robbertkrebbers on github
 
-project iris "https://gitlab.mpi-sws.org/iris/iris" ""
+# The URL below is a mirror; use https://gitlab.mpi-sws.org/iris/iris for issues
+# and PRs.
+project iris "https://github.com/rocq-iris/iris" ""
 # Contact @RalfJung, @robbertkrebbers on github
 
 project autosubst "https://github.com/coq-community/autosubst" "master"
 # Contact @RalfJung on github
 
-project iris_examples "https://gitlab.mpi-sws.org/iris/examples" "master"
+# The URL below is a mirror; use https://gitlab.mpi-sws.org/iris/examples for
+# issues and PRs.
+project iris_examples "https://github.com/rocq-iris/examples" "master"
 # Contact @RalfJung, @robbertkrebbers on github
 
 ########################################################################

--- a/dev/ci/nix/default.nix
+++ b/dev/ci/nix/default.nix
@@ -49,12 +49,12 @@ let corn = (coqPackages.corn.override { inherit coq bignums math-classes; })
   }); in
 
 let stdpp = coqPackages.stdpp.overrideAttrs (o: {
-    src = fetchTarball "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/master/stdpp-master.tar.bz2";
+    src = fetchTarball "https://github.com/rocq-iris/stdpp/archive/master.tar.gz";
   }); in
 
 let iris = (coqPackages.iris.override { inherit coq stdpp; })
   .overrideAttrs (o: {
-    src = fetchTarball "https://gitlab.mpi-sws.org/iris/iris/-/archive/master/iris-master.tar.bz2";
+    src = fetchTarball "https://github.com/rocq-iris/iris/archive/master.tar.gz";
     propagatedBuildInputs = [ stdpp ];
   }); in
 


### PR DESCRIPTION
MPI's gitlab server is buckling under the load of aggressive scrapers which are likely fueled by the global craze for LLMs. We had to install aggressive rate limiting.

So we set up a mirror on github to prevent Rocq CI from being caught up in this rate limiting.